### PR TITLE
Avoid queueing workloads that don't match CQ namespaceSelector

### DIFF
--- a/apis/config/v1alpha1/groupversion_info.go
+++ b/apis/config/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the config v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=config.x-k8s.io
+// +kubebuilder:object:generate=true
+// +groupName=config.x-k8s.io
 package v1alpha1
 
 import (

--- a/apis/kueue/v1alpha1/groupversion_info.go
+++ b/apis/kueue/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the kueue v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=kueue.x-k8s.io
+// +kubebuilder:object:generate=true
+// +groupName=kueue.x-k8s.io
 package v1alpha1
 
 import (

--- a/apis/kueue/webhooks/workload_webhook.go
+++ b/apis/kueue/webhooks/workload_webhook.go
@@ -148,7 +148,7 @@ func ValidateWorkloadUpdate(newObj, oldObj *kueue.Workload) field.ErrorList {
 	return allErrs
 }
 
-/// validateQueueNameUpdate validates that queueName is set once
+// validateQueueNameUpdate validates that queueName is set once
 func validateQueueNameUpdate(new, old string, path *field.Path) field.ErrorList {
 	if len(old) == 0 {
 		return nil

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -191,7 +191,7 @@ func (r *ClusterQueueReconciler) Update(e event.UpdateEvent) bool {
 	if err := r.cache.UpdateClusterQueue(newCq); err != nil {
 		log.Error(err, "Failed to update clusterQueue in cache")
 	}
-	if err := r.qManager.UpdateClusterQueue(newCq); err != nil {
+	if err := r.qManager.UpdateClusterQueue(context.Background(), newCq); err != nil {
 		log.Error(err, "Failed to update clusterQueue in queue manager")
 	}
 	return true
@@ -265,7 +265,7 @@ func (h *cqNamespaceHandler) Update(e event.UpdateEvent, q workqueue.RateLimitin
 			cqs.Insert(cq)
 		}
 	}
-	h.qManager.QueueInadmissibleWorkloads(cqs)
+	h.qManager.QueueInadmissibleWorkloads(context.Background(), cqs)
 }
 
 func (h *cqNamespaceHandler) Delete(event.DeleteEvent, workqueue.RateLimitingInterface) {

--- a/pkg/controller/core/resourceflavor_controller.go
+++ b/pkg/controller/core/resourceflavor_controller.go
@@ -109,7 +109,7 @@ func (r *ResourceFlavorReconciler) Create(e event.CreateEvent) bool {
 	// As long as one clusterQueue becomes active,
 	// we should inform clusterQueue controller to broadcast the event.
 	if cqNames := r.cache.AddOrUpdateResourceFlavor(flv.DeepCopy()); len(cqNames) > 0 {
-		r.qManager.QueueInadmissibleWorkloads(cqNames)
+		r.qManager.QueueInadmissibleWorkloads(context.Background(), cqNames)
 		// If at least one CQ becomes active, then those CQs should now get evaluated by the scheduler;
 		// note that the workloads in those CQs are not necessarily "inadmissible", and hence we trigger a
 		// broadcast here in all cases.
@@ -128,7 +128,7 @@ func (r *ResourceFlavorReconciler) Delete(e event.DeleteEvent) bool {
 	log.V(2).Info("ResourceFlavor delete event")
 
 	if cqNames := r.cache.DeleteResourceFlavor(flv); len(cqNames) > 0 {
-		r.qManager.QueueInadmissibleWorkloads(cqNames)
+		r.qManager.QueueInadmissibleWorkloads(context.Background(), cqNames)
 	}
 	return false
 }
@@ -147,7 +147,7 @@ func (r *ResourceFlavorReconciler) Update(e event.UpdateEvent) bool {
 	}
 
 	if cqNames := r.cache.AddOrUpdateResourceFlavor(flv.DeepCopy()); len(cqNames) > 0 {
-		r.qManager.QueueInadmissibleWorkloads(cqNames)
+		r.qManager.QueueInadmissibleWorkloads(context.Background(), cqNames)
 	}
 	return false
 }

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -144,6 +144,8 @@ func (r *WorkloadReconciler) Delete(e event.DeleteEvent) bool {
 	}
 	log := r.log.WithValues("workload", klog.KObj(wl), "queue", wl.Spec.QueueName, "status", status)
 	log.V(2).Info("Workload delete event")
+	ctx := ctrl.LoggerInto(context.Background(), log)
+
 	// When assigning a clusterQueue to a workload, we assume it in the cache. If
 	// the state is unknown, the workload could have been assumed and we need
 	// to clear it from the cache.
@@ -155,7 +157,7 @@ func (r *WorkloadReconciler) Delete(e event.DeleteEvent) bool {
 		}
 
 		// trigger the move of associated inadmissibleWorkloads if required.
-		r.queues.QueueAssociatedInadmissibleWorkloads(wl)
+		r.queues.QueueAssociatedInadmissibleWorkloads(ctx, wl)
 	}
 
 	// Even if the state is unknown, the last cached state tells us whether the
@@ -174,6 +176,8 @@ func (r *WorkloadReconciler) Update(e event.UpdateEvent) bool {
 
 	status := workloadStatus(wl)
 	log := r.log.WithValues("workload", klog.KObj(wl), "queue", wl.Spec.QueueName, "status", status)
+	ctx := ctrl.LoggerInto(context.Background(), log)
+
 	prevQueue := oldWl.Spec.QueueName
 	if prevQueue != wl.Spec.QueueName {
 		log = log.WithValues("prevQueue", prevQueue)
@@ -202,7 +206,7 @@ func (r *WorkloadReconciler) Update(e event.UpdateEvent) bool {
 		r.queues.DeleteWorkload(oldWl)
 
 		// trigger the move of associated inadmissibleWorkloads if required.
-		r.queues.QueueAssociatedInadmissibleWorkloads(wl)
+		r.queues.QueueAssociatedInadmissibleWorkloads(ctx, wl)
 
 	case prevStatus == pending && status == pending:
 		if !r.queues.UpdateWorkload(oldWl, wlCopy) {
@@ -220,7 +224,7 @@ func (r *WorkloadReconciler) Update(e event.UpdateEvent) bool {
 			log.Error(err, "Failed to delete workload from cache")
 		}
 		// trigger the move of associated inadmissibleWorkloads if required.
-		r.queues.QueueAssociatedInadmissibleWorkloads(wl)
+		r.queues.QueueAssociatedInadmissibleWorkloads(ctx, wl)
 
 		if !r.queues.AddOrUpdateWorkload(wlCopy) {
 			log.V(2).Info("Queue for workload didn't exist; ignored for now")

--- a/pkg/queue/cluster_queue_best_effort_fifo.go
+++ b/pkg/queue/cluster_queue_best_effort_fifo.go
@@ -17,8 +17,6 @@ limitations under the License.
 package queue
 
 import (
-	"k8s.io/apimachinery/pkg/api/equality"
-
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -27,9 +25,6 @@ import (
 // BestEffortFIFO.
 type ClusterQueueBestEffortFIFO struct {
 	*ClusterQueueImpl
-
-	// inadmissibleWorkloads are workloads that have been tried at least once and couldn't be admitted.
-	inadmissibleWorkloads map[string]*workload.Info
 }
 
 var _ ClusterQueue = &ClusterQueueBestEffortFIFO{}
@@ -39,90 +34,13 @@ const BestEffortFIFO = kueue.BestEffortFIFO
 func newClusterQueueBestEffortFIFO(cq *kueue.ClusterQueue) (ClusterQueue, error) {
 	cqImpl := newClusterQueueImpl(keyFunc, byCreationTime)
 	cqBE := &ClusterQueueBestEffortFIFO{
-		ClusterQueueImpl:      cqImpl,
-		inadmissibleWorkloads: make(map[string]*workload.Info),
+		ClusterQueueImpl: cqImpl,
 	}
 
-	cqBE.Update(cq)
-	return cqBE, nil
+	err := cqBE.Update(cq)
+	return cqBE, err
 }
 
-func (cq *ClusterQueueBestEffortFIFO) PushOrUpdate(wInfo *workload.Info) {
-	key := workload.Key(wInfo.Obj)
-	oldInfo := cq.inadmissibleWorkloads[key]
-	if oldInfo != nil {
-		// update in place if the workload was inadmissible and didn't change
-		// to potentially become admissible.
-		if equality.Semantic.DeepEqual(oldInfo.Obj.Spec, wInfo.Obj.Spec) {
-			cq.inadmissibleWorkloads[key] = wInfo
-			return
-		}
-		// otherwise move or update in place in the queue.
-		delete(cq.inadmissibleWorkloads, key)
-	}
-
-	cq.ClusterQueueImpl.PushOrUpdate(wInfo)
-}
-
-func (cq *ClusterQueueBestEffortFIFO) Delete(w *kueue.Workload) {
-	delete(cq.inadmissibleWorkloads, workload.Key(w))
-	cq.ClusterQueueImpl.Delete(w)
-}
-
-func (cq *ClusterQueueBestEffortFIFO) DeleteFromQueue(q *Queue) {
-	for _, w := range q.items {
-		key := workload.Key(w.Obj)
-		if wl := cq.inadmissibleWorkloads[key]; wl != nil {
-			delete(cq.inadmissibleWorkloads, key)
-		}
-	}
-	cq.ClusterQueueImpl.DeleteFromQueue(q)
-}
-
-// RequeueIfNotPresent inserts a workload that cannot be admitted into
-// ClusterQueue, unless it is already in the queue. If immediate is true,
-// the workload will be pushed back to heap directly. If not,
-// the workload will be put into the inadmissibleWorkloads.
-func (cq *ClusterQueueBestEffortFIFO) RequeueIfNotPresent(wInfo *workload.Info, immediate bool) bool {
-	key := workload.Key(wInfo.Obj)
-	if immediate {
-		// If the workload was inadmissible, move it back into the queue.
-		inadmissibleWl := cq.inadmissibleWorkloads[key]
-		if inadmissibleWl != nil {
-			wInfo = inadmissibleWl
-			delete(cq.inadmissibleWorkloads, key)
-		}
-		return cq.ClusterQueueImpl.pushIfNotPresent(wInfo)
-	}
-
-	if cq.inadmissibleWorkloads[key] != nil {
-		return false
-	}
-
-	if data := cq.heap.GetByKey(key); data != nil {
-		return false
-	}
-
-	cq.inadmissibleWorkloads[key] = wInfo
-
-	return true
-}
-
-// QueueInadmissibleWorkloads moves all workloads from inadmissibleWorkloads to heap.
-// If at least one workload is moved, returns true. Otherwise returns false.
-func (cq *ClusterQueueBestEffortFIFO) QueueInadmissibleWorkloads() bool {
-	if len(cq.inadmissibleWorkloads) == 0 {
-		return false
-	}
-
-	for _, wInfo := range cq.inadmissibleWorkloads {
-		cq.ClusterQueueImpl.pushIfNotPresent(wInfo)
-	}
-
-	cq.inadmissibleWorkloads = make(map[string]*workload.Info)
-	return true
-}
-
-func (cq *ClusterQueueBestEffortFIFO) Pending() int32 {
-	return cq.ClusterQueueImpl.Pending() + int32(len(cq.inadmissibleWorkloads))
+func (cq *ClusterQueueBestEffortFIFO) RequeueIfNotPresent(wInfo *workload.Info, reason RequeueReason) bool {
+	return cq.ClusterQueueImpl.requeueIfNotPresent(wInfo, reason == RequeueReasonFailedAfterNomination)
 }

--- a/pkg/queue/cluster_queue_best_effort_fifo_test.go
+++ b/pkg/queue/cluster_queue_best_effort_fifo_test.go
@@ -20,160 +20,44 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
-func TestClusterQueueBestEffortFIFO(t *testing.T) {
-	clusterQueue := utiltesting.MakeClusterQueue("cq").Obj()
-	var workloads = []*kueue.Workload{
-		utiltesting.MakeWorkload("w1", "ns1").Queue("q1").Obj(),
-		utiltesting.MakeWorkload("w2", "ns2").Queue("q2").Obj(),
-	}
-	var updatedWorkloads = make([]*kueue.Workload, len(workloads))
-
-	updatedWorkloads[0] = workloads[0].DeepCopy()
-	updatedWorkloads[0].Spec.QueueName = "q2"
-	updatedWorkloads[1] = workloads[1].DeepCopy()
-	updatedWorkloads[1].Spec.QueueName = "q1"
-
-	tests := map[string]struct {
-		workloadsToAdd                 []*kueue.Workload
-		inadmissibleWorkloadsToRequeue []*workload.Info
-		admissibleWorkloadsToRequeue   []*workload.Info
-		workloadsToUpdate              []*kueue.Workload
-		workloadsToDelete              []*kueue.Workload
-		queueInadmissibleWorkloads     bool
-		wantActiveWorkloads            sets.String
-		wantPending                    int32
+func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
+	tests := map[RequeueReason]struct {
+		wantInadmissible bool
 	}{
-		"add, update, delete workload": {
-			workloadsToAdd:                 []*kueue.Workload{workloads[0], workloads[1]},
-			inadmissibleWorkloadsToRequeue: []*workload.Info{},
-			workloadsToUpdate:              []*kueue.Workload{updatedWorkloads[0]},
-			workloadsToDelete:              []*kueue.Workload{workloads[0]},
-			wantActiveWorkloads:            sets.NewString(workloads[1].Name),
-			wantPending:                    1,
+		RequeueReasonFailedAfterNomination: {
+			wantInadmissible: false,
 		},
-		"re-queue inadmissible workload": {
-			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
-			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1])},
-			wantActiveWorkloads:            sets.NewString(workloads[0].Name),
-			wantPending:                    2,
+		RequeueReasonNamespaceMismatch: {
+			wantInadmissible: true,
 		},
-		"re-queue admissible workload that was inadmissible": {
-			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
-			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1])},
-			admissibleWorkloadsToRequeue:   []*workload.Info{workload.NewInfo(workloads[1])},
-			wantActiveWorkloads:            sets.NewString(workloads[0].Name, workloads[1].Name),
-			wantPending:                    2,
-		},
-		"re-queue inadmissible workload and flush": {
-			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
-			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1])},
-			queueInadmissibleWorkloads:     true,
-			wantActiveWorkloads:            sets.NewString(workloads[0].Name, workloads[1].Name),
-			wantPending:                    2,
-		},
-		"update inadmissible workload": {
-			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
-			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1])},
-			workloadsToUpdate:              []*kueue.Workload{updatedWorkloads[1]},
-			wantActiveWorkloads:            sets.NewString(workloads[0].Name, workloads[1].Name),
-			wantPending:                    2,
-		},
-		"delete inadmissible workload": {
-			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
-			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1])},
-			workloadsToDelete:              []*kueue.Workload{workloads[1]},
-			queueInadmissibleWorkloads:     true,
-			wantActiveWorkloads:            sets.NewString(workloads[0].Name),
-			wantPending:                    1,
+		RequeueReasonGeneric: {
+			wantInadmissible: true,
 		},
 	}
 
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			cq, err := newClusterQueueBestEffortFIFO(clusterQueue)
-			if err != nil {
-				t.Fatalf("Failed creating ClusterQueue %v", err)
+	for reason, test := range tests {
+		t.Run(string(reason), func(t *testing.T) {
+			cq, _ := newClusterQueueBestEffortFIFO(&kueue.ClusterQueue{
+				Spec: kueue.ClusterQueueSpec{
+					QueueingStrategy: kueue.StrictFIFO,
+				},
+			})
+			wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
+			if ok := cq.RequeueIfNotPresent(workload.NewInfo(wl), reason); !ok {
+				t.Error("failed to requeue nonexistent workload")
 			}
 
-			for _, w := range test.workloadsToAdd {
-				cq.PushOrUpdate(workload.NewInfo(w))
+			_, gotInadmissible := cq.(*ClusterQueueBestEffortFIFO).inadmissibleWorkloads[workload.Key(wl)]
+			if diff := cmp.Diff(test.wantInadmissible, gotInadmissible); diff != "" {
+				t.Errorf("Unexpected inadmissible status (-want,+got):\n%s", diff)
 			}
 
-			for _, w := range test.inadmissibleWorkloadsToRequeue {
-				cq.RequeueIfNotPresent(w, false)
-			}
-			for _, w := range test.admissibleWorkloadsToRequeue {
-				cq.RequeueIfNotPresent(w, true)
-			}
-
-			for _, w := range test.workloadsToUpdate {
-				cq.PushOrUpdate(workload.NewInfo(w))
-			}
-
-			for _, w := range test.workloadsToDelete {
-				cq.Delete(w)
-			}
-
-			if test.queueInadmissibleWorkloads {
-				cq.QueueInadmissibleWorkloads()
-			}
-
-			gotWorkloads, _ := cq.Dump()
-			if diff := cmp.Diff(test.wantActiveWorkloads, gotWorkloads); diff != "" {
-				t.Errorf("Unexpected items in cluster foo (-want,+got):\n%s", diff)
-			}
-			if got := cq.Pending(); got != test.wantPending {
-				t.Errorf("Got %d pending workloads, want %d", got, test.wantPending)
-			}
 		})
-	}
-}
-
-func TestDeleteFromQueue(t *testing.T) {
-	cq := utiltesting.MakeClusterQueue("cq").Obj()
-	cqImpl, err := newClusterQueueBestEffortFIFO(cq)
-	if err != nil {
-		t.Fatalf("Failed creating ClusterQueue %v", err)
-	}
-	q := utiltesting.MakeQueue("foo", "").ClusterQueue(cq.Name).Obj()
-	qImpl := newQueue(q)
-	wl1 := utiltesting.MakeWorkload("wl1", "").Queue(q.Name).Obj()
-	wl2 := utiltesting.MakeWorkload("wl2", "").Queue(q.Name).Obj()
-	wl3 := utiltesting.MakeWorkload("wl3", "").Queue(q.Name).Obj()
-	wl4 := utiltesting.MakeWorkload("wl4", "").Queue(q.Name).Obj()
-	admissibleworkloads := []*kueue.Workload{wl1, wl2}
-	inadmissibleWorkloads := []*kueue.Workload{wl3, wl4}
-
-	for _, w := range admissibleworkloads {
-		wInfo := workload.NewInfo(w)
-		cqImpl.PushOrUpdate(wInfo)
-		qImpl.AddOrUpdate(wInfo)
-	}
-
-	for _, w := range inadmissibleWorkloads {
-		wInfo := workload.NewInfo(w)
-		cqImpl.RequeueIfNotPresent(wInfo, false)
-		qImpl.AddOrUpdate(wInfo)
-	}
-
-	wantPending := len(admissibleworkloads) + len(inadmissibleWorkloads)
-	if pending := cqImpl.Pending(); pending != int32(wantPending) {
-		t.Errorf("clusterQueue's workload number not right, want %v, got %v", wantPending, pending)
-	}
-	fifo := cqImpl.(*ClusterQueueBestEffortFIFO)
-	if len(fifo.inadmissibleWorkloads) != len(inadmissibleWorkloads) {
-		t.Errorf("clusterQueue's workload number in inadmissibleWorkloads not right, want %v, got %v", len(inadmissibleWorkloads), len(fifo.inadmissibleWorkloads))
-	}
-
-	cqImpl.DeleteFromQueue(qImpl)
-	if cqImpl.Pending() != 0 {
-		t.Error("clusterQueue should be empty")
 	}
 }

--- a/pkg/queue/cluster_queue_interface.go
+++ b/pkg/queue/cluster_queue_interface.go
@@ -17,19 +17,29 @@ limitations under the License.
 package queue
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+type RequeueReason string
+
+const (
+	RequeueReasonFailedAfterNomination RequeueReason = "FailedAfterNomination"
+	RequeueReasonNamespaceMismatch     RequeueReason = "NamespaceMismatch"
+	RequeueReasonGeneric               RequeueReason = ""
 )
 
 // ClusterQueue is an interface for a cluster queue to store workloads waiting
 // to be scheduled.
 type ClusterQueue interface {
 	// Update updates the properties of this ClusterQueue.
-	Update(*kueue.ClusterQueue)
+	Update(*kueue.ClusterQueue) error
 	// Cohort returns the Cohort of this ClusterQueue.
 	Cohort() string
 
@@ -59,11 +69,11 @@ type ClusterQueue interface {
 	// compete with other workloads, until cluster events free up quota.
 	// The workload should not be reinserted if it's already in the ClusterQueue.
 	// Returns true if the workload was inserted.
-	RequeueIfNotPresent(*workload.Info, bool) bool
+	RequeueIfNotPresent(*workload.Info, RequeueReason) bool
 	// QueueInadmissibleWorkloads moves all workloads put in temporary placeholder stage
 	// to the ClusterQueue. If at least one workload is moved,
 	// returns true. Otherwise returns false.
-	QueueInadmissibleWorkloads() bool
+	QueueInadmissibleWorkloads(ctx context.Context, client client.Client) bool
 
 	// Pending returns the number of pending workloads.
 	Pending() int32
@@ -71,6 +81,7 @@ type ClusterQueue interface {
 	// this ClusterQueue. It returns false if the queue is empty.
 	// Otherwise returns true.
 	Dump() (sets.String, bool)
+	DumpInadmissible() (sets.String, bool)
 	// Info returns workload.Info for the workload key.
 	// Users of this method should not modify the returned object.
 	Info(string) *workload.Info

--- a/pkg/queue/cluster_queue_strict_fifo.go
+++ b/pkg/queue/cluster_queue_strict_fifo.go
@@ -25,7 +25,7 @@ import (
 // ClusterQueueStrictFIFO is the implementation for the ClusterQueue for
 // StrictFIFO.
 type ClusterQueueStrictFIFO struct {
-	ClusterQueueImpl
+	*ClusterQueueImpl
 }
 
 var _ ClusterQueue = &ClusterQueueStrictFIFO{}
@@ -34,8 +34,12 @@ const StrictFIFO = kueue.StrictFIFO
 
 func newClusterQueueStrictFIFO(cq *kueue.ClusterQueue) (ClusterQueue, error) {
 	cqImpl := newClusterQueueImpl(keyFunc, byCreationTime)
-	cqImpl.Update(cq)
-	return cqImpl, nil
+	cqStrict := &ClusterQueueStrictFIFO{
+		ClusterQueueImpl: cqImpl,
+	}
+
+	err := cqStrict.Update(cq)
+	return cqStrict, err
 }
 
 // byCreationTime is the function used by the clusterQueue heap algorithm to sort

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -416,7 +416,7 @@ func TestRequeueWorkloadStrictFIFO(t *testing.T) {
 				_ = manager.AddOrUpdateWorkload(tc.workload)
 			}
 			info := workload.NewInfo(tc.workload)
-			if requeued := manager.RequeueWorkload(ctx, info, true); requeued != tc.wantRequeued {
+			if requeued := manager.RequeueWorkload(ctx, info, RequeueReasonGeneric); requeued != tc.wantRequeued {
 				t.Errorf("RequeueWorkload returned %t, want %t", requeued, tc.wantRequeued)
 			}
 		})
@@ -829,7 +829,7 @@ func TestHeadsAsync(t *testing.T) {
 				// Remove the initial workload from the manager.
 				mgr.Heads(ctx)
 				go func() {
-					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), true)
+					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination)
 				}()
 			},
 			wantHeads: []workload.Info{
@@ -857,7 +857,7 @@ func TestHeadsAsync(t *testing.T) {
 				// Remove the initial workload from the manager.
 				mgr.Heads(ctx)
 				go func() {
-					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), true)
+					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination)
 				}()
 			},
 			wantHeads: []workload.Info{
@@ -889,7 +889,7 @@ func TestHeadsAsync(t *testing.T) {
 				// Remove the initial workload from the manager.
 				mgr.Heads(ctx)
 				go func() {
-					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), true)
+					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination)
 				}()
 			},
 			wantHeads: []workload.Info{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR updates the scheduler to avoid re-queueing workloads that don't match the cq NamespaceSelector.

The initial idea was to not add those workloads when first observed, but this is not enough to address this issue since a namespace label or CQ namespaceSelector could change by the time the workload that was initially accepted into the queue. Those changes could make the workload inadmissible due to not matching namespaceSelector, and so we still need a code path that handles the case during re-queueing.

The consequence is that such workloads will get evaluated, but at most once. To optimize away this wasted cycle, we will need to avoid adding the workload from the beginning, but this can be done as a followup because this PR is too long (I already made the changes to the workload controller to update the workload status for this case on another branch).

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/kueue/issues/301

#### Special notes for your reviewer:

