### PR TITLE
add example MPI operator job

### DIFF
--- a/site/content/en/docs/tasks/run_mpi_jobs.md
+++ b/site/content/en/docs/tasks/run_mpi_jobs.md
@@ -105,3 +105,5 @@ spec:
                 cpu: 1
                 memory: 1Gi
 ```
+
+For equivalent instructions for doing this in Python, see [Run Python Jobs](/docs/tasks/run_python_jobs/#mpi-operator-job).

--- a/site/static/examples/python/sample-mpijob.py
+++ b/site/static/examples/python/sample-mpijob.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+import argparse
+from kubernetes import config, client
+import mpijob.models as models
+
+# sample-mpijob.py
+# This example will demonstrate full steps to submit a Job via the MPI Operator
+
+# Make sure your cluster is running!
+config.load_kube_config()
+crd_api = client.CustomObjectsApi()
+api_client = crd_api.api_client
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description="Submit Kueue MPI Operator Job Example",
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "--job-name",
+        help="generateName field to set for job (job prefix does not work here)",
+        default="pi",
+    )
+    parser.add_argument(
+        "--image",
+        help="container image to use",
+        default="mpioperator/mpi-pi:openmpi",
+    )
+    parser.add_argument(
+        "--command",
+        help="command to run",
+        default="mpirun",
+    )
+    parser.add_argument(
+        "--args",
+        nargs="+",
+        help="args for container",
+        default=["-n", "2", "/home/mpiuser/pi"],
+    )
+    return parser
+
+
+def generate_job_crd(job_name, image, command, args):
+    """
+    Generate an equivalent job CRD to sample-job.yaml
+    """
+    metadata = client.V1ObjectMeta(
+        name=job_name, labels={"kueue.x-k8s.io/queue-name": "user-queue"}
+    )
+
+    # containers for launcher and worker
+    launcher_container = client.V1Container(
+        image=image,
+        name="mpi-launcher",
+        command=[command],
+        args=args,
+        security_context=client.V1SecurityContext(run_as_user=1000),
+        resources={
+            "limits": {
+                "cpu": 1,
+                "memory": "1Gi",
+            }
+        },
+    )
+
+    worker_container = client.V1Container(
+        image=image,
+        name="mpi-worker",
+        command=["/usr/sbin/sshd"],
+        args=["-De", "-f", "/home/mpiuser/.sshd_config"],
+        security_context=client.V1SecurityContext(run_as_user=1000),
+        resources={
+            "limits": {
+                "cpu": 1,
+                "memory": "1Gi",
+            }
+        },
+    )
+
+    # Create the Launcher and worker replica specs
+    launcher = models.V2beta1ReplicaSpec(
+        replicas=1,
+        template=client.V1PodTemplateSpec(
+            spec=client.V1PodSpec(containers=[launcher_container])
+        ),
+    )
+
+    worker = models.V2beta1ReplicaSpec(
+        replicas=2,
+        template=client.V1PodTemplateSpec(
+            spec=client.V1PodSpec(containers=[worker_container])
+        ),
+    )
+
+    # runPolicy for jobspec
+    policy = models.V2beta1RunPolicy(
+        clean_pod_policy="Running", ttl_seconds_after_finished=60
+    )
+
+    # Create the jobspec
+    jobspec = models.V2beta1MPIJobSpec(
+        slots_per_worker=1,
+        run_policy=policy,
+        ssh_auth_mount_path="/home/mpiuser/.ssh",
+        mpi_replica_specs={"Launcher": launcher, "Worker": worker},
+    )
+    return models.V2beta1MPIJob(
+        metadata=metadata,
+        api_version="kubeflow.org/v2beta1",
+        kind="MPIJob",
+        spec=jobspec,
+    )
+
+
+def main():
+    """
+    Run an MPI job. This requires the MPI Operator to be installed.
+    """
+    parser = get_parser()
+    args, _ = parser.parse_known_args()
+
+    # Generate a CRD spec
+    crd = generate_job_crd(args.job_name, args.image, args.command, args.args)
+    crd_api = client.CustomObjectsApi()
+
+    print(f"📦️ Container image selected is {args.image}...")
+    print(f"⭐️ Creating sample job with prefix {args.job_name}...")
+    crd_api.create_namespaced_custom_object(
+        group="kubeflow.org",
+        version="v2beta1",
+        namespace="default",
+        plural="mpijobs",
+        body=crd,
+    )
+    print(
+        'Use:\n"kubectl get queue" to see queue assignment\n"kubectl get jobs" to see jobs'
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This will add a Python example for Kueue + the MPI Operator. We were being blocked by https://github.com/kubernetes-sigs/kueue/issues/961, and determined that the order of operations for installing Kueue and the MPI Operator is important - the MPI operator must be installed first! Once that is done, each of the YAML applied example and the Python example worked. 

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This is the last example (for the time being) of interacting with Kueue from Python. The use case is developers interacting with Kueue from Python (typically in workflow tools).

#### Which issue(s) this PR fixes:

Fixes #961 

Also - if there is an additional documentation change we want to make to ensure it's clear about the order of install, I can add that here as well.

#### Special notes for your reviewer:

Happy Friday! Work is over wooo!

#### Does this PR introduce a user-facing change?

```release-note
NONE
```