### PR TITLE
Immediate requeue in BestEffortFIFO should put a workload for retry

### DIFF
--- a/CHANGELOG/CHANGELOG-0.2.md
+++ b/CHANGELOG/CHANGELOG-0.2.md
@@ -1,0 +1,6 @@
+## v0.2.0
+
+Changes since `v0.1.0`:
+
+- Fixed bug in a BestEffortFIFO ClusterQueue where a workload might not be
+  retried after a transient error.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

If a workload is in the inadmissible set, but then we do an immediate requeue, the workload should move back into the queue.

Add a RELEASE NOTE

#### Which issue(s) this PR fixes:

Part of #241

#### Special notes for your reviewer:

Should we cherry-pick into the release-0.1 branch?