### PR TITLE
Consider priority across ClusterQueues in a cohort

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -974,7 +974,7 @@ func TestEntryOrdering(t *testing.T) {
 		{
 			Info: workload.Info{
 				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "alpha",
+					Name:              "old_borrowing",
 					CreationTimestamp: metav1.NewTime(now),
 				}},
 			},
@@ -987,7 +987,7 @@ func TestEntryOrdering(t *testing.T) {
 		{
 			Info: workload.Info{
 				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "beta",
+					Name:              "old",
 					CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 				}},
 			},
@@ -995,7 +995,7 @@ func TestEntryOrdering(t *testing.T) {
 		{
 			Info: workload.Info{
 				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "gamma",
+					Name:              "new",
 					CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
 				}},
 			},
@@ -1003,7 +1003,32 @@ func TestEntryOrdering(t *testing.T) {
 		{
 			Info: workload.Info{
 				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
-					Name:              "delta",
+					Name:              "high_pri_borrowing",
+					CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
+				}, Spec: kueue.WorkloadSpec{
+					Priority: pointer.Int32(1),
+				}},
+			},
+			assignment: flavorassigner.Assignment{
+				TotalBorrow: cache.FlavorResourceQuantities{
+					"flavor": {},
+				},
+			},
+		},
+		{
+			Info: workload.Info{
+				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+					Name:              "new_high_pri",
+					CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
+				}, Spec: kueue.WorkloadSpec{
+					Priority: pointer.Int32(1),
+				}},
+			},
+		},
+		{
+			Info: workload.Info{
+				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+					Name:              "new_borrowing",
 					CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
 				}},
 			},
@@ -1017,7 +1042,7 @@ func TestEntryOrdering(t *testing.T) {
 			Info: workload.Info{
 				Obj: &kueue.Workload{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:              "epsilon",
+						Name:              "evicted_borrowing",
 						CreationTimestamp: metav1.NewTime(now),
 					},
 					Status: kueue.WorkloadStatus{
@@ -1042,8 +1067,8 @@ func TestEntryOrdering(t *testing.T) {
 			Info: workload.Info{
 				Obj: &kueue.Workload{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:              "zeta",
-						CreationTimestamp: metav1.NewTime(now.Add(2 * time.Second)),
+						Name:              "recently_evicted",
+						CreationTimestamp: metav1.NewTime(now),
 					},
 					Status: kueue.WorkloadStatus{
 						Conditions: []metav1.Condition{
@@ -1064,7 +1089,7 @@ func TestEntryOrdering(t *testing.T) {
 	for i, e := range input {
 		order[i] = e.Obj.Name
 	}
-	wantOrder := []string{"beta", "zeta", "gamma", "alpha", "epsilon", "delta"}
+	wantOrder := []string{"new_high_pri", "old", "recently_evicted", "new", "high_pri_borrowing", "old_borrowing", "evicted_borrowing", "new_borrowing"}
 	if diff := cmp.Diff(wantOrder, order); diff != "" {
 		t.Errorf("Unexpected order (-want,+got):\n%s", diff)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a CQ "A" with StrictFIFO strategy has pending workloads, it can block admissions in another CQ "B" in the same cohort with newer workloads, if they cannot be immediately admitted either, as introduced in #475 and #805. This allows CQ "A" to reclaim quota as soon as running workloads finish.
However, higher priority workloads should be able to be admitted first.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Prevent workloads in ClusterQueue with StrictFIFO from blocking higher priority workloads in other ClusterQueues in the same cohort that require preemption
```