### PR TITLE
[jobframework] Check the potential failure of RunWithPodSetsInfo

### DIFF
--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -34,7 +34,7 @@ type GenericJob interface {
 	// Suspend will suspend the job.
 	Suspend()
 	// RunWithPodSetsInfo will inject the node affinity and podSet counts extracting from workload to job and unsuspend it.
-	RunWithPodSetsInfo(nodeSelectors []PodSetInfo)
+	RunWithPodSetsInfo(nodeSelectors []PodSetInfo) error
 	// RestorePodSetsInfo will restore the original node affinity and podSet counts of the job.
 	// Returns whether any change was done.
 	RestorePodSetsInfo(nodeSelectors []PodSetInfo) bool

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -210,10 +210,10 @@ func (j *Job) PodSets() []kueue.PodSet {
 	}
 }
 
-func (j *Job) RunWithPodSetsInfo(podSetsInfo []jobframework.PodSetInfo) {
+func (j *Job) RunWithPodSetsInfo(podSetsInfo []jobframework.PodSetInfo) error {
 	j.Spec.Suspend = pointer.Bool(false)
-	if len(podSetsInfo) == 0 {
-		return
+	if len(podSetsInfo) != 1 {
+		return jobframework.BadPodSetsInfoLenError(1, len(podSetsInfo))
 	}
 
 	info := podSetsInfo[0]
@@ -225,6 +225,7 @@ func (j *Job) RunWithPodSetsInfo(podSetsInfo []jobframework.PodSetInfo) {
 			j.Spec.Completions = j.Spec.Parallelism
 		}
 	}
+	return nil
 }
 
 func (j *Job) RestorePodSetsInfo(podSetsInfo []jobframework.PodSetInfo) bool {

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -113,12 +113,10 @@ func (j *JobSet) PodSets() []kueue.PodSet {
 	return podSets
 }
 
-func (j *JobSet) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) {
+func (j *JobSet) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error {
 	j.Spec.Suspend = pointer.Bool(false)
 	if len(podSetInfos) != len(j.Spec.ReplicatedJobs) {
-		// this is very unlikely, however in order to avoid any potential
-		// out of bounds access
-		return
+		return jobframework.BadPodSetsInfoLenError(len(j.Spec.ReplicatedJobs), len(podSetInfos))
 	}
 
 	// If there are Jobs already created by the JobSet, their node selectors will be updated by the JobSet controller
@@ -127,6 +125,7 @@ func (j *JobSet) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) {
 		templateSpec := &j.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec
 		templateSpec.NodeSelector = maps.MergeKeepFirst(podSetInfos[index].NodeSelector, templateSpec.NodeSelector)
 	}
+	return nil
 }
 
 func (j *JobSet) RestorePodSetsInfo(podSetInfos []jobframework.PodSetInfo) bool {

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -112,10 +112,11 @@ func (j *RayJob) PodSets() []kueue.PodSet {
 	return podSets
 }
 
-func (j *RayJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) {
+func (j *RayJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error {
 	j.Spec.Suspend = false
-	if len(podSetInfos) != len(j.Spec.RayClusterSpec.WorkerGroupSpecs)+1 {
-		return
+	expectedLen := len(j.Spec.RayClusterSpec.WorkerGroupSpecs) + 1
+	if len(podSetInfos) != expectedLen {
+		return jobframework.BadPodSetsInfoLenError(expectedLen, len(podSetInfos))
 	}
 
 	// head
@@ -127,6 +128,7 @@ func (j *RayJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) {
 		workerPodSpec := &j.Spec.RayClusterSpec.WorkerGroupSpecs[index].Template.Spec
 		workerPodSpec.NodeSelector = maps.MergeKeepFirst(podSetInfos[index+1].NodeSelector, workerPodSpec.NodeSelector)
 	}
+	return nil
 }
 
 func (j *RayJob) RestorePodSetsInfo(podSetInfos []jobframework.PodSetInfo) bool {

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rayjob
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -151,8 +152,26 @@ func TestNodeSelectors(t *testing.T) {
 		}).
 		Obj())
 
+	// RunWithPodSetsInfo with invalid info should fail
+	runErr := job.RunWithPodSetsInfo([]jobframework.PodSetInfo{
+		{
+			NodeSelector: map[string]string{
+				"newKey": "newValue",
+			},
+		},
+		{
+			NodeSelector: map[string]string{
+				"key-wg1": "updated-value-wg1",
+			},
+		},
+	})
+
+	if !errors.Is(runErr, jobframework.ErrInvalidPodsetInfo) {
+		t.Errorf("expecting error for bad PodSetsInfo on RunWithPodSetsInfo")
+	}
+
 	// RunWithPodSetsInfo should append or update the node selectors
-	job.RunWithPodSetsInfo([]jobframework.PodSetInfo{
+	runErr = job.RunWithPodSetsInfo([]jobframework.PodSetInfo{
 		{
 			NodeSelector: map[string]string{
 				"newKey": "newValue",
@@ -169,6 +188,10 @@ func TestNodeSelectors(t *testing.T) {
 			},
 		},
 	})
+
+	if runErr != nil {
+		t.Errorf("unexpected error on RunWithPodSetsInfo: %s", runErr.Error())
+	}
 
 	if diff := cmp.Diff(
 		map[string]string{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add a way to verify if the provided  PodSetsInfo is accepted by the job controller.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```