### PR TITLE
Do ClusterQueue updates after QW is updated in cache

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -29,7 +29,7 @@ const (
 
 	// UpdatesBatchPeriod is the batch period to hold queuedworkload updates
 	// before syncing a Queue and CLusterQueue onbjects.
-	UpdatesBatchPeriod = 3 * time.Second
+	UpdatesBatchPeriod = time.Second
 
 	// DefaultPriority is used to set priority of workloads
 	// that do not specify any priority class and there is no priority class

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/queue"
+)
+
+// SetupControllers sets up the core controllers. It returns the name of the
+// controller that failed to create and an error, if any.
+func SetupControllers(mgr ctrl.Manager, qManager *queue.Manager, cc *cache.Cache) (string, error) {
+	if err := NewQueueReconciler(mgr.GetClient(), qManager).SetupWithManager(mgr); err != nil {
+		return "Queue", err
+	}
+	cqRec := NewClusterQueueReconciler(mgr.GetClient(), qManager, cc)
+	if err := cqRec.SetupWithManager(mgr); err != nil {
+		return "ClusterQueue", err
+	}
+	if err := NewQueuedWorkloadReconciler(mgr.GetClient(), qManager, cc, cqRec).SetupWithManager(mgr); err != nil {
+		return "QueuedWorkload", err
+	}
+	if err := NewResourceFlavorReconciler(cc).SetupWithManager(mgr); err != nil {
+		return "ResourceFlavor", err
+	}
+	return "", nil
+}

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -25,14 +25,15 @@ import (
 // SetupControllers sets up the core controllers. It returns the name of the
 // controller that failed to create and an error, if any.
 func SetupControllers(mgr ctrl.Manager, qManager *queue.Manager, cc *cache.Cache) (string, error) {
-	if err := NewQueueReconciler(mgr.GetClient(), qManager).SetupWithManager(mgr); err != nil {
+	qRec := NewQueueReconciler(mgr.GetClient(), qManager)
+	if err := qRec.SetupWithManager(mgr); err != nil {
 		return "Queue", err
 	}
 	cqRec := NewClusterQueueReconciler(mgr.GetClient(), qManager, cc)
 	if err := cqRec.SetupWithManager(mgr); err != nil {
 		return "ClusterQueue", err
 	}
-	if err := NewQueuedWorkloadReconciler(mgr.GetClient(), qManager, cc, cqRec).SetupWithManager(mgr); err != nil {
+	if err := NewQueuedWorkloadReconciler(mgr.GetClient(), qManager, cc, qRec, cqRec).SetupWithManager(mgr); err != nil {
 		return "QueuedWorkload", err
 	}
 	if err := NewResourceFlavorReconciler(cc).SetupWithManager(mgr); err != nil {

--- a/pkg/controller/core/queue_controller.go
+++ b/pkg/controller/core/queue_controller.go
@@ -48,11 +48,11 @@ func NewQueueReconciler(client client.Client, queues *queue.Manager) *QueueRecon
 		log:        ctrl.Log.WithName("queue-reconciler"),
 		queues:     queues,
 		client:     client,
-		qwUpdateCh: make(chan event.GenericEvent),
+		qwUpdateCh: make(chan event.GenericEvent, qwUpdateBuffer),
 	}
 }
 
-func (r *QueueReconciler) NotifyQWUpdate(w *kueue.QueuedWorkload) {
+func (r *QueueReconciler) NotifyQueuedWorkloadUpdate(w *kueue.QueuedWorkload) {
 	r.qwUpdateCh <- event.GenericEvent{Object: w}
 }
 
@@ -133,6 +133,10 @@ func (r *QueueReconciler) Generic(e event.GenericEvent) bool {
 	return true
 }
 
+// qWorkloadHandler signals the controller to reconcile the Queue associated
+// to the workload in the event.
+// Since the events come from a channel Source, only the Generic handler will
+// receive events.
 type qWorkloadHandler struct{}
 
 func (h *qWorkloadHandler) Create(event.CreateEvent, workqueue.RateLimitingInterface) {

--- a/test/integration/controller/core/suite_test.go
+++ b/test/integration/controller/core/suite_test.go
@@ -72,12 +72,6 @@ func managerSetup(mgr manager.Manager) {
 	queues := queue.NewManager(mgr.GetClient())
 	cCache := cache.New(mgr.GetClient())
 
-	err = core.NewQueueReconciler(mgr.GetClient(), queues).SetupWithManager(mgr)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	err = core.NewClusterQueueReconciler(mgr.GetClient(), queues, cCache).SetupWithManager(mgr)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	err = core.NewQueuedWorkloadReconciler(mgr.GetClient(), queues, cCache).SetupWithManager(mgr)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	failedCtrl, err := core.SetupControllers(mgr, queues, cCache)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Introduce and expose a Source so that a different controller can push events into the ClusterQueue controller.

This allows the QueuedWorkload controller to trigger CQ updates only after it has updated the cache, preventing race conditions.

#### Which issue(s) this PR fixes:

Fixes #101 

#### Special notes for your reviewer:

