### PR TITLE
Improve naming consistency for podSetsInfo

### DIFF
--- a/cmd/experimental/podtaintstolerations/controller/pod_jobs.go
+++ b/cmd/experimental/podtaintstolerations/controller/pod_jobs.go
@@ -73,7 +73,7 @@ func (p *Pod) Suspend() {
 	// Not used, see Stop()
 }
 
-func (p *Pod) Stop(ctx context.Context, c client.Client, podSetInfos []jobframework.PodSetInfo) error {
+func (p *Pod) Stop(ctx context.Context, c client.Client, podSetsInfo []jobframework.PodSetInfo) error {
 	if err := client.IgnoreNotFound(c.Delete(ctx, p.Object())); err != nil {
 		return err
 	}
@@ -97,8 +97,8 @@ func (p *Pod) PodSets() []kueue.PodSet {
 	}
 }
 
-func (j *Pod) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) {
-	info := podSetInfos[0]
+func (j *Pod) RunWithPodSetsInfo(podSetsInfo []jobframework.PodSetInfo) {
+	info := podSetsInfo[0]
 
 	var admissionTaintIsSet bool
 	selectorIsSet := map[string]bool{}
@@ -145,7 +145,7 @@ func (j *Pod) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) {
 	}
 }
 
-func (p *Pod) RestorePodSetsInfo(podSetInfos []jobframework.PodSetInfo) {
+func (p *Pod) RestorePodSetsInfo(podSetsInfo []jobframework.PodSetInfo) {
 	// Existing Pod tolerations cannot be removed.
 	// Restoring is not needed anyways b/c suspending == deleting for Pods.
 }

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -34,10 +34,10 @@ type GenericJob interface {
 	// Suspend will suspend the job.
 	Suspend()
 	// RunWithPodSetsInfo will inject the node affinity and podSet counts extracting from workload to job and unsuspend it.
-	RunWithPodSetsInfo(nodeSelectors []PodSetInfo) error
+	RunWithPodSetsInfo(podSetsInfo []PodSetInfo) error
 	// RestorePodSetsInfo will restore the original node affinity and podSet counts of the job.
 	// Returns whether any change was done.
-	RestorePodSetsInfo(nodeSelectors []PodSetInfo) bool
+	RestorePodSetsInfo(podSetsInfo []PodSetInfo) bool
 	// Finished means whether the job is completed/failed or not,
 	// condition represents the workload finished condition.
 	Finished() (condition metav1.Condition, finished bool)

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -645,14 +645,14 @@ func extractPriorityFromPodSets(podSets []kueue.PodSet) string {
 	return ""
 }
 
-// getPodSetsInfoFromStatus extracts podSetInfos from workload status, based on
+// getPodSetsInfoFromStatus extracts podSetsInfo from workload status, based on
 // admission, and admission checks.
 func (r *JobReconciler) getPodSetsInfoFromStatus(ctx context.Context, w *kueue.Workload) ([]PodSetInfo, error) {
 	if len(w.Status.Admission.PodSetAssignments) == 0 {
 		return nil, nil
 	}
 
-	podSetInfos := make([]PodSetInfo, len(w.Status.Admission.PodSetAssignments))
+	podSetsInfo := make([]PodSetInfo, len(w.Status.Admission.PodSetAssignments))
 
 	for i, podSetFlavor := range w.Status.Admission.PodSetAssignments {
 		processedFlvs := sets.NewString()
@@ -692,9 +692,9 @@ func (r *JobReconciler) getPodSetsInfoFromStatus(ctx context.Context, w *kueue.W
 				}
 			}
 		}
-		podSetInfos[i] = podSetInfo
+		podSetsInfo[i] = podSetInfo
 	}
-	return podSetInfos, nil
+	return podSetsInfo, nil
 }
 
 func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job GenericJob, object client.Object) error {

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -112,17 +112,17 @@ func (j *JobSet) PodSets() []kueue.PodSet {
 	return podSets
 }
 
-func (j *JobSet) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error {
+func (j *JobSet) RunWithPodSetsInfo(podSetsInfo []jobframework.PodSetInfo) error {
 	j.Spec.Suspend = ptr.To(false)
-	if len(podSetInfos) != len(j.Spec.ReplicatedJobs) {
-		return jobframework.BadPodSetsInfoLenError(len(j.Spec.ReplicatedJobs), len(podSetInfos))
+	if len(podSetsInfo) != len(j.Spec.ReplicatedJobs) {
+		return jobframework.BadPodSetsInfoLenError(len(j.Spec.ReplicatedJobs), len(podSetsInfo))
 	}
 
 	// If there are Jobs already created by the JobSet, their node selectors will be updated by the JobSet controller
 	// before unsuspending the individual Jobs.
 	for index := range j.Spec.ReplicatedJobs {
 		template := &j.Spec.ReplicatedJobs[index].Template.Spec.Template
-		info := podSetInfos[index]
+		info := podSetsInfo[index]
 		if err := jobframework.Merge(&template.ObjectMeta, &template.Spec, info); err != nil {
 			return nil
 		}
@@ -130,14 +130,14 @@ func (j *JobSet) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error
 	return nil
 }
 
-func (j *JobSet) RestorePodSetsInfo(podSetInfos []jobframework.PodSetInfo) bool {
-	if len(podSetInfos) == 0 {
+func (j *JobSet) RestorePodSetsInfo(podSetsInfo []jobframework.PodSetInfo) bool {
+	if len(podSetsInfo) == 0 {
 		return false
 	}
 	changed := false
 	for index := range j.Spec.ReplicatedJobs {
 		replica := &j.Spec.ReplicatedJobs[index].Template.Spec.Template
-		info := podSetInfos[index]
+		info := podSetsInfo[index]
 		changed = jobframework.Restore(&replica.ObjectMeta, &replica.Spec, info) || changed
 	}
 	return changed

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
@@ -49,18 +49,18 @@ func (j *KubeflowJob) Suspend() {
 	j.KFJobControl.RunPolicy().Suspend = ptr.To(true)
 }
 
-func (j *KubeflowJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error {
+func (j *KubeflowJob) RunWithPodSetsInfo(podSetsInfo []jobframework.PodSetInfo) error {
 	j.KFJobControl.RunPolicy().Suspend = ptr.To(false)
 	orderedReplicaTypes := j.OrderedReplicaTypes()
 
-	if len(podSetInfos) != len(orderedReplicaTypes) {
-		return jobframework.BadPodSetsInfoLenError(len(orderedReplicaTypes), len(podSetInfos))
+	if len(podSetsInfo) != len(orderedReplicaTypes) {
+		return jobframework.BadPodSetsInfoLenError(len(orderedReplicaTypes), len(podSetsInfo))
 	}
 	// The node selectors are provided in the same order as the generated list of
 	// podSets, use the same ordering logic to restore them.
-	for index := range podSetInfos {
+	for index := range podSetsInfo {
 		replicaType := orderedReplicaTypes[index]
-		info := podSetInfos[index]
+		info := podSetsInfo[index]
 		replica := &j.KFJobControl.ReplicaSpecs()[replicaType].Template
 		if err := jobframework.Merge(&replica.ObjectMeta, &replica.Spec, info); err != nil {
 			return err
@@ -70,10 +70,10 @@ func (j *KubeflowJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) 
 	return nil
 }
 
-func (j *KubeflowJob) RestorePodSetsInfo(podSetInfos []jobframework.PodSetInfo) bool {
+func (j *KubeflowJob) RestorePodSetsInfo(podSetsInfo []jobframework.PodSetInfo) bool {
 	orderedReplicaTypes := j.OrderedReplicaTypes()
 	changed := false
-	for index, info := range podSetInfos {
+	for index, info := range podSetsInfo {
 		replicaType := orderedReplicaTypes[index]
 		replica := &j.KFJobControl.ReplicaSpecs()[replicaType].Template
 		changed = jobframework.Restore(&replica.ObjectMeta, &replica.Spec, info) || changed

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -113,19 +113,19 @@ func (j *MPIJob) PodSets() []kueue.PodSet {
 	return podSets
 }
 
-func (j *MPIJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error {
+func (j *MPIJob) RunWithPodSetsInfo(podSetsInfo []jobframework.PodSetInfo) error {
 	j.Spec.RunPolicy.Suspend = ptr.To(false)
 	orderedReplicaTypes := orderedReplicaTypes(&j.Spec)
 
-	if len(podSetInfos) != len(orderedReplicaTypes) {
-		return jobframework.BadPodSetsInfoLenError(len(orderedReplicaTypes), len(podSetInfos))
+	if len(podSetsInfo) != len(orderedReplicaTypes) {
+		return jobframework.BadPodSetsInfoLenError(len(orderedReplicaTypes), len(podSetsInfo))
 	}
 
 	// The node selectors are provided in the same order as the generated list of
 	// podSets, use the same ordering logic to restore them.
-	for index := range podSetInfos {
+	for index := range podSetsInfo {
 		replicaType := orderedReplicaTypes[index]
-		info := podSetInfos[index]
+		info := podSetsInfo[index]
 		replica := &j.Spec.MPIReplicaSpecs[replicaType].Template
 		if err := jobframework.Merge(&replica.ObjectMeta, &replica.Spec, info); err != nil {
 			return err
@@ -134,10 +134,10 @@ func (j *MPIJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error
 	return nil
 }
 
-func (j *MPIJob) RestorePodSetsInfo(podSetInfos []jobframework.PodSetInfo) bool {
+func (j *MPIJob) RestorePodSetsInfo(podSetsInfo []jobframework.PodSetInfo) bool {
 	orderedReplicaTypes := orderedReplicaTypes(&j.Spec)
 	changed := false
-	for index, info := range podSetInfos {
+	for index, info := range podSetsInfo {
 		replicaType := orderedReplicaTypes[index]
 		replica := &j.Spec.MPIReplicaSpecs[replicaType].Template
 		changed = jobframework.Restore(&replica.ObjectMeta, &replica.Spec, info) || changed

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -111,17 +111,17 @@ func (j *RayJob) PodSets() []kueue.PodSet {
 	return podSets
 }
 
-func (j *RayJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error {
+func (j *RayJob) RunWithPodSetsInfo(podSetsInfo []jobframework.PodSetInfo) error {
 	expectedLen := len(j.Spec.RayClusterSpec.WorkerGroupSpecs) + 1
-	if len(podSetInfos) != expectedLen {
-		return jobframework.BadPodSetsInfoLenError(expectedLen, len(podSetInfos))
+	if len(podSetsInfo) != expectedLen {
+		return jobframework.BadPodSetsInfoLenError(expectedLen, len(podSetsInfo))
 	}
 
 	j.Spec.Suspend = false
 
 	// head
 	headPod := &j.Spec.RayClusterSpec.HeadGroupSpec.Template
-	info := podSetInfos[0]
+	info := podSetsInfo[0]
 	if err := jobframework.Merge(&headPod.ObjectMeta, &headPod.Spec, info); err != nil {
 		return err
 	}
@@ -129,7 +129,7 @@ func (j *RayJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error
 	// workers
 	for index := range j.Spec.RayClusterSpec.WorkerGroupSpecs {
 		workerPod := &j.Spec.RayClusterSpec.WorkerGroupSpecs[index].Template
-		info := podSetInfos[index+1]
+		info := podSetsInfo[index+1]
 		if err := jobframework.Merge(&workerPod.ObjectMeta, &workerPod.Spec, info); err != nil {
 			return err
 		}
@@ -137,20 +137,20 @@ func (j *RayJob) RunWithPodSetsInfo(podSetInfos []jobframework.PodSetInfo) error
 	return nil
 }
 
-func (j *RayJob) RestorePodSetsInfo(podSetInfos []jobframework.PodSetInfo) bool {
-	if len(podSetInfos) != len(j.Spec.RayClusterSpec.WorkerGroupSpecs)+1 {
+func (j *RayJob) RestorePodSetsInfo(podSetsInfo []jobframework.PodSetInfo) bool {
+	if len(podSetsInfo) != len(j.Spec.RayClusterSpec.WorkerGroupSpecs)+1 {
 		return false
 	}
 
 	changed := false
 	// head
 	headPod := &j.Spec.RayClusterSpec.HeadGroupSpec.Template
-	changed = jobframework.Restore(&headPod.ObjectMeta, &headPod.Spec, podSetInfos[0]) || changed
+	changed = jobframework.Restore(&headPod.ObjectMeta, &headPod.Spec, podSetsInfo[0]) || changed
 
 	// workers
 	for index := range j.Spec.RayClusterSpec.WorkerGroupSpecs {
 		workerPod := &j.Spec.RayClusterSpec.WorkerGroupSpecs[index].Template
-		info := podSetInfos[index+1]
+		info := podSetsInfo[index+1]
 		changed = jobframework.Restore(&workerPod.ObjectMeta, &workerPod.Spec, info) || changed
 	}
 	return changed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

To improve naming consistency in the codebase. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Changes:
1. podSetInfos -> podSetsInfo
2. nodeSelectors -> podSetsInfo (in interface.go)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```