### PR TITLE
Sync AmissionCheck API with KEP one

### DIFF
--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -21,39 +21,43 @@ import (
 )
 
 const (
-	// The check cannot pass at this moment, back off (possibly
+	// CheckStateRetry means that the check cannot pass at this moment, back off (possibly
 	// allowing other to try, unblock quota) and retry.
 	// A workload having at least one check in the state,
 	// will be evicted if admitted will not be considered
 	// for admission.
 	CheckStateRetry = "Retry"
 
-	// The check will not pass in the near future. It is not worth
+	// CheckStateRejected means that the check will not pass in the near future. It is not worth
 	// to retry.
-	//NOTE: The admission behaviour is currently the same as for retry,
+	// NOTE: The admission behaviour is currently the same as for retry,
 	// we can consider marking the workload as "Finished" with a failure
 	// description.
 	CheckStateRejected = "Rejected"
 
-	// The state can be
+	// CheckStatePending means that the check still hasn't been performed and the state can be
 	// 1. Unknown, the condition was added by kueue and its controller was not able to evaluate it.
 	// 2. Set by its controller and reevaluated after quota is reserved.
 	CheckStatePending = "Pending"
 
-	// The check has passed.
+	// CheckStateReady means that the check has passed.
 	// A workload having all its checks ready, and quota reserved can begin execution.
 	CheckStateReady = "Ready"
 )
 
 // AdmissionCheckSpec defines the desired state of AdmissionCheck
 type AdmissionCheckSpec struct {
-	// ControllerName identifies the controller managing this condition.
-	// +optional
+	// controllerName is name of the controller which will actually perform
+	// the checks. This is the name with which controller identifies with,
+	// not necessarily a K8S Pod or Deployment name. Cannot be empty.
 	ControllerName string `json:"controllerName"`
 
-	// RetryDelayMinutes specifies the duration in minutes between two checks for the same
-	// workload.
+	// RetryDelayMinutes specifies how long to keep the workload suspended
+	// after a failed check (after it transitioned to False).
+	// After that the check state goes to "Unknown".
+	// The default is 15 min.
 	// +optional
+	// +kubebuilder:default=15
 	RetryDelayMinutes *int64 `json:"retryDelayMinutes,omitempty"`
 
 	// Parameters identifies the resource providing additional check parameters.

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -48,8 +48,9 @@ spec:
             description: AdmissionCheckSpec defines the desired state of AdmissionCheck
             properties:
               controllerName:
-                description: ControllerName identifies the controller managing this
-                  condition.
+                description: controllerName is name of the controller which will actually
+                  perform the checks. This is the name with which controller identifies
+                  with, not necessarily a K8S Pod or Deployment name. Cannot be empty.
                 type: string
               parameters:
                 description: Parameters identifies the resource providing additional
@@ -70,10 +71,15 @@ spec:
                 - name
                 type: object
               retryDelayMinutes:
-                description: RetryDelayMinutes specifies the duration in minutes between
-                  two checks for the same workload.
+                default: 15
+                description: RetryDelayMinutes specifies how long to keep the workload
+                  suspended after a failed check (after it transitioned to False).
+                  After that the check state goes to "Unknown". The default is 15
+                  min.
                 format: int64
                 type: integer
+            required:
+            - controllerName
             type: object
           status:
             description: AdmissionCheckStatus defines the observed state of AdmissionCheck

--- a/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
@@ -35,8 +35,9 @@ spec:
             description: AdmissionCheckSpec defines the desired state of AdmissionCheck
             properties:
               controllerName:
-                description: ControllerName identifies the controller managing this
-                  condition.
+                description: controllerName is name of the controller which will actually
+                  perform the checks. This is the name with which controller identifies
+                  with, not necessarily a K8S Pod or Deployment name. Cannot be empty.
                 type: string
               parameters:
                 description: Parameters identifies the resource providing additional
@@ -57,10 +58,15 @@ spec:
                 - name
                 type: object
               retryDelayMinutes:
-                description: RetryDelayMinutes specifies the duration in minutes between
-                  two checks for the same workload.
+                default: 15
+                description: RetryDelayMinutes specifies how long to keep the workload
+                  suspended after a failed check (after it transitioned to False).
+                  After that the check state goes to "Unknown". The default is 15
+                  min.
                 format: int64
                 type: integer
+            required:
+            - controllerName
             type: object
           status:
             description: AdmissionCheckStatus defines the observed state of AdmissionCheck

--- a/test/integration/webhook/admissioncheck_test.go
+++ b/test/integration/webhook/admissioncheck_test.go
@@ -1,0 +1,43 @@
+package webhook
+
+import (
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("AdmissionCheck Webhook", func() {
+	ginkgo.When("Creating a AdmissionCheck", func() {
+
+		ginkgo.DescribeTable("Defaulting on creating", func(ac, wantAC kueue.AdmissionCheck) {
+			gomega.Expect(k8sClient.Create(ctx, &ac)).Should(gomega.Succeed())
+			defer func() {
+				util.ExpectAdmissionCheckToBeDeleted(ctx, k8sClient, &ac, true)
+			}()
+			gomega.Expect(ac).To(gomega.BeComparableTo(wantAC,
+				cmpopts.IgnoreTypes(kueue.AdmissionCheckStatus{}),
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "UID", "ResourceVersion", "Generation", "CreationTimestamp", "ManagedFields")))
+		},
+			ginkgo.Entry("All defaults",
+				kueue.AdmissionCheck{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+					},
+				},
+				kueue.AdmissionCheck{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "foo",
+					},
+					Spec: kueue.AdmissionCheckSpec{
+						RetryDelayMinutes: ptr.To[int64](15),
+					},
+				},
+			),
+		)
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
I synchronized the AdmissionCheck API with [KEP](https://github.com/kubernetes-sigs/kueue/tree/79d810b422f9851ca288e8a7fb9bfd81e67f062b/keps/993-two-phase-admission) one.

1. Clean up comments.
2. Make `.spec.ControllerName` required field.
3. Set default value to `.spec.retryDelayMinutes`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Set default value to `.spec.retryDelayMinutes`,
```