### PR TITLE
Add scheduler integration tests for creating objects out of order

### DIFF
--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -340,7 +340,7 @@ func ExpectClusterQueueToBeDeleted(ctx context.Context, k8sClient client.Client,
 
 func ExpectResourceFlavorToBeDeleted(ctx context.Context, k8sClient client.Client, rf *kueue.ResourceFlavor, deleteRf bool) {
 	if deleteRf {
-		gomega.Expect(DeleteResourceFlavor(ctx, k8sClient, rf)).ToNot(gomega.HaveOccurred())
+		gomega.Expect(DeleteResourceFlavor(ctx, k8sClient, rf)).To(gomega.Succeed())
 	}
 	gomega.Eventually(func() error {
 		var newRF kueue.ResourceFlavor


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Exercise the multiple orders in which objects can be observed by kueue. They should all lead to admissible workloads.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

