### PR TITLE
Assigning the same flavor to codependent resources

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -129,45 +129,47 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			wantClusterQueues: map[string]*ClusterQueue{
 				"a": {
 					Name: "a",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{
-						corev1.ResourceCPU: {{Name: "default", Min: 10000, Max: pointer.Int64(20000)}},
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						corev1.ResourceCPU: {
+							Flavors: []FlavorLimits{{Name: "default", Min: 10000, Max: pointer.Int64(20000)}},
+						},
 					},
 					NamespaceSelector: labels.Nothing(),
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
-					UsedResources:     Resources{corev1.ResourceCPU: {"default": 0}},
+					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					Status:            Active,
 				},
 				"b": {
 					Name: "b",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{
-						corev1.ResourceCPU: {{Name: "default", Min: 15000}},
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						corev1.ResourceCPU: {Flavors: []FlavorLimits{{Name: "default", Min: 15000}}},
 					},
 					NamespaceSelector: labels.Nothing(),
-					UsedResources:     Resources{corev1.ResourceCPU: {"default": 0}},
+					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
 					Status:            Active,
 				},
 				"c": {
 					Name:                 "c",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{},
+					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
-					UsedResources:        Resources{},
+					UsedResources:        ResourceQuantities{},
 					Status:               Active,
 				},
 				"d": {
 					Name:                 "d",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{},
+					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
-					UsedResources:        Resources{},
+					UsedResources:        ResourceQuantities{},
 					Status:               Active,
 				},
 				"e": {
 					Name: "e",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{
-						corev1.ResourceCPU: {{Name: "nonexistent-flavor", Min: 15000}},
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						corev1.ResourceCPU: {Flavors: []FlavorLimits{{Name: "nonexistent-flavor", Min: 15000}}},
 					},
 					NamespaceSelector: labels.Nothing(),
-					UsedResources:     Resources{corev1.ResourceCPU: {"nonexistent-flavor": 0}},
+					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"nonexistent-flavor": 0}},
 					LabelKeys:         nil,
 					Status:            Pending,
 				},
@@ -193,45 +195,45 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			wantClusterQueues: map[string]*ClusterQueue{
 				"a": {
 					Name: "a",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{
-						corev1.ResourceCPU: {{Name: "default", Min: 10000, Max: pointer.Int64(20000)}},
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						corev1.ResourceCPU: {Flavors: []FlavorLimits{{Name: "default", Min: 10000, Max: pointer.Int64(20000)}}},
 					},
 					NamespaceSelector: labels.Nothing(),
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
-					UsedResources:     Resources{corev1.ResourceCPU: {"default": 0}},
+					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					Status:            Active,
 				},
 				"b": {
 					Name: "b",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{
-						corev1.ResourceCPU: {{Name: "default", Min: 15000}},
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						corev1.ResourceCPU: {Flavors: []FlavorLimits{{Name: "default", Min: 15000}}},
 					},
 					NamespaceSelector: labels.Nothing(),
-					UsedResources:     Resources{corev1.ResourceCPU: {"default": 0}},
+					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
 					Status:            Active,
 				},
 				"c": {
 					Name:                 "c",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{},
+					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
-					UsedResources:        Resources{},
+					UsedResources:        ResourceQuantities{},
 					Status:               Active,
 				},
 				"d": {
 					Name:                 "d",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{},
+					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
-					UsedResources:        Resources{},
+					UsedResources:        ResourceQuantities{},
 					Status:               Active,
 				},
 				"e": {
 					Name: "e",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{
-						corev1.ResourceCPU: {{Name: "nonexistent-flavor", Min: 15000}},
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						corev1.ResourceCPU: {Flavors: []FlavorLimits{{Name: "nonexistent-flavor", Min: 15000}}},
 					},
 					NamespaceSelector: labels.Nothing(),
-					UsedResources:     Resources{corev1.ResourceCPU: {"nonexistent-flavor": 0}},
+					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"nonexistent-flavor": 0}},
 					LabelKeys:         nil,
 					Status:            Pending,
 				},
@@ -306,42 +308,42 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			wantClusterQueues: map[string]*ClusterQueue{
 				"a": {
 					Name: "a",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{
-						corev1.ResourceCPU: {{Name: "default", Min: 5000, Max: pointer.Int64(10000)}},
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						corev1.ResourceCPU: {Flavors: []FlavorLimits{{Name: "default", Min: 5000, Max: pointer.Int64(10000)}}},
 					},
 					NamespaceSelector: labels.Nothing(),
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType", "region")},
-					UsedResources:     Resources{corev1.ResourceCPU: {"default": 0}},
+					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					Status:            Active,
 				},
 				"b": {
 					Name:                 "b",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{},
+					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Everything(),
-					UsedResources:        Resources{},
+					UsedResources:        ResourceQuantities{},
 					Status:               Active,
 				},
 				"c": {
 					Name:                 "c",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{},
+					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
-					UsedResources:        Resources{},
+					UsedResources:        ResourceQuantities{},
 					Status:               Active,
 				},
 				"d": {
 					Name:                 "d",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{},
+					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
-					UsedResources:        Resources{},
+					UsedResources:        ResourceQuantities{},
 					Status:               Active,
 				},
 				"e": {
 					Name: "e",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{
-						corev1.ResourceCPU: {{Name: "default", Min: 5000, Max: pointer.Int64(10000)}},
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						corev1.ResourceCPU: {Flavors: []FlavorLimits{{Name: "default", Min: 5000, Max: pointer.Int64(10000)}}},
 					},
 					NamespaceSelector: labels.Nothing(),
-					UsedResources:     Resources{corev1.ResourceCPU: {"default": 0}},
+					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType", "region")},
 					Status:            Active,
 				},
@@ -366,28 +368,28 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			wantClusterQueues: map[string]*ClusterQueue{
 				"b": {
 					Name: "b",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{
-						corev1.ResourceCPU: {{Name: "default", Min: 15000}},
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						corev1.ResourceCPU: {Flavors: []FlavorLimits{{Name: "default", Min: 15000}}},
 					},
 					NamespaceSelector: labels.Nothing(),
-					UsedResources:     Resources{corev1.ResourceCPU: {"default": 0}},
+					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
 					Status:            Active,
 				},
 				"c": {
 					Name:                 "c",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{},
+					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
-					UsedResources:        Resources{},
+					UsedResources:        ResourceQuantities{},
 					Status:               Active,
 				},
 				"e": {
 					Name: "e",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{
-						corev1.ResourceCPU: {{Name: "nonexistent-flavor", Min: 15000}},
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						corev1.ResourceCPU: {Flavors: []FlavorLimits{{Name: "nonexistent-flavor", Min: 15000}}},
 					},
 					NamespaceSelector: labels.Nothing(),
-					UsedResources:     Resources{corev1.ResourceCPU: {"nonexistent-flavor": 0}},
+					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"nonexistent-flavor": 0}},
 					LabelKeys:         nil,
 					Status:            Pending,
 				},
@@ -408,45 +410,45 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			wantClusterQueues: map[string]*ClusterQueue{
 				"a": {
 					Name: "a",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{
-						corev1.ResourceCPU: {{Name: "default", Min: 10000, Max: pointer.Int64(20000)}},
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						corev1.ResourceCPU: {Flavors: []FlavorLimits{{Name: "default", Min: 10000, Max: pointer.Int64(20000)}}},
 					},
 					NamespaceSelector: labels.Nothing(),
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
-					UsedResources:     Resources{corev1.ResourceCPU: {"default": 0}},
+					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					Status:            Active,
 				},
 				"b": {
 					Name: "b",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{
-						corev1.ResourceCPU: {{Name: "default", Min: 15000}},
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						corev1.ResourceCPU: {Flavors: []FlavorLimits{{Name: "default", Min: 15000}}},
 					},
 					NamespaceSelector: labels.Nothing(),
-					UsedResources:     Resources{corev1.ResourceCPU: {"default": 0}},
+					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
 					Status:            Active,
 				},
 				"c": {
 					Name:                 "c",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{},
+					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
-					UsedResources:        Resources{},
+					UsedResources:        ResourceQuantities{},
 					Status:               Active,
 				},
 				"d": {
 					Name:                 "d",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{},
+					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
-					UsedResources:        Resources{},
+					UsedResources:        ResourceQuantities{},
 					Status:               Active,
 				},
 				"e": {
 					Name: "e",
-					RequestableResources: map[corev1.ResourceName][]FlavorLimits{
-						corev1.ResourceCPU: {{Name: "nonexistent-flavor", Min: 15000}},
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						corev1.ResourceCPU: {Flavors: []FlavorLimits{{Name: "nonexistent-flavor", Min: 15000}}},
 					},
 					NamespaceSelector: labels.Nothing(),
-					UsedResources:     Resources{corev1.ResourceCPU: {"nonexistent-flavor": 0}},
+					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"nonexistent-flavor": 0}},
 					LabelKeys:         nil,
 					Status:            Active,
 				},
@@ -454,6 +456,87 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			wantCohorts: map[string]sets.String{
 				"one": sets.NewString("a", "b"),
 				"two": sets.NewString("c", "e"),
+			},
+		},
+		{
+			name: "Add ClusterQueue with codependent resources",
+			operation: func(cache *Cache) {
+				err := cache.AddClusterQueue(context.Background(),
+					&kueue.ClusterQueue{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "foo",
+						},
+						Spec: kueue.ClusterQueueSpec{
+							Resources: []kueue.Resource{
+								{
+									Name: "cpu",
+									Flavors: []kueue.Flavor{
+										{Name: "foo"},
+										{Name: "bar"},
+									},
+								},
+								{
+									Name: "memory",
+									Flavors: []kueue.Flavor{
+										{Name: "foo"},
+										{Name: "bar"},
+									},
+								},
+								{
+									Name: "example.com/gpu",
+									Flavors: []kueue.Flavor{
+										{Name: "theta"},
+										{Name: "gamma"},
+									},
+								},
+							},
+						},
+					})
+				if err != nil {
+					t.Fatalf("Adding ClusterQueue: %v", err)
+				}
+			},
+			wantClusterQueues: map[string]*ClusterQueue{
+				"foo": {
+					Name:              "foo",
+					NamespaceSelector: labels.Nothing(),
+					RequestableResources: map[corev1.ResourceName]*Resource{
+						"cpu": {
+							Flavors: []FlavorLimits{
+								{Name: "foo"},
+								{Name: "bar"},
+							},
+							CodependentResources: sets.NewString("cpu", "memory"),
+						},
+						"memory": {
+							Flavors: []FlavorLimits{
+								{Name: "foo"},
+								{Name: "bar"},
+							},
+							CodependentResources: sets.NewString("cpu", "memory"),
+						},
+						"example.com/gpu": {
+							Flavors: []FlavorLimits{
+								{Name: "theta"},
+								{Name: "gamma"},
+							},
+						},
+					},
+					UsedResources: ResourceQuantities{
+						"cpu": map[string]int64{
+							"bar": 0,
+							"foo": 0,
+						},
+						"memory": map[string]int64{
+							"bar": 0,
+							"foo": 0,
+						},
+						"example.com/gpu": map[string]int64{
+							"theta": 0,
+							"gamma": 0,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -474,7 +557,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				}
 				gotCohorts[name] = gotCohort
 			}
-			if diff := cmp.Diff(tc.wantCohorts, gotCohorts); diff != "" {
+			if diff := cmp.Diff(tc.wantCohorts, gotCohorts, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Unexpected cohorts (-want,+got):\n%s", diff)
 			}
 		})
@@ -563,7 +646,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 
 	type result struct {
 		Workloads     sets.String
-		UsedResources Resources
+		UsedResources ResourceQuantities
 	}
 
 	steps := []struct {
@@ -594,11 +677,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("a", "b"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c", "d"),
-					UsedResources: Resources{"cpu": {"on-demand": 0, "spot": 0}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 0, "spot": 0}},
 				},
 			},
 		},
@@ -617,11 +700,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("a", "b"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c"),
-					UsedResources: Resources{"cpu": {"on-demand": 0, "spot": 0}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 0, "spot": 0}},
 				},
 			},
 		},
@@ -639,11 +722,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("a", "b"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c"),
-					UsedResources: Resources{"cpu": {"on-demand": 0, "spot": 0}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 0, "spot": 0}},
 				},
 			},
 		},
@@ -662,11 +745,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("b"),
-					UsedResources: Resources{"cpu": {"on-demand": 0, "spot": 0}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 0, "spot": 0}},
 				},
 				"two": {
 					Workloads:     sets.NewString("a", "c"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 			},
 		},
@@ -685,11 +768,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("a", "b"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c"),
-					UsedResources: Resources{"cpu": {"on-demand": 0, "spot": 0}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 0, "spot": 0}},
 				},
 			},
 		},
@@ -708,11 +791,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("a", "b"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c"),
-					UsedResources: Resources{"cpu": {"on-demand": 0, "spot": 0}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 0, "spot": 0}},
 				},
 			},
 		},
@@ -730,11 +813,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("a", "b"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c", "d"),
-					UsedResources: Resources{"cpu": {"on-demand": 0, "spot": 0}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 0, "spot": 0}},
 				},
 			},
 		},
@@ -749,11 +832,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("b"),
-					UsedResources: Resources{"cpu": {"on-demand": 0, "spot": 0}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 0, "spot": 0}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c"),
-					UsedResources: Resources{"cpu": {"on-demand": 0, "spot": 0}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 0, "spot": 0}},
 				},
 			},
 		},
@@ -769,11 +852,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("a", "b"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c"),
-					UsedResources: Resources{"cpu": {"on-demand": 0, "spot": 0}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 0, "spot": 0}},
 				},
 			},
 		},
@@ -788,11 +871,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("a", "b"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c"),
-					UsedResources: Resources{"cpu": {"on-demand": 0, "spot": 0}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 0, "spot": 0}},
 				},
 			},
 		},
@@ -819,11 +902,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("a", "b", "d"),
-					UsedResources: Resources{"cpu": {"on-demand": 20, "spot": 30}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 20, "spot": 30}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c", "e"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 			},
 			wantAssumedWorkloads: map[string]string{
@@ -846,11 +929,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("a", "b"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c"),
-					UsedResources: Resources{"cpu": {"on-demand": 0, "spot": 0}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 0, "spot": 0}},
 				},
 			},
 			wantAssumedWorkloads: map[string]string{},
@@ -880,11 +963,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("a", "b"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c", "e"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 			},
 			wantAssumedWorkloads: map[string]string{
@@ -906,11 +989,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("a", "b"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c"),
-					UsedResources: Resources{"cpu": {"on-demand": 0, "spot": 0}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 0, "spot": 0}},
 				},
 			},
 		},
@@ -942,11 +1025,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantResults: map[string]result{
 				"one": {
 					Workloads:     sets.NewString("a", "b", "d"),
-					UsedResources: Resources{"cpu": {"on-demand": 20, "spot": 30}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 20, "spot": 30}},
 				},
 				"two": {
 					Workloads:     sets.NewString("c", "e"),
-					UsedResources: Resources{"cpu": {"on-demand": 10, "spot": 15}},
+					UsedResources: ResourceQuantities{"cpu": {"on-demand": 10, "spot": 15}},
 				},
 			},
 			wantAssumedWorkloads: map[string]string{
@@ -1470,7 +1553,7 @@ func TestFlavorInUse(t *testing.T) {
 	}
 }
 
-func TestUpdateWithFlavors(t *testing.T) {
+func TestClusterQueueUpdateWithFlavors(t *testing.T) {
 	rf := utiltesting.MakeResourceFlavor("x86").Obj()
 	flavor := utiltesting.MakeFlavor(rf.Name, "5").Obj()
 
@@ -1540,6 +1623,136 @@ func TestUpdateWithFlavors(t *testing.T) {
 
 			if cq.Status != tc.wantStatus {
 				t.Fatalf("got different status, want: %v, got: %v", tc.wantStatus, cq.Status)
+			}
+		})
+	}
+}
+
+func TestClusterQueueUpdateCodependentResources(t *testing.T) {
+	cases := map[string]struct {
+		cq     ClusterQueue
+		wantCQ ClusterQueue
+	}{
+		"no codependent resources": {
+			cq: ClusterQueue{
+				RequestableResources: map[corev1.ResourceName]*Resource{
+					"cpu": {
+						Flavors: []FlavorLimits{
+							{Name: "alpha"},
+							{Name: "beta"},
+						},
+					},
+					"memory": {
+						Flavors: []FlavorLimits{
+							{Name: "default"},
+						},
+					},
+					"example.com/gpu": {
+						Flavors: []FlavorLimits{
+							{Name: "gamma"},
+							{Name: "theta"},
+						},
+					},
+				},
+			},
+			wantCQ: ClusterQueue{
+				RequestableResources: map[corev1.ResourceName]*Resource{
+					"cpu": {
+						Flavors: []FlavorLimits{
+							{Name: "alpha"},
+							{Name: "beta"},
+						},
+					},
+					"memory": {
+						Flavors: []FlavorLimits{
+							{Name: "default"},
+						},
+					},
+					"example.com/gpu": {
+						Flavors: []FlavorLimits{
+							{Name: "gamma"},
+							{Name: "theta"},
+						},
+					},
+				},
+			},
+		},
+		"some codependent resources": {
+			cq: ClusterQueue{
+				RequestableResources: map[corev1.ResourceName]*Resource{
+					"cpu": {
+						Flavors: []FlavorLimits{
+							{Name: "alpha"},
+							{Name: "beta"},
+						},
+					},
+					"memory": {
+						Flavors: []FlavorLimits{
+							{Name: "alpha"},
+							{Name: "beta"},
+						},
+					},
+					"example.com/gpu": {
+						Flavors: []FlavorLimits{
+							{Name: "gamma"},
+							{Name: "theta"},
+						},
+					},
+					"example.com/foo": {
+						Flavors: []FlavorLimits{
+							{Name: "default"},
+						},
+					},
+					"example.com/bar": {
+						Flavors: []FlavorLimits{
+							{Name: "default"},
+						},
+					},
+				},
+			},
+			wantCQ: ClusterQueue{
+				RequestableResources: map[corev1.ResourceName]*Resource{
+					"cpu": {
+						Flavors: []FlavorLimits{
+							{Name: "alpha"},
+							{Name: "beta"},
+						},
+						CodependentResources: sets.NewString("cpu", "memory"),
+					},
+					"memory": {
+						Flavors: []FlavorLimits{
+							{Name: "alpha"},
+							{Name: "beta"},
+						},
+						CodependentResources: sets.NewString("cpu", "memory"),
+					},
+					"example.com/gpu": {
+						Flavors: []FlavorLimits{
+							{Name: "gamma"},
+							{Name: "theta"},
+						},
+					},
+					"example.com/foo": {
+						Flavors: []FlavorLimits{
+							{Name: "default"},
+						},
+						CodependentResources: sets.NewString("example.com/foo", "example.com/bar"),
+					},
+					"example.com/bar": {
+						Flavors: []FlavorLimits{
+							{Name: "default"},
+						},
+						CodependentResources: sets.NewString("example.com/foo", "example.com/bar"),
+					},
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc.cq.UpdateCodependentResources()
+			if diff := cmp.Diff(tc.wantCQ, tc.cq, cmpopts.IgnoreUnexported(ClusterQueue{})); diff != "" {
+				t.Errorf("Unexpected ClusterQueue after updating codependent resources: (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -69,7 +69,7 @@ func (c *ClusterQueue) snapshot() *ClusterQueue {
 	cc := &ClusterQueue{
 		Name:                 c.Name,
 		RequestableResources: c.RequestableResources, // Shallow copy is enough.
-		UsedResources:        make(Resources, len(c.UsedResources)),
+		UsedResources:        make(ResourceQuantities, len(c.UsedResources)),
 		Workloads:            make(map[string]*workload.Info, len(c.Workloads)),
 		LabelKeys:            c.LabelKeys, // Shallow copy is enough.
 		NamespaceSelector:    c.NamespaceSelector,
@@ -91,20 +91,20 @@ func (c *ClusterQueue) snapshot() *ClusterQueue {
 
 func (c *ClusterQueue) accumulateResources(cohort *Cohort) {
 	if cohort.RequestableResources == nil {
-		cohort.RequestableResources = make(Resources, len(c.RequestableResources))
+		cohort.RequestableResources = make(ResourceQuantities, len(c.RequestableResources))
 	}
-	for name, flavors := range c.RequestableResources {
+	for name, res := range c.RequestableResources {
 		req := cohort.RequestableResources[name]
 		if req == nil {
-			req = make(map[string]int64, len(flavors))
+			req = make(map[string]int64, len(res.Flavors))
 			cohort.RequestableResources[name] = req
 		}
-		for _, flavor := range flavors {
+		for _, flavor := range res.Flavors {
 			req[flavor.Name] += flavor.Min
 		}
 	}
 	if cohort.UsedResources == nil {
-		cohort.UsedResources = make(Resources, len(c.UsedResources))
+		cohort.UsedResources = make(ResourceQuantities, len(c.UsedResources))
 	}
 	for res, flavors := range c.UsedResources {
 		used := cohort.UsedResources[res]

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -270,7 +270,7 @@ func TestSnapshot(t *testing.T) {
 	snapshot := cache.Snapshot()
 	wantCohort := Cohort{
 		Name: "foo",
-		RequestableResources: Resources{
+		RequestableResources: ResourceQuantities{
 			corev1.ResourceCPU: map[string]int64{
 				"demand": 100_000,
 				"spot":   300_000,
@@ -279,7 +279,7 @@ func TestSnapshot(t *testing.T) {
 				"default": 50,
 			},
 		},
-		UsedResources: Resources{
+		UsedResources: ResourceQuantities{
 			corev1.ResourceCPU: map[string]int64{
 				"demand": 10_000,
 				"spot":   10_000,
@@ -294,19 +294,21 @@ func TestSnapshot(t *testing.T) {
 			"foofoo": {
 				Name:   "foofoo",
 				Cohort: &wantCohort,
-				RequestableResources: map[corev1.ResourceName][]FlavorLimits{
+				RequestableResources: map[corev1.ResourceName]*Resource{
 					corev1.ResourceCPU: {
-						{
-							Name: "demand",
-							Min:  100_000,
-						},
-						{
-							Name: "spot",
-							Min:  200_000,
+						Flavors: []FlavorLimits{
+							{
+								Name: "demand",
+								Min:  100_000,
+							},
+							{
+								Name: "spot",
+								Min:  200_000,
+							},
 						},
 					},
 				},
-				UsedResources: Resources{
+				UsedResources: ResourceQuantities{
 					corev1.ResourceCPU: map[string]int64{
 						"demand": 10_000,
 						"spot":   0,
@@ -322,21 +324,25 @@ func TestSnapshot(t *testing.T) {
 			"foobar": {
 				Name:   "foobar",
 				Cohort: &wantCohort,
-				RequestableResources: map[corev1.ResourceName][]FlavorLimits{
+				RequestableResources: map[corev1.ResourceName]*Resource{
 					corev1.ResourceCPU: {
-						{
-							Name: "spot",
-							Min:  100_000,
+						Flavors: []FlavorLimits{
+							{
+								Name: "spot",
+								Min:  100_000,
+							},
 						},
 					},
 					"example.com/gpu": {
-						{
-							Name: "default",
-							Min:  50,
+						Flavors: []FlavorLimits{
+							{
+								Name: "default",
+								Min:  50,
+							},
 						},
 					},
 				},
-				UsedResources: Resources{
+				UsedResources: ResourceQuantities{
 					corev1.ResourceCPU: map[string]int64{
 						"spot": 10_000,
 					},
@@ -354,15 +360,17 @@ func TestSnapshot(t *testing.T) {
 			},
 			"bar": {
 				Name: "bar",
-				RequestableResources: map[corev1.ResourceName][]FlavorLimits{
+				RequestableResources: map[corev1.ResourceName]*Resource{
 					corev1.ResourceCPU: {
-						{
-							Name: "default",
-							Min:  100_000,
+						Flavors: []FlavorLimits{
+							{
+								Name: "default",
+								Min:  100_000,
+							},
 						},
 					},
 				},
-				UsedResources: Resources{
+				UsedResources: ResourceQuantities{
 					corev1.ResourceCPU: map[string]int64{"default": 0},
 				},
 				Workloads:         map[string]*workload.Info{},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When adding a ClusterQueue to the cache, identify the resources that share the same list of flavors, which we call codependent.

When admitting, iterate through flavors, checking that all the codependent resources have enough quota for the flavor.

#### Which issue(s) this PR fixes:

Fixes #167

#### Special notes for your reviewer:

This assumes that #308 is implemented.