### PR TITLE
Make a copy of workload when admitting to avoid cache corruption

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -308,7 +308,7 @@ func (s *Scheduler) admit(ctx context.Context, e *entry) error {
 	log.V(2).Info("Workload assumed in the cache")
 
 	s.admissionRoutineWrapper.Run(func() {
-		err := s.client.Update(ctx, newWorkload)
+		err := s.client.Update(ctx, newWorkload.DeepCopy())
 		if err == nil {
 			s.recorder.Eventf(newWorkload, corev1.EventTypeNormal, "Admitted", "Admitted by ClusterQueue %v", admission.ClusterQueue)
 			log.V(2).Info("Workload successfully admitted and assigned flavors")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The client would update the object in place. Since we store it in the cache, the object might be temporarily corrupted, which could cause conflicts with some cache update operations.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

This is a candidate for cherry-pick, if we decide to release 0.1.2