### PR TITLE
fix config arg path to always match configmap mount path

### DIFF
--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - args:
-        - --config=controller_manager_config.yaml
+        - --config=/controller_manager_config.yaml
         - --zap-log-level=2
         command:
         - /manager

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
       - name: manager
         args:
-        - "--config=controller_manager_config.yaml"
+        - "--config=/controller_manager_config.yaml"
         - "--zap-log-level=2"
         volumeMounts:
         - name: manager-config

--- a/config/dev/manager_config_patch.yaml
+++ b/config/dev/manager_config_patch.yaml
@@ -9,6 +9,6 @@ spec:
       containers:
       - name: manager
         args:
-        - "--config=controller_manager_config.yaml"
+        - "--config=/controller_manager_config.yaml"
         - "--zap-devel"
         - "--zap-log-level=3"

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -216,7 +216,7 @@ spec:
       containers:
       - name: manager
         args:
-        - --config=controller_manager_config.yaml
+        - --config=/controller_manager_config.yaml
         - --zap-log-level=2
 +       - --feature-gates=PartialAdmission=true
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The config mountPath is /controller_manager_config.yaml, yet it has been given to the manager in a command line arg without a path, simply trusting the current working directory to be the root.

When debugging kueue via a buildpack built container, the manager resides in another folder and the config isn't found without changing the --config arg. The command line arg could always simply specify the exact, matching path to the file.

This adds the path to the various instances of --config usage in the project.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This imposes no change to functionality anywhere, but makes setting up debugging easier.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```