### PR TITLE
Use generic Set for ClusterQueues in cohort

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -561,7 +561,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			gotCohorts := make(map[string]sets.Set[string], len(cache.cohorts))
 			for name, cohort := range cache.cohorts {
 				gotCohort := sets.New[string]()
-				for cq := range cohort.members {
+				for cq := range cohort.Members {
 					gotCohort.Insert(cq.Name)
 				}
 				gotCohorts[name] = gotCohort

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -50,13 +50,13 @@ func (c *Cache) Snapshot() Snapshot {
 		snap.ResourceFlavors[rf.Name] = rf
 	}
 	for _, cohort := range c.cohorts {
-		cohortCopy := newCohort(cohort.Name, len(cohort.members))
-		for cq := range cohort.members {
+		cohortCopy := newCohort(cohort.Name, cohort.Members.Len())
+		for cq := range cohort.Members {
 			if cq.Active() {
 				cqCopy := snap.ClusterQueues[cq.Name]
 				cqCopy.accumulateResources(cohortCopy)
 				cqCopy.Cohort = cohortCopy
-				cohortCopy.members[cqCopy] = struct{}{}
+				cohortCopy.Members.Insert(cqCopy)
 			}
 		}
 	}

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -400,7 +400,7 @@ func TestSnapshot(t *testing.T) {
 		},
 		InactiveClusterQueueSets: sets.New("flavor-nonexistent-cq"),
 	}
-	if diff := cmp.Diff(wantSnapshot, snapshot, cmpopts.IgnoreUnexported(Cohort{}, ClusterQueue{})); diff != "" {
+	if diff := cmp.Diff(wantSnapshot, snapshot, cmpopts.IgnoreUnexported(ClusterQueue{}), cmpopts.IgnoreFields(Cohort{}, "Members")); diff != "" {
 		t.Errorf("Unexpected Snapshot (-want,+got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Using a generic Set to hold the ClusterQueues in a cohort improves readability.

Exporting the members of the cohort enables the implementation of preemption within a cohort.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

