### PR TITLE
fix panic when flavor is not found

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -271,7 +271,7 @@ func findFlavorForResource(
 	for _, flvLimit := range cq.RequestableResources[name] {
 		flavor, exist := resourceFlavors[flvLimit.Name]
 		if !exist {
-			log.Error(nil, "Flavor %v not found", flvLimit.Name)
+			log.Error(nil, "Flavor not found", "Flavor", flvLimit.Name)
 			continue
 		}
 		_, untolerated := corev1helpers.FindMatchingUntoleratedTaint(flavor.Taints, spec.Tolerations, func(t *corev1.Taint) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kueue panics when flavor is not found

```bash
2022-03-22T17:49:08.503+0800	DPANIC	scheduler	odd number of arguments passed as key-value pairs for logging	{"queuedWorkload": {"name":"job1","namespace":"default"}, "clusterQueue": {"name":"cluster-total"}, "ignored key": "default"}
sigs.k8s.io/kueue/pkg/scheduler.(*entry).assignFlavors
	/Users/wangqingcan/Documents/github/kueue-denkensk/src/sigs.k8s.io/kueue/pkg/scheduler/scheduler.go:183
sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).nominate
	/Users/wangqingcan/Documents/github/kueue-denkensk/src/sigs.k8s.io/kueue/pkg/scheduler/scheduler.go:162
sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).schedule
	/Users/wangqingcan/Documents/github/kueue-denkensk/src/sigs.k8s.io/kueue/pkg/scheduler/scheduler.go:89
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1
	/Users/wangqingcan/Documents/github/kueue-denkensk/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:188
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
	/Users/wangqingcan/Documents/github/kueue-denkensk/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
	/Users/wangqingcan/Documents/github/kueue-denkensk/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/Users/wangqingcan/Documents/github/kueue-denkensk/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext
	/Users/wangqingcan/Documents/github/kueue-denkensk/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:188
k8s.io/apimachinery/pkg/util/wait.UntilWithContext
	/Users/wangqingcan/Documents/github/kueue-denkensk/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:99
sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).Start
	/Users/wangqingcan/Documents/github/kueue-denkensk/src/sigs.k8s.io/kueue/pkg/scheduler/scheduler.go:66
```



#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

