### PR TITLE
RBAC add missing resource to kubebuilder set

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - watch
+- apiGroups:
   - batch
   resources:
   - jobs

--- a/pkg/controller/core/capacity_controller.go
+++ b/pkg/controller/core/capacity_controller.go
@@ -41,6 +41,7 @@ func NewCapacityReconciler(cache *capacity.Cache) *CapacityReconciler {
 	}
 }
 
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=capacities,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=capacities/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=capacities/finalizers,verbs=update

--- a/pkg/controller/core/queue_controller.go
+++ b/pkg/controller/core/queue_controller.go
@@ -41,6 +41,7 @@ func NewQueueReconciler(queues *queue.Manager) *QueueReconciler {
 	}
 }
 
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=queues,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=queues/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=queues/finalizers,verbs=update

--- a/pkg/controller/core/queuedworkload_controller.go
+++ b/pkg/controller/core/queuedworkload_controller.go
@@ -52,6 +52,7 @@ func NewQueuedWorkloadReconciler(queues *queue.Manager, cache *capacity.Cache) *
 	}
 }
 
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=queuedworkloads,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=queuedworkloads/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=queuedworkloads/finalizers,verbs=update

--- a/pkg/controller/workload/job/job_controller.go
+++ b/pkg/controller/workload/job/job_controller.go
@@ -83,6 +83,7 @@ func (r *JobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=queuedworkloads,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>

#### What this PR does / why we need it:
This is on the logs 
```bash
1.6455346824721851e+09  LEVEL(-2)       job-reconciler  Job assigned a capacity, unsuspending{"job": {"name":"sample-job-zkvlc","namespace":"default"}}                                       
E0222 12:58:02.473038       1 event.go:267] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"sample-job-zkvlc.16d61d13464ee05b", 
GenerateName:"", Namespace:"default", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, D
eletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:""
, ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"QueuedWorkload", Namespace:"default", Name:"sample-job-zkvlc", UID:"b495fad9-c39c-49b7-8200-62a575326ce
a", APIVersion:"kueue.x-k8s.io/v1alpha1", ResourceVersion:"34819", FieldPath:""}, Reason:"Assigned", Message:"Assigned to capacity cluster-total", Source:v1.EventSource{Component:"kueue-mana
ger", Host:""}, FirstTimestamp:time.Date(2022, time.February, 22, 12, 58, 2, 471653467, time.Local), LastTimestamp:time.Date(2022, time.February, 22, 12, 58, 2, 471653467, time.Local), Count
:1, Type:"Normal", EventTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", Report
ingInstance:""}': 'events is forbidden: User "system:serviceaccount:kueue-system:kueue-controller-manager" cannot create resource "events" in API group "" in the namespace "default"' (will n
ot retry!)  
```

TLDR:  ` 'events is forbidden: User "system:serviceaccount:kueue-system:kueue-controller-manager" cannot create resource "events" in API group "" in the namespace "default"' `

THis patch fix the underlying issue, now the logs are clean, and RBAC is happy


#### Special notes for your reviewer:

