### PR TITLE
Automated cherry pick of #907: Sort resourceUsages according to resourceName

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -830,6 +831,10 @@ func (c *Cache) Usage(cqObj *kueue.ClusterQueue) ([]kueue.FlavorUsage, int, erro
 				}
 				outFlvUsage.Resources = append(outFlvUsage.Resources, rUsage)
 			}
+			// The resourceUsages should be in a stable order to avoid endless creation of update events.
+			sort.Slice(outFlvUsage.Resources, func(i, j int) bool {
+				return outFlvUsage.Resources[i].Name < outFlvUsage.Resources[j].Name
+			})
 			usage = append(usage, outFlvUsage)
 		}
 	}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1327,7 +1327,15 @@ func TestClusterQueueUsage(t *testing.T) {
 			*utiltesting.MakeFlavorQuotas("model_b").
 				Resource("example.com/gpu", "5").
 				Obj(),
-		).Cohort("one").Obj()
+		).
+		ResourceGroup(
+			*utiltesting.MakeFlavorQuotas("interconnect_a").
+				Resource("example.com/vf-0", "5", "5").
+				Resource("example.com/vf-1", "5", "5").
+				Resource("example.com/vf-2", "5", "5").
+				Obj(),
+		).
+		Cohort("one").Obj()
 	cqWithOutCohort := cq.DeepCopy()
 	cqWithOutCohort.Spec.Cohort = ""
 	workloads := []kueue.Workload{
@@ -1372,6 +1380,14 @@ func TestClusterQueueUsage(t *testing.T) {
 						Name: "example.com/gpu",
 					}},
 				},
+				{
+					Name: "interconnect_a",
+					Resources: []kueue.ResourceUsage{
+						{Name: "example.com/vf-0"},
+						{Name: "example.com/vf-1"},
+						{Name: "example.com/vf-2"},
+					},
+				},
 			},
 			wantWorkloads: 1,
 		},
@@ -1402,6 +1418,14 @@ func TestClusterQueueUsage(t *testing.T) {
 						Borrowed: resource.MustParse("1"),
 					}},
 				},
+				{
+					Name: "interconnect_a",
+					Resources: []kueue.ResourceUsage{
+						{Name: "example.com/vf-0"},
+						{Name: "example.com/vf-1"},
+						{Name: "example.com/vf-2"},
+					},
+				},
 			},
 			wantWorkloads: 2,
 		},
@@ -1431,6 +1455,14 @@ func TestClusterQueueUsage(t *testing.T) {
 						Total:    resource.MustParse("6"),
 						Borrowed: resource.MustParse("0"),
 					}},
+				},
+				{
+					Name: "interconnect_a",
+					Resources: []kueue.ResourceUsage{
+						{Name: "example.com/vf-0"},
+						{Name: "example.com/vf-1"},
+						{Name: "example.com/vf-2"},
+					},
 				},
 			},
 			wantWorkloads: 2,


### PR DESCRIPTION
Cherry pick of #907 on release-0.3.
#907: Sort resourceUsages according to resourceName
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
Fix a bug that updates events for clusterQueues are created endlessly.
```