### PR TITLE
Cherry-pick node selectors management test to 0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ test-integration: manifests generate fmt vet envtest ginkgo mpi-operator-crd ## 
 
 CREATE_KIND_CLUSTER ?= true
 .PHONY: test-e2e
-test-e2e: kustomize manifests generate fmt vet envtest ginkgo
+test-e2e: kustomize manifests generate ginkgo
 	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) CREATE_KIND_CLUSTER=$(CREATE_KIND_CLUSTER) ARTIFACTS=$(ARTIFACTS) IMAGE_TAG=$(IMAGE_TAG) ./hack/e2e-test.sh
 
 .PHONY: ci-lint

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ E2E_TARGET ?= ./test/e2e/...
 
 E2E_KIND_VERSION ?= kindest/node:v1.24.7
 
+# E2E_K8S_VERSIONS sets the list of k8s versions included in test-e2e-all
+E2E_K8S_VERSIONS ?= 1.24.7 1.25.3 1.26.2 1.27.2
+
 # For local testing, we should allow user to use different kind cluster name
 # Default will delete default kind cluster
 KIND_CLUSTER_NAME ?= kind
@@ -150,8 +153,18 @@ test-integration: manifests generate fmt vet envtest ginkgo mpi-operator-crd ## 
 
 CREATE_KIND_CLUSTER ?= true
 .PHONY: test-e2e
-test-e2e: kustomize manifests generate ginkgo
-	E2E_KIND_VERSION=$(E2E_KIND_VERSION) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) CREATE_KIND_CLUSTER=$(CREATE_KIND_CLUSTER) ARTIFACTS=$(ARTIFACTS) IMAGE_TAG=$(IMAGE_TAG) ./hack/e2e-test.sh
+test-e2e: kustomize manifests generate ginkgo run-test-e2e-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+E2E_TARGETS := $(addprefix run-test-e2e-,${E2E_K8S_VERSIONS})
+.PHONY: test-e2e-all
+test-e2e-all: kustomize manifests generate envtest ginkgo $(E2E_TARGETS)
+
+FORCE:
+
+run-test-e2e-%: K8S_VERSION = $(@:run-test-e2e-%=%)
+run-test-e2e-%: FORCE
+	@echo Running e2e for k8s ${K8S_VERSION}
+	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) CREATE_KIND_CLUSTER=$(CREATE_KIND_CLUSTER) ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) ./hack/e2e-test.sh
 
 .PHONY: ci-lint
 ci-lint: golangci-lint

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -27,6 +27,9 @@ export KIND=$ROOT_DIR/bin/kind
 function cleanup {
     if [ $CREATE_KIND_CLUSTER == 'true' ]
     then
+	if [ ! -d "$ARTIFACTS" ]; then
+		mkdir -p "$ARTIFACTS"
+	fi
         kubectl logs -n kube-system kube-scheduler-kind-control-plane > $ARTIFACTS/kube-scheduler.log
         kubectl logs -n kube-system kube-controller-manager-kind-control-plane > $ARTIFACTS/kube-controller-manager.log
         kubectl logs -n kueue-system deployment/kueue-controller-manager > $ARTIFACTS/kueue-controller-manager.log

--- a/hack/kind-cluster.yaml
+++ b/hack/kind-cluster.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    scheduler:
+      extraArgs:
+        v: "2"
+    controllerManager:
+      extraArgs:
+        v: "2"
+- role: worker

--- a/hack/kind-cluster.yaml
+++ b/hack/kind-cluster.yaml
@@ -13,3 +13,8 @@ nodes:
       extraArgs:
         v: "2"
 - role: worker
+  labels:
+    instance-type: on-demand
+- role: worker
+  labels:
+    instance-type: spot

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -298,7 +298,7 @@ func (s *Scheduler) admit(ctx context.Context, e *entry) error {
 			waitTime := time.Since(e.Obj.CreationTimestamp.Time)
 			s.recorder.Eventf(newWorkload, corev1.EventTypeNormal, "Admitted", "Admitted by ClusterQueue %v, wait time was %.0fs", admission.ClusterQueue, waitTime.Seconds())
 			metrics.AdmittedWorkload(admission.ClusterQueue, waitTime)
-			log.V(2).Info("Workload successfully admitted and assigned flavors")
+			log.V(2).Info("Workload successfully admitted and assigned flavors", "assignments", admission.PodSetAssignments)
 			return
 		}
 		// Ignore errors because the workload or clusterQueue could have been deleted

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -128,12 +128,9 @@ func (j *JobWrapper) Request(r corev1.ResourceName, v string) *JobWrapper {
 }
 
 func (j *JobWrapper) Image(name string, image string, args []string) *JobWrapper {
-	j.Spec.Template.Spec.Containers[0] = corev1.Container{
-		Name:      name,
-		Image:     image,
-		Args:      args,
-		Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
-	}
+	j.Spec.Template.Spec.Containers[0].Name = name
+	j.Spec.Template.Spec.Containers[0].Image = image
+	j.Spec.Template.Spec.Containers[0].Args = args
 	return j
 }
 

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -18,6 +18,8 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -44,9 +46,13 @@ const (
 )
 
 func TestAPIs(t *testing.T) {
+	suiteName := "End To End Suite"
+	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
+		suiteName = fmt.Sprintf("%s: %s", suiteName, ver)
+	}
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	ginkgo.RunSpecs(t,
-		"End To End Suite",
+		suiteName,
 	)
 }
 

--- a/test/integration/controller/job/job_controller_test.go
+++ b/test/integration/controller/job/job_controller_test.go
@@ -723,6 +723,9 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", func() {
 				*testing.MakeFlavorQuotas("spot-untainted").Resource(corev1.ResourceCPU, "5").Obj(),
 				*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
 			).
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+			}).
 			Obj()
 		gomega.Expect(k8sClient.Create(ctx, devClusterQ)).Should(gomega.Succeed())
 	})
@@ -898,4 +901,56 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", func() {
 			})
 		})
 	})
+
+	ginkgo.It("Should readmit preempted Job in alternative flavor", func() {
+		devLocalQ = testing.MakeLocalQueue("dev-queue", ns.Name).ClusterQueue(devClusterQ.Name).Obj()
+		gomega.Expect(k8sClient.Create(ctx, devLocalQ)).Should(gomega.Succeed())
+
+		highPriorityClass := testing.MakePriorityClass("high").PriorityValue(100).Obj()
+		gomega.Expect(k8sClient.Create(ctx, highPriorityClass))
+
+		lowJobKey := types.NamespacedName{Name: "low", Namespace: ns.Name}
+		ginkgo.By("Low priority job is unsuspended and has nodeSelector", func() {
+			job := testingjob.MakeJob("low", ns.Name).
+				Queue(devLocalQ.Name).
+				Parallelism(5).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+
+			expectJobUnsuspendedWithNodeSelectors(lowJobKey, map[string]string{
+				instanceKey: "spot-untainted",
+			})
+		})
+
+		ginkgo.By("High priority job preemtps low priority job", func() {
+			job := testingjob.MakeJob("high", ns.Name).
+				Queue(devLocalQ.Name).
+				PriorityClass("high").
+				Parallelism(5).
+				Request(corev1.ResourceCPU, "1").
+				NodeSelector(instanceKey, "spot-untainted"). // target the same flavor to cause preemption
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+
+			highJobKey := types.NamespacedName{Name: "high", Namespace: ns.Name}
+			expectJobUnsuspendedWithNodeSelectors(highJobKey, map[string]string{
+				instanceKey: "spot-untainted",
+			})
+		})
+
+		ginkgo.By("Preempted job should be admitted on second flavor", func() {
+			expectJobUnsuspendedWithNodeSelectors(lowJobKey, map[string]string{
+				instanceKey: "on-demand",
+			})
+		})
+	})
 })
+
+func expectJobUnsuspendedWithNodeSelectors(key types.NamespacedName, ns map[string]string) {
+	job := &batchv1.Job{}
+	gomega.EventuallyWithOffset(1, func() []any {
+		gomega.Expect(k8sClient.Get(ctx, key, job)).To(gomega.Succeed())
+		return []any{*job.Spec.Suspend, job.Spec.Template.Spec.NodeSelector}
+	}, util.Timeout, util.Interval).Should(gomega.Equal([]any{false, ns}))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Cherry-pick node selectors management test to 0.3.

Includes #890 and #885

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```