### PR TITLE
Have a single heap per ClusterQueue

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Queue")
 		os.Exit(1)
 	}
-	if err = core.NewClusterQueueReconciler(mgr.GetClient(), cache).SetupWithManager(mgr); err != nil {
+	if err = core.NewClusterQueueReconciler(mgr.GetClient(), queues, cache).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterQueue")
 		os.Exit(1)
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -76,7 +76,8 @@ func newCohort(name string, size int) *Cohort {
 	}
 }
 
-// ClusterQueue is the internal implementation of kueue.ClusterQueue
+// ClusterQueue is the internal implementation of kueue.ClusterQueue that
+// holds admitted workloads.
 type ClusterQueue struct {
 	Name                 string
 	Cohort               *Cohort
@@ -88,10 +89,6 @@ type ClusterQueue struct {
 	// that can be matched against the flavors.
 	LabelKeys map[corev1.ResourceName]sets.String
 
-	// TODO(#87) introduce a single heap for per ClusterQueue.
-	// QueueingStrategy indicates the queueing strategy of the workloads
-	// across the queues in this ClusterQueue.
-	QueueingStrategy  kueue.QueueingStrategy
 	NamespaceSelector labels.Selector
 }
 
@@ -106,9 +103,8 @@ type FlavorInfo struct {
 
 func NewClusterQueue(cq *kueue.ClusterQueue) (*ClusterQueue, error) {
 	c := &ClusterQueue{
-		Name:             cq.Name,
-		Workloads:        map[string]*workload.Info{},
-		QueueingStrategy: cq.Spec.QueueingStrategy,
+		Name:      cq.Name,
+		Workloads: map[string]*workload.Info{},
 	}
 	if err := c.update(cq); err != nil {
 		return nil, err

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -55,7 +55,6 @@ func (c *ClusterQueue) snapshot() *ClusterQueue {
 		UsedResources:        make(Resources, len(c.UsedResources)),
 		Workloads:            make(map[string]*workload.Info, len(c.Workloads)),
 		LabelKeys:            c.LabelKeys, // Shallow copy is enough.
-		QueueingStrategy:     c.QueueingStrategy,
 		NamespaceSelector:    c.NamespaceSelector,
 	}
 	for res, flavors := range c.UsedResources {

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -21,12 +21,15 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	kueue "sigs.k8s.io/kueue/api/v1alpha1"
 )
 
-func TestFIFOQueue(t *testing.T) {
-	q := newQueue()
+func TestFIFOClusterQueue(t *testing.T) {
+	q := newClusterQueue(&kueue.ClusterQueue{
+		Spec: kueue.ClusterQueueSpec{
+			QueueingStrategy: kueue.StrictFIFO,
+		},
+	})
 	now := metav1.Now()
 	ws := []*kueue.QueuedWorkload{
 		{

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package testing
 
 import (
+	"time"
+
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -137,9 +139,18 @@ func (w *QueuedWorkloadWrapper) Request(r corev1.ResourceName, q string) *Queued
 	return w
 }
 
-// Queue updates the queue name of the job
-func (w *QueuedWorkloadWrapper) Queue(queue string) *QueuedWorkloadWrapper {
-	w.Spec.QueueName = queue
+func (w *QueuedWorkloadWrapper) Queue(q string) *QueuedWorkloadWrapper {
+	w.Spec.QueueName = q
+	return w
+}
+
+func (w *QueuedWorkloadWrapper) Admit(a *kueue.Admission) *QueuedWorkloadWrapper {
+	w.Spec.Admission = a
+	return w
+}
+
+func (w *QueuedWorkloadWrapper) Creation(t time.Time) *QueuedWorkloadWrapper {
+	w.CreationTimestamp = metav1.NewTime(t)
 	return w
 }
 

--- a/test/integration/controller/core/suite_test.go
+++ b/test/integration/controller/core/suite_test.go
@@ -76,7 +76,7 @@ func managerSetup(mgr manager.Manager) {
 	err = core.NewQueueReconciler(mgr.GetClient(), queues).SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = core.NewClusterQueueReconciler(mgr.GetClient(), cCache).SetupWithManager(mgr)
+	err = core.NewClusterQueueReconciler(mgr.GetClient(), queues, cCache).SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = core.NewQueuedWorkloadReconciler(queues, cCache).SetupWithManager(mgr)

--- a/test/integration/scheduler/suite_test.go
+++ b/test/integration/scheduler/suite_test.go
@@ -79,7 +79,7 @@ func managerAndSchedulerSetup(mgr manager.Manager) {
 	err = kueuectrl.NewQueueReconciler(mgr.GetClient(), queues).SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = kueuectrl.NewClusterQueueReconciler(mgr.GetClient(), cache).SetupWithManager(mgr)
+	err = kueuectrl.NewClusterQueueReconciler(mgr.GetClient(), queues, cache).SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = kueuectrl.NewQueuedWorkloadReconciler(queues, cache).SetupWithManager(mgr)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Introduces a second implementation of ClusterQueue in `pkg/queue` which specializes on queueing.

Workloads associated to a Queue move as a block if the clusterQueue changes.

#### Which issue(s) this PR fixes:

Fixes #87

#### Special notes for your reviewer:

