### PR TITLE
Set Job controller concurrency to 5 and drop other controllers to 1

### DIFF
--- a/config/components/manager/controller_manager_config.yaml
+++ b/config/components/manager/controller_manager_config.yaml
@@ -11,11 +11,11 @@ leaderElection:
   resourceName: c1f6bfd2.kueue.x-k8s.io
 controller:
   groupKindConcurrency:
-    Job.batch: 3
-    LocalQueue.kueue.x-k8s.io: 3
-    ClusterQueue.kueue.x-k8s.io: 3
-    ResourceFlavor.kueue.x-k8s.io: 3
-    Workload.kueue.x-k8s.io: 3
+    Job.batch: 5
+    LocalQueue.kueue.x-k8s.io: 1
+    ClusterQueue.kueue.x-k8s.io: 1
+    ResourceFlavor.kueue.x-k8s.io: 1
+    Workload.kueue.x-k8s.io: 1
 clientConnection:
   qps: 50
   burst: 100


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

On small to medium clusters higher parallelism on controllers other than Job, particularly ClusterQueue and LocalQueue controllers, can actually lead to poor performance. On those clusters the amount of ApiServer write QPS is fairly limited and using them for *Queue status (pod counter) updates chokes more important components. 


