### PR TITLE
Avoid changing snapshot in preemption

### DIFF
--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -248,11 +248,9 @@ func findCandidates(wl *kueue.Workload, cq *cache.ClusterQueue, resPerFlv resour
 	}
 
 	if cq.Cohort != nil && cq.Preemption.ReclaimWithinCohort != kueue.PreemptionPolicyNever {
-		cqs := cq.Cohort.Members
-		cqs.Delete(cq)
-		for cohortCQ := range cqs {
-			if !cqIsBorrowing(cohortCQ, resPerFlv) {
-				// Can't reclaim quota from ClusterQueues that are not borrowing.
+		for cohortCQ := range cq.Cohort.Members {
+			if cq == cohortCQ || !cqIsBorrowing(cohortCQ, resPerFlv) {
+				// Can't reclaim quota from itself or ClusterQueues that are not borrowing.
 				continue
 			}
 			onlyLowerPrio := true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Following #805, in an admission cycle, we should only allow one admission/preemption if there are any CQs borrowing quota.
However, to make internal calculations, the preemption logic was deleting CQs from a cohort in the snapshot, corrupting the calculation of whether a cohort was borrowing quota in the scheduling cycle:

https://github.com/kubernetes-sigs/kueue/blob/0547fb163b2bb88dcaa42989fd2e513ca7d84d49/pkg/scheduler/scheduler.go#L144-L159

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed scheduler to only allow one admission or preemption per cycle within a cohort that has ClusterQueues borrowing quota
```