### PR TITLE
Automated cherry pick of #787: fix panic in clusterqueue_webhook

### DIFF
--- a/apis/kueue/webhooks/clusterqueue_webhook.go
+++ b/apis/kueue/webhooks/clusterqueue_webhook.go
@@ -159,6 +159,9 @@ func validateFlavorQuotas(flavorQuotas kueue.FlavorQuotas, coveredResources []co
 	}
 
 	for i, rq := range flavorQuotas.Resources {
+		if i >= len(coveredResources) {
+			break
+		}
 		path := path.Child("resources").Index(i)
 		if rq.Name != coveredResources[i] {
 			allErrs = append(allErrs, field.Invalid(path.Child("name"), rq.Name, "must match the name in coveredResources"))


### PR DESCRIPTION
Cherry pick of #787 on release-0.3.
#787: Update steps of release process
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
Fix panic in cluster queue if resources and coveredResources do not have the same length.
```