### PR TITLE
Use the x-k8s.io domain for queue name annotation

### DIFF
--- a/config/samples/sample-job.yaml
+++ b/config/samples/sample-job.yaml
@@ -3,7 +3,7 @@ kind: Job
 metadata:
   generateName: sample-job-
   annotations:
-    controller.kubernetes.io/queue-name: main
+    kueue.x-k8s.io/queue-name: main
 spec:
   parallelism: 3
   completions: 3

--- a/controllers/job_controller.go
+++ b/controllers/job_controller.go
@@ -36,8 +36,9 @@ import (
 )
 
 var (
-	ownerKey        = ".metadata.controller"
-	queueAnnotation = "controller.kubernetes.io/queue-name"
+	ownerKey = ".metadata.controller"
+	// TODO(#23): Use the kubernetes.io domain when graduating APIs to beta.
+	queueAnnotation = "kueue.x-k8s.io/queue-name"
 )
 
 // JobReconciler reconciles a Job object


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Annotations using the  `kubernetes.io` domain should be registered in the official kubernetes documentation. Use `x-k8s.io` for now.

#### Which issue(s) this PR fixes:

Fixes #25

#### Special notes for your reviewer:

