### PR TITLE
[rayjob] Make the TestNodeSelectors test table driven.

### DIFF
--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -113,11 +113,12 @@ func (j *RayJob) PodSets() []kueue.PodSet {
 }
 
 func (j *RayJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error {
-	j.Spec.Suspend = false
 	expectedLen := len(j.Spec.RayClusterSpec.WorkerGroupSpecs) + 1
 	if len(podSetInfos) != expectedLen {
 		return jobframework.BadPodSetsInfoLenError(expectedLen, len(podSetInfos))
 	}
+
+	j.Spec.Suspend = false
 
 	// head
 	headPodSpec := &j.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package rayjob
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 
@@ -124,8 +124,7 @@ func TestPodSets(t *testing.T) {
 }
 
 func TestNodeSelectors(t *testing.T) {
-
-	job := (*RayJob)(testingrayutil.MakeJob("job", "ns").
+	baseJob := testingrayutil.MakeJob("job", "ns").
 		WithHeadGroupSpec(rayjobapi.HeadGroupSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
@@ -150,111 +149,122 @@ func TestNodeSelectors(t *testing.T) {
 				},
 			},
 		}).
-		Obj())
+		Obj()
 
-	// RunWithPodSetsInfo with invalid info should fail
-	runErr := job.RunWithPodSetsInfo([]jobframework.PodSetInfo{
-		{
-			NodeSelector: map[string]string{
-				"newKey": "newValue",
+	cases := map[string]struct {
+		job          *rayjobapi.RayJob
+		runInfo      []jobframework.PodSetInfo
+		restoreInfo  []jobframework.PodSetInfo
+		wantRunError error
+		wantAfterRun *rayjobapi.RayJob
+		wantFinal    *rayjobapi.RayJob
+	}{
+		"valid configuration": {
+			job: baseJob.DeepCopy(),
+			runInfo: []jobframework.PodSetInfo{
+				{
+					NodeSelector: map[string]string{
+						"newKey": "newValue",
+					},
+				},
+				{
+					NodeSelector: map[string]string{
+						"key-wg1": "updated-value-wg1",
+					},
+				},
+				{
+					NodeSelector: map[string]string{
+						// don't add anything
+					},
+				},
 			},
-		},
-		{
-			NodeSelector: map[string]string{
-				"key-wg1": "updated-value-wg1",
+			restoreInfo: []jobframework.PodSetInfo{
+				{
+					NodeSelector: map[string]string{
+						// clean it all
+					},
+				},
+				{
+					NodeSelector: map[string]string{
+						"key-wg1": "value-wg1",
+					},
+				},
+				{
+					NodeSelector: map[string]string{
+						"key-wg2": "value-wg2",
+					},
+				},
 			},
-		},
-	})
+			wantAfterRun: testingrayutil.MakeJob("job", "ns").
+				Suspend(false).
+				WithHeadGroupSpec(rayjobapi.HeadGroupSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							NodeSelector: map[string]string{
+								"newKey": "newValue",
+							},
+						},
+					},
+				}).
+				WithWorkerGroups(rayjobapi.WorkerGroupSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							NodeSelector: map[string]string{
+								"key-wg1": "updated-value-wg1",
+							},
+						},
+					},
+				}, rayjobapi.WorkerGroupSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							NodeSelector: map[string]string{
+								"key-wg2": "value-wg2",
+							},
+						},
+					},
+				}).
+				Obj(),
 
-	if !errors.Is(runErr, jobframework.ErrInvalidPodsetInfo) {
-		t.Errorf("expecting error for bad PodSetsInfo on RunWithPodSetsInfo")
+			wantFinal: baseJob.DeepCopy(),
+		},
+		"invalid runInfo": {
+			job: baseJob.DeepCopy(),
+			runInfo: []jobframework.PodSetInfo{
+				{
+					NodeSelector: map[string]string{
+						"newKey": "newValue",
+					},
+				},
+				{
+					NodeSelector: map[string]string{
+						"key-wg1": "updated-value-wg1",
+					},
+				},
+			},
+			wantRunError: jobframework.ErrInvalidPodsetInfo,
+			wantAfterRun: baseJob.DeepCopy(),
+		},
 	}
 
-	// RunWithPodSetsInfo should append or update the node selectors
-	runErr = job.RunWithPodSetsInfo([]jobframework.PodSetInfo{
-		{
-			NodeSelector: map[string]string{
-				"newKey": "newValue",
-			},
-		},
-		{
-			NodeSelector: map[string]string{
-				"key-wg1": "updated-value-wg1",
-			},
-		},
-		{
-			NodeSelector: map[string]string{
-				// don't add anything
-			},
-		},
-	})
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			genJob := (*RayJob)(tc.job)
+			gotRunError := genJob.RunWithPodSetsInfo(tc.runInfo)
 
-	if runErr != nil {
-		t.Errorf("unexpected error on RunWithPodSetsInfo: %s", runErr.Error())
-	}
+			if diff := cmp.Diff(tc.wantRunError, gotRunError, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected run error (-want/+got): %s", diff)
+			}
+			if diff := cmp.Diff(tc.wantAfterRun, tc.job); diff != "" {
+				t.Errorf("Unexpected job after run (-want/+got): %s", diff)
+			}
 
-	if diff := cmp.Diff(
-		map[string]string{
-			"newKey": "newValue",
-		},
-		job.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector); diff != "" {
-		t.Errorf("head node selectors mismatch (-want +got):\n%s", diff)
-	}
-
-	if diff := cmp.Diff(
-		map[string]string{
-			"key-wg1": "updated-value-wg1",
-		},
-		job.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector); diff != "" {
-		t.Errorf("wg1 node selectors mismatch (-want +got):\n%s", diff)
-	}
-
-	if diff := cmp.Diff(
-		map[string]string{
-			"key-wg2": "value-wg2",
-		},
-		job.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Spec.NodeSelector); diff != "" {
-		t.Errorf("wg2 node selectors mismatch (-want +got):\n%s", diff)
-	}
-
-	// restore should replace node selectors
-	job.RestorePodSetsInfo([]jobframework.PodSetInfo{
-		{
-			NodeSelector: map[string]string{
-				// clean it all
-			},
-		},
-		{
-			NodeSelector: map[string]string{
-				"key-wg1": "restored-value-wg1",
-			},
-		},
-		{
-			NodeSelector: map[string]string{
-				"key-wg2-2": "value-wg2-2",
-			},
-		},
-	})
-
-	if diff := cmp.Diff(
-		map[string]string{},
-		job.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector); diff != "" {
-		t.Errorf("head node selectors mismatch (-want +got):\n%s", diff)
-	}
-
-	if diff := cmp.Diff(
-		map[string]string{
-			"key-wg1": "restored-value-wg1",
-		},
-		job.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector); diff != "" {
-		t.Errorf("wg1 node selectors mismatch (-want +got):\n%s", diff)
-	}
-
-	if diff := cmp.Diff(
-		map[string]string{
-			"key-wg2-2": "value-wg2-2",
-		},
-		job.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Spec.NodeSelector); diff != "" {
-		t.Errorf("wg2 node selectors mismatch (-want +got):\n%s", diff)
+			if tc.wantRunError == nil {
+				genJob.Suspend()
+				genJob.RestorePodSetsInfo(tc.restoreInfo)
+				if diff := cmp.Diff(tc.wantFinal, tc.job); diff != "" {
+					t.Errorf("Unexpected job after restore (-want/+got): %s", diff)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[rayjob] Rework Info management test.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```