### PR TITLE
Update the queue name in workload only when the job is standalone

### DIFF
--- a/CHANGELOG/CHANGELOG-0.4.md
+++ b/CHANGELOG/CHANGELOG-0.4.md
@@ -1,0 +1,7 @@
+## v0.4.0
+
+Changes since `v0.3.0`:
+
+### Bug fixes
+
+- Fix a bug that updates a queue name in workloads with an empty value when using framework jobs that use batch/job internally, such as MPIJob. #713 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -180,7 +180,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 
 		// update queue name if changed.
 		q := QueueName(job)
-		if wl.Spec.QueueName != q {
+		if wl.Spec.QueueName != q && isStandaloneJob {
 			log.V(2).Info("Job changed queues, updating workload")
 			wl.Spec.QueueName = q
 			err := r.client.Update(ctx, wl)

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -90,7 +90,7 @@ func (j *JobWrapper) Queue(queue string) *JobWrapper {
 	return j
 }
 
-// Queue updates the queue name of the job by annotation (deprecated)
+// QueueNameAnnotation updates the queue name of the job by annotation (deprecated)
 func (j *JobWrapper) QueueNameAnnotation(queue string) *JobWrapper {
 	j.Annotations[jobframework.QueueAnnotation] = queue
 	return j


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Currently, the batch/job integration controller updates the queue name in workloads even if the batch/job is a child job, although a child job generally doesn't have a label indicating the queue name (`kueue.x-k8s.io/queue-name`).

So when we deploy the framework Jobs that use batch/job internally, such as MPIJob, and the framework job is waiting to be admitted by the ClusterQueue, the batch/job integration controller updates the `.spec.queueName` in the workload with an empty value by reconciling for a child batch/job.

Therefore I changed the condition to update the queue name in workloads so that the batch/job updates the field only when the batch/job is a parent job.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #697 

#### Special notes for your reviewer:

