### PR TITLE
Replace utils/maps::Clone function with std maps::Clone function after it was introduced in go 1.21

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,7 +39,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/equality"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
-	"sigs.k8s.io/kueue/pkg/util/maps"
 	utilpriority "sigs.k8s.io/kueue/pkg/util/priority"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	"sigs.k8s.io/kueue/pkg/workload"

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -19,6 +19,7 @@ package job
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -40,7 +41,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	"sigs.k8s.io/kueue/pkg/util/maps"
+	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 )
 
 var (
@@ -218,7 +219,7 @@ func (j *Job) RunWithPodSetsInfo(podSetsInfo []jobframework.PodSetInfo) error {
 	}
 
 	info := podSetsInfo[0]
-	j.Spec.Template.Spec.NodeSelector = maps.MergeKeepFirst(info.NodeSelector, j.Spec.Template.Spec.NodeSelector)
+	j.Spec.Template.Spec.NodeSelector = utilmaps.MergeKeepFirst(info.NodeSelector, j.Spec.Template.Spec.NodeSelector)
 
 	if j.minPodsCount() != nil {
 		j.Spec.Parallelism = ptr.To(info.Count)

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -18,6 +18,7 @@ package jobset
 
 import (
 	"context"
+	"maps"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -32,7 +33,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	"sigs.k8s.io/kueue/pkg/util/maps"
+	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 )
 
@@ -124,7 +125,7 @@ func (j *JobSet) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error
 	// before unsuspending the individual Jobs.
 	for index := range j.Spec.ReplicatedJobs {
 		templateSpec := &j.Spec.ReplicatedJobs[index].Template.Spec.Template.Spec
-		templateSpec.NodeSelector = maps.MergeKeepFirst(podSetInfos[index].NodeSelector, templateSpec.NodeSelector)
+		templateSpec.NodeSelector = utilmaps.MergeKeepFirst(podSetInfos[index].NodeSelector, templateSpec.NodeSelector)
 	}
 	return nil
 }

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package kubeflowjob
 
 import (
+	"maps"
 	"strings"
 
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
@@ -29,7 +30,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	"sigs.k8s.io/kueue/pkg/util/maps"
+	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 )
 
 type KubeflowJob struct {
@@ -64,7 +65,7 @@ func (j *KubeflowJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) 
 		replicaType := orderedReplicaTypes[index]
 		info := podSetInfos[index]
 		replicaSpec := &j.KFJobControl.ReplicaSpecs()[replicaType].Template.Spec
-		replicaSpec.NodeSelector = maps.MergeKeepFirst(info.NodeSelector, replicaSpec.NodeSelector)
+		replicaSpec.NodeSelector = utilmaps.MergeKeepFirst(info.NodeSelector, replicaSpec.NodeSelector)
 	}
 	return nil
 }

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -18,6 +18,7 @@ package mpijob
 
 import (
 	"context"
+	"maps"
 	"strings"
 
 	kubeflow "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
@@ -32,7 +33,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	"sigs.k8s.io/kueue/pkg/util/maps"
+	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 )
 
 var (
@@ -129,7 +130,7 @@ func (j *MPIJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error
 		replicaType := orderedReplicaTypes[index]
 		info := podSetInfos[index]
 		replicaSpec := &j.Spec.MPIReplicaSpecs[replicaType].Template.Spec
-		replicaSpec.NodeSelector = maps.MergeKeepFirst(info.NodeSelector, replicaSpec.NodeSelector)
+		replicaSpec.NodeSelector = utilmaps.MergeKeepFirst(info.NodeSelector, replicaSpec.NodeSelector)
 	}
 	return nil
 }

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -18,6 +18,7 @@ package rayjob
 
 import (
 	"context"
+	"maps"
 	"strings"
 
 	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
@@ -29,7 +30,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	"sigs.k8s.io/kueue/pkg/util/maps"
+	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 )
 
 var (
@@ -123,12 +124,12 @@ func (j *RayJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error
 
 	// head
 	headPodSpec := &j.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec
-	headPodSpec.NodeSelector = maps.MergeKeepFirst(podSetInfos[0].NodeSelector, headPodSpec.NodeSelector)
+	headPodSpec.NodeSelector = utilmaps.MergeKeepFirst(podSetInfos[0].NodeSelector, headPodSpec.NodeSelector)
 
 	// workers
 	for index := range j.Spec.RayClusterSpec.WorkerGroupSpecs {
 		workerPodSpec := &j.Spec.RayClusterSpec.WorkerGroupSpecs[index].Template.Spec
-		workerPodSpec.NodeSelector = maps.MergeKeepFirst(podSetInfos[index+1].NodeSelector, workerPodSpec.NodeSelector)
+		workerPodSpec.NodeSelector = utilmaps.MergeKeepFirst(podSetInfos[index+1].NodeSelector, workerPodSpec.NodeSelector)
 	}
 	return nil
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"time"
@@ -45,7 +46,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	"sigs.k8s.io/kueue/pkg/util/limitrange"
-	"sigs.k8s.io/kueue/pkg/util/maps"
+	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 	"sigs.k8s.io/kueue/pkg/util/priority"
 	"sigs.k8s.io/kueue/pkg/util/resource"
 	"sigs.k8s.io/kueue/pkg/util/routine"
@@ -120,7 +121,7 @@ func (cu *cohortsUsage) add(cohort string, assigment cache.FlavorResourceQuantit
 
 	for flavor, resources := range assigment {
 		if _, found := cohortUsage[flavor]; found {
-			cohortUsage[flavor] = maps.Merge(cohortUsage[flavor], resources, func(a, b int64) int64 { return a + b })
+			cohortUsage[flavor] = utilmaps.Merge(cohortUsage[flavor], resources, func(a, b int64) int64 { return a + b })
 		} else {
 			cohortUsage[flavor] = maps.Clone(resources)
 		}
@@ -129,8 +130,8 @@ func (cu *cohortsUsage) add(cohort string, assigment cache.FlavorResourceQuantit
 }
 
 func (cu *cohortsUsage) totalUsageForCommonFlavorResources(cohort string, assigment cache.FlavorResourceQuantities) cache.FlavorResourceQuantities {
-	return maps.Intersect((*cu)[cohort], assigment, func(a, b map[corev1.ResourceName]int64) map[corev1.ResourceName]int64 {
-		return maps.Intersect(a, b, func(a, b int64) int64 { return a + b })
+	return utilmaps.Intersect((*cu)[cohort], assigment, func(a, b map[corev1.ResourceName]int64) map[corev1.ResourceName]int64 {
+		return utilmaps.Intersect(a, b, func(a, b int64) int64 { return a + b })
 	})
 }
 

--- a/pkg/util/maps/maps.go
+++ b/pkg/util/maps/maps.go
@@ -18,30 +18,17 @@ limitations under the License.
 // when `x/exp/maps` graduates to stable.
 package maps
 
-// Clone clones the input preserving the difference between nil and empty
-func Clone[K comparable, V any, S ~map[K]V](s S) S {
-	if s == nil {
-		return nil
-	}
-
-	if len(s) == 0 {
-		return S{}
-	}
-
-	ret := make(S, len(s))
-	for k, v := range s {
-		ret[k] = v
-	}
-	return ret
-}
+import (
+	"maps"
+)
 
 // Merge merges a and b while resolving the conflicts by calling commonKeyValue
 func Merge[K comparable, V any, S ~map[K]V](a, b S, commonKeyValue func(a, b V) V) S {
 	if a == nil {
-		return Clone(b)
+		return maps.Clone(b)
 	}
 
-	ret := Clone(a)
+	ret := maps.Clone(a)
 
 	for k, v := range b {
 		if _, found := a[k]; found {

--- a/pkg/util/maps/maps_test.go
+++ b/pkg/util/maps/maps_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package maps
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -46,7 +47,7 @@ func TestToRefMap(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			result := Clone(tc.orig)
+			result := maps.Clone(tc.orig)
 			if diff := cmp.Diff(tc.orig, result); diff != "" {
 				t.Errorf("Unexpected result (-want,+got):\n%s", diff)
 			}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -19,6 +19,7 @@ package workload
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -33,7 +34,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	"sigs.k8s.io/kueue/pkg/util/limitrange"
-	"sigs.k8s.io/kueue/pkg/util/maps"
 )
 
 var (

--- a/test/integration/controller/jobs/job/job_controller_test.go
+++ b/test/integration/controller/jobs/job/job_controller_test.go
@@ -18,6 +18,7 @@ package job
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
@@ -38,7 +39,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
-	"sigs.k8s.io/kueue/pkg/util/maps"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/pkg/workload"


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### Which issue(s) this PR fixes:
Fixes #1047

#### Special notes for your reviewer:
PR made according to the [discussion](https://github.com/kubernetes-sigs/kueue/pull/1141#discussion_r1332910569) 

#### Does this PR introduce a user-facing change?
```
NONE
```