### PR TITLE
Remove unneeded type parameters from sets

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1456,7 +1456,7 @@ func TestLocalQueueUsage(t *testing.T) {
 					Queue("test").
 					Request(corev1.ResourceCPU, "5").Obj(),
 			},
-			inAdmissibleWl: sets.New[string]("one"),
+			inAdmissibleWl: sets.New("one"),
 		},
 		"workloads is nothing": {
 			cq: &cq,
@@ -1561,7 +1561,7 @@ func TestLocalQueueUsage(t *testing.T) {
 					Request(corev1.ResourceCPU, "100000").
 					Request("example.com/gpu", "3").Obj(),
 			},
-			inAdmissibleWl: sets.New[string]("two"),
+			inAdmissibleWl: sets.New("two"),
 			wantUsage: []kueue.LocalQueueFlavorUsage{
 				{
 					Name: "default",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
I removed unneeded type parameters from sets.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```