### PR TITLE
[jobframework] Add `JobWithCustomStop` optional job interface

### DIFF
--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -14,6 +14,8 @@ limitations under the License.
 package jobframework
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,9 +33,6 @@ type GenericJob interface {
 	IsSuspended() bool
 	// Suspend will suspend the job.
 	Suspend()
-	// ResetStatus will reset the job status to the original state.
-	// If true, status is modified, if not, status is as it was.
-	ResetStatus() bool
 	// RunWithPodSetsInfo will inject the node affinity and podSet counts extracting from workload to job and unsuspend it.
 	RunWithPodSetsInfo(nodeSelectors []PodSetInfo)
 	// RestorePodSetsInfo will restore the original node affinity and podSet counts of the job.
@@ -61,6 +60,11 @@ type GenericJob interface {
 type JobWithReclaimablePods interface {
 	// ReclaimablePods returns the list of reclaimable pods.
 	ReclaimablePods() []kueue.ReclaimablePod
+}
+
+type JobWithCustomStop interface {
+	// Stop implements a custom stop procedure
+	Stop(ctx context.Context, c client.Client, podSetsInfo []PodSetInfo) error
 }
 
 func ParentWorkloadName(job GenericJob) string {

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -96,14 +96,6 @@ func (j *MPIJob) Suspend() {
 	j.Spec.RunPolicy.Suspend = pointer.Bool(true)
 }
 
-func (j *MPIJob) ResetStatus() bool {
-	if j.Status.StartTime == nil {
-		return false
-	}
-	j.Status.StartTime = nil
-	return true
-}
-
 func (j *MPIJob) GetGVK() schema.GroupVersionKind {
 	return gvk
 }

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -81,14 +81,6 @@ func (j *RayJob) Suspend() {
 	j.Spec.Suspend = true
 }
 
-func (j *RayJob) ResetStatus() bool {
-	if j.Status.StartTime == nil {
-		return false
-	}
-	j.Status.StartTime = nil
-	return true
-}
-
 func (j *RayJob) GetGVK() schema.GroupVersionKind {
 	return gvk
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add `JobWithCustomStop` optional job interface  which can/should be implemented by jobs which need a more complex flow to stop, for example batch/job where `Status.StartTime` needs to be `nil` before attempting to update the node selector. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```