### PR TITLE
WIP: Additional Kueue performance metrics

### DIFF
--- a/test/performance/config.yaml
+++ b/test/performance/config.yaml
@@ -59,7 +59,7 @@ steps:
     Method: GenericPrometheusQuery
     Params:
       action: start
-      metricName: Job (Kueue) API performance
+      metricName: job_api_performance
       metricVersion: v1
       unit: s
       queries:
@@ -76,7 +76,27 @@ steps:
         - name: perc_90_pod_waiting_time
           query: quantile(0.90, kube_pod_start_time{namespace=~"{{$namespacePrefix}}.*"} - kube_pod_created{namespace=~"{{$namespacePrefix}}.*"})                
         - name: max_job_throughput
-          query: max_over_time(sum(rate(kueue_admitted_workloads_total{cluster_queue="{{$clusterQueue}}"}[1m]))[{{$testTimeout}}:5s])                               
+          query: max_over_time(sum(rate(kueue_admitted_workloads_total{cluster_queue="{{$clusterQueue}}"}[1m]))[{{$testTimeout}}:5s])     
+  - Identifier: GenericPrometheusQueryAdditional
+    Method: GenericPrometheusQuery
+    Params:
+      action: start
+      metricName: kueue_api_performance
+      metricVersion: v1
+      unit: s
+      queries:    
+        - name: kueue_admission_attempt_success_avg
+          query: kueue_admission_attempt_duration_seconds_sum{result="success"}/kueue_admission_attempt_duration_seconds_count{result="success"}    
+        - name: kueue_admission_attempt_inadmissible_avg
+          query: kueue_admission_attempt_duration_seconds_sum{result="inadmissible"}/kueue_admission_attempt_duration_seconds_count{result="inadmissible"}
+        - name: perc_90_kueue_admission_attempt_success
+          query: histogram_quantile(0.90, sum(rate(kueue_admission_attempt_duration_seconds_bucket{result="success"}[{{$testTimeout}}])) by (le))  
+        - name: perc_90_kueue_admission_attempt_inadmissible
+          query: histogram_quantile(0.90, sum(rate(kueue_admission_attempt_duration_seconds_bucket{result="inadmissible"}[{{$testTimeout}}])) by (le))
+        - name: kueue_admission_wait_time_avg
+          query: kueue_admission_wait_time_seconds_sum / kueue_admission_wait_time_seconds_count
+        - name: perc_90_kueue_admission_wait_time
+          query: histogram_quantile(0.90, sum(rate(kueue_admission_wait_time_seconds_bucket[{{$testTimeout}}])) by (le))     
 - name: Sleep
   measurements:
   - Identifier: sleep
@@ -178,4 +198,11 @@ steps:
     Method: GenericPrometheusQuery
     Params:
       action: gather
-      enableViolations: true      
+      enableViolations: true
+- name: Gather additional Prometheus measurements
+  measurements:
+  - Identifier: GenericPrometheusQueryAdditional
+    Method: GenericPrometheusQuery
+    Params:
+      action: gather
+      enableViolations: true                

--- a/test/performance/run-test.sh
+++ b/test/performance/run-test.sh
@@ -96,14 +96,14 @@ for item in "${EXPERIMENTS[@]}"; do
         echo -ne "$(jq '.dataItems[] | select(.labels.Metric=="create_to_start").data.Perc90' "$experiment_dir"/JobLifecycleLatency*.json),"
         echo -ne "$(jq '.dataItems[] | select(.labels.Metric=="start_to_complete").data.Perc50' "$experiment_dir"/JobLifecycleLatency*.json),"
         echo -ne "$(jq '.dataItems[] | select(.labels.Metric=="start_to_complete").data.Perc90' "$experiment_dir"/JobLifecycleLatency*.json),"
-        echo -ne "$(jq '.dataItems[0].data.max_job_throughput' "$experiment_dir"/GenericPrometheusQuery*.json),"
-        echo -ne "$(jq '.dataItems[0].data.total_jobs_scheduled' "$experiment_dir"/GenericPrometheusQuery*.json),"
-        echo -ne "$(jq '.dataItems[0].data.total_pods_scheduled' "$experiment_dir"/GenericPrometheusQuery*.json),"
+        echo -ne "$(jq '.dataItems[0].data.max_job_throughput' "$experiment_dir"/*job_api_performance*.json),"
+        echo -ne "$(jq '.dataItems[0].data.total_jobs_scheduled' "$experiment_dir"/*job_api_performance*.json),"
+        echo -ne "$(jq '.dataItems[0].data.total_pods_scheduled' "$experiment_dir"/*job_api_performance*.json),"
         echo -ne "$(jq '.dataItems[0].data.job_performance' "$experiment_dir"/Timer*.json)",
-        echo -ne "$(jq '.dataItems[0].data.avg_pod_waiting_time' "$experiment_dir"/GenericPrometheusQuery*.json),"
-        echo -ne "$(jq '.dataItems[0].data.perc_90_pod_waiting_time' "$experiment_dir"/GenericPrometheusQuery*.json),"
-        echo -ne "$(jq '.dataItems[0].data.avg_pod_running_time' "$experiment_dir"/GenericPrometheusQuery*.json),"
-        jq '.dataItems[0].data.perc_90_pod_completion_time' "$experiment_dir"/GenericPrometheusQuery*.json
+        echo -ne "$(jq '.dataItems[0].data.avg_pod_waiting_time' "$experiment_dir"/*job_api_performance*.json),"
+        echo -ne "$(jq '.dataItems[0].data.perc_90_pod_waiting_time' "$experiment_dir"/*job_api_performance*.json),"
+        echo -ne "$(jq '.dataItems[0].data.avg_pod_running_time' "$experiment_dir"/*job_api_performance*.json),"
+        jq '.dataItems[0].data.perc_90_pod_completion_time' "$experiment_dir"/*job_api_performance*.json
     } >>"$report_dir_name/summary.csv"
     if [[ "$USE_KUEUE" == true ]]; then
         kubectl delete -f prerequisites/cluster-queue.yaml


### PR DESCRIPTION
The PR contains additional performance measurements based on Kueue Prometheus metrics:

* Average successful admission attempt duration:
`kueue_admission_attempt_duration_seconds_sum{result="success"}/kueue_admission_attempt_duration_seconds_count{result="success"}`
* Average `inadmissible` attempt duration:
`kueue_admission_attempt_duration_seconds_sum{result="inadmissible"}/kueue_admission_attempt_duration_seconds_count{result="inadmissible"}`
* Perc90 successful admission attempt duration:
`histogram_quantile(0.90, sum(rate(kueue_admission_attempt_duration_seconds_bucket{result="success"}[{{$testTimeout}}])) by (le))`
* Perc90 `inadmissible` attempt duration:
`histogram_quantile(0.90, sum(rate(kueue_admission_attempt_duration_seconds_bucket{result="inadmissible"}[{{$testTimeout}}])) by (le))`
* Average admission wait time:
`kueue_admission_wait_time_seconds_sum / kueue_admission_wait_time_seconds_count`
* Perc90 admission wait time:
`histogram_quantile(0.90, sum(rate(kueue_admission_wait_time_seconds_bucket[{{$testTimeout}}])) by (le))`

ToDos:

* Accuracy of the metrics needs to be evaluated on different Kubernetes setups
* Need to decide which metrics are useful to put on the summary file (`summary.csv`)
