### PR TITLE
[jobframework] Make `ReclaimablePods` optional

### DIFF
--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 )
 
+// GenericJob if the interface which needs to be implemented by all jobs
+// managed by the kueue's jobframework.
 type GenericJob interface {
 	// Object returns the job instance.
 	Object() client.Object
@@ -51,6 +53,12 @@ type GenericJob interface {
 	PodsReady() bool
 	// GetGVK returns GVK (Group Version Kind) for the job.
 	GetGVK() schema.GroupVersionKind
+}
+
+// Optional interfaces, are meant to implemented by jobs to enable additional
+// features of the jobframework reconciler.
+
+type JobWithReclaimablePods interface {
 	// ReclaimablePods returns the list of reclaimable pods.
 	ReclaimablePods() []kueue.ReclaimablePod
 }

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -130,7 +130,8 @@ type Job struct {
 	*batchv1.Job
 }
 
-var _ jobframework.GenericJob = &Job{}
+var _ jobframework.GenericJob = (*Job)(nil)
+var _ jobframework.JobWithReclaimablePods = (*Job)(nil)
 
 func (j *Job) Object() client.Object {
 	return j.Job

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -112,10 +112,6 @@ func (j *MPIJob) GetGVK() schema.GroupVersionKind {
 	return gvk
 }
 
-func (j *MPIJob) ReclaimablePods() []kueue.ReclaimablePod {
-	return nil
-}
-
 func (j *MPIJob) PodSets() []kueue.PodSet {
 	replicaTypes := orderedReplicaTypes(&j.Spec)
 	podSets := make([]kueue.PodSet, len(replicaTypes))

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -230,10 +230,6 @@ func (j *RayJob) PodsReady() bool {
 	return j.Status.RayClusterStatus.State == rayjobapi.Ready
 }
 
-func (j *RayJob) ReclaimablePods() []kueue.ReclaimablePod {
-	return nil
-}
-
 // SetupWithManager sets up the controller with the Manager. It indexes workloads
 // based on the owning jobs.
 func (r *RayJobReconciler) SetupWithManager(mgr ctrl.Manager) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 Make `ReclaimablePods` optional,  this way a job integration that is not supporting reclaimable no longer need to implement a dummy version of this method. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #782

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```