### PR TITLE
Stop using the deprecated library, github.com/go-logr/logr/testing

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	logrtesting "github.com/go-logr/logr/testing"
+	"github.com/go-logr/logr/testr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
@@ -776,7 +776,7 @@ func TestSchedule(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			log := logrtesting.NewTestLoggerWithOptions(t, logrtesting.Options{
+			log := testr.NewWithOptions(t, testr.Options{
 				Verbosity: 2,
 			})
 			ctx := ctrl.LoggerInto(context.Background(), log)
@@ -1624,7 +1624,7 @@ func TestEntryAssignFlavors(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			log := logrtesting.NewTestLoggerWithOptions(t, logrtesting.Options{
+			log := testr.NewWithOptions(t, testr.Options{
 				Verbosity: 2,
 			})
 			tc.clusterQueue.UpdateCodependentResources()
@@ -1779,7 +1779,7 @@ func TestRequeueAndUpdate(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			log := logrtesting.NewTestLoggerWithOptions(t, logrtesting.Options{
+			log := testr.NewWithOptions(t, testr.Options{
 				Verbosity: 2,
 			})
 			ctx := ctrl.LoggerInto(context.Background(), log)


### PR DESCRIPTION
Signed-off-by: tenzen-y <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
According to [this](https://pkg.go.dev/github.com/go-logr/logr@v1.2.3/testing), `github.com/go-logr/logr/testing` is deprecated. So we need to use `github.com/go-logr/logr/testr` instead of `github.com/go-logr/logr/testing`.

> Package testing provides support for using logr in tests. Deprecated. See github.com/go-logr/logr/testr instead.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

