### PR TITLE
Fix: Enforce borrowed=0 if ClusterQueue doesn't belong to a cohort

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -838,9 +838,12 @@ func (c *Cache) Usage(cqObj *kueue.ClusterQueue) ([]kueue.FlavorUsage, int, erro
 					Name:  rName,
 					Total: workload.ResourceQuantity(rName, used),
 				}
-				borrowed := used - rQuota.Nominal
-				if borrowed > 0 {
-					rUsage.Borrowed = workload.ResourceQuantity(rName, borrowed)
+				// Enforce `borrowed=0` if the clusterQueue doesn't belong to a cohort.
+				if cq.Cohort != nil {
+					borrowed := used - rQuota.Nominal
+					if borrowed > 0 {
+						rUsage.Borrowed = workload.ResourceQuantity(rName, borrowed)
+					}
 				}
 				outFlvUsage.Resources = append(outFlvUsage.Resources, rUsage)
 			}

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -160,7 +160,7 @@ func (p *Preemptor) applyPreemptionWithSSA(ctx context.Context, w *kueue.Workloa
 // The heuristic first removes candidates, in the input order, while their
 // ClusterQueues are still borrowing resources and while the incoming Workload
 // doesn't fit in the quota.
-// Once the Worklod fits, the heuristic tries to add Workloads back, in the
+// Once the Workload fits, the heuristic tries to add Workloads back, in the
 // reverse order in which they were removed, while the incoming Workload still
 // fits.
 func minimalPreemptions(wl *workload.Info, assignment flavorassigner.Assignment, snapshot *cache.Snapshot, resPerFlv resourcesPerFlavor, candidates []*workload.Info, allowBorrowing bool) []*workload.Info {
@@ -281,6 +281,9 @@ func findCandidates(wl *kueue.Workload, cq *cache.ClusterQueue, resPerFlv resour
 }
 
 func cqIsBorrowing(cq *cache.ClusterQueue, resPerFlv resourcesPerFlavor) bool {
+	if cq.Cohort == nil {
+		return false
+	}
 	for _, rg := range cq.ResourceGroups {
 		for _, fQuotas := range rg.Flavors {
 			fUsage := cq.Usage[fQuotas.Name]

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -114,6 +114,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 					*testing.MakeFlavorQuotas(flavorModelB).
 						Resource(resourceGPU, "5", "5").Obj(),
 				).
+				Cohort("cohort").
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
 			localQueue = testing.MakeLocalQueue("queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Enforce `.status.flavorUsage[*].resources[*].borrowed=0` if ClusterQueue doesn't belong to a cohort.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #746 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix: Enforce borrowed=0 if ClusterQueue doesn't belong to a cohort.
```