### PR TITLE
configured e2e tests to run with existing cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,8 +144,11 @@ test-integration: manifests generate fmt vet envtest ginkgo ## Run tests.
 	$(GINKGO) --junit-report=junit.xml --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET)
 
 USE_EXISTING_CLUSTER ?= false
-.PHONY: test-e2e-kind
-test-e2e-kind: kustomize manifests generate fmt vet envtest ginkgo kind-image-build
+ifeq (false, $(USE_EXISTING_CLUSTER))
+BUILD_WITH_KIND=kind-image-build
+endif
+.PHONY: test-e2e
+test-e2e: kustomize manifests generate fmt vet envtest ginkgo $(BUILD_WITH_KIND)
 	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) ARTIFACTS=$(ARTIFACTS) IMAGE_TAG=$(IMAGE_TAG) ./hack/e2e-test.sh
 
 .PHONY: ci-lint

--- a/Makefile
+++ b/Makefile
@@ -143,13 +143,10 @@ test-integration: manifests generate fmt vet envtest ginkgo ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) --arch=amd64 use $(ENVTEST_K8S_VERSION) -p path)" \
 	$(GINKGO) --junit-report=junit.xml --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET)
 
-USE_EXISTING_CLUSTER ?= false
-ifeq (false, $(USE_EXISTING_CLUSTER))
-BUILD_WITH_KIND=kind-image-build
-endif
+CREATE_KIND_CLUSTER ?= true
 .PHONY: test-e2e
-test-e2e: kustomize manifests generate fmt vet envtest ginkgo $(BUILD_WITH_KIND)
-	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) USE_EXISTING_CLUSTER=$(USE_EXISTING_CLUSTER) ARTIFACTS=$(ARTIFACTS) IMAGE_TAG=$(IMAGE_TAG) ./hack/e2e-test.sh
+test-e2e: kustomize manifests generate fmt vet envtest ginkgo
+	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) CREATE_KIND_CLUSTER=$(CREATE_KIND_CLUSTER) ARTIFACTS=$(ARTIFACTS) IMAGE_TAG=$(IMAGE_TAG) ./hack/e2e-test.sh
 
 .PHONY: ci-lint
 ci-lint: golangci-lint

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -38,7 +38,10 @@ function startup {
 }
 
 function kind_load {
-    $KIND load docker-image $IMAGE_TAG --name $KIND_CLUSTER_NAME
+    if [ $USE_EXISTING_CLUSTER == 'false' ]
+    then
+        $KIND load docker-image $IMAGE_TAG --name $KIND_CLUSTER_NAME
+    fi
 }
 
 function kueue_deploy {

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -23,22 +23,22 @@ export GINKGO=$PWD/bin/ginkgo
 export KIND=$PWD/bin/kind
 
 function cleanup {
-    if [ $USE_EXISTING_CLUSTER == 'false' ]
+    if [ $CREATE_KIND_CLUSTER == 'true' ]
     then
-        $KIND delete cluster --name $KIND_CLUSTER_NAME
+        $KIND delete cluster --name $KIND_CLUSTER_NAME || { echo "You need to run make kind-image-build before this script"; exit -1; }
     fi
     (cd config/components/manager && $KUSTOMIZE edit set image controller=gcr.io/k8s-staging-kueue/kueue:main)
 }
 
 function startup {
-    if [ $USE_EXISTING_CLUSTER == 'false' ]
+    if [ $CREATE_KIND_CLUSTER == 'true' ]
     then
         $KIND create cluster --name $KIND_CLUSTER_NAME --image $E2E_KIND_VERSION
     fi
 }
 
 function kind_load {
-    if [ $USE_EXISTING_CLUSTER == 'false' ]
+    if [ $CREATE_KIND_CLUSTER == 'true' ]
     then
         $KIND load docker-image $IMAGE_TAG --name $KIND_CLUSTER_NAME
     fi


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

It allows us to run e2e tests on existing clusters. This could be useful for release testing on cloud vendors kubernetes clusters.

To run with a kind cluster
```
make test-e2e
```

To run with an existing cluster (assuming kubectl is configured for it)
```
make test-e2e USE_EXISTING_CLUSTER=true IMAGE_TAG=tag
```

#### Which issue(s) this PR fixes:

Fixes #431 

#### Special notes for your reviewer:
I tested this by manually running a kind cluster and building the image built by the target `image-build`. Then I ran the e2e tests:
```
make test-e2e USE_EXISTING_CLUSTER=true IMAGE_TAG=gcr.io/k8s-staging-kueue/kueue:e0ec723-dirty
```
