### PR TITLE
Ignore reconciling against unmanaged child jobs in the jobframework

### DIFF
--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package jobframework
+package constants
 
 const (
 	// QueueLabel is the label key in the workload that holds the queue name.

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 )
 
 type GenericJob interface {
@@ -55,13 +56,17 @@ type GenericJob interface {
 }
 
 func ParentWorkloadName(job GenericJob) string {
-	return job.Object().GetAnnotations()[ParentWorkloadAnnotation]
+	return job.Object().GetAnnotations()[constants.ParentWorkloadAnnotation]
 }
 
 func QueueName(job GenericJob) string {
-	if queueLabel := job.Object().GetLabels()[QueueLabel]; queueLabel != "" {
+	return QueueNameForObject(job.Object())
+}
+
+func QueueNameForObject(object client.Object) string {
+	if queueLabel := object.GetLabels()[constants.QueueLabel]; queueLabel != "" {
 		return queueLabel
 	}
 	// fallback to the annotation (deprecated)
-	return job.Object().GetAnnotations()[QueueAnnotation]
+	return object.GetAnnotations()[constants.QueueAnnotation]
 }

--- a/pkg/controller/jobframework/known_frameworks.go
+++ b/pkg/controller/jobframework/known_frameworks.go
@@ -19,11 +19,20 @@ package jobframework
 import (
 	"strings"
 
+	kubeflow "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func KnownWorkloadOwner(owner *metav1.OwnerReference) bool {
 	return IsMPIJob(owner)
+}
+
+func KnownWorkloadOwnerObject(owner *metav1.OwnerReference) client.Object {
+	if IsMPIJob(owner) {
+		return &kubeflow.MPIJob{}
+	}
+	return nil
 }
 
 func IsMPIJob(owner *metav1.OwnerReference) bool {

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	kubeflow "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
+	batchv1 "k8s.io/api/batch/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	testingmpijob "sigs.k8s.io/kueue/pkg/util/testingjobs/mpijob"
+)
+
+func TestIsParentJobManaged(t *testing.T) {
+	parentJobName := "test-job-parent"
+	childJobName := "test-job-child"
+	jobNamespace := "default"
+	cases := map[string]struct {
+		parentJob   client.Object
+		job         client.Object
+		wantManaged bool
+		wantErr     error
+	}{
+		"child job doesn't have ownerReference": {
+			parentJob: testingmpijob.MakeMPIJob(parentJobName, jobNamespace).
+				UID(parentJobName).
+				Obj(),
+			job: testingjob.MakeJob(childJobName, jobNamespace).
+				Obj(),
+			wantErr: errChildJobOwnerNotFound,
+		},
+		"child job has ownerReference with unknown workload owner": {
+			parentJob: testingjob.MakeJob(parentJobName, jobNamespace).
+				UID(parentJobName).
+				Obj(),
+			job: testingjob.MakeJob(childJobName, jobNamespace).
+				OwnerReference(parentJobName, batchv1.SchemeGroupVersion.WithKind("Job")).
+				Obj(),
+			wantErr: errUnknownWorkloadOwner,
+		},
+		"child job has ownerReference with known non-existing workload owner": {
+			job: testingjob.MakeJob(childJobName, jobNamespace).
+				OwnerReference(parentJobName, kubeflow.SchemeGroupVersionKind).
+				Obj(),
+			wantErr: errWorkloadOwnerNotFound,
+		},
+		"child job has ownerReference with known existing workload owner, and the parent job has queue-name label": {
+			parentJob: testingmpijob.MakeMPIJob(parentJobName, jobNamespace).
+				UID(parentJobName).
+				Queue("test-q").
+				Obj(),
+			job: testingjob.MakeJob(childJobName, jobNamespace).
+				OwnerReference(parentJobName, kubeflow.SchemeGroupVersionKind).
+				Obj(),
+			wantManaged: true,
+		},
+		"child job has ownerReference with known existing workload owner, and the parent job doesn't has queue-name label": {
+			parentJob: testingmpijob.MakeMPIJob(parentJobName, jobNamespace).
+				UID(parentJobName).
+				Obj(),
+			job: testingjob.MakeJob(childJobName, jobNamespace).
+				OwnerReference(parentJobName, kubeflow.SchemeGroupVersionKind).
+				Obj(),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			builder := utiltesting.NewClientBuilder(kubeflow.AddToScheme)
+			if tc.parentJob != nil {
+				builder = builder.WithObjects(tc.parentJob)
+			}
+			cl := builder.Build()
+			r := JobReconciler{client: cl}
+			got, gotErr := r.isParentJobManaged(context.Background(), tc.job, jobNamespace)
+			if tc.wantManaged != got {
+				t.Errorf("Unexpected response from isParentManaged want: %v,got: %v", tc.wantManaged, got)
+			}
+			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); len(diff) != 0 {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -20,22 +20,25 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"sigs.k8s.io/kueue/pkg/controller/constants"
+	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 )
 
 var (
 	annotationsPath       = field.NewPath("metadata", "annotations")
 	labelsPath            = field.NewPath("metadata", "labels")
-	parentWorkloadKeyPath = annotationsPath.Key(ParentWorkloadAnnotation)
-	queueNameLabelPath    = labelsPath.Key(QueueLabel)
+	parentWorkloadKeyPath = annotationsPath.Key(constants.ParentWorkloadAnnotation)
+	queueNameLabelPath    = labelsPath.Key(constants.QueueLabel)
 
-	originalNodeSelectorsWorkloadKeyPath = annotationsPath.Key(OriginalNodeSelectorsAnnotation)
-	originalPodSetsInfosWorkloadKeyPath  = annotationsPath.Key(OriginalPodSetsInfoAnnotation)
+	originalNodeSelectorsWorkloadKeyPath = annotationsPath.Key(controllerconsts.OriginalNodeSelectorsAnnotation)
+	originalPodSetsInfosWorkloadKeyPath  = annotationsPath.Key(controllerconsts.OriginalPodSetsInfoAnnotation)
 )
 
 func ValidateCreateForQueueName(job GenericJob) field.ErrorList {
 	var allErrs field.ErrorList
-	allErrs = append(allErrs, validateLabelAsCRDName(job, QueueLabel)...)
-	allErrs = append(allErrs, ValidateAnnotationAsCRDName(job, QueueAnnotation)...)
+	allErrs = append(allErrs, validateLabelAsCRDName(job, constants.QueueLabel)...)
+	allErrs = append(allErrs, ValidateAnnotationAsCRDName(job, constants.QueueAnnotation)...)
 	return allErrs
 }
 
@@ -79,11 +82,11 @@ func ValidateUpdateForParentWorkload(oldJob, newJob GenericJob) field.ErrorList 
 func ValidateUpdateForOriginalNodeSelectors(oldJob, newJob GenericJob) field.ErrorList {
 	var allErrs field.ErrorList
 	if oldJob.IsSuspended() == newJob.IsSuspended() {
-		if errList := apivalidation.ValidateImmutableField(oldJob.Object().GetAnnotations()[OriginalNodeSelectorsAnnotation],
-			newJob.Object().GetAnnotations()[OriginalNodeSelectorsAnnotation], originalNodeSelectorsWorkloadKeyPath); len(errList) > 0 {
+		if errList := apivalidation.ValidateImmutableField(oldJob.Object().GetAnnotations()[constants.OriginalNodeSelectorsAnnotation],
+			newJob.Object().GetAnnotations()[constants.OriginalNodeSelectorsAnnotation], originalNodeSelectorsWorkloadKeyPath); len(errList) > 0 {
 			allErrs = append(allErrs, field.Forbidden(originalNodeSelectorsWorkloadKeyPath, "this annotation is immutable while the job is not changing its suspended state"))
 		}
-	} else if av, found := newJob.Object().GetAnnotations()[OriginalNodeSelectorsAnnotation]; found {
+	} else if av, found := newJob.Object().GetAnnotations()[controllerconsts.OriginalNodeSelectorsAnnotation]; found {
 		out := []PodSetInfo{}
 		if err := json.Unmarshal([]byte(av), &out); err != nil {
 			allErrs = append(allErrs, field.Invalid(originalNodeSelectorsWorkloadKeyPath, av, err.Error()))
@@ -95,11 +98,11 @@ func ValidateUpdateForOriginalNodeSelectors(oldJob, newJob GenericJob) field.Err
 func ValidateUpdateForOriginalPodSetsInfo(oldJob, newJob GenericJob) field.ErrorList {
 	var allErrs field.ErrorList
 	if oldJob.IsSuspended() == newJob.IsSuspended() {
-		if errList := apivalidation.ValidateImmutableField(oldJob.Object().GetAnnotations()[OriginalPodSetsInfoAnnotation],
-			newJob.Object().GetAnnotations()[OriginalPodSetsInfoAnnotation], originalPodSetsInfosWorkloadKeyPath); len(errList) > 0 {
+		if errList := apivalidation.ValidateImmutableField(oldJob.Object().GetAnnotations()[controllerconsts.OriginalPodSetsInfoAnnotation],
+			newJob.Object().GetAnnotations()[controllerconsts.OriginalPodSetsInfoAnnotation], originalPodSetsInfosWorkloadKeyPath); len(errList) > 0 {
 			allErrs = append(allErrs, field.Forbidden(originalPodSetsInfosWorkloadKeyPath, "this annotation is immutable while the job is not changing its suspended state"))
 		}
-	} else if av, found := newJob.Object().GetAnnotations()[OriginalPodSetsInfoAnnotation]; found {
+	} else if av, found := newJob.Object().GetAnnotations()[controllerconsts.OriginalPodSetsInfoAnnotation]; found {
 		out := []PodSetInfo{}
 		if err := json.Unmarshal([]byte(av), &out); err != nil {
 			allErrs = append(allErrs, field.Invalid(originalPodSetsInfosWorkloadKeyPath, av, err.Error()))

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -30,6 +30,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 )
 
@@ -74,7 +75,7 @@ func (w *JobWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		if pwName, err := jobframework.GetWorkloadNameForOwnerRef(owner); err != nil {
 			return err
 		} else {
-			job.Annotations[jobframework.ParentWorkloadAnnotation] = pwName
+			job.Annotations[constants.ParentWorkloadAnnotation] = pwName
 		}
 	}
 
@@ -96,7 +97,7 @@ func (w *JobWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) err
 
 func validateCreate(job *Job) field.ErrorList {
 	var allErrs field.ErrorList
-	allErrs = append(allErrs, jobframework.ValidateAnnotationAsCRDName(job, jobframework.ParentWorkloadAnnotation)...)
+	allErrs = append(allErrs, jobframework.ValidateAnnotationAsCRDName(job, constants.ParentWorkloadAnnotation)...)
 	allErrs = append(allErrs, jobframework.ValidateCreateForQueueName(job)...)
 	allErrs = append(allErrs, validatePartialAdmissionCreate(job)...)
 	return allErrs

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -26,6 +26,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	testingutil "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 )
@@ -37,11 +38,11 @@ const (
 var (
 	annotationsPath          = field.NewPath("metadata", "annotations")
 	labelsPath               = field.NewPath("metadata", "labels")
-	parentWorkloadKeyPath    = annotationsPath.Key(jobframework.ParentWorkloadAnnotation)
-	queueNameLabelPath       = labelsPath.Key(jobframework.QueueLabel)
-	queueNameAnnotationsPath = annotationsPath.Key(jobframework.QueueAnnotation)
+	parentWorkloadKeyPath    = annotationsPath.Key(constants.ParentWorkloadAnnotation)
+	queueNameLabelPath       = labelsPath.Key(constants.QueueLabel)
+	queueNameAnnotationsPath = annotationsPath.Key(constants.QueueAnnotation)
 
-	originalNodeSelectorsKeyPath = annotationsPath.Key(jobframework.OriginalNodeSelectorsAnnotation)
+	originalNodeSelectorsKeyPath = annotationsPath.Key(constants.OriginalNodeSelectorsAnnotation)
 )
 
 func TestValidateCreate(t *testing.T) {

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -24,12 +24,12 @@ import (
 	kubeflow "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	testingutil "sigs.k8s.io/kueue/pkg/util/testingjobs/mpijob"
 )
 
 var (
-	originalNodeSelectorsKeyPath = field.NewPath("metadata", "annotations").Key(jobframework.OriginalNodeSelectorsAnnotation)
+	originalNodeSelectorsKeyPath = field.NewPath("metadata", "annotations").Key(constants.OriginalNodeSelectorsAnnotation)
 )
 
 func TestUpdate(t *testing.T) {

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -25,7 +25,7 @@ import (
 	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/pointer"
 	testingrayutil "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
 )
@@ -217,7 +217,7 @@ func TestValidateUpdate(t *testing.T) {
 				ShutdownAfterJobFinishes(true).
 				Obj(),
 			wantErr: field.ErrorList{
-				field.Forbidden(field.NewPath("metadata", "labels").Key(jobframework.QueueLabel), "must not update queue name when job is unsuspend"),
+				field.Forbidden(field.NewPath("metadata", "labels").Key(constants.QueueLabel), "must not update queue name when job is unsuspend"),
 			}.ToAggregate(),
 		},
 		"managed - queue name can change while suspended": {

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -22,8 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 
-	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/pointer"
 )
 
@@ -93,24 +94,24 @@ func (j *JobWrapper) Queue(queue string) *JobWrapper {
 	if j.Labels == nil {
 		j.Labels = make(map[string]string)
 	}
-	j.Labels[jobframework.QueueLabel] = queue
+	j.Labels[constants.QueueLabel] = queue
 	return j
 }
 
 // QueueNameAnnotation updates the queue name of the job by annotation (deprecated)
 func (j *JobWrapper) QueueNameAnnotation(queue string) *JobWrapper {
-	j.Annotations[jobframework.QueueAnnotation] = queue
+	j.Annotations[constants.QueueAnnotation] = queue
 	return j
 }
 
 // ParentWorkload sets the parent-workload annotation
 func (j *JobWrapper) ParentWorkload(parentWorkload string) *JobWrapper {
-	j.Annotations[jobframework.ParentWorkloadAnnotation] = parentWorkload
+	j.Annotations[constants.ParentWorkloadAnnotation] = parentWorkload
 	return j
 }
 
 func (j *JobWrapper) OriginalNodeSelectorsAnnotation(content string) *JobWrapper {
-	j.Annotations[jobframework.OriginalNodeSelectorsAnnotation] = content
+	j.Annotations[constants.OriginalNodeSelectorsAnnotation] = content
 	return j
 }
 
@@ -147,14 +148,22 @@ func (j *JobWrapper) Image(name string, image string, args []string) *JobWrapper
 	return j
 }
 
+// OwnerReference adds a ownerReference to the default container.
 func (j *JobWrapper) OwnerReference(ownerName string, ownerGVK schema.GroupVersionKind) *JobWrapper {
 	j.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
 		{
 			APIVersion: ownerGVK.GroupVersion().String(),
 			Kind:       ownerGVK.Kind,
 			Name:       ownerName,
+			UID:        types.UID(ownerName),
 			Controller: pointer.Bool(true),
 		},
 	}
+	return j
+}
+
+// UID updates the uid of the job.
+func (j *JobWrapper) UID(uid string) *JobWrapper {
+	j.ObjectMeta.UID = types.UID(uid)
 	return j
 }

--- a/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
+++ b/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
@@ -22,15 +22,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
-	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/pointer"
 )
 
-// JobWrapper wraps a Job.
+// MPIJobWrapper wraps a Job.
 type MPIJobWrapper struct{ kubeflow.MPIJob }
 
-// MakeJob creates a wrapper for a suspended job with a single container and parallelism=1.
+// MakeMPIJob creates a wrapper for a suspended job with a single container and parallelism=1.
 func MakeMPIJob(name, ns string) *MPIJobWrapper {
 	return &MPIJobWrapper{kubeflow.MPIJob{
 		ObjectMeta: metav1.ObjectMeta{
@@ -96,12 +97,12 @@ func (j *MPIJobWrapper) Obj() *kubeflow.MPIJob {
 	return &j.MPIJob
 }
 
-// Queue updates the queue name of the job
+// Queue updates the queue name of the job.
 func (j *MPIJobWrapper) Queue(queue string) *MPIJobWrapper {
 	if j.Labels == nil {
 		j.Labels = make(map[string]string)
 	}
-	j.Labels[jobframework.QueueLabel] = queue
+	j.Labels[constants.QueueLabel] = queue
 	return j
 }
 
@@ -117,14 +118,20 @@ func (j *MPIJobWrapper) Parallelism(p int32) *MPIJobWrapper {
 	return j
 }
 
-// OriginalNodeSelectorsAnnotation updates the original node selectors annotation
+// OriginalNodeSelectorsAnnotation updates the original node selectors annotation.
 func (j *MPIJobWrapper) OriginalNodeSelectorsAnnotation(content string) *MPIJobWrapper {
-	j.Annotations[jobframework.OriginalNodeSelectorsAnnotation] = content
+	j.Annotations[constants.OriginalNodeSelectorsAnnotation] = content
 	return j
 }
 
-// Suspend updates the suspend status of the job
+// Suspend updates the suspend status of the job.
 func (j *MPIJobWrapper) Suspend(s bool) *MPIJobWrapper {
 	j.Spec.RunPolicy.Suspend = &s
+	return j
+}
+
+// UID updates the uid of the job.
+func (j *MPIJobWrapper) UID(uid string) *MPIJobWrapper {
+	j.ObjectMeta.UID = types.UID(uid)
 	return j
 }

--- a/pkg/util/testingjobs/rayjob/wrappers.go
+++ b/pkg/util/testingjobs/rayjob/wrappers.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/pointer"
 )
 
@@ -92,7 +92,7 @@ func (j *JobWrapper) Queue(queue string) *JobWrapper {
 	if j.Labels == nil {
 		j.Labels = make(map[string]string)
 	}
-	j.Labels[jobframework.QueueLabel] = queue
+	j.Labels[constants.QueueLabel] = queue
 	return j
 }
 

--- a/test/integration/controller/job/job_webhook_test.go
+++ b/test/integration/controller/job/job_webhook_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/util/pointer"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
@@ -82,7 +83,7 @@ var _ = ginkgo.Describe("Job Webhook", func() {
 			createdJob := &batchv1.Job{}
 			gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 
-			createdJob.Annotations = map[string]string{jobframework.QueueAnnotation: "queue"}
+			createdJob.Annotations = map[string]string{constants.QueueAnnotation: "queue"}
 			createdJob.Spec.Suspend = pointer.Bool(false)
 			gomega.Expect(k8sClient.Update(ctx, createdJob)).ShouldNot(gomega.Succeed())
 		})
@@ -148,7 +149,7 @@ var _ = ginkgo.Describe("Job Webhook", func() {
 			createdJob := &batchv1.Job{}
 			gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 
-			createdJob.Labels[jobframework.QueueLabel] = "queue2"
+			createdJob.Labels[constants.QueueLabel] = "queue2"
 			createdJob.Spec.Suspend = pointer.Bool(false)
 			gomega.Expect(k8sClient.Update(ctx, createdJob)).ShouldNot(gomega.Succeed())
 		})

--- a/test/integration/controller/rayjob/rayjob_controller_test.go
+++ b/test/integration/controller/rayjob/rayjob_controller_test.go
@@ -33,6 +33,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadrayjob "sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
 	"sigs.k8s.io/kueue/pkg/util/testing"
@@ -134,7 +135,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 		ginkgo.By("checking the workload is updated with queue name when the job does")
 		jobQueueName := "test-queue"
-		createdJob.Annotations = map[string]string{jobframework.QueueAnnotation: jobQueueName}
+		createdJob.Annotations = map[string]string{constants.QueueAnnotation: jobQueueName}
 		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
 		gomega.Eventually(func() bool {
 			if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
@@ -315,9 +316,9 @@ var _ = ginkgo.Describe("Job controller for workloads when only jobs with queue 
 		ginkgo.By("checking the workload is created when queue name is set")
 		jobQueueName := "test-queue"
 		if createdJob.Labels == nil {
-			createdJob.Labels = map[string]string{jobframework.QueueAnnotation: jobQueueName}
+			createdJob.Labels = map[string]string{constants.QueueAnnotation: jobQueueName}
 		} else {
-			createdJob.Labels[jobframework.QueueLabel] = jobQueueName
+			createdJob.Labels[constants.QueueLabel] = jobQueueName
 		}
 		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
 		gomega.Eventually(func() error {
@@ -378,7 +379,7 @@ var _ = ginkgo.Describe("Job controller when waitForPodsReady enabled", ginkgo.O
 			ginkgo.By("Create a job")
 			job := testingrayjob.MakeJob(jobName, ns.Name).Obj()
 			jobQueueName := "test-queue"
-			job.Annotations = map[string]string{jobframework.QueueAnnotation: jobQueueName}
+			job.Annotations = map[string]string{constants.QueueAnnotation: jobQueueName}
 			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
 			lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
 			setInitStatus(jobName, ns.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
I fixed a bug that reconciles against unmanaged child batch/job.

#### Which issue(s) this PR fixes:
Fixes #800

#### Special notes for your reviewer:
I have replicated https://github.com/kubernetes-sigs/kueue/pull/821.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug where a child batch/job of an unmanaged parent (doesn't have queue name) was being suspended.
```