### PR TITLE
Add integration test for admitting multiple workloads after they didn't fit

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -120,7 +120,7 @@ func (s *Scheduler) schedule(ctx context.Context) {
 			log.Error(err, "Failed admitting workload by clusterQueue")
 			e.admissible = false
 			e.noAdmissionReason = err.Error()
-			err := workload.UpdateWorkloadStatus(ctx, s.client, e.Obj, kueue.QueuedWorkloadAdmitted, corev1.ConditionFalse, "Pending", err.Error())
+			err := workload.UpdateStatus(ctx, s.client, e.Obj, kueue.QueuedWorkloadAdmitted, corev1.ConditionFalse, "Pending", err.Error())
 			if err != nil {
 				log.Error(err, "Updating QueuedWorkload status")
 			}
@@ -413,7 +413,7 @@ func (e entryOrdering) Less(i, j int) bool {
 func (s *Scheduler) requeueAndUpdate(log logr.Logger, ctx context.Context, w *workload.Info, message string) {
 	added := s.queues.RequeueWorkload(ctx, w)
 	log.V(2).Info("Workload re-queued", "queuedWorkload", klog.KObj(w.Obj), "queue", klog.KRef(w.Obj.Namespace, w.Obj.Spec.QueueName), "added", added)
-	err := workload.UpdateWorkloadStatus(ctx, s.client, w.Obj, kueue.QueuedWorkloadAdmitted, corev1.ConditionFalse, "Pending", message)
+	err := workload.UpdateStatus(ctx, s.client, w.Obj, kueue.QueuedWorkloadAdmitted, corev1.ConditionFalse, "Pending", message)
 	if err != nil {
 		log.Error(err, "Could not update QueuedWorkload status")
 	}

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -256,7 +256,7 @@ func TestUpdateWorkloadStatus(t *testing.T) {
 			workload.Status = tc.oldStatus
 			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(workload).Build()
 			ctx := context.Background()
-			err := UpdateWorkloadStatus(ctx, cl, workload, tc.condType, tc.condStatus, tc.reason, tc.message)
+			err := UpdateStatus(ctx, cl, workload, tc.condType, tc.condStatus, tc.reason, tc.message)
 			if err != nil {
 				t.Fatalf("Failed updating status: %v", err)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We have had issues with phantom pods in kube-scheduler staying in the cache.

This test tries to replicate a similar scenario in kueue. I don't think there is currently a bug, because:
1. We don't use the `assumedWorkloads` map when calculating the snapshot.
1. Even if we used it, we use Update using the resourceVersion that we had in the queue, which cause the second scheduling attempt to fail.
1. We clear the assume cache on failure.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

The challenging scenario is like follows:

1. Workload A doesn't fit because workload B is running
3. Workload A update comes in while we are attempting to admit workload A (this could be a status update)
4. Workload B finishes (or there is capacity for other reasons), so Workload A is admitted.
5. We try to admit workload A again (because it was in the queue). This should not leave phantom workloads in the cache.
6. Workload C that requests B-A resources should fit

I simulate this at a high level by first creating a big workload (workload B above), followed by 2 small workloads (A & C) that don't fit.
Once the big workload finishes, the 2 workloads should be admitted. If there is a bug, only one of them would be admitted.