### PR TITLE
KEP 993: Two Stage Admission Process

### DIFF
--- a/keps/993-two-phase-admission/README.md
+++ b/keps/993-two-phase-admission/README.md
@@ -1,0 +1,282 @@
+# KEP-993: Two Stage Admission Process
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories (Optional)](#user-stories-optional)
+    - [Story 1](#story-1)
+    - [Story 2](#story-2)
+  - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+    - [Unit Tests](#unit-tests)
+    - [Integration tests](#integration-tests)
+  - [Graduation Criteria](#graduation-criteria)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Summary
+
+This KEP defines the extension point to plug in arbitrary, additional checks
+for workloads before they are admitted for execution. These external checks may
+be implemented inside or outside of Kueue and may provide functionality like
+budgeting, capacity provisioning or some elements of multicluster dispatching.
+
+## Motivation
+
+With the growth of Kueue, not all desired elements may land inside of the core
+Kueue. Some users may even not want to publish their custom admission logic in
+a public repository. At the same time, we don’t want to force users to
+fork Kueue. Thus, an pluggable mechanism for workload admission needs to
+be established.
+
+### Goals
+
+Define mechanism to allow external controllers:
+
+* to give green light to admit a workload.
+* to temporarily hold workload admission.
+* to stop a previously admitted workload and move it back to the
+suspended state.
+
+### Non-Goals
+
+Provide a specific design or implementation for any external controller.
+
+## Proposal
+
+Extend ClusterQueue definition with a list of external controller names that
+need to give green light to admit a workload. Until all of the controllers, which
+identify with these names, don’t give a green light, the workload will not
+be admitted. 
+
+Each workload that goes to such a queue, will get additional conditions, 
+in a dedicated field in the status, each reflecting the go/no-go 
+decision of each of the external controllers. Once
+a controller is confident that the workload can be admitted, it flips the
+status of the corresponding condition from "Unknown" to "True". 
+
+If a controller changes its mind about a workload, it can switch the condition
+back to false and the workload will be immediately suspended.
+
+### User Stories (Optional)
+
+#### Story 1
+
+I want to use the [Cluster Autoscaler ProvisioningRequest API](https://github.com/kubernetes/autoscaler/pull/5848) 
+to ensure that the resources can be provided in full before starting the workload.  
+
+#### Story 2
+
+I want to base workload admission on budget. I have the actual consumption metrics
+in my Prometheus/Datadog/Stackdriver/whatever monitoring system. And weekly
+budget in a CRD, per namespace. I’m happy to modify some small existing sample
+controller, but I don’t want to fork the whole Kueue to adjust some minor details.
+ 
+### Notes/Constraints/Caveats (Optional)
+
+Each of the go/no-go decisions is best-effort and can be reversed at any time. 
+
+### Risks and Mitigations
+
+## Design Details
+
+TL;DR; 
+* extend ClusterQueueSpec with the list of checks.
+* add extra conditions to Workload status.
+* introduce new CRD, AdmissionCheck.
+
+Details:
+
+We will extend ClusterQueueSpec definition by adding a reference to
+AdmissionChecks that the queue needs to perform before admitting a
+workload. The design of AdmissionChecks is similar to IngressClass
+- it allows passing additional parameters, specific to particular checks
+that need to be performed. 
+
+```
+// ClusterQueueSpec defines the desired state of ClusterQueue.
+type ClusterQueueSpec struct {
+[...]
+	// List of AdmissionCheck names that needs to be passed
+	// to admit a workload. The order of the checks doesn't matter,
+	// all of them will be started at the same time.
+	AdmissionChecks []string `json:"admissionChecks"`
+}
+
+// WorkloadStatus defines the observed state of Workload.
+type WorkloadStatus struct {
+[...]
+	// Status of admission checks, if there are any specified 
+	// for the ClusterQueue in which the workload is queued.
+	AdmissionChecksConditions []metav1.Condition `json:"admissionChecksConditions,omitempty"`
+}
+
+// Condition names used in WorkloadStatus
+const (
+	AdmissionPrecheck string = "AdmissionPrecheck"
+)
+
+// Cluster-scoped top-level object defining a check that 
+// can be referenced in ClusterQueue.
+type AdmissionCheck struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec AdmissionCheckSpec `json:"spec,omitempty"`
+}
+
+// Condition Reasons used by AdmissionChecks.
+const (
+	// The check cannot pass at this moment, back off (possibly 
+	// allowing other to try, unblock quota) and retry. Can be set only
+	// when Condition status is set to "False"
+	Retry string = "Retry"
+	// The check will not pass in the near future. It is not worth
+	// to retry. Can be set together with Condition status "False".
+	Reject string = "Reject"
+	// The check might pass if there was fewer workloads. Proceed
+	// with any pending workload preemption. Should be set 
+	// when condition status is still "Unknown" 
+	BookQuotaRequired status = "BookQuotaRequired"
+)
+
+// AdmissionCheckSpec defines the desired state of AdmissionCheck.
+type AdmissionCheckSpec struct {
+	// Name of the controller which will actually perform
+	// the checks. This is the name with which controller indentifies with,
+	// not a K8S pod or deployment name. Cannot be empty. 
+	ControllerName string `json:"controllerName"`
+
+	// How long to keep the workload suspended 
+	// after a failed check (after it transitioned to False).
+	// After that the check state goes to "Unknown".
+	// The default is 15 min. 
+	RetryDelayMinutes *int64 `json:"retryDelayMinutes,omitempty"`
+
+	// A reference to the additional parameters for the check. 
+	Parameters *AdmissionCheckParametersReference `json:"parameters,omitempty"`
+
+	// How should the workload book quota (and possibly preempt others) 
+	// before the check pass. The default is NoBooking.
+	// If different modes are used for different AdmissionChecks,
+	// the most restrictive one is used.
+	QuotaBooking *QuotaBookingMode `json:"quotaBooking,omitempty"`
+}
+
+// Definitons of QuotaBookingModes.
+// BookAfterQuotaCheck is more restrictive than NoBooking.
+const (
+	// No booking, unless a check explicitely asks for it reporting quota exhausted.
+	NoBooking QuotaBookingMode = "NoBooking"
+	
+	// Book quota (and preempt) immediately after the basic quota checks 
+	// are done, without waiting for the additional checks to cpmplete.
+	BookAfterQuotaCheck QuotaBookingMode = "BookAfterQuotaCheck"
+)
+
+// Points to where the parameters for the checks are. 
+// As clusterqueue are in cluster scope - this should be
+// a dedicated CRD specific for the Controller.
+type AdmissionCheckParametersReference struct {
+	// ApiGroup is the group for the resource being referenced. 
+	APIGroup string `json:"apiGroup"`
+
+	// Kind is the type of the resource being referenced.
+	Kind string `json:"kind"`
+
+	// Name is the name of the resource being referenced.
+	Name string `json:"name"`
+}
+```
+
+For every workload that is put to a ClusterQueue that has AdmissionChecks
+configured Kueue will add:
+
+* “AdmissionPrecheck” set false to Conditions.
+* “<checkName>” set to "Unknown" for each of the AdmissionChecks to AdmissionCheckConditions.
+
+Kueue will perform the very same checks that it does today, 
+before admitting a workload. However, once the basic checks 
+pass AND there are some AdmissionChecks configured, AND the
+workload is not in on-hold retry state from some check, it will:
+
+1. Fill the Admission field in workload, with the desired flavor assignment. 
+2. Not do any preemptions yet (unless BookCapacity is set to true).
+3. Set “AdmissionPrecheck” to true.
+
+Kueue will only pass as many pods past AdmissionPrecheck as there would
+fit in the quota together, possibly limited by a Kueue configuration option.
+That would violate a bit BestEffort logic of queues - if there is 1000 tasks
+in a queue that doesn’t pass quota and 1001st task passes, the best effort
+queue would let it in. BestEffort queue with 1000 tasks that don’t pass
+AdmissionChecks would not let 1001st task in (it will not reach the
+checks). Without this limitation, a large number of tasks could be switched
+back and forth from Precheck to suspended state. 
+
+Then it will wait until all additional check conditions are satisfied (set
+to "True"). Once it happens, the Kueue will recheck that Admission settings
+are still valid (check quota/preemptions/reclamation) and admit the
+workload (doing preemptions if needed). Kueue will also recheck all of the
+prechecked workloads on every other workload admission, to make sure
+that their flavor admission is still possible. 
+
+If any of these checks fails (either on the final check or when admission
+other workloads), the workload gets back to the suspended state, and gets
+their AdmissionChecks and AdmissionPrecheck cleared.
+
+If any check is switched to "False", with reason "Reject" or "Retry", the workload is either
+completely rejected or switched back to suspend state (with retry delay).
+Setting reason to BookQuotaRequired (while keeping condition as "Unknown")
+means that some other, external quota is reached
+and Kueue should try to preempt some workloads, before the check can
+succeed.
+
+The controller implementing a particular check should:
+ 
+* Watch all AdmissionCheck objects to know which one should be
+handled by it. 
+* Watch all controller specific parameter objects, potentially referenced
+from AdmissionCheck.
+* Watch all workloads and process those that have AdmissionCheck for this
+particular controller and are past AdmissionPrecheck.
+* After approving the workload, keep an eye on the check if it starts failing,
+fail the check and cause the workload to move back to the suspended state.
+
+### Test Plan
+
+[ x ] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+##### Prerequisite testing updates
+
+#### Unit Tests
+
+#### Integration tests
+
+The tests should cover:
+
+* Transition from `Suspended` to `Prechecked`, with `AdmissionChecks` added.
+* Transition from `Prechecked` and `AdmissionCheck` passed back to `Admitted`
+* Transition from `Prechecked` back to `Suspended` because of quota change
+* Transition from `Prechecked` and AdmissionCheck passed back to `Suspended` because of different resource flavors available. 
+* Transition from `Prechecked` to `Suspended` due to Retry with 1 and 2 AdmissionChecks.
+* Transition from `Prechecked` to `Rejected` with 1 and 2 AdmissionChecks (only one is required to reject a workload)
+* Transition from `Prechecked` to `Admitted` with 0 AdmissionChecks.
+
+### Graduation Criteria
+
+## Implementation History
+
+## Drawbacks
+
+## Alternatives
+
+

--- a/keps/993-two-phase-admission/kep.yaml
+++ b/keps/993-two-phase-admission/kep.yaml
@@ -1,0 +1,31 @@
+title: Two Stage Admission Process
+kep-number: 993
+authors:
+  - "@mwielgus"
+status: draft
+creation-date: 2023-07-18
+reviewers:
+  - "@kerthcet"
+  - "@alculquicondor"
+approvers:
+  - "@alculquicondor"
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: beta
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v0.5"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  beta: "v0.5"
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
+disable-supported: false
+
+# The following PRR answers are required at beta release
+# metrics:
+#   - my_feature_metric


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Two Stage Admission Process - to allow external controllers to co-decide about workload admission. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #993 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```