### PR TITLE
[workload] Get default resource values from LimitRanges

### DIFF
--- a/apis/kueue/webhooks/workload_webhook.go
+++ b/apis/kueue/webhooks/workload_webhook.go
@@ -19,7 +19,6 @@ package webhooks
 import (
 	"context"
 
-	corev1 "k8s.io/api/core/v1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -61,28 +60,7 @@ func (w *WorkloadWebhook) Default(ctx context.Context, obj runtime.Object) error
 			podSet.Name = kueue.DefaultPodSetName
 		}
 	}
-	for i := range wl.Spec.PodSets {
-		podSet := &wl.Spec.PodSets[i]
-		setContainersDefaults(podSet.Template.Spec.InitContainers)
-		setContainersDefaults(podSet.Template.Spec.Containers)
-	}
 	return nil
-}
-
-func setContainersDefaults(containers []corev1.Container) {
-	for i := range containers {
-		c := &containers[i]
-		if c.Resources.Limits != nil {
-			if c.Resources.Requests == nil {
-				c.Resources.Requests = make(corev1.ResourceList)
-			}
-			for k, v := range c.Resources.Limits {
-				if _, exists := c.Resources.Requests[k]; !exists {
-					c.Resources.Requests[k] = v.DeepCopy()
-				}
-			}
-		}
-	}
 }
 
 // +kubebuilder:webhook:path=/validate-kueue-x-k8s-io-v1beta1-workload,mutating=false,failurePolicy=fail,sideEffects=None,groups=kueue.x-k8s.io,resources=workloads;workloads/status,verbs=create;update,versions=v1beta1,name=vworkload.kb.io,admissionReviewVersions=v1

--- a/apis/kueue/webhooks/workload_webhook_test.go
+++ b/apis/kueue/webhooks/workload_webhook_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -70,113 +69,6 @@ func TestWorkloadWebhookDefault(t *testing.T) {
 					PodSets: []kueue.PodSet{
 						{},
 						{},
-					},
-				},
-			},
-		},
-		"copy limits to requests": {
-			wl: kueue.Workload{
-				Spec: kueue.WorkloadSpec{
-					PodSets: []kueue.PodSet{
-						{
-							Name: "foo",
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									InitContainers: []corev1.Container{
-										{
-											Resources: corev1.ResourceRequirements{
-												Requests: corev1.ResourceList{
-													"cpu": resource.MustParse("1"),
-												},
-												Limits: corev1.ResourceList{
-													"cpu":    resource.MustParse("2"),
-													"memory": resource.MustParse("1Mi"),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-						{
-							Name: "bar",
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{
-											Resources: corev1.ResourceRequirements{
-												Limits: corev1.ResourceList{
-													"cpu":    resource.MustParse("1.5"),
-													"memory": resource.MustParse("5Mi"),
-												},
-											},
-										},
-										{
-											Resources: corev1.ResourceRequirements{
-												Requests: corev1.ResourceList{
-													"cpu": resource.MustParse("1"),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantWl: kueue.Workload{
-				Spec: kueue.WorkloadSpec{
-					PodSets: []kueue.PodSet{
-						{
-							Name: "foo",
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									InitContainers: []corev1.Container{
-										{
-											Resources: corev1.ResourceRequirements{
-												Requests: corev1.ResourceList{
-													"cpu":    resource.MustParse("1"),
-													"memory": resource.MustParse("1Mi"),
-												},
-												Limits: corev1.ResourceList{
-													"cpu":    resource.MustParse("2"),
-													"memory": resource.MustParse("1Mi"),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-						{
-							Name: "bar",
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{
-										{
-											Resources: corev1.ResourceRequirements{
-												Requests: corev1.ResourceList{
-													"cpu":    resource.MustParse("1.5"),
-													"memory": resource.MustParse("5Mi"),
-												},
-												Limits: corev1.ResourceList{
-													"cpu":    resource.MustParse("1.5"),
-													"memory": resource.MustParse("5Mi"),
-												},
-											},
-										},
-										{
-											Resources: corev1.ResourceRequirements{
-												Requests: corev1.ResourceList{
-													"cpu": resource.MustParse("1"),
-												},
-											},
-										},
-									},
-								},
-							},
-						},
 					},
 				},
 			},

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -16,6 +16,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - limitranges
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - get

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +37,8 @@ import (
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/queue"
+	"sigs.k8s.io/kueue/pkg/util/limitrange"
+	"sigs.k8s.io/kueue/pkg/util/resource"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -119,6 +122,7 @@ func NewWorkloadReconciler(client client.Client, queues *queue.Manager, cache *c
 }
 
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update
+//+kubebuilder:rbac:groups="",resources=limitranges,verbs=get;list;watch
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads/finalizers,verbs=update
@@ -200,6 +204,7 @@ func (r *WorkloadReconciler) Create(e event.CreateEvent) bool {
 
 	wlCopy := wl.DeepCopy()
 	handlePodOverhead(r.log, wlCopy, r.client)
+	r.handlePodLimitRange(log, wlCopy)
 
 	if wl.Status.Admission == nil {
 		if !r.queues.AddOrUpdateWorkload(wlCopy) {
@@ -279,6 +284,7 @@ func (r *WorkloadReconciler) Update(e event.UpdateEvent) bool {
 	wlCopy := wl.DeepCopy()
 	// We do not handle old workload here as it will be deleted or replaced by new one anyway.
 	handlePodOverhead(r.log, wlCopy, r.client)
+	r.handlePodLimitRange(log, wlCopy)
 
 	switch {
 	case status == finished:
@@ -422,6 +428,39 @@ func handlePodOverhead(log logr.Logger, wl *kueue.Workload, c client.Client) {
 			if runtimeClass.Overhead != nil {
 				podSpec.Overhead = runtimeClass.Overhead.PodFixed
 			}
+		}
+	}
+}
+
+func (r *WorkloadReconciler) handlePodLimitRange(log logr.Logger, wl *kueue.Workload) {
+	ctx := context.TODO()
+	// get the list of limit ranges
+	var list corev1.LimitRangeList
+	if err := r.client.List(ctx, &list, &client.ListOptions{Namespace: wl.Namespace}); err != nil {
+		log.Error(err, "Could not list LimitRanges")
+		return
+	}
+
+	if len(list.Items) == 0 {
+		return
+	}
+	summary := limitrange.Summarize(list.Items...)
+	containerLimits, found := summary[corev1.LimitTypeContainer]
+	if !found {
+		return
+	}
+
+	for pi := range wl.Spec.PodSets {
+		pod := &wl.Spec.PodSets[pi].Template.Spec
+		for ci := range pod.InitContainers {
+			res := &pod.InitContainers[ci].Resources
+			res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
+			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
+		}
+		for ci := range pod.Containers {
+			res := &pod.Containers[ci].Resources
+			res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
+			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
 		}
 	}
 }

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -36,6 +36,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/util/limitrange"
 	"sigs.k8s.io/kueue/pkg/util/resource"
@@ -438,7 +439,7 @@ func (r *WorkloadReconciler) handlePodLimitRange(log logr.Logger, wl *kueue.Work
 	ctx := context.TODO()
 	// get the list of limit ranges
 	var list corev1.LimitRangeList
-	if err := r.client.List(ctx, &list, &client.ListOptions{Namespace: wl.Namespace}); err != nil {
+	if err := r.client.List(ctx, &list, &client.ListOptions{Namespace: wl.Namespace}, client.MatchingFields{indexer.LimitRangeHasContainerType: "true"}); err != nil {
 		log.Error(err, "Could not list LimitRanges")
 		return
 	}

--- a/pkg/util/limitrange/limitrange.go
+++ b/pkg/util/limitrange/limitrange.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package limitrange
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/kueue/pkg/util/resource"
+)
+
+type Summary map[corev1.LimitType]corev1.LimitRangeItem
+
+// Summarize summarizes the provides ranges by:
+// 1. keeping the lowest values for Max and MaxLimitReqestRatio limits
+// 2. keeping the highest values for Min limits
+// 3. keeping the first encountered values for Default and DefaultRequests
+func Summarize(ranges ...corev1.LimitRange) Summary {
+	ret := make(Summary, 3)
+	for i := range ranges {
+		for _, item := range ranges[i].Spec.Limits {
+			ret[item.Type] = addToSummary(ret[item.Type], item)
+		}
+	}
+	return ret
+}
+
+func addToSummary(summary, item corev1.LimitRangeItem) corev1.LimitRangeItem {
+	summary.Max = resource.MergeResourceListKeepMin(summary.Max, item.Max)
+	summary.Min = resource.MergeResourceListKeepMax(summary.Min, item.Min)
+
+	summary.Default = resource.MergeResourceListKeepFirst(summary.Default, item.Default)
+	summary.DefaultRequest = resource.MergeResourceListKeepFirst(summary.DefaultRequest, item.DefaultRequest)
+
+	summary.MaxLimitRequestRatio = resource.MergeResourceListKeepMin(summary.MaxLimitRequestRatio, item.MaxLimitRequestRatio)
+	return summary
+}

--- a/pkg/util/limitrange/limitrange_test.go
+++ b/pkg/util/limitrange/limitrange_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package limitrange
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+)
+
+var (
+	ar1    = apiresource.MustParse("1")
+	ar2    = apiresource.MustParse("2")
+	ar500m = apiresource.MustParse("500m")
+	ar1Gi  = apiresource.MustParse("1Gi")
+	ar2Gi  = apiresource.MustParse("2Gi")
+)
+
+func TestSummarize(t *testing.T) {
+
+	cases := map[string]struct {
+		ranges   []corev1.LimitRange
+		expected Summary
+	}{
+		"empty": {
+			ranges:   []corev1.LimitRange{},
+			expected: map[corev1.LimitType]corev1.LimitRangeItem{},
+		},
+		"podDefaults": {
+			ranges: []corev1.LimitRange{
+				{
+					Spec: corev1.LimitRangeSpec{
+						Limits: []corev1.LimitRangeItem{
+							{
+								Type: corev1.LimitTypePod,
+								Default: corev1.ResourceList{
+									corev1.ResourceCPU: ar2,
+								},
+								DefaultRequest: corev1.ResourceList{
+									corev1.ResourceCPU:    ar500m,
+									corev1.ResourceMemory: ar1Gi,
+								},
+							},
+						},
+					},
+				},
+				{
+					Spec: corev1.LimitRangeSpec{
+						Limits: []corev1.LimitRangeItem{
+							{
+								Type: corev1.LimitTypePod,
+								Default: corev1.ResourceList{
+									corev1.ResourceMemory: ar2Gi,
+								},
+								DefaultRequest: corev1.ResourceList{
+									corev1.ResourceCPU: ar1,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[corev1.LimitType]corev1.LimitRangeItem{
+				corev1.LimitTypePod: {
+					Default: corev1.ResourceList{
+						corev1.ResourceCPU:    ar2,
+						corev1.ResourceMemory: ar2Gi,
+					},
+					DefaultRequest: corev1.ResourceList{
+						corev1.ResourceCPU:    ar500m,
+						corev1.ResourceMemory: ar1Gi,
+					},
+				},
+			},
+		},
+		"limits": {
+			ranges: []corev1.LimitRange{
+				{
+					Spec: corev1.LimitRangeSpec{
+						Limits: []corev1.LimitRangeItem{
+							{
+								Type: corev1.LimitTypePod,
+								Max: corev1.ResourceList{
+									corev1.ResourceCPU: ar2,
+								},
+								Min: corev1.ResourceList{
+									corev1.ResourceCPU:    ar500m,
+									corev1.ResourceMemory: ar1Gi,
+								},
+								MaxLimitRequestRatio: corev1.ResourceList{
+									corev1.ResourceCPU: ar2,
+								},
+							},
+						},
+					},
+				},
+				{
+					Spec: corev1.LimitRangeSpec{
+						Limits: []corev1.LimitRangeItem{
+							{
+								Type: corev1.LimitTypePod,
+								Max: corev1.ResourceList{
+									corev1.ResourceMemory: ar2Gi,
+								},
+								Min: corev1.ResourceList{
+									corev1.ResourceCPU: ar1,
+								},
+								MaxLimitRequestRatio: corev1.ResourceList{
+									corev1.ResourceCPU: ar500m,
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: Summary{
+				corev1.LimitTypePod: {
+					Max: corev1.ResourceList{
+						corev1.ResourceCPU:    ar2,
+						corev1.ResourceMemory: ar2Gi,
+					},
+					Min: corev1.ResourceList{
+						corev1.ResourceCPU:    ar1,
+						corev1.ResourceMemory: ar1Gi,
+					},
+					MaxLimitRequestRatio: corev1.ResourceList{
+						corev1.ResourceCPU: ar500m,
+					},
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			result := Summarize(tc.ranges...)
+			if diff := cmp.Diff(tc.expected, result); diff != "" {
+				t.Errorf("Unexpected result (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/util/resource/resource.go
+++ b/pkg/util/resource/resource.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+)
+
+type resolveConflict func(a, b apiresource.Quantity) apiresource.Quantity
+
+func mergeResourceList(a, b corev1.ResourceList, f resolveConflict) corev1.ResourceList {
+	if a == nil {
+		return b.DeepCopy()
+	}
+	ret := a.DeepCopy()
+
+	for k, vb := range b {
+		if va, exists := ret[k]; !exists {
+			ret[k] = vb.DeepCopy()
+		} else {
+			if f != nil {
+				ret[k] = f(va, vb)
+			}
+		}
+	}
+	return ret
+}
+
+// MergeResourceListKeepFirst creates a new ResourceList holding all resource values from dst
+// and any new values from src
+func MergeResourceListKeepFirst(dst, src corev1.ResourceList) corev1.ResourceList {
+	return mergeResourceList(dst, src, nil)
+}
+
+// MergeResourceListKeepMax creates a new ResourceList holding all the values from a and b
+// and resolve potential conflicts by keeping the highest value.
+func MergeResourceListKeepMax(a, b corev1.ResourceList) corev1.ResourceList {
+	return mergeResourceList(a, b, func(a, b apiresource.Quantity) apiresource.Quantity {
+		if a.Cmp(b) < 0 {
+			return b
+		}
+		return a
+	})
+}
+
+// MergeResourceListKeepMin creates a new ResourceList holding all the values from a and b
+// and resolve potential conflicts by keeping the lowest value.
+func MergeResourceListKeepMin(a, b corev1.ResourceList) corev1.ResourceList {
+	return mergeResourceList(a, b, func(a, b apiresource.Quantity) apiresource.Quantity {
+		if a.Cmp(b) > 0 {
+			return b
+		}
+		return a
+	})
+}
+
+// MergeResourceListKeepSum creates a new ResourceList holding all the values from a and b
+// and resolve potential conflicts by adding up the tow values.
+func MergeResourceListKeepSum(a, b corev1.ResourceList) corev1.ResourceList {
+	return mergeResourceList(a, b, func(a, b apiresource.Quantity) apiresource.Quantity {
+		a.Add(b)
+		return a
+	})
+}

--- a/pkg/util/resource/resource_test.go
+++ b/pkg/util/resource/resource_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestMerge(t *testing.T) {
+	rl_500mcpu_2GiMem := corev1.ResourceList{
+		corev1.ResourceCPU:    apiresource.MustParse("500m"),
+		corev1.ResourceMemory: apiresource.MustParse("2Gi"),
+	}
+	rl_1cpu := corev1.ResourceList{
+		corev1.ResourceCPU: apiresource.MustParse("1"),
+	}
+	rl_1cpu_1GiMem := corev1.ResourceList{
+		corev1.ResourceCPU:    apiresource.MustParse("1"),
+		corev1.ResourceMemory: apiresource.MustParse("1Gi"),
+	}
+
+	type oper_result struct {
+		oper   func(a, b corev1.ResourceList) corev1.ResourceList
+		result corev1.ResourceList
+	}
+	cases := map[string]struct {
+		a    corev1.ResourceList
+		b    corev1.ResourceList
+		want map[string]oper_result
+	}{
+		"asymmetric": {
+			a: rl_1cpu,
+			b: rl_500mcpu_2GiMem,
+			want: map[string]oper_result{
+				"merge": {
+					oper: MergeResourceListKeepFirst,
+					result: corev1.ResourceList{
+						corev1.ResourceCPU:    apiresource.MustParse("1"),
+						corev1.ResourceMemory: apiresource.MustParse("2Gi"),
+					},
+				},
+				"min": {
+					oper: MergeResourceListKeepMin,
+					result: corev1.ResourceList{
+						corev1.ResourceCPU:    apiresource.MustParse("500m"),
+						corev1.ResourceMemory: apiresource.MustParse("2Gi"),
+					},
+				},
+				"max": {
+					oper: MergeResourceListKeepMax,
+					result: corev1.ResourceList{
+						corev1.ResourceCPU:    apiresource.MustParse("1"),
+						corev1.ResourceMemory: apiresource.MustParse("2Gi"),
+					},
+				},
+				"sum": {
+					oper: MergeResourceListKeepSum,
+					result: corev1.ResourceList{
+						corev1.ResourceCPU:    apiresource.MustParse("1500m"),
+						corev1.ResourceMemory: apiresource.MustParse("2Gi"),
+					},
+				},
+			},
+		},
+		"symmetric": {
+			a: rl_1cpu_1GiMem,
+			b: rl_500mcpu_2GiMem,
+			want: map[string]oper_result{
+				"merge": {
+					oper: MergeResourceListKeepFirst,
+					result: corev1.ResourceList{
+						corev1.ResourceCPU:    apiresource.MustParse("1"),
+						corev1.ResourceMemory: apiresource.MustParse("1Gi"),
+					},
+				},
+				"min": {
+					oper: MergeResourceListKeepMin,
+					result: corev1.ResourceList{
+						corev1.ResourceCPU:    apiresource.MustParse("500m"),
+						corev1.ResourceMemory: apiresource.MustParse("1Gi"),
+					},
+				},
+				"max": {
+					oper: MergeResourceListKeepMax,
+					result: corev1.ResourceList{
+						corev1.ResourceCPU:    apiresource.MustParse("1"),
+						corev1.ResourceMemory: apiresource.MustParse("2Gi"),
+					},
+				},
+				"sum": {
+					oper: MergeResourceListKeepSum,
+					result: corev1.ResourceList{
+						corev1.ResourceCPU:    apiresource.MustParse("1500m"),
+						corev1.ResourceMemory: apiresource.MustParse("3Gi"),
+					},
+				},
+			},
+		},
+		"nil source": {
+			a: rl_1cpu_1GiMem,
+			b: nil,
+			want: map[string]oper_result{
+				"merge": {
+					oper:   MergeResourceListKeepFirst,
+					result: rl_1cpu_1GiMem,
+				},
+				"min": {
+					oper:   MergeResourceListKeepMin,
+					result: rl_1cpu_1GiMem,
+				},
+				"max": {
+					oper:   MergeResourceListKeepMax,
+					result: rl_1cpu_1GiMem,
+				},
+				"sum": {
+					oper:   MergeResourceListKeepSum,
+					result: rl_1cpu_1GiMem,
+				},
+			},
+		},
+		"nil destination": {
+			a: nil,
+			b: rl_1cpu_1GiMem,
+			want: map[string]oper_result{
+				"merge": {
+					oper:   MergeResourceListKeepFirst,
+					result: rl_1cpu_1GiMem,
+				},
+				"min": {
+					oper:   MergeResourceListKeepMin,
+					result: rl_1cpu_1GiMem,
+				},
+				"max": {
+					oper:   MergeResourceListKeepMax,
+					result: rl_1cpu_1GiMem,
+				},
+				"sum": {
+					oper:   MergeResourceListKeepSum,
+					result: rl_1cpu_1GiMem,
+				},
+			},
+		},
+		"nil": {
+			a: nil,
+			b: nil,
+			want: map[string]oper_result{
+				"merge": {
+					oper:   MergeResourceListKeepFirst,
+					result: nil,
+				},
+				"min": {
+					oper:   MergeResourceListKeepMin,
+					result: nil,
+				},
+				"max": {
+					oper:   MergeResourceListKeepMax,
+					result: nil,
+				},
+				"sum": {
+					oper:   MergeResourceListKeepSum,
+					result: nil,
+				},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			for opname, oper := range tc.want {
+				t.Run(opname, func(t *testing.T) {
+					result := oper.oper(tc.a, tc.b)
+					if diff := cmp.Diff(oper.result, result); diff != "" {
+						t.Errorf("Unexpected result (-want,+got):\n%s", diff)
+					}
+				})
+			}
+		})
+	}
+
+}

--- a/test/integration/controller/core/workload_controller_test.go
+++ b/test/integration/controller/core/workload_controller_test.go
@@ -24,13 +24,16 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/test/util"
 )
 
@@ -247,6 +250,93 @@ var _ = ginkgo.Describe("Workload controller", func() {
 					}},
 				}},
 			}, ignoreCqCondition))
+		})
+	})
+
+	ginkgo.When("When LimitRanges are defined", func() {
+		ginkgo.BeforeEach(func() {
+			limitRange := testing.MakeLimitRange("limits", ns.Name).WithValue("DefaultRequest", corev1.ResourceCPU, "3").Obj()
+			gomega.Expect(k8sClient.Create(ctx, limitRange)).To(gomega.Succeed())
+			clusterQueue = testing.MakeClusterQueue("clusterqueue").
+				ResourceGroup(*testing.MakeFlavorQuotas(flavorOnDemand).
+					Resource(corev1.ResourceCPU, "5", "5").Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
+			localQueue = testing.MakeLocalQueue("queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
+		})
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteRuntimeClass(ctx, k8sClient, runtimeClass)).To(gomega.Succeed())
+			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		})
+
+		ginkgo.It("Should use the range defined default requests, if provided", func() {
+			ginkgo.By("Create and admit workload")
+			wl = testing.MakeWorkload("one", ns.Name).
+				Queue(localQueue.Name).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+			admitPatch := workload.BaseSSAWorkload(wl)
+			admitPatch.Status.Admission = testing.MakeAdmission(clusterQueue.Name).
+				Flavor(corev1.ResourceCPU, flavorOnDemand).Obj()
+			gomega.Expect(k8sClient.Status().Patch(ctx, admitPatch, client.Apply, client.FieldOwner(constants.AdmissionName))).To(gomega.Succeed())
+
+			ginkgo.By("Got ClusterQueueStatus")
+			gomega.Eventually(func() kueue.ClusterQueueStatus {
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+				return updatedCQ.Status
+			}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+				PendingWorkloads:  0,
+				AdmittedWorkloads: 1,
+				FlavorsUsage: []kueue.FlavorUsage{{
+					Name: flavorOnDemand,
+					Resources: []kueue.ResourceUsage{{
+						Name:  corev1.ResourceCPU,
+						Total: resource.MustParse("3"),
+					}},
+				}},
+			}, ignoreCqCondition))
+
+			ginkgo.By("PodSets do not change", func() {
+				wlRead := kueue.Workload{}
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &wlRead)).To(gomega.Succeed())
+				gomega.Expect(equality.Semantic.DeepEqual(wl.Spec.PodSets, wlRead.Spec.PodSets)).To(gomega.BeTrue())
+			})
+		})
+		ginkgo.It("Should not use the range defined requests, if provided by the workload", func() {
+			ginkgo.By("Create and admit workload")
+			wl = testing.MakeWorkload("one", ns.Name).
+				Queue(localQueue.Name).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+			admitPatch := workload.BaseSSAWorkload(wl)
+			admitPatch.Status.Admission = testing.MakeAdmission(clusterQueue.Name).
+				Flavor(corev1.ResourceCPU, flavorOnDemand).Obj()
+			gomega.Expect(k8sClient.Status().Patch(ctx, admitPatch, client.Apply, client.FieldOwner(constants.AdmissionName))).To(gomega.Succeed())
+
+			ginkgo.By("Got ClusterQueueStatus")
+			gomega.Eventually(func() kueue.ClusterQueueStatus {
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+				return updatedCQ.Status
+			}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+				PendingWorkloads:  0,
+				AdmittedWorkloads: 1,
+				FlavorsUsage: []kueue.FlavorUsage{{
+					Name: flavorOnDemand,
+					Resources: []kueue.ResourceUsage{{
+						Name:  corev1.ResourceCPU,
+						Total: resource.MustParse("1"),
+					}},
+				}},
+			}, ignoreCqCondition))
+
+			ginkgo.By("PodSets do not change", func() {
+				wlRead := kueue.Workload{}
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &wlRead)).To(gomega.Succeed())
+				gomega.Expect(equality.Semantic.DeepEqual(wl.Spec.PodSets, wlRead.Spec.PodSets)).To(gomega.BeTrue())
+			})
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add the possibility to use default workload resource values based on [LimitRanges](https://kubernetes.io/docs/concepts/policy/limit-range/#constraints-on-resource-limits-and-requests) if present in the target namespace.

The order by which Requested resource values are set becomes:
1. Job spec
3. LimitRanges in the target namespace
2. Limits  set for the same container in the Job Spec

In addition, this provides a more generic alternative approach to fix #590, by moving the limits to request default in the workload controller without an impact to the workload's spec .

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #541, #590

#### Special notes for your reviewer:

