### PR TITLE
Always try to stop a job on eviction

### DIFF
--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -36,7 +36,8 @@ type GenericJob interface {
 	// RunWithPodSetsInfo will inject the node affinity and podSet counts extracting from workload to job and unsuspend it.
 	RunWithPodSetsInfo(nodeSelectors []PodSetInfo)
 	// RestorePodSetsInfo will restore the original node affinity and podSet counts of the job.
-	RestorePodSetsInfo(nodeSelectors []PodSetInfo)
+	// Returns whether any change was done.
+	RestorePodSetsInfo(nodeSelectors []PodSetInfo) bool
 	// Finished means whether the job is completed/failed or not,
 	// condition represents the workload finished condition.
 	Finished() (condition metav1.Condition, finished bool)
@@ -59,8 +60,10 @@ type JobWithReclaimablePods interface {
 }
 
 type JobWithCustomStop interface {
-	// Stop implements a custom stop procedure
-	Stop(ctx context.Context, c client.Client, podSetsInfo []PodSetInfo) error
+	// Stop implements a custom stop procedure.
+	// The function should be idempotent: not do any API calls if the job is already stopped.
+	// Returns whether the Job stopped with this call or an error
+	Stop(ctx context.Context, c client.Client, podSetsInfo []PodSetInfo) (bool, error)
 }
 
 type JobWithPriorityClass interface {

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -129,16 +129,19 @@ func (j *JobSet) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) {
 	}
 }
 
-func (j *JobSet) RestorePodSetsInfo(podSetInfos []jobframework.PodSetInfo) {
+func (j *JobSet) RestorePodSetsInfo(podSetInfos []jobframework.PodSetInfo) bool {
 	if len(podSetInfos) == 0 {
-		return
+		return false
 	}
+	changed := false
 	for index := range j.Spec.ReplicatedJobs {
 		if equality.Semantic.DeepEqual(j.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.NodeSelector, podSetInfos[index].NodeSelector) {
 			continue
 		}
+		changed = true
 		j.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec.NodeSelector = maps.Clone(podSetInfos[index].NodeSelector)
 	}
+	return changed
 }
 
 func (j *JobSet) Finished() (metav1.Condition, bool) {

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -130,15 +130,18 @@ func (j *MPIJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) {
 	}
 }
 
-func (j *MPIJob) RestorePodSetsInfo(podSetInfos []jobframework.PodSetInfo) {
+func (j *MPIJob) RestorePodSetsInfo(podSetInfos []jobframework.PodSetInfo) bool {
 	orderedReplicaTypes := orderedReplicaTypes(&j.Spec)
+	changed := false
 	for index, info := range podSetInfos {
 		replicaType := orderedReplicaTypes[index]
 		replicaSpec := &j.Spec.MPIReplicaSpecs[replicaType].Template.Spec
 		if !equality.Semantic.DeepEqual(replicaSpec.NodeSelector, info.NodeSelector) {
+			changed = true
 			replicaSpec.NodeSelector = maps.Clone(info.NodeSelector)
 		}
 	}
+	return changed
 }
 
 func (j *MPIJob) Finished() (metav1.Condition, bool) {

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package testing
 
 import (
+	"time"
+
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -170,5 +172,17 @@ func (j *JobWrapper) OwnerReference(ownerName string, ownerGVK schema.GroupVersi
 // UID updates the uid of the job.
 func (j *JobWrapper) UID(uid string) *JobWrapper {
 	j.ObjectMeta.UID = types.UID(uid)
+	return j
+}
+
+// StartTime sets the .status.startTime
+func (j *JobWrapper) StartTime(t time.Time) *JobWrapper {
+	j.Status.StartTime = &metav1.Time{Time: t}
+	return j
+}
+
+// Active sets the .status.active
+func (j *JobWrapper) Active(c int32) *JobWrapper {
+	j.Status.Active = c
 	return j
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Preempting a batch/Job requires 3 API calls to the Job object because of the restrictions in the immutability of node affinity for started jobs.

This means that if any of the first 2 API calls fails, the job is not fully stopped and could have incompatible node affinities in a future admission.

This PR makes sure that a second sync is able to pick up from where the last failure happened.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Improve job controller to be resilient to API failures during preemption
```