### PR TITLE
[makefile][e2e] Run e2e with multiple k8s versions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ E2E_TARGET ?= ./test/e2e/...
 
 E2E_KIND_VERSION ?= kindest/node:v1.24.7
 
+# E2E_K8S_VERSIONS sets the list of k8s versions included in test-e2e-all
+E2E_K8S_VERSIONS ?= 1.24.7 1.25.3 1.26.2 1.27.2
+
 # For local testing, we should allow user to use different kind cluster name
 # Default will delete default kind cluster
 KIND_CLUSTER_NAME ?= kind
@@ -155,8 +158,18 @@ test-integration: manifests generate envtest ginkgo mpi-operator-crd ray-operato
 
 CREATE_KIND_CLUSTER ?= true
 .PHONY: test-e2e
-test-e2e: kustomize manifests generate ginkgo
-	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) CREATE_KIND_CLUSTER=$(CREATE_KIND_CLUSTER) ARTIFACTS=$(ARTIFACTS) IMAGE_TAG=$(IMAGE_TAG) ./hack/e2e-test.sh
+test-e2e: kustomize manifests generate ginkgo run-test-e2e-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+E2E_TARGETS := $(addprefix run-test-e2e-,${E2E_K8S_VERSIONS})
+.PHONY: test-e2e-all
+test-e2e-all: kustomize manifests generate envtest ginkgo $(E2E_TARGETS)
+
+FORCE:
+
+run-test-e2e-%: K8S_VERSION = $(@:run-test-e2e-%=%)
+run-test-e2e-%: FORCE
+	@echo Running e2e for k8s ${K8S_VERSION}
+	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) CREATE_KIND_CLUSTER=$(CREATE_KIND_CLUSTER) ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) ./hack/e2e-test.sh
 
 .PHONY: ci-lint
 ci-lint: golangci-lint

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -27,6 +27,9 @@ export KIND=$ROOT_DIR/bin/kind
 function cleanup {
     if [ $CREATE_KIND_CLUSTER == 'true' ]
     then
+	if [ ! -d "$ARTIFACTS" ]; then
+		mkdir -p "$ARTIFACTS"
+	fi
         kubectl logs -n kube-system kube-scheduler-kind-control-plane > $ARTIFACTS/kube-scheduler.log
         kubectl logs -n kube-system kube-controller-manager-kind-control-plane > $ARTIFACTS/kube-controller-manager.log
         kubectl logs -n kueue-system deployment/kueue-controller-manager > $ARTIFACTS/kueue-controller-manager.log

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -18,6 +18,8 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -44,9 +46,13 @@ const (
 )
 
 func TestAPIs(t *testing.T) {
+	suiteName := "End To End Suite"
+	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
+		suiteName = fmt.Sprintf("%s: %s", suiteName, ver)
+	}
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t,
-		"End To End Suite",
+		suiteName,
 	)
 }
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add a new make target `test-e2e-all` which runs the e2e test for all k8s versions specified in `E2E_K8S_VERSIONS`.
Default `E2E_K8S_VERSIONS` is `1.24.7` `1.25.3` `1.26.2` `1.27.2`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #875

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```