### PR TITLE
Validate queueName is immutable when the workload is admitted

### DIFF
--- a/test/integration/controller/core/workload_controller_test.go
+++ b/test/integration/controller/core/workload_controller_test.go
@@ -88,8 +88,8 @@ var _ = ginkgo.Describe("Workload controller", func() {
 			gomega.Expect(framework.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		})
 		ginkgo.It("Should update status when workloads are created", func() {
-			wl = testing.MakeWorkload("two", ns.Name).Queue("nonCreatedQueue").Request(corev1.ResourceCPU, "1").Obj()
-			message = fmt.Sprintf("Queue %s doesn't exist", "nonCreatedQueue")
+			wl = testing.MakeWorkload("two", ns.Name).Queue("non-created-queue").Request(corev1.ResourceCPU, "1").Obj()
+			message = fmt.Sprintf("Queue %s doesn't exist", "non-created-queue")
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 			gomega.Eventually(func() int {
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedQueueWorkload)).To(gomega.Succeed())

--- a/test/integration/webhook/v1alpha1/workload_test.go
+++ b/test/integration/webhook/v1alpha1/workload_test.go
@@ -126,9 +126,12 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 			gomega.Expect(errors.IsForbidden(err)).Should(gomega.BeTrue(), "error: %v", err)
 		})
 
-		ginkgo.It("Should forbid the change of spec.queueName", func() {
+		ginkgo.It("Should forbid the change of spec.queueName of an admitted workload", func() {
 			ginkgo.By("Creating a new Workload")
-			workload := testing.MakeWorkload(workloadName, ns.Name).Queue("queue1").Obj()
+			workload := testing.MakeWorkload(workloadName, ns.Name).
+				Queue("queue1").
+				Admit(testing.MakeAdmission("cq").Obj()).
+				Obj()
 			gomega.Expect(k8sClient.Create(ctx, workload)).Should(gomega.Succeed())
 
 			ginkgo.By("Updating queueName")


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

queueName should only be immutable if the workload is admitted. Before admission (or after preemption) the user should be able to point to a different queue.

Also:
- validate that queueName is a valid reference name.
- validate that admission can be unset

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

