### PR TITLE
Commonize webhooks and indexing

### DIFF
--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+func ApplyDefaultForSuspend(job GenericJob, manageJobsWithoutQueueName bool) {
+	if job.QueueName() != "" || manageJobsWithoutQueueName {
+		if !job.IsSuspended() {
+			job.Suspend()
+		}
+	}
+}

--- a/pkg/controller/jobframework/indexer.go
+++ b/pkg/controller/jobframework/indexer.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+)
+
+func SetupOwnerIndex(ctx context.Context, indexer client.FieldIndexer, gvk schema.GroupVersionKind) error {
+	return indexer.IndexField(ctx, &kueue.Workload{}, GetOwnerKey(gvk), func(o client.Object) []string {
+		// grab the Workload object, extract the owner...
+		wl := o.(*kueue.Workload)
+		owner := metav1.GetControllerOf(wl)
+		if owner == nil {
+			return nil
+		}
+		// ...make sure it's the job with matching GVK...
+		if owner.Kind != gvk.Kind || owner.APIVersion != gvk.GroupVersion().String() {
+			return nil
+		}
+		// ...and if so, return it
+		return []string{owner.Name}
+	})
+}

--- a/pkg/controller/jobframework/indexer.go
+++ b/pkg/controller/jobframework/indexer.go
@@ -23,8 +23,8 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
-func SetupOwnerIndex(ctx context.Context, indexer client.FieldIndexer, gvk schema.GroupVersionKind) error {
-	return indexer.IndexField(ctx, &kueue.Workload{}, GetOwnerKey(gvk), func(o client.Object) []string {
+func SetupWorkloadOwnerIndex(ctx context.Context, indexer client.FieldIndexer, gvk schema.GroupVersionKind) error {
+	return indexer.IndexField(ctx, &kueue.Workload{}, getOwnerKey(gvk), func(o client.Object) []string {
 		// grab the Workload object, extract the owner...
 		wl := o.(*kueue.Workload)
 		owner := metav1.GetControllerOf(wl)

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -24,19 +24,19 @@ import (
 type GenericJob interface {
 	// Object returns the job instance.
 	Object() client.Object
-	// IsSuspend returns whether the job is suspended or not.
-	IsSuspend() bool
+	// IsSuspended returns whether the job is suspended or not.
+	IsSuspended() bool
 	// Suspend will suspend the job.
-	Suspend() error
+	Suspend()
 	// UnSuspend will unsuspend the job.
-	UnSuspend() error
+	UnSuspend()
 	// ResetStatus will reset the job status to the original state.
 	// If true, status is modified, if not, status is as it was.
 	ResetStatus() bool
 	// InjectNodeAffinity will inject the node affinity extracting from workload to job.
-	InjectNodeAffinity(nodeSelectors []map[string]string) error
+	InjectNodeAffinity(nodeSelectors []map[string]string)
 	// RestoreNodeAffinity will restore the original node affinity of job.
-	RestoreNodeAffinity(podSets []kueue.PodSet) error
+	RestoreNodeAffinity(podSets []kueue.PodSet)
 	// Finished means whether the job is completed/failed or not,
 	// condition represents the workload finished condition.
 	Finished() (condition metav1.Condition, finished bool)

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -28,13 +28,11 @@ type GenericJob interface {
 	IsSuspended() bool
 	// Suspend will suspend the job.
 	Suspend()
-	// UnSuspend will unsuspend the job.
-	UnSuspend()
 	// ResetStatus will reset the job status to the original state.
 	// If true, status is modified, if not, status is as it was.
 	ResetStatus() bool
-	// InjectNodeAffinity will inject the node affinity extracting from workload to job.
-	InjectNodeAffinity(nodeSelectors []map[string]string)
+	// RunWithNodeAffinity will inject the node affinity extracting from workload to job and unsuspend the job.
+	RunWithNodeAffinity(nodeSelectors []map[string]string)
 	// RestoreNodeAffinity will restore the original node affinity of job.
 	RestoreNodeAffinity(podSets []kueue.PodSet)
 	// Finished means whether the job is completed/failed or not,

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -232,7 +232,7 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 
 	var workloads kueue.WorkloadList
 	if err := r.client.List(ctx, &workloads, client.InNamespace(object.GetNamespace()),
-		client.MatchingFields{GetOwnerKey(job.GetGVK()): object.GetName()}); err != nil {
+		client.MatchingFields{getOwnerKey(job.GetGVK()): object.GetName()}); err != nil {
 		log.Error(err, "Unable to list child workloads")
 		return nil, err
 	}
@@ -304,8 +304,7 @@ func (r *JobReconciler) startJob(ctx context.Context, job GenericJob, object cli
 	if err != nil {
 		return err
 	}
-	job.InjectNodeAffinity(nodeSelectors)
-	job.UnSuspend()
+	job.RunWithNodeAffinity(nodeSelectors)
 
 	if err := r.client.Update(ctx, object); err != nil {
 		return err

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -29,14 +29,7 @@ var (
 	QueueNamePath         = annotationsPath.Key(constants.QueueAnnotation)
 )
 
-func ApplyDefaultForSuspend(job GenericJob, manageJobsWithoutQueueName bool) {
-	if job.QueueName() != "" || manageJobsWithoutQueueName {
-		if !job.IsSuspended() {
-			job.Suspend()
-		}
-	}
-}
-func ValidateCreateForCRDNameAnnotation(job GenericJob, crdNameAnnotation string) field.ErrorList {
+func ValidateAnnotationAsCRDName(job GenericJob, crdNameAnnotation string) field.ErrorList {
 	var allErrs field.ErrorList
 	if value, exists := job.Object().GetAnnotations()[crdNameAnnotation]; exists {
 		if errs := validation.IsDNS1123Subdomain(value); len(errs) > 0 {

--- a/pkg/controller/jobframework/webhook.go
+++ b/pkg/controller/jobframework/webhook.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+import (
+	"strings"
+
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"sigs.k8s.io/kueue/pkg/constants"
+)
+
+var (
+	annotationsPath       = field.NewPath("metadata", "annotations")
+	ParentWorkloadKeyPath = annotationsPath.Key(constants.ParentWorkloadAnnotation)
+	QueueNamePath         = annotationsPath.Key(constants.QueueAnnotation)
+)
+
+func ApplyDefaultForSuspend(job GenericJob, manageJobsWithoutQueueName bool) {
+	if job.QueueName() != "" || manageJobsWithoutQueueName {
+		if !job.IsSuspended() {
+			job.Suspend()
+		}
+	}
+}
+func ValidateCreateForCRDNameAnnotation(job GenericJob, crdNameAnnotation string) field.ErrorList {
+	var allErrs field.ErrorList
+	if value, exists := job.Object().GetAnnotations()[crdNameAnnotation]; exists {
+		if errs := validation.IsDNS1123Subdomain(value); len(errs) > 0 {
+			allErrs = append(allErrs, field.Invalid(annotationsPath.Key(crdNameAnnotation), value, strings.Join(errs, ",")))
+		}
+	}
+	return allErrs
+}
+
+func ValidateUpdateForQueueName(oldJob, newJob GenericJob) field.ErrorList {
+	var allErrs field.ErrorList
+	if !newJob.IsSuspended() && (oldJob.QueueName() != newJob.QueueName()) {
+		allErrs = append(allErrs, field.Forbidden(QueueNamePath, "must not update queue name when job is unsuspend"))
+	}
+	return allErrs
+}
+
+func ValidateUpdateForParentWorkload(oldJob, newJob GenericJob) field.ErrorList {
+	var allErrs field.ErrorList
+	if errList := apivalidation.ValidateImmutableField(newJob.ParentWorkloadName(),
+		oldJob.ParentWorkloadName(), ParentWorkloadKeyPath); len(errList) > 0 {
+		allErrs = append(allErrs, field.Forbidden(ParentWorkloadKeyPath, "this annotation is immutable"))
+	}
+	return allErrs
+}

--- a/pkg/controller/jobframework/workload_names.go
+++ b/pkg/controller/jobframework/workload_names.go
@@ -59,6 +59,6 @@ func getHash(ownerName string, gvk schema.GroupVersionKind) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func GetOwnerKey(ownerGVK schema.GroupVersionKind) string {
+func getOwnerKey(ownerGVK schema.GroupVersionKind) string {
 	return fmt.Sprintf(".metadata.ownerReferences[%s.%s]", ownerGVK.Group, ownerGVK.Kind)
 }

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -124,6 +124,7 @@ func (j *Job) ParentWorkloadName() string {
 func (j *Job) QueueName() string {
 	return j.Annotations[constants.QueueAnnotation]
 }
+
 func (j *Job) IsSuspended() bool {
 	return j.Spec.Suspend != nil && *j.Spec.Suspend
 }
@@ -134,10 +135,6 @@ func (j *Job) IsActive() bool {
 
 func (j *Job) Suspend() {
 	j.Spec.Suspend = pointer.Bool(true)
-}
-
-func (j *Job) UnSuspend() {
-	j.Spec.Suspend = pointer.Bool(false)
 }
 
 func (j *Job) ResetStatus() bool {
@@ -162,7 +159,8 @@ func (j *Job) PodSets() []kueue.PodSet {
 	}
 }
 
-func (j *Job) InjectNodeAffinity(nodeSelectors []map[string]string) {
+func (j *Job) RunWithNodeAffinity(nodeSelectors []map[string]string) {
+	j.Spec.Suspend = pointer.Bool(false)
 	if len(nodeSelectors) == 0 {
 		return
 	}
@@ -272,7 +270,7 @@ func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {
 	}); err != nil {
 		return err
 	}
-	return jobframework.SetupOwnerIndex(ctx, indexer, gvk)
+	return jobframework.SetupWorkloadOwnerIndex(ctx, indexer, gvk)
 }
 
 //+kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -124,8 +124,7 @@ func (j *Job) ParentWorkloadName() string {
 func (j *Job) QueueName() string {
 	return j.Annotations[constants.QueueAnnotation]
 }
-
-func (j *Job) IsSuspend() bool {
+func (j *Job) IsSuspended() bool {
 	return j.Spec.Suspend != nil && *j.Spec.Suspend
 }
 
@@ -133,14 +132,12 @@ func (j *Job) IsActive() bool {
 	return j.Status.Active != 0
 }
 
-func (j *Job) Suspend() error {
+func (j *Job) Suspend() {
 	j.Spec.Suspend = pointer.Bool(true)
-	return nil
 }
 
-func (j *Job) UnSuspend() error {
+func (j *Job) UnSuspend() {
 	j.Spec.Suspend = pointer.Bool(false)
-	return nil
 }
 
 func (j *Job) ResetStatus() bool {
@@ -165,9 +162,9 @@ func (j *Job) PodSets() []kueue.PodSet {
 	}
 }
 
-func (j *Job) InjectNodeAffinity(nodeSelectors []map[string]string) error {
+func (j *Job) InjectNodeAffinity(nodeSelectors []map[string]string) {
 	if len(nodeSelectors) == 0 {
-		return nil
+		return
 	}
 
 	if j.Spec.Template.Spec.NodeSelector == nil {
@@ -177,13 +174,11 @@ func (j *Job) InjectNodeAffinity(nodeSelectors []map[string]string) error {
 			j.Spec.Template.Spec.NodeSelector[k] = v
 		}
 	}
-
-	return nil
 }
 
-func (j *Job) RestoreNodeAffinity(podSets []kueue.PodSet) error {
+func (j *Job) RestoreNodeAffinity(podSets []kueue.PodSet) {
 	if len(podSets) == 0 || equality.Semantic.DeepEqual(j.Spec.Template.Spec.NodeSelector, podSets[0].Template.Spec.NodeSelector) {
-		return nil
+		return
 	}
 
 	j.Spec.Template.Spec.NodeSelector = map[string]string{}
@@ -191,7 +186,6 @@ func (j *Job) RestoreNodeAffinity(podSets []kueue.PodSet) error {
 	for k, v := range podSets[0].Template.Spec.NodeSelector {
 		j.Spec.Template.Spec.NodeSelector[k] = v
 	}
-	return nil
 }
 
 func (j *Job) Finished() (metav1.Condition, bool) {
@@ -278,17 +272,7 @@ func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {
 	}); err != nil {
 		return err
 	}
-	return indexer.IndexField(ctx, &kueue.Workload{}, jobframework.GetOwnerKey(gvk), func(o client.Object) []string {
-		// grab the Workload object, extract the owner...
-		wl := o.(*kueue.Workload)
-		owner := metav1.GetControllerOf(wl)
-		// ...make sure it's a Job...
-		if owner == nil || owner.APIVersion != batchv1.SchemeGroupVersion.String() || owner.Kind != "Job" {
-			return nil
-		}
-		// ...and if so, return it
-		return []string{owner.Name}
-	})
+	return jobframework.SetupOwnerIndex(ctx, indexer, gvk)
 }
 
 //+kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -90,8 +90,8 @@ func (w *JobWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) err
 
 func validateCreate(job jobframework.GenericJob) field.ErrorList {
 	var allErrs field.ErrorList
-	allErrs = append(allErrs, jobframework.ValidateCreateForCRDNameAnnotation(job, constants.ParentWorkloadAnnotation)...)
-	allErrs = append(allErrs, jobframework.ValidateCreateForCRDNameAnnotation(job, constants.QueueAnnotation)...)
+	allErrs = append(allErrs, jobframework.ValidateAnnotationAsCRDName(job, constants.ParentWorkloadAnnotation)...)
+	allErrs = append(allErrs, jobframework.ValidateAnnotationAsCRDName(job, constants.QueueAnnotation)...)
 	return allErrs
 }
 

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -18,13 +18,10 @@ package job
 
 import (
 	"context"
-	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
-	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -32,7 +29,6 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	"sigs.k8s.io/kueue/pkg/util/pointer"
 )
 
 type JobWebhook struct {
@@ -59,12 +55,6 @@ func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 
 var _ webhook.CustomDefaulter = &JobWebhook{}
 
-var (
-	annotationsPath       = field.NewPath("metadata", "annotations")
-	suspendPath           = field.NewPath("job", "spec", "suspend")
-	parentWorkloadKeyPath = annotationsPath.Key(constants.ParentWorkloadAnnotation)
-)
-
 // Default implements webhook.CustomDefaulter so a webhook will be registered for the type
 func (w *JobWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	job := obj.(*batchv1.Job)
@@ -82,15 +72,7 @@ func (w *JobWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		}
 	}
 
-	batchJob := Job{*job}
-	if batchJob.QueueName() == "" && !w.manageJobsWithoutQueueName {
-		return nil
-	}
-
-	if !(*job.Spec.Suspend) {
-		job.Spec.Suspend = pointer.Bool(true)
-	}
-
+	jobframework.ApplyDefaultForSuspend(&Job{*job}, w.manageJobsWithoutQueueName)
 	return nil
 }
 
@@ -101,18 +83,15 @@ var _ webhook.CustomValidator = &JobWebhook{}
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
 func (w *JobWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
 	job := obj.(*batchv1.Job)
-	return validateCreate(job).ToAggregate()
+	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")
+	log.V(5).Info("Validating create", "job", klog.KObj(job))
+	return validateCreate(&Job{*job}).ToAggregate()
 }
 
-func validateCreate(job *batchv1.Job) field.ErrorList {
+func validateCreate(job jobframework.GenericJob) field.ErrorList {
 	var allErrs field.ErrorList
-	for _, crdNameAnnotation := range []string{constants.ParentWorkloadAnnotation, constants.QueueAnnotation} {
-		if value, exists := job.Annotations[crdNameAnnotation]; exists {
-			if errs := validation.IsDNS1123Subdomain(value); len(errs) > 0 {
-				allErrs = append(allErrs, field.Invalid(annotationsPath.Key(crdNameAnnotation), value, strings.Join(errs, ",")))
-			}
-		}
-	}
+	allErrs = append(allErrs, jobframework.ValidateCreateForCRDNameAnnotation(job, constants.ParentWorkloadAnnotation)...)
+	allErrs = append(allErrs, jobframework.ValidateCreateForCRDNameAnnotation(job, constants.QueueAnnotation)...)
 	return allErrs
 }
 
@@ -122,22 +101,13 @@ func (w *JobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.
 	newJob := newObj.(*batchv1.Job)
 	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")
 	log.V(5).Info("Validating update", "job", klog.KObj(newJob))
-	return validateUpdate(oldJob, newJob).ToAggregate()
+	return validateUpdate(&Job{*oldJob}, &Job{*newJob}).ToAggregate()
 }
 
-func validateUpdate(oldJob, newJob *batchv1.Job) field.ErrorList {
+func validateUpdate(oldJob, newJob jobframework.GenericJob) field.ErrorList {
 	allErrs := validateCreate(newJob)
-
-	oldBatchJob := Job{*oldJob}
-	newBatchJob := Job{*newJob}
-	if !*newJob.Spec.Suspend && (oldBatchJob.QueueName() != newBatchJob.QueueName()) {
-		allErrs = append(allErrs, field.Forbidden(suspendPath, "must not update queue name when job is unsuspend"))
-	}
-
-	if errList := apivalidation.ValidateImmutableField(newJob.Annotations[constants.ParentWorkloadAnnotation],
-		oldJob.Annotations[constants.ParentWorkloadAnnotation], parentWorkloadKeyPath); len(errList) > 0 {
-		allErrs = append(allErrs, field.Forbidden(parentWorkloadKeyPath, "this annotation is immutable"))
-	}
+	allErrs = append(allErrs, jobframework.ValidateUpdateForParentWorkload(oldJob, newJob)...)
+	allErrs = append(allErrs, jobframework.ValidateUpdateForQueueName(oldJob, newJob)...)
 	return allErrs
 }
 

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -88,10 +88,6 @@ func (j *MPIJob) Suspend() {
 	j.Spec.RunPolicy.Suspend = pointer.Bool(true)
 }
 
-func (j *MPIJob) UnSuspend() {
-	j.Spec.RunPolicy.Suspend = pointer.Bool(false)
-}
-
 func (j *MPIJob) ResetStatus() bool {
 	if j.Status.StartTime == nil {
 		return false
@@ -117,7 +113,8 @@ func (j *MPIJob) PodSets() []kueue.PodSet {
 	return podSets
 }
 
-func (j *MPIJob) InjectNodeAffinity(nodeSelectors []map[string]string) {
+func (j *MPIJob) RunWithNodeAffinity(nodeSelectors []map[string]string) {
+	j.Spec.RunPolicy.Suspend = pointer.Bool(false)
 	if len(nodeSelectors) == 0 {
 		return
 	}
@@ -235,7 +232,7 @@ func (r *MPIJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {
-	return jobframework.SetupOwnerIndex(ctx, indexer, gvk)
+	return jobframework.SetupWorkloadOwnerIndex(ctx, indexer, gvk)
 }
 
 //+kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -77,7 +77,7 @@ func (w *MPIJobWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) 
 }
 
 func validateCreate(job jobframework.GenericJob) field.ErrorList {
-	return jobframework.ValidateCreateForCRDNameAnnotation(job, constants.QueueAnnotation)
+	return jobframework.ValidateAnnotationAsCRDName(job, constants.QueueAnnotation)
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
@@ -86,11 +86,7 @@ func (w *MPIJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runti
 	newJob := newObj.(*kubeflow.MPIJob)
 	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")
 	log.Info("Validating update", "job", klog.KObj(newJob))
-	return validateUpdate(&MPIJob{*oldJob}, &MPIJob{*newJob}).ToAggregate()
-}
-
-func validateUpdate(oldJob, newJob jobframework.GenericJob) field.ErrorList {
-	return jobframework.ValidateUpdateForQueueName(oldJob, newJob)
+	return jobframework.ValidateUpdateForQueueName(&MPIJob{*oldJob}, &MPIJob{*newJob}).ToAggregate()
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -18,11 +18,9 @@ package mpijob
 
 import (
 	"context"
-	"strings"
 
 	kubeflow "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -30,7 +28,6 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	"sigs.k8s.io/kueue/pkg/util/pointer"
 )
 
 type MPIJobWebhook struct {
@@ -57,25 +54,13 @@ func SetupMPIJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 
 var _ webhook.CustomDefaulter = &MPIJobWebhook{}
 
-var (
-	annotationsPath = field.NewPath("metadata", "annotations")
-	suspendPath     = field.NewPath("spec", "runPolicy", "suspend")
-)
-
 // Default implements webhook.CustomDefaulter so a webhook will be registered for the type
 func (w *MPIJobWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	job := obj.(*kubeflow.MPIJob)
 	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")
 	log.V(5).Info("Applying defaults", "job", klog.KObj(job))
 
-	mpiJob := MPIJob{*job}
-	if mpiJob.QueueName() == "" && !w.manageJobsWithoutQueueName {
-		return nil
-	}
-
-	if !(*job.Spec.RunPolicy.Suspend) {
-		job.Spec.RunPolicy.Suspend = pointer.Bool(true)
-	}
+	jobframework.ApplyDefaultForSuspend(&MPIJob{*job}, w.manageJobsWithoutQueueName)
 	return nil
 }
 
@@ -86,20 +71,13 @@ var _ webhook.CustomValidator = &MPIJobWebhook{}
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
 func (w *MPIJobWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) error {
 	job := obj.(*kubeflow.MPIJob)
-	return validateCreate(job).ToAggregate()
+	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")
+	log.Info("Validating create", "job", klog.KObj(job))
+	return validateCreate(&MPIJob{*job}).ToAggregate()
 }
 
-func validateCreate(job *kubeflow.MPIJob) field.ErrorList {
-	klog.InfoS("validateCreate invoked", "mpijob", job.Name)
-	var allErrs field.ErrorList
-	for _, crdNameAnnotation := range []string{constants.QueueAnnotation} {
-		if value, exists := job.Annotations[crdNameAnnotation]; exists {
-			if errs := validation.IsDNS1123Subdomain(value); len(errs) > 0 {
-				allErrs = append(allErrs, field.Invalid(annotationsPath.Key(crdNameAnnotation), value, strings.Join(errs, ",")))
-			}
-		}
-	}
-	return allErrs
+func validateCreate(job jobframework.GenericJob) field.ErrorList {
+	return jobframework.ValidateCreateForCRDNameAnnotation(job, constants.QueueAnnotation)
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
@@ -107,20 +85,12 @@ func (w *MPIJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runti
 	oldJob := oldObj.(*kubeflow.MPIJob)
 	newJob := newObj.(*kubeflow.MPIJob)
 	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")
-	log.Info("Validating update", "mpijob", klog.KObj(newJob))
-	return validateUpdate(oldJob, newJob).ToAggregate()
+	log.Info("Validating update", "job", klog.KObj(newJob))
+	return validateUpdate(&MPIJob{*oldJob}, &MPIJob{*newJob}).ToAggregate()
 }
 
-func validateUpdate(oldJob, newJob *kubeflow.MPIJob) field.ErrorList {
-	allErrs := validateCreate(newJob)
-
-	oldMPIJob := MPIJob{*oldJob}
-	newMPIJob := MPIJob{*newJob}
-	if !*newJob.Spec.RunPolicy.Suspend && (oldMPIJob.QueueName() != newMPIJob.QueueName()) {
-		allErrs = append(allErrs, field.Forbidden(suspendPath, "must not update queue name when job is unsuspend"))
-	}
-
-	return allErrs
+func validateUpdate(oldJob, newJob jobframework.GenericJob) field.ErrorList {
+	return jobframework.ValidateUpdateForQueueName(oldJob, newJob)
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

1. to commonize the webhook and indexing code between Job and MPIJob
2. to introduce utility methods for webhood and indexing which will be ready to use for new frameworks

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #369

#### Special notes for your reviewer:

Related changes to GenericJob API:
- removed `error` being returned by some functions (such as `Suspend` and `UnSuspend`) it is not needed for now and it makes the code cleaner as the methods are used in webhooks
- renamed IsSuspend as IsSuspended

Note that, this changes could be a separate PR, but I coupled them for now to avoid conflicts as I'm using these functions.