### PR TITLE
Add validation for API lists sizes

### DIFF
--- a/apis/kueue/v1alpha1/clusterqueue_types.go
+++ b/apis/kueue/v1alpha1/clusterqueue_types.go
@@ -44,6 +44,8 @@ type ClusterQueueSpec struct {
 	// ClusterQueue, all the codependent resources that the Workload requests get
 	// assigned the same flavor.
 	//
+	// resources can be up to 16 elements.
+	//
 	// +listType=map
 	// +listMapKey=name
 	Resources []Resource `json:"resources,omitempty"`
@@ -187,6 +189,8 @@ type Resource struct {
 	// A workload is limited to the selected type by converting the labels to a node
 	// selector that gets injected into the workload. This list can’t be empty, at
 	// least one flavor must exist.
+	//
+	// flavors can be up to 16 elements.
 	//
 	// +listType=map
 	// +listMapKey=name

--- a/apis/kueue/v1alpha1/resourceflavor_types.go
+++ b/apis/kueue/v1alpha1/resourceflavor_types.go
@@ -33,11 +33,17 @@ type ResourceFlavor struct {
 	// converted to node affinity constraints on the workload’s pods.
 	// For example, cloud.provider.com/accelerator: nvidia-tesla-k80.
 	// More info: http://kubernetes.io/docs/user-guide/labels
+	//
+	// labels can be up to 8 elements.
 	Labels map[string]string `json:"labels,omitempty"`
 
 	// taints associated with this flavor that workloads must explicitly
 	// “tolerate” to be able to use this flavor.
 	// For example, cloud.provider.com/preemptible="true":NoSchedule
+	//
+	// taints can be up to 8 elements.
+	//
+	// +listType=atomic
 	Taints []corev1.Taint `json:"taints,omitempty"`
 }
 

--- a/apis/kueue/v1alpha1/workload_types.go
+++ b/apis/kueue/v1alpha1/workload_types.go
@@ -25,7 +25,7 @@ import (
 type WorkloadSpec struct {
 	// podSets is a list of sets of homogeneous pods, each described by a Pod spec
 	// and a count.
-	// There must be at least one element.
+	// There must be at least one element and at most 8.
 	// podSets cannot be changed.
 	//
 	// +listType=map

--- a/apis/kueue/webhooks/common.go
+++ b/apis/kueue/webhooks/common.go
@@ -1,0 +1,26 @@
+package webhooks
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func validateResourceName(name corev1.ResourceName, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	for _, msg := range validation.IsQualifiedName(string(name)) {
+		allErrs = append(allErrs, field.Invalid(fldPath, name, msg))
+	}
+	return allErrs
+}
+
+// validateNameReference is the same validation applied to name of an ObjectMeta.
+func validateNameReference(name string, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	if msgs := validation.IsDNS1123Subdomain(name); len(msgs) > 0 {
+		for _, msg := range msgs {
+			allErrs = append(allErrs, field.Invalid(path, name, msg))
+		}
+	}
+	return allErrs
+}

--- a/apis/kueue/webhooks/queue_webhook.go
+++ b/apis/kueue/webhooks/queue_webhook.go
@@ -49,7 +49,7 @@ var _ webhook.CustomValidator = &QueueWebhook{}
 func (w *QueueWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
 	q := obj.(*kueue.Queue)
 	queueLog.V(5).Info("Validating create", "queue", klog.KObj(q))
-	return ValidateQueueCreate(q).ToAggregate()
+	return ValidateQueue(q).ToAggregate()
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
@@ -65,12 +65,10 @@ func (w *QueueWebhook) ValidateDelete(ctx context.Context, obj runtime.Object) e
 	return nil
 }
 
-func ValidateQueueCreate(q *kueue.Queue) field.ErrorList {
+func ValidateQueue(q *kueue.Queue) field.ErrorList {
 	var allErrs field.ErrorList
 	clusterQueuePath := field.NewPath("spec", "clusterQueue")
-	for _, msg := range apivalidation.NameIsDNSSubdomain(string(q.Spec.ClusterQueue), false) {
-		allErrs = append(allErrs, field.Invalid(clusterQueuePath, q.Spec.ClusterQueue, msg))
-	}
+	allErrs = append(allErrs, validateNameReference(string(q.Spec.ClusterQueue), clusterQueuePath)...)
 	return allErrs
 }
 

--- a/apis/kueue/webhooks/queue_webhook_test.go
+++ b/apis/kueue/webhooks/queue_webhook_test.go
@@ -46,7 +46,7 @@ func TestValidateQueueCreate(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			errList := ValidateQueueCreate(tc.queue)
+			errList := ValidateQueue(tc.queue)
 			if diff := cmp.Diff(tc.wantErr, errList, cmpopts.IgnoreFields(field.Error{}, "Detail", "BadValue")); diff != "" {
 				t.Errorf("ValidateQueueCreate() mismatch (-want +got):\n%s", diff)
 			}

--- a/config/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -162,7 +162,8 @@ spec:
                   the flavors in the same order or not have any matching flavors.
                   When two resources match their flavors, they are said to be codependent.
                   When a workload is admitted by this ClusterQueue, all the codependent
-                  resources that the Workload requests get assigned the same flavor."
+                  resources that the Workload requests get assigned the same flavor.
+                  \n resources can be up to 16 elements."
                 items:
                   properties:
                     flavors:
@@ -182,7 +183,7 @@ spec:
                         is 20 (10 k80 + 10 p100). A workload is limited to the selected
                         type by converting the labels to a node selector that gets
                         injected into the workload. This list can’t be empty, at least
-                        one flavor must exist."
+                        one flavor must exist. \n flavors can be up to 16 elements."
                       items:
                         properties:
                           name:

--- a/config/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
+++ b/config/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
@@ -33,16 +33,18 @@ spec:
           labels:
             additionalProperties:
               type: string
-            description: 'labels associated with this flavor. They are matched against
+            description: "labels associated with this flavor. They are matched against
               or converted to node affinity constraints on the workload’s pods. For
               example, cloud.provider.com/accelerator: nvidia-tesla-k80. More info:
-              http://kubernetes.io/docs/user-guide/labels'
+              http://kubernetes.io/docs/user-guide/labels \n labels can be up to 8
+              elements."
             type: object
           metadata:
             type: object
           taints:
-            description: taints associated with this flavor that workloads must explicitly
-              “tolerate” to be able to use this flavor. For example, cloud.provider.com/preemptible="true":NoSchedule
+            description: "taints associated with this flavor that workloads must explicitly
+              “tolerate” to be able to use this flavor. For example, cloud.provider.com/preemptible=\"true\":NoSchedule
+              \n taints can be up to 8 elements."
             items:
               description: The node this Taint is attached to has the "effect" on
                 any pod that does not tolerate the Taint.
@@ -68,6 +70,7 @@ spec:
               - key
               type: object
             type: array
+            x-kubernetes-list-type: atomic
         type: object
     served: true
     storage: true

--- a/config/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -85,8 +85,8 @@ spec:
                 type: object
               podSets:
                 description: podSets is a list of sets of homogeneous pods, each described
-                  by a Pod spec and a count. There must be at least one element. podSets
-                  cannot be changed.
+                  by a Pod spec and a count. There must be at least one element and
+                  at most 8. podSets cannot be changed.
                 items:
                   properties:
                     count:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

Add validation for the maximum size of lists in the API. Notably:
- Max number of resources and flavors in ClusterQueue is 16
- Max number of labels and taints in ResourceFlavor is 8
- Max number of podSets in a Workload is 8

Also add some validations for some object references and taints.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This PR builds on top of #326, so you can review from the 2nd commit.
