### PR TITLE
Add meta.name to sample-job

### DIFF
--- a/config/samples/sample-job.yaml
+++ b/config/samples/sample-job.yaml
@@ -1,6 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  name: sample-job
   generateName: sample-job-
   annotations:
     kueue.x-k8s.io/queue-name: main


### PR DESCRIPTION
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind failing-test
/kind flake

-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
This PR fixes the following result

```bash
[eduardo@fedora kueue]$ kubectl delete -f config/samples/sample-job.yaml                       
error: error when deleting "config/samples/sample-job.yaml": resource name may not be empty 
```

After manually creating the sample job, the user has to delete the job from the generated name, but can't do so from the sample file

