### PR TITLE
Fix typos in integrationmanager

### DIFF
--- a/pkg/controller/jobframework/integrationmanager.go
+++ b/pkg/controller/jobframework/integrationmanager.go
@@ -107,7 +107,7 @@ func (m *integrationManager) getList() []string {
 	return ret
 }
 
-// RegisterIntegration registeres a new framework, returns an error when
+// RegisterIntegration registers a new framework, returns an error when
 // attempting to register multiple frameworks with the same name of if a
 // mandatory callback is missing.
 func RegisterIntegration(name string, cb IntegrationCallbacks) error {

--- a/pkg/controller/jobframework/integrationmanager_test.go
+++ b/pkg/controller/jobframework/integrationmanager_test.go
@@ -208,29 +208,29 @@ func compareCallbacks(x, y interface{}) bool {
 func TestForEach(t *testing.T) {
 	foeEachError := errors.New("test error")
 	cases := map[string]struct {
-		registerd []string
-		errorOn   string
-		wantCalls []string
-		wantError error
+		registered []string
+		errorOn    string
+		wantCalls  []string
+		wantError  error
 	}{
 		"all": {
-			registerd: []string{"a", "b", "c", "d", "e"},
-			errorOn:   "",
-			wantCalls: []string{"a", "b", "c", "d", "e"},
-			wantError: nil,
+			registered: []string{"a", "b", "c", "d", "e"},
+			errorOn:    "",
+			wantCalls:  []string{"a", "b", "c", "d", "e"},
+			wantError:  nil,
 		},
 		"partial": {
-			registerd: []string{"a", "b", "c", "d", "e"},
-			errorOn:   "c",
-			wantCalls: []string{"a", "b", "c"},
-			wantError: foeEachError,
+			registered: []string{"a", "b", "c", "d", "e"},
+			errorOn:    "c",
+			wantCalls:  []string{"a", "b", "c"},
+			wantError:  foeEachError,
 		},
 	}
 
 	for tcName, tc := range cases {
 		t.Run(tcName, func(t *testing.T) {
 			manager := integrationManager{}
-			for _, name := range tc.registerd {
+			for _, name := range tc.registered {
 				if err := manager.register(name, testIntegrationCallbacks); err != nil {
 					t.Fatalf("unable to register %s, %s", name, err.Error())
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes typos:
1. `registeres -> registers`
2. `registerd -> registered`


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```