### PR TITLE
Use resourceVersion when setting Admitted=False 

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -704,8 +704,8 @@ func (c *Cache) DeleteWorkload(w *kueue.Workload) error {
 }
 
 func (c *Cache) IsAssumedOrAdmittedWorkload(w workload.Info) bool {
-	c.Lock()
-	defer c.Unlock()
+	c.RLock()
+	defer c.RUnlock()
 
 	k := workload.Key(w.Obj)
 	if _, assumed := c.assumedWorkloads[k]; assumed {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -258,6 +258,9 @@ func UnsetAdmissionWithCondition(
 		Message:            api.TruncateConditionMessage(message),
 	}
 	newWl := BaseSSAWorkload(wl)
+	// Use resourceVersion to avoid overriding admissions by the scheduler that
+	// happen in a different routine.
+	newWl.ResourceVersion = wl.ResourceVersion
 	newWl.Status.Conditions = []metav1.Condition{condition}
 	return c.Status().Patch(ctx, newWl, client.Apply, client.FieldOwner(constants.AdmissionName))
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Use resourceVersion in the SSA patch when setting Admitted=False. This guarantees that we don't accidentally override an admission that happens in a different routine.

The price to pay is potentially slower scheduling when workloads don't fit because of conflicts, but this should only happen just when a LocalQueue or ClusterQueue is created after a Workload.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #678

#### Special notes for your reviewer:

