### PR TITLE
[DOC] Queue visibility documentation

### DIFF
--- a/site/content/en/docs/tasks/_index.md
+++ b/site/content/en/docs/tasks/_index.md
@@ -23,6 +23,8 @@ As a batch administrator, you can learn how to:
   to Kueue objects.
 - [Administer cluster quotas](/docs/tasks/administer_cluster_quotas) with ClusterQueues and LocalQueues.
 - Setup [Sequential Admission with Ready Pods](/docs/tasks/setup_sequential_admission).
+- As a batch administrator, you can learn how to
+  [monitor pending workloads](/docs/tasks/monitor_pending_workloads).
 
 ### Batch user
 

--- a/site/content/en/docs/tasks/monitor_pending_workloads.md
+++ b/site/content/en/docs/tasks/monitor_pending_workloads.md
@@ -1,0 +1,94 @@
+---
+title: "Monitor pending workloads"
+date: 2023-09-27
+weight: 3
+description: >
+  Monitor pending workloads.
+---
+
+This page shows you how to monitor pending workloads.
+
+The intended audience for this page are [batch administrators](/docs/tasks#batch-administrator).
+
+From version v0.5.0, Kueue provides the ability for a batch administrators to monitor
+the pipeline of pending jobs, and help users to estimate when their jobs will
+start.
+
+## Before you begin
+
+Make sure the following conditions are met:
+
+- A Kubernetes cluster is running.
+- The kubectl command-line tool has communication with your cluster.
+- [Kueue is installed](/docs/installation) in version 0.5.0 or later.
+
+## Enabling feature QueueVisibility
+
+QueueVisibility is an `Alpha` feature disabled by default, check the [Change the feature gates configuration](/docs/installation/#change-the-feature-gates-configuration) section of the [Installation](/docs/installation/) for details.
+
+## Monitor pending workloads
+
+> _Available in Kueue v0.5.0 and later_
+To install a simple setup of cluster queue, run the following command:
+
+```shell
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/kueue/main/site/static/examples/admin/single-clusterqueue-setup.yaml
+```
+
+For example, let's create 10 jobs in a loop
+
+```shell
+for i in {1..10}; do kubectl create -f https://raw.githubusercontent.com/kubernetes-sigs/kueue/main/site/static/examples/jobs/sample-job.yaml; done
+```
+
+To view the pending workload status, run the following command:
+
+```shell
+kubectl describe clusterqueues.kueue.x-k8s.io
+```
+
+The output is similar to the following:
+
+```shell
+Status:
+  ...
+  Pending Workloads:  10
+  Pending Workloads Status:
+    Cluster Queue Pending Workload:
+      Name:            job-sample-job-gswhv-afff9
+      Namespace:       default
+      Name:            job-sample-job-v8dwc-ab5b7
+      Namespace:       default
+      Name:            job-sample-job-lrxbj-a9a91
+      Namespace:       default
+      Name:            job-sample-job-dj6nb-e6ef8
+      Namespace:       default
+      Name:            job-sample-job-6hdgw-bb26e
+      Namespace:       default
+      Name:            job-sample-job-2d268-693a7
+      Namespace:       default
+      Name:            job-sample-job-bfkd7-5e739
+      Namespace:       default
+      Name:            job-sample-job-8sbgz-506c6
+      Namespace:       default
+      Name:            job-sample-job-k2bmq-44616
+      Namespace:       default
+      Name:            job-sample-job-c724j-50fd2
+      Namespace:       default
+    Last Change Time:  2023-09-28T09:22:12Z
+```
+
+The `QueueVisibility.ClusterQueues.MaxCount` parameter indicates the maximal number of pending workloads exposed in the ClusterQueue status. By default, Kueue will set this parameter to 10. When the value is set to 0, then ClusterQueues visibility updates are disabled.
+
+```yaml
+    queueVisibility:
+      clusterQueues: 
+        maxCount: 0
+```
+
+The `QueueVisibility.UpdateIntervalSeconds` parameter allows to control the period of snapshot updates after Kueue startup. Defaults to 5s. It also can be changed in Kueue configuration
+
+```yaml
+    queueVisibility:
+      updateIntervalSeconds: 5s
+```

--- a/site/content/en/docs/tasks/monitor_pending_workloads.md
+++ b/site/content/en/docs/tasks/monitor_pending_workloads.md
@@ -20,7 +20,7 @@ Make sure the following conditions are met:
 
 - A Kubernetes cluster is running.
 - The kubectl command-line tool has communication with your cluster.
-- [Kueue is installed](/docs/installation) in version 0.5.0 or later.
+- [Kueue is installed](/docs/installation) in version v0.5.0 or later.
 
 ## Enabling feature QueueVisibility
 
@@ -79,7 +79,9 @@ Status:
     Last Change Time:  2023-09-28T09:22:12Z
 ```
 
-The `QueueVisibility.ClusterQueues.MaxCount` parameter indicates the maximal number of pending workloads exposed in the ClusterQueue status. 
+To configure queue visibility, please, follow the instruction how to [install Kueue with a custom manager configuration](/docs/installation/#install-a-custom-configured-released-version).
+
+The `queueVisibility.clusterQueues.maxCount` parameter indicates the maximal number of pending workloads exposed in the ClusterQueue status. 
 By default, Kueue will set this parameter to 10. 
 When the value is set to 0, then ClusterQueues visibility updates are disabled.
 
@@ -89,7 +91,7 @@ When the value is set to 0, then ClusterQueues visibility updates are disabled.
         maxCount: 0
 ```
 
-The `QueueVisibility.UpdateIntervalSeconds` parameter allows to control the period of snapshot updates after Kueue startup. 
+The `queueVisibility.updateIntervalSeconds` parameter allows to control the period of snapshot updates after Kueue startup. 
 Defaults to 5s. 
 It also can be changed in Kueue configuration:
 

--- a/site/content/en/docs/tasks/monitor_pending_workloads.md
+++ b/site/content/en/docs/tasks/monitor_pending_workloads.md
@@ -29,6 +29,7 @@ QueueVisibility is an `Alpha` feature disabled by default, check the [Change the
 ## Monitor pending workloads
 
 > _Available in Kueue v0.5.0 and later_
+
 To install a simple setup of cluster queue, run the following command:
 
 ```shell
@@ -78,7 +79,9 @@ Status:
     Last Change Time:  2023-09-28T09:22:12Z
 ```
 
-The `QueueVisibility.ClusterQueues.MaxCount` parameter indicates the maximal number of pending workloads exposed in the ClusterQueue status. By default, Kueue will set this parameter to 10. When the value is set to 0, then ClusterQueues visibility updates are disabled.
+The `QueueVisibility.ClusterQueues.MaxCount` parameter indicates the maximal number of pending workloads exposed in the ClusterQueue status. 
+By default, Kueue will set this parameter to 10. 
+When the value is set to 0, then ClusterQueues visibility updates are disabled.
 
 ```yaml
     queueVisibility:
@@ -86,7 +89,9 @@ The `QueueVisibility.ClusterQueues.MaxCount` parameter indicates the maximal num
         maxCount: 0
 ```
 
-The `QueueVisibility.UpdateIntervalSeconds` parameter allows to control the period of snapshot updates after Kueue startup. Defaults to 5s. It also can be changed in Kueue configuration
+The `QueueVisibility.UpdateIntervalSeconds` parameter allows to control the period of snapshot updates after Kueue startup. 
+Defaults to 5s. 
+It also can be changed in Kueue configuration:
 
 ```yaml
     queueVisibility:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1159

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
added a page that describes monitoring pending workloads
```