### PR TITLE
[cherry-pick] Fix: Adjust resources when the LocalQueue is created after workloads …

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -26,7 +26,6 @@ import (
 	nodev1 "k8s.io/api/node/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -38,8 +37,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/queue"
-	"sigs.k8s.io/kueue/pkg/util/limitrange"
-	"sigs.k8s.io/kueue/pkg/util/resource"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -189,8 +186,9 @@ func (r *WorkloadReconciler) Create(e event.CreateEvent) bool {
 		return true
 	}
 
+	ctx := ctrl.LoggerInto(context.Background(), log)
 	wlCopy := wl.DeepCopy()
-	r.adjustResources(log, wlCopy)
+	workload.AdjustResources(ctx, r.client, wlCopy)
 
 	if !workload.IsAdmitted(wl) {
 		if !r.queues.AddOrUpdateWorkload(wlCopy) {
@@ -276,7 +274,7 @@ func (r *WorkloadReconciler) Update(e event.UpdateEvent) bool {
 
 	wlCopy := wl.DeepCopy()
 	// We do not handle old workload here as it will be deleted or replaced by new one anyway.
-	r.adjustResources(log, wlCopy)
+	workload.AdjustResources(ctrl.LoggerInto(ctx, log), r.client, wlCopy)
 
 	switch {
 	case status == finished:
@@ -394,81 +392,6 @@ func workloadStatus(w *kueue.Workload) string {
 	return pending
 }
 
-// We do not verify Pod's RuntimeClass legality here as this will be performed in admission controller.
-// As a result, the pod's Overhead is not always correct. E.g. if we set a non-existent runtime class name to
-// `pod.Spec.RuntimeClassName` and we also set the `pod.Spec.Overhead`, in real world, the pod creation will be
-// rejected due to the mismatch with RuntimeClass. However, in the future we assume that they are correct.
-func (r *WorkloadReconciler) handlePodOverhead(log logr.Logger, wl *kueue.Workload) {
-	ctx := context.Background()
-
-	for i := range wl.Spec.PodSets {
-		podSpec := &wl.Spec.PodSets[i].Template.Spec
-		if podSpec.RuntimeClassName != nil && len(podSpec.Overhead) == 0 {
-			var runtimeClass nodev1.RuntimeClass
-			if err := r.client.Get(ctx, types.NamespacedName{Name: *podSpec.RuntimeClassName}, &runtimeClass); err != nil {
-				log.Error(err, "Could not get RuntimeClass")
-				continue
-			}
-			if runtimeClass.Overhead != nil {
-				podSpec.Overhead = runtimeClass.Overhead.PodFixed
-			}
-		}
-	}
-}
-
-func (r *WorkloadReconciler) handlePodLimitRange(log logr.Logger, wl *kueue.Workload) {
-	ctx := context.TODO()
-	// get the list of limit ranges
-	var list corev1.LimitRangeList
-	if err := r.client.List(ctx, &list, &client.ListOptions{Namespace: wl.Namespace}, client.MatchingFields{indexer.LimitRangeHasContainerType: "true"}); err != nil {
-		log.Error(err, "Could not list LimitRanges")
-		return
-	}
-
-	if len(list.Items) == 0 {
-		return
-	}
-	summary := limitrange.Summarize(list.Items...)
-	containerLimits, found := summary[corev1.LimitTypeContainer]
-	if !found {
-		return
-	}
-
-	for pi := range wl.Spec.PodSets {
-		pod := &wl.Spec.PodSets[pi].Template.Spec
-		for ci := range pod.InitContainers {
-			res := &pod.InitContainers[ci].Resources
-			res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
-			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
-		}
-		for ci := range pod.Containers {
-			res := &pod.Containers[ci].Resources
-			res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
-			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
-		}
-	}
-}
-
-func (r *WorkloadReconciler) handleLimitsToRequests(wl *kueue.Workload) {
-	for pi := range wl.Spec.PodSets {
-		pod := &wl.Spec.PodSets[pi].Template.Spec
-		for ci := range pod.InitContainers {
-			res := &pod.InitContainers[ci].Resources
-			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, res.Limits)
-		}
-		for ci := range pod.Containers {
-			res := &pod.Containers[ci].Resources
-			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, res.Limits)
-		}
-	}
-}
-
-func (r *WorkloadReconciler) adjustResources(log logr.Logger, wl *kueue.Workload) {
-	r.handlePodOverhead(log, wl)
-	r.handlePodLimitRange(log, wl)
-	r.handleLimitsToRequests(wl)
-}
-
 type resourceUpdatesHandler struct {
 	r *WorkloadReconciler
 }
@@ -525,7 +448,7 @@ func (h *resourceUpdatesHandler) queueReconcileForPending(ctx context.Context, _
 		wlCopy := w.DeepCopy()
 		log := log.WithValues("workload", klog.KObj(wlCopy))
 		log.V(5).Info("Queue reconcile for")
-		h.r.adjustResources(log, wlCopy)
+		workload.AdjustResources(ctrl.LoggerInto(ctx, log), h.r.client, wlCopy)
 		if !h.r.queues.AddOrUpdateWorkload(wlCopy) {
 			log.V(2).Info("Queue for workload didn't exist")
 		}

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -168,6 +168,7 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 		if workload.IsAdmitted(&w) {
 			continue
 		}
+		workload.AdjustResources(ctx, m.client, &w)
 		qImpl.AddOrUpdate(workload.NewInfo(&w))
 	}
 	cq := m.clusterQueues[qImpl.ClusterQueue]

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package workload
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	nodev1 "k8s.io/api/node/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/util/limitrange"
+	"sigs.k8s.io/kueue/pkg/util/resource"
+)
+
+// We do not verify Pod's RuntimeClass legality here as this will be performed in admission controller.
+// As a result, the pod's Overhead is not always correct. E.g. if we set a non-existent runtime class name to
+// `pod.Spec.RuntimeClassName` and we also set the `pod.Spec.Overhead`, in real world, the pod creation will be
+// rejected due to the mismatch with RuntimeClass. However, in the future we assume that they are correct.
+func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload) []error {
+	var errs []error
+	for i := range wl.Spec.PodSets {
+		podSpec := &wl.Spec.PodSets[i].Template.Spec
+		if podSpec.RuntimeClassName != nil && len(podSpec.Overhead) == 0 {
+			var runtimeClass nodev1.RuntimeClass
+			if err := cl.Get(ctx, types.NamespacedName{Name: *podSpec.RuntimeClassName}, &runtimeClass); err != nil {
+				errs = append(errs, fmt.Errorf("in podSet %s: %w", wl.Spec.PodSets[i].Name, err))
+				continue
+			}
+			if runtimeClass.Overhead != nil {
+				podSpec.Overhead = runtimeClass.Overhead.PodFixed
+			}
+		}
+	}
+	return errs
+}
+
+func handlePodLimitRange(ctx context.Context, cl client.Client, wl *kueue.Workload) error {
+	// get the list of limit ranges
+	var list corev1.LimitRangeList
+	if err := cl.List(ctx, &list, &client.ListOptions{Namespace: wl.Namespace}, client.MatchingFields{indexer.LimitRangeHasContainerType: "true"}); err != nil {
+		return err
+	}
+
+	if len(list.Items) == 0 {
+		return nil
+	}
+	summary := limitrange.Summarize(list.Items...)
+	containerLimits, found := summary[corev1.LimitTypeContainer]
+	if !found {
+		return nil
+	}
+
+	for pi := range wl.Spec.PodSets {
+		pod := &wl.Spec.PodSets[pi].Template.Spec
+		for ci := range pod.InitContainers {
+			res := &pod.InitContainers[ci].Resources
+			res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
+			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
+		}
+		for ci := range pod.Containers {
+			res := &pod.Containers[ci].Resources
+			res.Limits = resource.MergeResourceListKeepFirst(res.Limits, containerLimits.Default)
+			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, containerLimits.DefaultRequest)
+		}
+	}
+	return nil
+}
+
+func handleLimitsToRequests(wl *kueue.Workload) {
+	for pi := range wl.Spec.PodSets {
+		pod := &wl.Spec.PodSets[pi].Template.Spec
+		for ci := range pod.InitContainers {
+			res := &pod.InitContainers[ci].Resources
+			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, res.Limits)
+		}
+		for ci := range pod.Containers {
+			res := &pod.Containers[ci].Resources
+			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, res.Limits)
+		}
+	}
+}
+
+// AdjustResources adjusts the resource requests of a workload based on:
+// - PodOverhead
+// - LimitRanges
+// - Limits
+func AdjustResources(ctx context.Context, cl client.Client, wl *kueue.Workload) {
+	log := ctrl.LoggerFrom(ctx)
+	for _, err := range handlePodOverhead(ctx, cl, wl) {
+		log.Error(err, "Failures adjusting requests for pod overhead")
+	}
+	if err := handlePodLimitRange(ctx, cl, wl); err != nil {
+		log.Error(err, "Failed adjusting requests for LimitRanges")
+	}
+	handleLimitsToRequests(wl)
+}

--- a/test/integration/scheduler/workload_controller_test.go
+++ b/test/integration/scheduler/workload_controller_test.go
@@ -285,7 +285,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 		})
 	})
 
-	ginkgo.When("When the workload defines only resource limits", func() {
+	ginkgo.When("the workload defines only resource limits and the LocalQueue is created late", func() {
 		ginkgo.BeforeEach(func() {
 			gomega.Expect(k8sClient.Create(ctx, onDemandFlavor)).To(gomega.Succeed())
 			clusterQueue = testing.MakeClusterQueue("clusterqueue").
@@ -294,7 +294,6 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
 			localQueue = testing.MakeLocalQueue("queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
-			gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
 		})
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
@@ -306,9 +305,11 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			ginkgo.By("Create and wait for workload admission", func() {
 				wl = testing.MakeWorkload("one", ns.Name).
 					Queue(localQueue.Name).
-					Request(corev1.ResourceCPU, "1").
+					Limit(corev1.ResourceCPU, "1").
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+				gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
 
 				gomega.Eventually(func() bool {
 					read := kueue.Workload{}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Cherry-pick of #1197

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adjust resources (based on LimitRanges, PodOverhead and resource limits) on existing Workloads when a LocalQueue is created
```