### PR TITLE
Only set a podSet name if there is only one

### DIFF
--- a/apis/kueue/webhooks/workload_webhook.go
+++ b/apis/kueue/webhooks/workload_webhook.go
@@ -53,11 +53,14 @@ func (w *WorkloadWebhook) Default(ctx context.Context, obj runtime.Object) error
 	wl := obj.(*kueue.Workload)
 	workloadlog.V(5).Info("Applying defaults", "workload", klog.KObj(wl))
 
-	for i := range wl.Spec.PodSets {
-		podSet := &wl.Spec.PodSets[i]
+	if len(wl.Spec.PodSets) == 1 {
+		podSet := &wl.Spec.PodSets[0]
 		if len(podSet.Name) == 0 {
 			podSet.Name = kueue.DefaultPodSetName
 		}
+	}
+	for i := range wl.Spec.PodSets {
+		podSet := &wl.Spec.PodSets[i]
 		setContainersDefaults(podSet.Spec.InitContainers)
 		setContainersDefaults(podSet.Spec.Containers)
 	}

--- a/apis/kueue/webhooks/workload_webhook_test.go
+++ b/apis/kueue/webhooks/workload_webhook_test.go
@@ -57,6 +57,24 @@ func TestWorkloadWebhookDefault(t *testing.T) {
 				},
 			},
 		},
+		"don't set podSetName if multiple": {
+			wl: kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						{},
+						{},
+					},
+				},
+			},
+			wantWl: kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						{},
+						{},
+					},
+				},
+			},
+		},
 		"copy limits to requests": {
 			wl: kueue.Workload{
 				Spec: kueue.WorkloadSpec{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If we always set a default name, we get an error like this:

```
The Workload "sample-workload" is invalid: spec.podSets[1]: Duplicate value: map[string]interface {}{"name":"main"}
```

Which is confusing, because the user didn't set this name.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

This PR is based on #317. Review only from second commit.
