### PR TITLE
Get ClusterQueues with a specific ResourceFlavor from the cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -803,16 +803,17 @@ func (c *Cache) deleteClusterQueueFromCohort(cq *ClusterQueue) {
 	cq.Cohort = nil
 }
 
-func (c *Cache) FlavorInUse(flavor string) (string, bool) {
+func (c *Cache) ClusterQueuesUsingFlavor(flavor string) []string {
 	c.RLock()
 	defer c.RUnlock()
+	var cqs []string
 
 	for _, cq := range c.clusterQueues {
 		if cq.flavorInUse(flavor) {
-			return cq.Name, true
+			cqs = append(cqs, cq.Name)
 		}
 	}
-	return "", false
+	return cqs
 }
 
 func (c *Cache) MatchingClusterQueues(nsLabels map[string]string) sets.String {


### PR DESCRIPTION
Signed-off-by: tenzen-y <yuki.iwai.tz@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
As discussed in https://github.com/kubernetes-sigs/kueue/pull/415#discussion_r1054785383, I updated `func (c *Cache) FlavorInUse(flavor string) (string, bool)` to `func (c *Cache) ClusterQueuesUsingFlavor(flavor string) []string` so that available to get clusterQueues with a specific resourceFlavor from the cache.

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

