### PR TITLE
Reduce cardinality of pending_workloads metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -53,8 +53,8 @@ var (
 		prometheus.GaugeOpts{
 			Subsystem: subsystemName,
 			Name:      "pending_workloads",
-			Help:      "Number of pending workloads, per queue and cluster_queue.",
-		}, []string{"cluster_queue", "queue"})
+			Help:      "Number of pending workloads, per cluster_queue.",
+		}, []string{"cluster_queue"})
 )
 
 func AdmissionAttempt(result AdmissionResult, duration time.Duration) {

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
-	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -73,12 +72,4 @@ func (q *Queue) AddIfNotPresent(w *workload.Info) bool {
 		return true
 	}
 	return false
-}
-
-func (q *Queue) reportPendingWorkloads() {
-	metrics.PendingWorkloads.WithLabelValues(q.ClusterQueue, q.Key).Set(float64(len(q.items)))
-}
-
-func (q *Queue) resetPendingWorkloads() {
-	metrics.PendingWorkloads.DeleteLabelValues(q.ClusterQueue, q.Key)
 }

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -118,6 +118,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 				PendingWorkloads: 5,
 				UsedResources:    emptyUsedResources,
 			}))
+			framework.ExpectPendingWorkloadsMetric(clusterQueue, 5)
 
 			ginkgo.By("Admitting workloads")
 			admissions := []*kueue.Admission{
@@ -168,6 +169,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 					},
 				},
 			}))
+			framework.ExpectPendingWorkloadsMetric(clusterQueue, 1)
 
 			ginkgo.By("Finishing workloads")
 			for _, w := range workloads {
@@ -188,6 +190,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 			}, framework.Timeout, framework.Interval).Should(testing.Equal(kueue.ClusterQueueStatus{
 				UsedResources: emptyUsedResources,
 			}))
+			framework.ExpectPendingWorkloadsMetric(clusterQueue, 0)
 		})
 	})
 })

--- a/test/integration/controller/core/queue_controller_test.go
+++ b/test/integration/controller/core/queue_controller_test.go
@@ -82,7 +82,6 @@ var _ = ginkgo.Describe("Queue controller", func() {
 			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(queue), &updatedQueue)).To(gomega.Succeed())
 			return updatedQueue.Status
 		}, framework.Timeout, framework.Interval).Should(testing.Equal(kueue.QueueStatus{PendingWorkloads: 3}))
-		framework.ExpectPendingWorkloadsMetric(queue, 3)
 
 		ginkgo.By("Admitting workloads")
 		for _, w := range workloads {
@@ -99,7 +98,6 @@ var _ = ginkgo.Describe("Queue controller", func() {
 			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(queue), &updatedQueue)).To(gomega.Succeed())
 			return updatedQueue.Status
 		}, framework.Timeout, framework.Interval).Should(testing.Equal(kueue.QueueStatus{PendingWorkloads: 0}))
-		framework.ExpectPendingWorkloadsMetric(queue, 0)
 
 		ginkgo.By("Finishing workloads")
 		for _, w := range workloads {

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -43,7 +43,6 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/metrics"
-	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/workload"
 	// +kubebuilder:scaffold:imports
 )
@@ -248,8 +247,8 @@ func ExpectWorkloadsToBeFrozen(ctx context.Context, k8sClient client.Client, cq 
 	}, Timeout, Interval).Should(gomega.Equal(len(wls)), "Not enough workloads are frozen")
 }
 
-func ExpectPendingWorkloadsMetric(q *kueue.Queue, v int) {
-	metric := metrics.PendingWorkloads.WithLabelValues(string(q.Spec.ClusterQueue), queue.Key(q))
+func ExpectPendingWorkloadsMetric(cq *kueue.ClusterQueue, v int) {
+	metric := metrics.PendingWorkloads.WithLabelValues(cq.Name)
 	gomega.EventuallyWithOffset(1, func() int {
 		v, err := testutil.GetGaugeMetricValue(metric)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Remove the `queue` label from the `pending_workloads` metric.

As opposed to ClusterQueues, Queues are more likely to be unbounded by administrators, which could lead to cardinality explosion.
OTOH, administrators are more likely to care about metrics per ClusterQueue. Users, who might be the owners of Queues, might not even have access to metrics. They can still check the Queue status.

#### Which issue(s) this PR fixes:

Ref https://github.com/kubernetes-sigs/kueue/pull/291#discussion_r916296493

#### Special notes for your reviewer:

