### PR TITLE
fix typo with reference to flux operator

### DIFF
--- a/site/static/examples/python/sample-flux-operator-job.py
+++ b/site/static/examples/python/sample-flux-operator-job.py
@@ -88,7 +88,7 @@ def generate_minicluster_crd(job_name, image, command, args, quiet=False, tasks=
 
 def main():
     """
-    Run an MPI job. This requires the MPI Operator to be installed.
+    Run an example job using the Flux Operator.
     """
     parser = get_parser()
     args, _ = parser.parse_known_args()


### PR DESCRIPTION
This is a quick fix for a typo mentioned in https://github.com/kubernetes-sigs/kueue/pull/962#discussion_r1267322857.

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The docstring is referencing the wrong operator.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```