### PR TITLE
[workload] WaitForPodsReady: Requeue at the back of the queue after timeout

### DIFF
--- a/CHANGELOG/CHANGELOG-0.4.md
+++ b/CHANGELOG/CHANGELOG-0.4.md
@@ -5,6 +5,7 @@ Changes since `v0.3.0`:
 ### Features
 
 - Add LimitRange based validation before admission #613
+- Move the workloads evicted due to pods ready timeout to the end of the queue. #689
 
 ### Production Readiness
 

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -137,6 +137,19 @@ const (
 	// WorkloadPodsReady means that at least `.spec.podSets[*].count` Pods are
 	// ready or have succeeded.
 	WorkloadPodsReady = "PodsReady"
+
+	// WorkloadEvicted means that the Workload was evicted by a ClusterQueue
+	WorkloadEvicted = "Evicted"
+)
+
+const (
+	// WorkloadEvictedByPreemption indicates that the workload was evicted
+	// in order to free resources for a workload with a higher priority.
+	WorkloadEvictedByPreemption = "Preempted"
+
+	// WorkloadEvictedByPodsReadyTimeout indicates that the eviction took
+	// place due to a PodsReady timeout.
+	WorkloadEvictedByPodsReadyTimeout = "PodsReadyTimeout"
 )
 
 // +kubebuilder:object:root=true

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -181,7 +181,7 @@ func (r *WorkloadReconciler) reconcileNotReadyTimeout(ctx context.Context, req c
 	} else {
 		log.V(2).Info("Start the eviction of the workload due to exceeding the PodsReady timeout")
 		workload.SetEvictedCondition(wl, kueue.WorkloadEvictedByPodsReadyTimeout, fmt.Sprintf("Exceeded the PodsReady timeout %s", req.NamespacedName.String()))
-		err := workload.ApplyAdmissionStatus(ctx, r.client, wl, true)
+		err := workload.ApplyAdmissionStatus(ctx, r.client, wl, false)
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 }

--- a/pkg/queue/cluster_queue_best_effort_fifo.go
+++ b/pkg/queue/cluster_queue_best_effort_fifo.go
@@ -30,7 +30,7 @@ type ClusterQueueBestEffortFIFO struct {
 var _ ClusterQueue = &ClusterQueueBestEffortFIFO{}
 
 func newClusterQueueBestEffortFIFO(cq *kueue.ClusterQueue) (ClusterQueue, error) {
-	cqImpl := newClusterQueueImpl(keyFunc, byCreationTime)
+	cqImpl := newClusterQueueImpl(keyFunc, queueOrdering)
 	cqBE := &ClusterQueueBestEffortFIFO{
 		clusterQueueBase: cqImpl,
 	}

--- a/pkg/queue/cluster_queue_impl_test.go
+++ b/pkg/queue/cluster_queue_impl_test.go
@@ -37,7 +37,7 @@ const (
 )
 
 func Test_PushOrUpdate(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, byCreationTime)
+	cq := newClusterQueueImpl(keyFunc, queueOrdering)
 	wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 	if cq.Pending() != 0 {
 		t.Error("ClusterQueue should be empty")
@@ -57,7 +57,7 @@ func Test_PushOrUpdate(t *testing.T) {
 }
 
 func Test_Pop(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, byCreationTime)
+	cq := newClusterQueueImpl(keyFunc, queueOrdering)
 	now := time.Now()
 	wl1 := workload.NewInfo(utiltesting.MakeWorkload("workload-1", defaultNamespace).Creation(now).Obj())
 	wl2 := workload.NewInfo(utiltesting.MakeWorkload("workload-2", defaultNamespace).Creation(now.Add(time.Second)).Obj())
@@ -80,7 +80,7 @@ func Test_Pop(t *testing.T) {
 }
 
 func Test_Delete(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, byCreationTime)
+	cq := newClusterQueueImpl(keyFunc, queueOrdering)
 	wl1 := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 	wl2 := utiltesting.MakeWorkload("workload-2", defaultNamespace).Obj()
 	cq.PushOrUpdate(workload.NewInfo(wl1))
@@ -101,7 +101,7 @@ func Test_Delete(t *testing.T) {
 }
 
 func Test_Info(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, byCreationTime)
+	cq := newClusterQueueImpl(keyFunc, queueOrdering)
 	wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 	if info := cq.Info(keyFunc(workload.NewInfo(wl))); info != nil {
 		t.Error("workload doesn't exist")
@@ -113,7 +113,7 @@ func Test_Info(t *testing.T) {
 }
 
 func Test_AddFromLocalQueue(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, byCreationTime)
+	cq := newClusterQueueImpl(keyFunc, queueOrdering)
 	wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 	queue := &LocalQueue{
 		items: map[string]*workload.Info{
@@ -131,7 +131,7 @@ func Test_AddFromLocalQueue(t *testing.T) {
 }
 
 func Test_DeleteFromLocalQueue(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, byCreationTime)
+	cq := newClusterQueueImpl(keyFunc, queueOrdering)
 	q := utiltesting.MakeLocalQueue("foo", "").ClusterQueue("cq").Obj()
 	qImpl := newLocalQueue(q)
 	wl1 := utiltesting.MakeWorkload("wl1", "").Queue(q.Name).Obj()
@@ -261,7 +261,7 @@ func TestClusterQueueImpl(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			cq := newClusterQueueImpl(keyFunc, byCreationTime)
+			cq := newClusterQueueImpl(keyFunc, queueOrdering)
 
 			err := cq.Update(utiltesting.MakeClusterQueue("cq").
 				NamespaceSelector(&metav1.LabelSelector{
@@ -315,7 +315,7 @@ func TestClusterQueueImpl(t *testing.T) {
 }
 
 func TestQueueInadmissibleWorkloadsDuringScheduling(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, byCreationTime)
+	cq := newClusterQueueImpl(keyFunc, queueOrdering)
 	cq.namespaceSelector = labels.Everything()
 	wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 	cl := utiltesting.NewFakeClient(

--- a/pkg/queue/cluster_queue_strict_fifo_test.go
+++ b/pkg/queue/cluster_queue_strict_fifo_test.go
@@ -100,6 +100,7 @@ func TestFIFOClusterQueue(t *testing.T) {
 func TestStrictFIFO(t *testing.T) {
 	t1 := time.Now()
 	t2 := t1.Add(time.Second)
+	t3 := t2.Add(time.Second)
 	for _, tt := range []struct {
 		name     string
 		w1       *kueue.Workload
@@ -145,6 +146,33 @@ func TestStrictFIFO(t *testing.T) {
 				},
 			},
 			expected: "w1",
+		},
+		{
+			name: "w1.priority equals w2.priority and w1.create time is earlier than w2.create time but w1 was evicted",
+			w1: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "w1",
+					CreationTimestamp: metav1.NewTime(t1),
+				},
+				Status: kueue.WorkloadStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               kueue.WorkloadEvicted,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(t3),
+							Reason:             kueue.WorkloadEvictedByPodsReadyTimeout,
+							Message:            "by test",
+						},
+					},
+				},
+			},
+			w2: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "w2",
+					CreationTimestamp: metav1.NewTime(t2),
+				},
+			},
+			expected: "w2",
 		},
 		{
 			name: "p1.priority is lower than p2.priority and w1.create time is earlier than w2.create time",

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -141,6 +141,14 @@ func (p *Preemptor) issuePreemptions(ctx context.Context, targets []*workload.In
 			errCh.SendErrorWithCancel(err, cancel)
 			return
 		}
+
+		workload.SetEvictedCondition(patch, kueue.WorkloadEvictedByPreemption, "Preempted to accommodate a higher priority Workload")
+		err = workload.ApplyAdmissionStatus(ctx, p.client, patch, false)
+		if err != nil {
+			errCh.SendErrorWithCancel(err, cancel)
+			return
+		}
+
 		origin := "ClusterQueue"
 		if cq.Name != target.ClusterQueue {
 			origin = "cohort"

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -19,6 +19,7 @@ package workload
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -192,6 +193,66 @@ func TestUpdateWorkloadStatus(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantStatus, updatedWl.Status, ignoreConditionTimestamps); diff != "" {
 				t.Errorf("Unexpected status after updating (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetQueueOrderTimestamp(t *testing.T) {
+	creationTime := metav1.Now()
+	conditionTime := metav1.NewTime(time.Now().Add(time.Hour))
+	cases := map[string]struct {
+		wl   *kueue.Workload
+		want metav1.Time
+	}{
+		"no condition": {
+			wl: utiltesting.MakeWorkload("name", "ns").
+				Creation(creationTime.Time).
+				Obj(),
+			want: creationTime,
+		},
+		"evicted by preemption": {
+			wl: utiltesting.MakeWorkload("name", "ns").
+				Creation(creationTime.Time).
+				Condition(metav1.Condition{
+					Type:               kueue.WorkloadEvicted,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: conditionTime,
+					Reason:             kueue.WorkloadEvictedByPreemption,
+				}).
+				Obj(),
+			want: creationTime,
+		},
+		"evicted by PodsReady timeout": {
+			wl: utiltesting.MakeWorkload("name", "ns").
+				Creation(creationTime.Time).
+				Condition(metav1.Condition{
+					Type:               kueue.WorkloadEvicted,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: conditionTime,
+					Reason:             kueue.WorkloadEvictedByPodsReadyTimeout,
+				}).
+				Obj(),
+			want: conditionTime,
+		},
+		"after eviction": {
+			wl: utiltesting.MakeWorkload("name", "ns").
+				Creation(creationTime.Time).
+				Condition(metav1.Condition{
+					Type:               kueue.WorkloadEvicted,
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: conditionTime,
+					Reason:             kueue.WorkloadEvictedByPodsReadyTimeout,
+				}).
+				Obj(),
+			want: creationTime,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotTime := GetQueueOrderTimestamp(tc.wl)
+			if diff := cmp.Diff(*gotTime, tc.want); diff != "" {
+				t.Errorf("Unexpected time (-want,+got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

A new workload condition , `Evicted`, is added,  which gets set when:

1. The workload gets preempted
2. The workload hits the PodsReady timeout

In case of  PodsReady timeout, the condition transition timestamp will be used in scheduler sorting, therefore the workload will be moved at the end of the queue. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #599

#### Special notes for your reviewer:

The  preemption based `Eviction` will be used in solving #510.