### PR TITLE
[workload] Finish with failure on admission check rejection.

### DIFF
--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -454,6 +454,18 @@ func HasRetryOrRejectedChecks(wl *kueue.Workload) bool {
 	return false
 }
 
+// Returns the list of Rejected admission checks
+func GetRejectedChecks(wl *kueue.Workload) []string {
+	rejectedChecks := make([]string, 0, len(wl.Status.AdmissionChecks))
+	for i := range wl.Status.AdmissionChecks {
+		ac := wl.Status.AdmissionChecks[i]
+		if ac.Status == metav1.ConditionFalse && ac.Reason == kueue.CheckStateRejected {
+			rejectedChecks = append(rejectedChecks, ac.Type)
+		}
+	}
+	return rejectedChecks
+}
+
 // Returns true if the workload is admitted.
 func IsAdmitted(w *kueue.Workload) bool {
 	return apimeta.IsStatusConditionTrue(w.Status.Conditions, kueue.WorkloadAdmitted)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Finish the workload with failure if any of its admission checks is marked as Rejected.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to  #1136 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Finish the workload with failure if any of its admission checks is marked as Rejected.
```