### PR TITLE
fix: revert change when assume failed

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -256,6 +256,9 @@ func (s *Scheduler) admit(ctx context.Context, e *entry) error {
 	}
 	newWorkload.Spec.Admission = admission
 	if err := s.cache.AssumeWorkload(newWorkload); err != nil {
+		// Ignore errors because the workload or clusterQueue could have been deleted
+		// by an event.
+		_ = s.cache.ForgetWorkload(newWorkload)
 		return err
 	}
 	log.V(2).Info("Workload assumed in the cache")


### PR DESCRIPTION
Signed-off-by: kerthcet <kerthcet@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When we call `AssumeWorkload` failed, we should revert the change from cache, this can prevent repeated errors below:
``` 
 1.651373093434779e+09	LEVEL(-2)	scheduler	Workload re-queued	{"workload": {"name":"job","namespace":"core-67497"}, "queue": {"name":"queue-for-selector","namespace":"core-67497"}, "added": true, "status": "nominated"}
    1.6513730934347966e+09	LEVEL(-3)	scheduler	Obtained ClusterQueue heads	{"count": 1}
    1.6513730934348316e+09	LEVEL(-3)	scheduler	Workload evaluated for admission	{"workload": {"name":"job","namespace":"core-67497"}, "clusterQueue": {"name":"cluster-queue-with-selector"}, "status": "nominated", "reason": "Failed to admit workload: the workload is already assumed to ClusterQueue \"cluster-queue-with-selector\""}
    1.6513730934348483e+09	LEVEL(-2)	scheduler	Workload re-queued	{"workload": {"name":"job","namespace":"core-67497"}, "queue": {"name":"queue-for-selector","namespace":"core-67497"}, "added": true, "status": "nominated"}
    1.6513730934348657e+09	LEVEL(-3)	scheduler	Obtained ClusterQueue heads	{"count": 1}
    1.6513730934348927e+09	LEVEL(-3)	scheduler	Workload evaluated for admission	{"workload": {"name":"job","namespace":"core-67497"}, "clusterQueue": {"name":"cluster-queue-with-selector"}, "status": "nominated", "reason": "Failed to admit workload: the workload is already assumed to ClusterQueue \"cluster-queue-with-selector\""}
    1.65137309343491e+09	LEVEL(-2)	scheduler	Workload re-queued	{"workload": {"name":"job","namespace":"core-67497"}, "queue": {"name":"queue-for-selector","namespace":"core-67497"}, "added": true, "status": "nominated"}
    1.651373093434927e+09	LEVEL(-3)	scheduler	Obtained ClusterQueue heads	{"count": 1}
    1.6513730934349582e+09	LEVEL(-3)	scheduler	Workload evaluated for admission	{"workload": {"name":"job","namespace":"core-67497"}, "clusterQueue": {"name":"cluster-queue-with-selector"}, "status": "nominated", "reason": "Failed to admit workload: the workload is already assumed to ClusterQueue \"cluster-queue-with-selector\""}
    1.6513730934349744e+09	LEVEL(-2)	scheduler	Workload re-queued	{"workload": {"name":"job","namespace":"core-67497"}, "queue": {"name":"queue-for-selector","namespace":"core-67497"}, "added": true, "status": "nominated"}
    1.6513730934349918e+09	LEVEL(-3)	scheduler	Obtained ClusterQueue heads	{"count": 1}
    1.6513730934350374e+09	LEVEL(-3)	scheduler	Workload evaluated for admission	{"workload": {"name":"job","namespace":"core-67497"}, "clusterQueue": {"name":"cluster-queue-with-selector"}, "status": "nominated", "reason": "Failed to admit workload: the workload is already assumed to ClusterQueue \"cluster-queue-with-selector\""}
    1.6513730934350533e+09	LEVEL(-2)	scheduler	Workload re-queued	{"workload": {"name":"job","namespace":"core-67497"}, "queue": {"name":"queue-for-selector","namespace":"core-67497"}, "added": true, "status": "nominated"}
    1.6513730934350712e+09	LEVEL(-3)	scheduler	Obtained ClusterQueue heads	{"count": 1}
    1.6513730934350991e+09	LEVEL(-3)	scheduler	Workload evaluated for admission	{"workload": {"name":"job","namespace":"core-67497"}, "clusterQueue": {"name":"cluster-queue-with-selector"}, "status": "nominated", "reason": "Failed to admit workload: the workload is already assumed to ClusterQueue \"cluster-queue-with-selector\""}
    1.651373093435116e+09	LEVEL(-2)	scheduler	Workload re-queued	{"workload": {"name":"job","namespace":"core-67497"}, "queue": {"name":"queue-for-selector","namespace":"core-67497"}, "added": true, "status": "nominated"}
    1.6513730934351332e+09	LEVEL(-3)	scheduler	Obtained ClusterQueue heads	{"count": 1}
    1.6513730934351614e+09	LEVEL(-3)	scheduler	Workload evaluated for admission	{"workload": {"name":"job","namespace":"core-67497"}, "clusterQueue": {"name":"cluster-queue-with-selector"}, "status": "nominated", "reason": "Failed to admit workload: the workload is already assumed to ClusterQueue \"cluster-queue-with-selector\""}
    1.6513730934351766e+09	LEVEL(-2)	scheduler	Workload re-queued	{"workload": {"name":"job","namespace":"core-67497"}, "queue": {"name":"queue-for-selector","namespace":"core-67497"}, "added": true, "status": "nominated"}
    1.6513730934351943e+09	LEVEL(-3)	scheduler	Obtained ClusterQueue heads	{"count": 1}
    1.6513730934352279e+09	LEVEL(-3)	scheduler	Workload evaluated for admission	{"workload": {"name":"job","namespace":"core-67497"}, "clusterQueue": {"name":"cluster-queue-with-selector"}, "status": "nominated", "reason": "Failed to admit workload: the workload is already assumed to ClusterQueue \"cluster-queue-with-selector\""}
    1.6513730934352517e+09	LEVEL(-2)	scheduler	Workload re-queued	{"workload": {"name":"job","namespace":"core-67497"}, "queue": {"name":"queue-for-selector","namespace":"core-67497"}, "added": true, "status": "nominated"}
    1.65137309343527e+09	LEVEL(-3)	scheduler	Obtained ClusterQueue heads	{"count": 1}
    1.6513730934352994e+09	LEVEL(-3)	scheduler	Workload evaluated for admission	{"workload": {"name":"job","namespace":"core-67497"}, "clusterQueue": {"name":"cluster-queue-with-selector"}, "status": "nominated", "reason": "Failed to admit workload: the workload is already assumed to ClusterQueue \"cluster-queue-with-selector\""}
```

Refer to https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kueue/227/pull-kueue-test-integration-main/1520594730851766272/build-log.txt
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes-sigs/kueue/issues/241

#### Special notes for your reviewer:

