### PR TITLE
Fix a generic event handler for resourceFlavors in the clusterQueue controller

### DIFF
--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -314,7 +314,7 @@ func (h *cqResourceFlavorHandler) Generic(e event.GenericEvent, q workqueue.Rate
 
 	if cqs := h.cache.ClusterQueuesUsingFlavor(rf.Name); len(cqs) != 0 {
 		for _, cq := range cqs {
-			req := &reconcile.Request{
+			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name: cq,
 				}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
According to [this](https://github.com/kubernetes-sigs/controller-runtime/blob/ffb74e54a54bcb10a615c501416820e06051b9b4/pkg/internal/controller/controller.go#L302-L312), the reconcileHandler requires a non-pointer `Request`. 

So current implementations, when the resourceFlavors were created, the clusterQueue controller can not queue clusterQueues to reconcileQueue like the following:

```shell
...
  2023-03-16T01:09:36.715346+09:00      LEVEL(-2)       cluster-queue-reconciler        core/clusterqueue_controller.go:222     Got generic event       {"obj": {"name":"model-c"}, "kind": "/, Kind="}
  2023-03-16T01:09:36.718727+09:00      ERROR   controller/controller.go:309    Queue item was not a Request    {"controller": "clusterqueue", "controllerGroup": "kueue.x-k8s.io", "controllerKind": "ClusterQueue", "type": "*reconcile.Request", "value": "/cluster-queue.queue-controller"}
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /Users/tenzen-y/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:309
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /Users/tenzen-y/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:274
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /Users/tenzen-y/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:235
...
```

I faced this issue on #623.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

