### PR TITLE
add event for queuedWorkload

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 
 	kueuev1alpha1 "sigs.k8s.io/kueue/api/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/capacity"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/workload/job"
 	"sigs.k8s.io/kueue/pkg/queue"
@@ -121,7 +122,8 @@ func main() {
 	go func() {
 		queues.CleanUpOnContext(ctx)
 	}()
-	sched := scheduler.New(queues, cache, mgr.GetClient())
+	sched := scheduler.New(queues, cache, mgr.GetClient(),
+		mgr.GetEventRecorderFor(constants.ManagerName))
 	go func() {
 		sched.Start(ctx)
 	}()

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -21,4 +21,6 @@ const (
 	//
 	// TODO(#23): Use the kubernetes.io domain when graduating APIs to beta.
 	QueueAnnotation = "kueue.x-k8s.io/queue-name"
+
+	ManagerName = "kueue-manager"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
First Part of #9 

#### Special notes for your reviewer:
The event only includes the message that when it is assigned a capacity in the scheduling loop.
```bash
Status:
  Conditions:
    Last Probe Time:       2022-02-18T17:11:02Z
    Last Transition Time:  2022-02-18T17:11:02Z
    Message:               Job finished successfully
    Reason:                JobFinished
    Status:                True
    Type:                  Finished
Events:
  Type    Reason    Age   From           Message
  ----    ------    ----  ----           -------
  Normal  Assigned  14s   kueue-manager  Assigned to capacity cluster-total
```
