### PR TITLE
Add default namespace to job in /samples

### DIFF
--- a/config/samples/sample-job.yaml
+++ b/config/samples/sample-job.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   generateName: sample-job-
+  namespace: default
   annotations:
     kueue.x-k8s.io/queue-name: main
 spec:
@@ -12,7 +13,7 @@ spec:
     spec:
       containers:
       - name: dummy-job
-        image: gcr.io/k8s-staging-perf-tests/sleep:latest
+        image: gcr.io/k8s-staging-perf-tests/sleep:v0.0.3
         args: ["30s"]
         resources:
           requests:


### PR DESCRIPTION
1. Add default namespace to Job, make sure it is in the sanme namespace with localQUeue
2. Add tag to image, no need to pull images always in kind

Signed-off-by: Kante Yin <kerthcet@gmail.com>

/kind cleanup

