### PR TITLE
Fix scheduler getting stuck when there are admission failures

### DIFF
--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -144,7 +144,7 @@ func (r *ClusterQueueReconciler) Update(e event.UpdateEvent) bool {
 }
 
 func (r *ClusterQueueReconciler) Generic(e event.GenericEvent) bool {
-	r.log.V(3).Info("Ignore generic event", "obj", klog.KObj(e.Object), "kind", e.Object.GetObjectKind().GroupVersionKind())
+	r.log.V(3).Info("Got QueuedWorkload event", "queuedWorkload", klog.KObj(e.Object))
 	return true
 }
 

--- a/pkg/controller/core/queue_controller.go
+++ b/pkg/controller/core/queue_controller.go
@@ -129,7 +129,7 @@ func (r *QueueReconciler) Update(e event.UpdateEvent) bool {
 }
 
 func (r *QueueReconciler) Generic(e event.GenericEvent) bool {
-	r.log.V(3).Info("Ignore generic event", "obj", klog.KObj(e.Object), "kind", e.Object.GetObjectKind().GroupVersionKind())
+	r.log.V(3).Info("Got QueuedWorkload event", "queuedWorkload", klog.KObj(e.Object))
 	return true
 }
 

--- a/pkg/queue/cluster_queue_impl.go
+++ b/pkg/queue/cluster_queue_impl.go
@@ -106,3 +106,11 @@ func (c *ClusterQueueImpl) Dump() (sets.String, bool) {
 	}
 	return elements, true
 }
+
+func (c *ClusterQueueImpl) Info(key string) *workload.Info {
+	item := c.heap.items[key]
+	if item != nil {
+		return &item.obj
+	}
+	return nil
+}

--- a/pkg/queue/cluster_queue_interface.go
+++ b/pkg/queue/cluster_queue_interface.go
@@ -56,6 +56,9 @@ type ClusterQueue interface {
 	// this ClusterQueue. It returns false if the queue is empty.
 	// Otherwise returns true.
 	Dump() (sets.String, bool)
+	// Info returns workload.Info for the workload key.
+	// Users of this method should not modify the returned object.
+	Info(string) *workload.Info
 }
 
 var registry = map[kueue.QueueingStrategy]func(cq *kueue.ClusterQueue) (ClusterQueue, error){

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -272,10 +272,7 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info) bool
 		return false
 	}
 
-	if !q.AddIfNotPresent(info) {
-		return false
-	}
-
+	q.AddIfNotPresent(info)
 	cq := m.clusterQueues[q.ClusterQueue]
 	if cq == nil {
 		return false
@@ -312,21 +309,8 @@ func (m *Manager) UpdateWorkload(oldW, w *kueue.QueuedWorkload) bool {
 	defer m.Unlock()
 	if oldW.Spec.QueueName != w.Spec.QueueName {
 		m.deleteWorkloadFromQueueAndClusterQueue(w, queueKeyForWorkload(oldW))
-		return m.addOrUpdateWorkload(w)
 	}
-
-	q := m.queues[queueKeyForWorkload(w)]
-	if q == nil {
-		return false
-	}
-	q.AddOrUpdate(w)
-	cq := m.clusterQueues[q.ClusterQueue]
-	if cq != nil {
-		cq.PushOrUpdate(w)
-		m.cond.Broadcast()
-		return true
-	}
-	return false
+	return m.addOrUpdateWorkload(w)
 }
 
 // CleanUpOnContext tracks the context. When closed, it wakes routines waiting

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -54,12 +54,17 @@ func (q *Queue) update(apiQueue *kueue.Queue) {
 
 func (q *Queue) AddOrUpdate(w *kueue.QueuedWorkload) {
 	key := workload.Key(w)
-	info := q.items[key]
-	if info != nil {
-		info.Obj = w
-		return
-	}
 	q.items[key] = workload.NewInfo(w)
+}
+
+func (q *Queue) AddIfNotPresent(w *workload.Info) bool {
+	key := workload.Key(w.Obj)
+	_, ok := q.items[key]
+	if !ok {
+		q.items[key] = w
+		return true
+	}
+	return false
 }
 
 // heap.Interface implementation inspired by

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -165,6 +165,7 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 			log.V(2).Info("Workload didn't fit in remaining clusterQueue even when borrowing")
 			continue
 		}
+		log.V(3).Info("Nominated workload for admission")
 		entries = append(entries, e)
 	}
 	return entries
@@ -397,8 +398,8 @@ func (e entryOrdering) Less(i, j int) bool {
 }
 
 func (s *Scheduler) requeueAndUpdate(log logr.Logger, ctx context.Context, w *workload.Info, message string) {
-	existed := s.queues.RequeueWorkload(ctx, w)
-	log.V(2).Info("Workload re-queued", "queuedWorkload", klog.KObj(w.Obj), "queue", klog.KRef(w.Obj.Namespace, w.Obj.Spec.QueueName), "existed", existed)
+	added := s.queues.RequeueWorkload(ctx, w)
+	log.V(2).Info("Workload re-queued", "queuedWorkload", klog.KObj(w.Obj), "queue", klog.KRef(w.Obj.Namespace, w.Obj.Spec.QueueName), "added", added)
 	err := workload.UpdateWorkloadStatus(ctx, s.client, w.Obj, kueue.QueuedWorkloadAdmitted, corev1.ConditionFalse, "Pending", message)
 	if err != nil {
 		log.Error(err, "Could not update QueuedWorkload status")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

When requeueing, we need to notify the condition.

Also fixed queue manager to keep the most up-to-date object in a Queue

#### Which issue(s) this PR fixes:

Fixes #158 

#### Special notes for your reviewer:

Used #161 to see that the scheduler issued a requeue, but there was no following scheduling attempts, suggesting that the scheduler was hanging waiting for kueues.