### PR TITLE
Eliminate Helm chart footgun: pin kueue version by default

### DIFF
--- a/charts/kueue/Chart.yaml
+++ b/charts/kueue/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.4.2"
+appVersion: "v0.4.2"

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -20,7 +20,8 @@ controllerManager:
     image:
       repository: gcr.io/k8s-staging-kueue/kueue
       # tag, if defined will use the given image tag, else Chart.AppVersion will be used
-      tag: main
+      # By default set to `null`, so it uses the Chart.AppVersion
+      tag: null
       # This should be set to 'IfNotPresent' for released version      
       pullPolicy: Always
     resources:


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

If no options are set when installing this Helm chart, even on releases (e.g.
[v0.4.2](https://github.com/kubernetes-sigs/kueue/blob/v0.4.2/charts/kueue/values.yaml#L23)), the default image tag is set to `main`. This means that the version of `kueue` is not pinned, and if the pod gets re-created the container image may get fetched again.

If the new version of `kueue` introduces new CRDs, like v0.4.1 or v0.4.2 did (`AdmissionCheck`), this can bring your scheduler down.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No issue, I decided to open a PR right away. 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
default kueue container version in the Helm chart is now pinned to the latest release
```