### PR TITLE
Revert "Feat: add assumedWorkloads to ClusterQueue in package cache"

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -101,7 +101,6 @@ type ClusterQueue struct {
 	RequestableResources map[corev1.ResourceName][]FlavorLimits
 	UsedResources        Resources
 	Workloads            map[string]*workload.Info
-	AssumedWorkloads     sets.String
 	NamespaceSelector    labels.Selector
 	// The set of key labels from all flavors of a resource.
 	// Those keys define the affinity terms of a workload
@@ -119,9 +118,8 @@ type FlavorLimits struct {
 
 func (c *Cache) newClusterQueue(cq *kueue.ClusterQueue) (*ClusterQueue, error) {
 	cqImpl := &ClusterQueue{
-		Name:             cq.Name,
-		Workloads:        map[string]*workload.Info{},
-		AssumedWorkloads: sets.String{},
+		Name:      cq.Name,
+		Workloads: map[string]*workload.Info{},
 	}
 	if err := cqImpl.update(cq, c.resourceFlavors); err != nil {
 		return nil, err
@@ -220,7 +218,6 @@ func (c *ClusterQueue) deleteWorkload(w *kueue.Workload) {
 	}
 	c.updateWorkloadUsage(wi, -1)
 	delete(c.Workloads, k)
-	c.AssumedWorkloads.Delete(k)
 }
 
 func (c *ClusterQueue) updateWorkloadUsage(wi *workload.Info, m int64) {
@@ -403,6 +400,7 @@ func (c *Cache) DeleteWorkload(w *kueue.Workload) error {
 	}
 
 	c.cleanupAssumedState(w)
+
 	cq.deleteWorkload(w)
 	return nil
 }
@@ -429,20 +427,8 @@ func (c *Cache) AssumeWorkload(w *kueue.Workload) error {
 	if err := cq.addWorkload(w); err != nil {
 		return err
 	}
-	c.addAssumedWorkload(cq, k)
+	c.assumedWorkloads[k] = string(w.Spec.Admission.ClusterQueue)
 	return nil
-}
-
-func (c *Cache) addAssumedWorkload(cq *ClusterQueue, key string) {
-	c.assumedWorkloads[key] = cq.Name
-	cq.AssumedWorkloads.Insert(key)
-}
-
-func (c *Cache) deleteAssumedWorkload(cqName, key string) {
-	delete(c.assumedWorkloads, key)
-	if cq, exists := c.clusterQueues[cqName]; exists {
-		cq.AssumedWorkloads.Delete(key)
-	}
 }
 
 func (c *Cache) ForgetWorkload(w *kueue.Workload) error {
@@ -507,7 +493,7 @@ func (c *Cache) cleanupAssumedState(w *kueue.Workload) {
 				assumedCQ.deleteWorkload(w)
 			}
 		}
-		c.deleteAssumedWorkload(string(w.Spec.Admission.ClusterQueue), k)
+		delete(c.assumedWorkloads, k)
 	}
 }
 


### PR DESCRIPTION
This reverts commit f9e7a83f2ace7851f4b72ef93de0ab9ec82553b7.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`Assumed` is a temporary state of workloads in memory, we can't rely on this to get all running workloads.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
None
