### PR TITLE
Remove Active condition from QueuedWorkload

### DIFF
--- a/api/v1alpha1/queuedworkload_types.go
+++ b/api/v1alpha1/queuedworkload_types.go
@@ -101,9 +101,6 @@ type QueuedWorkloadCondition struct {
 	//
 	// Admitted: the QueuedWorkload was admitted through a ClusterQueue.
 	//
-	// Active: the associated workload is active: it is not suspended or it has
-	// non-terminated pods.
-	//
 	// Finished: the associated workload finished running (failed or succeeded).
 	Type QueuedWorkloadConditionType `json:"type"`
 
@@ -134,11 +131,6 @@ type QueuedWorkloadConditionType string
 const (
 	// QueuedWorkloadAdmitted means that the QueuedWorkload was admitted by a ClusterQueue.
 	QueuedWorkloadAdmitted QueuedWorkloadConditionType = "Admitted"
-
-	// QueuedWorkloadActive means that the workload associated to the
-	// QueuedWorkload is active: it is not suspended or it has non-terminated
-	// Pods.
-	QueuedWorkloadActive QueuedWorkloadConditionType = "Active"
 
 	// QueuedWorkloadFinished means that the workload associated to the
 	// ResourceClaim finished running (failed or succeeded).

--- a/config/crd/bases/kueue.x-k8s.io_queuedworkloads.yaml
+++ b/config/crd/bases/kueue.x-k8s.io_queuedworkloads.yaml
@@ -7356,10 +7356,8 @@ spec:
                       type: string
                     type:
                       description: "type of condition could be: \n Admitted: the QueuedWorkload
-                        was admitted through a ClusterQueue. \n Active: the associated
-                        workload is active: it is not suspended or it has non-terminated
-                        pods. \n Finished: the associated workload finished running
-                        (failed or succeeded)."
+                        was admitted through a ClusterQueue. \n Finished: the associated
+                        workload finished running (failed or succeeded)."
                       type: string
                   required:
                   - status


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Remove Active condition from QW, we don't yet set it, and I don't think it is something that Kueue should be tracking. The Admitted condition is good enough for now.

We could add it back in the future if we get clarity on how to set it.

