### PR TITLE
[slices] Avoid unnecessary allocation in CmpNoOrder

### DIFF
--- a/pkg/util/slices/slices.go
+++ b/pkg/util/slices/slices.go
@@ -63,22 +63,20 @@ func Map[From any, To any, S ~[]From](s S, mapFunc func(*From) To) []To {
 }
 
 // CmpNoOrder returns true if the two provided slices have the same elements
-// regardless of their order. It counts occurences of particular values in both slices and
-// then compares them.
+// regardless of their order.
 func CmpNoOrder[E comparable, S ~[]E](a, b S) bool {
 	if len(a) != len(b) {
 		return false
 	}
 
-	counterA := make(map[E]int)
-	counterB := make(map[E]int)
+	counters := make(map[E]int, len(a))
 	for i := range a {
-		counterA[a[i]] = counterA[a[i]] + 1
-		counterB[b[i]] = counterB[b[i]] + 1
+		counters[a[i]]++
+		counters[b[i]]--
 	}
 
-	for k := range counterA {
-		if counterA[k] != counterB[k] {
+	for _, v := range counters {
+		if v != 0 {
 			return false
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 Avoid unnecessary allocation in CmpNoOrde
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```