### PR TITLE
Add tenzen-y as approver for Makefile, hack and test

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -17,3 +17,9 @@ filters:
   "^go\\.(mod|sum)$":
     approvers:
     - kerthcet
+  "^(Make|Docker)file$":
+    approvers:
+    - tenzen-y
+  "^cloudbuild\\.yaml$":
+    approvers:
+    - tenzen-y

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,5 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- kerthcet
 - tenzen-y

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,5 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- kerthcet
 - tenzen-y


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

@tenzen-y has been a valuable contributor to kueue during the development of releases 0.3 and 0.4.
I can only imagine his ownership will grow from now.

For now, I propose he owns:
- The building stack (Makefile, Dockerfile, cloudbuild)
- The tests (integration, e2e, util).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```