### PR TITLE
Add AdmissionCheckReconciler

### DIFF
--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -151,6 +151,32 @@ rules:
   - apiGroups:
       - kueue.x-k8s.io
     resources:
+      - admissionchecks
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - admissionchecks/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - admissionchecks/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - kueue.x-k8s.io
+    resources:
       - clusterqueues
     verbs:
       - create

--- a/config/components/crd/kustomization.yaml
+++ b/config/components/crd/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - bases/kueue.x-k8s.io_clusterqueues.yaml
 - bases/kueue.x-k8s.io_workloads.yaml
 - bases/kueue.x-k8s.io_resourceflavors.yaml
+- bases/kueue.x-k8s.io_admissionchecks.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patches:

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -152,6 +152,32 @@ rules:
 - apiGroups:
   - kueue.x-k8s.io
   resources:
+  - admissionchecks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - admissionchecks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - admissionchecks/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
   - clusterqueues
   verbs:
   - create

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -194,7 +194,7 @@ func (c *Cache) updateClusterQueues() sets.Set[string] {
 		// because it is not expensive to do so, and is not worth tracking which ClusterQueues use
 		// which flavors.
 		cq.UpdateWithFlavors(c.resourceFlavors)
-		cq.UpdateWithAdmissionChecks(c.admissionChecks)
+		cq.updateWithAdmissionChecks(c.admissionChecks)
 		curStatus := cq.Status
 		if prevStatus == pending && curStatus == active {
 			cqs.Insert(cq.Name)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -244,7 +244,7 @@ func (c *Cache) ClusterQueueReadiness(name string) (metav1.ConditionStatus, stri
 	defer c.RUnlock()
 	cq := c.clusterQueues[name]
 	if cq == nil {
-		return metav1.ConditionFalse, "NotFound", "Cluster queue not found"
+		return metav1.ConditionFalse, "NotFound", "ClusterQueue not found"
 	}
 	if cq != nil && cq.Status == active {
 		return metav1.ConditionTrue, "Ready", "Can admit new workloads"

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -37,8 +37,11 @@ type ClusterQueue struct {
 	// The following fields are not populated in a snapshot.
 
 	// Key is localQueue's key (namespace/name).
-	localQueues       map[string]*queue
-	podsReadyTracking bool
+	localQueues               map[string]*queue
+	podsReadyTracking         bool
+	admissionChecks           sets.Set[string]
+	hasMissingFlavors         bool
+	hasMissingAdmissionChecks bool
 }
 
 // Cohort is a set of ClusterQueues that can borrow resources from each other.
@@ -131,7 +134,7 @@ var defaultPreemption = kueue.ClusterQueuePreemption{
 	WithinClusterQueue:  kueue.PreemptionPolicyNever,
 }
 
-func (c *ClusterQueue) update(in *kueue.ClusterQueue, resourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) error {
+func (c *ClusterQueue) update(in *kueue.ClusterQueue, resourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor, admissionChecks sets.Set[string]) error {
 	c.updateResourceGroups(in.Spec.ResourceGroups)
 	nsSelector, err := metav1.LabelSelectorAsSelector(in.Spec.NamespaceSelector)
 	if err != nil {
@@ -151,8 +154,12 @@ func (c *ClusterQueue) update(in *kueue.ClusterQueue, resourceFlavors map[kueue.
 			usedFlavorResources[f.Name] = usedResources
 		}
 	}
+
+	c.admissionChecks = sets.New(in.Spec.AdmissionChecks...)
+
 	c.Usage = usedFlavorResources
 	c.UpdateWithFlavors(resourceFlavors)
+	c.UpdateWithAdmissionChecks(admissionChecks)
 
 	if in.Spec.Preemption != nil {
 		c.Preemption = *in.Spec.Preemption
@@ -202,18 +209,43 @@ func (c *ClusterQueue) UpdateRGByResource() {
 	}
 }
 
+func (c *ClusterQueue) updateQueueStatus() {
+	status := active
+	if c.hasMissingFlavors || c.hasMissingAdmissionChecks {
+		status = pending
+	}
+	if c.Status == terminating {
+		status = terminating
+	}
+	if status != c.Status {
+		c.Status = status
+		metrics.ReportClusterQueueStatus(c.Name, c.Status)
+	}
+}
+
+func (c *ClusterQueue) inactiveReason() (string, string) {
+	switch c.Status {
+	case terminating:
+		return "Terminating", "Can't admit new workloads; clusterQueue is terminating"
+	case pending:
+		switch {
+		case c.hasMissingFlavors && c.hasMissingAdmissionChecks:
+			return "FlavorAndCheckNotFound", "Can't admit new workloads; some flavors and admission checks are not found"
+		case c.hasMissingFlavors:
+			return "FlavorNotFound", "Can't admit new workloads; some flavors are not found"
+		default:
+			return "CheckNotFound", "Can't admit new workloads; some admission checks are not found"
+
+		}
+	}
+	return "Ready", "Can admit new flavors"
+}
+
 // UpdateWithFlavors updates a ClusterQueue based on the passed ResourceFlavors set.
 // Exported only for testing.
 func (c *ClusterQueue) UpdateWithFlavors(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
-	status := active
-	if flavorNotFound := c.updateLabelKeys(flavors); flavorNotFound {
-		status = pending
-	}
-
-	if c.Status != terminating {
-		c.Status = status
-	}
-	metrics.ReportClusterQueueStatus(c.Name, c.Status)
+	c.hasMissingFlavors = c.updateLabelKeys(flavors)
+	c.updateQueueStatus()
 }
 
 func (c *ClusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) bool {
@@ -241,6 +273,22 @@ func (c *ClusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference
 	}
 
 	return flavorNotFound
+}
+
+// UpdateWithAdmissionChecks updates a ClusterQueue based on the passed AdmissionChecks set.
+func (c *ClusterQueue) UpdateWithAdmissionChecks(checks sets.Set[string]) {
+	hasMissing := false
+	for ac := range c.admissionChecks {
+		if !checks.Has(ac) {
+			hasMissing = true
+			break
+		}
+	}
+
+	if hasMissing != c.hasMissingAdmissionChecks {
+		c.hasMissingAdmissionChecks = hasMissing
+		c.updateQueueStatus()
+	}
 }
 
 func (c *ClusterQueue) addWorkload(w *kueue.Workload) error {

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -230,11 +230,11 @@ func (c *ClusterQueue) inactiveReason() (string, string) {
 	case pending:
 		switch {
 		case c.hasMissingFlavors && c.hasMissingAdmissionChecks:
-			return "FlavorAndCheckNotFound", "Can't admit new workloads; some flavors and admission checks are not found"
+			return "FlavorAndCheckNotFound", "Can't admit new workloads; some resourceFlavors and admissionChecks are not found"
 		case c.hasMissingFlavors:
-			return "FlavorNotFound", "Can't admit new workloads; some flavors are not found"
+			return "FlavorNotFound", "Can't admit new workloads; some resourceFlavors are not found"
 		default:
-			return "CheckNotFound", "Can't admit new workloads; some admission checks are not found"
+			return "CheckNotFound", "Can't admit new workloads; some admissionChecks are not found"
 
 		}
 	}

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -159,7 +159,7 @@ func (c *ClusterQueue) update(in *kueue.ClusterQueue, resourceFlavors map[kueue.
 
 	c.Usage = usedFlavorResources
 	c.UpdateWithFlavors(resourceFlavors)
-	c.UpdateWithAdmissionChecks(admissionChecks)
+	c.updateWithAdmissionChecks(admissionChecks)
 
 	if in.Spec.Preemption != nil {
 		c.Preemption = *in.Spec.Preemption
@@ -275,8 +275,8 @@ func (c *ClusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference
 	return flavorNotFound
 }
 
-// UpdateWithAdmissionChecks updates a ClusterQueue based on the passed AdmissionChecks set.
-func (c *ClusterQueue) UpdateWithAdmissionChecks(checks sets.Set[string]) {
+// updateWithAdmissionChecks updates a ClusterQueue based on the passed AdmissionChecks set.
+func (c *ClusterQueue) updateWithAdmissionChecks(checks sets.Set[string]) {
 	hasMissing := false
 	for ac := range c.admissionChecks {
 		if !checks.Has(ac) {

--- a/pkg/controller/core/admissioncheck_controller.go
+++ b/pkg/controller/core/admissioncheck_controller.go
@@ -51,6 +51,20 @@ type AdmissionCheckReconciler struct {
 	watchers   []AdmissionCheckUpdateWatcher
 }
 
+func NewAdmissionCheckReconciler(
+	client client.Client,
+	qMgr *queue.Manager,
+	cache *cache.Cache,
+) *AdmissionCheckReconciler {
+	return &AdmissionCheckReconciler{
+		log:        ctrl.Log.WithName("admissioncheck-reconciler"),
+		qManager:   qMgr,
+		client:     client,
+		cache:      cache,
+		cqUpdateCh: make(chan event.GenericEvent, updateChBuffer),
+	}
+}
+
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=admissionchecks,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=admissionchecks/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=admissionchecks/finalizers,verbs=update
@@ -213,18 +227,4 @@ func (r *AdmissionCheckReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WatchesRawSource(&source.Channel{Source: r.cqUpdateCh}, &handler).
 		WithEventFilter(r).
 		Complete(r)
-}
-
-func NewAdAdmissionCheckReconciler(
-	client client.Client,
-	qMgr *queue.Manager,
-	cache *cache.Cache,
-) *AdmissionCheckReconciler {
-	return &AdmissionCheckReconciler{
-		log:        ctrl.Log.WithName("admissioncheck-reconciler"),
-		qManager:   qMgr,
-		client:     client,
-		cache:      cache,
-		cqUpdateCh: make(chan event.GenericEvent, updateChBuffer),
-	}
 }

--- a/pkg/controller/core/admissioncheck_controller.go
+++ b/pkg/controller/core/admissioncheck_controller.go
@@ -149,7 +149,6 @@ func (r *AdmissionCheckReconciler) Update(e event.UpdateEvent) bool {
 
 func (r *AdmissionCheckReconciler) Delete(e event.DeleteEvent) bool {
 	ac, isAc := e.Object.(*kueue.AdmissionCheck)
-
 	if !isAc {
 		return false
 	}
@@ -168,7 +167,7 @@ func (r *AdmissionCheckReconciler) Generic(e event.GenericEvent) bool {
 }
 
 func (r *AdmissionCheckReconciler) NotifyClusterQueueUpdate(oldCq *kueue.ClusterQueue, newCq *kueue.ClusterQueue) {
-	log := r.log.WithValues("oldCq", klog.KObj(oldCq), "newCq", klog.KObj(newCq))
+	log := r.log.WithValues("oldClusterQueue", klog.KObj(oldCq), "newClusterQueue", klog.KObj(newCq))
 	log.V(5).Info("Cluster queue notification")
 	noChange := newCq != nil && oldCq != nil && slices.CmpNoOrder(oldCq.Spec.AdmissionChecks, newCq.Spec.AdmissionChecks)
 	if noChange {
@@ -199,10 +198,7 @@ func (h *acCqHandler) Delete(context.Context, event.DeleteEvent, workqueue.RateL
 
 func (h *acCqHandler) Generic(ctx context.Context, e event.GenericEvent, q workqueue.RateLimitingInterface) {
 	cq := e.Object.(*kueue.ClusterQueue)
-	if cq.Name == "" {
-		return
-	}
-	log := log.FromContext(ctx).WithValues("cq", klog.KObj(cq))
+	log := log.FromContext(ctx).WithValues("clusterQueue", klog.KObj(cq))
 	log.V(6).Info("Cluster queue generic event")
 
 	for _, ac := range cq.Spec.AdmissionChecks {

--- a/pkg/controller/core/admissioncheck_controller.go
+++ b/pkg/controller/core/admissioncheck_controller.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/queue"
+	"sigs.k8s.io/kueue/pkg/util/slices"
+)
+
+type AdmissionCheckUpdateWatcher interface {
+	NotifyAdmissionCheckUpdate(oldAc, newAc *kueue.AdmissionCheck)
+}
+
+// AdmissionCheckReconciler reconciles a AdmissionCheck object
+type AdmissionCheckReconciler struct {
+	log        logr.Logger
+	qManager   *queue.Manager
+	client     client.Client
+	cache      *cache.Cache
+	cqUpdateCh chan event.GenericEvent
+	watchers   []AdmissionCheckUpdateWatcher
+}
+
+//+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=admissionchecks,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=admissionchecks/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=kueue.x-k8s.io,resources=admissionchecks/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *AdmissionCheckReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	ac := &kueue.AdmissionCheck{}
+
+	if err := r.client.Get(ctx, req.NamespacedName, ac); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	log := log.FromContext(ctx).WithValues("admissionCheck", klog.KObj(ac))
+	if ac.DeletionTimestamp.IsZero() {
+		if controllerutil.AddFinalizer(ac, kueue.ResourceInUseFinalizerName) {
+			if err := r.client.Update(ctx, ac); err != nil {
+				return ctrl.Result{}, err
+			}
+			log.V(5).Info("Added finalizer")
+		}
+	} else {
+		if controllerutil.ContainsFinalizer(ac, kueue.ResourceInUseFinalizerName) {
+			if cqs := r.cache.ClusterQueuesUsingAdmissionCheck(ac.Name); len(cqs) != 0 {
+				log.V(3).Info("admissionCheck is still in use", "ClusterQueues", cqs)
+				// We avoid to return error here to prevent backoff requeue, which is passive and wasteful.
+				// Instead, we drive the removal of finalizer by ClusterQueue Update/Delete events
+				// when the admissionCheck is no longer in use.
+				return ctrl.Result{}, nil
+			}
+			controllerutil.RemoveFinalizer(ac, kueue.ResourceInUseFinalizerName)
+			if err := r.client.Update(ctx, ac); err != nil {
+				return ctrl.Result{}, err
+			}
+			log.V(5).Info("Removed finalizer")
+		}
+	}
+	return ctrl.Result{}, nil
+}
+func (r *AdmissionCheckReconciler) notifyWatchers(oldAc, newAc *kueue.AdmissionCheck) {
+	for _, w := range r.watchers {
+		w.NotifyAdmissionCheckUpdate(oldAc, newAc)
+	}
+}
+
+func (r *AdmissionCheckReconciler) AddUpdateWatchers(watchers ...AdmissionCheckUpdateWatcher) {
+	r.watchers = append(r.watchers, watchers...)
+}
+
+func (r *AdmissionCheckReconciler) Create(e event.CreateEvent) bool {
+	ac, isAc := e.Object.(*kueue.AdmissionCheck)
+	if !isAc {
+		return false
+	}
+	defer r.notifyWatchers(nil, ac)
+	r.log.WithValues("admissionCheck", klog.KObj(ac)).V(5).Info("Create event")
+	if cqNames := r.cache.AddOrUpdateAdmissionCheck(ac); len(cqNames) > 0 {
+		r.qManager.QueueInadmissibleWorkloads(context.Background(), cqNames)
+	}
+	return true
+}
+
+func (r *AdmissionCheckReconciler) Update(e event.UpdateEvent) bool {
+	newAc, isAc := e.ObjectNew.(*kueue.AdmissionCheck)
+	if !isAc {
+		return false
+	}
+	oldAc, isAc := e.ObjectNew.(*kueue.AdmissionCheck)
+	if !isAc {
+		return false
+	}
+	defer r.notifyWatchers(oldAc, newAc)
+	r.log.WithValues("admissionCheck", klog.KObj(newAc)).V(5).Info("Update event")
+	if !newAc.DeletionTimestamp.IsZero() {
+		return true
+	}
+	if cqNames := r.cache.AddOrUpdateAdmissionCheck(newAc); len(cqNames) > 0 {
+		r.qManager.QueueInadmissibleWorkloads(context.Background(), cqNames)
+	}
+	return false
+}
+
+func (r *AdmissionCheckReconciler) Delete(e event.DeleteEvent) bool {
+	ac, isAc := e.Object.(*kueue.AdmissionCheck)
+
+	if !isAc {
+		return false
+	}
+	defer r.notifyWatchers(ac, nil)
+	r.log.WithValues("admissionCheck", klog.KObj(ac)).V(5).Info("Delete event")
+
+	if cqNames := r.cache.DeleteAdmissionCheck(ac); len(cqNames) > 0 {
+		r.qManager.QueueInadmissibleWorkloads(context.Background(), cqNames)
+	}
+	return true
+}
+
+func (r *AdmissionCheckReconciler) Generic(e event.GenericEvent) bool {
+	r.log.WithValues("object", klog.KObj(e.Object), "kind", e.Object.GetObjectKind().GroupVersionKind()).V(5).Info("Generic event")
+	return true
+}
+
+func (r *AdmissionCheckReconciler) NotifyClusterQueueUpdate(oldCq *kueue.ClusterQueue, newCq *kueue.ClusterQueue) {
+	log := r.log.WithValues("oldCq", klog.KObj(oldCq), "newCq", klog.KObj(newCq))
+	log.V(5).Info("Cluster queue notification")
+	noChange := newCq != nil && oldCq != nil && slices.CmpNoOrder(oldCq.Spec.AdmissionChecks, newCq.Spec.AdmissionChecks)
+	if noChange {
+		return
+	}
+
+	if oldCq != nil {
+		r.cqUpdateCh <- event.GenericEvent{Object: oldCq}
+	}
+
+	if newCq != nil {
+		r.cqUpdateCh <- event.GenericEvent{Object: newCq}
+	}
+}
+
+type acCqHandler struct {
+	cache *cache.Cache
+}
+
+func (h *acCqHandler) Create(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
+}
+
+func (h *acCqHandler) Update(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
+}
+
+func (h *acCqHandler) Delete(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface) {
+}
+
+func (h *acCqHandler) Generic(ctx context.Context, e event.GenericEvent, q workqueue.RateLimitingInterface) {
+	cq := e.Object.(*kueue.ClusterQueue)
+	if cq.Name == "" {
+		return
+	}
+	log := log.FromContext(ctx).WithValues("cq", klog.KObj(cq))
+	log.V(6).Info("Cluster queue generic event")
+
+	for _, ac := range cq.Spec.AdmissionChecks {
+		if cqs := h.cache.ClusterQueuesUsingAdmissionCheck(ac); len(cqs) == 0 {
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: ac,
+				},
+			}
+			q.Add(req)
+		}
+	}
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *AdmissionCheckReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	handler := acCqHandler{
+		cache: r.cache,
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&kueue.AdmissionCheck{}).
+		WatchesRawSource(&source.Channel{Source: r.cqUpdateCh}, &handler).
+		WithEventFilter(r).
+		Complete(r)
+}
+
+func NewAdAdmissionCheckReconciler(
+	client client.Client,
+	qMgr *queue.Manager,
+	cache *cache.Cache,
+) *AdmissionCheckReconciler {
+	return &AdmissionCheckReconciler{
+		log:        ctrl.Log.WithName("admissioncheck-reconciler"),
+		qManager:   qMgr,
+		client:     client,
+		cache:      cache,
+		cqUpdateCh: make(chan event.GenericEvent, updateChBuffer),
+	}
+}

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -62,6 +62,7 @@ type ClusterQueueReconciler struct {
 	snapshotsQueue                       workqueue.Interface
 	wlUpdateCh                           chan event.GenericEvent
 	rfUpdateCh                           chan event.GenericEvent
+	acUpdateCh                           chan event.GenericEvent
 	watchers                             []ClusterQueueUpdateWatcher
 	reportResourceMetrics                bool
 	queueVisibilityUpdateInterval        time.Duration
@@ -126,6 +127,7 @@ func NewClusterQueueReconciler(
 		snapshotsQueue:                       workqueue.New(),
 		wlUpdateCh:                           make(chan event.GenericEvent, updateChBuffer),
 		rfUpdateCh:                           make(chan event.GenericEvent, updateChBuffer),
+		acUpdateCh:                           make(chan event.GenericEvent, updateChBuffer),
 		watchers:                             options.Watchers,
 		reportResourceMetrics:                options.ReportResourceMetrics,
 		queueVisibilityUpdateInterval:        options.QueueVisibilityUpdateInterval,
@@ -182,18 +184,13 @@ func (r *ClusterQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		if err := r.updateCqStatusIfChanged(ctx, newCQObj, metav1.ConditionTrue, "Ready", msg); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
-	} else if r.cache.ClusterQueueTerminating(newCQObj.Name) {
-		msg := "Can't admit new workloads; clusterQueue is terminating"
-		if err := r.updateCqStatusIfChanged(ctx, newCQObj, metav1.ConditionFalse, "Terminating", msg); err != nil {
-			return ctrl.Result{}, client.IgnoreNotFound(err)
-		}
 	} else {
-		msg := "Can't admit new workloads; some flavors are not found"
-		if err := r.updateCqStatusIfChanged(ctx, newCQObj, metav1.ConditionFalse, "FlavorNotFound", msg); err != nil {
+
+		reason, msg := r.cache.ClusterQueueInactiveReason(newCQObj.Name)
+		if err := r.updateCqStatusIfChanged(ctx, newCQObj, metav1.ConditionFalse, reason, msg); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 	}
-
 	return ctrl.Result{}, nil
 }
 
@@ -228,6 +225,15 @@ func (r *ClusterQueueReconciler) NotifyResourceFlavorUpdate(oldRF, newRF *kueue.
 	if newRF == nil {
 		r.rfUpdateCh <- event.GenericEvent{Object: oldRF}
 		return
+	}
+}
+
+func (r *ClusterQueueReconciler) NotifyAdmissionCheckUpdate(oldAc, newAc *kueue.AdmissionCheck) {
+	switch {
+	case oldAc != nil:
+		r.acUpdateCh <- event.GenericEvent{Object: oldAc}
+	case newAc != nil:
+		r.acUpdateCh <- event.GenericEvent{Object: newAc}
 	}
 }
 
@@ -501,6 +507,36 @@ func (h *cqResourceFlavorHandler) Generic(_ context.Context, e event.GenericEven
 	}
 }
 
+type cqAdmissionCheckHandler struct {
+	cache *cache.Cache
+}
+
+func (h *cqAdmissionCheckHandler) Create(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
+}
+
+func (h *cqAdmissionCheckHandler) Update(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
+}
+
+func (h *cqAdmissionCheckHandler) Delete(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface) {
+}
+
+func (h *cqAdmissionCheckHandler) Generic(_ context.Context, e event.GenericEvent, q workqueue.RateLimitingInterface) {
+	ac, isAc := e.Object.(*kueue.AdmissionCheck)
+	if !isAc {
+		return
+	}
+
+	if cqs := h.cache.ClusterQueuesUsingAdmissionCheck(ac.Name); len(cqs) != 0 {
+		for _, cq := range cqs {
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: cq,
+				}}
+			q.Add(req)
+		}
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterQueueReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	wHandler := cqWorkloadHandler{
@@ -513,11 +549,15 @@ func (r *ClusterQueueReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	rfHandler := cqResourceFlavorHandler{
 		cache: r.cache,
 	}
+	acHandler := cqAdmissionCheckHandler{
+		cache: r.cache,
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kueue.ClusterQueue{}).
 		Watches(&corev1.Namespace{}, &nsHandler).
 		WatchesRawSource(&source.Channel{Source: r.wlUpdateCh}, &wHandler).
 		WatchesRawSource(&source.Channel{Source: r.rfUpdateCh}, &rfHandler).
+		WatchesRawSource(&source.Channel{Source: r.acUpdateCh}, &acHandler).
 		WithEventFilter(r).
 		Complete(r)
 }

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -179,17 +179,9 @@ func (r *ClusterQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	newCQObj := cqObj.DeepCopy()
-	if r.cache.ClusterQueueActive(newCQObj.Name) {
-		msg := "Can admit new workloads"
-		if err := r.updateCqStatusIfChanged(ctx, newCQObj, metav1.ConditionTrue, "Ready", msg); err != nil {
-			return ctrl.Result{}, client.IgnoreNotFound(err)
-		}
-	} else {
-
-		reason, msg := r.cache.ClusterQueueInactiveReason(newCQObj.Name)
-		if err := r.updateCqStatusIfChanged(ctx, newCQObj, metav1.ConditionFalse, reason, msg); err != nil {
-			return ctrl.Result{}, client.IgnoreNotFound(err)
-		}
+	cqCondition, reason, msg := r.cache.ClusterQueueReadiness(newCQObj.Name)
+	if err := r.updateCqStatusIfChanged(ctx, newCQObj, cqCondition, reason, msg); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	return ctrl.Result{}, nil
 }

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -35,7 +35,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *queue.Manager, cc *cache.Cache
 	if err := rfRec.SetupWithManager(mgr); err != nil {
 		return "ResourceFlavor", err
 	}
-	acRec := NewAdAdmissionCheckReconciler(mgr.GetClient(), qManager, cc)
+	acRec := NewAdmissionCheckReconciler(mgr.GetClient(), qManager, cc)
 	if err := acRec.SetupWithManager(mgr); err != nil {
 		return "AdmissionCheck", err
 	}

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -35,6 +35,10 @@ func SetupControllers(mgr ctrl.Manager, qManager *queue.Manager, cc *cache.Cache
 	if err := rfRec.SetupWithManager(mgr); err != nil {
 		return "ResourceFlavor", err
 	}
+	acRec := NewAdAdmissionCheckReconciler(mgr.GetClient(), qManager, cc)
+	if err := acRec.SetupWithManager(mgr); err != nil {
+		return "AdmissionCheck", err
+	}
 	qRec := NewLocalQueueReconciler(mgr.GetClient(), qManager, cc)
 	if err := qRec.SetupWithManager(mgr); err != nil {
 		return "LocalQueue", err
@@ -47,12 +51,13 @@ func SetupControllers(mgr ctrl.Manager, qManager *queue.Manager, cc *cache.Cache
 		WithQueueVisibilityUpdateInterval(queueVisibilityUpdateInterval(cfg)),
 		WithQueueVisibilityClusterQueuesMaxCount(queueVisibilityClusterQueuesMaxCount(cfg)),
 		WithReportResourceMetrics(cfg.Metrics.EnableClusterQueueResources),
-		WithWatchers(rfRec),
+		WithWatchers(rfRec, acRec),
 	)
 	if err := mgr.Add(cqRec); err != nil {
 		return "Unable to add ClusterQueue to manager", err
 	}
 	rfRec.AddUpdateWatcher(cqRec)
+	acRec.AddUpdateWatchers(cqRec)
 	if err := cqRec.SetupWithManager(mgr); err != nil {
 		return "ClusterQueue", err
 	}

--- a/pkg/util/testing/not_found_error_cmp.go
+++ b/pkg/util/testing/not_found_error_cmp.go
@@ -32,6 +32,10 @@ type notFoundErrorMatch struct {
 }
 
 func (matcher *notFoundErrorMatch) Match(actual interface{}) (success bool, err error) {
+	if actual == nil {
+		return false, nil
+	}
+
 	err, ok := actual.(error)
 	if !ok {
 		return false, fmt.Errorf("NotFoundError expects an error")

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -550,3 +550,19 @@ func (lr *LimitRangeWrapper) WithValue(member string, t corev1.ResourceName, q s
 func (lr *LimitRangeWrapper) Obj() *corev1.LimitRange {
 	return &lr.LimitRange
 }
+
+type AdmissionCheckWrapper struct{ kueue.AdmissionCheck }
+
+func MakeAdmissionCheck(name string) *AdmissionCheckWrapper {
+	return &AdmissionCheckWrapper{
+		AdmissionCheck: kueue.AdmissionCheck{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		},
+	}
+}
+
+func (ac *AdmissionCheckWrapper) Obj() *kueue.AdmissionCheck {
+	return &ac.AdmissionCheck
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -187,8 +187,11 @@ var _ = ginkgo.Describe("Kueue", func() {
 			onDemandRF   *kueue.ResourceFlavor
 			localQueue   *kueue.LocalQueue
 			clusterQueue *kueue.ClusterQueue
+			check        *kueue.AdmissionCheck
 		)
 		ginkgo.BeforeEach(func() {
+			check = testing.MakeAdmissionCheck("check1").Obj()
+			gomega.Expect(k8sClient.Create(ctx, check)).Should(gomega.Succeed())
 			onDemandRF = testing.MakeResourceFlavor("on-demand").
 				Label("instance-type", "on-demand").Obj()
 			gomega.Expect(k8sClient.Create(ctx, onDemandRF)).Should(gomega.Succeed())
@@ -210,6 +213,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 			gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
 			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, clusterQueue, true)
 			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, onDemandRF, true)
+			gomega.Expect(k8sClient.Delete(ctx, check)).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("Should unsuspend a job only after all checks are cleared", func() {

--- a/test/integration/controller/core/admissioncheck_controller_test.go
+++ b/test/integration/controller/core/admissioncheck_controller_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+// +kubebuilder:docs-gen:collapse=Imports
+
+var _ = ginkgo.Describe("AdmissionCheck controller", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "core-admissioncheck-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.When("one clusterQueue references admissionChecks", func() {
+		var admissionCheck *kueue.AdmissionCheck
+		var clusterQueue *kueue.ClusterQueue
+
+		ginkgo.BeforeEach(func() {
+			admissionCheck = utiltesting.MakeAdmissionCheck("check1").Obj()
+			clusterQueue = utiltesting.MakeClusterQueue("foo").
+				AdmissionChecks("check1").
+				Obj()
+
+			gomega.Expect(k8sClient.Create(ctx, admissionCheck)).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
+
+			ginkgo.By("Wait for the queue to become active", func() {
+				gomega.Eventually(func() bool {
+					var cq kueue.ClusterQueue
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &cq)
+					if err != nil {
+						return false
+					}
+					return apimeta.IsStatusConditionTrue(cq.Status.Conditions, kueue.ClusterQueueActive)
+				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+			})
+		})
+
+		ginkgo.AfterEach(func() {
+			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectAdmissionCheckToBeDeleted(ctx, k8sClient, admissionCheck, true)
+		})
+
+		ginkgo.It("Should delete the admissionCheck when the corresponding clusterQueue no longer uses the admissionCheck", func() {
+			ginkgo.By("Try to delete admissionCheck")
+			gomega.Expect(util.DeleteAdmissionCheck(ctx, k8sClient, admissionCheck)).To(gomega.Succeed())
+			var ac kueue.AdmissionCheck
+			gomega.Eventually(func() []string {
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(admissionCheck), &ac)).To(gomega.Succeed())
+				return ac.GetFinalizers()
+			}, util.Timeout, util.Interval).Should(gomega.BeComparableTo([]string{kueue.ResourceInUseFinalizerName}))
+			gomega.Expect(ac.GetDeletionTimestamp()).ShouldNot(gomega.BeNil())
+
+			ginkgo.By("Update clusterQueue's cohort")
+			var cq kueue.ClusterQueue
+			gomega.Eventually(func() error {
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &cq)).To(gomega.Succeed())
+				cq.Spec.Cohort = "foo-cohort"
+				return k8sClient.Update(ctx, &cq)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKeyFromObject(admissionCheck), &ac)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Change clusterQueue's checks")
+			gomega.Eventually(func() error {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &cq)
+				if err != nil {
+					return err
+				}
+				cq.Spec.AdmissionChecks = []string{"check2"}
+				return k8sClient.Update(ctx, &cq)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKeyFromObject(admissionCheck), &ac)
+			}, util.Timeout, util.Interval).Should(utiltesting.BeNotFoundError())
+		})
+
+		ginkgo.It("Should delete the admissionCheck when the corresponding clusterQueue is deleted", func() {
+			gomega.Expect(util.DeleteAdmissionCheck(ctx, k8sClient, admissionCheck)).To(gomega.Succeed())
+
+			var rf kueue.AdmissionCheck
+			gomega.Eventually(func() []string {
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(admissionCheck), &rf)).To(gomega.Succeed())
+				return rf.GetFinalizers()
+			}, util.Timeout, util.Interval).Should(gomega.BeComparableTo([]string{kueue.ResourceInUseFinalizerName}))
+			gomega.Expect(rf.GetDeletionTimestamp()).ShouldNot(gomega.BeNil())
+
+			gomega.Expect(util.DeleteClusterQueue(ctx, k8sClient, clusterQueue)).To(gomega.Succeed())
+			gomega.Eventually(func() error {
+				return k8sClient.Get(ctx, client.ObjectKeyFromObject(admissionCheck), &rf)
+			}, util.Timeout, util.Interval).Should(utiltesting.BeNotFoundError())
+		})
+	})
+})

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -488,6 +488,8 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 			wl             *kueue.Workload
 			cpuArchAFlavor *kueue.ResourceFlavor
 			cpuArchBFlavor *kueue.ResourceFlavor
+			check1         *kueue.AdmissionCheck
+			check2         *kueue.AdmissionCheck
 		)
 
 		ginkgo.BeforeEach(func() {
@@ -495,7 +497,10 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 				ResourceGroup(
 					*testing.MakeFlavorQuotas(flavorCPUArchA).Resource(corev1.ResourceCPU, "5", "5").Obj(),
 					*testing.MakeFlavorQuotas(flavorCPUArchB).Resource(corev1.ResourceCPU, "5", "5").Obj(),
-				).Obj()
+				).
+				AdmissionChecks("check1", "check2").
+				Obj()
+
 			gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
 			lq = testing.MakeLocalQueue("bar-lq", ns.Name).ClusterQueue(cq.Name).Obj()
 			gomega.Expect(k8sClient.Create(ctx, lq)).To(gomega.Succeed())
@@ -509,9 +514,18 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, cq, true)
 			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, cpuArchAFlavor, true)
 			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, cpuArchBFlavor, true)
+			util.ExpectAdmissionCheckToBeDeleted(ctx, k8sClient, check1, true)
+			util.ExpectAdmissionCheckToBeDeleted(ctx, k8sClient, check2, true)
 		})
 
 		ginkgo.It("Should update status conditions when flavors are created", func() {
+
+			check1 = testing.MakeAdmissionCheck("check1").Obj()
+			gomega.Expect(k8sClient.Create(ctx, check1)).To(gomega.Succeed())
+
+			check2 = testing.MakeAdmissionCheck("check2").Obj()
+			gomega.Expect(k8sClient.Create(ctx, check2)).To(gomega.Succeed())
+
 			ginkgo.By("All Flavors are not found")
 
 			gomega.Eventually(func() []metav1.Condition {
@@ -546,6 +560,62 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 			ginkgo.By("All flavors are created")
 			cpuArchBFlavor = testing.MakeResourceFlavor(flavorCPUArchB).Obj()
 			gomega.Expect(k8sClient.Create(ctx, cpuArchBFlavor)).To(gomega.Succeed())
+			gomega.Eventually(func() []metav1.Condition {
+				var updatedCq kueue.ClusterQueue
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &updatedCq)).To(gomega.Succeed())
+				return updatedCq.Status.Conditions
+			}, util.Timeout, util.Interval).Should(gomega.BeComparableTo([]metav1.Condition{
+				{
+					Type:    kueue.ClusterQueueActive,
+					Status:  metav1.ConditionTrue,
+					Reason:  "Ready",
+					Message: "Can admit new workloads",
+				},
+			}, ignoreConditionTimestamps))
+		})
+
+		ginkgo.It("Should update status conditions when  admission checks are created", func() {
+
+			cpuArchAFlavor = testing.MakeResourceFlavor(flavorCPUArchA).Obj()
+			gomega.Expect(k8sClient.Create(ctx, cpuArchAFlavor)).To(gomega.Succeed())
+
+			cpuArchBFlavor = testing.MakeResourceFlavor(flavorCPUArchB).Obj()
+			gomega.Expect(k8sClient.Create(ctx, cpuArchBFlavor)).To(gomega.Succeed())
+
+			ginkgo.By("All checks are not found")
+
+			gomega.Eventually(func() []metav1.Condition {
+				var updatedCq kueue.ClusterQueue
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &updatedCq)).To(gomega.Succeed())
+				return updatedCq.Status.Conditions
+			}, util.Timeout, util.Interval).Should(gomega.BeComparableTo([]metav1.Condition{
+				{
+					Type:    kueue.ClusterQueueActive,
+					Status:  metav1.ConditionFalse,
+					Reason:  "CheckNotFound",
+					Message: "Can't admit new workloads; some admission checks are not found",
+				},
+			}, ignoreConditionTimestamps))
+
+			ginkgo.By("One of the checks is not found")
+			check1 = testing.MakeAdmissionCheck("check1").Obj()
+			gomega.Expect(k8sClient.Create(ctx, check1)).To(gomega.Succeed())
+			gomega.Eventually(func() []metav1.Condition {
+				var updatedCq kueue.ClusterQueue
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &updatedCq)).To(gomega.Succeed())
+				return updatedCq.Status.Conditions
+			}, util.Timeout, util.Interval).Should(gomega.BeComparableTo([]metav1.Condition{
+				{
+					Type:    kueue.ClusterQueueActive,
+					Status:  metav1.ConditionFalse,
+					Reason:  "CheckNotFound",
+					Message: "Can't admit new workloads; some admission checks are not found",
+				},
+			}, ignoreConditionTimestamps))
+
+			ginkgo.By("All checks are created")
+			check2 = testing.MakeAdmissionCheck("check2").Obj()
+			gomega.Expect(k8sClient.Create(ctx, check2)).To(gomega.Succeed())
 			gomega.Eventually(func() []metav1.Condition {
 				var updatedCq kueue.ClusterQueue
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &updatedCq)).To(gomega.Succeed())

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -182,7 +182,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 						Type:    kueue.ClusterQueueActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "FlavorNotFound",
-						Message: "Can't admit new workloads; some flavors are not found",
+						Message: "Can't admit new workloads; some resourceFlavors are not found",
 					},
 				},
 			}, ignoreConditionTimestamps, ignorePendingWorkloadsStatus))
@@ -537,7 +537,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
 					Reason:  "FlavorNotFound",
-					Message: "Can't admit new workloads; some flavors are not found",
+					Message: "Can't admit new workloads; some resourceFlavors are not found",
 				},
 			}, ignoreConditionTimestamps))
 
@@ -553,7 +553,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
 					Reason:  "FlavorNotFound",
-					Message: "Can't admit new workloads; some flavors are not found",
+					Message: "Can't admit new workloads; some resourceFlavors are not found",
 				},
 			}, ignoreConditionTimestamps))
 
@@ -574,7 +574,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 			}, ignoreConditionTimestamps))
 		})
 
-		ginkgo.It("Should update status conditions when  admission checks are created", func() {
+		ginkgo.It("Should update status conditions when admission checks are created", func() {
 
 			cpuArchAFlavor = testing.MakeResourceFlavor(flavorCPUArchA).Obj()
 			gomega.Expect(k8sClient.Create(ctx, cpuArchAFlavor)).To(gomega.Succeed())
@@ -593,7 +593,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
 					Reason:  "CheckNotFound",
-					Message: "Can't admit new workloads; some admission checks are not found",
+					Message: "Can't admit new workloads; some admissionChecks are not found",
 				},
 			}, ignoreConditionTimestamps))
 
@@ -609,7 +609,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
 					Reason:  "CheckNotFound",
-					Message: "Can't admit new workloads; some admission checks are not found",
+					Message: "Can't admit new workloads; some admissionChecks are not found",
 				},
 			}, ignoreConditionTimestamps))
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -287,13 +287,16 @@ func ExpectClusterQueueStatusMetric(cq *kueue.ClusterQueue, status metrics.Clust
 }
 
 func ExpectAdmissionCheckToBeDeleted(ctx context.Context, k8sClient client.Client, ac *kueue.AdmissionCheck, deleteAC bool) {
+	if ac == nil {
+		return
+	}
 	if deleteAC {
-		gomega.Expect(DeleteAdmissionCheck(ctx, k8sClient, ac)).NotTo(gomega.HaveOccurred())
+		gomega.Expect(client.IgnoreNotFound(DeleteAdmissionCheck(ctx, k8sClient, ac))).NotTo(gomega.HaveOccurred())
 	}
 	gomega.EventuallyWithOffset(1, func() error {
 		var newAC kueue.AdmissionCheck
 		return k8sClient.Get(ctx, client.ObjectKeyFromObject(ac), &newAC)
-	}, Timeout, Timeout).Should(testing.BeNotFoundError())
+	}, Timeout, Interval).Should(testing.BeNotFoundError())
 }
 
 func ExpectClusterQueueToBeDeleted(ctx context.Context, k8sClient client.Client, cq *kueue.ClusterQueue, deleteCq bool) {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -291,7 +291,7 @@ func ExpectAdmissionCheckToBeDeleted(ctx context.Context, k8sClient client.Clien
 		return
 	}
 	if deleteAC {
-		gomega.Expect(client.IgnoreNotFound(DeleteAdmissionCheck(ctx, k8sClient, ac))).NotTo(gomega.HaveOccurred())
+		gomega.Expect(client.IgnoreNotFound(DeleteAdmissionCheck(ctx, k8sClient, ac))).To(gomega.Succeed())
 	}
 	gomega.EventuallyWithOffset(1, func() error {
 		var newAC kueue.AdmissionCheck


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[controller/core] Add AdmissionCheckReconciler
Its main goal at this stage is to help managing the active status of the
cluster queues mast on the admission checks presence.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relate to #993

#### Special notes for your reviewer:

In draft pending #1045 merge.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Manage cluster queue active state based on admission checks life cycle.
```