### PR TITLE
Explicitly set the number of controller workers in config and increase it to 3

### DIFF
--- a/config/components/manager/controller_manager_config.yaml
+++ b/config/components/manager/controller_manager_config.yaml
@@ -9,6 +9,13 @@ webhook:
 leaderElection:
   leaderElect: true
   resourceName: c1f6bfd2.kueue.x-k8s.io
+controller:
+  groupKindConcurrency:
+    Job.batch: 3
+    LocalQueue.kueue.x-k8s.io: 3
+    ClusterQueue.kueue.x-k8s.io: 3
+    ResourceFlavor.kueue.x-k8s.io: 3
+    Workload.kueue.x-k8s.io: 3
 #waitForPodsReady:
 #  enable: true
 #manageJobsWithoutQueueName: true


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Currently all controllers run on a single worker which may impact performance on larger clusters. The current configuration allows to define the concurrency but the setting is well hidden in the controller-runtime config api. The PR exposes the flags in the default config and increases the worker count to 3 for all controllers (except cert rotator). 

Before:
```
{"level":"info","ts":"2023-01-11T13:39:28.372773686Z","caller":"controller/controller.go:227","msg":"Starting workers","controller":"cert-rotator","worker count":1}
{"level":"info","ts":"2023-01-11T13:39:30.57174952Z","caller":"controller/controller.go:227","msg":"Starting workers","controller":"localqueue","controllerGroup":"kueue.x-k8s.io","controllerKind":"LocalQueue","worker count":1}
{"level":"info","ts":"2023-01-11T13:39:30.572415846Z","caller":"controller/controller.go:227","msg":"Starting workers","controller":"workload","controllerGroup":"kueue.x-k8s.io","controllerKind":"Workload","worker count":1}
{"level":"info","ts":"2023-01-11T13:39:30.673441074Z","caller":"controller/controller.go:227","msg":"Starting workers","controller":"resourceflavor","controllerGroup":"kueue.x-k8s.io","controllerKind":"ResourceFlavor","worker count":1}
{"level":"info","ts":"2023-01-11T13:39:30.675709487Z","caller":"controller/controller.go:227","msg":"Starting workers","controller":"clusterqueue","controllerGroup":"kueue.x-k8s.io","controllerKind":"ClusterQueue","worker count":1}
{"level":"info","ts":"2023-01-11T13:39:30.67697426Z","caller":"controller/controller.go:227","msg":"Starting workers","controller":"job","controllerGroup":"batch","controllerKind":"Job","worker count":1}
```

After:
```
{"level":"info","ts":"2023-01-11T13:44:19.309769668Z","caller":"controller/controller.go:227","msg":"Starting workers","controller":"cert-rotator","worker count":1}
{"level":"info","ts":"2023-01-11T13:44:21.322903372Z","caller":"controller/controller.go:227","msg":"Starting workers","controller":"localqueue","controllerGroup":"kueue.x-k8s.io","controllerKind":"LocalQueue","worker count":3}
{"level":"info","ts":"2023-01-11T13:44:21.32375014Z","caller":"controller/controller.go:227","msg":"Starting workers","controller":"workload","controllerGroup":"kueue.x-k8s.io","controllerKind":"Workload","worker count":3}
{"level":"info","ts":"2023-01-11T13:44:21.424279831Z","caller":"controller/controller.go:227","msg":"Starting workers","controller":"resourceflavor","controllerGroup":"kueue.x-k8s.io","controllerKind":"ResourceFlavor","worker count":3}
{"level":"info","ts":"2023-01-11T13:44:21.425654279Z","caller":"controller/controller.go:227","msg":"Starting workers","controller":"clusterqueue","controllerGroup":"kueue.x-k8s.io","controllerKind":"ClusterQueue","worker count":3}
{"level":"info","ts":"2023-01-11T13:44:21.427033767Z","caller":"controller/controller.go:227","msg":"Starting workers","controller":"job","controllerGroup":"batch","controllerKind":"Job","worker count":3}
```
