### PR TITLE
[workload] Drop Quota Reservation on cluster queue deletion.

### DIFF
--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -170,7 +170,7 @@ func (r *ClusterQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 		if controllerutil.ContainsFinalizer(&cqObj, kueue.ResourceInUseFinalizerName) {
 			// The clusterQueue is being deleted, remove the finalizer only if
-			// there are no active admitted workloads.
+			// there are no active reserving workloads.
 			if r.cache.ClusterQueueEmpty(cqObj.Name) {
 				controllerutil.RemoveFinalizer(&cqObj, kueue.ResourceInUseFinalizerName)
 				if err := r.client.Update(ctx, &cqObj); err != nil {

--- a/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
@@ -157,7 +157,7 @@ var _ = ginkgo.Describe("Provisioning", func() {
 					if err != nil {
 						return err
 					}
-					util.SetWorkloadsAdmissionCkeck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
+					util.SetWorkloadsAdmissionCheck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
 					return nil
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -182,7 +182,7 @@ var _ = ginkgo.Describe("Provisioning", func() {
 					if err != nil {
 						return err
 					}
-					util.SetWorkloadsAdmissionCkeck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
+					util.SetWorkloadsAdmissionCheck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
 					return nil
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -256,7 +256,7 @@ var _ = ginkgo.Describe("Provisioning", func() {
 						return err
 					}
 					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, updatedWl, nil)).To(gomega.Succeed())
-					util.SetWorkloadsAdmissionCkeck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
+					util.SetWorkloadsAdmissionCheck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
 					return nil
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -281,7 +281,7 @@ var _ = ginkgo.Describe("Provisioning", func() {
 					if err != nil {
 						return err
 					}
-					util.SetWorkloadsAdmissionCkeck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
+					util.SetWorkloadsAdmissionCheck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
 					return nil
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -351,7 +351,7 @@ var _ = ginkgo.Describe("Provisioning", func() {
 					if err != nil {
 						return err
 					}
-					util.SetWorkloadsAdmissionCkeck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
+					util.SetWorkloadsAdmissionCheck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
 					return nil
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -407,7 +407,7 @@ var _ = ginkgo.Describe("Provisioning", func() {
 					if err != nil {
 						return err
 					}
-					util.SetWorkloadsAdmissionCkeck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
+					util.SetWorkloadsAdmissionCheck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
 					return nil
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -708,15 +709,23 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 
 	ginkgo.When("Deleting clusterQueues", func() {
 		var (
-			cq *kueue.ClusterQueue
-			lq *kueue.LocalQueue
+			cq    *kueue.ClusterQueue
+			lq    *kueue.LocalQueue
+			check *kueue.AdmissionCheck
 		)
 
 		ginkgo.BeforeEach(func() {
-			cq = testing.MakeClusterQueue("foo-cq").Obj()
+			check = testing.MakeAdmissionCheck("check").ControllerName("check-controller").Obj()
+			gomega.Expect(k8sClient.Create(ctx, check)).To(gomega.Succeed())
+
+			cq = testing.MakeClusterQueue("foo-cq").AdmissionChecks(check.Name).Obj()
 			lq = testing.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
 			gomega.Expect(k8sClient.Create(ctx, lq)).To(gomega.Succeed())
 			gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func() {
+			util.ExpectAdmissionCheckToBeDeleted(ctx, k8sClient, check, true)
 		})
 
 		ginkgo.It("Should delete clusterQueues successfully when no admitted workloads are running", func() {
@@ -724,12 +733,20 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 		})
 
 		ginkgo.It("Should be stuck in termination until admitted workloads finished running", func() {
+			util.SetAdmissionCheckActive(ctx, k8sClient, check, metav1.ConditionTrue)
 			util.ExpectClusterQueueStatusMetric(cq, metrics.CQStatusActive)
 
 			ginkgo.By("Admit workload")
 			wl := testing.MakeWorkload("workload", ns.Name).Queue(lq.Name).Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 			gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, testing.MakeAdmission(cq.Name).Obj())).To(gomega.Succeed())
+			util.SetWorkloadsAdmissionCkeck(ctx, k8sClient, wl, check.Name, kueue.CheckStateReady, true)
+			gomega.Eventually(func(g gomega.Gomega) {
+				key := client.ObjectKeyFromObject(wl)
+				updatedWl := &kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, key, updatedWl)).To(gomega.Succeed())
+				g.Expect(apimeta.IsStatusConditionTrue(updatedWl.Status.Conditions, kueue.WorkloadAdmitted)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Delete clusterQueue")
 			gomega.Expect(util.DeleteClusterQueue(ctx, k8sClient, cq)).To(gomega.Succeed())
@@ -748,6 +765,19 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 				var newCQ kueue.ClusterQueue
 				return k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &newCQ)
 			}, util.Timeout, util.Interval).Should(testing.BeNotFoundError())
+		})
+
+		ginkgo.It("Should delete the cluster without waiting for reserving only workloads to finish", func() {
+			util.SetAdmissionCheckActive(ctx, k8sClient, check, metav1.ConditionTrue)
+			util.ExpectClusterQueueStatusMetric(cq, metrics.CQStatusActive)
+
+			ginkgo.By("Setting quota reservation")
+			wl := testing.MakeWorkload("workload", ns.Name).Queue(lq.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+			gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, testing.MakeAdmission(cq.Name).Obj())).To(gomega.Succeed())
+
+			ginkgo.By("Delete clusterQueue")
+			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, cq, true)
 		})
 	})
 })

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -308,7 +308,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 
 			ginkgo.By("Setting the admission check for the first 4 workloads")
 			for _, w := range workloads[:4] {
-				util.SetWorkloadsAdmissionCkeck(ctx, k8sClient, w, ac.Name, kueue.CheckStateReady, true)
+				util.SetWorkloadsAdmissionCheck(ctx, k8sClient, w, ac.Name, kueue.CheckStateReady, true)
 			}
 
 			gomega.Eventually(func() kueue.ClusterQueueStatus {
@@ -740,7 +740,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 			wl := testing.MakeWorkload("workload", ns.Name).Queue(lq.Name).Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 			gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, testing.MakeAdmission(cq.Name).Obj())).To(gomega.Succeed())
-			util.SetWorkloadsAdmissionCkeck(ctx, k8sClient, wl, check.Name, kueue.CheckStateReady, true)
+			util.SetWorkloadsAdmissionCheck(ctx, k8sClient, wl, check.Name, kueue.CheckStateReady, true)
 			gomega.Eventually(func(g gomega.Gomega) {
 				key := client.ObjectKeyFromObject(wl)
 				updatedWl := &kueue.Workload{}

--- a/test/integration/controller/core/localqueue_controller_test.go
+++ b/test/integration/controller/core/localqueue_controller_test.go
@@ -294,7 +294,7 @@ var _ = ginkgo.Describe("Queue controller", ginkgo.Ordered, ginkgo.ContinueOnFai
 
 		ginkgo.By("Setting the workloads admission checks")
 		for _, w := range workloads {
-			util.SetWorkloadsAdmissionCkeck(ctx, k8sClient, w, ac.Name, kueue.CheckStateReady, true)
+			util.SetWorkloadsAdmissionCheck(ctx, k8sClient, w, ac.Name, kueue.CheckStateReady, true)
 		}
 
 		gomega.Eventually(func() kueue.LocalQueueStatus {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -462,7 +462,7 @@ func SetAdmissionCheckActive(ctx context.Context, k8sClient client.Client, admis
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
-func SetWorkloadsAdmissionCkeck(ctx context.Context, k8sClient client.Client, wl *kueue.Workload, check string, state kueue.CheckState, expectExisting bool) {
+func SetWorkloadsAdmissionCheck(ctx context.Context, k8sClient client.Client, wl *kueue.Workload, check string, state kueue.CheckState, expectExisting bool) {
 	var updatedWorkload kueue.Workload
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
 		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWorkload)).To(gomega.Succeed())


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Drop the workloads quota reservation if it's not Admitted and the target ClusterQueue is deleted.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1253 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```