### PR TITLE
Automated cherry pick of #759: Fix: Enforce borrowed=0 if ClusterQueue doesn't belong to a cohort

### DIFF
--- a/CHANGELOG/CHANGELOG-0.3.md
+++ b/CHANGELOG/CHANGELOG-0.3.md
@@ -6,6 +6,7 @@ Changes since `v0.3.0`:
 
 - Fix a bug that the validation webhook doesn't validate the queue name set as a label when creating MPIJob. #711
 - Fix a bug that updates a queue name in workloads with an empty value when using framework jobs that use batch/job internally, such as MPIJob. #713
+- Fix a bug in which borrowed values are set to a non-zero value even though the ClusterQueue doesn't belong to a cohort. #759 
 
 ## v0.3.0
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -793,9 +793,12 @@ func (c *Cache) Usage(cqObj *kueue.ClusterQueue) ([]kueue.FlavorUsage, int, erro
 					Name:  rName,
 					Total: workload.ResourceQuantity(rName, used),
 				}
-				borrowed := used - rQuota.Nominal
-				if borrowed > 0 {
-					rUsage.Borrowed = workload.ResourceQuantity(rName, borrowed)
+				// Enforce `borrowed=0` if the clusterQueue doesn't belong to a cohort.
+				if cq.Cohort != nil {
+					borrowed := used - rQuota.Nominal
+					if borrowed > 0 {
+						rUsage.Borrowed = workload.ResourceQuantity(rName, borrowed)
+					}
 				}
 				outFlvUsage.Resources = append(outFlvUsage.Resources, rUsage)
 			}

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -161,7 +161,7 @@ func (p *Preemptor) applyPreemptionWithSSA(ctx context.Context, w *kueue.Workloa
 // The heuristic first removes candidates, in the input order, while their
 // ClusterQueues are still borrowing resources and while the incoming Workload
 // doesn't fit in the quota.
-// Once the Worklod fits, the heuristic tries to add Workloads back, in the
+// Once the Workload fits, the heuristic tries to add Workloads back, in the
 // reverse order in which they were removed, while the incoming Workload still
 // fits.
 func minimalPreemptions(wl *workload.Info, assignment flavorassigner.Assignment, snapshot *cache.Snapshot, resPerFlv resourcesPerFlavor, candidates []*workload.Info, allowBorrowing bool) []*workload.Info {
@@ -264,6 +264,9 @@ func findCandidates(wl *kueue.Workload, cq *cache.ClusterQueue, resPerFlv resour
 }
 
 func cqIsBorrowing(cq *cache.ClusterQueue, resPerFlv resourcesPerFlavor) bool {
+	if cq.Cohort == nil {
+		return false
+	}
 	for _, rg := range cq.ResourceGroups {
 		for _, fQuotas := range rg.Flavors {
 			fUsage := cq.Usage[fQuotas.Name]

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -114,6 +114,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 					*testing.MakeFlavorQuotas(flavorModelB).
 						Resource(resourceGPU, "5", "5").Obj(),
 				).
+				Cohort("cohort").
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
 			localQueue = testing.MakeLocalQueue("queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()


### PR DESCRIPTION
Cherry pick of #759 on release-0.3.
#759: Fix: Enforce borrowed=0 if ClusterQueue doesn't belong to a cohort
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
Fix: Enforce borrowed=0 if ClusterQueue doesn't belong to a cohort.
```