### PR TITLE
Add Kind and GroupVersion to SSA object

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -49,7 +49,7 @@ import (
 )
 
 const (
-	errCouldNotAdmitWL = "Could not admit workload and assigning flavors in apiserver"
+	errCouldNotAdmitWL = "Could not admit Workload and assign flavors in apiserver"
 )
 
 type Scheduler struct {
@@ -364,7 +364,7 @@ func (s *Scheduler) applyAdmissionWithSSA(ctx context.Context, w *kueue.Workload
 // workloadAdmissionFrom returns only the fields necessary for admission using
 // ServerSideApply.
 func workloadAdmissionFrom(w *kueue.Workload) *kueue.Workload {
-	return &kueue.Workload{
+	wlCopy := &kueue.Workload{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:        w.UID,
 			Name:       w.Name,
@@ -376,6 +376,13 @@ func workloadAdmissionFrom(w *kueue.Workload) *kueue.Workload {
 			Admission: w.Spec.Admission.DeepCopy(),
 		},
 	}
+	if wlCopy.APIVersion == "" {
+		wlCopy.APIVersion = kueue.GroupVersion.String()
+	}
+	if wlCopy.Kind == "" {
+		wlCopy.Kind = "Workload"
+	}
+	return wlCopy
 }
 
 // findFlavorForCodepResources returns a flavor which can satisfy the resource request,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

SSA requires these fields to be populated. The error looks like this.

```
Incorrect version specified in apply patch. Specified patch version: , expected: kueue.x-k8s.io/v1alpha2
```

Controller-runtime event objects don't include these fields.

Note that is issue is transient, as re-queuing would obtain the object from the client, which properly adds the fields. That's why I'm not adding an integration test, as they were all passing.

#### Which issue(s) this PR fixes:

Fixes #406

#### Special notes for your reviewer:

