### PR TITLE
Fix prometheus rolebinding

### DIFF
--- a/config/components/prometheus/role.yaml
+++ b/config/components/prometheus/role.yaml
@@ -42,5 +42,8 @@ roleRef:
   name: prometheus-k8s
 subjects:
 - kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring
+- kind: ServiceAccount
   name: prometheus-operator
   namespace: monitoring


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Both prometheus-k8s and prometheus-operator service accounts require permissions to list services, endpoints and pods.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

