### PR TITLE
Add status label to pending_workloads metric

### DIFF
--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -303,6 +303,6 @@ func (r *ClusterQueueReconciler) Status(cq *kueue.ClusterQueue) (kueue.ClusterQu
 	return kueue.ClusterQueueStatus{
 		UsedResources:     usage,
 		AdmittedWorkloads: int32(workloads),
-		PendingWorkloads:  r.qManager.Pending(cq),
+		PendingWorkloads:  int32(r.qManager.Pending(cq)),
 	}, nil
 }

--- a/pkg/queue/cluster_queue_impl.go
+++ b/pkg/queue/cluster_queue_impl.go
@@ -173,8 +173,16 @@ func (c *ClusterQueueImpl) QueueInadmissibleWorkloads(ctx context.Context, clien
 	return moved
 }
 
-func (c *ClusterQueueImpl) Pending() int32 {
-	return int32(c.heap.Len()) + int32(len(c.inadmissibleWorkloads))
+func (c *ClusterQueueImpl) Pending() int {
+	return c.PendingActive() + c.PendingInadmissible()
+}
+
+func (c *ClusterQueueImpl) PendingActive() int {
+	return c.heap.Len()
+}
+
+func (c *ClusterQueueImpl) PendingInadmissible() int {
+	return len(c.inadmissibleWorkloads)
 }
 
 func (c *ClusterQueueImpl) Pop() *workload.Info {

--- a/pkg/queue/cluster_queue_impl_test.go
+++ b/pkg/queue/cluster_queue_impl_test.go
@@ -169,7 +169,7 @@ func Test_DeleteFromQueue(t *testing.T) {
 	}
 
 	wantPending := len(admissibleworkloads) + len(inadmissibleWorkloads)
-	if pending := cq.Pending(); pending != int32(wantPending) {
+	if pending := cq.Pending(); pending != wantPending {
 		t.Errorf("clusterQueue's workload number not right, want %v, got %v", wantPending, pending)
 	}
 	if len(cq.inadmissibleWorkloads) != len(inadmissibleWorkloads) {
@@ -226,7 +226,7 @@ func TestClusterQueueImpl(t *testing.T) {
 		workloadsToDelete                 []*kueue.Workload
 		queueInadmissibleWorkloads        bool
 		wantActiveWorkloads               sets.String
-		wantPending                       int32
+		wantPending                       int
 		wantInadmissibleWorkloadsRequeued bool
 	}{
 		"add, update, delete workload": {

--- a/pkg/queue/cluster_queue_interface.go
+++ b/pkg/queue/cluster_queue_interface.go
@@ -75,8 +75,17 @@ type ClusterQueue interface {
 	// returns true. Otherwise returns false.
 	QueueInadmissibleWorkloads(ctx context.Context, client client.Client) bool
 
-	// Pending returns the number of pending workloads.
-	Pending() int32
+	// Pending returns the total number of pending workloads.
+	Pending() int
+
+	// PendingActive returns the number of active pending workloads,
+	// workloads that are in the admission queue.
+	PendingActive() int
+	// PendingInadmissible returns the number of inadmissible pending workloads,
+	// workloads that were already tried and are waiting for cluster conditions
+	// to change to potentially become admissible.
+	PendingInadmissible() int
+
 	// Dump produces a dump of the current workloads in the heap of
 	// this ClusterQueue. It returns false if the queue is empty.
 	// Otherwise returns true.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -132,7 +132,7 @@ func (s *Scheduler) schedule(ctx context.Context) {
 	}
 
 	// 6. Requeue the heads that were not scheduled.
-	result := metrics.InadmissibleAdmissionResult
+	result := metrics.AdmissionResultInadmissible
 	for _, e := range entries {
 		log.V(3).Info("Workload evaluated for admission",
 			"workload", klog.KObj(e.Obj),
@@ -142,7 +142,7 @@ func (s *Scheduler) schedule(ctx context.Context) {
 		if e.status != assumed {
 			s.requeueAndUpdate(log, ctx, e)
 		} else {
-			result = metrics.SuccessAdmissionResult
+			result = metrics.AdmissionResultSuccess
 		}
 	}
 	metrics.AdmissionAttempt(result, time.Since(startTime))

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -120,7 +120,8 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 				PendingWorkloads: 5,
 				UsedResources:    emptyUsedResources,
 			}))
-			framework.ExpectPendingWorkloadsMetric(clusterQueue, 5)
+			// Workloads are inadmissible because ResourceFlavors don't exist in this test suite.
+			framework.ExpectPendingWorkloadsMetric(clusterQueue, 0, 5)
 			framework.ExpectAdmittedActiveWorkloadsMetric(clusterQueue, 0)
 
 			ginkgo.By("Admitting workloads")
@@ -172,7 +173,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 					},
 				},
 			}))
-			framework.ExpectPendingWorkloadsMetric(clusterQueue, 1)
+			framework.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
 			framework.ExpectAdmittedActiveWorkloadsMetric(clusterQueue, 4)
 
 			ginkgo.By("Finishing workloads")
@@ -194,7 +195,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 			}, framework.Timeout, framework.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
 				UsedResources: emptyUsedResources,
 			}))
-			framework.ExpectPendingWorkloadsMetric(clusterQueue, 0)
+			framework.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(clusterQueue, 0)
 		})
 	})

--- a/test/integration/controller/job/job_controller_test.go
+++ b/test/integration/controller/job/job_controller_test.go
@@ -368,7 +368,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", func() {
 			return createdProdJob1.Spec.Suspend
 		}, framework.Timeout, framework.Interval).Should(gomega.Equal(pointer.Bool(false)))
 		gomega.Expect(createdProdJob1.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
-		framework.ExpectPendingWorkloadsMetric(prodClusterQ, 0)
+		framework.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
 		framework.ExpectAdmittedActiveWorkloadsMetric(prodClusterQ, 1)
 
 		ginkgo.By("checking a second no-fit prod job does not start")
@@ -380,7 +380,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", func() {
 			gomega.Expect(k8sClient.Get(ctx, lookupKey2, createdProdJob2)).Should(gomega.Succeed())
 			return createdProdJob2.Spec.Suspend
 		}, framework.ConsistentDuration, framework.Interval).Should(gomega.Equal(pointer.Bool(true)))
-		framework.ExpectPendingWorkloadsMetric(prodClusterQ, 1)
+		framework.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 1)
 		framework.ExpectAdmittedActiveWorkloadsMetric(prodClusterQ, 1)
 
 		ginkgo.By("checking a dev job starts")
@@ -393,7 +393,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", func() {
 			return createdDevJob.Spec.Suspend
 		}, framework.Timeout, framework.Interval).Should(gomega.Equal(pointer.Bool(false)))
 		gomega.Expect(createdDevJob.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
-		framework.ExpectPendingWorkloadsMetric(devClusterQ, 0)
+		framework.ExpectPendingWorkloadsMetric(devClusterQ, 0, 0)
 		framework.ExpectAdmittedActiveWorkloadsMetric(devClusterQ, 1)
 
 		ginkgo.By("checking the second prod job starts when the first finishes")
@@ -410,7 +410,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", func() {
 			return createdProdJob2.Spec.Suspend
 		}, framework.Timeout, framework.Interval).Should(gomega.Equal(pointer.Bool(false)))
 		gomega.Expect(createdProdJob2.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
-		framework.ExpectPendingWorkloadsMetric(prodClusterQ, 0)
+		framework.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
 		framework.ExpectAdmittedActiveWorkloadsMetric(prodClusterQ, 1)
 	})
 })

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -125,7 +125,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			gomega.Expect(k8sClient.Create(ctx, prodWl1)).Should(gomega.Succeed())
 			onDemandFlavorAdmission := testing.MakeAdmission(prodClusterQ.Name).Flavor(corev1.ResourceCPU, onDemandFlavor.Name).Obj()
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, prodWl1, onDemandFlavorAdmission)
-			framework.ExpectPendingWorkloadsMetric(prodClusterQ, 0)
+			framework.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(prodClusterQ, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 1)
 
@@ -133,13 +133,14 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			prodWl2 := testing.MakeWorkload("prod-wl2", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "5").Obj()
 			gomega.Expect(k8sClient.Create(ctx, prodWl2)).Should(gomega.Succeed())
 			framework.ExpectWorkloadsToBePending(ctx, k8sClient, prodWl2)
-			framework.ExpectPendingWorkloadsMetric(prodClusterQ, 1)
+			framework.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 1)
 
 			ginkgo.By("checking a dev workload gets admitted")
 			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(devQueue.Name).Request(corev1.ResourceCPU, "5").Obj()
 			gomega.Expect(k8sClient.Create(ctx, devWl)).Should(gomega.Succeed())
 			spotUntaintedFlavorAdmission := testing.MakeAdmission(devClusterQ.Name).Flavor(corev1.ResourceCPU, spotUntaintedFlavor.Name).Obj()
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, devWl, spotUntaintedFlavorAdmission)
+			framework.ExpectPendingWorkloadsMetric(devClusterQ, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(devClusterQ, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(devClusterQ, 1)
 
@@ -154,7 +155,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				})
 			gomega.Expect(k8sClient.Status().Update(ctx, prodWl1)).Should(gomega.Succeed())
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, prodWl2, onDemandFlavorAdmission)
-			framework.ExpectPendingWorkloadsMetric(prodClusterQ, 0)
+			framework.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(prodClusterQ, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 2)
 		})
@@ -169,7 +170,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wlHighPriority := testing.MakeWorkload("wl-high-priority", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "5").Priority(&highPriorityVal).Obj()
 			gomega.Expect(k8sClient.Create(ctx, wlHighPriority)).Should(gomega.Succeed())
 
-			framework.ExpectPendingWorkloadsMetric(prodClusterQ, 0)
+			framework.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(prodClusterQ, 0)
 			// delay creating the queue until after workloads are created.
 			gomega.Expect(k8sClient.Create(ctx, queue)).Should(gomega.Succeed())
@@ -180,7 +181,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("checking the workload with high priority gets admitted")
 			framework.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, prodClusterQ.Name, wlHighPriority)
 
-			framework.ExpectPendingWorkloadsMetric(prodClusterQ, 1)
+			framework.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 1)
 			framework.ExpectAdmittedActiveWorkloadsMetric(prodClusterQ, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 1)
 		})
@@ -221,7 +222,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
 			expectAdmission := testing.MakeAdmission(cq.Name).Flavor(corev1.ResourceCPU, onDemandFlavor.Name).Obj()
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectAdmission)
-			framework.ExpectPendingWorkloadsMetric(cq, 0)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 
@@ -229,7 +230,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wl2 := testing.MakeWorkload("on-demand-wl2", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "4").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
 			framework.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
-			framework.ExpectPendingWorkloadsMetric(cq, 1)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 1)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 
@@ -237,14 +238,14 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wl3 := testing.MakeWorkload("on-demand-wl3", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "1").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl3)).Should(gomega.Succeed())
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3, expectAdmission)
-			framework.ExpectPendingWorkloadsMetric(cq, 1)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 1)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 2)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 2)
 
 			ginkgo.By("Second big workload starts after the first one is deleted")
 			gomega.Expect(k8sClient.Delete(ctx, wl1, client.PropagationPolicy(metav1.DeletePropagationBackground))).Should(gomega.Succeed())
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, expectAdmission)
-			framework.ExpectPendingWorkloadsMetric(cq, 0)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 2)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 3)
 		})
@@ -269,7 +270,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
 			expectAdmission := testing.MakeAdmission(fooCQ.Name).Flavor(corev1.ResourceCPU, onDemandFlavor.Name).Obj()
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectAdmission)
-			framework.ExpectPendingWorkloadsMetric(fooCQ, 0)
+			framework.ExpectPendingWorkloadsMetric(fooCQ, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(fooCQ, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(fooCQ, 1)
 
@@ -277,7 +278,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wl2 := testing.MakeWorkload("on-demand-wl2", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "8").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
 			framework.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
-			framework.ExpectPendingWorkloadsMetric(cq, 1)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 1)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 0)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 0)
 
@@ -286,7 +287,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			gomega.Expect(k8sClient.Create(ctx, wl3)).Should(gomega.Succeed())
 			expectAdmission = testing.MakeAdmission(fooCQ.Name).Flavor(corev1.ResourceCPU, onDemandFlavor.Name).Obj()
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3, expectAdmission)
-			framework.ExpectPendingWorkloadsMetric(fooCQ, 0)
+			framework.ExpectPendingWorkloadsMetric(fooCQ, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(fooCQ, 2)
 			framework.ExpectAdmittedWorkloadsTotalMetric(fooCQ, 2)
 
@@ -294,7 +295,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			gomega.Expect(k8sClient.Delete(ctx, wl1, client.PropagationPolicy(metav1.DeletePropagationBackground))).Should(gomega.Succeed())
 			expectAdmission = testing.MakeAdmission(cq.Name).Flavor(corev1.ResourceCPU, onDemandFlavor.Name).Obj()
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, expectAdmission)
-			framework.ExpectPendingWorkloadsMetric(cq, 0)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 		})
@@ -328,7 +329,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wl := testing.MakeWorkload("on-demand-wl", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "6").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
 			framework.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
-			framework.ExpectPendingWorkloadsMetric(cq, 1)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 1)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 0)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 0)
 
@@ -342,7 +343,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			expectAdmission := testing.MakeAdmission(cq.Name).Flavor(corev1.ResourceCPU, onDemandFlavor.Name).Obj()
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
-			framework.ExpectPendingWorkloadsMetric(cq, 0)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 		})
@@ -399,7 +400,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wl2 := testing.MakeWorkload("wl2", nsFoo.Name).Queue(queueFoo.Name).Request(corev1.ResourceCPU, "1").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
 			framework.ExpectWorkloadsToBePending(ctx, k8sClient, wl1, wl2)
-			framework.ExpectPendingWorkloadsMetric(cq, 2)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 2)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 0)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 0)
 
@@ -409,7 +410,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			framework.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, cq.Name, wl1)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
-			framework.ExpectPendingWorkloadsMetric(cq, 1)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 1)
 		})
 	})
 
@@ -441,7 +442,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wl := testing.MakeWorkload("workload", ns.Name).Queue(fooQ.Name).Request(corev1.ResourceCPU, "1").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
 			framework.ExpectWorkloadsToBeFrozen(ctx, k8sClient, fooCQ.Name, wl)
-			framework.ExpectPendingWorkloadsMetric(fooCQ, 1)
+			framework.ExpectPendingWorkloadsMetric(fooCQ, 0, 1)
 			framework.ExpectAdmittedActiveWorkloadsMetric(fooCQ, 0)
 			framework.ExpectAdmittedWorkloadsTotalMetric(fooCQ, 0)
 
@@ -452,7 +453,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				gomega.Expect(framework.DeleteResourceFlavor(ctx, k8sClient, fooFlavor)).To(gomega.Succeed())
 			}()
 			framework.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, fooCQ.Name, wl)
-			framework.ExpectPendingWorkloadsMetric(fooCQ, 0)
+			framework.ExpectPendingWorkloadsMetric(fooCQ, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(fooCQ, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(fooCQ, 1)
 		})
@@ -495,7 +496,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			expectAdmission := testing.MakeAdmission(cq.Name).Flavor(corev1.ResourceCPU, onDemandFlavor.Name).Obj()
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectAdmission)
-			framework.ExpectPendingWorkloadsMetric(cq, 0)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 
@@ -503,7 +504,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wl2 := testing.MakeWorkload("on-demand-wl2", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "5").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
 			framework.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
-			framework.ExpectPendingWorkloadsMetric(cq, 1)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 1)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 
@@ -513,7 +514,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			expectAdmission = testing.MakeAdmission(cq.Name).Flavor(corev1.ResourceCPU, spotTaintedFlavor.Name).Obj()
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3, expectAdmission)
-			framework.ExpectPendingWorkloadsMetric(cq, 1)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 1)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 2)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 2)
 		})
@@ -556,7 +557,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectAdmission)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
-			framework.ExpectPendingWorkloadsMetric(cq, 0)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 0)
 
 			ginkgo.By("checking a second workload with affinity to on-demand gets admitted")
 			wl2 := testing.MakeWorkload("affinity-wl", ns.Name).Queue(queue.Name).
@@ -566,7 +567,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			gomega.Expect(len(wl2.Spec.PodSets[0].Spec.NodeSelector)).Should(gomega.Equal(2))
 			expectAdmission = testing.MakeAdmission(cq.Name).Flavor(corev1.ResourceCPU, onDemandFlavor.Name).Obj()
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, expectAdmission)
-			framework.ExpectPendingWorkloadsMetric(cq, 0)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 2)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 2)
 		})
@@ -609,7 +610,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				Request(corev1.ResourceCPU, "10").Toleration(spotToleration).Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
 			framework.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
-			framework.ExpectPendingWorkloadsMetric(prodBEClusterQ, 1)
+			framework.ExpectPendingWorkloadsMetric(prodBEClusterQ, 0, 1)
 			framework.ExpectAdmittedActiveWorkloadsMetric(prodBEClusterQ, 0)
 			framework.ExpectAdmittedWorkloadsTotalMetric(prodBEClusterQ, 0)
 
@@ -628,7 +629,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			expectAdmission := testing.MakeAdmission(prodBEClusterQ.Name).Flavor(corev1.ResourceCPU, onDemandFlavor.Name).Obj()
 			framework.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
-			framework.ExpectPendingWorkloadsMetric(prodBEClusterQ, 0)
+			framework.ExpectPendingWorkloadsMetric(prodBEClusterQ, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(prodBEClusterQ, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(prodBEClusterQ, 1)
 		})
@@ -662,8 +663,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
 			gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
 			framework.ExpectWorkloadsToBePending(ctx, k8sClient, wl1, wl2)
-			framework.ExpectPendingWorkloadsMetric(prodBEClusterQ, 1)
-			framework.ExpectPendingWorkloadsMetric(devBEClusterQ, 1)
+			framework.ExpectPendingWorkloadsMetric(prodBEClusterQ, 0, 1)
+			framework.ExpectPendingWorkloadsMetric(devBEClusterQ, 0, 1)
 			framework.ExpectAdmittedActiveWorkloadsMetric(prodBEClusterQ, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(devBEClusterQ, 0)
 			framework.ExpectAdmittedWorkloadsTotalMetric(prodBEClusterQ, 0)
@@ -685,8 +686,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			framework.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, prodBEClusterQ.Name, wl1)
 			framework.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, devBEClusterQ.Name, wl2)
-			framework.ExpectPendingWorkloadsMetric(prodBEClusterQ, 0)
-			framework.ExpectPendingWorkloadsMetric(devBEClusterQ, 0)
+			framework.ExpectPendingWorkloadsMetric(prodBEClusterQ, 0, 0)
+			framework.ExpectPendingWorkloadsMetric(devBEClusterQ, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(prodBEClusterQ, 1)
 			framework.ExpectAdmittedActiveWorkloadsMetric(devBEClusterQ, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(prodBEClusterQ, 1)
@@ -725,7 +726,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			gomega.Expect(k8sClient.Create(ctx, bigWl)).Should(gomega.Succeed())
 
 			framework.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, cq.Name, bigWl)
-			framework.ExpectPendingWorkloadsMetric(cq, 0)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 
@@ -736,7 +737,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			gomega.Expect(k8sClient.Create(ctx, smallWl2)).Should(gomega.Succeed())
 
 			framework.ExpectWorkloadsToBePending(ctx, k8sClient, smallWl1, smallWl2)
-			framework.ExpectPendingWorkloadsMetric(cq, 2)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 2)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 1)
 
 			ginkgo.By("Marking the big workload as finished")
@@ -748,7 +749,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			})
 
 			framework.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, cq.Name, smallWl1, smallWl2)
-			framework.ExpectPendingWorkloadsMetric(cq, 0)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 2)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 3)
 		})
@@ -819,7 +820,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				gomega.Expect(k8sClient.Get(ctx, lookupKey, wl3)).Should(gomega.Succeed())
 				return wl3.Spec.Admission == nil
 			}, framework.ConsistentDuration, framework.Interval).Should(gomega.Equal(true))
-			framework.ExpectPendingWorkloadsMetric(strictFIFOClusterQ, 2)
+			framework.ExpectPendingWorkloadsMetric(strictFIFOClusterQ, 2, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(strictFIFOClusterQ, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(strictFIFOClusterQ, 1)
 		})
@@ -845,7 +846,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			framework.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, strictFIFOClusterQ.Name, wl1, wl3)
 			framework.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
-			framework.ExpectPendingWorkloadsMetric(strictFIFOClusterQ, 1)
+			framework.ExpectPendingWorkloadsMetric(strictFIFOClusterQ, 0, 1)
 		})
 	})
 
@@ -894,7 +895,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			framework.ExpectWorkloadsToBeFrozen(ctx, k8sClient, cq.Name, wl2)
 			framework.ExpectAdmittedActiveWorkloadsMetric(cq, 1)
 			framework.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
-			framework.ExpectPendingWorkloadsMetric(cq, 1)
+			framework.ExpectPendingWorkloadsMetric(cq, 0, 1)
 		})
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a label for the status of workloads in a ClusterQueue. This is useful for administrators to tell if a ClusterQueue has too many inadmissible workloads, which could be an indication of misconfiguration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #324

#### Special notes for your reviewer:

