### PR TITLE
Add kerthcet as approver for deps, controllers, webhooks and utils

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,15 +1,19 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-approvers:
-  - github-admin-team
-  - ahg-g
-  - alculquicondor
-  - denkensk
+filters:
+  ".*":
+    approvers:
+    - ahg-g
+    - alculquicondor
+    - denkensk
 
-reviewers:
-  - ahg-g
-  - alculquicondor
-  - ArangoGutierrez
-  - denkensk
-  - kerthcet
-  - tenzen-y
+    reviewers:
+    - ahg-g
+    - alculquicondor
+    - ArangoGutierrez
+    - denkensk
+    - kerthcet
+    - tenzen-y
+  "^go\\.(mod|sum)$":
+    approvers:
+    - kerthcet

--- a/pkg/controller/OWNERS
+++ b/pkg/controller/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- kerthcet

--- a/pkg/util/OWNERS
+++ b/pkg/util/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- kerthcet

--- a/pkg/webhooks/OWNERS
+++ b/pkg/webhooks/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- kerthcet


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/milestone v0.4

#### What this PR does / why we need it:

Add @kerthcet as approver for:
- deps (go.mod/go.sum)
- controllers (including integrations)
- webhooks
- utils

@kerthcet has been a long standing contributor to Kueue and has made numerous contributions and reviews to the project.

He is already deeply familiar with these packages and I'm confident that he can expand his ownership of kueue  in the future.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```