### PR TITLE
README fix usage guidelines for IMAGE_REGISTRY

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ API proposal and a high-level description of how it operates; while [bit.ly/kueu
 You can run Kueue with the following command:
 
 ```sh
-IMAGE_REGISTRY=registry.example.com/my-user/kueue:latest make image-build image-push deploy
+IMAGE_REGISTRY=registry.example.com/my-user make image-build image-push deploy
 ```
 
 The controller will run in the `kueue-system` namespace.


### PR DESCRIPTION
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>

#### What type of PR is this?
/kind cleanup
/kind documentation


#### What this PR does / why we need it:
 Makefile states
```
IMAGE_REGISTRY ?= gcr.io/k8s-staging-kueue
IMAGE_NAME := kueue
IMAGE_TAG_NAME ?= $(VERSION)
```
But README goes all the way just on IMAGE_REGISTRY, this patch fix that 


