### PR TITLE
[doc] Links to API reference from concept pages

### DIFF
--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -83,3 +83,7 @@ Kueue ensures that the list of the Workloads AdmissionCheckStates is in sync wit
 
 Is a component that monitors Workloads maintaining the content of its specific `admissionCheckStates` and the `Active` condition of the AdmissionChecks it's  controlling.
 The logic for how an AdmissionCheck changes states is not part of Kueue.
+
+## What's next?
+
+- Read the [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-AdmissionCheck) for `AdmissionCheck`

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -391,3 +391,4 @@ Note that, whenever possible and when the configured policy allows it, Kueue avo
 - Create [local queues](/docs/concepts/local_queue)
 - Create [resource flavors](/docs/concepts/resource_flavor) if you haven't already done so.
 - Learn how to [administer cluster quotas](/docs/tasks/administer_cluster_quotas).
+- Read the [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ClusterQueue) for `ClusterQueue`

--- a/site/content/en/docs/concepts/local_queue.md
+++ b/site/content/en/docs/concepts/local_queue.md
@@ -38,3 +38,4 @@ kubectl get -n my-namespace queues
 ## What's next?
 
 - Launch a [Workload](/docs/concepts/workload) through a local queue
+- Read the [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-LocalQueue) for `LocalQueue`

--- a/site/content/en/docs/concepts/resource_flavor.md
+++ b/site/content/en/docs/concepts/resource_flavor.md
@@ -97,3 +97,4 @@ metadata:
 ## What's next?
 
 - Learn about [cluster queues](/docs/concepts/cluster_queue).
+- Read the [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ResourceFlavor) for `ResourceFlavor`

--- a/site/content/en/docs/concepts/workload.md
+++ b/site/content/en/docs/concepts/workload.md
@@ -127,3 +127,4 @@ The `count` can only increase while the workload holds a Quota Reservation.
 
 - Learn about [workload priority class](/docs/concepts/workload_priority_class).
 - Learn how to [run jobs](/docs/tasks/run_jobs)
+- Read the [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-Workload) for `Workload`

--- a/site/content/en/docs/concepts/workload_priority_class.md
+++ b/site/content/en/docs/concepts/workload_priority_class.md
@@ -112,3 +112,4 @@ Workload's `PriorityClassSource` and `PriorityClassName` fields are immutable.
 
 - Learn how to [run jobs](/docs/tasks/run_jobs)
 - Learn how to [run jobs with workload priority](/docs/tasks/run_job_with_workload_priority)
+- Read the [API reference](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-WorkloadPriorityClass) for `WorkloadPriorityClass`

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -230,3 +230,7 @@ The currently supported features are:
 | `PartialAdmission` | `true` | Beta | 0.5 |  |
 | `ProvisioningACC` | `false` | Alpha | 0.5 |  |
 | `QueueVisibility` | `false` | Alpha | 0.5 |  |
+
+## What's next
+
+- Read the [API reference](/docs/reference/kueue-config.v1beta1/#Configuration) for  `Configuration`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1281

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```