### PR TITLE
Validate ClusterQueue cohort to be a valid object name

### DIFF
--- a/apis/kueue/webhooks/clusterqueue_webhook.go
+++ b/apis/kueue/webhooks/clusterqueue_webhook.go
@@ -99,6 +99,9 @@ func ValidateClusterQueue(cq *kueue.ClusterQueue) field.ErrorList {
 	path := field.NewPath("spec")
 
 	var allErrs field.ErrorList
+	if len(cq.Spec.Cohort) != 0 {
+		allErrs = append(allErrs, validateNameReference(cq.Spec.Cohort, path.Child("cohort"))...)
+	}
 	allErrs = append(allErrs, validateResources(cq.Spec.Resources, path.Child("resources"))...)
 	allErrs = append(allErrs, validateQueueingStrategy(string(cq.Spec.QueueingStrategy), path.Child("queueingStrategy"))...)
 	allErrs = append(allErrs, validateNamespaceSelector(cq.Spec.NamespaceSelector, path.Child("namespaceSelector"))...)

--- a/apis/kueue/webhooks/clusterqueue_webhook_test.go
+++ b/apis/kueue/webhooks/clusterqueue_webhook_test.go
@@ -40,18 +40,29 @@ func TestValidateClusterQueue(t *testing.T) {
 		wantErr      field.ErrorList
 	}{
 		{
-			name: "native resources with qualified names",
+			name: "built-in resources with qualified names",
 			clusterQueue: testingutil.MakeClusterQueue("cluster-queue").Resource(
 				testingutil.MakeResource("cpu").Obj(),
 			).Obj(),
 		},
 		{
-			name: "native resources with unqualified names",
+			name: "invalid resource name",
 			clusterQueue: testingutil.MakeClusterQueue("cluster-queue").Resource(
 				testingutil.MakeResource("@cpu").Obj(),
 			).Obj(),
 			wantErr: field.ErrorList{
 				field.Invalid(resourceField.Index(0).Child("name"), "@cpu", ""),
+			},
+		},
+		{
+			name:         "in cohort",
+			clusterQueue: testingutil.MakeClusterQueue("cluster-queue").Cohort("prod").Obj(),
+		},
+		{
+			name:         "invalid cohort",
+			clusterQueue: testingutil.MakeClusterQueue("cluster-queue").Cohort("@prod").Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(specField.Child("cohort"), "@prod", ""),
 			},
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Use the same validation as for API resource names for `ClusterQueue.spec.cohort` to prevent arbitrary strings.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

