### PR TITLE
Preemption admission check controller. KEP update.

### DIFF
--- a/keps/993-two-phase-admission/README.md
+++ b/keps/993-two-phase-admission/README.md
@@ -271,7 +271,7 @@ The preemption controller uses the kueue cache, since it needs to check the stat
 At every run the controller will get the list of workloads pending preemption.
 
 The workloads pending preemption are divided into:
-- `preemtingLeter` - Workloads having at least one check that uses AfterCheckPassedOrOnDemand policy with the state `pending`.
+- `preemtingLater` - Workloads having at least one check that uses AfterCheckPassedOrOnDemand policy with the state `pending`.
 - `preemtingNow` - Workloads that expect to be able to issue evictions or potentially change their preemption state in the current cycle.
 
 Then:

--- a/keps/993-two-phase-admission/README.md
+++ b/keps/993-two-phase-admission/README.md
@@ -260,7 +260,7 @@ In this proposal, the time to evict the preemption candidates varies based on th
 the scheduler will not issue the eviction during it's process instead it will set a `Pending` admission check
 that is manged by a new built-in admission check controller.
 
-The **Admission Check Controller** will:
+The **Preemption Admission Check Controller** will:
 
 - Watch for a change in state of the workloads pending preemption.
 - Watch for workloads that are finishing execution and therefore releasing quota.

--- a/keps/993-two-phase-admission/README.md
+++ b/keps/993-two-phase-admission/README.md
@@ -256,7 +256,7 @@ The controller implementing a particular check should:
 
 ### Preemption Admission Check Controller
 
-Because now, the time when the eviction of the preemption candidate should vary based on the preemptor state
+In this proposal, the time to evict the preemption candidates varies based on the preemptor state
 the scheduler will not issue the eviction during it's process instead it will set a `Pending` admission check
 that is manged by a new built-in admission check controller.
 
@@ -266,13 +266,13 @@ The **Admission Check Controller** will:
 - Watch for workloads that are finishing execution and therefore releasing quota.
 - Watch for AdmissionCheck changes, since the preemption policy can change.
 
-Since evaluating the current preemption state and the needs of a workload requires checking the sate of all resource pool the events are rate limited the kueue's cache is used.
+The preemption controller uses the kueue cache, since it needs to check the state of workloads admitted to the ClusterQueues.
 
 At every run the controller will get the list of workloads pending preemption.
-Since for some of these workloads is not necessary to issue eviction at that given point (eg. Having a pending check that uses AfterCheckPassedOrOnDemand policy) their quota reservation will be ignored.
-Fore every other preemption pending workloads, it will check if it can fit without evicting other workloads, case in which the preemption admission check condition will be set to `Ready`.
-If eviction of other workload is still needed, an updated list candidates is created and eviction is issued for all of them.
-If the updated list of candidates is empty, meaning that the preemption can no longer succeed, the preemption admission check is set as `Retry`, the workload will louse it's quota reservation and requeued.
+1. Since for some of these workloads is not necessary to issue eviction at that given point (eg. Having a pending check that uses AfterCheckPassedOrOnDemand policy) their quota reservation will be ignored.
+2. For every other preemption pending workloads, it will check if it can fit without evicting other workloads, case in which the preemption admission check condition will be set to `Ready`.
+3. If eviction of other workload is still needed, an updated list candidates is created and eviction is issued for all of them.
+4. If the updated list of candidates is empty, meaning that the preemption can no longer succeed, the preemption admission check is set as `Retry`, the workload will lose it's quota reservation and be requeued.
 
 
 ### Test Plan

--- a/keps/993-two-phase-admission/README.md
+++ b/keps/993-two-phase-admission/README.md
@@ -256,9 +256,9 @@ The controller implementing a particular check should:
 
 ### Preemption Admission Check Controller
 
-In this proposal, the time to evict the preemption candidates varies based on the preemptor state
-the scheduler will not issue the eviction during it's process instead it will set a `Pending` admission check
-that is manged by a new built-in admission check controller.
+In this proposal, the time to evict the preemption candidates varies based on the preemptor state.
+The scheduler will not issue the eviction during it's process instead it will set a `Pending` admission check
+that is manged by a single instance of a new built-in admission check controller.
 
 The **Preemption Admission Check Controller** will:
 
@@ -271,7 +271,7 @@ The preemption controller uses the kueue cache, since it needs to check the stat
 At every run the controller will get the list of workloads pending preemption.
 
 The workloads pending preemption are divided into:
-- `preemtingLetaer` - Workloads having at least one check that uses AfterCheckPassedOrOnDemand policy with the state `pending`.
+- `preemtingLeter` - Workloads having at least one check that uses AfterCheckPassedOrOnDemand policy with the state `pending`.
 - `preemtingNow` - Workloads that expect to be able to issue evictions or potentially change their preemption state in the current cycle.
 
 Then:
@@ -286,7 +286,9 @@ Then:
         - Issue the eviction to the candidates.
         - Add it to the snapshot
       - If the updated list is empty, meaning the preemption cannot be done.
-        - Set its admission check to `Ready`
+        - Set its admission check to `Retry`, the quota reservation will be lost and the workload placed in the queue waiting for a new QuotaReservation.
+
+**NOTE** The list of candidates is picked out from the list of workloads holding a QuotaReservation, regardless if they are fully Admitted or not.
 
 ### Test Plan
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Preemption admission check controller. KEP update.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1677

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```