### PR TITLE
Cleanups on ClusterQueue implementations

### DIFF
--- a/pkg/queue/cluster_queue_best_effort_fifo.go
+++ b/pkg/queue/cluster_queue_best_effort_fifo.go
@@ -24,7 +24,7 @@ import (
 // ClusterQueueBestEffortFIFO is the implementation for the ClusterQueue for
 // BestEffortFIFO.
 type ClusterQueueBestEffortFIFO struct {
-	*ClusterQueueImpl
+	*clusterQueueBase
 }
 
 var _ ClusterQueue = &ClusterQueueBestEffortFIFO{}
@@ -34,7 +34,7 @@ const BestEffortFIFO = kueue.BestEffortFIFO
 func newClusterQueueBestEffortFIFO(cq *kueue.ClusterQueue) (ClusterQueue, error) {
 	cqImpl := newClusterQueueImpl(keyFunc, byCreationTime)
 	cqBE := &ClusterQueueBestEffortFIFO{
-		ClusterQueueImpl: cqImpl,
+		clusterQueueBase: cqImpl,
 	}
 
 	err := cqBE.Update(cq)
@@ -42,5 +42,5 @@ func newClusterQueueBestEffortFIFO(cq *kueue.ClusterQueue) (ClusterQueue, error)
 }
 
 func (cq *ClusterQueueBestEffortFIFO) RequeueIfNotPresent(wInfo *workload.Info, reason RequeueReason) bool {
-	return cq.ClusterQueueImpl.requeueIfNotPresent(wInfo, reason == RequeueReasonFailedAfterNomination)
+	return cq.requeueIfNotPresent(wInfo, reason == RequeueReasonFailedAfterNomination)
 }

--- a/pkg/queue/cluster_queue_strict_fifo.go
+++ b/pkg/queue/cluster_queue_strict_fifo.go
@@ -25,7 +25,7 @@ import (
 // ClusterQueueStrictFIFO is the implementation for the ClusterQueue for
 // StrictFIFO.
 type ClusterQueueStrictFIFO struct {
-	*ClusterQueueImpl
+	*clusterQueueBase
 }
 
 var _ ClusterQueue = &ClusterQueueStrictFIFO{}
@@ -35,7 +35,7 @@ const StrictFIFO = kueue.StrictFIFO
 func newClusterQueueStrictFIFO(cq *kueue.ClusterQueue) (ClusterQueue, error) {
 	cqImpl := newClusterQueueImpl(keyFunc, byCreationTime)
 	cqStrict := &ClusterQueueStrictFIFO{
-		ClusterQueueImpl: cqImpl,
+		clusterQueueBase: cqImpl,
 	}
 
 	err := cqStrict.Update(cq)
@@ -61,5 +61,5 @@ func byCreationTime(a, b interface{}) bool {
 // If the reason for requeue is that the workload doesn't match the CQ's
 // namespace selector, then the requeue is not immediate.
 func (cq *ClusterQueueStrictFIFO) RequeueIfNotPresent(wInfo *workload.Info, reason RequeueReason) bool {
-	return cq.ClusterQueueImpl.requeueIfNotPresent(wInfo, reason != RequeueReasonNamespaceMismatch)
+	return cq.requeueIfNotPresent(wInfo, reason != RequeueReasonNamespaceMismatch)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Rename `ClusterQueueImpl` to `clusterQueueBase`, as it's not a complete implementation of `ClusterQueue`.

Rename `popId` to `popCycle` and update related comments.

#### Which issue(s) this PR fixes:

Follow ups to #427 and #428.

#### Special notes for your reviewer:

