### PR TITLE
WIP: Fix race condition when scheduling attempt and a requeuing event happen at the same time

### DIFF
--- a/pkg/queue/cluster_queue_impl.go
+++ b/pkg/queue/cluster_queue_impl.go
@@ -35,10 +35,6 @@ import (
 // ClusterQueueImpl is the base implementation of ClusterQueue interface.
 // It can be inherited and overwritten by other class.
 type ClusterQueueImpl struct {
-	// QueueingStrategy indicates the queueing strategy of the workloads
-	// across the queues in this ClusterQueue.
-	QueueingStrategy kueue.QueueingStrategy
-
 	heap              heap.Heap
 	cohort            string
 	namespaceSelector labels.Selector
@@ -57,7 +53,6 @@ func newClusterQueueImpl(keyFunc func(obj interface{}) string, lessFunc func(a, 
 var _ ClusterQueue = &ClusterQueueImpl{}
 
 func (c *ClusterQueueImpl) Update(apiCQ *kueue.ClusterQueue) error {
-	c.QueueingStrategy = apiCQ.Spec.QueueingStrategy
 	c.cohort = apiCQ.Spec.Cohort
 	nsSelector, err := metav1.LabelSelectorAsSelector(apiCQ.Spec.NamespaceSelector)
 	if err != nil {

--- a/pkg/util/testing/scheme.go
+++ b/pkg/util/testing/scheme.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1alpha2"
+)
+
+func MustGetScheme(t *testing.T) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed adding core to scheme: %v", err)
+	}
+	if err := kueue.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed adding kueue to scheme: %v", err)
+	}
+	return scheme
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When requeuing inadmissible workloads (for example, because a workload finishes) while a pending workload is being scheduled and fails, the pending workload could stay inadmissible. This can violate the `min` quota of a ClusterQueue.

This issue manifested as flakiness in the scheduler integration test `Should start workloads that are under min quota before borrowing`.

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kueue/410/pull-kueue-test-integration-main/1593368182620426240

The solution is similar to what we do in kube-scheduler: store the sequence number of scheduling attempt and compare that during requeue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

