### PR TITLE
Validate codependent flavors in ClusterQueue

### DIFF
--- a/apis/kueue/v1alpha1/clusterqueue_types.go
+++ b/apis/kueue/v1alpha1/clusterqueue_types.go
@@ -38,6 +38,12 @@ type ClusterQueueSpec struct {
 	//   - quota:
 	//       min: 100Gi
 	//
+	// Two resources must either have all the flavors in the same order or not
+	// have any matching flavors. When two resources match their flavors, they
+	// are said to be codependent. When a workload is admitted by this
+	// ClusterQueue, all the codependent resources that the Workload requests get
+	// assigned the same flavor.
+	//
 	// +listType=map
 	// +listMapKey=name
 	Resources []Resource `json:"resources,omitempty"`

--- a/config/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -158,7 +158,11 @@ spec:
                   availability of resources, although an integration with a resource
                   provisioner like Cluster Autoscaler is possible to achieve that.
                   Example: \n - name: cpu flavors: - quota: min: 100 - name: memory
-                  flavors: - quota: min: 100Gi"
+                  flavors: - quota: min: 100Gi \n Two resources must either have all
+                  the flavors in the same order or not have any matching flavors.
+                  When two resources match their flavors, they are said to be codependent.
+                  When a workload is admitted by this ClusterQueue, all the codependent
+                  resources that the Workload requests get assigned the same flavor."
                 items:
                   properties:
                     flavors:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

In a ClusterQueue two resources either have completely different flavors or they must share all flavors, in the same order.

Add validation and API documentation.

#### Which issue(s) this PR fixes:

Fixes #308

#### Special notes for your reviewer:

