### PR TITLE
[Cache] Sort resourceUsages according to resourceName

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -879,6 +880,10 @@ func (c *Cache) Usage(cqObj *kueue.ClusterQueue) ([]kueue.FlavorUsage, int, erro
 				}
 				outFlvUsage.Resources = append(outFlvUsage.Resources, rUsage)
 			}
+			// The resourceUsages should be in a stable order to avoid endless creation of update events.
+			sort.Slice(outFlvUsage.Resources, func(i, j int) bool {
+				return outFlvUsage.Resources[i].Name < outFlvUsage.Resources[j].Name
+			})
 			usage = append(usage, outFlvUsage)
 		}
 	}
@@ -912,6 +917,10 @@ func (c *Cache) LocalQueueUsage(qObj *kueue.LocalQueue) ([]kueue.LocalQueueFlavo
 					Total: workload.ResourceQuantity(rName, flvUsage[rName]),
 				})
 			}
+			// The resourceUsages should be in a stable order to avoid endless creation of update events.
+			sort.Slice(outFlvUsage.Resources, func(i, j int) bool {
+				return outFlvUsage.Resources[i].Name < outFlvUsage.Resources[j].Name
+			})
 			qFlvUsages = append(qFlvUsages, outFlvUsage)
 		}
 	}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1327,7 +1327,15 @@ func TestClusterQueueUsage(t *testing.T) {
 			*utiltesting.MakeFlavorQuotas("model_b").
 				Resource("example.com/gpu", "5").
 				Obj(),
-		).Cohort("one").Obj()
+		).
+		ResourceGroup(
+			*utiltesting.MakeFlavorQuotas("interconnect_a").
+				Resource("example.com/vf-0", "5", "5").
+				Resource("example.com/vf-1", "5", "5").
+				Resource("example.com/vf-2", "5", "5").
+				Obj(),
+		).
+		Cohort("one").Obj()
 	cqWithOutCohort := cq.DeepCopy()
 	cqWithOutCohort.Spec.Cohort = ""
 	workloads := []kueue.Workload{
@@ -1372,6 +1380,14 @@ func TestClusterQueueUsage(t *testing.T) {
 						Name: "example.com/gpu",
 					}},
 				},
+				{
+					Name: "interconnect_a",
+					Resources: []kueue.ResourceUsage{
+						{Name: "example.com/vf-0"},
+						{Name: "example.com/vf-1"},
+						{Name: "example.com/vf-2"},
+					},
+				},
 			},
 			wantWorkloads: 1,
 		},
@@ -1402,6 +1418,14 @@ func TestClusterQueueUsage(t *testing.T) {
 						Borrowed: resource.MustParse("1"),
 					}},
 				},
+				{
+					Name: "interconnect_a",
+					Resources: []kueue.ResourceUsage{
+						{Name: "example.com/vf-0"},
+						{Name: "example.com/vf-1"},
+						{Name: "example.com/vf-2"},
+					},
+				},
 			},
 			wantWorkloads: 2,
 		},
@@ -1431,6 +1455,14 @@ func TestClusterQueueUsage(t *testing.T) {
 						Total:    resource.MustParse("6"),
 						Borrowed: resource.MustParse("0"),
 					}},
+				},
+				{
+					Name: "interconnect_a",
+					Resources: []kueue.ResourceUsage{
+						{Name: "example.com/vf-0"},
+						{Name: "example.com/vf-1"},
+						{Name: "example.com/vf-2"},
+					},
 				},
 			},
 			wantWorkloads: 2,
@@ -1474,6 +1506,13 @@ func TestLocalQueueUsage(t *testing.T) {
 				Resource("example.com/gpu", "5").Obj(),
 			*utiltesting.MakeFlavorQuotas("model-b").
 				Resource("example.com/gpu", "5").Obj(),
+		).
+		ResourceGroup(
+			*utiltesting.MakeFlavorQuotas("interconnect-a").
+				Resource("example.com/vf-0", "5", "5").
+				Resource("example.com/vf-1", "5", "5").
+				Resource("example.com/vf-2", "5", "5").
+				Obj(),
 		).
 		Obj()
 	localQueue := *utiltesting.MakeLocalQueue("test", "ns1").
@@ -1520,6 +1559,14 @@ func TestLocalQueueUsage(t *testing.T) {
 							Name:  "example.com/gpu",
 							Total: resource.MustParse("0"),
 						},
+					},
+				},
+				{
+					Name: "interconnect-a",
+					Resources: []kueue.LocalQueueResourceUsage{
+						{Name: "example.com/vf-0"},
+						{Name: "example.com/vf-1"},
+						{Name: "example.com/vf-2"},
 					},
 				},
 			},
@@ -1576,6 +1623,14 @@ func TestLocalQueueUsage(t *testing.T) {
 						},
 					},
 				},
+				{
+					Name: "interconnect-a",
+					Resources: []kueue.LocalQueueResourceUsage{
+						{Name: "example.com/vf-0"},
+						{Name: "example.com/vf-1"},
+						{Name: "example.com/vf-2"},
+					},
+				},
 			},
 		},
 		"some workloads are inadmissible": {
@@ -1622,6 +1677,14 @@ func TestLocalQueueUsage(t *testing.T) {
 							Name:  "example.com/gpu",
 							Total: resource.MustParse("0"),
 						},
+					},
+				},
+				{
+					Name: "interconnect-a",
+					Resources: []kueue.LocalQueueResourceUsage{
+						{Name: "example.com/vf-0"},
+						{Name: "example.com/vf-1"},
+						{Name: "example.com/vf-2"},
 					},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The resourceUsages should be in a stable order to avoid endless creation of update events.
So, I added processes to sort resourceUsages according to resourceName in ClusterQueue and LocalQueue. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #902

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug that updates events for clusterQueues are created endlessly.
```