### PR TITLE
Skip requeueing workload if it was already admitted

### DIFF
--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -282,8 +282,8 @@ func (m *Manager) addOrUpdateWorkload(w *kueue.QueuedWorkload) bool {
 }
 
 // RequeueWorkload requeues the workload ensuring that the queue and the
-// workload still exist in the client cache. It won't requeue if the workload
-// is already in the queue (possible if the workload was updated).
+// workload still exist in the client cache and it's not admitted. It won't
+// requeue if the workload is already in the queue (possible if the workload was updated).
 func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info) bool {
 	m.Lock()
 	defer m.Unlock()
@@ -296,7 +296,7 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info) bool
 	var w kueue.QueuedWorkload
 	err := m.client.Get(ctx, client.ObjectKeyFromObject(info.Obj), &w)
 	// Since the client is cached, the only possible error is NotFound
-	if apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) || w.Spec.Admission != nil {
 		return false
 	}
 

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -378,6 +378,17 @@ func TestRequeueWorkload(t *testing.T) {
 			inClient: true,
 			inQueue:  true,
 		},
+		{
+			workload: &kueue.QueuedWorkload{
+				ObjectMeta: metav1.ObjectMeta{Name: "already_admitted"},
+				Spec: kueue.QueuedWorkloadSpec{
+					QueueName: "foo",
+					Admission: &kueue.Admission{},
+				},
+			},
+			inClient: true,
+			inQueue:  true,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.workload.Name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a workload update comes in while we are scheduling the same workload, we could be requeuing the same workload indefinitely even after it was already admitted.

It's unclear what happens in subsequent scheduling attempts. They might indefinitely fail or cause the workload to be re-admitted with no further effects.

Checking during requeue would put us on the safe side.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

