### PR TITLE
Add ClusterRoles and task on how to use them

### DIFF
--- a/config/rbac/batch_admin_role.yaml
+++ b/config/rbac/batch_admin_role.yaml
@@ -1,0 +1,9 @@
+# permissions for end users to manage all kueue objects.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: batch-admin-role
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/config/rbac/batch_user_role.yaml
+++ b/config/rbac/batch_user_role.yaml
@@ -1,0 +1,9 @@
+# permissions for end users to run jobs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: batch-user-role
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.kueue.x-k8s.io/batch-user: "true"

--- a/config/rbac/clusterqueue_editor_role.yaml
+++ b/config/rbac/clusterqueue_editor_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: clusterqueue-editor-role
+  labels:
+    rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
 - apiGroups:
   - kueue.x-k8s.io

--- a/config/rbac/clusterqueue_viewer_role.yaml
+++ b/config/rbac/clusterqueue_viewer_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: clusterqueue-viewer-role
+  labels:
+    rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
 - apiGroups:
   - kueue.x-k8s.io

--- a/config/rbac/job_editor_role.yaml
+++ b/config/rbac/job_editor_role.yaml
@@ -1,23 +1,27 @@
-# permissions for end users to view queues.
+# permissions for end users to edit jobs.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: queue-viewer-role
+  name: job-editor-role
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:
 - apiGroups:
-  - kueue.x-k8s.io
+  - batch
   resources:
-  - queues
+  - jobs
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
-  - kueue.x-k8s.io
+  - batch
   resources:
-  - queues/status
+  - jobs/status
   verbs:
   - get

--- a/config/rbac/job_viewer_role.yaml
+++ b/config/rbac/job_viewer_role.yaml
@@ -1,23 +1,23 @@
-# permissions for end users to view queues.
+# permissions for end users to view jobs.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: queue-viewer-role
+  name: job-viewer-role
   labels:
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:
 - apiGroups:
-  - kueue.x-k8s.io
+  - batch
   resources:
-  - queues
+  - jobs
   verbs:
   - get
   - list
   - watch
 - apiGroups:
-  - kueue.x-k8s.io
+  - batch
   resources:
-  - queues/status
+  - jobs/status
   verbs:
   - get

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -16,3 +16,16 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+# ClusterRoles for Kueue APIs
+- batch_admin_role.yaml
+- batch_user_role.yaml
+- clusterqueue_editor_role.yaml
+- clusterqueue_viewer_role.yaml
+- job_editor_role.yaml
+- job_viewer_role.yaml
+- queue_editor_role.yaml
+- queue_viewer_role.yaml
+- queuedworkload_editor_role.yaml
+- queuedworkload_viewer_role.yaml
+- resourceflavor_editor_role.yaml
+- resourceflavor_viewer_role.yaml

--- a/config/rbac/queue_editor_role.yaml
+++ b/config/rbac/queue_editor_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: queue-editor-role
+  labels:
+    rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
 - apiGroups:
   - kueue.x-k8s.io

--- a/config/rbac/queuedworkload_editor_role.yaml
+++ b/config/rbac/queuedworkload_editor_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: queuedworkload-editor-role
+  labels:
+    rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
 - apiGroups:
   - kueue.x-k8s.io

--- a/config/rbac/queuedworkload_viewer_role.yaml
+++ b/config/rbac/queuedworkload_viewer_role.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: queuedworkload-viewer-role
+  labels:
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
 rules:
 - apiGroups:
   - kueue.x-k8s.io

--- a/config/rbac/resourceflavor_editor_role.yaml
+++ b/config/rbac/resourceflavor_editor_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: resourceflavor-editor-role
+  labels:
+    rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
 - apiGroups:
   - kueue.x-k8s.io
@@ -16,9 +18,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - kueue.x-k8s.io
-  resources:
-  - resourceflavors/status
-  verbs:
-  - get

--- a/config/rbac/resourceflavor_viewer_role.yaml
+++ b/config/rbac/resourceflavor_viewer_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: resourceflavor-viewer-role
+  labels:
+    rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
 - apiGroups:
   - kueue.x-k8s.io
@@ -12,9 +14,3 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - kueue.x-k8s.io
-  resources:
-  - resourceflavors/status
-  verbs:
-  - get

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -8,6 +8,8 @@ personas such as _batch administrators_ and _batch users_.
 A _batch administrator_ manages the cluster infrastructure and establishes
 quotas and queues.
 
+- As a batch administrator, you can learn how to [setup role-based access control](manage_rbac.md)
+  to Kueue objects.
 - As a batch administrator, you can learn how to
   [administer cluster quotas](administer_cluster_quotas.md) with Queues and
   ClusterQueues.

--- a/docs/tasks/setup_rbac.md
+++ b/docs/tasks/setup_rbac.md
@@ -1,0 +1,97 @@
+# Manage role-based access control
+
+This page shows you how to setup role-based acess control (RBAC) in your cluster
+to control the types of users that can view and create Kueue objects.
+
+The page is intended for a [batch administrator](/docs/tasks#batch-administrator).
+
+## Before you begin
+
+Make sure the following conditions are met:
+
+- A Kubernetes cluster is running.
+- The kubectl command-line tool has communication with your cluster.
+- [Kueue is installed](/README.md#installation).
+
+This page assumes you are already familiar with [RBAC in kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
+
+## ClusterRoles included in the installation
+
+When you install Kueue, the following set of ClusterRoles are created for the
+two main personas that we assume will interact with Kueue:
+
+- `kueue-batch-admin-role` includes the permissions to manage ClusterQueues,
+  Queues, QueuedWorkloads, and ResourceFlavors.
+- `kueue-batch-user-role` includes the permissions to manage [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
+  and to view Queues and QueuedWorkloads.
+
+## Giving permissions to a batch administrator
+
+A batch administrator typically requires the `kueue-batch-admin-role` ClusterRole
+for all the namespaces.
+
+To bind the `kueue-batch-admin-role` role to a batch administrator, represented
+by the user `admin@example.com`, create a ClusterRoleBinding with a manifest
+similar to the following:
+
+```yaml
+# batch-admin-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: read-pods
+subjects:
+- kind: User
+  name: admin@example.com
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: kueue-batch-admin-role
+  apiGroup: rbac.authorization.k8s.io
+```
+
+To create the ClusterRoleBinding, save the preceding manifest and run the
+following command:
+
+```shell
+kubectl apply -f batch-admin-role-binding.yaml
+```
+
+## Giving permissions to a batch user
+
+A batch user typically requires permissions to:
+- Create and view Jobs in their namespace.
+- View the queues available in their namespace.
+- View the status of their [workloads](/docs/concepts/queued_workload.md) in their namespace.
+
+To give these permissions to a group of users `team-a@example.com` for the
+namespace `team-a`, create a RoleBinding with a manifest similar to the
+following:
+
+```yaml
+# team-a-batch-user-role-binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-pods
+  namespace: team-a
+subjects:
+- kind: Group
+  name: team-a@example.com
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: kueue-batch-user-role
+  apiGroup: rbac.authorization.k8s.io
+```
+
+To create the RoleBinding, save the preceding manifest and run the
+following command:
+
+```shell
+kubectl apply -f batch-admin-role-binding.yaml
+```
+
+## What's next?
+
+- Learn how to [administer cluster quotas](administer_cluster_quotas.md).


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

- Adds roles `kueue-batch-admin-role` and `kueue-batch-user-role` to simplify setting common permissions.
- Add a task that explains how to use them.

#### Which issue(s) this PR fixes:

Fixes #64 

#### Special notes for your reviewer:

