### PR TITLE
Ensure that Job owns the QueuedWorkload

### DIFF
--- a/test/integration/controller/job/job_controller_test.go
+++ b/test/integration/controller/job/job_controller_test.go
@@ -71,7 +71,8 @@ var _ = ginkgo.Describe("Job controller", func() {
 			err := k8sClient.Get(ctx, lookupKey, createdWorkload)
 			return err == nil
 		}, framework.Timeout, framework.Interval).Should(gomega.BeTrue())
-		gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(""))
+		gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(""), "The QueuedWorkload shouldn't have .spec.queueName set")
+		gomega.Expect(metav1.IsControlledBy(createdWorkload, job)).To(gomega.BeTrue(), "The QueuedWorkload should be owned by the Job")
 
 		ginkgo.By("checking the workload is created with priority and priorityName")
 		gomega.Expect(createdWorkload.Spec.PriorityClassName).Should(gomega.Equal(priorityClassName))

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -130,14 +130,14 @@ var _ = ginkgo.Describe("Scheduler", func() {
 	})
 
 	ginkgo.AfterEach(func() {
-		gomega.Expect(framework.DeleteNamespace(ctx, k8sClient, ns)).ToNot(gomega.HaveOccurred())
-		gomega.Expect(framework.DeleteClusterQueue(ctx, k8sClient, prodClusterQ)).ToNot(gomega.HaveOccurred())
-		gomega.Expect(framework.DeleteClusterQueue(ctx, k8sClient, devClusterQ)).ToNot(gomega.HaveOccurred())
-		gomega.Expect(framework.DeleteClusterQueue(ctx, k8sClient, prodBEClusterQ)).ToNot(gomega.HaveOccurred())
-		gomega.Expect(framework.DeleteClusterQueue(ctx, k8sClient, devBEClusterQ)).ToNot(gomega.HaveOccurred())
-		gomega.Expect(framework.DeleteResourceFlavor(ctx, k8sClient, onDemandFlavor)).ToNot(gomega.HaveOccurred())
-		gomega.Expect(framework.DeleteResourceFlavor(ctx, k8sClient, spotTaintedFlavor)).ToNot(gomega.HaveOccurred())
-		gomega.Expect(framework.DeleteResourceFlavor(ctx, k8sClient, spotUntaintedFlavor)).ToNot(gomega.HaveOccurred())
+		gomega.Expect(framework.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		gomega.Expect(framework.DeleteClusterQueue(ctx, k8sClient, prodClusterQ)).To(gomega.Succeed())
+		gomega.Expect(framework.DeleteClusterQueue(ctx, k8sClient, devClusterQ)).To(gomega.Succeed())
+		gomega.Expect(framework.DeleteClusterQueue(ctx, k8sClient, prodBEClusterQ)).To(gomega.Succeed())
+		gomega.Expect(framework.DeleteClusterQueue(ctx, k8sClient, devBEClusterQ)).To(gomega.Succeed())
+		gomega.Expect(framework.DeleteResourceFlavor(ctx, k8sClient, onDemandFlavor)).To(gomega.Succeed())
+		gomega.Expect(framework.DeleteResourceFlavor(ctx, k8sClient, spotTaintedFlavor)).To(gomega.Succeed())
+		gomega.Expect(framework.DeleteResourceFlavor(ctx, k8sClient, spotUntaintedFlavor)).To(gomega.Succeed())
 		ns = nil
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The reference is important so that the QW is cleaned up when the Job is deleted

Bonus: fix some ginkgo lingo

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

I initially tested if the QW would get deleted when the Job is deleted, but it doesn't work because there is no GC running in integration :upside_down_face: 