### PR TITLE
Remove redundant checks in the cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -537,18 +537,14 @@ func (c *Cache) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) err
 		return fmt.Errorf("listing queues that match the clusterQueue: %w", err)
 	}
 	for _, q := range queues.Items {
-		// Checking ClusterQueue name again because the field index is not available in tests.
-		if string(q.Spec.ClusterQueue) == cq.Name {
-			cqImpl.admittedWorkloadsPerQueue[queueKey(&q)] = 0
-		}
+		cqImpl.admittedWorkloadsPerQueue[queueKey(&q)] = 0
 	}
 	var workloads kueue.WorkloadList
 	if err := c.client.List(ctx, &workloads, client.MatchingFields{utilindexer.WorkloadClusterQueueKey: cq.Name}); err != nil {
 		return fmt.Errorf("listing workloads that match the queue: %w", err)
 	}
 	for i, w := range workloads.Items {
-		// Checking ClusterQueue name again because the field index is not available in tests.
-		if !workload.IsAdmitted(&w) || string(w.Status.Admission.ClusterQueue) != cq.Name {
+		if !workload.IsAdmitted(&w) {
 			continue
 		}
 		c.addOrUpdateWorkload(&workloads.Items[i])

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -91,10 +91,6 @@ func (m *Manager) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) e
 	}
 	addedWorkloads := false
 	for _, q := range queues.Items {
-		// Checking clusterQueue name again because the field index is not available in tests.
-		if string(q.Spec.ClusterQueue) != cq.Name {
-			continue
-		}
 		qImpl := m.localQueues[Key(&q)]
 		if qImpl != nil {
 			added := cqImpl.AddFromLocalQueue(qImpl)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We used to check redundantly in some places since the fake client didn't support the field indexer.
However, since #588, we can use the field indexer for the fake client. 

So, I removed the redundant checks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

