### PR TITLE
Fix client-go libraries bug

### DIFF
--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -95,6 +95,7 @@ const (
 )
 
 //+genclient
+//+genclient:nonNamespaced
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
 //+kubebuilder:subresource:status

--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -361,6 +361,7 @@ type ClusterQueuePreemption struct {
 }
 
 //+genclient
+//+genclient:nonNamespaced
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
 //+kubebuilder:resource:scope=Cluster

--- a/apis/kueue/v1beta1/provisioningrequestconfig_types.go
+++ b/apis/kueue/v1beta1/provisioningrequestconfig_types.go
@@ -58,6 +58,7 @@ type ProvisioningRequestConfigSpec struct {
 type Parameter string
 
 //+genclient
+//+genclient:nonNamespaced
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
 //+kubebuilder:resource:scope=Cluster

--- a/apis/kueue/v1beta1/resourceflavor_types.go
+++ b/apis/kueue/v1beta1/resourceflavor_types.go
@@ -22,6 +22,7 @@ import (
 )
 
 //+genclient
+//+genclient:nonNamespaced
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
 //+kubebuilder:resource:scope=Cluster,shortName={flavor,flavors}

--- a/apis/kueue/v1beta1/workloadpriorityclass_types.go
+++ b/apis/kueue/v1beta1/workloadpriorityclass_types.go
@@ -21,6 +21,7 @@ import (
 )
 
 //+genclient
+//+genclient:nonNamespaced
 //+kubebuilder:object:root=true
 //+kubebuilder:storageversion
 //+kubebuilder:resource:scope=Cluster

--- a/client-go/applyconfiguration/kueue/v1beta1/admissioncheck.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/admissioncheck.go
@@ -34,10 +34,9 @@ type AdmissionCheckApplyConfiguration struct {
 
 // AdmissionCheck constructs an declarative configuration of the AdmissionCheck type for use with
 // apply.
-func AdmissionCheck(name, namespace string) *AdmissionCheckApplyConfiguration {
+func AdmissionCheck(name string) *AdmissionCheckApplyConfiguration {
 	b := &AdmissionCheckApplyConfiguration{}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind("AdmissionCheck")
 	b.WithAPIVersion("kueue.x-k8s.io/v1beta1")
 	return b

--- a/client-go/applyconfiguration/kueue/v1beta1/clusterqueue.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/clusterqueue.go
@@ -34,10 +34,9 @@ type ClusterQueueApplyConfiguration struct {
 
 // ClusterQueue constructs an declarative configuration of the ClusterQueue type for use with
 // apply.
-func ClusterQueue(name, namespace string) *ClusterQueueApplyConfiguration {
+func ClusterQueue(name string) *ClusterQueueApplyConfiguration {
 	b := &ClusterQueueApplyConfiguration{}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind("ClusterQueue")
 	b.WithAPIVersion("kueue.x-k8s.io/v1beta1")
 	return b

--- a/client-go/applyconfiguration/kueue/v1beta1/provisioningrequestconfig.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/provisioningrequestconfig.go
@@ -33,10 +33,9 @@ type ProvisioningRequestConfigApplyConfiguration struct {
 
 // ProvisioningRequestConfig constructs an declarative configuration of the ProvisioningRequestConfig type for use with
 // apply.
-func ProvisioningRequestConfig(name, namespace string) *ProvisioningRequestConfigApplyConfiguration {
+func ProvisioningRequestConfig(name string) *ProvisioningRequestConfigApplyConfiguration {
 	b := &ProvisioningRequestConfigApplyConfiguration{}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind("ProvisioningRequestConfig")
 	b.WithAPIVersion("kueue.x-k8s.io/v1beta1")
 	return b

--- a/client-go/applyconfiguration/kueue/v1beta1/resourceflavor.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/resourceflavor.go
@@ -33,10 +33,9 @@ type ResourceFlavorApplyConfiguration struct {
 
 // ResourceFlavor constructs an declarative configuration of the ResourceFlavor type for use with
 // apply.
-func ResourceFlavor(name, namespace string) *ResourceFlavorApplyConfiguration {
+func ResourceFlavor(name string) *ResourceFlavorApplyConfiguration {
 	b := &ResourceFlavorApplyConfiguration{}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind("ResourceFlavor")
 	b.WithAPIVersion("kueue.x-k8s.io/v1beta1")
 	return b

--- a/client-go/applyconfiguration/kueue/v1beta1/workloadpriorityclass.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/workloadpriorityclass.go
@@ -34,10 +34,9 @@ type WorkloadPriorityClassApplyConfiguration struct {
 
 // WorkloadPriorityClass constructs an declarative configuration of the WorkloadPriorityClass type for use with
 // apply.
-func WorkloadPriorityClass(name, namespace string) *WorkloadPriorityClassApplyConfiguration {
+func WorkloadPriorityClass(name string) *WorkloadPriorityClassApplyConfiguration {
 	b := &WorkloadPriorityClassApplyConfiguration{}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind("WorkloadPriorityClass")
 	b.WithAPIVersion("kueue.x-k8s.io/v1beta1")
 	return b

--- a/client-go/clientset/versioned/typed/kueue/v1beta1/admissioncheck.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta1/admissioncheck.go
@@ -35,7 +35,7 @@ import (
 // AdmissionChecksGetter has a method to return a AdmissionCheckInterface.
 // A group's client should implement this interface.
 type AdmissionChecksGetter interface {
-	AdmissionChecks(namespace string) AdmissionCheckInterface
+	AdmissionChecks() AdmissionCheckInterface
 }
 
 // AdmissionCheckInterface has methods to work with AdmissionCheck resources.
@@ -57,14 +57,12 @@ type AdmissionCheckInterface interface {
 // admissionChecks implements AdmissionCheckInterface
 type admissionChecks struct {
 	client rest.Interface
-	ns     string
 }
 
 // newAdmissionChecks returns a AdmissionChecks
-func newAdmissionChecks(c *KueueV1beta1Client, namespace string) *admissionChecks {
+func newAdmissionChecks(c *KueueV1beta1Client) *admissionChecks {
 	return &admissionChecks{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -72,7 +70,6 @@ func newAdmissionChecks(c *KueueV1beta1Client, namespace string) *admissionCheck
 func (c *admissionChecks) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.AdmissionCheck, err error) {
 	result = &v1beta1.AdmissionCheck{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("admissionchecks").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,7 +86,6 @@ func (c *admissionChecks) List(ctx context.Context, opts v1.ListOptions) (result
 	}
 	result = &v1beta1.AdmissionCheckList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("admissionchecks").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,7 +102,6 @@ func (c *admissionChecks) Watch(ctx context.Context, opts v1.ListOptions) (watch
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("admissionchecks").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,7 +112,6 @@ func (c *admissionChecks) Watch(ctx context.Context, opts v1.ListOptions) (watch
 func (c *admissionChecks) Create(ctx context.Context, admissionCheck *v1beta1.AdmissionCheck, opts v1.CreateOptions) (result *v1beta1.AdmissionCheck, err error) {
 	result = &v1beta1.AdmissionCheck{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("admissionchecks").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(admissionCheck).
@@ -130,7 +124,6 @@ func (c *admissionChecks) Create(ctx context.Context, admissionCheck *v1beta1.Ad
 func (c *admissionChecks) Update(ctx context.Context, admissionCheck *v1beta1.AdmissionCheck, opts v1.UpdateOptions) (result *v1beta1.AdmissionCheck, err error) {
 	result = &v1beta1.AdmissionCheck{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("admissionchecks").
 		Name(admissionCheck.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -145,7 +138,6 @@ func (c *admissionChecks) Update(ctx context.Context, admissionCheck *v1beta1.Ad
 func (c *admissionChecks) UpdateStatus(ctx context.Context, admissionCheck *v1beta1.AdmissionCheck, opts v1.UpdateOptions) (result *v1beta1.AdmissionCheck, err error) {
 	result = &v1beta1.AdmissionCheck{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("admissionchecks").
 		Name(admissionCheck.Name).
 		SubResource("status").
@@ -159,7 +151,6 @@ func (c *admissionChecks) UpdateStatus(ctx context.Context, admissionCheck *v1be
 // Delete takes name of the admissionCheck and deletes it. Returns an error if one occurs.
 func (c *admissionChecks) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("admissionchecks").
 		Name(name).
 		Body(&opts).
@@ -174,7 +165,6 @@ func (c *admissionChecks) DeleteCollection(ctx context.Context, opts v1.DeleteOp
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("admissionchecks").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -187,7 +177,6 @@ func (c *admissionChecks) DeleteCollection(ctx context.Context, opts v1.DeleteOp
 func (c *admissionChecks) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.AdmissionCheck, err error) {
 	result = &v1beta1.AdmissionCheck{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("admissionchecks").
 		Name(name).
 		SubResource(subresources...).
@@ -214,7 +203,6 @@ func (c *admissionChecks) Apply(ctx context.Context, admissionCheck *kueuev1beta
 	}
 	result = &v1beta1.AdmissionCheck{}
 	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
 		Resource("admissionchecks").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -243,7 +231,6 @@ func (c *admissionChecks) ApplyStatus(ctx context.Context, admissionCheck *kueue
 
 	result = &v1beta1.AdmissionCheck{}
 	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
 		Resource("admissionchecks").
 		Name(*name).
 		SubResource("status").

--- a/client-go/clientset/versioned/typed/kueue/v1beta1/clusterqueue.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta1/clusterqueue.go
@@ -35,7 +35,7 @@ import (
 // ClusterQueuesGetter has a method to return a ClusterQueueInterface.
 // A group's client should implement this interface.
 type ClusterQueuesGetter interface {
-	ClusterQueues(namespace string) ClusterQueueInterface
+	ClusterQueues() ClusterQueueInterface
 }
 
 // ClusterQueueInterface has methods to work with ClusterQueue resources.
@@ -57,14 +57,12 @@ type ClusterQueueInterface interface {
 // clusterQueues implements ClusterQueueInterface
 type clusterQueues struct {
 	client rest.Interface
-	ns     string
 }
 
 // newClusterQueues returns a ClusterQueues
-func newClusterQueues(c *KueueV1beta1Client, namespace string) *clusterQueues {
+func newClusterQueues(c *KueueV1beta1Client) *clusterQueues {
 	return &clusterQueues{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -72,7 +70,6 @@ func newClusterQueues(c *KueueV1beta1Client, namespace string) *clusterQueues {
 func (c *clusterQueues) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.ClusterQueue, err error) {
 	result = &v1beta1.ClusterQueue{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("clusterqueues").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,7 +86,6 @@ func (c *clusterQueues) List(ctx context.Context, opts v1.ListOptions) (result *
 	}
 	result = &v1beta1.ClusterQueueList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("clusterqueues").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,7 +102,6 @@ func (c *clusterQueues) Watch(ctx context.Context, opts v1.ListOptions) (watch.I
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("clusterqueues").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,7 +112,6 @@ func (c *clusterQueues) Watch(ctx context.Context, opts v1.ListOptions) (watch.I
 func (c *clusterQueues) Create(ctx context.Context, clusterQueue *v1beta1.ClusterQueue, opts v1.CreateOptions) (result *v1beta1.ClusterQueue, err error) {
 	result = &v1beta1.ClusterQueue{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("clusterqueues").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(clusterQueue).
@@ -130,7 +124,6 @@ func (c *clusterQueues) Create(ctx context.Context, clusterQueue *v1beta1.Cluste
 func (c *clusterQueues) Update(ctx context.Context, clusterQueue *v1beta1.ClusterQueue, opts v1.UpdateOptions) (result *v1beta1.ClusterQueue, err error) {
 	result = &v1beta1.ClusterQueue{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("clusterqueues").
 		Name(clusterQueue.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -145,7 +138,6 @@ func (c *clusterQueues) Update(ctx context.Context, clusterQueue *v1beta1.Cluste
 func (c *clusterQueues) UpdateStatus(ctx context.Context, clusterQueue *v1beta1.ClusterQueue, opts v1.UpdateOptions) (result *v1beta1.ClusterQueue, err error) {
 	result = &v1beta1.ClusterQueue{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("clusterqueues").
 		Name(clusterQueue.Name).
 		SubResource("status").
@@ -159,7 +151,6 @@ func (c *clusterQueues) UpdateStatus(ctx context.Context, clusterQueue *v1beta1.
 // Delete takes name of the clusterQueue and deletes it. Returns an error if one occurs.
 func (c *clusterQueues) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("clusterqueues").
 		Name(name).
 		Body(&opts).
@@ -174,7 +165,6 @@ func (c *clusterQueues) DeleteCollection(ctx context.Context, opts v1.DeleteOpti
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("clusterqueues").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -187,7 +177,6 @@ func (c *clusterQueues) DeleteCollection(ctx context.Context, opts v1.DeleteOpti
 func (c *clusterQueues) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.ClusterQueue, err error) {
 	result = &v1beta1.ClusterQueue{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("clusterqueues").
 		Name(name).
 		SubResource(subresources...).
@@ -214,7 +203,6 @@ func (c *clusterQueues) Apply(ctx context.Context, clusterQueue *kueuev1beta1.Cl
 	}
 	result = &v1beta1.ClusterQueue{}
 	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
 		Resource("clusterqueues").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -243,7 +231,6 @@ func (c *clusterQueues) ApplyStatus(ctx context.Context, clusterQueue *kueuev1be
 
 	result = &v1beta1.ClusterQueue{}
 	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
 		Resource("clusterqueues").
 		Name(*name).
 		SubResource("status").

--- a/client-go/clientset/versioned/typed/kueue/v1beta1/fake/fake_admissioncheck.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta1/fake/fake_admissioncheck.go
@@ -34,7 +34,6 @@ import (
 // FakeAdmissionChecks implements AdmissionCheckInterface
 type FakeAdmissionChecks struct {
 	Fake *FakeKueueV1beta1
-	ns   string
 }
 
 var admissionchecksResource = v1beta1.SchemeGroupVersion.WithResource("admissionchecks")
@@ -44,8 +43,7 @@ var admissionchecksKind = v1beta1.SchemeGroupVersion.WithKind("AdmissionCheck")
 // Get takes name of the admissionCheck, and returns the corresponding admissionCheck object, and an error if there is any.
 func (c *FakeAdmissionChecks) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.AdmissionCheck, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(admissionchecksResource, c.ns, name), &v1beta1.AdmissionCheck{})
-
+		Invokes(testing.NewRootGetAction(admissionchecksResource, name), &v1beta1.AdmissionCheck{})
 	if obj == nil {
 		return nil, err
 	}
@@ -55,8 +53,7 @@ func (c *FakeAdmissionChecks) Get(ctx context.Context, name string, options v1.G
 // List takes label and field selectors, and returns the list of AdmissionChecks that match those selectors.
 func (c *FakeAdmissionChecks) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.AdmissionCheckList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(admissionchecksResource, admissionchecksKind, c.ns, opts), &v1beta1.AdmissionCheckList{})
-
+		Invokes(testing.NewRootListAction(admissionchecksResource, admissionchecksKind, opts), &v1beta1.AdmissionCheckList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -77,15 +74,13 @@ func (c *FakeAdmissionChecks) List(ctx context.Context, opts v1.ListOptions) (re
 // Watch returns a watch.Interface that watches the requested admissionChecks.
 func (c *FakeAdmissionChecks) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(admissionchecksResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(admissionchecksResource, opts))
 }
 
 // Create takes the representation of a admissionCheck and creates it.  Returns the server's representation of the admissionCheck, and an error, if there is any.
 func (c *FakeAdmissionChecks) Create(ctx context.Context, admissionCheck *v1beta1.AdmissionCheck, opts v1.CreateOptions) (result *v1beta1.AdmissionCheck, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(admissionchecksResource, c.ns, admissionCheck), &v1beta1.AdmissionCheck{})
-
+		Invokes(testing.NewRootCreateAction(admissionchecksResource, admissionCheck), &v1beta1.AdmissionCheck{})
 	if obj == nil {
 		return nil, err
 	}
@@ -95,8 +90,7 @@ func (c *FakeAdmissionChecks) Create(ctx context.Context, admissionCheck *v1beta
 // Update takes the representation of a admissionCheck and updates it. Returns the server's representation of the admissionCheck, and an error, if there is any.
 func (c *FakeAdmissionChecks) Update(ctx context.Context, admissionCheck *v1beta1.AdmissionCheck, opts v1.UpdateOptions) (result *v1beta1.AdmissionCheck, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(admissionchecksResource, c.ns, admissionCheck), &v1beta1.AdmissionCheck{})
-
+		Invokes(testing.NewRootUpdateAction(admissionchecksResource, admissionCheck), &v1beta1.AdmissionCheck{})
 	if obj == nil {
 		return nil, err
 	}
@@ -107,8 +101,7 @@ func (c *FakeAdmissionChecks) Update(ctx context.Context, admissionCheck *v1beta
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeAdmissionChecks) UpdateStatus(ctx context.Context, admissionCheck *v1beta1.AdmissionCheck, opts v1.UpdateOptions) (*v1beta1.AdmissionCheck, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(admissionchecksResource, "status", c.ns, admissionCheck), &v1beta1.AdmissionCheck{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(admissionchecksResource, "status", admissionCheck), &v1beta1.AdmissionCheck{})
 	if obj == nil {
 		return nil, err
 	}
@@ -118,14 +111,13 @@ func (c *FakeAdmissionChecks) UpdateStatus(ctx context.Context, admissionCheck *
 // Delete takes name of the admissionCheck and deletes it. Returns an error if one occurs.
 func (c *FakeAdmissionChecks) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(admissionchecksResource, c.ns, name, opts), &v1beta1.AdmissionCheck{})
-
+		Invokes(testing.NewRootDeleteActionWithOptions(admissionchecksResource, name, opts), &v1beta1.AdmissionCheck{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeAdmissionChecks) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(admissionchecksResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(admissionchecksResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.AdmissionCheckList{})
 	return err
@@ -134,8 +126,7 @@ func (c *FakeAdmissionChecks) DeleteCollection(ctx context.Context, opts v1.Dele
 // Patch applies the patch and returns the patched admissionCheck.
 func (c *FakeAdmissionChecks) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.AdmissionCheck, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(admissionchecksResource, c.ns, name, pt, data, subresources...), &v1beta1.AdmissionCheck{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(admissionchecksResource, name, pt, data, subresources...), &v1beta1.AdmissionCheck{})
 	if obj == nil {
 		return nil, err
 	}
@@ -156,8 +147,7 @@ func (c *FakeAdmissionChecks) Apply(ctx context.Context, admissionCheck *kueuev1
 		return nil, fmt.Errorf("admissionCheck.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(admissionchecksResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.AdmissionCheck{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(admissionchecksResource, *name, types.ApplyPatchType, data), &v1beta1.AdmissionCheck{})
 	if obj == nil {
 		return nil, err
 	}
@@ -179,8 +169,7 @@ func (c *FakeAdmissionChecks) ApplyStatus(ctx context.Context, admissionCheck *k
 		return nil, fmt.Errorf("admissionCheck.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(admissionchecksResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta1.AdmissionCheck{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(admissionchecksResource, *name, types.ApplyPatchType, data, "status"), &v1beta1.AdmissionCheck{})
 	if obj == nil {
 		return nil, err
 	}

--- a/client-go/clientset/versioned/typed/kueue/v1beta1/fake/fake_clusterqueue.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta1/fake/fake_clusterqueue.go
@@ -34,7 +34,6 @@ import (
 // FakeClusterQueues implements ClusterQueueInterface
 type FakeClusterQueues struct {
 	Fake *FakeKueueV1beta1
-	ns   string
 }
 
 var clusterqueuesResource = v1beta1.SchemeGroupVersion.WithResource("clusterqueues")
@@ -44,8 +43,7 @@ var clusterqueuesKind = v1beta1.SchemeGroupVersion.WithKind("ClusterQueue")
 // Get takes name of the clusterQueue, and returns the corresponding clusterQueue object, and an error if there is any.
 func (c *FakeClusterQueues) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.ClusterQueue, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(clusterqueuesResource, c.ns, name), &v1beta1.ClusterQueue{})
-
+		Invokes(testing.NewRootGetAction(clusterqueuesResource, name), &v1beta1.ClusterQueue{})
 	if obj == nil {
 		return nil, err
 	}
@@ -55,8 +53,7 @@ func (c *FakeClusterQueues) Get(ctx context.Context, name string, options v1.Get
 // List takes label and field selectors, and returns the list of ClusterQueues that match those selectors.
 func (c *FakeClusterQueues) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ClusterQueueList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(clusterqueuesResource, clusterqueuesKind, c.ns, opts), &v1beta1.ClusterQueueList{})
-
+		Invokes(testing.NewRootListAction(clusterqueuesResource, clusterqueuesKind, opts), &v1beta1.ClusterQueueList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -77,15 +74,13 @@ func (c *FakeClusterQueues) List(ctx context.Context, opts v1.ListOptions) (resu
 // Watch returns a watch.Interface that watches the requested clusterQueues.
 func (c *FakeClusterQueues) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(clusterqueuesResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(clusterqueuesResource, opts))
 }
 
 // Create takes the representation of a clusterQueue and creates it.  Returns the server's representation of the clusterQueue, and an error, if there is any.
 func (c *FakeClusterQueues) Create(ctx context.Context, clusterQueue *v1beta1.ClusterQueue, opts v1.CreateOptions) (result *v1beta1.ClusterQueue, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(clusterqueuesResource, c.ns, clusterQueue), &v1beta1.ClusterQueue{})
-
+		Invokes(testing.NewRootCreateAction(clusterqueuesResource, clusterQueue), &v1beta1.ClusterQueue{})
 	if obj == nil {
 		return nil, err
 	}
@@ -95,8 +90,7 @@ func (c *FakeClusterQueues) Create(ctx context.Context, clusterQueue *v1beta1.Cl
 // Update takes the representation of a clusterQueue and updates it. Returns the server's representation of the clusterQueue, and an error, if there is any.
 func (c *FakeClusterQueues) Update(ctx context.Context, clusterQueue *v1beta1.ClusterQueue, opts v1.UpdateOptions) (result *v1beta1.ClusterQueue, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(clusterqueuesResource, c.ns, clusterQueue), &v1beta1.ClusterQueue{})
-
+		Invokes(testing.NewRootUpdateAction(clusterqueuesResource, clusterQueue), &v1beta1.ClusterQueue{})
 	if obj == nil {
 		return nil, err
 	}
@@ -107,8 +101,7 @@ func (c *FakeClusterQueues) Update(ctx context.Context, clusterQueue *v1beta1.Cl
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeClusterQueues) UpdateStatus(ctx context.Context, clusterQueue *v1beta1.ClusterQueue, opts v1.UpdateOptions) (*v1beta1.ClusterQueue, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(clusterqueuesResource, "status", c.ns, clusterQueue), &v1beta1.ClusterQueue{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(clusterqueuesResource, "status", clusterQueue), &v1beta1.ClusterQueue{})
 	if obj == nil {
 		return nil, err
 	}
@@ -118,14 +111,13 @@ func (c *FakeClusterQueues) UpdateStatus(ctx context.Context, clusterQueue *v1be
 // Delete takes name of the clusterQueue and deletes it. Returns an error if one occurs.
 func (c *FakeClusterQueues) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(clusterqueuesResource, c.ns, name, opts), &v1beta1.ClusterQueue{})
-
+		Invokes(testing.NewRootDeleteActionWithOptions(clusterqueuesResource, name, opts), &v1beta1.ClusterQueue{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeClusterQueues) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(clusterqueuesResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(clusterqueuesResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.ClusterQueueList{})
 	return err
@@ -134,8 +126,7 @@ func (c *FakeClusterQueues) DeleteCollection(ctx context.Context, opts v1.Delete
 // Patch applies the patch and returns the patched clusterQueue.
 func (c *FakeClusterQueues) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.ClusterQueue, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(clusterqueuesResource, c.ns, name, pt, data, subresources...), &v1beta1.ClusterQueue{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(clusterqueuesResource, name, pt, data, subresources...), &v1beta1.ClusterQueue{})
 	if obj == nil {
 		return nil, err
 	}
@@ -156,8 +147,7 @@ func (c *FakeClusterQueues) Apply(ctx context.Context, clusterQueue *kueuev1beta
 		return nil, fmt.Errorf("clusterQueue.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(clusterqueuesResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.ClusterQueue{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(clusterqueuesResource, *name, types.ApplyPatchType, data), &v1beta1.ClusterQueue{})
 	if obj == nil {
 		return nil, err
 	}
@@ -179,8 +169,7 @@ func (c *FakeClusterQueues) ApplyStatus(ctx context.Context, clusterQueue *kueue
 		return nil, fmt.Errorf("clusterQueue.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(clusterqueuesResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1beta1.ClusterQueue{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(clusterqueuesResource, *name, types.ApplyPatchType, data, "status"), &v1beta1.ClusterQueue{})
 	if obj == nil {
 		return nil, err
 	}

--- a/client-go/clientset/versioned/typed/kueue/v1beta1/fake/fake_kueue_client.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta1/fake/fake_kueue_client.go
@@ -27,32 +27,32 @@ type FakeKueueV1beta1 struct {
 	*testing.Fake
 }
 
-func (c *FakeKueueV1beta1) AdmissionChecks(namespace string) v1beta1.AdmissionCheckInterface {
-	return &FakeAdmissionChecks{c, namespace}
+func (c *FakeKueueV1beta1) AdmissionChecks() v1beta1.AdmissionCheckInterface {
+	return &FakeAdmissionChecks{c}
 }
 
-func (c *FakeKueueV1beta1) ClusterQueues(namespace string) v1beta1.ClusterQueueInterface {
-	return &FakeClusterQueues{c, namespace}
+func (c *FakeKueueV1beta1) ClusterQueues() v1beta1.ClusterQueueInterface {
+	return &FakeClusterQueues{c}
 }
 
 func (c *FakeKueueV1beta1) LocalQueues(namespace string) v1beta1.LocalQueueInterface {
 	return &FakeLocalQueues{c, namespace}
 }
 
-func (c *FakeKueueV1beta1) ProvisioningRequestConfigs(namespace string) v1beta1.ProvisioningRequestConfigInterface {
-	return &FakeProvisioningRequestConfigs{c, namespace}
+func (c *FakeKueueV1beta1) ProvisioningRequestConfigs() v1beta1.ProvisioningRequestConfigInterface {
+	return &FakeProvisioningRequestConfigs{c}
 }
 
-func (c *FakeKueueV1beta1) ResourceFlavors(namespace string) v1beta1.ResourceFlavorInterface {
-	return &FakeResourceFlavors{c, namespace}
+func (c *FakeKueueV1beta1) ResourceFlavors() v1beta1.ResourceFlavorInterface {
+	return &FakeResourceFlavors{c}
 }
 
 func (c *FakeKueueV1beta1) Workloads(namespace string) v1beta1.WorkloadInterface {
 	return &FakeWorkloads{c, namespace}
 }
 
-func (c *FakeKueueV1beta1) WorkloadPriorityClasses(namespace string) v1beta1.WorkloadPriorityClassInterface {
-	return &FakeWorkloadPriorityClasses{c, namespace}
+func (c *FakeKueueV1beta1) WorkloadPriorityClasses() v1beta1.WorkloadPriorityClassInterface {
+	return &FakeWorkloadPriorityClasses{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/client-go/clientset/versioned/typed/kueue/v1beta1/fake/fake_provisioningrequestconfig.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta1/fake/fake_provisioningrequestconfig.go
@@ -34,7 +34,6 @@ import (
 // FakeProvisioningRequestConfigs implements ProvisioningRequestConfigInterface
 type FakeProvisioningRequestConfigs struct {
 	Fake *FakeKueueV1beta1
-	ns   string
 }
 
 var provisioningrequestconfigsResource = v1beta1.SchemeGroupVersion.WithResource("provisioningrequestconfigs")
@@ -44,8 +43,7 @@ var provisioningrequestconfigsKind = v1beta1.SchemeGroupVersion.WithKind("Provis
 // Get takes name of the provisioningRequestConfig, and returns the corresponding provisioningRequestConfig object, and an error if there is any.
 func (c *FakeProvisioningRequestConfigs) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.ProvisioningRequestConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(provisioningrequestconfigsResource, c.ns, name), &v1beta1.ProvisioningRequestConfig{})
-
+		Invokes(testing.NewRootGetAction(provisioningrequestconfigsResource, name), &v1beta1.ProvisioningRequestConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -55,8 +53,7 @@ func (c *FakeProvisioningRequestConfigs) Get(ctx context.Context, name string, o
 // List takes label and field selectors, and returns the list of ProvisioningRequestConfigs that match those selectors.
 func (c *FakeProvisioningRequestConfigs) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ProvisioningRequestConfigList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(provisioningrequestconfigsResource, provisioningrequestconfigsKind, c.ns, opts), &v1beta1.ProvisioningRequestConfigList{})
-
+		Invokes(testing.NewRootListAction(provisioningrequestconfigsResource, provisioningrequestconfigsKind, opts), &v1beta1.ProvisioningRequestConfigList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -77,15 +74,13 @@ func (c *FakeProvisioningRequestConfigs) List(ctx context.Context, opts v1.ListO
 // Watch returns a watch.Interface that watches the requested provisioningRequestConfigs.
 func (c *FakeProvisioningRequestConfigs) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(provisioningrequestconfigsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(provisioningrequestconfigsResource, opts))
 }
 
 // Create takes the representation of a provisioningRequestConfig and creates it.  Returns the server's representation of the provisioningRequestConfig, and an error, if there is any.
 func (c *FakeProvisioningRequestConfigs) Create(ctx context.Context, provisioningRequestConfig *v1beta1.ProvisioningRequestConfig, opts v1.CreateOptions) (result *v1beta1.ProvisioningRequestConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(provisioningrequestconfigsResource, c.ns, provisioningRequestConfig), &v1beta1.ProvisioningRequestConfig{})
-
+		Invokes(testing.NewRootCreateAction(provisioningrequestconfigsResource, provisioningRequestConfig), &v1beta1.ProvisioningRequestConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -95,8 +90,7 @@ func (c *FakeProvisioningRequestConfigs) Create(ctx context.Context, provisionin
 // Update takes the representation of a provisioningRequestConfig and updates it. Returns the server's representation of the provisioningRequestConfig, and an error, if there is any.
 func (c *FakeProvisioningRequestConfigs) Update(ctx context.Context, provisioningRequestConfig *v1beta1.ProvisioningRequestConfig, opts v1.UpdateOptions) (result *v1beta1.ProvisioningRequestConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(provisioningrequestconfigsResource, c.ns, provisioningRequestConfig), &v1beta1.ProvisioningRequestConfig{})
-
+		Invokes(testing.NewRootUpdateAction(provisioningrequestconfigsResource, provisioningRequestConfig), &v1beta1.ProvisioningRequestConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -106,14 +100,13 @@ func (c *FakeProvisioningRequestConfigs) Update(ctx context.Context, provisionin
 // Delete takes name of the provisioningRequestConfig and deletes it. Returns an error if one occurs.
 func (c *FakeProvisioningRequestConfigs) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(provisioningrequestconfigsResource, c.ns, name, opts), &v1beta1.ProvisioningRequestConfig{})
-
+		Invokes(testing.NewRootDeleteActionWithOptions(provisioningrequestconfigsResource, name, opts), &v1beta1.ProvisioningRequestConfig{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeProvisioningRequestConfigs) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(provisioningrequestconfigsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(provisioningrequestconfigsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.ProvisioningRequestConfigList{})
 	return err
@@ -122,8 +115,7 @@ func (c *FakeProvisioningRequestConfigs) DeleteCollection(ctx context.Context, o
 // Patch applies the patch and returns the patched provisioningRequestConfig.
 func (c *FakeProvisioningRequestConfigs) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.ProvisioningRequestConfig, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(provisioningrequestconfigsResource, c.ns, name, pt, data, subresources...), &v1beta1.ProvisioningRequestConfig{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(provisioningrequestconfigsResource, name, pt, data, subresources...), &v1beta1.ProvisioningRequestConfig{})
 	if obj == nil {
 		return nil, err
 	}
@@ -144,8 +136,7 @@ func (c *FakeProvisioningRequestConfigs) Apply(ctx context.Context, provisioning
 		return nil, fmt.Errorf("provisioningRequestConfig.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(provisioningrequestconfigsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.ProvisioningRequestConfig{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(provisioningrequestconfigsResource, *name, types.ApplyPatchType, data), &v1beta1.ProvisioningRequestConfig{})
 	if obj == nil {
 		return nil, err
 	}

--- a/client-go/clientset/versioned/typed/kueue/v1beta1/fake/fake_resourceflavor.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta1/fake/fake_resourceflavor.go
@@ -34,7 +34,6 @@ import (
 // FakeResourceFlavors implements ResourceFlavorInterface
 type FakeResourceFlavors struct {
 	Fake *FakeKueueV1beta1
-	ns   string
 }
 
 var resourceflavorsResource = v1beta1.SchemeGroupVersion.WithResource("resourceflavors")
@@ -44,8 +43,7 @@ var resourceflavorsKind = v1beta1.SchemeGroupVersion.WithKind("ResourceFlavor")
 // Get takes name of the resourceFlavor, and returns the corresponding resourceFlavor object, and an error if there is any.
 func (c *FakeResourceFlavors) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.ResourceFlavor, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(resourceflavorsResource, c.ns, name), &v1beta1.ResourceFlavor{})
-
+		Invokes(testing.NewRootGetAction(resourceflavorsResource, name), &v1beta1.ResourceFlavor{})
 	if obj == nil {
 		return nil, err
 	}
@@ -55,8 +53,7 @@ func (c *FakeResourceFlavors) Get(ctx context.Context, name string, options v1.G
 // List takes label and field selectors, and returns the list of ResourceFlavors that match those selectors.
 func (c *FakeResourceFlavors) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.ResourceFlavorList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(resourceflavorsResource, resourceflavorsKind, c.ns, opts), &v1beta1.ResourceFlavorList{})
-
+		Invokes(testing.NewRootListAction(resourceflavorsResource, resourceflavorsKind, opts), &v1beta1.ResourceFlavorList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -77,15 +74,13 @@ func (c *FakeResourceFlavors) List(ctx context.Context, opts v1.ListOptions) (re
 // Watch returns a watch.Interface that watches the requested resourceFlavors.
 func (c *FakeResourceFlavors) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(resourceflavorsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(resourceflavorsResource, opts))
 }
 
 // Create takes the representation of a resourceFlavor and creates it.  Returns the server's representation of the resourceFlavor, and an error, if there is any.
 func (c *FakeResourceFlavors) Create(ctx context.Context, resourceFlavor *v1beta1.ResourceFlavor, opts v1.CreateOptions) (result *v1beta1.ResourceFlavor, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(resourceflavorsResource, c.ns, resourceFlavor), &v1beta1.ResourceFlavor{})
-
+		Invokes(testing.NewRootCreateAction(resourceflavorsResource, resourceFlavor), &v1beta1.ResourceFlavor{})
 	if obj == nil {
 		return nil, err
 	}
@@ -95,8 +90,7 @@ func (c *FakeResourceFlavors) Create(ctx context.Context, resourceFlavor *v1beta
 // Update takes the representation of a resourceFlavor and updates it. Returns the server's representation of the resourceFlavor, and an error, if there is any.
 func (c *FakeResourceFlavors) Update(ctx context.Context, resourceFlavor *v1beta1.ResourceFlavor, opts v1.UpdateOptions) (result *v1beta1.ResourceFlavor, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(resourceflavorsResource, c.ns, resourceFlavor), &v1beta1.ResourceFlavor{})
-
+		Invokes(testing.NewRootUpdateAction(resourceflavorsResource, resourceFlavor), &v1beta1.ResourceFlavor{})
 	if obj == nil {
 		return nil, err
 	}
@@ -106,14 +100,13 @@ func (c *FakeResourceFlavors) Update(ctx context.Context, resourceFlavor *v1beta
 // Delete takes name of the resourceFlavor and deletes it. Returns an error if one occurs.
 func (c *FakeResourceFlavors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(resourceflavorsResource, c.ns, name, opts), &v1beta1.ResourceFlavor{})
-
+		Invokes(testing.NewRootDeleteActionWithOptions(resourceflavorsResource, name, opts), &v1beta1.ResourceFlavor{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeResourceFlavors) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(resourceflavorsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(resourceflavorsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.ResourceFlavorList{})
 	return err
@@ -122,8 +115,7 @@ func (c *FakeResourceFlavors) DeleteCollection(ctx context.Context, opts v1.Dele
 // Patch applies the patch and returns the patched resourceFlavor.
 func (c *FakeResourceFlavors) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.ResourceFlavor, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(resourceflavorsResource, c.ns, name, pt, data, subresources...), &v1beta1.ResourceFlavor{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(resourceflavorsResource, name, pt, data, subresources...), &v1beta1.ResourceFlavor{})
 	if obj == nil {
 		return nil, err
 	}
@@ -144,8 +136,7 @@ func (c *FakeResourceFlavors) Apply(ctx context.Context, resourceFlavor *kueuev1
 		return nil, fmt.Errorf("resourceFlavor.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(resourceflavorsResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.ResourceFlavor{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(resourceflavorsResource, *name, types.ApplyPatchType, data), &v1beta1.ResourceFlavor{})
 	if obj == nil {
 		return nil, err
 	}

--- a/client-go/clientset/versioned/typed/kueue/v1beta1/fake/fake_workloadpriorityclass.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta1/fake/fake_workloadpriorityclass.go
@@ -34,7 +34,6 @@ import (
 // FakeWorkloadPriorityClasses implements WorkloadPriorityClassInterface
 type FakeWorkloadPriorityClasses struct {
 	Fake *FakeKueueV1beta1
-	ns   string
 }
 
 var workloadpriorityclassesResource = v1beta1.SchemeGroupVersion.WithResource("workloadpriorityclasses")
@@ -44,8 +43,7 @@ var workloadpriorityclassesKind = v1beta1.SchemeGroupVersion.WithKind("WorkloadP
 // Get takes name of the workloadPriorityClass, and returns the corresponding workloadPriorityClass object, and an error if there is any.
 func (c *FakeWorkloadPriorityClasses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.WorkloadPriorityClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(workloadpriorityclassesResource, c.ns, name), &v1beta1.WorkloadPriorityClass{})
-
+		Invokes(testing.NewRootGetAction(workloadpriorityclassesResource, name), &v1beta1.WorkloadPriorityClass{})
 	if obj == nil {
 		return nil, err
 	}
@@ -55,8 +53,7 @@ func (c *FakeWorkloadPriorityClasses) Get(ctx context.Context, name string, opti
 // List takes label and field selectors, and returns the list of WorkloadPriorityClasses that match those selectors.
 func (c *FakeWorkloadPriorityClasses) List(ctx context.Context, opts v1.ListOptions) (result *v1beta1.WorkloadPriorityClassList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(workloadpriorityclassesResource, workloadpriorityclassesKind, c.ns, opts), &v1beta1.WorkloadPriorityClassList{})
-
+		Invokes(testing.NewRootListAction(workloadpriorityclassesResource, workloadpriorityclassesKind, opts), &v1beta1.WorkloadPriorityClassList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -77,15 +74,13 @@ func (c *FakeWorkloadPriorityClasses) List(ctx context.Context, opts v1.ListOpti
 // Watch returns a watch.Interface that watches the requested workloadPriorityClasses.
 func (c *FakeWorkloadPriorityClasses) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(workloadpriorityclassesResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(workloadpriorityclassesResource, opts))
 }
 
 // Create takes the representation of a workloadPriorityClass and creates it.  Returns the server's representation of the workloadPriorityClass, and an error, if there is any.
 func (c *FakeWorkloadPriorityClasses) Create(ctx context.Context, workloadPriorityClass *v1beta1.WorkloadPriorityClass, opts v1.CreateOptions) (result *v1beta1.WorkloadPriorityClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(workloadpriorityclassesResource, c.ns, workloadPriorityClass), &v1beta1.WorkloadPriorityClass{})
-
+		Invokes(testing.NewRootCreateAction(workloadpriorityclassesResource, workloadPriorityClass), &v1beta1.WorkloadPriorityClass{})
 	if obj == nil {
 		return nil, err
 	}
@@ -95,8 +90,7 @@ func (c *FakeWorkloadPriorityClasses) Create(ctx context.Context, workloadPriori
 // Update takes the representation of a workloadPriorityClass and updates it. Returns the server's representation of the workloadPriorityClass, and an error, if there is any.
 func (c *FakeWorkloadPriorityClasses) Update(ctx context.Context, workloadPriorityClass *v1beta1.WorkloadPriorityClass, opts v1.UpdateOptions) (result *v1beta1.WorkloadPriorityClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(workloadpriorityclassesResource, c.ns, workloadPriorityClass), &v1beta1.WorkloadPriorityClass{})
-
+		Invokes(testing.NewRootUpdateAction(workloadpriorityclassesResource, workloadPriorityClass), &v1beta1.WorkloadPriorityClass{})
 	if obj == nil {
 		return nil, err
 	}
@@ -106,14 +100,13 @@ func (c *FakeWorkloadPriorityClasses) Update(ctx context.Context, workloadPriori
 // Delete takes name of the workloadPriorityClass and deletes it. Returns an error if one occurs.
 func (c *FakeWorkloadPriorityClasses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(workloadpriorityclassesResource, c.ns, name, opts), &v1beta1.WorkloadPriorityClass{})
-
+		Invokes(testing.NewRootDeleteActionWithOptions(workloadpriorityclassesResource, name, opts), &v1beta1.WorkloadPriorityClass{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeWorkloadPriorityClasses) DeleteCollection(ctx context.Context, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(workloadpriorityclassesResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(workloadpriorityclassesResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1beta1.WorkloadPriorityClassList{})
 	return err
@@ -122,8 +115,7 @@ func (c *FakeWorkloadPriorityClasses) DeleteCollection(ctx context.Context, opts
 // Patch applies the patch and returns the patched workloadPriorityClass.
 func (c *FakeWorkloadPriorityClasses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.WorkloadPriorityClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(workloadpriorityclassesResource, c.ns, name, pt, data, subresources...), &v1beta1.WorkloadPriorityClass{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(workloadpriorityclassesResource, name, pt, data, subresources...), &v1beta1.WorkloadPriorityClass{})
 	if obj == nil {
 		return nil, err
 	}
@@ -144,8 +136,7 @@ func (c *FakeWorkloadPriorityClasses) Apply(ctx context.Context, workloadPriorit
 		return nil, fmt.Errorf("workloadPriorityClass.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(workloadpriorityclassesResource, c.ns, *name, types.ApplyPatchType, data), &v1beta1.WorkloadPriorityClass{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(workloadpriorityclassesResource, *name, types.ApplyPatchType, data), &v1beta1.WorkloadPriorityClass{})
 	if obj == nil {
 		return nil, err
 	}

--- a/client-go/clientset/versioned/typed/kueue/v1beta1/kueue_client.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta1/kueue_client.go
@@ -41,32 +41,32 @@ type KueueV1beta1Client struct {
 	restClient rest.Interface
 }
 
-func (c *KueueV1beta1Client) AdmissionChecks(namespace string) AdmissionCheckInterface {
-	return newAdmissionChecks(c, namespace)
+func (c *KueueV1beta1Client) AdmissionChecks() AdmissionCheckInterface {
+	return newAdmissionChecks(c)
 }
 
-func (c *KueueV1beta1Client) ClusterQueues(namespace string) ClusterQueueInterface {
-	return newClusterQueues(c, namespace)
+func (c *KueueV1beta1Client) ClusterQueues() ClusterQueueInterface {
+	return newClusterQueues(c)
 }
 
 func (c *KueueV1beta1Client) LocalQueues(namespace string) LocalQueueInterface {
 	return newLocalQueues(c, namespace)
 }
 
-func (c *KueueV1beta1Client) ProvisioningRequestConfigs(namespace string) ProvisioningRequestConfigInterface {
-	return newProvisioningRequestConfigs(c, namespace)
+func (c *KueueV1beta1Client) ProvisioningRequestConfigs() ProvisioningRequestConfigInterface {
+	return newProvisioningRequestConfigs(c)
 }
 
-func (c *KueueV1beta1Client) ResourceFlavors(namespace string) ResourceFlavorInterface {
-	return newResourceFlavors(c, namespace)
+func (c *KueueV1beta1Client) ResourceFlavors() ResourceFlavorInterface {
+	return newResourceFlavors(c)
 }
 
 func (c *KueueV1beta1Client) Workloads(namespace string) WorkloadInterface {
 	return newWorkloads(c, namespace)
 }
 
-func (c *KueueV1beta1Client) WorkloadPriorityClasses(namespace string) WorkloadPriorityClassInterface {
-	return newWorkloadPriorityClasses(c, namespace)
+func (c *KueueV1beta1Client) WorkloadPriorityClasses() WorkloadPriorityClassInterface {
+	return newWorkloadPriorityClasses(c)
 }
 
 // NewForConfig creates a new KueueV1beta1Client for the given config.

--- a/client-go/clientset/versioned/typed/kueue/v1beta1/provisioningrequestconfig.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta1/provisioningrequestconfig.go
@@ -35,7 +35,7 @@ import (
 // ProvisioningRequestConfigsGetter has a method to return a ProvisioningRequestConfigInterface.
 // A group's client should implement this interface.
 type ProvisioningRequestConfigsGetter interface {
-	ProvisioningRequestConfigs(namespace string) ProvisioningRequestConfigInterface
+	ProvisioningRequestConfigs() ProvisioningRequestConfigInterface
 }
 
 // ProvisioningRequestConfigInterface has methods to work with ProvisioningRequestConfig resources.
@@ -55,14 +55,12 @@ type ProvisioningRequestConfigInterface interface {
 // provisioningRequestConfigs implements ProvisioningRequestConfigInterface
 type provisioningRequestConfigs struct {
 	client rest.Interface
-	ns     string
 }
 
 // newProvisioningRequestConfigs returns a ProvisioningRequestConfigs
-func newProvisioningRequestConfigs(c *KueueV1beta1Client, namespace string) *provisioningRequestConfigs {
+func newProvisioningRequestConfigs(c *KueueV1beta1Client) *provisioningRequestConfigs {
 	return &provisioningRequestConfigs{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -70,7 +68,6 @@ func newProvisioningRequestConfigs(c *KueueV1beta1Client, namespace string) *pro
 func (c *provisioningRequestConfigs) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.ProvisioningRequestConfig, err error) {
 	result = &v1beta1.ProvisioningRequestConfig{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("provisioningrequestconfigs").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,7 +84,6 @@ func (c *provisioningRequestConfigs) List(ctx context.Context, opts v1.ListOptio
 	}
 	result = &v1beta1.ProvisioningRequestConfigList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("provisioningrequestconfigs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -104,7 +100,6 @@ func (c *provisioningRequestConfigs) Watch(ctx context.Context, opts v1.ListOpti
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("provisioningrequestconfigs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -115,7 +110,6 @@ func (c *provisioningRequestConfigs) Watch(ctx context.Context, opts v1.ListOpti
 func (c *provisioningRequestConfigs) Create(ctx context.Context, provisioningRequestConfig *v1beta1.ProvisioningRequestConfig, opts v1.CreateOptions) (result *v1beta1.ProvisioningRequestConfig, err error) {
 	result = &v1beta1.ProvisioningRequestConfig{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("provisioningrequestconfigs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(provisioningRequestConfig).
@@ -128,7 +122,6 @@ func (c *provisioningRequestConfigs) Create(ctx context.Context, provisioningReq
 func (c *provisioningRequestConfigs) Update(ctx context.Context, provisioningRequestConfig *v1beta1.ProvisioningRequestConfig, opts v1.UpdateOptions) (result *v1beta1.ProvisioningRequestConfig, err error) {
 	result = &v1beta1.ProvisioningRequestConfig{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("provisioningrequestconfigs").
 		Name(provisioningRequestConfig.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -141,7 +134,6 @@ func (c *provisioningRequestConfigs) Update(ctx context.Context, provisioningReq
 // Delete takes name of the provisioningRequestConfig and deletes it. Returns an error if one occurs.
 func (c *provisioningRequestConfigs) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("provisioningrequestconfigs").
 		Name(name).
 		Body(&opts).
@@ -156,7 +148,6 @@ func (c *provisioningRequestConfigs) DeleteCollection(ctx context.Context, opts 
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("provisioningrequestconfigs").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -169,7 +160,6 @@ func (c *provisioningRequestConfigs) DeleteCollection(ctx context.Context, opts 
 func (c *provisioningRequestConfigs) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.ProvisioningRequestConfig, err error) {
 	result = &v1beta1.ProvisioningRequestConfig{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("provisioningrequestconfigs").
 		Name(name).
 		SubResource(subresources...).
@@ -196,7 +186,6 @@ func (c *provisioningRequestConfigs) Apply(ctx context.Context, provisioningRequ
 	}
 	result = &v1beta1.ProvisioningRequestConfig{}
 	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
 		Resource("provisioningrequestconfigs").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/client-go/clientset/versioned/typed/kueue/v1beta1/resourceflavor.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta1/resourceflavor.go
@@ -35,7 +35,7 @@ import (
 // ResourceFlavorsGetter has a method to return a ResourceFlavorInterface.
 // A group's client should implement this interface.
 type ResourceFlavorsGetter interface {
-	ResourceFlavors(namespace string) ResourceFlavorInterface
+	ResourceFlavors() ResourceFlavorInterface
 }
 
 // ResourceFlavorInterface has methods to work with ResourceFlavor resources.
@@ -55,14 +55,12 @@ type ResourceFlavorInterface interface {
 // resourceFlavors implements ResourceFlavorInterface
 type resourceFlavors struct {
 	client rest.Interface
-	ns     string
 }
 
 // newResourceFlavors returns a ResourceFlavors
-func newResourceFlavors(c *KueueV1beta1Client, namespace string) *resourceFlavors {
+func newResourceFlavors(c *KueueV1beta1Client) *resourceFlavors {
 	return &resourceFlavors{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -70,7 +68,6 @@ func newResourceFlavors(c *KueueV1beta1Client, namespace string) *resourceFlavor
 func (c *resourceFlavors) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.ResourceFlavor, err error) {
 	result = &v1beta1.ResourceFlavor{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("resourceflavors").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,7 +84,6 @@ func (c *resourceFlavors) List(ctx context.Context, opts v1.ListOptions) (result
 	}
 	result = &v1beta1.ResourceFlavorList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("resourceflavors").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -104,7 +100,6 @@ func (c *resourceFlavors) Watch(ctx context.Context, opts v1.ListOptions) (watch
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("resourceflavors").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -115,7 +110,6 @@ func (c *resourceFlavors) Watch(ctx context.Context, opts v1.ListOptions) (watch
 func (c *resourceFlavors) Create(ctx context.Context, resourceFlavor *v1beta1.ResourceFlavor, opts v1.CreateOptions) (result *v1beta1.ResourceFlavor, err error) {
 	result = &v1beta1.ResourceFlavor{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("resourceflavors").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(resourceFlavor).
@@ -128,7 +122,6 @@ func (c *resourceFlavors) Create(ctx context.Context, resourceFlavor *v1beta1.Re
 func (c *resourceFlavors) Update(ctx context.Context, resourceFlavor *v1beta1.ResourceFlavor, opts v1.UpdateOptions) (result *v1beta1.ResourceFlavor, err error) {
 	result = &v1beta1.ResourceFlavor{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("resourceflavors").
 		Name(resourceFlavor.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -141,7 +134,6 @@ func (c *resourceFlavors) Update(ctx context.Context, resourceFlavor *v1beta1.Re
 // Delete takes name of the resourceFlavor and deletes it. Returns an error if one occurs.
 func (c *resourceFlavors) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("resourceflavors").
 		Name(name).
 		Body(&opts).
@@ -156,7 +148,6 @@ func (c *resourceFlavors) DeleteCollection(ctx context.Context, opts v1.DeleteOp
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("resourceflavors").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -169,7 +160,6 @@ func (c *resourceFlavors) DeleteCollection(ctx context.Context, opts v1.DeleteOp
 func (c *resourceFlavors) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.ResourceFlavor, err error) {
 	result = &v1beta1.ResourceFlavor{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("resourceflavors").
 		Name(name).
 		SubResource(subresources...).
@@ -196,7 +186,6 @@ func (c *resourceFlavors) Apply(ctx context.Context, resourceFlavor *kueuev1beta
 	}
 	result = &v1beta1.ResourceFlavor{}
 	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
 		Resource("resourceflavors").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/client-go/clientset/versioned/typed/kueue/v1beta1/workloadpriorityclass.go
+++ b/client-go/clientset/versioned/typed/kueue/v1beta1/workloadpriorityclass.go
@@ -35,7 +35,7 @@ import (
 // WorkloadPriorityClassesGetter has a method to return a WorkloadPriorityClassInterface.
 // A group's client should implement this interface.
 type WorkloadPriorityClassesGetter interface {
-	WorkloadPriorityClasses(namespace string) WorkloadPriorityClassInterface
+	WorkloadPriorityClasses() WorkloadPriorityClassInterface
 }
 
 // WorkloadPriorityClassInterface has methods to work with WorkloadPriorityClass resources.
@@ -55,14 +55,12 @@ type WorkloadPriorityClassInterface interface {
 // workloadPriorityClasses implements WorkloadPriorityClassInterface
 type workloadPriorityClasses struct {
 	client rest.Interface
-	ns     string
 }
 
 // newWorkloadPriorityClasses returns a WorkloadPriorityClasses
-func newWorkloadPriorityClasses(c *KueueV1beta1Client, namespace string) *workloadPriorityClasses {
+func newWorkloadPriorityClasses(c *KueueV1beta1Client) *workloadPriorityClasses {
 	return &workloadPriorityClasses{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -70,7 +68,6 @@ func newWorkloadPriorityClasses(c *KueueV1beta1Client, namespace string) *worklo
 func (c *workloadPriorityClasses) Get(ctx context.Context, name string, options v1.GetOptions) (result *v1beta1.WorkloadPriorityClass, err error) {
 	result = &v1beta1.WorkloadPriorityClass{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("workloadpriorityclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,7 +84,6 @@ func (c *workloadPriorityClasses) List(ctx context.Context, opts v1.ListOptions)
 	}
 	result = &v1beta1.WorkloadPriorityClassList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("workloadpriorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -104,7 +100,6 @@ func (c *workloadPriorityClasses) Watch(ctx context.Context, opts v1.ListOptions
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("workloadpriorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -115,7 +110,6 @@ func (c *workloadPriorityClasses) Watch(ctx context.Context, opts v1.ListOptions
 func (c *workloadPriorityClasses) Create(ctx context.Context, workloadPriorityClass *v1beta1.WorkloadPriorityClass, opts v1.CreateOptions) (result *v1beta1.WorkloadPriorityClass, err error) {
 	result = &v1beta1.WorkloadPriorityClass{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("workloadpriorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(workloadPriorityClass).
@@ -128,7 +122,6 @@ func (c *workloadPriorityClasses) Create(ctx context.Context, workloadPriorityCl
 func (c *workloadPriorityClasses) Update(ctx context.Context, workloadPriorityClass *v1beta1.WorkloadPriorityClass, opts v1.UpdateOptions) (result *v1beta1.WorkloadPriorityClass, err error) {
 	result = &v1beta1.WorkloadPriorityClass{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("workloadpriorityclasses").
 		Name(workloadPriorityClass.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -141,7 +134,6 @@ func (c *workloadPriorityClasses) Update(ctx context.Context, workloadPriorityCl
 // Delete takes name of the workloadPriorityClass and deletes it. Returns an error if one occurs.
 func (c *workloadPriorityClasses) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("workloadpriorityclasses").
 		Name(name).
 		Body(&opts).
@@ -156,7 +148,6 @@ func (c *workloadPriorityClasses) DeleteCollection(ctx context.Context, opts v1.
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("workloadpriorityclasses").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -169,7 +160,6 @@ func (c *workloadPriorityClasses) DeleteCollection(ctx context.Context, opts v1.
 func (c *workloadPriorityClasses) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions, subresources ...string) (result *v1beta1.WorkloadPriorityClass, err error) {
 	result = &v1beta1.WorkloadPriorityClass{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("workloadpriorityclasses").
 		Name(name).
 		SubResource(subresources...).
@@ -196,7 +186,6 @@ func (c *workloadPriorityClasses) Apply(ctx context.Context, workloadPriorityCla
 	}
 	result = &v1beta1.WorkloadPriorityClass{}
 	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
 		Resource("workloadpriorityclasses").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/client-go/informers/externalversions/kueue/v1beta1/admissioncheck.go
+++ b/client-go/informers/externalversions/kueue/v1beta1/admissioncheck.go
@@ -41,33 +41,32 @@ type AdmissionCheckInformer interface {
 type admissionCheckInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewAdmissionCheckInformer constructs a new informer for AdmissionCheck type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewAdmissionCheckInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredAdmissionCheckInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewAdmissionCheckInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredAdmissionCheckInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredAdmissionCheckInformer constructs a new informer for AdmissionCheck type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredAdmissionCheckInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredAdmissionCheckInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta1().AdmissionChecks(namespace).List(context.TODO(), options)
+				return client.KueueV1beta1().AdmissionChecks().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta1().AdmissionChecks(namespace).Watch(context.TODO(), options)
+				return client.KueueV1beta1().AdmissionChecks().Watch(context.TODO(), options)
 			},
 		},
 		&kueuev1beta1.AdmissionCheck{},
@@ -77,7 +76,7 @@ func NewFilteredAdmissionCheckInformer(client versioned.Interface, namespace str
 }
 
 func (f *admissionCheckInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredAdmissionCheckInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredAdmissionCheckInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *admissionCheckInformer) Informer() cache.SharedIndexInformer {

--- a/client-go/informers/externalversions/kueue/v1beta1/clusterqueue.go
+++ b/client-go/informers/externalversions/kueue/v1beta1/clusterqueue.go
@@ -41,33 +41,32 @@ type ClusterQueueInformer interface {
 type clusterQueueInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewClusterQueueInformer constructs a new informer for ClusterQueue type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewClusterQueueInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredClusterQueueInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewClusterQueueInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredClusterQueueInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredClusterQueueInformer constructs a new informer for ClusterQueue type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredClusterQueueInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredClusterQueueInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta1().ClusterQueues(namespace).List(context.TODO(), options)
+				return client.KueueV1beta1().ClusterQueues().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta1().ClusterQueues(namespace).Watch(context.TODO(), options)
+				return client.KueueV1beta1().ClusterQueues().Watch(context.TODO(), options)
 			},
 		},
 		&kueuev1beta1.ClusterQueue{},
@@ -77,7 +76,7 @@ func NewFilteredClusterQueueInformer(client versioned.Interface, namespace strin
 }
 
 func (f *clusterQueueInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredClusterQueueInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredClusterQueueInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *clusterQueueInformer) Informer() cache.SharedIndexInformer {

--- a/client-go/informers/externalversions/kueue/v1beta1/interface.go
+++ b/client-go/informers/externalversions/kueue/v1beta1/interface.go
@@ -52,12 +52,12 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // AdmissionChecks returns a AdmissionCheckInformer.
 func (v *version) AdmissionChecks() AdmissionCheckInformer {
-	return &admissionCheckInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &admissionCheckInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // ClusterQueues returns a ClusterQueueInformer.
 func (v *version) ClusterQueues() ClusterQueueInformer {
-	return &clusterQueueInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &clusterQueueInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // LocalQueues returns a LocalQueueInformer.
@@ -67,12 +67,12 @@ func (v *version) LocalQueues() LocalQueueInformer {
 
 // ProvisioningRequestConfigs returns a ProvisioningRequestConfigInformer.
 func (v *version) ProvisioningRequestConfigs() ProvisioningRequestConfigInformer {
-	return &provisioningRequestConfigInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &provisioningRequestConfigInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // ResourceFlavors returns a ResourceFlavorInformer.
 func (v *version) ResourceFlavors() ResourceFlavorInformer {
-	return &resourceFlavorInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &resourceFlavorInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // Workloads returns a WorkloadInformer.
@@ -82,5 +82,5 @@ func (v *version) Workloads() WorkloadInformer {
 
 // WorkloadPriorityClasses returns a WorkloadPriorityClassInformer.
 func (v *version) WorkloadPriorityClasses() WorkloadPriorityClassInformer {
-	return &workloadPriorityClassInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &workloadPriorityClassInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/client-go/informers/externalversions/kueue/v1beta1/provisioningrequestconfig.go
+++ b/client-go/informers/externalversions/kueue/v1beta1/provisioningrequestconfig.go
@@ -41,33 +41,32 @@ type ProvisioningRequestConfigInformer interface {
 type provisioningRequestConfigInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewProvisioningRequestConfigInformer constructs a new informer for ProvisioningRequestConfig type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewProvisioningRequestConfigInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredProvisioningRequestConfigInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewProvisioningRequestConfigInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredProvisioningRequestConfigInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredProvisioningRequestConfigInformer constructs a new informer for ProvisioningRequestConfig type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredProvisioningRequestConfigInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredProvisioningRequestConfigInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta1().ProvisioningRequestConfigs(namespace).List(context.TODO(), options)
+				return client.KueueV1beta1().ProvisioningRequestConfigs().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta1().ProvisioningRequestConfigs(namespace).Watch(context.TODO(), options)
+				return client.KueueV1beta1().ProvisioningRequestConfigs().Watch(context.TODO(), options)
 			},
 		},
 		&kueuev1beta1.ProvisioningRequestConfig{},
@@ -77,7 +76,7 @@ func NewFilteredProvisioningRequestConfigInformer(client versioned.Interface, na
 }
 
 func (f *provisioningRequestConfigInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredProvisioningRequestConfigInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredProvisioningRequestConfigInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *provisioningRequestConfigInformer) Informer() cache.SharedIndexInformer {

--- a/client-go/informers/externalversions/kueue/v1beta1/resourceflavor.go
+++ b/client-go/informers/externalversions/kueue/v1beta1/resourceflavor.go
@@ -41,33 +41,32 @@ type ResourceFlavorInformer interface {
 type resourceFlavorInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewResourceFlavorInformer constructs a new informer for ResourceFlavor type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewResourceFlavorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredResourceFlavorInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewResourceFlavorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredResourceFlavorInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredResourceFlavorInformer constructs a new informer for ResourceFlavor type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredResourceFlavorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredResourceFlavorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta1().ResourceFlavors(namespace).List(context.TODO(), options)
+				return client.KueueV1beta1().ResourceFlavors().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta1().ResourceFlavors(namespace).Watch(context.TODO(), options)
+				return client.KueueV1beta1().ResourceFlavors().Watch(context.TODO(), options)
 			},
 		},
 		&kueuev1beta1.ResourceFlavor{},
@@ -77,7 +76,7 @@ func NewFilteredResourceFlavorInformer(client versioned.Interface, namespace str
 }
 
 func (f *resourceFlavorInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredResourceFlavorInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredResourceFlavorInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *resourceFlavorInformer) Informer() cache.SharedIndexInformer {

--- a/client-go/informers/externalversions/kueue/v1beta1/workloadpriorityclass.go
+++ b/client-go/informers/externalversions/kueue/v1beta1/workloadpriorityclass.go
@@ -41,33 +41,32 @@ type WorkloadPriorityClassInformer interface {
 type workloadPriorityClassInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewWorkloadPriorityClassInformer constructs a new informer for WorkloadPriorityClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewWorkloadPriorityClassInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredWorkloadPriorityClassInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewWorkloadPriorityClassInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredWorkloadPriorityClassInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredWorkloadPriorityClassInformer constructs a new informer for WorkloadPriorityClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredWorkloadPriorityClassInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredWorkloadPriorityClassInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta1().WorkloadPriorityClasses(namespace).List(context.TODO(), options)
+				return client.KueueV1beta1().WorkloadPriorityClasses().List(context.TODO(), options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.KueueV1beta1().WorkloadPriorityClasses(namespace).Watch(context.TODO(), options)
+				return client.KueueV1beta1().WorkloadPriorityClasses().Watch(context.TODO(), options)
 			},
 		},
 		&kueuev1beta1.WorkloadPriorityClass{},
@@ -77,7 +76,7 @@ func NewFilteredWorkloadPriorityClassInformer(client versioned.Interface, namesp
 }
 
 func (f *workloadPriorityClassInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredWorkloadPriorityClassInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredWorkloadPriorityClassInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *workloadPriorityClassInformer) Informer() cache.SharedIndexInformer {

--- a/client-go/listers/kueue/v1beta1/admissioncheck.go
+++ b/client-go/listers/kueue/v1beta1/admissioncheck.go
@@ -30,8 +30,9 @@ type AdmissionCheckLister interface {
 	// List lists all AdmissionChecks in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.AdmissionCheck, err error)
-	// AdmissionChecks returns an object that can list and get AdmissionChecks.
-	AdmissionChecks(namespace string) AdmissionCheckNamespaceLister
+	// Get retrieves the AdmissionCheck from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1beta1.AdmissionCheck, error)
 	AdmissionCheckListerExpansion
 }
 
@@ -53,41 +54,9 @@ func (s *admissionCheckLister) List(selector labels.Selector) (ret []*v1beta1.Ad
 	return ret, err
 }
 
-// AdmissionChecks returns an object that can list and get AdmissionChecks.
-func (s *admissionCheckLister) AdmissionChecks(namespace string) AdmissionCheckNamespaceLister {
-	return admissionCheckNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// AdmissionCheckNamespaceLister helps list and get AdmissionChecks.
-// All objects returned here must be treated as read-only.
-type AdmissionCheckNamespaceLister interface {
-	// List lists all AdmissionChecks in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta1.AdmissionCheck, err error)
-	// Get retrieves the AdmissionCheck from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1beta1.AdmissionCheck, error)
-	AdmissionCheckNamespaceListerExpansion
-}
-
-// admissionCheckNamespaceLister implements the AdmissionCheckNamespaceLister
-// interface.
-type admissionCheckNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all AdmissionChecks in the indexer for a given namespace.
-func (s admissionCheckNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.AdmissionCheck, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1beta1.AdmissionCheck))
-	})
-	return ret, err
-}
-
-// Get retrieves the AdmissionCheck from the indexer for a given namespace and name.
-func (s admissionCheckNamespaceLister) Get(name string) (*v1beta1.AdmissionCheck, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the AdmissionCheck from the index for a given name.
+func (s *admissionCheckLister) Get(name string) (*v1beta1.AdmissionCheck, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/client-go/listers/kueue/v1beta1/clusterqueue.go
+++ b/client-go/listers/kueue/v1beta1/clusterqueue.go
@@ -30,8 +30,9 @@ type ClusterQueueLister interface {
 	// List lists all ClusterQueues in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.ClusterQueue, err error)
-	// ClusterQueues returns an object that can list and get ClusterQueues.
-	ClusterQueues(namespace string) ClusterQueueNamespaceLister
+	// Get retrieves the ClusterQueue from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1beta1.ClusterQueue, error)
 	ClusterQueueListerExpansion
 }
 
@@ -53,41 +54,9 @@ func (s *clusterQueueLister) List(selector labels.Selector) (ret []*v1beta1.Clus
 	return ret, err
 }
 
-// ClusterQueues returns an object that can list and get ClusterQueues.
-func (s *clusterQueueLister) ClusterQueues(namespace string) ClusterQueueNamespaceLister {
-	return clusterQueueNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// ClusterQueueNamespaceLister helps list and get ClusterQueues.
-// All objects returned here must be treated as read-only.
-type ClusterQueueNamespaceLister interface {
-	// List lists all ClusterQueues in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta1.ClusterQueue, err error)
-	// Get retrieves the ClusterQueue from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1beta1.ClusterQueue, error)
-	ClusterQueueNamespaceListerExpansion
-}
-
-// clusterQueueNamespaceLister implements the ClusterQueueNamespaceLister
-// interface.
-type clusterQueueNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all ClusterQueues in the indexer for a given namespace.
-func (s clusterQueueNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.ClusterQueue, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1beta1.ClusterQueue))
-	})
-	return ret, err
-}
-
-// Get retrieves the ClusterQueue from the indexer for a given namespace and name.
-func (s clusterQueueNamespaceLister) Get(name string) (*v1beta1.ClusterQueue, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the ClusterQueue from the index for a given name.
+func (s *clusterQueueLister) Get(name string) (*v1beta1.ClusterQueue, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/client-go/listers/kueue/v1beta1/expansion_generated.go
+++ b/client-go/listers/kueue/v1beta1/expansion_generated.go
@@ -21,17 +21,9 @@ package v1beta1
 // AdmissionCheckLister.
 type AdmissionCheckListerExpansion interface{}
 
-// AdmissionCheckNamespaceListerExpansion allows custom methods to be added to
-// AdmissionCheckNamespaceLister.
-type AdmissionCheckNamespaceListerExpansion interface{}
-
 // ClusterQueueListerExpansion allows custom methods to be added to
 // ClusterQueueLister.
 type ClusterQueueListerExpansion interface{}
-
-// ClusterQueueNamespaceListerExpansion allows custom methods to be added to
-// ClusterQueueNamespaceLister.
-type ClusterQueueNamespaceListerExpansion interface{}
 
 // LocalQueueListerExpansion allows custom methods to be added to
 // LocalQueueLister.
@@ -45,17 +37,9 @@ type LocalQueueNamespaceListerExpansion interface{}
 // ProvisioningRequestConfigLister.
 type ProvisioningRequestConfigListerExpansion interface{}
 
-// ProvisioningRequestConfigNamespaceListerExpansion allows custom methods to be added to
-// ProvisioningRequestConfigNamespaceLister.
-type ProvisioningRequestConfigNamespaceListerExpansion interface{}
-
 // ResourceFlavorListerExpansion allows custom methods to be added to
 // ResourceFlavorLister.
 type ResourceFlavorListerExpansion interface{}
-
-// ResourceFlavorNamespaceListerExpansion allows custom methods to be added to
-// ResourceFlavorNamespaceLister.
-type ResourceFlavorNamespaceListerExpansion interface{}
 
 // WorkloadListerExpansion allows custom methods to be added to
 // WorkloadLister.
@@ -68,7 +52,3 @@ type WorkloadNamespaceListerExpansion interface{}
 // WorkloadPriorityClassListerExpansion allows custom methods to be added to
 // WorkloadPriorityClassLister.
 type WorkloadPriorityClassListerExpansion interface{}
-
-// WorkloadPriorityClassNamespaceListerExpansion allows custom methods to be added to
-// WorkloadPriorityClassNamespaceLister.
-type WorkloadPriorityClassNamespaceListerExpansion interface{}

--- a/client-go/listers/kueue/v1beta1/provisioningrequestconfig.go
+++ b/client-go/listers/kueue/v1beta1/provisioningrequestconfig.go
@@ -30,8 +30,9 @@ type ProvisioningRequestConfigLister interface {
 	// List lists all ProvisioningRequestConfigs in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.ProvisioningRequestConfig, err error)
-	// ProvisioningRequestConfigs returns an object that can list and get ProvisioningRequestConfigs.
-	ProvisioningRequestConfigs(namespace string) ProvisioningRequestConfigNamespaceLister
+	// Get retrieves the ProvisioningRequestConfig from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1beta1.ProvisioningRequestConfig, error)
 	ProvisioningRequestConfigListerExpansion
 }
 
@@ -53,41 +54,9 @@ func (s *provisioningRequestConfigLister) List(selector labels.Selector) (ret []
 	return ret, err
 }
 
-// ProvisioningRequestConfigs returns an object that can list and get ProvisioningRequestConfigs.
-func (s *provisioningRequestConfigLister) ProvisioningRequestConfigs(namespace string) ProvisioningRequestConfigNamespaceLister {
-	return provisioningRequestConfigNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// ProvisioningRequestConfigNamespaceLister helps list and get ProvisioningRequestConfigs.
-// All objects returned here must be treated as read-only.
-type ProvisioningRequestConfigNamespaceLister interface {
-	// List lists all ProvisioningRequestConfigs in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta1.ProvisioningRequestConfig, err error)
-	// Get retrieves the ProvisioningRequestConfig from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1beta1.ProvisioningRequestConfig, error)
-	ProvisioningRequestConfigNamespaceListerExpansion
-}
-
-// provisioningRequestConfigNamespaceLister implements the ProvisioningRequestConfigNamespaceLister
-// interface.
-type provisioningRequestConfigNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all ProvisioningRequestConfigs in the indexer for a given namespace.
-func (s provisioningRequestConfigNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.ProvisioningRequestConfig, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1beta1.ProvisioningRequestConfig))
-	})
-	return ret, err
-}
-
-// Get retrieves the ProvisioningRequestConfig from the indexer for a given namespace and name.
-func (s provisioningRequestConfigNamespaceLister) Get(name string) (*v1beta1.ProvisioningRequestConfig, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the ProvisioningRequestConfig from the index for a given name.
+func (s *provisioningRequestConfigLister) Get(name string) (*v1beta1.ProvisioningRequestConfig, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/client-go/listers/kueue/v1beta1/resourceflavor.go
+++ b/client-go/listers/kueue/v1beta1/resourceflavor.go
@@ -30,8 +30,9 @@ type ResourceFlavorLister interface {
 	// List lists all ResourceFlavors in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.ResourceFlavor, err error)
-	// ResourceFlavors returns an object that can list and get ResourceFlavors.
-	ResourceFlavors(namespace string) ResourceFlavorNamespaceLister
+	// Get retrieves the ResourceFlavor from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1beta1.ResourceFlavor, error)
 	ResourceFlavorListerExpansion
 }
 
@@ -53,41 +54,9 @@ func (s *resourceFlavorLister) List(selector labels.Selector) (ret []*v1beta1.Re
 	return ret, err
 }
 
-// ResourceFlavors returns an object that can list and get ResourceFlavors.
-func (s *resourceFlavorLister) ResourceFlavors(namespace string) ResourceFlavorNamespaceLister {
-	return resourceFlavorNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// ResourceFlavorNamespaceLister helps list and get ResourceFlavors.
-// All objects returned here must be treated as read-only.
-type ResourceFlavorNamespaceLister interface {
-	// List lists all ResourceFlavors in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta1.ResourceFlavor, err error)
-	// Get retrieves the ResourceFlavor from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1beta1.ResourceFlavor, error)
-	ResourceFlavorNamespaceListerExpansion
-}
-
-// resourceFlavorNamespaceLister implements the ResourceFlavorNamespaceLister
-// interface.
-type resourceFlavorNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all ResourceFlavors in the indexer for a given namespace.
-func (s resourceFlavorNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.ResourceFlavor, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1beta1.ResourceFlavor))
-	})
-	return ret, err
-}
-
-// Get retrieves the ResourceFlavor from the indexer for a given namespace and name.
-func (s resourceFlavorNamespaceLister) Get(name string) (*v1beta1.ResourceFlavor, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the ResourceFlavor from the index for a given name.
+func (s *resourceFlavorLister) Get(name string) (*v1beta1.ResourceFlavor, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/client-go/listers/kueue/v1beta1/workloadpriorityclass.go
+++ b/client-go/listers/kueue/v1beta1/workloadpriorityclass.go
@@ -30,8 +30,9 @@ type WorkloadPriorityClassLister interface {
 	// List lists all WorkloadPriorityClasses in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1beta1.WorkloadPriorityClass, err error)
-	// WorkloadPriorityClasses returns an object that can list and get WorkloadPriorityClasses.
-	WorkloadPriorityClasses(namespace string) WorkloadPriorityClassNamespaceLister
+	// Get retrieves the WorkloadPriorityClass from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1beta1.WorkloadPriorityClass, error)
 	WorkloadPriorityClassListerExpansion
 }
 
@@ -53,41 +54,9 @@ func (s *workloadPriorityClassLister) List(selector labels.Selector) (ret []*v1b
 	return ret, err
 }
 
-// WorkloadPriorityClasses returns an object that can list and get WorkloadPriorityClasses.
-func (s *workloadPriorityClassLister) WorkloadPriorityClasses(namespace string) WorkloadPriorityClassNamespaceLister {
-	return workloadPriorityClassNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// WorkloadPriorityClassNamespaceLister helps list and get WorkloadPriorityClasses.
-// All objects returned here must be treated as read-only.
-type WorkloadPriorityClassNamespaceLister interface {
-	// List lists all WorkloadPriorityClasses in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1beta1.WorkloadPriorityClass, err error)
-	// Get retrieves the WorkloadPriorityClass from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1beta1.WorkloadPriorityClass, error)
-	WorkloadPriorityClassNamespaceListerExpansion
-}
-
-// workloadPriorityClassNamespaceLister implements the WorkloadPriorityClassNamespaceLister
-// interface.
-type workloadPriorityClassNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all WorkloadPriorityClasses in the indexer for a given namespace.
-func (s workloadPriorityClassNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.WorkloadPriorityClass, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1beta1.WorkloadPriorityClass))
-	})
-	return ret, err
-}
-
-// Get retrieves the WorkloadPriorityClass from the indexer for a given namespace and name.
-func (s workloadPriorityClassNamespaceLister) Get(name string) (*v1beta1.WorkloadPriorityClass, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the WorkloadPriorityClass from the index for a given name.
+func (s *workloadPriorityClassLister) Get(name string) (*v1beta1.WorkloadPriorityClass, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The client-go libraries for the Cluster scope, such as `ClusterQueue`, don't work fine since the libraries are generated for the Namespaced scope resources.

So, I fixed markers for the code-generator so that we can generate proper libraries.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
When we use the current client-go libraries, we will face the following errors:

```go
an empty namespace may not be set when a resource name is provided
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix client-go libraries bug that can not operate clusterScoped resources like ClusterQueue and ResourceFlavor.
```
