### PR TITLE
Fix UpdateWorkloadStatus

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -400,8 +400,8 @@ func (s *Scheduler) requeueAndUpdate(log logr.Logger, ctx context.Context, w *wo
 	if s.queues.RequeueWorkload(ctx, w) {
 		log.V(2).Info("Workload re-queued", "queuedWorkload", klog.KObj(w.Obj), "queue", klog.KRef(w.Obj.Namespace, w.Obj.Spec.QueueName))
 	}
-	if err := workload.UpdateWorkloadStatus(ctx, s.client, w.Obj, kueue.QueuedWorkloadAdmitted, corev1.ConditionFalse,
-		"Pending", message); err != nil {
+	err := workload.UpdateWorkloadStatus(ctx, s.client, w.Obj, kueue.QueuedWorkloadAdmitted, corev1.ConditionFalse, "Pending", message)
+	if err != nil {
 		log.Error(err, "Updating QueuedWorkload status")
 	}
 }

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -194,14 +194,15 @@ func UpdateWorkloadStatus(ctx context.Context,
 		Reason:             reason,
 		Message:            message,
 	}
-	var newWl kueue.QueuedWorkload
+	// Avoid modifying the object in the cache.
+	newWl := *wl
+	newWl.Status = *newWl.Status.DeepCopy()
 
 	if conditionIndex == -1 {
-		wl.Status.Conditions = append(wl.Status.Conditions, condition)
-		return c.Status().Update(ctx, wl)
+		newWl.Status.Conditions = append(newWl.Status.Conditions, condition)
+	} else {
+		newWl.Status.Conditions[conditionIndex] = condition
 	}
-
-	wl.Status.Conditions[conditionIndex] = condition
 
 	return c.Status().Update(ctx, &newWl)
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The helper was not updating the status when the condition already existed. It was passing an empty object to the client.

Added a unit test

#### Which issue(s) this PR fixes:

Fixes #158 

#### Special notes for your reviewer:

