### PR TITLE
Use server-side-apply for admission

### DIFF
--- a/apis/kueue/v1alpha1/workload_types.go
+++ b/apis/kueue/v1alpha1/workload_types.go
@@ -34,7 +34,7 @@ type WorkloadSpec struct {
 
 	// queueName is the name of the queue the Workload is associated with.
 	// queueName cannot be changed once set.
-	QueueName string `json:"queueName"`
+	QueueName string `json:"queueName,omitempty"`
 
 	// admission holds the parameters of the admission of the workload by a ClusterQueue.
 	// admission cannot be changed once set.

--- a/config/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -7437,8 +7437,6 @@ spec:
                 description: queueName is the name of the queue the Workload is associated
                   with. queueName cannot be changed once set.
                 type: string
-            required:
-            - queueName
             type: object
           status:
             description: WorkloadStatus defines the observed state of Workload

--- a/main.go
+++ b/main.go
@@ -193,7 +193,7 @@ func setupScheduler(ctx context.Context, mgr ctrl.Manager, cCache *cache.Cache, 
 		queues,
 		cCache,
 		mgr.GetClient(),
-		mgr.GetEventRecorderFor(constants.ManagerName),
+		mgr.GetEventRecorderFor(constants.AdmissionName),
 	)
 	go sched.Start(ctx)
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -25,8 +25,8 @@ const (
 	QueueAnnotation = "kueue.x-k8s.io/queue-name"
 
 	KueueName         = "kueue"
-	ManagerName       = KueueName + "-manager"
 	JobControllerName = KueueName + "-job-controller"
+	AdmissionName     = KueueName + "-admission"
 
 	// UpdatesBatchPeriod is the batch period to hold workload updates
 	// before syncing a Queue and ClusterQueue objects.

--- a/test/integration/controller/job/suite_test.go
+++ b/test/integration/controller/job/suite_test.go
@@ -76,7 +76,7 @@ func managerAndSchedulerSetup(opts ...job.Option) framework.ManagerSetup {
 			mgr.GetEventRecorderFor(constants.JobControllerName), opts...).SetupWithManager(mgr)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.ManagerName))
+		sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName))
 		go func() {
 			sched.Start(ctx)
 		}()

--- a/test/integration/scheduler/suite_test.go
+++ b/test/integration/scheduler/suite_test.go
@@ -85,7 +85,7 @@ func managerAndSchedulerSetup(mgr manager.Manager, ctx context.Context) {
 	err = workloadjob.SetupIndexes(mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.ManagerName))
+	sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName))
 	go func() {
 		sched.Start(ctx)
 	}()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This would reduce the chances of conflict updating a Workload, because a controller might have updated the workload's status.

There would still be conflicts in the case of Spec updates. This is achieved setting the .metadata.generation field.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #164

#### Special notes for your reviewer:

