### PR TITLE
Add cluster_queue_status metric

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -85,19 +85,10 @@ func newCohort(name string, size int) *Cohort {
 	}
 }
 
-type ClusterQueueStatus int
-
 const (
-	// Pending means the ClusterQueue is accepted but not yet active,
-	// this can be because of a missing ResourceFlavor referenced by the ClusterQueue.
-	// In this state, the ClusterQueue can't admit new workloads and its quota can't be borrowed
-	// by other active ClusterQueues in the cohort.
-	Pending ClusterQueueStatus = iota
-	// Active means the ClusterQueue can admit new workloads and its quota
-	// can be borrowed by other ClusterQueues in the cohort.
-	Active
-	// Terminating means the clusterQueue is in pending deletion.
-	Terminating
+	pending     = metrics.CQStatusPending
+	active      = metrics.CQStatusActive
+	terminating = metrics.CQStatusTerminating
 )
 
 // ClusterQueue is the internal implementation of kueue.ClusterQueue that
@@ -113,7 +104,7 @@ type ClusterQueue struct {
 	// Those keys define the affinity terms of a workload
 	// that can be matched against the flavors.
 	LabelKeys map[corev1.ResourceName]sets.String
-	Status    ClusterQueueStatus
+	Status    metrics.ClusterQueueStatus
 
 	// The following fields are not populated in a snapshot.
 
@@ -158,7 +149,7 @@ func (c *Cache) newClusterQueue(cq *kueue.ClusterQueue) (*ClusterQueue, error) {
 }
 
 func (c *ClusterQueue) Active() bool {
-	return c.Status == Active
+	return c.Status == active
 }
 
 func (c *ClusterQueue) update(in *kueue.ClusterQueue, resourceFlavors map[string]*kueue.ResourceFlavor) error {
@@ -211,14 +202,15 @@ func (c *ClusterQueue) UpdateCodependentResources() {
 // UpdateWithFlavors updates a ClusterQueue based on the passed ResourceFlavors set.
 // Exported only for testing.
 func (c *ClusterQueue) UpdateWithFlavors(flavors map[string]*kueue.ResourceFlavor) {
-	status := Active
+	status := active
 	if flavorNotFound := c.updateLabelKeys(flavors); flavorNotFound {
-		status = Pending
+		status = pending
 	}
 
-	if c.Status != Terminating {
+	if c.Status != terminating {
 		c.Status = status
 	}
+	metrics.ReportClusterQueueStatus(c.Name, c.Status)
 }
 
 func (c *ClusterQueue) updateLabelKeys(flavors map[string]*kueue.ResourceFlavor) bool {
@@ -336,7 +328,7 @@ func (c *Cache) updateClusterQueues() sets.String {
 		// which flavors.
 		cq.UpdateWithFlavors(c.resourceFlavors)
 		curStatus := cq.Status
-		if prevStatus == Pending && curStatus == Active {
+		if prevStatus == pending && curStatus == active {
 			cqs.Insert(cq.Name)
 		}
 	}
@@ -358,14 +350,14 @@ func (c *Cache) DeleteResourceFlavor(rf *kueue.ResourceFlavor) sets.String {
 }
 
 func (c *Cache) ClusterQueueActive(name string) bool {
-	return c.clusterQueueInStatus(name, Active)
+	return c.clusterQueueInStatus(name, active)
 }
 
 func (c *Cache) ClusterQueueTerminating(name string) bool {
-	return c.clusterQueueInStatus(name, Terminating)
+	return c.clusterQueueInStatus(name, terminating)
 }
 
-func (c *Cache) clusterQueueInStatus(name string, status ClusterQueueStatus) bool {
+func (c *Cache) clusterQueueInStatus(name string, status metrics.ClusterQueueStatus) bool {
 	c.RLock()
 	defer c.RUnlock()
 
@@ -380,7 +372,8 @@ func (c *Cache) TerminateClusterQueue(name string) {
 	c.Lock()
 	defer c.Unlock()
 	if cq, exists := c.clusterQueues[name]; exists {
-		cq.Status = Terminating
+		cq.Status = terminating
+		metrics.ReportClusterQueueStatus(cq.Name, cq.Status)
 	}
 }
 
@@ -474,7 +467,7 @@ func (c *Cache) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 	}
 	c.deleteClusterQueueFromCohort(cqImpl)
 	delete(c.clusterQueues, cq.Name)
-	metrics.AdmittedActiveWorkloads.DeleteLabelValues(cq.Name)
+	metrics.ClearCacheMetrics(cq.Name)
 }
 
 func (c *Cache) AddQueue(q *kueue.Queue) error {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/pointer"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -137,7 +138,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector: labels.Nothing(),
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
 					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
-					Status:            Active,
+					Status:            active,
 				},
 				"b": {
 					Name: "b",
@@ -147,21 +148,21 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector: labels.Nothing(),
 					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
-					Status:            Active,
+					Status:            active,
 				},
 				"c": {
 					Name:                 "c",
 					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
 					UsedResources:        ResourceQuantities{},
-					Status:               Active,
+					Status:               active,
 				},
 				"d": {
 					Name:                 "d",
 					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
 					UsedResources:        ResourceQuantities{},
-					Status:               Active,
+					Status:               active,
 				},
 				"e": {
 					Name: "e",
@@ -171,7 +172,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector: labels.Nothing(),
 					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"nonexistent-flavor": 0}},
 					LabelKeys:         nil,
-					Status:            Pending,
+					Status:            pending,
 				},
 			},
 			wantCohorts: map[string]sets.String{
@@ -201,7 +202,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector: labels.Nothing(),
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
 					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
-					Status:            Active,
+					Status:            active,
 				},
 				"b": {
 					Name: "b",
@@ -211,21 +212,21 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector: labels.Nothing(),
 					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
-					Status:            Active,
+					Status:            active,
 				},
 				"c": {
 					Name:                 "c",
 					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
 					UsedResources:        ResourceQuantities{},
-					Status:               Active,
+					Status:               active,
 				},
 				"d": {
 					Name:                 "d",
 					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
 					UsedResources:        ResourceQuantities{},
-					Status:               Active,
+					Status:               active,
 				},
 				"e": {
 					Name: "e",
@@ -235,7 +236,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector: labels.Nothing(),
 					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"nonexistent-flavor": 0}},
 					LabelKeys:         nil,
-					Status:            Pending,
+					Status:            pending,
 				},
 			},
 			wantCohorts: map[string]sets.String{
@@ -314,28 +315,28 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector: labels.Nothing(),
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType", "region")},
 					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
-					Status:            Active,
+					Status:            active,
 				},
 				"b": {
 					Name:                 "b",
 					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Everything(),
 					UsedResources:        ResourceQuantities{},
-					Status:               Active,
+					Status:               active,
 				},
 				"c": {
 					Name:                 "c",
 					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
 					UsedResources:        ResourceQuantities{},
-					Status:               Active,
+					Status:               active,
 				},
 				"d": {
 					Name:                 "d",
 					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
 					UsedResources:        ResourceQuantities{},
-					Status:               Active,
+					Status:               active,
 				},
 				"e": {
 					Name: "e",
@@ -345,7 +346,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector: labels.Nothing(),
 					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType", "region")},
-					Status:            Active,
+					Status:            active,
 				},
 			},
 			wantCohorts: map[string]sets.String{
@@ -374,14 +375,14 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector: labels.Nothing(),
 					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
-					Status:            Active,
+					Status:            active,
 				},
 				"c": {
 					Name:                 "c",
 					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
 					UsedResources:        ResourceQuantities{},
-					Status:               Active,
+					Status:               active,
 				},
 				"e": {
 					Name: "e",
@@ -391,7 +392,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector: labels.Nothing(),
 					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"nonexistent-flavor": 0}},
 					LabelKeys:         nil,
-					Status:            Pending,
+					Status:            pending,
 				},
 			},
 			wantCohorts: map[string]sets.String{
@@ -416,7 +417,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector: labels.Nothing(),
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
 					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
-					Status:            Active,
+					Status:            active,
 				},
 				"b": {
 					Name: "b",
@@ -426,21 +427,21 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector: labels.Nothing(),
 					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"default": 0}},
 					LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: sets.NewString("cpuType")},
-					Status:            Active,
+					Status:            active,
 				},
 				"c": {
 					Name:                 "c",
 					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
 					UsedResources:        ResourceQuantities{},
-					Status:               Active,
+					Status:               active,
 				},
 				"d": {
 					Name:                 "d",
 					RequestableResources: map[corev1.ResourceName]*Resource{},
 					NamespaceSelector:    labels.Nothing(),
 					UsedResources:        ResourceQuantities{},
-					Status:               Active,
+					Status:               active,
 				},
 				"e": {
 					Name: "e",
@@ -450,7 +451,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector: labels.Nothing(),
 					UsedResources:     ResourceQuantities{corev1.ResourceCPU: {"nonexistent-flavor": 0}},
 					LabelKeys:         nil,
-					Status:            Active,
+					Status:            active,
 				},
 			},
 			wantCohorts: map[string]sets.String{
@@ -536,6 +537,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							"gamma": 0,
 						},
 					},
+					Status: pending,
 				},
 			},
 		},
@@ -1559,50 +1561,50 @@ func TestClusterQueueUpdateWithFlavors(t *testing.T) {
 
 	testcases := []struct {
 		name         string
-		curStatus    ClusterQueueStatus
+		curStatus    metrics.ClusterQueueStatus
 		clusterQueue *kueue.ClusterQueue
 		flavors      map[string]*kueue.ResourceFlavor
-		wantStatus   ClusterQueueStatus
+		wantStatus   metrics.ClusterQueueStatus
 	}{
 		{
 			name:      "Pending clusterQueue updated existent flavors",
-			curStatus: Pending,
+			curStatus: pending,
 			clusterQueue: utiltesting.MakeClusterQueue("cq").
 				Resource(utiltesting.MakeResource("cpu").Flavor(flavor).Obj()).
 				Obj(),
 			flavors: map[string]*kueue.ResourceFlavor{
 				rf.Name: rf,
 			},
-			wantStatus: Active,
+			wantStatus: active,
 		},
 		{
 			name:      "Active clusterQueue updated with not found flavors",
-			curStatus: Active,
+			curStatus: active,
 			clusterQueue: utiltesting.MakeClusterQueue("cq").
 				Resource(utiltesting.MakeResource("cpu").Flavor(flavor).Obj()).
 				Obj(),
 			flavors:    map[string]*kueue.ResourceFlavor{},
-			wantStatus: Pending,
+			wantStatus: pending,
 		},
 		{
 			name:      "Terminating clusterQueue updated with existent flavors",
-			curStatus: Terminating,
+			curStatus: terminating,
 			clusterQueue: utiltesting.MakeClusterQueue("cq").
 				Resource(utiltesting.MakeResource("cpu").Flavor(flavor).Obj()).
 				Obj(),
 			flavors: map[string]*kueue.ResourceFlavor{
 				rf.Name: rf,
 			},
-			wantStatus: Terminating,
+			wantStatus: terminating,
 		},
 		{
 			name:      "Terminating clusterQueue updated with not found flavors",
-			curStatus: Terminating,
+			curStatus: terminating,
 			clusterQueue: utiltesting.MakeClusterQueue("cq").
 				Resource(utiltesting.MakeResource("cpu").Flavor(flavor).Obj()).
 				Obj(),
 			flavors:    map[string]*kueue.ResourceFlavor{},
-			wantStatus: Terminating,
+			wantStatus: terminating,
 		},
 	}
 

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -319,7 +319,7 @@ func TestSnapshot(t *testing.T) {
 				},
 				LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: {"baz": {}, "foo": {}, "instance": {}}},
 				NamespaceSelector: labels.Nothing(),
-				Status:            Active,
+				Status:            active,
 			},
 			"foobar": {
 				Name:   "foobar",
@@ -356,7 +356,7 @@ func TestSnapshot(t *testing.T) {
 				},
 				NamespaceSelector: labels.Nothing(),
 				LabelKeys:         map[corev1.ResourceName]sets.String{corev1.ResourceCPU: {"baz": {}, "instance": {}}},
-				Status:            Active,
+				Status:            active,
 			},
 			"bar": {
 				Name: "bar",
@@ -375,7 +375,7 @@ func TestSnapshot(t *testing.T) {
 				},
 				Workloads:         map[string]*workload.Info{},
 				NamespaceSelector: labels.Nothing(),
-				Status:            Active,
+				Status:            active,
 			},
 		},
 		ResourceFlavors: map[string]*kueue.ResourceFlavor{

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/pointer"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/test/integration/framework"
@@ -431,6 +432,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.It("Should be inactive until the flavor is created", func() {
 			ginkgo.By("Creating one workload")
+			framework.ExpectClusterQueueStatusMetric(fooCQ, metrics.CQStatusPending)
 			wl := testing.MakeWorkload("workload", ns.Name).Queue(fooQ.Name).Request(corev1.ResourceCPU, "1").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
 			framework.ExpectWorkloadsToBeFrozen(ctx, k8sClient, fooCQ.Name, wl)
@@ -444,6 +446,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			defer func() {
 				gomega.Expect(framework.DeleteResourceFlavor(ctx, k8sClient, fooFlavor)).To(gomega.Succeed())
 			}()
+			framework.ExpectClusterQueueStatusMetric(fooCQ, metrics.CQStatusActive)
 			framework.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, fooCQ.Name, wl)
 			framework.ExpectPendingWorkloadsMetric(fooCQ, 0, 0)
 			framework.ExpectAdmittedActiveWorkloadsMetric(fooCQ, 1)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds cluster_queue_status metric so administrators can monitor if a cluster queue is:
- pending: missing resource flavors
- active: ready to admit workloads
- terminating: marked for deletion but still has running workloads.

#### Which issue(s) this PR fixes:

Fixes #340 

#### Special notes for your reviewer:

