### PR TITLE
[batch/job] Partial admission - sync completions

### DIFF
--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -82,6 +82,16 @@ func (j *JobWrapper) Completions(p int32) *JobWrapper {
 	return j
 }
 
+// Indexed sets the job's completion to Indexed of NonIndexed
+func (j *JobWrapper) Indexed(indexed bool) *JobWrapper {
+	mode := batchv1.NonIndexedCompletion
+	if indexed {
+		mode = batchv1.IndexedCompletion
+	}
+	j.Spec.CompletionMode = &mode
+	return j
+}
+
 // PriorityClass updates job priorityclass.
 func (j *JobWrapper) PriorityClass(pc string) *JobWrapper {
 	j.Spec.Template.Spec.PriorityClassName = pc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Synchronize `batch/job.completions` with `parallelism` in case of partial admission

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to: #970

#### Special notes for your reviewer:

This is the first step fixing #970.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Synchronize batch/job.completions with parallelism in case of partial admission
```