### PR TITLE
Makefile add arguments for img building and pushing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
+ARG BUILDER_IMAGE
+ARG BASE_IMAGE
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM ${BUILDER_IMAGE} as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -17,9 +19,7 @@ COPY pkg/ pkg/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM ${BASE_IMAGE}
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ API proposal and a high-level description of how it operates; while [bit.ly/kueu
 You can run Kueue with the following command:
 
 ```sh
-IMG=registry.example.com/kueue:latest make docker-build docker-push deploy
+IMAGE_REGISTRY=registry.example.com/my-user/kueue:latest make image-build image-push deploy
 ```
 
 The controller will run in the `kueue-system` namespace.


### PR DESCRIPTION
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>

 example on with my setup

```bash
[eduardo@fedora kueue]$ make image-build                                                                                                                                                   [54/1922]
buildah bud -t quay.io/eduardoarango/kueue:21194b5-dirty \
        --build-arg BASE_IMAGE=gcr.io/distroless/static:nonroot \                              
        --build-arg BUILDER_IMAGE=golang:1.17 \                                                
         \                          
         ./                            
[1/2] STEP 1/9: FROM golang:1.17 AS builder
Trying to pull docker.io/library/golang:1.17...                                         
Getting image source signatures
Copying blob 412caad352a3 skipped: already exists  
Copying blob e6d3e61f7a50 skipped: already exists  
Copying blob 9297634c9537 skipped: already exists  
Copying blob 461bb1d8c517 skipped: already exists  
Copying blob 0c6b8ff8c37e skipped: already exists  
Copying blob 378ec17cbe4c done  
Copying blob e6ff4e95ec2f done  
Copying config 836f6d7d89 done  
Writing manifest to image destination
Storing signatures
[1/2] STEP 2/9: WORKDIR /workspace
[1/2] STEP 3/9: COPY go.mod go.mod
[1/2] STEP 4/9: COPY go.sum go.sum
[1/2] STEP 5/9: RUN go mod download
[1/2] STEP 6/9: COPY main.go main.go
[1/2] STEP 7/9: COPY api/ api/
[1/2] STEP 8/9: COPY pkg/ pkg/
[1/2] STEP 9/9: RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
[2/2] STEP 1/5: FROM gcr.io/distroless/static:nonroot
[2/2] STEP 2/5: WORKDIR /
[2/2] STEP 3/5: COPY --from=builder /workspace/manager .
[2/2] STEP 4/5: USER 65532:65532
[2/2] STEP 5/5: ENTRYPOINT ["/manager"]
[2/2] COMMIT quay.io/eduardoarango/controller:21194b5-dirty
Getting image source signatures
Copying blob 5b1fa8e3e100 skipped: already exists  
Copying blob 160339bf3e6b done  
Copying config 943ad44513 done  
Writing manifest to image destination
Storing signatures
--> 943ad44513c
Successfully tagged quay.io/eduardoarango/kueue:21194b5-dirty
943ad44513cdd39f082c15dff7fbf0f117fb1f0c9c124a54e6581ea770a98359
```
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #47

#### Special notes for your reviewer:

