### PR TITLE
Fix Flaky test: Kueue when Creating a Job With Queueing [It] Should unsuspend a job and set nodeSelectors

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -141,7 +141,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 				return workload.IsAdmitted(createdWorkload) &&
 					apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadFinished)
 
-			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+			}, util.LongTimeout, util.Interval).Should(gomega.BeTrue())
 		})
 
 		ginkgo.It("Should readmit preempted job into a separate flavor", func() {

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -21,7 +21,10 @@ import (
 )
 
 const (
-	Timeout            = time.Second * 30
+	Timeout = time.Second * 30
+	// LongTimeout is meant for E2E tests when waiting for complex operations
+	// such as running pods to completion.
+	LongTimeout        = time.Second * 45
 	ConsistentDuration = time.Second * 3
 	Interval           = time.Millisecond * 250
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Create const LongTimeout for e2e test. 
Pods in test sometimes takes long time because of the image pulling.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1021

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```