### PR TITLE
[KEP] A mechanism to stop a ClusterQueue

### DIFF
--- a/keps/1284-cluster-queue-stop/README.md
+++ b/keps/1284-cluster-queue-stop/README.md
@@ -68,7 +68,7 @@ type ClusterQueueSpec struct {
 	//
 	// - StopNow - Admitted workloads are evictred and Reserving workloads will cancel the reservatio.
 	// - WaitForAdmitted - Admitted workloads will run to completion and Reserving workloads will cancel the reservatio.
-	// - WaitForAdmitted - Admitted and Reserving workloads will run to completion.
+	// - WaitForReserving - Admitted and Reserving workloads will run to completion.
 	//
 	// +optional
 	// +kubebuilder:validation:Enum=StopNow;WaitForAdmitted;WaitForReserving

--- a/keps/1284-cluster-queue-stop/README.md
+++ b/keps/1284-cluster-queue-stop/README.md
@@ -25,7 +25,7 @@
 <!-- /toc -->
 
 ## Summary
-Add setting in a ClusterQueue that an administrator is able to use in order to to pause new admissions and have the option to cancel current QuotaReservations and Evict admitted workloads.
+Add setting in a ClusterQueue that an administrator is able to use in order to pause new admissions and have the option to cancel current QuotaReservations and Evict admitted workloads.
 
 ## Motivation
 
@@ -37,7 +37,7 @@ Add a setting in a ClusterQueue that an administrator is able to use in order to
 
 ### Non-Goals
 
-Manage the QuotaReservation and Admission of workloads form the same cohort that might borrow resources from the ClusterQueue in question.
+Manage the QuotaReservation and Admission of workloads from the same cohort that might borrow resources from the ClusterQueue in question.
 
 ## Proposal
 
@@ -50,7 +50,7 @@ As a cluster administrator I want to be able to stop the new admissions in a spe
 
 ### Notes/Constraints/Caveats
 Managing the Reservation canceling and Eviction of workloads in other queues from the same cohort that
-are potentially borrowing resources form the stopped queue adds a considerable amount of complexity
+are potentially borrowing resources from the stopped queue adds a considerable amount of complexity
 while having a limited added value, therefore these cases are not covered in this first iteration. 
 
 ### Risks and Mitigations
@@ -72,8 +72,8 @@ type ClusterQueueSpec struct {
 	// - HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.
 	// - Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.
 	//
-	// +optional
 	// +kubebuilder:validation:Enum=None;Hold;HoldAndDrain
+	// +kubebuilder:default="None"
 	StopPolicy StopPolicy `json:"stopPolicy,omitempty"`
 }
 
@@ -81,8 +81,8 @@ type StopPolicy string
 
 const (
 	None         StopPolicy = "None"
-	HoldAndDrain StopPolicy = "HoldAndDrain"
 	Hold         StopPolicy = "Hold"
+	HoldAndDrain StopPolicy = "HoldAndDrain"
 )
 
 
@@ -113,7 +113,7 @@ To be added depending on the added code complexity.
 
 #### Integration tests
 
-The `cotrollers/core` suite should check:
+The `controllers/core` suite should check:
 
 1. ClusterQueue - Once the `stopPolicy` is set a ClusterQueue becomes Inactive.
 2. Workload - Once its ClusterQueue `stopPolicy` is set, depending on the value:

--- a/keps/1284-cluster-queue-stop/README.md
+++ b/keps/1284-cluster-queue-stop/README.md
@@ -119,6 +119,7 @@ The `controllers/core` suite should check:
 2. Workload - Once its ClusterQueue `stopPolicy` is set, depending on the value:
 - The Reserving workloads are canceling the reservation.
 - The Admitted workloads get Evicted and the Reserving ones cancel their reservation.
+- New workload is not admitted when cluster queue is inactive
 
 ### Graduation Criteria
 

--- a/keps/1284-cluster-queue-stop/README.md
+++ b/keps/1284-cluster-queue-stop/README.md
@@ -7,6 +7,7 @@
 - [Proposal](#proposal)
   - [User Stories](#user-stories)
     - [Story 1](#story-1)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [API/ClusterQueue](#apiclusterqueue)
@@ -47,11 +48,12 @@ Add a new member in the ClusterQueue implementation `stopPolicy` the presence of
 
 As a cluster administrator I want to be able to stop the new admissions in a specific ClusterQueue with the option of Evicting currently admitted Workloads or canceling QuotaReservations.
 
-### Risks and Mitigations
-
+### Notes/Constraints/Caveats
 Managing the Reservation canceling and Eviction of workloads in other queues from the same cohort that
 are potentially borrowing resources form the stopped queue adds a considerable amount of complexity
 while having a limited added value, therefore these cases are not covered in this first iteration. 
+
+### Risks and Mitigations
 
 ## Design Details
 
@@ -66,21 +68,21 @@ type ClusterQueueSpec struct {
 	//
 	// Depending on its value, its associated workloads will:
 	//
-	// - StopNow - Admitted workloads are evictred and Reserving workloads will cancel the reservatio.
-	// - WaitForAdmitted - Admitted workloads will run to completion and Reserving workloads will cancel the reservatio.
-	// - WaitForReserving - Admitted and Reserving workloads will run to completion.
+	// - None - Workloads are admitted
+	// - HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.
+	// - Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.
 	//
 	// +optional
-	// +kubebuilder:validation:Enum=StopNow;WaitForAdmitted;WaitForReserving
+	// +kubebuilder:validation:Enum=None;Hold;HoldAndDrain
 	StopPolicy StopPolicy `json:"stopPolicy,omitempty"`
 }
 
 type StopPolicy string
 
 const (
-	StopNow StopPolicy = "StopNow"
-	WaitForAdmitted StopPolicy = "WaitForAdmitted"
-	WaitForReserving StopPolicy = "WaitForReserving"
+	None         StopPolicy = "None"
+	HoldAndDrain StopPolicy = "HoldAndDrain"
+	Hold         StopPolicy = "Hold"
 )
 
 

--- a/keps/1284-cluster-queue-stop/README.md
+++ b/keps/1284-cluster-queue-stop/README.md
@@ -1,0 +1,131 @@
+# KEP-1284: Add a mechanism to stop a ClusterQueue.
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+    - [Story 1](#story-1)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [API/ClusterQueue](#apiclusterqueue)
+  - [Controllers](#controllers)
+    - [ClusterQueue](#clusterqueue)
+    - [Workload](#workload)
+  - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+    - [Unit Tests](#unit-tests)
+    - [Integration tests](#integration-tests)
+  - [Graduation Criteria](#graduation-criteria)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Summary
+Add setting in a ClusterQueue that an administrator is able to use in order to to pause new admissions and have the option to cancel current QuotaReservations and Evict admitted workloads.
+
+## Motivation
+
+This is a common admin journey to control usage from a user.
+
+### Goals
+
+Add a setting in a ClusterQueue that an administrator is able to use in order to to pause new admissions and have the option to cancel current QuotaReservations and Evict admitted workloads.
+
+### Non-Goals
+
+Manage the QuotaReservation and Admission of workloads form the same cohort that might borrow resources from the ClusterQueue in question.
+
+## Proposal
+
+Add a new member in the ClusterQueue implementation `stopPolicy` the presence of which will mark the ClusterQueue as Inactive and it's value will control how the `Admitted` or `Reserving` workloads are affected.
+
+### User Stories
+#### Story 1
+
+As a cluster administrator I want to be able to stop the new admissions in a specific ClusterQueue with the option of Evicting currently admitted Workloads or canceling QuotaReservations.
+
+### Risks and Mitigations
+
+Managing the Reservation canceling and Eviction of workloads in other queues from the same cohort that
+are potentially borrowing resources form the stopped queue adds a considerable amount of complexity
+while having a limited added value, therefore these cases are not covered in this first iteration. 
+
+## Design Details
+
+### API/ClusterQueue
+
+```go
+type ClusterQueueSpec struct {
+	// ....
+
+	// stopPolicy - if set the ClusterQueue is considered Inactive, no new reservation being
+	// made. 
+	//
+	// Depending on its value, its associated workloads will:
+	//
+	// - StopNow - Admitted workloads are evictred and Reserving workloads will cancel the reservatio.
+	// - WaitForAdmitted - Admitted workloads will run to completion and Reserving workloads will cancel the reservatio.
+	// - WaitForAdmitted - Admitted and Reserving workloads will run to completion.
+	//
+	// +optional
+	// +kubebuilder:validation:Enum=StopNow;WaitForAdmitted;WaitForReserving
+	StopPolicy StopPolicy `json:"stopPolicy,omitempty"`
+}
+
+type StopPolicy string
+
+const (
+	StopNow StopPolicy = "StopNow"
+	WaitForAdmitted StopPolicy = "WaitForAdmitted"
+	WaitForReserving StopPolicy = "WaitForReserving"
+)
+
+
+```
+### Controllers
+#### ClusterQueue
+
+Once the `stopPolicy` is set the cluster queue is marked as inactive with a relevant status message.
+
+#### Workload
+
+If the cluster queue associated to a workload has the `stopPolicy` changed depending on the policy value and state of the
+workload it should Evict or cancel the reservation of the workload.
+
+### Test Plan
+
+
+[x] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+##### Prerequisite testing updates
+
+
+#### Unit Tests
+
+To be added depending on the added code complexity.
+
+#### Integration tests
+
+The `cotrollers/core` suite should check:
+
+1. ClusterQueue - Once the `stopPolicy` is set a ClusterQueue becomes Inactive.
+2. Workload - Once its ClusterQueue `stopPolicy` is set, depending on the value:
+- The Reserving workloads are canceling the reservation.
+- The Admitted workloads get Evicted and the Reserving ones cancel their reservation.
+
+### Graduation Criteria
+
+
+## Implementation History
+
+
+## Drawbacks
+
+
+## Alternatives
+

--- a/keps/1284-cluster-queue-stop/kep.yaml
+++ b/keps/1284-cluster-queue-stop/kep.yaml
@@ -1,0 +1,26 @@
+title: Add a mechanism to stop a ClusterQueue
+kep-number: 1284
+authors:
+  - "@trasc"
+status: implementable
+creation-date: 2023-10-30
+reviewers:
+  - "@tenzen-y"
+  - "@mwielgus"
+approvers:
+  - "@alculquicondor"
+
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: beta
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v0.6"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  beta: "v0.6"
+
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
A mechanism to stop a ClusterQueue

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #1284

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```