### PR TITLE
[jobframework] Move `EquivalentToWorkload` functionality into framework

### DIFF
--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -42,8 +42,6 @@ type GenericJob interface {
 	Finished() (condition metav1.Condition, finished bool)
 	// PodSets will build workload podSets corresponding to the job.
 	PodSets() []kueue.PodSet
-	// EquivalentToWorkload validates whether the workload is semantically equal to the job.
-	EquivalentToWorkload(wl kueue.Workload) bool
 	// PriorityClass returns the job's priority class name.
 	PriorityClass() string
 	// IsActive returns true if there are any running pods.

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -262,36 +262,6 @@ func (j *Job) Finished() (metav1.Condition, bool) {
 	return condition, finished
 }
 
-func (j *Job) EquivalentToWorkload(wl kueue.Workload) bool {
-	if len(wl.Spec.PodSets) != 1 {
-		return false
-	}
-
-	ps0 := &wl.Spec.PodSets[0]
-
-	// if the job accepts partial admission
-	if mpc := j.minPodsCount(); mpc != nil {
-		if pointer.Int32Deref(ps0.MinCount, -1) != *mpc {
-			return false
-		}
-
-		if j.IsSuspended() && j.podsCount() != ps0.Count {
-			return false
-		}
-	} else if j.podsCount() != ps0.Count {
-		return false
-	}
-
-	// nodeSelector may change, hence we are not checking for
-	// equality of the whole j.Spec.Template.Spec.
-	if !equality.Semantic.DeepEqual(j.Spec.Template.Spec.InitContainers,
-		wl.Spec.PodSets[0].Template.Spec.InitContainers) {
-		return false
-	}
-	return equality.Semantic.DeepEqual(j.Spec.Template.Spec.Containers,
-		wl.Spec.PodSets[0].Template.Spec.Containers)
-}
-
 func (j *Job) PriorityClass() string {
 	return j.Spec.Template.Spec.PriorityClassName
 }

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -164,29 +164,6 @@ func (j *MPIJob) Finished() (metav1.Condition, bool) {
 	return condition, finished
 }
 
-func (j *MPIJob) EquivalentToWorkload(wl kueue.Workload) bool {
-	if len(wl.Spec.PodSets) != len(j.Spec.MPIReplicaSpecs) {
-		return false
-	}
-	for index, mpiReplicaType := range orderedReplicaTypes(&j.Spec) {
-		mpiReplicaSpec := j.Spec.MPIReplicaSpecs[mpiReplicaType]
-		if pointer.Int32Deref(mpiReplicaSpec.Replicas, 1) != wl.Spec.PodSets[index].Count {
-			return false
-		}
-		// nodeSelector may change, hence we are not checking for
-		// equality of the whole j.Spec.Template.Spec.
-		if !equality.Semantic.DeepEqual(mpiReplicaSpec.Template.Spec.InitContainers,
-			wl.Spec.PodSets[index].Template.Spec.InitContainers) {
-			return false
-		}
-		if !equality.Semantic.DeepEqual(mpiReplicaSpec.Template.Spec.Containers,
-			wl.Spec.PodSets[index].Template.Spec.Containers) {
-			return false
-		}
-	}
-	return true
-}
-
 // PriorityClass calculates the priorityClass name needed for workload according to the following priorities:
 //  1. .spec.runPolicy.schedulingPolicy.priorityClass
 //  2. .spec.mpiReplicaSpecs[Launcher].template.spec.priorityClassName

--- a/pkg/util/equality/podset.go
+++ b/pkg/util/equality/podset.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package equality
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/utils/pointer"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+)
+
+// TODO: Revisit this, maybe we should extend the check to everything that could potentially impact
+// the workload scheduling (priority, nodeSelectors(when suspended), tolerations and maybe more)
+func comparePodTemplate(a, b *corev1.PodSpec) bool {
+	if !equality.Semantic.DeepEqual(a.InitContainers, b.InitContainers) {
+		return false
+	}
+	return equality.Semantic.DeepEqual(a.Containers, b.Containers)
+}
+
+func ComparePodSets(a, b *kueue.PodSet, checkCount bool) bool {
+	if checkCount && a.Count != b.Count {
+		return false
+	}
+	if pointer.Int32Deref(a.MinCount, -1) != pointer.Int32Deref(b.MinCount, -1) {
+		return false
+	}
+
+	return comparePodTemplate(&a.Template.Spec, &b.Template.Spec)
+}
+
+func ComparePodSetSlices(a, b []kueue.PodSet, checkCount bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !ComparePodSets(&a[i], &b[i], checkCount) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/util/equality/podset_test.go
+++ b/pkg/util/equality/podset_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package equality
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	utiltestting "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+func TestComparePodSetSlices(t *testing.T) {
+	cases := map[string]struct {
+		a           []kueue.PodSet
+		b           []kueue.PodSet
+		checkCounts bool
+		wantEqual   bool
+	}{
+		"different name": {
+			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
+			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps2", 10).SetMinimumCount(5).Obj()},
+			wantEqual: true,
+		},
+		"different count": {
+			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
+			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 20).SetMinimumCount(5).Obj()},
+			wantEqual: true,
+		},
+		"different min count": {
+			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
+			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(2).Obj()},
+			wantEqual: false,
+		},
+		"different node selector": {
+			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
+			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).NodeSelector(map[string]string{"key": "val"}).Obj()},
+			wantEqual: true,
+		},
+		"different requests": {
+			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Request("res", "1").Obj()},
+			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Request("res", "2").Obj()},
+			wantEqual: false,
+		},
+		"different requests in init containers": {
+			a: []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).InitContainers(corev1.Container{
+				Image: "img1",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"res": resource.MustParse("1"),
+					},
+				},
+			}).Obj()},
+			b: []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).InitContainers(corev1.Container{
+				Image: "img1",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						"res": resource.MustParse("2"),
+					},
+				},
+			}).Obj()},
+			wantEqual: false,
+		},
+		"different count when checked": {
+			a:           []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
+			b:           []kueue.PodSet{*utiltestting.MakePodSet("ps", 20).SetMinimumCount(5).Obj()},
+			checkCounts: true,
+			wantEqual:   false,
+		},
+		"different slice len": {
+			a:         []kueue.PodSet{{}, {}},
+			b:         []kueue.PodSet{{}, {}, {}},
+			wantEqual: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ComparePodSetSlices(tc.a, tc.b, tc.checkCounts)
+			if got != tc.wantEqual {
+				t.Errorf("Unexpected result, want %v", tc.wantEqual)
+			}
+		})
+	}
+}

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -217,6 +217,11 @@ func (p *PodSetWrapper) InitContainers(containers ...corev1.Container) *PodSetWr
 	return p
 }
 
+func (p *PodSetWrapper) NodeSelector(kv map[string]string) *PodSetWrapper {
+	p.Template.Spec.NodeSelector = kv
+	return p
+}
+
 // AdmissionWrapper wraps an Admission
 type AdmissionWrapper struct{ kueue.Admission }
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -87,7 +87,11 @@ func (i *Info) Update(wl *kueue.Workload) {
 }
 
 func (i *Info) CanBePartiallyAdmitted() bool {
-	ps := i.Obj.Spec.PodSets
+	return CanBePartiallyAdmitted(i.Obj)
+}
+
+func CanBePartiallyAdmitted(wl *kueue.Workload) bool {
+	ps := wl.Spec.PodSets
 	for psi := range ps {
 		if ps[psi].Count > pointer.Int32Deref(ps[psi].MinCount, ps[psi].Count) {
 			return true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Move `EquivalentToWorkload` functionality into the jobframework and simplify the GenericJob interface.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #782

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```