### PR TITLE
fix test in workload defaulter

### DIFF
--- a/test/integration/webhook/v1alpha1/workload_test.go
+++ b/test/integration/webhook/v1alpha1/workload_test.go
@@ -45,10 +45,22 @@ var _ = ginkgo.AfterEach(func() {
 
 var _ = ginkgo.Describe("Workload defaulting webhook", func() {
 	ginkgo.Context("When creating a Workload", func() {
-		ginkgo.It("Should set default values", func() {
+		ginkgo.It("Should set default podSet name", func() {
 			ginkgo.By("Creating a new Workload")
-			workload := testing.MakeWorkload(workloadName, ns.Name).Obj()
-			gomega.Expect(k8sClient.Create(ctx, workload)).Should(gomega.Succeed())
+			workload := kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: workloadName, Namespace: ns.Name},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						{
+							Count: 1,
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{},
+							},
+						},
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, &workload)).Should(gomega.Succeed())
 
 			created := &kueue.Workload{}
 			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{


### PR DESCRIPTION
Signed-off-by: kerthcet <kerthcet@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When testing workload defaulting, we should use plain workload for `MakeWorkload()` will set the podSet name automatically.

We don't have this problem in other API tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

