### PR TITLE
Add metric for admitted active workloads

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -56,6 +56,14 @@ var (
 			Help:      "Number of pending workloads, per cluster_queue.",
 		}, []string{"cluster_queue"},
 	)
+
+	AdmittedActiveWorkloads = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: subsystemName,
+			Name:      "admitted_active_workloads",
+			Help:      "Number of admitted workloads that are active (unsuspended and not finished), per cluster_queue",
+		}, []string{"cluster_queue"},
+	)
 )
 
 func AdmissionAttempt(result AdmissionResult, duration time.Duration) {
@@ -68,5 +76,6 @@ func Register() {
 		admissionAttempts,
 		admissionAttemptLatency,
 		PendingWorkloads,
+		AdmittedActiveWorkloads,
 	)
 }

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -34,7 +34,8 @@ type Info struct {
 	Obj *kueue.Workload
 	// list of total resources requested by the podsets.
 	TotalRequests []PodSetResources
-	// Populated from queue.
+	// Populated from the queue during admission or from the admission field if
+	// already admitted.
 	ClusterQueue string
 }
 
@@ -45,10 +46,14 @@ type PodSetResources struct {
 }
 
 func NewInfo(w *kueue.Workload) *Info {
-	return &Info{
+	info := &Info{
 		Obj:           w,
 		TotalRequests: totalRequests(&w.Spec),
 	}
+	if w.Spec.Admission != nil {
+		info.ClusterQueue = string(w.Spec.Admission.ClusterQueue)
+	}
+	return info
 }
 
 func (i *Info) Update(wl *kueue.Workload) {

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -119,6 +119,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 				UsedResources:    emptyUsedResources,
 			}))
 			framework.ExpectPendingWorkloadsMetric(clusterQueue, 5)
+			framework.ExpectAdmittedActiveWorkloadsMetric(clusterQueue, 0)
 
 			ginkgo.By("Admitting workloads")
 			admissions := []*kueue.Admission{
@@ -170,6 +171,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 				},
 			}))
 			framework.ExpectPendingWorkloadsMetric(clusterQueue, 1)
+			framework.ExpectAdmittedActiveWorkloadsMetric(clusterQueue, 4)
 
 			ginkgo.By("Finishing workloads")
 			for _, w := range workloads {
@@ -191,6 +193,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 				UsedResources: emptyUsedResources,
 			}))
 			framework.ExpectPendingWorkloadsMetric(clusterQueue, 0)
+			framework.ExpectAdmittedActiveWorkloadsMetric(clusterQueue, 0)
 		})
 	})
 })

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -44,7 +44,6 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/workload"
-	// +kubebuilder:scaffold:imports
 )
 
 type ManagerSetup func(manager.Manager, context.Context)
@@ -249,6 +248,15 @@ func ExpectWorkloadsToBeFrozen(ctx context.Context, k8sClient client.Client, cq 
 
 func ExpectPendingWorkloadsMetric(cq *kueue.ClusterQueue, v int) {
 	metric := metrics.PendingWorkloads.WithLabelValues(cq.Name)
+	gomega.EventuallyWithOffset(1, func() int {
+		v, err := testutil.GetGaugeMetricValue(metric)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred())
+		return int(v)
+	}, Timeout, Interval).Should(gomega.Equal(v))
+}
+
+func ExpectAdmittedActiveWorkloadsMetric(cq *kueue.ClusterQueue, v int) {
+	metric := metrics.AdmittedActiveWorkloads.WithLabelValues(cq.Name)
 	gomega.EventuallyWithOffset(1, func() int {
 		v, err := testutil.GetGaugeMetricValue(metric)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add a metric that keeps track of admitted workloads that are still active (running).

This requires keeping track of admitted workloads per queue in the cache, which can also be used to report queue status.

#### Which issue(s) this PR fixes:

Part of #199 

#### Special notes for your reviewer:

The metric will under-report active workloads if the queue is deleted, or the queue switches cluster queue, which should be disallowed with finalizers and webhooks #171 