### PR TITLE
Automated cherry pick of #361: Change references of v1alpha1 to v1alpha2 in docs

### DIFF
--- a/docs/concepts/cluster_queue.md
+++ b/docs/concepts/cluster_queue.md
@@ -11,7 +11,7 @@ Only [cluster administrators](/docs/tasks#batch-administrator) should create `Cl
 A sample ClusterQueue looks like the following:
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ClusterQueue
 metadata:
   name: cluster-total
@@ -66,7 +66,7 @@ Kueue assigns the same flavor to the codependent resources that the pod set requ
 An example of a ClusterQueue with codependent resources looks like the following:
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ClusterQueue
 metadata:
   name: cluster-total
@@ -159,7 +159,7 @@ instead of adding labels to custom ResourceFlavors.
 A sample ResourceFlavor looks like the following:
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ResourceFlavor
 metadata:
   name: spot
@@ -219,7 +219,7 @@ ResourceFlavor without any labels or taints. Such ResourceFlavor is called an
 empty ResourceFlavor and its sample looks like the following:
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ResourceFlavor
 metadata:
   name: default
@@ -265,7 +265,7 @@ semantics:
 Assume you created the following two ClusterQueues:
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ClusterQueue
 metadata:
   name: team-a-cq
@@ -286,7 +286,7 @@ spec:
 ```
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ClusterQueue
 metadata:
   name: team-b-cq

--- a/docs/concepts/workload.md
+++ b/docs/concepts/workload.md
@@ -17,7 +17,7 @@ the decisions and statuses.
 The manifest for a Workload looks like the following:
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: Workload
 metadata:
   name: sample-job

--- a/docs/tasks/administer_cluster_quotas.md
+++ b/docs/tasks/administer_cluster_quotas.md
@@ -34,7 +34,7 @@ Write the manifest for the ClusterQueue. It should look similar to the following
 
 ```yaml
 # cluster-total.yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ClusterQueue
 metadata:
   name: cluster-total
@@ -78,7 +78,7 @@ Write the manifest for the ResourceFlavor. It should look similar to the followi
 
 ```yaml
 # default-flavor.yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ResourceFlavor
 metadata:
   name: default
@@ -105,7 +105,7 @@ Write the manifest for the LocalQueue. It should look similar to the following:
 
 ```yaml
 # default-user-queue.yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: LocalQueue
 metadata:
   namespace: default
@@ -139,7 +139,7 @@ following:
 
 ```yaml
 # flavor-x86.yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ResourceFlavor
 metadata:
   name: x86
@@ -149,7 +149,7 @@ metadata:
 
 ```yaml
 # flavor-arm.yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ResourceFlavor
 metadata:
   name: arm
@@ -175,7 +175,7 @@ look similar to the following:
 
 ```yaml
 # cluster-total.yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ClusterQueue
 metadata:
   name: cluster-total
@@ -220,7 +220,7 @@ ClusterQueues `team-a-cq` and `team-b-cq`.
 
 ```yaml
 # team-a-cq.yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ClusterQueue
 metadata:
   name: team-a-cq
@@ -244,7 +244,7 @@ spec:
 
 ```yaml
 # team-b-cq.yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ClusterQueue
 metadata:
   name: team-b-cq
@@ -288,7 +288,7 @@ tenants look like the following:
 
 ```yaml
 # team-a-cq.yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ClusterQueue
 metadata:
   name: team-a-cq
@@ -314,7 +314,7 @@ spec:
 
 ```yaml
 # team-b-cq.yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ClusterQueue
 metadata:
   name: team-b-cq
@@ -340,7 +340,7 @@ spec:
 
 ```yaml
 # shared-cq.yaml
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ClusterQueue
 metadata:
   name: shared-cq

--- a/docs/tasks/run_jobs.md
+++ b/docs/tasks/run_jobs.md
@@ -110,7 +110,7 @@ Name:         sample-job-jtz5f
 Namespace:    default
 Labels:       <none>
 Annotations:  <none>
-API Version:  kueue.x-k8s.io/v1alpha1
+API Version:  kueue.x-k8s.io/v1alpha2
 Kind:         Workload
 Metadata:
   ...


### PR DESCRIPTION
Cherry pick of #361 on release-0.2.
#361: Change references of v1alpha1 to v1alpha2 in docs
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```