### PR TITLE
Cleanup: Use ResourceFlavor.metadata.labels

### DIFF
--- a/apis/kueue/v1alpha2/resourceflavor_types.go
+++ b/apis/kueue/v1alpha2/resourceflavor_types.go
@@ -29,14 +29,6 @@ type ResourceFlavor struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// labels associated with this flavor. They are matched against or
-	// converted to node affinity constraints on the workload’s pods.
-	// For example, cloud.provider.com/accelerator: nvidia-tesla-k80.
-	// More info: http://kubernetes.io/docs/user-guide/labels
-	//
-	// labels can be up to 8 elements.
-	Labels map[string]string `json:"labels,omitempty"`
-
 	// taints associated with this flavor that workloads must explicitly
 	// “tolerate” to be able to use this flavor.
 	// For example, cloud.provider.com/preemptible="true":NoSchedule

--- a/apis/kueue/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/kueue/v1alpha2/zz_generated.deepcopy.go
@@ -358,13 +358,6 @@ func (in *ResourceFlavor) DeepCopyInto(out *ResourceFlavor) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	if in.Labels != nil {
-		in, out := &in.Labels, &out.Labels
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
-		}
-	}
 	if in.Taints != nil {
 		in, out := &in.Taints, &out.Taints
 		*out = make([]corev1.Taint, len(*in))

--- a/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
@@ -30,15 +30,6 @@ spec:
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
-          labels:
-            additionalProperties:
-              type: string
-            description: "labels associated with this flavor. They are matched against
-              or converted to node affinity constraints on the workload’s pods. For
-              example, cloud.provider.com/accelerator: nvidia-tesla-k80. More info:
-              http://kubernetes.io/docs/user-guide/labels \n labels can be up to 8
-              elements."
-            type: object
           metadata:
             type: object
           taints:

--- a/docs/concepts/cluster_queue.md
+++ b/docs/concepts/cluster_queue.md
@@ -163,8 +163,8 @@ apiVersion: kueue.x-k8s.io/v1alpha1
 kind: ResourceFlavor
 metadata:
   name: spot
-labels:
-  instance-type: spot
+  labels:
+    instance-type: spot
 taints:
 - effect: NoSchedule
   key: spot
@@ -177,7 +177,7 @@ ClusterQueue in the `.spec.resources[*].flavors[*].name` field.
 ### ResourceFlavor labels
 
 To associate a ResourceFlavor with a subset of nodes of you cluster, you can
-configure the `.labels` field with matching node labels that uniquely identify
+configure the `.metadata.labels` field with matching node labels that uniquely identify
 the nodes. If you are using [cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler)
 (or equivalent controllers), make sure it is configured to add those labels when
 adding new nodes.

--- a/docs/tasks/administer_cluster_quotas.md
+++ b/docs/tasks/administer_cluster_quotas.md
@@ -143,8 +143,8 @@ apiVersion: kueue.x-k8s.io/v1alpha1
 kind: ResourceFlavor
 metadata:
   name: x86
-labels:
-  cpu-arch: x86
+  labels:
+    cpu-arch: x86
 ```
 
 ```yaml
@@ -153,8 +153,8 @@ apiVersion: kueue.x-k8s.io/v1alpha1
 kind: ResourceFlavor
 metadata:
   name: arm
-labels:
-  cpu-arch: arm
+  labels:
+    cpu-arch: arm
 ```
 
 To create the ResourceFlavors, run the following command:

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -103,8 +103,10 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 	}
 	setup := func(cache *Cache) {
 		cache.AddOrUpdateResourceFlavor(&kueue.ResourceFlavor{
-			ObjectMeta: metav1.ObjectMeta{Name: "default"},
-			Labels:     map[string]string{"cpuType": "default"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "default",
+				Labels: map[string]string{"cpuType": "default"},
+			},
 		})
 		for _, c := range initialClusterQueues {
 			if err := cache.AddClusterQueue(context.Background(), &c); err != nil {
@@ -189,8 +191,10 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					}
 				}
 				cache.AddOrUpdateResourceFlavor(&kueue.ResourceFlavor{
-					ObjectMeta: metav1.ObjectMeta{Name: "default"},
-					Labels:     map[string]string{"cpuType": "default"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "default",
+						Labels: map[string]string{"cpuType": "default"},
+					},
 				})
 			},
 			wantClusterQueues: map[string]*ClusterQueue{
@@ -302,8 +306,10 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					}
 				}
 				cache.AddOrUpdateResourceFlavor(&kueue.ResourceFlavor{
-					ObjectMeta: metav1.ObjectMeta{Name: "default"},
-					Labels:     map[string]string{"cpuType": "default", "region": "central"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "default",
+						Labels: map[string]string{"cpuType": "default", "region": "central"},
+					},
 				})
 			},
 			wantClusterQueues: map[string]*ClusterQueue{

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -152,16 +152,19 @@ func TestSnapshot(t *testing.T) {
 	}
 	flavors := []kueue.ResourceFlavor{
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "demand"},
-			Labels:     map[string]string{"foo": "bar", "instance": "demand"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "demand",
+				Labels: map[string]string{"foo": "bar", "instance": "demand"},
+			},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "spot"},
-			Labels:     map[string]string{"baz": "bar", "instance": "spot"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "spot",
+				Labels: map[string]string{"baz": "bar", "instance": "spot"},
+			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "default"},
-			Labels:     nil,
 		},
 	}
 
@@ -381,15 +384,18 @@ func TestSnapshot(t *testing.T) {
 		ResourceFlavors: map[string]*kueue.ResourceFlavor{
 			"default": {
 				ObjectMeta: metav1.ObjectMeta{Name: "default"},
-				Labels:     nil,
 			},
 			"demand": {
-				ObjectMeta: metav1.ObjectMeta{Name: "demand"},
-				Labels:     map[string]string{"foo": "bar", "instance": "demand"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "demand",
+					Labels: map[string]string{"foo": "bar", "instance": "demand"},
+				},
 			},
 			"spot": {
-				ObjectMeta: metav1.ObjectMeta{Name: "spot"},
-				Labels:     map[string]string{"baz": "bar", "instance": "spot"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "spot",
+					Labels: map[string]string{"baz": "bar", "instance": "spot"},
+				},
 			},
 		},
 		InactiveClusterQueueSets: sets.String{"flavor-nonexistent-cq": {}},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -885,20 +885,28 @@ func TestEntryAssignFlavors(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "default"},
 		},
 		"one": {
-			ObjectMeta: metav1.ObjectMeta{Name: "one"},
-			Labels:     map[string]string{"type": "one"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "one",
+				Labels: map[string]string{"type": "one"},
+			},
 		},
 		"two": {
-			ObjectMeta: metav1.ObjectMeta{Name: "two"},
-			Labels:     map[string]string{"type": "two"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "two",
+				Labels: map[string]string{"type": "two"},
+			},
 		},
 		"b_one": {
-			ObjectMeta: metav1.ObjectMeta{Name: "b_one"},
-			Labels:     map[string]string{"b_type": "one"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "b_one",
+				Labels: map[string]string{"b_type": "one"},
+			},
 		},
 		"b_two": {
-			ObjectMeta: metav1.ObjectMeta{Name: "b_two"},
-			Labels:     map[string]string{"b_type": "two"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "b_two",
+				Labels: map[string]string{"b_type": "two"},
+			},
 		},
 		"tainted": {
 			ObjectMeta: metav1.ObjectMeta{Name: "tainted"},

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -385,9 +385,9 @@ type ResourceFlavorWrapper struct{ kueue.ResourceFlavor }
 func MakeResourceFlavor(name string) *ResourceFlavorWrapper {
 	return &ResourceFlavorWrapper{kueue.ResourceFlavor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: map[string]string{},
 		},
-		Labels: map[string]string{},
 	}}
 }
 


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
ResourceFlavor's `.labels` field is removed. Now users can specify the labels in `.metadata.labels`.

#### Which issue(s) this PR fixes:
Fixes #334 

#### Special notes for your reviewer:

