### PR TITLE
Clean up go module after generating codes

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -43,3 +43,6 @@ then
   fi
   mv sigs.k8s.io/kueue/client-go ${KUEUE_ROOT}/client-go
 fi
+
+# We need to clean up the go.mod file since code-generator adds temporary library to the go.mod file.
+"${GO_CMD}" mod tidy


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The code-generator adds temporary module to go.mod when generating codes. So we should clean up go.mod.

```shell
diff --git a/go.mod b/go.mod
index 806cc12..4e11427 100644
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
        github.com/stretchr/testify v1.8.2 // indirect
        go.uber.org/atomic v1.11.0 // indirect
        go.uber.org/multierr v1.11.0 // indirect
+       golang.org/x/crypto v0.1.0 // indirect
        golang.org/x/mod v0.10.0 // indirect
        golang.org/x/net v0.10.0 // indirect
        golang.org/x/oauth2 v0.6.0 // indirect
diff --git a/go.sum b/go.sum
index ead83fc..d79d991 100644
--- a/go.sum
+++ b/go.sum
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```