### PR TITLE
Add integration test framework

### DIFF
--- a/test/integration/controller/job/job_controller_test.go
+++ b/test/integration/controller/job/job_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package job
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -29,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	kueue "sigs.k8s.io/kueue/api/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/constants"
@@ -52,32 +50,9 @@ const (
 	interval           = time.Millisecond * 250
 )
 
-var (
-	ctx    context.Context
-	cancel context.CancelFunc
-)
-
 // +kubebuilder:docs-gen:collapse=Imports
 
 var _ = ginkgo.Describe("Job controller", func() {
-	ginkgo.BeforeEach(func() {
-		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-			Scheme: scheme.Scheme,
-		})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create manager")
-
-		err = workloadjob.NewReconciler(mgr.GetScheme(), mgr.GetClient(), mgr.GetEventRecorderFor(constants.JobControllerName)).SetupWithManager(mgr)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		ctx, cancel = context.WithCancel(context.TODO())
-		go func() {
-			defer ginkgo.GinkgoRecover()
-			err = mgr.Start(ctx)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to run manager")
-		}()
-	})
-
-	ginkgo.AfterEach(func() { cancel() })
 
 	ginkgo.It("Should reconcile workload and job", func() {
 		ginkgo.By("checking the job gets suspended when created unsuspended")

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	kueuev1alpha1 "sigs.k8s.io/kueue/api/v1alpha1"
+	//+kubebuilder:scaffold:imports
+)
+
+type ManagerSetup func(manager.Manager)
+
+func BeforeSuite(ctx context.Context, crdPath string, mgrSetup ManagerSetup) (*rest.Config, client.Client, *envtest.Environment) {
+	ctrl.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseDevMode(true)))
+
+	ginkgo.By("bootstrapping test environment")
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{crdPath},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err := testEnv.Start()
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	gomega.ExpectWithOffset(1, cfg).NotTo(gomega.BeNil())
+
+	err = kueuev1alpha1.AddToScheme(scheme.Scheme)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	gomega.ExpectWithOffset(1, k8sClient).NotTo(gomega.BeNil())
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: "0", // disable metrics to avoid conflicts between packages.
+	})
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred(), "failed to create manager")
+
+	mgrSetup(mgr)
+
+	go func() {
+		defer ginkgo.GinkgoRecover()
+		err := mgr.Start(ctx)
+		gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred(), "failed to run manager")
+	}()
+
+	return cfg, k8sClient, testEnv
+}
+
+func AfterSuite(testEnv *envtest.Environment) {
+	ginkgo.By("tearing down the test environment")
+	err := testEnv.Stop()
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+}

--- a/test/integration/scheduler/suite_test.go
+++ b/test/integration/scheduler/suite_test.go
@@ -23,26 +23,21 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 
-	kueue "sigs.k8s.io/kueue/api/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/capacity"
 	"sigs.k8s.io/kueue/pkg/constants"
 	kueuectrl "sigs.k8s.io/kueue/pkg/controller/core"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/workload/job"
 	"sigs.k8s.io/kueue/pkg/queue"
+	"sigs.k8s.io/kueue/test/integration/framework"
 	//+kubebuilder:scaffold:imports
 )
-
-// These tests use Ginkgo (BDD-style Go testing framework). Refer to
-// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
 	cfg       *rest.Config
@@ -50,47 +45,29 @@ var (
 	testEnv   *envtest.Environment
 	ctx       context.Context
 	cancel    context.CancelFunc
-	sched     *scheduler.Scheduler
 )
 
-func TestAPIs(t *testing.T) {
+func TestScheduler(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 
 	ginkgo.RunSpecsWithDefaultAndCustomReporters(t,
-		"Controller Suite",
+		"Scheduler Suite",
 		[]ginkgo.Reporter{printer.NewlineReporter{}})
 }
 
 var _ = ginkgo.BeforeSuite(func() {
-	ctrl.SetLogger(zap.New(zap.WriteTo(ginkgo.GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.Background())
+	crdPath := filepath.Join("..", "..", "..", "config", "crd", "bases")
+	cfg, k8sClient, testEnv = framework.BeforeSuite(ctx, crdPath, managerAndSchedulerSetup)
+}, 60)
 
-	ginkgo.By("bootstrapping test environment")
-	testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
-		ErrorIfCRDPathMissing: true,
-	}
+var _ = ginkgo.AfterSuite(func() {
+	cancel()
+	framework.AfterSuite(testEnv)
+})
 
-	var err error
-	cfg, err = testEnv.Start()
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(cfg).NotTo(gomega.BeNil())
-
-	err = kueue.AddToScheme(scheme.Scheme)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	//+kubebuilder:scaffold:scheme
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	gomega.Expect(k8sClient).NotTo(gomega.BeNil())
-
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:             scheme.Scheme,
-		MetricsBindAddress: "0", // disable metrics to avoid conflicts with other pkgs
-	})
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to create manager")
-
-	err = queue.SetupIndexes(mgr.GetFieldIndexer())
+func managerAndSchedulerSetup(mgr manager.Manager) {
+	err := queue.SetupIndexes(mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = capacity.SetupIndexes(mgr.GetFieldIndexer())
@@ -112,21 +89,8 @@ var _ = ginkgo.BeforeSuite(func() {
 		mgr.GetEventRecorderFor(constants.JobControllerName)).SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	ctx, cancel = context.WithCancel(context.TODO())
-	sched = scheduler.New(queues, cache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.ManagerName))
+	sched := scheduler.New(queues, cache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.ManagerName))
 	go func() {
 		sched.Start(ctx)
 	}()
-	go func() {
-		defer ginkgo.GinkgoRecover()
-		err = mgr.Start(ctx)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to run manager")
-	}()
-}, 60)
-
-var _ = ginkgo.AfterSuite(func() {
-	ginkgo.By("tearing down the test environment")
-	cancel()
-	err := testEnv.Stop()
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-})
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Puts duplicated code between suites in a framework package.

In the job controller, moves the manager setup from every case to once per suite. Initially I wanted to start a manager every time, but such isolation doesn't make much sense if we are sharing the same apiserver/etcd between tests.

#### Which issue(s) this PR fixes:

Part of #68

#### Special notes for your reviewer:

