### PR TITLE
Split integration tests into their own folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,12 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+test: generate fmt vet ## Run tests.
+	go test ./pkg/... -coverprofile cover.out
+
+.PHONY: test-integration
+test-integration: manifests generate fmt vet envtest ## Run tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./test/integration/...
 
 ##@ Build
 

--- a/main.go
+++ b/main.go
@@ -32,8 +32,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	kueuev1alpha1 "sigs.k8s.io/kueue/api/v1alpha1"
-	"sigs.k8s.io/kueue/controllers"
 	"sigs.k8s.io/kueue/pkg/capacity"
+	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/controller/workload/job"
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	//+kubebuilder:scaffold:imports
@@ -89,19 +90,19 @@ func main() {
 
 	queues := queue.NewManager(mgr.GetClient())
 	cache := capacity.NewCache(mgr.GetClient())
-	if err = controllers.NewQueueReconciler(queues).SetupWithManager(mgr); err != nil {
+	if err = core.NewQueueReconciler(queues).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Queue")
 		os.Exit(1)
 	}
-	if err = controllers.NewCapacityReconciler(cache).SetupWithManager(mgr); err != nil {
+	if err = core.NewCapacityReconciler(cache).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Capacity")
 		os.Exit(1)
 	}
-	if err = controllers.NewQueuedWorkloadReconciler(queues, cache).SetupWithManager(mgr); err != nil {
+	if err = core.NewQueuedWorkloadReconciler(queues, cache).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "QueuedWorkload")
 		os.Exit(1)
 	}
-	if err = controllers.NewJobReconciler(mgr.GetScheme(), mgr.GetClient()).SetupWithManager(mgr); err != nil {
+	if err = job.NewReconciler(mgr.GetScheme(), mgr.GetClient()).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Job")
 		os.Exit(1)
 	}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+	// QueueAnnotation is the annotation in the workload that holds the queue name.
+	//
+	// TODO(#23): Use the kubernetes.io domain when graduating APIs to beta.
+	QueueAnnotation = "kueue.x-k8s.io/queue-name"
+)

--- a/pkg/controller/core/capacity_controller.go
+++ b/pkg/controller/core/capacity_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package core
 
 import (
 	"context"

--- a/pkg/controller/core/queue_controller.go
+++ b/pkg/controller/core/queue_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package core
 
 import (
 	"context"

--- a/pkg/controller/core/queuedworkload_controller.go
+++ b/pkg/controller/core/queuedworkload_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package core
 
 import (
 	"context"

--- a/pkg/controller/workload/job/job_controller.go
+++ b/pkg/controller/workload/job/job_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package job
 
 import (
 	"context"
@@ -33,11 +33,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/api/v1alpha1"
+	"sigs.k8s.io/kueue/pkg/constants"
 )
 
 var (
-	ownerKey        = ".metadata.controller"
-	queueAnnotation = "controller.kubernetes.io/queue-name"
+	ownerKey = ".metadata.controller"
 )
 
 // JobReconciler reconciles a Job object
@@ -47,7 +47,7 @@ type JobReconciler struct {
 	log    logr.Logger
 }
 
-func NewJobReconciler(scheme *runtime.Scheme, client client.Client) *JobReconciler {
+func NewReconciler(scheme *runtime.Scheme, client client.Client) *JobReconciler {
 	return &JobReconciler{
 		log:    ctrl.Log.WithName("job-reconciler"),
 		scheme: scheme,
@@ -289,7 +289,7 @@ func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job *batchv
 	}
 
 	// Create the corresponding workload.
-	wl, err := constructWorkloadFromJob(job, r.scheme)
+	wl, err := ConstructWorkloadFor(job, r.scheme)
 	if err != nil {
 		return err
 	}
@@ -355,7 +355,7 @@ func (r *JobReconciler) ensureAtMostOneWorkload(ctx context.Context, job *batchv
 	return match, nil
 }
 
-func constructWorkloadFromJob(job *batchv1.Job, scheme *runtime.Scheme) (*kueue.QueuedWorkload, error) {
+func ConstructWorkloadFor(job *batchv1.Job, scheme *runtime.Scheme) (*kueue.QueuedWorkload, error) {
 	w := &kueue.QueuedWorkload{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      job.Name,
@@ -438,5 +438,5 @@ func jobAndWorkloadEqual(job *batchv1.Job, wl *kueue.QueuedWorkload) bool {
 }
 
 func queueName(job *batchv1.Job) string {
-	return job.Annotations[queueAnnotation]
+	return job.Annotations[constants.QueueAnnotation]
 }

--- a/test/integration/controller/job/suite_test.go
+++ b/test/integration/controller/job/suite_test.go
@@ -56,7 +56,7 @@ var _ = BeforeSuite(func() {
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

- Move integration tests into their own folder so that we can more easily run unit tests.
- Put controllers into pkg, splitting them in two kinds: core and workload (intended for integrating diverse custom job APIs).

#### Which issue(s) this PR fixes:

Part of #20
Fixes #25 

#### Special notes for your reviewer:

