### PR TITLE
Fix race condition on admission error

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -124,9 +124,7 @@ func (s *Scheduler) schedule(ctx context.Context) {
 			continue
 		}
 		log := log.WithValues("workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", e.ClusterQueue))
-		if err := s.admit(ctrl.LoggerInto(ctx, log), e); err == nil {
-			e.status = assumed
-		} else {
+		if err := s.admit(ctrl.LoggerInto(ctx, log), e); err != nil {
 			e.inadmissibleMsg = fmt.Sprintf("Failed to admit workload: %v", err)
 		}
 		// Even if there was a failure, we shouldn't admit other workloads to this
@@ -330,6 +328,7 @@ func (s *Scheduler) admit(ctx context.Context, e *entry) error {
 	if err := s.cache.AssumeWorkload(newWorkload); err != nil {
 		return err
 	}
+	e.status = assumed
 	log.V(2).Info("Workload assumed in the cache")
 
 	s.admissionRoutineWrapper.Run(func() {

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -60,7 +60,7 @@ type Framework struct {
 func (f *Framework) Setup() (context.Context, *rest.Config, client.Client) {
 	opts := func(o *zap.Options) {
 		o.TimeEncoder = zapcore.RFC3339NanoTimeEncoder
-		o.ZapOpts = []zaplog.Option{zaplog.AddCaller(), zaplog.AddCallerSkip(-1)}
+		o.ZapOpts = []zaplog.Option{zaplog.AddCaller()}
 	}
 	ctrl.SetLogger(zap.New(
 		zap.WriteTo(ginkgo.GinkgoWriter),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The assumed status must be written before starting the admission goroutine. Otherwise, there is a race when requeuing, which needs to read the status.

In a separate commit: remove unnecessary log skip from integration tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This bug is unlikely to happen in production, as the goroutine first does an API call before attempting a requeue, which is slow.
