### PR TITLE
Adding featuregate for cluster queue visibility

### DIFF
--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -40,6 +40,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/util/resource"
@@ -587,7 +588,7 @@ func (r *ClusterQueueReconciler) updateCqStatusIfChanged(
 
 // Taking snapshot of cluster queue is enabled when maxcount non-zero
 func (r *ClusterQueueReconciler) isVisibilityEnabled() bool {
-	return r.queueVisibilityClusterQueuesMaxCount > 0
+	return features.Enabled(features.ClusterQueueVisibility) && r.queueVisibilityClusterQueuesMaxCount > 0
 }
 
 func (r *ClusterQueueReconciler) getWorkloadsStatus(cq *kueue.ClusterQueue) *kueue.ClusterQueuePendingWorkloadsStatus {

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -588,7 +588,7 @@ func (r *ClusterQueueReconciler) updateCqStatusIfChanged(
 
 // Taking snapshot of cluster queue is enabled when maxcount non-zero
 func (r *ClusterQueueReconciler) isVisibilityEnabled() bool {
-	return features.Enabled(features.ClusterQueueVisibility) && r.queueVisibilityClusterQueuesMaxCount > 0
+	return features.Enabled(features.QueueVisibility) && r.queueVisibilityClusterQueuesMaxCount > 0
 }
 
 func (r *ClusterQueueReconciler) getWorkloadsStatus(cq *kueue.ClusterQueue) *kueue.ClusterQueuePendingWorkloadsStatus {

--- a/pkg/controller/core/clusterqueue_controller_test.go
+++ b/pkg/controller/core/clusterqueue_controller_test.go
@@ -31,6 +31,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/queue"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -521,6 +522,7 @@ func TestClusterQueuePendingWorkloadsStatus(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
+		defer features.SetFeatureGateDuringTest(t, features.ClusterQueueVisibility, true)()
 		t.Run(name, func(t *testing.T) {
 			cq := utiltesting.MakeClusterQueue(cqName).
 				QueueingStrategy(kueue.StrictFIFO).Obj()

--- a/pkg/controller/core/clusterqueue_controller_test.go
+++ b/pkg/controller/core/clusterqueue_controller_test.go
@@ -502,8 +502,11 @@ func TestClusterQueuePendingWorkloadsStatus(t *testing.T) {
 		wantPendingWorkloadsStatus           *kueue.ClusterQueuePendingWorkloadsStatus
 		enableQueueVisibility                bool
 	}{
-		"taking snapshot of cluster queue is disabled": {},
-		"taking snapshot of cluster queue is enabled": {
+		"queue visibility is disabled": {},
+		"queue visibility is disabled but maxcount is provided": {
+			queueVisibilityClusterQueuesMaxCount: 2,
+		},
+		"queue visibility is enabled": {
 			queueVisibilityClusterQueuesMaxCount: 2,
 			queueVisibilityUpdateInterval:        10 * time.Millisecond,
 			enableQueueVisibility:                true,

--- a/pkg/controller/core/clusterqueue_controller_test.go
+++ b/pkg/controller/core/clusterqueue_controller_test.go
@@ -500,11 +500,13 @@ func TestClusterQueuePendingWorkloadsStatus(t *testing.T) {
 		queueVisibilityUpdateInterval        time.Duration
 		queueVisibilityClusterQueuesMaxCount int32
 		wantPendingWorkloadsStatus           *kueue.ClusterQueuePendingWorkloadsStatus
+		enableQueueVisibility                bool
 	}{
 		"taking snapshot of cluster queue is disabled": {},
 		"taking snapshot of cluster queue is enabled": {
 			queueVisibilityClusterQueuesMaxCount: 2,
 			queueVisibilityUpdateInterval:        10 * time.Millisecond,
+			enableQueueVisibility:                true,
 			wantPendingWorkloadsStatus: &kueue.ClusterQueuePendingWorkloadsStatus{
 				Head: []kueue.ClusterQueuePendingWorkload{
 					{Name: "one"}, {Name: "two"},
@@ -514,6 +516,7 @@ func TestClusterQueuePendingWorkloadsStatus(t *testing.T) {
 		"verify the head of pending workloads when the number of pending workloads exceeds MaxCount": {
 			queueVisibilityClusterQueuesMaxCount: 1,
 			queueVisibilityUpdateInterval:        10 * time.Millisecond,
+			enableQueueVisibility:                true,
 			wantPendingWorkloadsStatus: &kueue.ClusterQueuePendingWorkloadsStatus{
 				Head: []kueue.ClusterQueuePendingWorkload{
 					{Name: "one"},
@@ -522,7 +525,7 @@ func TestClusterQueuePendingWorkloadsStatus(t *testing.T) {
 		},
 	}
 	for name, tc := range testCases {
-		defer features.SetFeatureGateDuringTest(t, features.ClusterQueueVisibility, true)()
+		defer features.SetFeatureGateDuringTest(t, features.QueueVisibility, tc.enableQueueVisibility)()
 		t.Run(name, func(t *testing.T) {
 			cq := utiltesting.MakeClusterQueue(cqName).
 				QueueingStrategy(kueue.StrictFIFO).Obj()

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -33,8 +33,12 @@ const (
 	//
 	// Enables partial admission.
 	PartialAdmission featuregate.Feature = "PartialAdmission"
-	// Enables cluster queue visibility.
-	ClusterQueueVisibility featuregate.Feature = "ClusterQueueVisibility"
+	// owner: @stuton
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/168-pending-workloads-visibility
+	// alpha: v0.5
+	//
+	// Enables queue visibility.
+	QueueVisibility featuregate.Feature = "QueueVisibility"
 )
 
 func init() {
@@ -48,8 +52,8 @@ func init() {
 // Entries are separated from each other with blank lines to avoid sweeping gofmt changes
 // when adding or removing one entry.
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PartialAdmission:       {Default: false, PreRelease: featuregate.Alpha},
-	ClusterQueueVisibility: {Default: false, PreRelease: featuregate.Alpha},
+	PartialAdmission: {Default: false, PreRelease: featuregate.Alpha},
+	QueueVisibility:  {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) func() {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -33,6 +33,8 @@ const (
 	//
 	// Enables partial admission.
 	PartialAdmission featuregate.Feature = "PartialAdmission"
+	// Enables cluster queue visibility.
+	ClusterQueueVisibility featuregate.Feature = "ClusterQueueVisibility"
 )
 
 func init() {
@@ -46,7 +48,8 @@ func init() {
 // Entries are separated from each other with blank lines to avoid sweeping gofmt changes
 // when adding or removing one entry.
 var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PartialAdmission: {Default: false, PreRelease: featuregate.Alpha},
+	PartialAdmission:       {Default: false, PreRelease: featuregate.Alpha},
+	ClusterQueueVisibility: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) func() {

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -226,4 +226,4 @@ The currently supported features are:
 | Feature | Default | Stage | Since | Until |
 |---------|---------|-------|-------|-------|
 | `PartialAdmission` | `false` | Alpha | 0.4 |  |
-| `ClusterQueueVisibility` | `false` | Alpha | 0.5 |  |
+| `QueueVisibility` | `false` | Alpha | 0.5 |  |

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -226,3 +226,4 @@ The currently supported features are:
 | Feature | Default | Stage | Since | Until |
 |---------|---------|-------|-------|-------|
 | `PartialAdmission` | `false` | Alpha | 0.4 |  |
+| `ClusterQueueVisibility` | `false` | Alpha | 0.5 |  |

--- a/test/integration/controller/core/admissioncheck_controller_test.go
+++ b/test/integration/controller/core/admissioncheck_controller_test.go
@@ -26,13 +26,23 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
 )
 
 // +kubebuilder:docs-gen:collapse=Imports
 
-var _ = ginkgo.Describe("AdmissionCheck controller", func() {
+var _ = ginkgo.Describe("AdmissionCheck controller", ginkgo.Ordered, func() {
 	var ns *corev1.Namespace
+
+	ginkgo.BeforeAll(func() {
+		fwk = &framework.Framework{CRDPath: crdPath, WebhookPath: webhookPath}
+		cfg = fwk.Init()
+		ctx, k8sClient = fwk.RunManager(cfg, managerSetup)
+	})
+	ginkgo.AfterAll(func() {
+		fwk.Teardown()
+	})
 
 	ginkgo.BeforeEach(func() {
 		ns = &corev1.Namespace{

--- a/test/integration/controller/core/admissioncheck_controller_test.go
+++ b/test/integration/controller/core/admissioncheck_controller_test.go
@@ -32,7 +32,7 @@ import (
 
 // +kubebuilder:docs-gen:collapse=Imports
 
-var _ = ginkgo.Describe("AdmissionCheck controller", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("AdmissionCheck controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var ns *corev1.Namespace
 
 	ginkgo.BeforeAll(func() {

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -80,6 +81,10 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 			},
 		}
 	)
+
+	ginkgo.BeforeAll(func() {
+		gomega.Expect(features.SetEnable(features.QueueVisibility, true)).To(gomega.Succeed())
+	})
 
 	ginkgo.BeforeEach(func() {
 		ns = &corev1.Namespace{
@@ -676,7 +681,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", func() {
 		})
 	})
 
-	ginkgo.When("Reconciling clusterQueue pending workload status", func() {
+	ginkgo.When("Reconciling clusterQueue pending workload status when queue visibility is enabled", ginkgo.Ordered, func() {
 		var (
 			clusterQueue   *kueue.ClusterQueue
 			localQueue     *kueue.LocalQueue

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -52,7 +52,7 @@ var ignoreConditionTimestamps = cmpopts.IgnoreFields(metav1.Condition{}, "LastTr
 var ignoreLastChangeTime = cmpopts.IgnoreFields(kueue.ClusterQueuePendingWorkloadsStatus{}, "LastChangeTime")
 var ignorePendingWorkloadsStatus = cmpopts.IgnoreFields(kueue.ClusterQueueStatus{}, "PendingWorkloadsStatus")
 
-var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns               *corev1.Namespace
 		emptyUsedFlavors = []kueue.FlavorUsage{
@@ -688,7 +688,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, func() {
 	})
 })
 
-var _ = ginkgo.Describe("ClusterQueue controller with queue visibility is enabled", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("ClusterQueue controller with queue visibility is enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var ns *corev1.Namespace
 
 	ginkgo.BeforeAll(func() {

--- a/test/integration/controller/core/localqueue_controller_test.go
+++ b/test/integration/controller/core/localqueue_controller_test.go
@@ -32,7 +32,7 @@ import (
 
 // +kubebuilder:docs-gen:collapse=Imports
 
-var _ = ginkgo.Describe("Queue controller", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("Queue controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	const (
 		flavorModelC = "model-c"
 		flavorModelD = "model-d"

--- a/test/integration/controller/core/localqueue_controller_test.go
+++ b/test/integration/controller/core/localqueue_controller_test.go
@@ -26,12 +26,13 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
 )
 
 // +kubebuilder:docs-gen:collapse=Imports
 
-var _ = ginkgo.Describe("Queue controller", func() {
+var _ = ginkgo.Describe("Queue controller", ginkgo.Ordered, func() {
 	const (
 		flavorModelC = "model-c"
 		flavorModelD = "model-d"
@@ -45,6 +46,15 @@ var _ = ginkgo.Describe("Queue controller", func() {
 			*testing.MakeResourceFlavor(flavorModelD).Label(resourceGPU.String(), flavorModelD).Obj(),
 		}
 	)
+
+	ginkgo.BeforeAll(func() {
+		fwk = &framework.Framework{CRDPath: crdPath, WebhookPath: webhookPath}
+		cfg = fwk.Init()
+		ctx, k8sClient = fwk.RunManager(cfg, managerSetup)
+	})
+	ginkgo.AfterAll(func() {
+		fwk.Teardown()
+	})
 
 	ginkgo.BeforeEach(func() {
 		ns = &corev1.Namespace{

--- a/test/integration/controller/core/resourceflavor_controller_test.go
+++ b/test/integration/controller/core/resourceflavor_controller_test.go
@@ -32,7 +32,7 @@ import (
 
 // +kubebuilder:docs-gen:collapse=Imports
 
-var _ = ginkgo.Describe("ResourceFlavor controller", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("ResourceFlavor controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var ns *corev1.Namespace
 
 	ginkgo.BeforeAll(func() {

--- a/test/integration/controller/core/resourceflavor_controller_test.go
+++ b/test/integration/controller/core/resourceflavor_controller_test.go
@@ -26,13 +26,23 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
 )
 
 // +kubebuilder:docs-gen:collapse=Imports
 
-var _ = ginkgo.Describe("ResourceFlavor controller", func() {
+var _ = ginkgo.Describe("ResourceFlavor controller", ginkgo.Ordered, func() {
 	var ns *corev1.Namespace
+
+	ginkgo.BeforeAll(func() {
+		fwk = &framework.Framework{CRDPath: crdPath, WebhookPath: webhookPath}
+		cfg = fwk.Init()
+		ctx, k8sClient = fwk.RunManager(cfg, managerSetup)
+	})
+	ginkgo.AfterAll(func() {
+		fwk.Teardown()
+	})
 
 	ginkgo.BeforeEach(func() {
 		ns = &corev1.Namespace{

--- a/test/integration/controller/core/suite_test.go
+++ b/test/integration/controller/core/suite_test.go
@@ -85,7 +85,7 @@ func managerSetup(mgr manager.Manager, ctx context.Context) {
 	cCache := cache.New(mgr.GetClient())
 	queues := queue.NewManager(mgr.GetClient(), cCache)
 
-	gomega.Expect(features.SetEnable(features.ClusterQueueVisibility, true)).To(gomega.Succeed())
+	gomega.Expect(features.SetEnable(features.QueueVisibility, true)).To(gomega.Succeed())
 
 	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, controllersCfg)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)

--- a/test/integration/controller/core/suite_test.go
+++ b/test/integration/controller/core/suite_test.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
-	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
@@ -84,8 +83,6 @@ func managerSetup(mgr manager.Manager, ctx context.Context) {
 
 	cCache := cache.New(mgr.GetClient())
 	queues := queue.NewManager(mgr.GetClient(), cCache)
-
-	gomega.Expect(features.SetEnable(features.QueueVisibility, true)).To(gomega.Succeed())
 
 	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, controllersCfg)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)

--- a/test/integration/controller/core/suite_test.go
+++ b/test/integration/controller/core/suite_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
@@ -83,6 +84,8 @@ func managerSetup(mgr manager.Manager, ctx context.Context) {
 
 	cCache := cache.New(mgr.GetClient())
 	queues := queue.NewManager(mgr.GetClient(), cCache)
+
+	gomega.Expect(features.SetEnable(features.ClusterQueueVisibility, true)).To(gomega.Succeed())
 
 	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, controllersCfg)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)

--- a/test/integration/controller/core/suite_test.go
+++ b/test/integration/controller/core/suite_test.go
@@ -38,10 +38,12 @@ import (
 )
 
 var (
-	cfg       *rest.Config
-	k8sClient client.Client
-	ctx       context.Context
-	fwk       *framework.Framework
+	cfg         *rest.Config
+	k8sClient   client.Client
+	ctx         context.Context
+	fwk         *framework.Framework
+	crdPath     = filepath.Join("..", "..", "..", "..", "config", "components", "crd", "bases")
+	webhookPath = filepath.Join("..", "..", "..", "..", "config", "components", "webhook")
 )
 
 func TestAPIs(t *testing.T) {
@@ -51,19 +53,6 @@ func TestAPIs(t *testing.T) {
 		"Core Controllers Suite",
 	)
 }
-
-var _ = ginkgo.BeforeSuite(func() {
-	fwk = &framework.Framework{
-		CRDPath:     filepath.Join("..", "..", "..", "..", "config", "components", "crd", "bases"),
-		WebhookPath: filepath.Join("..", "..", "..", "..", "config", "components", "webhook"),
-	}
-	cfg = fwk.Init()
-	ctx, k8sClient = fwk.RunManager(cfg, managerSetup)
-})
-
-var _ = ginkgo.AfterSuite(func() {
-	fwk.Teardown()
-})
 
 func managerSetup(mgr manager.Manager, ctx context.Context) {
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())

--- a/test/integration/controller/core/workload_controller_test.go
+++ b/test/integration/controller/core/workload_controller_test.go
@@ -35,7 +35,7 @@ import (
 
 // +kubebuilder:docs-gen:collapse=Imports
 
-var _ = ginkgo.Describe("Workload controller", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("Workload controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns                   *corev1.Namespace
 		updatedQueueWorkload kueue.Workload

--- a/test/integration/controller/core/workload_controller_test.go
+++ b/test/integration/controller/core/workload_controller_test.go
@@ -29,12 +29,13 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	"sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
 )
 
 // +kubebuilder:docs-gen:collapse=Imports
 
-var _ = ginkgo.Describe("Workload controller", func() {
+var _ = ginkgo.Describe("Workload controller", ginkgo.Ordered, func() {
 	var (
 		ns                   *corev1.Namespace
 		updatedQueueWorkload kueue.Workload
@@ -43,6 +44,15 @@ var _ = ginkgo.Describe("Workload controller", func() {
 		message              string
 		clusterQueue         *kueue.ClusterQueue
 	)
+
+	ginkgo.BeforeAll(func() {
+		fwk = &framework.Framework{CRDPath: crdPath, WebhookPath: webhookPath}
+		cfg = fwk.Init()
+		ctx, k8sClient = fwk.RunManager(cfg, managerSetup)
+	})
+	ginkgo.AfterAll(func() {
+		fwk.Teardown()
+	})
 
 	ginkgo.BeforeEach(func() {
 		ns = &corev1.Namespace{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Enable visibility of cluster queue using feature gate flag

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1102 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enabling/disabling visibility of cluster queue using feature gate flag
```