### PR TITLE
Update sample-job command

### DIFF
--- a/config/samples/sample-job.yaml
+++ b/config/samples/sample-job.yaml
@@ -13,7 +13,7 @@ spec:
       containers:
       - name: dummy-job
         image: gcr.io/k8s-staging-perf-tests/sleep:latest
-        command: ["sleep",  "30"]
+        args: ["30s"]
         resources:
           requests:
             cpu: 1


### PR DESCRIPTION
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>

After https://github.com/kubernetes-sigs/kueue/pull/50 , I am getting 

```bash
  Warning  Failed     8s                 kubelet            Error: container create failed: time="2022-02-23T21:08:56Z" level=error msg="container_linux.go:380: starting container process ca
used: exec: \"sleep\": executable file not found in $PATH" 
```

this patch addresses that error

`sleep` bin is not in path , is in `/sleep` so we have to explicitly call if, see:

```bash
[eduardo@fedora kueue]$ skopeo inspect docker://gcr.io/k8s-staging-perf-tests/sleep:latest 
{
    "Name": "gcr.io/k8s-staging-perf-tests/sleep",
    "Digest": "sha256:366414c196307bd0336d71cba38843beec699a6264231b8ee025b9a288a0977f",
    "RepoTags": [
        "latest",
        "v0.0.1",
        "v0.0.2"
    ],
    "Created": "2022-02-07T10:01:43.771147464Z",
    "DockerVersion": "20.10.2",
    "Labels": null,
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:2df365faf0e3007f983fadd7a65ba51d41b488eb2ed8fc70f4bf97043cfea560",
        "sha256:632347799c32473577407dd95fb84696d9efd9305f5dcd008d9dde618172fc2f"
    ],
    "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
        "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
    ]
}
```



