### PR TITLE
Trigger cq reconciliation on snapshot change

### DIFF
--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -63,6 +63,7 @@ type ClusterQueueReconciler struct {
 	wlUpdateCh                           chan event.GenericEvent
 	rfUpdateCh                           chan event.GenericEvent
 	acUpdateCh                           chan event.GenericEvent
+	shUpdateCh                           chan event.GenericEvent
 	watchers                             []ClusterQueueUpdateWatcher
 	reportResourceMetrics                bool
 	queueVisibilityUpdateInterval        time.Duration
@@ -128,6 +129,7 @@ func NewClusterQueueReconciler(
 		wlUpdateCh:                           make(chan event.GenericEvent, updateChBuffer),
 		rfUpdateCh:                           make(chan event.GenericEvent, updateChBuffer),
 		acUpdateCh:                           make(chan event.GenericEvent, updateChBuffer),
+		shUpdateCh:                           make(chan event.GenericEvent, updateChBuffer),
 		watchers:                             options.Watchers,
 		reportResourceMetrics:                options.ReportResourceMetrics,
 		queueVisibilityUpdateInterval:        options.QueueVisibilityUpdateInterval,
@@ -503,6 +505,10 @@ type cqAdmissionCheckHandler struct {
 	cache *cache.Cache
 }
 
+type cqSnapshotHandler struct {
+	queueVisibilityUpdateInterval time.Duration
+}
+
 func (h *cqAdmissionCheckHandler) Create(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 }
 
@@ -529,6 +535,33 @@ func (h *cqAdmissionCheckHandler) Generic(_ context.Context, e event.GenericEven
 	}
 }
 
+func (h *cqSnapshotHandler) Create(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
+}
+
+func (h *cqSnapshotHandler) Update(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
+}
+
+func (h *cqSnapshotHandler) Delete(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface) {
+}
+
+func (h *cqSnapshotHandler) Generic(_ context.Context, e event.GenericEvent, q workqueue.RateLimitingInterface) {
+	cq, isCq := e.Object.(*kueue.ClusterQueue)
+	if !isCq {
+		return
+	}
+	remainingTime := constants.UpdatesBatchPeriod
+	if cq.Status.PendingWorkloadsStatus != nil {
+		remainingTime = h.queueVisibilityUpdateInterval - time.Since(cq.Status.PendingWorkloadsStatus.LastChangeTime.Time)
+		if remainingTime <= constants.UpdatesBatchPeriod {
+			remainingTime = constants.UpdatesBatchPeriod
+		}
+	}
+	q.AddAfter(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: cq.Name,
+		}}, remainingTime)
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterQueueReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	wHandler := cqWorkloadHandler{
@@ -544,12 +577,16 @@ func (r *ClusterQueueReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	acHandler := cqAdmissionCheckHandler{
 		cache: r.cache,
 	}
+	shHandler := cqSnapshotHandler{
+		queueVisibilityUpdateInterval: r.queueVisibilityUpdateInterval,
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kueue.ClusterQueue{}).
 		Watches(&corev1.Namespace{}, &nsHandler).
 		WatchesRawSource(&source.Channel{Source: r.wlUpdateCh}, &wHandler).
 		WatchesRawSource(&source.Channel{Source: r.rfUpdateCh}, &rfHandler).
 		WatchesRawSource(&source.Channel{Source: r.acUpdateCh}, &acHandler).
+		WatchesRawSource(&source.Channel{Source: r.shUpdateCh}, &shHandler).
 		WithEventFilter(r).
 		Complete(r)
 }
@@ -594,19 +631,13 @@ func (r *ClusterQueueReconciler) getWorkloadsStatus(cq *kueue.ClusterQueue) *kue
 	if !r.isVisibilityEnabled() {
 		return nil
 	}
-	if cq.Status.PendingWorkloadsStatus == nil {
+	pendingWorkloads := r.qManager.GetSnapshot(cq.Name)
+	if cq.Status.PendingWorkloadsStatus == nil ||
+		cq.Status.PendingWorkloadsStatus.Head == nil ||
+		!equality.Semantic.DeepEqual(cq.Status.PendingWorkloadsStatus.Head, pendingWorkloads) {
 		return &kueue.ClusterQueuePendingWorkloadsStatus{
-			Head:           r.qManager.GetSnapshot(cq.Name),
+			Head:           pendingWorkloads,
 			LastChangeTime: metav1.Time{Time: time.Now()},
-		}
-	}
-	if time.Since(cq.Status.PendingWorkloadsStatus.LastChangeTime.Time) >= r.queueVisibilityUpdateInterval {
-		pendingWorkloads := r.qManager.GetSnapshot(cq.Name)
-		if !equality.Semantic.DeepEqual(cq.Status.PendingWorkloadsStatus.Head, pendingWorkloads) {
-			return &kueue.ClusterQueuePendingWorkloadsStatus{
-				Head:           pendingWorkloads,
-				LastChangeTime: metav1.Time{Time: time.Now()},
-			}
 		}
 	}
 	return cq.Status.PendingWorkloadsStatus
@@ -655,6 +686,16 @@ func (r *ClusterQueueReconciler) processNextSnapshot(ctx context.Context) bool {
 	}()
 
 	defer r.snapshotsQueue.Done(key)
-	r.qManager.UpdateSnapshot(key.(string), r.queueVisibilityClusterQueuesMaxCount)
+
+	cqName := key.(string)
+	if r.qManager.UpdateSnapshot(cqName, r.queueVisibilityClusterQueuesMaxCount) {
+		log.WithValues("cqName", cqName)
+		log.Info("Triggering CQ update due to snapshot change", "cqName", cqName)
+		r.shUpdateCh <- event.GenericEvent{Object: &kueue.ClusterQueue{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: cqName,
+			},
+		}}
+	}
 	return true
 }

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -571,7 +571,7 @@ func (m *Manager) getClusterQueue(cqName string) ClusterQueue {
 }
 
 // UpdateSnapshot computes the new snapshot and replaces if it differs from the
-// pevious version. It returns true if the snapshot was actually updated.
+// previous version. It returns true if the snapshot was actually updated.
 func (m *Manager) UpdateSnapshot(cqName string, maxCount int32) bool {
 	cq := m.getClusterQueue(cqName)
 	if cq == nil {

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -569,12 +570,14 @@ func (m *Manager) getClusterQueue(cqName string) ClusterQueue {
 	return m.clusterQueues[cqName]
 }
 
-func (m *Manager) UpdateSnapshot(cqName string, maxCount int32) {
+// UpdateSnapshot computes the new snapshot and replaces if it differs from the
+// pevious version. It returns true if the snapshot was actually updated.
+func (m *Manager) UpdateSnapshot(cqName string, maxCount int32) bool {
 	cq := m.getClusterQueue(cqName)
 	if cq == nil {
-		return
+		return false
 	}
-	workloads := make([]kueue.ClusterQueuePendingWorkload, 0)
+	newSnapshot := make([]kueue.ClusterQueuePendingWorkload, 0)
 	for index, info := range cq.Snapshot() {
 		if int32(index) >= maxCount {
 			break
@@ -582,12 +585,17 @@ func (m *Manager) UpdateSnapshot(cqName string, maxCount int32) {
 		if info == nil {
 			continue
 		}
-		workloads = append(workloads, kueue.ClusterQueuePendingWorkload{
+		newSnapshot = append(newSnapshot, kueue.ClusterQueuePendingWorkload{
 			Name:      info.Obj.Name,
 			Namespace: info.Obj.Namespace,
 		})
 	}
-	m.setSnapshot(cqName, workloads)
+	prevSnapshot := m.GetSnapshot(cqName)
+	if !equality.Semantic.DeepEqual(prevSnapshot, newSnapshot) {
+		m.setSnapshot(cqName, newSnapshot)
+		return true
+	}
+	return false
 }
 
 func (m *Manager) setSnapshot(cqName string, workloads []kueue.ClusterQueuePendingWorkload) {

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -801,9 +801,10 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 				},
 			}, ignoreLastChangeTime))
 
-			ginkgo.By("Finishing workload")
-			util.FinishWorkloads(ctx, k8sClient, workloadsFirstBatch...)
-			util.FinishWorkloads(ctx, k8sClient, workloadsSecondBatch...)
+			ginkgo.By("Finishing workload", func() {
+				util.FinishWorkloads(ctx, k8sClient, workloadsFirstBatch...)
+				util.FinishWorkloads(ctx, k8sClient, workloadsSecondBatch...)
+			})
 
 			ginkgo.By("Awaiting for the pending workloads status to be updated after the workloads are finished")
 			gomega.Eventually(func() *kueue.ClusterQueuePendingWorkloadsStatus {

--- a/test/integration/controller/core/suite_test.go
+++ b/test/integration/controller/core/suite_test.go
@@ -75,7 +75,7 @@ func managerSetup(mgr manager.Manager, ctx context.Context) {
 	controllersCfg := &config.Configuration{}
 	controllersCfg.Metrics.EnableClusterQueueResources = true
 	controllersCfg.QueueVisibility = &config.QueueVisibility{
-		UpdateIntervalSeconds: 1,
+		UpdateIntervalSeconds: 2,
 		ClusterQueues: &config.ClusterQueueVisibility{
 			MaxCount: 3,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1122

#### Special notes for your reviewer:

When the snapshot is updated it triggers reconciliation, when the next status update is expected.

Tested by running in a loop and no flakes after 100 repeats

I have disabled the check for time https://github.com/kubernetes-sigs/kueue/blob/ee5b6ba29a1bbed1574262e362182573c5f6fa5e/pkg/controller/core/clusterqueue_controller.go#L603. With this check the test flakes, as there is a possibility, that the last reconciliation is triggered by snapshot updated, and `< UpdateInterval`, so it would not result in queue change. Further, the next snapshot check would not trigger another reconciliation as the snapshot is not changed. I think we can improve the behavior by marking a snapshot by snapshot revisions (1, 2, 3...). Then, we could skip comparing the contents of the snapshot and queue if the current snapshot used by cluster queue has revision >= the revision of the snapshot in manager. Ticketed: https://github.com/kubernetes-sigs/kueue/issues/1138.

Bumped the update interval to 2s to make the test fail almost every time on master, while currently it passes almost every time.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Ensure the Cluster queue status with pending workloads is changed
```