### PR TITLE
Renamed flavor.resourceFlavor to flavor.name

### DIFF
--- a/apis/core/v1alpha1/clusterqueue_types.go
+++ b/apis/core/v1alpha1/clusterqueue_types.go
@@ -183,14 +183,14 @@ type Resource struct {
 	// least one flavor must exist.
 	//
 	// +listType=map
-	// +listMapKey=resourceFlavor
+	// +listMapKey=name
 	Flavors []Flavor `json:"flavors,omitempty"`
 }
 
 type Flavor struct {
-	// resourceFlavor is a reference to the resourceFlavor that defines this flavor.
+	// name is a reference to the resourceFlavor that defines this flavor.
 	// +kubebuilder:default=default
-	ResourceFlavor ResourceFlavorReference `json:"resourceFlavor"`
+	Name ResourceFlavorReference `json:"name"`
 
 	// quota is the limit of resource usage at a point in time.
 	Quota Quota `json:"quota"`

--- a/config/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -180,6 +180,11 @@ spec:
                         can’t be empty, at least one flavor must exist."
                       items:
                         properties:
+                          name:
+                            default: default
+                            description: name is a reference to the resourceFlavor
+                              that defines this flavor.
+                            type: string
                           quota:
                             description: quota is the limit of resource usage at a
                               point in time.
@@ -210,18 +215,13 @@ spec:
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
                             type: object
-                          resourceFlavor:
-                            default: default
-                            description: resourceFlavor is a reference to the resourceFlavor
-                              that defines this flavor.
-                            type: string
                         required:
+                        - name
                         - quota
-                        - resourceFlavor
                         type: object
                       type: array
                       x-kubernetes-list-map-keys:
-                      - resourceFlavor
+                      - name
                       x-kubernetes-list-type: map
                     name:
                       description: name of the resource. For example, cpu, memory

--- a/docs/concepts/cluster_queue.md
+++ b/docs/concepts/cluster_queue.md
@@ -19,12 +19,12 @@ spec:
   requestableResources:
   - name: "cpu"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 9
   - name: "memory"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 36Gi
 ```
@@ -103,7 +103,7 @@ taints:
 ```
 
 You can use the `.metadata.name` to reference a flavor from a ClusterQueue in
-the `.spec.requestableResources[*].flavors[*].resourceFlavor` field.
+the `.spec.requestableResources[*].flavors[*].name` field.
 
 For each resource of each [pod set](workload.md#pod-sets) in a Workload, Kueue
 assigns the first flavor in the `.spec.requestableResources[*].resources.flavors`
@@ -199,12 +199,12 @@ spec:
   requestableResources:
   - name: "cpu"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 9
   - name: "memory"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 36Gi
 ```
@@ -220,12 +220,12 @@ spec:
   requestableResources:
   - name: "cpu"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 12
   - name: "memory"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 48Gi
 ```

--- a/docs/tasks/administer_cluster_quotas.md
+++ b/docs/tasks/administer_cluster_quotas.md
@@ -43,12 +43,12 @@ spec:
   requestableResources:
   - name: "cpu"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 9
   - name: "memory"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 36Gi
 ```
@@ -184,15 +184,15 @@ spec:
   requestableResources:
   - name: "cpu"
     flavors:
-    - resourceFlavor: x86
+    - name: x86
       quota:
         min: 9
-    - resourceFlavor: arm
+    - name: arm
       quota:
         min: 12
   - name: "memory"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 84Gi
 ```
@@ -230,13 +230,13 @@ spec:
   requestableResources:
   - name: "cpu"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 9
         max: 15
   - name: "memory"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 36Gi
         max: 60Gi
@@ -254,12 +254,12 @@ spec:
   requestableResources:
   - name: "cpu"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 12
   - name: "memory"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 48Gi
 ```
@@ -298,16 +298,16 @@ spec:
   requestableResources:
   - name: "cpu"
     flavors:
-    - resourceFlavor: arm
+    - name: arm
       quota:
         min: 9
         max: 9
-    - resourceFlavor: x86
+    - name: x86
       quota:
         min: 0
   - name: "memory"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 36Gi
 ```
@@ -324,16 +324,16 @@ spec:
   requestableResources:
   - name: "cpu"
     flavors:
-    - resourceFlavor: arm
+    - name: arm
       quota:
         min: 12
         max: 12
-    - resourceFlavor: x86
+    - name: x86
       quota:
         min: 0
   - name: "memory"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 48Gi
 ```
@@ -350,12 +350,12 @@ spec:
   requestableResources:
   - name: "cpu"
     flavors:
-    - resourceFlavor: x86
+    - name: x86
       quota:
         min: 6
   - name: "memory"
     flavors:
-    - resourceFlavor: default
+    - name: default
       quota:
         min: 24Gi
 ```

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -131,7 +131,7 @@ func (c *ClusterQueue) update(in *kueue.ClusterQueue, resourceFlavors map[string
 		existingUsedFlavors := c.UsedResources[r.Name]
 		usedFlavors := make(map[string]int64, len(r.Flavors))
 		for _, f := range r.Flavors {
-			usedFlavors[string(f.ResourceFlavor)] = existingUsedFlavors[string(f.ResourceFlavor)]
+			usedFlavors[string(f.Name)] = existingUsedFlavors[string(f.Name)]
 		}
 		usedResources[r.Name] = usedFlavors
 	}
@@ -473,7 +473,7 @@ func resourceLimitsByName(in []kueue.Resource) map[corev1.ResourceName][]FlavorL
 		for i := range flavors {
 			f := &r.Flavors[i]
 			fLimits := FlavorLimits{
-				Name: string(f.ResourceFlavor),
+				Name: string(f.Name),
 				Min:  workload.ResourceValue(r.Name, f.Quota.Min),
 			}
 			if f.Quota.Max != nil {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -46,7 +46,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					{
 						Name: corev1.ResourceCPU,
 						Flavors: []kueue.Flavor{{
-							ResourceFlavor: "default",
+							Name: "default",
 							Quota: kueue.Quota{
 								Min: resource.MustParse("10"),
 								Max: pointer.Quantity(resource.MustParse("20")),
@@ -64,7 +64,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					{
 						Name: corev1.ResourceCPU,
 						Flavors: []kueue.Flavor{{
-							ResourceFlavor: "default",
+							Name: "default",
 							Quota: kueue.Quota{
 								Min: resource.MustParse("15"),
 							},
@@ -208,7 +208,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 									Name: corev1.ResourceCPU,
 									Flavors: []kueue.Flavor{
 										{
-											ResourceFlavor: "default",
+											Name: "default",
 											Quota: kueue.Quota{
 												Min: resource.MustParse("5"),
 												Max: pointer.Quantity(resource.MustParse("10")),
@@ -340,8 +340,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 					{
 						Name: "cpu",
 						Flavors: []kueue.Flavor{
-							{ResourceFlavor: "on-demand"},
-							{ResourceFlavor: "spot"},
+							{Name: "on-demand"},
+							{Name: "spot"},
 						},
 					},
 				},
@@ -354,8 +354,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 					{
 						Name: "cpu",
 						Flavors: []kueue.Flavor{
-							{ResourceFlavor: "on-demand"},
-							{ResourceFlavor: "spot"},
+							{Name: "on-demand"},
+							{Name: "spot"},
 						},
 					},
 				},
@@ -801,7 +801,7 @@ func TestClusterQueueUsage(t *testing.T) {
 					Name: corev1.ResourceCPU,
 					Flavors: []kueue.Flavor{
 						{
-							ResourceFlavor: "default",
+							Name: "default",
 							Quota: kueue.Quota{
 								Min: resource.MustParse("10"),
 								Max: pointer.Quantity(resource.MustParse("20")),
@@ -813,14 +813,14 @@ func TestClusterQueueUsage(t *testing.T) {
 					Name: "example.com/gpu",
 					Flavors: []kueue.Flavor{
 						{
-							ResourceFlavor: "model_a",
+							Name: "model_a",
 							Quota: kueue.Quota{
 								Min: resource.MustParse("5"),
 								Max: pointer.Quantity(resource.MustParse("10")),
 							},
 						},
 						{
-							ResourceFlavor: "model_b",
+							Name: "model_b",
 							Quota: kueue.Quota{
 								Min: resource.MustParse("5"),
 								// No max.

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -53,13 +53,13 @@ func TestSnapshot(t *testing.T) {
 						Name: corev1.ResourceCPU,
 						Flavors: []kueue.Flavor{
 							{
-								ResourceFlavor: "demand",
+								Name: "demand",
 								Quota: kueue.Quota{
 									Min: resource.MustParse("100"),
 								},
 							},
 							{
-								ResourceFlavor: "spot",
+								Name: "spot",
 								Quota: kueue.Quota{
 									Min: resource.MustParse("200"),
 								},
@@ -80,7 +80,7 @@ func TestSnapshot(t *testing.T) {
 						Name: corev1.ResourceCPU,
 						Flavors: []kueue.Flavor{
 							{
-								ResourceFlavor: "spot",
+								Name: "spot",
 								Quota: kueue.Quota{
 									Min: resource.MustParse("100"),
 								},
@@ -91,7 +91,7 @@ func TestSnapshot(t *testing.T) {
 						Name: "example.com/gpu",
 						Flavors: []kueue.Flavor{
 							{
-								ResourceFlavor: "default",
+								Name: "default",
 								Quota: kueue.Quota{
 									Min: resource.MustParse("50"),
 								},
@@ -111,7 +111,7 @@ func TestSnapshot(t *testing.T) {
 						Name: corev1.ResourceCPU,
 						Flavors: []kueue.Flavor{
 							{
-								ResourceFlavor: "default",
+								Name: "default",
 								Quota: kueue.Quota{
 									Min: resource.MustParse("100"),
 								},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -75,7 +75,7 @@ func TestSchedule(t *testing.T) {
 						Name: corev1.ResourceCPU,
 						Flavors: []kueue.Flavor{
 							{
-								ResourceFlavor: "default",
+								Name: "default",
 								Quota: kueue.Quota{
 									Min: resource.MustParse("50"),
 									Max: pointer.Quantity(resource.MustParse("50")),
@@ -105,14 +105,14 @@ func TestSchedule(t *testing.T) {
 						Name: corev1.ResourceCPU,
 						Flavors: []kueue.Flavor{
 							{
-								ResourceFlavor: "on-demand",
+								Name: "on-demand",
 								Quota: kueue.Quota{
 									Min: resource.MustParse("50"),
 									Max: pointer.Quantity(resource.MustParse("100")),
 								},
 							},
 							{
-								ResourceFlavor: "spot",
+								Name: "spot",
 								Quota: kueue.Quota{
 									Min: resource.MustParse("100"),
 									Max: pointer.Quantity(resource.MustParse("100")),
@@ -142,14 +142,14 @@ func TestSchedule(t *testing.T) {
 						Name: corev1.ResourceCPU,
 						Flavors: []kueue.Flavor{
 							{
-								ResourceFlavor: "on-demand",
+								Name: "on-demand",
 								Quota: kueue.Quota{
 									Min: resource.MustParse("50"),
 									Max: pointer.Quantity(resource.MustParse("60")),
 								},
 							},
 							{
-								ResourceFlavor: "spot",
+								Name: "spot",
 								Quota: kueue.Quota{
 									Min: resource.MustParse("0"),
 									Max: pointer.Quantity(resource.MustParse("100")),
@@ -161,7 +161,7 @@ func TestSchedule(t *testing.T) {
 						Name: "example.com/gpu",
 						Flavors: []kueue.Flavor{
 							{
-								ResourceFlavor: "model-a",
+								Name: "model-a",
 								Quota: kueue.Quota{
 									Min: resource.MustParse("20"),
 									Max: pointer.Quantity(resource.MustParse("20")),

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -312,7 +312,7 @@ type FlavorWrapper struct{ kueue.Flavor }
 // MakeFlavor creates a wrapper for a resource flavor.
 func MakeFlavor(rf, min string) *FlavorWrapper {
 	return &FlavorWrapper{kueue.Flavor{
-		ResourceFlavor: kueue.ResourceFlavorReference(rf),
+		Name: kueue.ResourceFlavorReference(rf),
 		Quota: kueue.Quota{
 			Min: resource.MustParse(min),
 		},


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Renames clusterQueue.spec.requestableResources[*].flavors[*].resourceFlavor -> spec.requestableResources[*].flavors[*].name


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

