### PR TITLE
Fix: add permission to watch RuntimeClass

### DIFF
--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -173,6 +173,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - scheduling.k8s.io
   resources:

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -122,7 +122,7 @@ func NewWorkloadReconciler(client client.Client, queues *queue.Manager, cache *c
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads/finalizers,verbs=update
-//+kubebuilder:rbac:groups=node.k8s.io,resources=runtimeclasses,verbs=get;list
+//+kubebuilder:rbac:groups=node.k8s.io,resources=runtimeclasses,verbs=get;list;watch
 
 func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var wl kueue.Workload


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Kueue needs watch permissions to maintain the informer for RuntimeClass

#### Which issue(s) this PR fixes:

Fixes #564

#### Special notes for your reviewer:

This issue wouldn't show in integration tests.
And we can't simulate a RuntimeClass in a kind cluster, our current E2E test platform.
