### PR TITLE
Add permission to update frameworkjob status

### DIFF
--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -81,6 +81,7 @@ rules:
   - jobs/status
   verbs:
   - get
+  - update
 - apiGroups:
   - kubeflow.org
   resources:
@@ -97,6 +98,7 @@ rules:
   - mpijobs/status
   verbs:
   - get
+  - update
 - apiGroups:
   - kueue.x-k8s.io
   resources:

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -296,7 +296,7 @@ func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {
 //+kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update;patch
 //+kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
+//+kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get;update
 //+kubebuilder:rbac:groups=batch,resources=jobs/finalizers,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads/status,verbs=get;update;patch

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -247,7 +247,7 @@ func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {
 //+kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update;patch
 //+kubebuilder:rbac:groups=kubeflow.org,resources=mpijobs,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=kubeflow.org,resources=mpijobs/status,verbs=get
+//+kubebuilder:rbac:groups=kubeflow.org,resources=mpijobs/status,verbs=get;update
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads/finalizers,verbs=update


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Even though the framework job controllers don't have permission to update the job status, controllers try to update statuses when stopJob.

https://github.com/kubernetes-sigs/kueue/blob/74f45f69612a2d36ace91ae455f1e9fdbcd53037/pkg/controller/jobframework/reconciler.go#L369-L373

In fact, I faced the below error in kueue v0.3.1:

```
{"level":"error","ts":"2023-05-23T10:29:47.851178422Z","caller":"jobframework/reconciler.go:265","msg":"stopping job","controller":"job","controllerGroup":"batch","controllerKind":"Job","Job":{"name":"pi-1-launcher","namespace":"xxxxxxxxx"},"namespace":"xxxxxxxxx","name":"pi-1-launcher","reconcileID":"c8e2eff9-107f-48fd-a036-a5879372237c","job":"xxxxxxxxx/pi-1-launcher","error":"jobs.batch \"pi-1-launcher\" is forbidden: User \"system:serviceaccount:kueue-system:kueue-controller-manager\" cannot update resource \"jobs/status\" in API group \"batch\" in the namespace \"xxxxxxxxx\"","stacktrace":"sigs.k8s.io/kueue/pkg/controller/jobframework.(*JobReconciler).ensureOneWorkload\n\t/workspace/pkg/controller/jobframework/reconciler.go:265\nsigs.k8s.io/kueue/pkg/controller/jobframework.(*JobReconciler).ReconcileGenericJob\n\t/workspace/pkg/controller/jobframework/reconciler.go:121\nsigs.k8s.io/kueue/pkg/controller/jobs/job.(*JobReconciler).Reconcile\n\t/workspace/pkg/controller/jobs/job/job_controller.go:280\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:122\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:323\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.5/pkg/internal/controller/controller.go:235"}
```

So, I added permission to update statuses.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add permission to update frameworkjob status.
```