### PR TITLE
Fix e2e test not load the right image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ test-integration: manifests generate fmt vet envtest ginkgo ## Run tests.
 
 USE_EXISTING_CLUSTER ?= false
 .PHONY: test-e2e-kind
-test-e2e-kind: manifests generate fmt vet envtest ginkgo kind-image-build
+test-e2e-kind: kustomize manifests generate fmt vet envtest ginkgo kind-image-build
 	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) ARTIFACTS=$(ARTIFACTS) IMAGE_TAG=$(IMAGE_TAG) ./hack/e2e-test.sh
 
 .PHONY: ci-lint
@@ -270,4 +270,3 @@ KIND = $(shell pwd)/bin/kind
 .PHONY: kind
 kind:
 	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install sigs.k8s.io/kind@v0.16.0
-

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -1,29 +1,53 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
 export KUSTOMIZE=$PWD/bin/kustomize
 export GINKGO=$PWD/bin/ginkgo
 export KIND=$PWD/bin/kind
+
 function cleanup {
-    if [ $USE_EXISTING_CLUSTER == 'false' ] 
-    then 
+    if [ $USE_EXISTING_CLUSTER == 'false' ]
+    then
         $KIND delete cluster --name $KIND_CLUSTER_NAME
     fi
     (cd config/components/manager && $KUSTOMIZE edit set image controller=gcr.io/k8s-staging-kueue/kueue:main)
 }
+
 function startup {
-    if [ $USE_EXISTING_CLUSTER == 'false' ] 
-    then 
+    if [ $USE_EXISTING_CLUSTER == 'false' ]
+    then
         $KIND create cluster --name $KIND_CLUSTER_NAME --image $E2E_KIND_VERSION
     fi
 }
+
 function kind_load {
     $KIND load docker-image $IMAGE_TAG --name $KIND_CLUSTER_NAME
 }
+
 function kueue_deploy {
     (cd config/components/manager && $KUSTOMIZE edit set image controller=$IMAGE_TAG)
     kubectl apply -k test/e2e/config
 }
+
 trap cleanup EXIT
 startup
 kind_load
 kueue_deploy
 $GINKGO --junit-report=junit.xml --output-dir=$ARTIFACTS -v ./test/e2e/...
-


### PR DESCRIPTION
Signed-off-by: kerthcet <kerthcet@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

From the e2e-main log, we found that the kustomize not exists, then new built image will not be loaded successfully, this may cause test error like https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kueue/414/pull-kueue-test-e2e-main/1595440995208531968#1:build-log.txt%3A299

```
Image: "gcr.io/k8s-staging-kueue/kueue:v0.3.0-devel-81-g2437b7f" with ID "sha256:03dc0be9da9af117f7ac63c8d968e29c966393c08da99d5a18475e0102dc4762" not yet present on node "kind-control-plane", loading...
./hack/e2e-test.sh: line 21: /home/prow/go/src/sigs.k8s.io/kueue/bin/kustomize: No such file or directory
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

