### PR TITLE
Workload finalizer

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -117,14 +118,31 @@ func NewReconciler(
 
 func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Request, job GenericJob) (ctrl.Result, error) {
 	object := job.Object()
-	if err := r.client.Get(ctx, req.NamespacedName, object); err != nil {
-		// we'll ignore not-found errors, since there is nothing to do.
+	log := ctrl.LoggerFrom(ctx).WithValues("job", req.String())
+	ctx = ctrl.LoggerInto(ctx, log)
+
+	err := r.client.Get(ctx, req.NamespacedName, object)
+
+	if apierrors.IsNotFound(err) || !object.GetDeletionTimestamp().IsZero() {
+		workloads := kueue.WorkloadList{}
+		if err := r.client.List(ctx, &workloads, client.InNamespace(req.Namespace),
+			client.MatchingFields{getOwnerKey(job.GetGVK()): req.Name}); err != nil {
+			log.Error(err, "Unable to list child workloads")
+			return ctrl.Result{}, err
+		}
+		for i := range workloads.Items {
+			err := r.removeFinalizer(ctx, &workloads.Items[i])
+			if client.IgnoreNotFound(err) != nil {
+				log.Error(err, "Removing finalizer")
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	namespacedName := types.NamespacedName{Name: object.GetName(), Namespace: object.GetNamespace()}
-
-	log := ctrl.LoggerFrom(ctx).WithValues("job", namespacedName.String())
-	ctx = ctrl.LoggerInto(ctx, log)
 
 	isStandaloneJob := ParentWorkloadName(job) == ""
 
@@ -137,7 +155,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 				"queueName", QueueName(job), "parentWorkload", ParentWorkloadName(job))
 			return ctrl.Result{}, nil
 		}
-		isParentJobManaged, err := r.IsParentJobManaged(ctx, job.Object(), namespacedName.Namespace)
+		isParentJobManaged, err := r.IsParentJobManaged(ctx, job.Object(), req.Namespace)
 		if err != nil {
 			log.Error(err, "couldn't check whether the parent job is managed by kueue")
 			return ctrl.Result{}, err
@@ -180,6 +198,17 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 
 	if wl != nil && apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadFinished) {
 		return ctrl.Result{}, nil
+	}
+
+	// 1.1 If the workload is pending deletion, suspend the job if needed
+	// and drop the finalizer.
+	if wl != nil && !wl.DeletionTimestamp.IsZero() {
+		log.V(2).Info("The workload is marked for deletion")
+		err := r.stopJob(ctx, job, object, wl, "Workload is deleted")
+		if err != nil {
+			log.Error(err, "Suspending job with deleted workload")
+		}
+		return ctrl.Result{}, err
 	}
 
 	// 2. handle job is finished.
@@ -373,14 +402,20 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 	// Delete duplicate workload instances.
 	existedWls := 0
 	for i := range toDelete {
-		err := r.client.Delete(ctx, toDelete[i])
+		wlKey := workload.Key(toDelete[i])
+		err := r.removeFinalizer(ctx, toDelete[i])
+		if err != nil && !apierrors.IsNotFound(err) {
+			log.Error(err, "Failed to remove workload finalizer", "wl", wlKey)
+		}
+
+		err = r.client.Delete(ctx, toDelete[i])
 		if err != nil && !apierrors.IsNotFound(err) {
 			return nil, fmt.Errorf("deleting not matching workload: %w", err)
 		}
 		if err == nil {
 			existedWls++
 			r.record.Eventf(object, corev1.EventTypeNormal, "DeletedWorkload",
-				"Deleted not matching Workload: %v", workload.Key(toDelete[i]))
+				"Deleted not matching Workload: %v", wlKey)
 		}
 	}
 
@@ -436,6 +471,11 @@ func (r *JobReconciler) equivalentToWorkload(job GenericJob, object client.Objec
 
 // startJob will unsuspend the job, and also inject the node affinity.
 func (r *JobReconciler) startJob(ctx context.Context, job GenericJob, object client.Object, wl *kueue.Workload) error {
+	err := r.addFinalizer(ctx, wl)
+	if err != nil {
+		return err
+	}
+
 	info, err := r.getPodSetsInfoFromAdmission(ctx, wl)
 	if err != nil {
 		return err
@@ -464,22 +504,37 @@ func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, object clie
 		if stoppedNow {
 			r.record.Eventf(object, corev1.EventTypeNormal, "Stopped", eventMsg)
 		}
-		return err
+		if err != nil {
+			return err
+		}
+	} else if !job.IsSuspended() {
+		job.Suspend()
+		if info != nil {
+			job.RestorePodSetsInfo(info)
+		}
+		if err := r.client.Update(ctx, object); err != nil {
+			return err
+		}
+		r.record.Eventf(object, corev1.EventTypeNormal, "Stopped", eventMsg)
 	}
 
-	if job.IsSuspended() {
-		return nil
+	if wl != nil {
+		return r.removeFinalizer(ctx, wl)
 	}
+	return nil
+}
 
-	job.Suspend()
-	if info != nil {
-		job.RestorePodSetsInfo(info)
+func (r *JobReconciler) addFinalizer(ctx context.Context, wl *kueue.Workload) error {
+	if controllerutil.AddFinalizer(wl, kueue.ResourceInUseFinalizerName) {
+		return r.client.Update(ctx, wl)
 	}
-	if err := r.client.Update(ctx, object); err != nil {
-		return err
-	}
+	return nil
+}
 
-	r.record.Eventf(object, corev1.EventTypeNormal, "Stopped", eventMsg)
+func (r *JobReconciler) removeFinalizer(ctx context.Context, wl *kueue.Workload) error {
+	if controllerutil.RemoveFinalizer(wl, kueue.ResourceInUseFinalizerName) {
+		return r.client.Update(ctx, wl)
+	}
 	return nil
 }
 

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -374,6 +374,7 @@ func TestReconciler(t *testing.T) {
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
 					Obj(),
@@ -413,6 +414,7 @@ func TestReconciler(t *testing.T) {
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
 						*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).
 							SetMinimumCount(5).
@@ -638,7 +640,7 @@ func TestReconciler(t *testing.T) {
 			},
 			wantErr: jobframework.ErrExtraWorkloads,
 		},
-		"when workload is evicted, suspend, reset startTime and restore node affinity": {
+		"when workload is evicted, suspend, reset startTime, restore node affinity and remove the finalizer": {
 			job: *baseJobWrapper.Clone().
 				Queue("foo").
 				Suspend(false).
@@ -648,6 +650,7 @@ func TestReconciler(t *testing.T) {
 				Obj(),
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet("main", 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
 					Condition(metav1.Condition{

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -367,13 +367,13 @@ func TestReconciler(t *testing.T) {
 				Suspend(false).
 				Obj(),
 			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("a", "ns").
+				*utiltesting.MakeWorkload("a", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("a", "ns").
+				*utiltesting.MakeWorkload("a", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
@@ -387,7 +387,7 @@ func TestReconciler(t *testing.T) {
 			job:     *baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("a", "ns").
+				*utiltesting.MakeWorkload("a", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
 					Obj(),
@@ -407,13 +407,13 @@ func TestReconciler(t *testing.T) {
 				Parallelism(8).
 				Obj(),
 			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("a", "ns").
+				*utiltesting.MakeWorkload("a", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(8).Obj()).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("a", "ns").
+				*utiltesting.MakeWorkload("a", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
 						*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).
@@ -437,7 +437,7 @@ func TestReconciler(t *testing.T) {
 				SetAnnotation(JobMinParallelismAnnotation, "5").
 				Obj(),
 			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("a", "ns").
+				*utiltesting.MakeWorkload("a", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
 						*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).
 							SetMinimumCount(5).
@@ -462,7 +462,7 @@ func TestReconciler(t *testing.T) {
 				UID("test-uid").
 				Obj(),
 			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("job", "ns").
+				*utiltesting.MakeWorkload("job", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue("test-queue").
 					Priority(0).
@@ -485,7 +485,7 @@ func TestReconciler(t *testing.T) {
 				UID(strings.Repeat("long-uid", 8)).
 				Obj(),
 			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("job", "ns").
+				*utiltesting.MakeWorkload("job", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue("test-queue").
 					Priority(0).
@@ -573,12 +573,12 @@ func TestReconciler(t *testing.T) {
 				ParentWorkload("unit-test").
 				Obj(),
 			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("parent-workload", "ns").
+				*utiltesting.MakeWorkload("parent-workload", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("parent-workload", "ns").
+				*utiltesting.MakeWorkload("parent-workload", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
 					Obj(),
 			},
@@ -597,13 +597,13 @@ func TestReconciler(t *testing.T) {
 				Queue("test-queue").
 				Obj(),
 			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("parent-workload", "ns").
+				*utiltesting.MakeWorkload("parent-workload", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("parent-workload", "ns").
+				*utiltesting.MakeWorkload("parent-workload", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
 					Obj(),
@@ -624,23 +624,23 @@ func TestReconciler(t *testing.T) {
 				Parallelism(5).
 				Obj(),
 			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("first-workload", "ns").
+				*utiltesting.MakeWorkload("first-workload", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").Obj()).
 					Obj(),
-				*utiltesting.MakeWorkload("second-workload", "ns").
+				*utiltesting.MakeWorkload("second-workload", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("first-workload", "ns").
+				*utiltesting.MakeWorkload("first-workload", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").Obj()).
 					Obj(),
 			},
 			wantErr: jobframework.ErrExtraWorkloads,
 		},
-		"when workload is evicted, suspend, reset startTime, restore node affinity and remove the finalizer": {
+		"when workload is evicted, suspend, reset startTime and restore node affinity": {
 			job: *baseJobWrapper.Clone().
 				Queue("foo").
 				Suspend(false).
@@ -649,7 +649,7 @@ func TestReconciler(t *testing.T) {
 				Active(10).
 				Obj(),
 			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("a", "ns").
+				*utiltesting.MakeWorkload("a", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet("main", 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
@@ -665,7 +665,7 @@ func TestReconciler(t *testing.T) {
 				Active(10).
 				Obj(),
 			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("a", "ns").
+				*utiltesting.MakeWorkload("a", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet("main", 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
 					Condition(metav1.Condition{
@@ -684,7 +684,7 @@ func TestReconciler(t *testing.T) {
 				Active(10).
 				Obj(),
 			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("a", "ns").
+				*utiltesting.MakeWorkload("a", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet("main", 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
 					Condition(metav1.Condition{
@@ -699,7 +699,7 @@ func TestReconciler(t *testing.T) {
 				Active(10).
 				Obj(),
 			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("a", "ns").
+				*utiltesting.MakeWorkload("a", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet("main", 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
 					Condition(metav1.Condition{
@@ -717,7 +717,7 @@ func TestReconciler(t *testing.T) {
 				Active(10).
 				Obj(),
 			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("a", "ns").
+				*utiltesting.MakeWorkload("a", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet("main", 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
 					Condition(metav1.Condition{
@@ -732,11 +732,34 @@ func TestReconciler(t *testing.T) {
 				Active(10).
 				Obj(),
 			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("a", "ns").
+				*utiltesting.MakeWorkload("a", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet("main", 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Admit(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
 					Condition(metav1.Condition{
 						Type:   kueue.WorkloadEvicted,
+						Status: metav1.ConditionTrue,
+					}).
+					Obj(),
+			},
+		},
+		"when the workload is finished, its finalizer is removed": {
+			job: *baseJobWrapper.Clone().Queue("foo").Obj(),
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("a", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltesting.MakePodSet("main", 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadFinished,
+						Status: metav1.ConditionTrue,
+					}).
+					Obj(),
+			},
+			wantJob: *baseJobWrapper.Clone().Queue("foo").Obj(),
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("a", "ns").
+					PodSets(*utiltesting.MakePodSet("main", 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadFinished,
 						Status: metav1.ConditionTrue,
 					}).
 					Obj(),
@@ -752,9 +775,11 @@ func TestReconciler(t *testing.T) {
 			}
 			kcBuilder := clientBuilder.
 				WithObjects(&tc.job)
+
 			for i := range tc.workloads {
 				kcBuilder = kcBuilder.WithStatusSubresource(&tc.workloads[i])
 			}
+
 			kClient := kcBuilder.Build()
 			for i := range tc.workloads {
 				if err := ctrl.SetControllerReference(&tc.job, &tc.workloads[i], kClient.Scheme()); err != nil {

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -75,6 +75,11 @@ func (w *WorkloadWrapper) Obj() *kueue.Workload {
 	return &w.Workload
 }
 
+func (w *WorkloadWrapper) Finalizers(fin ...string) *WorkloadWrapper {
+	w.ObjectMeta.Finalizers = fin
+	return w
+}
+
 func (w *WorkloadWrapper) Request(r corev1.ResourceName, q string) *WorkloadWrapper {
 	w.Spec.PodSets[0].Template.Spec.Containers[0].Resources.Requests[r] = resource.MustParse(q)
 	return w

--- a/test/integration/controller/job/job_controller_test.go
+++ b/test/integration/controller/job/job_controller_test.go
@@ -38,6 +38,8 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/maps"
+	"sigs.k8s.io/kueue/pkg/util/pointer"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -875,15 +877,30 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 			return createdProdJob.Spec.Suspend
 		}, util.Timeout, util.Interval).Should(gomega.Equal(ptr.To(true)))
 
+		originalSelector := maps.Clone(createdProdJob.Spec.Template.Spec.NodeSelector)
+
 		ginkgo.By("creating another localQueue of the same name and in the same namespace as the job")
 		prodLocalQ = testing.MakeLocalQueue(localQueue.Name, ns.Name).ClusterQueue(prodClusterQ.Name).Obj()
 		gomega.Expect(k8sClient.Create(ctx, prodLocalQ)).Should(gomega.Succeed())
 
-		ginkgo.By("job should be unsuspended")
+		ginkgo.By("job should be unsuspended and NodeSelector properly set")
 		gomega.Eventually(func() *bool {
 			gomega.Expect(k8sClient.Get(ctx, lookupKey, createdProdJob)).Should(gomega.Succeed())
 			return createdProdJob.Spec.Suspend
 		}, util.Timeout, util.Interval).Should(gomega.Equal(ptr.To(false)))
+
+		runningSelector := maps.Clone(createdProdJob.Spec.Template.Spec.NodeSelector)
+		gomega.Expect(runningSelector).NotTo(gomega.Equal(originalSelector))
+
+		expectedSelector := maps.Clone(originalSelector)
+		if expectedSelector == nil {
+			expectedSelector = onDemandFlavor.Spec.NodeLabels
+		} else {
+			for k, v := range onDemandFlavor.Spec.NodeLabels {
+				expectedSelector[k] = v
+			}
+		}
+		gomega.Expect(runningSelector).To(gomega.Equal(expectedSelector))
 	})
 
 	ginkgo.When("The workload's admission is removed", func() {
@@ -904,7 +921,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 				}, util.Timeout, util.Interval).Should(gomega.Equal(ptr.To(true)))
 			})
 
-			// backup the the podSet's node selector
+			// backup the podSet's node selector
 			originalNodeSelector := createdJob.Spec.Template.Spec.NodeSelector
 
 			ginkgo.By("create a localQueue", func() {
@@ -941,6 +958,123 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 					gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 					return createdJob.Spec.Template.Spec.NodeSelector
 				}, util.Timeout, util.Interval).Should(gomega.Equal(originalNodeSelector))
+			})
+		})
+	})
+
+	ginkgo.When("The workload is deleted while admitted", func() {
+		ginkgo.It("Should restore the original node selectors", func() {
+			localQueue := testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(prodClusterQ.Name).Obj()
+			job := testingjob.MakeJob(jobName, ns.Name).Queue(localQueue.Name).Request(corev1.ResourceCPU, "2").Suspend(false).Obj()
+			lookupKey := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
+			createdJob := &batchv1.Job{}
+
+			ginkgo.By("create a job", func() {
+				gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("job should be suspend", func() {
+				gomega.Eventually(func() *bool {
+					gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+					return createdJob.Spec.Suspend
+				}, util.Timeout, util.Interval).Should(gomega.Equal(pointer.Bool(true)))
+			})
+
+			// backup the podSet's node selector
+			originalNodeSelector := createdJob.Spec.Template.Spec.NodeSelector
+
+			ginkgo.By("create a localQueue", func() {
+				gomega.Expect(k8sClient.Create(ctx, localQueue)).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("job should be unsuspended", func() {
+				gomega.Eventually(func() *bool {
+					gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+					return createdJob.Spec.Suspend
+				}, util.Timeout, util.Interval).Should(gomega.Equal(pointer.Bool(false)))
+			})
+
+			ginkgo.By("the node selector should be updated", func() {
+				gomega.Eventually(func() map[string]string {
+					gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+					return createdJob.Spec.Template.Spec.NodeSelector
+				}, util.Timeout, util.Interval).ShouldNot(gomega.Equal(originalNodeSelector))
+			})
+
+			ginkgo.By("delete the localQueue to prevent readmission", func() {
+				gomega.Expect(util.DeleteLocalQueue(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("deleting the workload", func() {
+				wl := &kueue.Workload{}
+				wlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name), Namespace: job.Namespace}
+				gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+				gomega.Expect(k8sClient.Delete(ctx, wl)).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("the node selector should be restored", func() {
+				gomega.Eventually(func() map[string]string {
+					gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+					return createdJob.Spec.Template.Spec.NodeSelector
+				}, util.Timeout, util.Interval).Should(gomega.Equal(originalNodeSelector))
+			})
+		})
+	})
+
+	ginkgo.When("The job is deleted while admitted", func() {
+		ginkgo.It("Its workload should also be deleted", func() {
+			localQueue := testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(prodClusterQ.Name).Obj()
+			job := testingjob.MakeJob(jobName, ns.Name).Queue(localQueue.Name).Request(corev1.ResourceCPU, "2").Suspend(false).Obj()
+			lookupKey := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
+			createdJob := &batchv1.Job{}
+
+			ginkgo.By("create a job", func() {
+				gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("job should be suspend", func() {
+				gomega.Eventually(func() *bool {
+					gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+					return createdJob.Spec.Suspend
+				}, util.Timeout, util.Interval).Should(gomega.Equal(pointer.Bool(true)))
+			})
+
+			ginkgo.By("create a localQueue", func() {
+				gomega.Expect(k8sClient.Create(ctx, localQueue)).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("job should be unsuspended", func() {
+				gomega.Eventually(func() *bool {
+					gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+					return createdJob.Spec.Suspend
+				}, util.Timeout, util.Interval).Should(gomega.Equal(pointer.Bool(false)))
+			})
+
+			wlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name), Namespace: job.Namespace}
+			ginkgo.By("checking the finalizer is set", func() {
+				gomega.Eventually(func() []string {
+					wl := &kueue.Workload{}
+					gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+					return wl.Finalizers
+				}, util.Timeout, util.Interval).Should(gomega.ContainElement(kueue.ResourceInUseFinalizerName))
+			})
+
+			ginkgo.By("deleting the job", func() {
+				gomega.Expect(k8sClient.Delete(ctx, job)).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("checking the workload is removed or the finalizer is no longer set", func() {
+				gomega.Eventually(func() []string {
+					wl := &kueue.Workload{}
+					err := k8sClient.Get(ctx, wlKey, wl)
+					if err != nil {
+						if apierrors.IsNotFound(err) {
+							return []string{}
+						}
+						return []string{kueue.ResourceInUseFinalizerName}
+					}
+					return wl.Finalizers
+				}, util.Timeout, util.Interval).ShouldNot(gomega.ContainElement(kueue.ResourceInUseFinalizerName))
 			})
 		})
 	})

--- a/test/integration/controller/job/job_controller_test.go
+++ b/test/integration/controller/job/job_controller_test.go
@@ -39,7 +39,6 @@ import (
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/maps"
-	"sigs.k8s.io/kueue/pkg/util/pointer"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -977,7 +976,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 				gomega.Eventually(func() *bool {
 					gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 					return createdJob.Spec.Suspend
-				}, util.Timeout, util.Interval).Should(gomega.Equal(pointer.Bool(true)))
+				}, util.Timeout, util.Interval).Should(gomega.Equal(ptr.To[bool](true)))
 			})
 
 			// backup the podSet's node selector
@@ -991,7 +990,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 				gomega.Eventually(func() *bool {
 					gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 					return createdJob.Spec.Suspend
-				}, util.Timeout, util.Interval).Should(gomega.Equal(pointer.Bool(false)))
+				}, util.Timeout, util.Interval).Should(gomega.Equal(ptr.To[bool](false)))
 			})
 
 			ginkgo.By("the node selector should be updated", func() {
@@ -1036,7 +1035,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 				gomega.Eventually(func() *bool {
 					gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 					return createdJob.Spec.Suspend
-				}, util.Timeout, util.Interval).Should(gomega.Equal(pointer.Bool(true)))
+				}, util.Timeout, util.Interval).Should(gomega.Equal(ptr.To[bool](true)))
 			})
 
 			ginkgo.By("create a localQueue", func() {
@@ -1047,7 +1046,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 				gomega.Eventually(func() *bool {
 					gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 					return createdJob.Spec.Suspend
-				}, util.Timeout, util.Interval).Should(gomega.Equal(pointer.Bool(false)))
+				}, util.Timeout, util.Interval).Should(gomega.Equal(ptr.To[bool](false)))
 			})
 
 			wlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name), Namespace: job.Namespace}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add and manage resourceInUse finalizer for workloads, to add the posibility to restore the podSets Info upon workload deletion.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #518

#### Special notes for your reviewer:

This PR is split of #834 ,  the code was reviewed there.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```