### PR TITLE
Move version/commint logs after the logging is fully set up

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,8 +69,6 @@ func init() {
 }
 
 func main() {
-	setupLog.Info("Initializing", "gitVersion", version.GitVersion, "gitCommit", version.GitCommit)
-
 	var configFile string
 	flag.StringVar(&configFile, "config", "",
 		"The controller will load its initial configuration from this file. "+
@@ -84,6 +82,7 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	setupLog.Info("Initializing", "gitVersion", version.GitVersion, "gitCommit", version.GitCommit)
 
 	options, cfg := apply(configFile)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Currently the version and commit information is not printed due to wrong placement of the log (before init). This PR moves it after the init.

Before:
```
Version/commit is NOT printed
```

After:
```
{"level":"info","ts":"2023-01-11T14:53:15.204052+01:00","logger":"setup","caller":"kueue/main.go:85","msg":"Initializing","gitVersion":"v0.3.0-devel-168-gc326046-dirty","gitCommit":"c326046d8e41b57bf242fba021bedaa12613abf9"}
```
