### PR TITLE
Ensure whether or not framework CRDs are installed by meta.IsNoMatchError()

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -227,13 +226,7 @@ func setupControllers(mgr ctrl.Manager, cCache *cache.Cache, queues *queue.Manag
 				return err
 			}
 			if _, err = mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
-				// TODO: If the below PR is released, we need to change a way to check if the GVK is registered.
-				// REF: https://github.com/kubernetes-sigs/controller-runtime/pull/2425
-				// if !meta.IsNoMatchError(err) {
-				//   return err
-				// }
-				var NoMatchingErr *discovery.ErrGroupDiscoveryFailed
-				if !meta.IsNoMatchError(err) && !errors.As(err, &NoMatchingErr) {
+				if !meta.IsNoMatchError(err) {
 					return err
 				}
 				log.Info("No matching API server for job framework, skip to create controller and webhook")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The kueue-controller should ensure whether or not framework CRDs are installed by `meta.IsNoMatchError()`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1054

#### Special notes for your reviewer:
I verified that the improvement works fine on my local:


```
...
{"level":"info","ts":"2023-09-19T18:33:52.997737585Z","logger":"setup","caller":"kueue/main.go:239","msg":"No matching API server for job framework, skip to create controller and webhook","jobFrameworkName":"jobset.x-k8s.io/jobset"}
...
{"level":"info","ts":"2023-09-19T18:33:52.998965835Z","logger":"setup","caller":"kueue/main.go:239","msg":"No matching API server for job framework, skip to create controller and webhook","jobFrameworkName":"kubeflow.org/pytorchjob"}
...
{"level":"info","ts":"2023-09-19T18:33:53.000000335Z","logger":"setup","caller":"kueue/main.go:239","msg":"No matching API server for job framework, skip to create controller and webhook","jobFrameworkName":"kubeflow.org/tfjob"}
...
{"level":"info","ts":"2023-09-19T18:33:53.003614335Z","logger":"setup","caller":"kueue/main.go:239","msg":"No matching API server for job framework, skip to create controller and webhook","jobFrameworkName":"kubeflow.org/xgboostjob"}
...
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```