### PR TITLE
Automated cherry pick of #384: Fix the broken links for admission

### DIFF
--- a/docs/concepts/cluster_queue.md
+++ b/docs/concepts/cluster_queue.md
@@ -129,7 +129,7 @@ namespaceSelector:
 You can set different queueing strategies in a ClusterQueue using the
 `.spec.queueingStrategy` field. The queueing strategy determines how workloads
 are ordered in the ClusterQueue and how they are re-queued after an unsuccessful
-[admission](.#admission) attempt.
+[admission](README.md#admission) attempt.
 
 The following are the supported queueing strategies:
 

--- a/docs/concepts/workload.md
+++ b/docs/concepts/workload.md
@@ -2,7 +2,7 @@
 
 A _workload_ is an application that will run to completion. It can be composed
 by one or multiple Pods that, loosely or tightly coupled, that, as a whole,
-complete a task. A workload is the unit of [admission](.#admission) in Kueue.
+complete a task. A workload is the unit of [admission](README.md#admission) in Kueue.
 
 The prototypical workload can be represented with a
 [Kubernetes `batch/v1.Job`](https://kubernetes.io/docs/concepts/workloads/controllers/job/).


### PR DESCRIPTION
Cherry pick of #384 on release-0.2.
#384: Fix the broken links for admission
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```