### PR TITLE
Set user agent with semantic version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,1 @@
-# More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore build and test binaries.
-bin/
-testbin/
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,14 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY main.go main.go
-COPY apis/ apis/
-COPY pkg/ pkg/
+COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN make build GO_BUILD_ENV='CGO_ENABLED=0 GOOS=linux GOARCH=amd64'
 
 FROM ${BASE_IMAGE}
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/bin/manager .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,12 @@ GO_TEST_FLAGS ?= -race
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+version_pkg = sigs.k8s.io/kueue/pkg/version
+LD_FLAGS += -X '$(version_pkg).GitVersion=$(GIT_TAG)'
+LD_FLAGS += -X '$(version_pkg).GitCommit=$(shell git rev-parse HEAD)'
+
 .PHONY: all
-all: build
+all: generate fmt vet build
 
 ##@ General
 
@@ -128,8 +132,8 @@ verify: gomod-verify vet ci-lint fmt-verify manifests generate
 ##@ Build
 
 .PHONY: build
-build: generate fmt vet ## Build manager binary.
-	$(GO_CMD) build -o bin/manager main.go
+build:
+	$(GO_BUILD_ENV) $(GO_CMD) build -ldflags="$(LD_FLAGS)" -o bin/manager main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -24,8 +24,9 @@ const (
 	// TODO(#23): Use the kubernetes.io domain when graduating APIs to beta.
 	QueueAnnotation = "kueue.x-k8s.io/queue-name"
 
-	ManagerName       = "kueue-manager"
-	JobControllerName = "kueue-job-controller"
+	KueueName         = "kueue"
+	ManagerName       = KueueName + "-manager"
+	JobControllerName = KueueName + "-job-controller"
 
 	// UpdatesBatchPeriod is the batch period to hold workload updates
 	// before syncing a Queue and ClusterQueue objects.

--- a/pkg/util/useragent/useragent.go
+++ b/pkg/util/useragent/useragent.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package useragent
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/version"
+)
+
+// adjustVersion strips "alpha", "beta", etc. from version in form
+// major.minor.patch-[alpha|beta|etc].
+func adjustVersion(v string) string {
+	if len(v) == 0 {
+		return "unknown"
+	}
+	seg := strings.SplitN(v, "-", 2)
+	return seg[0]
+}
+
+// adjustCommit returns sufficient significant figures of the commit's git hash.
+func adjustCommit(c string) string {
+	if len(c) == 0 {
+		return "unknown"
+	}
+	if len(c) > 7 {
+		return c[:7]
+	}
+	return c
+}
+
+// Default returns User-Agent string built from static global vars.
+func Default() string {
+	return fmt.Sprintf("%s/%s (%s/%s) %s",
+		constants.KueueName,
+		adjustVersion(version.GitVersion),
+		runtime.GOOS,
+		runtime.GOARCH,
+		adjustCommit(version.GitCommit))
+}

--- a/pkg/util/useragent/useragent_test.go
+++ b/pkg/util/useragent/useragent_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package useragent
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+func TestDefault(t *testing.T) {
+	want := fmt.Sprintf("kueue/v0.0.0 (%s/%s) abcd012", runtime.GOOS, runtime.GOARCH)
+	ua := Default()
+	if ua != want {
+		t.Errorf("Default()=%q, want %q", ua, want)
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// Base version information.
+//
+// This is the fallback data used when version information from git is not
+// provided via go ldflags.
+//
+// If you are looking at these fields in the git tree, they look
+// strange. They are modified on the fly by the build process.
+var (
+	GitVersion string = "v0.0.0-main"
+	GitCommit  string = "abcd01234" // sha1 from git, output of $(git rev-parse HEAD)
+)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Set user agent, which is used in apiserver logs:

```
"HTTP" verb="LIST" URI="/apis/kueue.x-k8s.io/v1alpha1/queues?limit=500&resourceVersion=0" latency="660.871µs" userAgent="kueue/0.2.0 (linux/amd64) 1f19339" audit-ID="dccde1a6-cb8b-467f-a4cb-7c2f56838aea
```

The first part of the user agent (`kueue`) would also be used as the field manager in the API objects created by kueue.

Also log the full version and commit:

```
{"level":"info","ts":"2022-08-17T18:58:01.271033131Z","logger":"setup","caller":"logr@v1.2.3/logr.go:261","msg":"Initializing","gitVersion":"0.2.0-devel-151-g1f19339-dirty","gitCommit":"1f1933977eaf9d2fa671dbeb6791df657e23a27f"}
```

#### Which issue(s) this PR fixes:

Fixes #336 

#### Special notes for your reviewer:

