### PR TITLE
Adding toleration to the job doesn't trigger workload change

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -619,12 +619,13 @@ func equivalentToWorkload(job GenericJob, wl *kueue.Workload) bool {
 	jobPodSets := clearMinCountsIfFeatureDisabled(job.PodSets())
 
 	if !workload.CanBePartiallyAdmitted(wl) || !workload.HasQuotaReservation(wl) {
+		changePodSpecFields := job.IsActive() && !job.IsSuspended()
 		// the two sets should fully match.
-		return equality.ComparePodSetSlices(jobPodSets, wl.Spec.PodSets, true)
+		return equality.ComparePodSetSlices(jobPodSets, wl.Spec.PodSets, true, changePodSpecFields)
 	}
 
 	// Check everything but the pod counts.
-	if !equality.ComparePodSetSlices(jobPodSets, wl.Spec.PodSets, false) {
+	if !equality.ComparePodSetSlices(jobPodSets, wl.Spec.PodSets, false, false) {
 		return false
 	}
 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -613,7 +613,7 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, wl *ku
 	return true, nil
 }
 
-// get the expected podsets during the job execution, returns nil if the workload has no reservation or
+// expectedRunningPodSets gets the expected podsets during the job execution, returns nil if the workload has no reservation or
 // the admission does not match.
 func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Workload) []kueue.PodSet {
 	if !workload.HasQuotaReservation(wl) {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	"sigs.k8s.io/kueue/pkg/util/maps"
 	utilpriority "sigs.k8s.io/kueue/pkg/util/priority"
+	"sigs.k8s.io/kueue/pkg/util/slices"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -562,7 +563,7 @@ func FindMatchingWorkloads(ctx context.Context, c client.Client, job GenericJob)
 
 	for i := range workloads.Items {
 		w := &workloads.Items[i]
-		if match == nil && equivalentToWorkload(job, w) {
+		if match == nil && equivalentToWorkload(ctx, c, job, w) {
 			match = w
 		} else {
 			toDelete = append(toDelete, w)
@@ -594,7 +595,7 @@ func (r *JobReconciler) ensurePrebuiltWorkloadOwnership(ctx context.Context, wl 
 }
 
 func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, wl *kueue.Workload, job GenericJob) (bool, error) {
-	if !equivalentToWorkload(job, wl) {
+	if !equivalentToWorkload(ctx, r.client, job, wl) {
 		// mark the workload as finished
 		err := workload.UpdateStatus(ctx, r.client, wl,
 			kueue.WorkloadFinished,
@@ -607,8 +608,39 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, wl *ku
 	return true, nil
 }
 
+// get the expected podsets during the job execution, returns nil if the workload has no reservation or
+// the admission dose not fit.
+func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Workload) []kueue.PodSet {
+	if !workload.HasQuotaReservation(wl) {
+		return nil
+	}
+	info, err := getPodSetsInfoFromStatus(ctx, c, wl)
+	if err != nil {
+		return nil
+	}
+	infoMap := slices.ToRefMap(info, func(psi *podset.PodSetInfo) string { return psi.Name })
+	runningPodSets := wl.Spec.DeepCopy().PodSets
+	canBePartiallyAdmitted := workload.CanBePartiallyAdmitted(wl)
+	for i := range runningPodSets {
+		ps := &runningPodSets[i]
+		psi, found := infoMap[ps.Name]
+		if !found {
+			return nil
+		}
+		err := podset.Merge(&ps.Template.ObjectMeta, &ps.Template.Spec, *psi)
+		if err != nil {
+			return nil
+		}
+		if canBePartiallyAdmitted && ps.MinCount != nil {
+			// update the expected running count
+			ps.Count = psi.Count
+		}
+	}
+	return runningPodSets
+}
+
 // equivalentToWorkload checks if the job corresponds to the workload
-func equivalentToWorkload(job GenericJob, wl *kueue.Workload) bool {
+func equivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, wl *kueue.Workload) bool {
 	owner := metav1.GetControllerOf(wl)
 	// Indexes don't work in unit tests, so we explicitly check for the
 	// owner here.
@@ -618,34 +650,14 @@ func equivalentToWorkload(job GenericJob, wl *kueue.Workload) bool {
 
 	jobPodSets := clearMinCountsIfFeatureDisabled(job.PodSets())
 
-	if !workload.CanBePartiallyAdmitted(wl) || !workload.HasQuotaReservation(wl) {
-		changePodSpecFields := job.IsActive() && !job.IsSuspended()
-		// the two sets should fully match.
-		return equality.ComparePodSetSlices(jobPodSets, wl.Spec.PodSets, true, changePodSpecFields)
-	}
-
-	// Check everything but the pod counts.
-	if !equality.ComparePodSetSlices(jobPodSets, wl.Spec.PodSets, false, false) {
-		return false
-	}
-
-	// If the workload is admitted but the job is suspended, ignore counts.
-	// This might allow some violating jobs to pass equivalency checks, but their
-	// workloads would be invalidated in the next sync after unsuspending.
-	if job.IsSuspended() {
-		return true
-	}
-
-	for i, psAssigment := range wl.Status.Admission.PodSetAssignments {
-		assignedCount := wl.Spec.PodSets[i].Count
-		if jobPodSets[i].MinCount != nil {
-			assignedCount = ptr.Deref(psAssigment.Count, assignedCount)
+	if runningPodSets := expectedRunningPodSets(ctx, c, wl); runningPodSets != nil {
+		if equality.ComparePodSetSlices(jobPodSets, runningPodSets) {
+			return true
 		}
-		if jobPodSets[i].Count != assignedCount {
-			return false
-		}
+		return job.IsSuspended() && equality.ComparePodSetSlices(jobPodSets, wl.Spec.PodSets)
 	}
-	return true
+
+	return equality.ComparePodSetSlices(jobPodSets, wl.Spec.PodSets)
 }
 
 func (r *JobReconciler) updateWorkloadToMatchJob(ctx context.Context, job GenericJob, object client.Object, wl *kueue.Workload) (*kueue.Workload, error) {
@@ -669,7 +681,7 @@ func (r *JobReconciler) updateWorkloadToMatchJob(ctx context.Context, job Generi
 
 // startJob will unsuspend the job, and also inject the node affinity.
 func (r *JobReconciler) startJob(ctx context.Context, job GenericJob, object client.Object, wl *kueue.Workload) error {
-	info, err := r.getPodSetsInfoFromStatus(ctx, wl)
+	info, err := getPodSetsInfoFromStatus(ctx, r.client, wl)
 	if err != nil {
 		return err
 	}
@@ -820,7 +832,7 @@ func extractPriorityFromPodSets(podSets []kueue.PodSet) string {
 
 // getPodSetsInfoFromStatus extracts podSetsInfo from workload status, based on
 // admission, and admission checks.
-func (r *JobReconciler) getPodSetsInfoFromStatus(ctx context.Context, w *kueue.Workload) ([]podset.PodSetInfo, error) {
+func getPodSetsInfoFromStatus(ctx context.Context, c client.Client, w *kueue.Workload) ([]podset.PodSetInfo, error) {
 	if len(w.Status.Admission.PodSetAssignments) == 0 {
 		return nil, nil
 	}
@@ -828,7 +840,7 @@ func (r *JobReconciler) getPodSetsInfoFromStatus(ctx context.Context, w *kueue.W
 	podSetsInfo := make([]podset.PodSetInfo, len(w.Status.Admission.PodSetAssignments))
 
 	for i, podSetFlavor := range w.Status.Admission.PodSetAssignments {
-		info, err := podset.FromAssignment(ctx, r.client, &podSetFlavor, w.Spec.PodSets[i].Count)
+		info, err := podset.FromAssignment(ctx, c, &podSetFlavor, w.Spec.PodSets[i].Count)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/jobs/kubeflow/jobs/mxjob/mxjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/mxjob/mxjob_controller_test.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -365,9 +366,29 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("worker", 10).Request(v1.ResourceCPU, "5").Obj(),
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq").
-						AssignmentPodCount(1).
-						AssignmentPodCount(5).
-						AssignmentPodCount(10).
+						PodSets(
+							kueue.PodSetAssignment{
+								Name: "scheduler",
+								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+									v1.ResourceCPU: "default",
+								},
+								Count: ptr.To[int32](1),
+							},
+							kueue.PodSetAssignment{
+								Name: "server",
+								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+									v1.ResourceCPU: "default",
+								},
+								Count: ptr.To[int32](2),
+							},
+							kueue.PodSetAssignment{
+								Name: "worker",
+								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+									v1.ResourceCPU: "default",
+								},
+								Count: ptr.To[int32](5),
+							},
+						).
 						Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -397,9 +418,29 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("worker", 10).Request(v1.ResourceCPU, "5").Obj(),
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq").
-						AssignmentPodCount(1).
-						AssignmentPodCount(5).
-						AssignmentPodCount(10).
+						PodSets(
+							kueue.PodSetAssignment{
+								Name: "scheduler",
+								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+									v1.ResourceCPU: "default",
+								},
+								Count: ptr.To[int32](1),
+							},
+							kueue.PodSetAssignment{
+								Name: "server",
+								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+									v1.ResourceCPU: "default",
+								},
+								Count: ptr.To[int32](2),
+							},
+							kueue.PodSetAssignment{
+								Name: "worker",
+								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+									v1.ResourceCPU: "default",
+								},
+								Count: ptr.To[int32](5),
+							},
+						).
 						Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -291,8 +292,22 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("worker", 10).Request(v1.ResourceCPU, "5").Obj(),
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq").
-						AssignmentPodCount(1).
-						AssignmentPodCount(10).
+						PodSets(
+							kueue.PodSetAssignment{
+								Name: "master",
+								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+									v1.ResourceCPU: "default",
+								},
+								Count: ptr.To[int32](1),
+							},
+							kueue.PodSetAssignment{
+								Name: "worker",
+								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+									v1.ResourceCPU: "default",
+								},
+								Count: ptr.To[int32](10),
+							},
+						).
 						Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -319,8 +334,22 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("worker", 10).Request(v1.ResourceCPU, "5").Obj(),
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq").
-						AssignmentPodCount(1).
-						AssignmentPodCount(10).
+						PodSets(
+							kueue.PodSetAssignment{
+								Name: "master",
+								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+									v1.ResourceCPU: "default",
+								},
+								Count: ptr.To[int32](1),
+							},
+							kueue.PodSetAssignment{
+								Name: "worker",
+								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+									v1.ResourceCPU: "default",
+								},
+								Count: ptr.To[int32](10),
+							},
+						).
 						Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -338,6 +367,7 @@ func TestReconciler(t *testing.T) {
 			if err := SetupIndexes(ctx, utiltesting.AsIndexer(kcBuilder)); err != nil {
 				t.Fatalf("Failed to setup indexes: %v", err)
 			}
+			kcBuilder = kcBuilder.WithObjects(utiltesting.MakeResourceFlavor("default").Obj())
 			kcBuilder = kcBuilder.WithObjects(tc.job)
 			for i := range tc.workloads {
 				kcBuilder = kcBuilder.WithStatusSubresource(&tc.workloads[i])

--- a/pkg/util/equality/podset.go
+++ b/pkg/util/equality/podset.go
@@ -26,14 +26,17 @@ import (
 
 // TODO: Revisit this, maybe we should extend the check to everything that could potentially impact
 // the workload scheduling (priority, nodeSelectors(when suspended), tolerations and maybe more)
-func comparePodTemplate(a, b *corev1.PodSpec) bool {
+func comparePodTemplate(a, b *corev1.PodSpec, checkCount, changePodSpecFields bool) bool {
+	if changePodSpecFields && !equality.Semantic.DeepEqual(a.Tolerations, b.Tolerations) {
+		return false
+	}
 	if !equality.Semantic.DeepEqual(a.InitContainers, b.InitContainers) {
 		return false
 	}
 	return equality.Semantic.DeepEqual(a.Containers, b.Containers)
 }
 
-func ComparePodSets(a, b *kueue.PodSet, checkCount bool) bool {
+func ComparePodSets(a, b *kueue.PodSet, checkCount, changePodSpecFields bool) bool {
 	if checkCount && a.Count != b.Count {
 		return false
 	}
@@ -41,15 +44,15 @@ func ComparePodSets(a, b *kueue.PodSet, checkCount bool) bool {
 		return false
 	}
 
-	return comparePodTemplate(&a.Template.Spec, &b.Template.Spec)
+	return comparePodTemplate(&a.Template.Spec, &b.Template.Spec, checkCount, changePodSpecFields)
 }
 
-func ComparePodSetSlices(a, b []kueue.PodSet, checkCount bool) bool {
+func ComparePodSetSlices(a, b []kueue.PodSet, checkCount, changePodSpecFields bool) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i := range a {
-		if !ComparePodSets(&a[i], &b[i], checkCount) {
+		if !ComparePodSets(&a[i], &b[i], checkCount, changePodSpecFields) {
 			return false
 		}
 	}

--- a/pkg/util/equality/podset.go
+++ b/pkg/util/equality/podset.go
@@ -26,8 +26,8 @@ import (
 
 // TODO: Revisit this, maybe we should extend the check to everything that could potentially impact
 // the workload scheduling (priority, nodeSelectors(when suspended), tolerations and maybe more)
-func comparePodTemplate(a, b *corev1.PodSpec, checkCount, changePodSpecFields bool) bool {
-	if changePodSpecFields && !equality.Semantic.DeepEqual(a.Tolerations, b.Tolerations) {
+func comparePodTemplate(a, b *corev1.PodSpec) bool {
+	if !equality.Semantic.DeepEqual(a.Tolerations, b.Tolerations) {
 		return false
 	}
 	if !equality.Semantic.DeepEqual(a.InitContainers, b.InitContainers) {
@@ -36,23 +36,23 @@ func comparePodTemplate(a, b *corev1.PodSpec, checkCount, changePodSpecFields bo
 	return equality.Semantic.DeepEqual(a.Containers, b.Containers)
 }
 
-func ComparePodSets(a, b *kueue.PodSet, checkCount, changePodSpecFields bool) bool {
-	if checkCount && a.Count != b.Count {
+func ComparePodSets(a, b *kueue.PodSet) bool {
+	if a.Count != b.Count {
 		return false
 	}
 	if ptr.Deref(a.MinCount, -1) != ptr.Deref(b.MinCount, -1) {
 		return false
 	}
 
-	return comparePodTemplate(&a.Template.Spec, &b.Template.Spec, checkCount, changePodSpecFields)
+	return comparePodTemplate(&a.Template.Spec, &b.Template.Spec)
 }
 
-func ComparePodSetSlices(a, b []kueue.PodSet, checkCount, changePodSpecFields bool) bool {
+func ComparePodSetSlices(a, b []kueue.PodSet) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i := range a {
-		if !ComparePodSets(&a[i], &b[i], checkCount, changePodSpecFields) {
+		if !ComparePodSets(&a[i], &b[i]) {
 			return false
 		}
 	}

--- a/pkg/util/equality/podset_test.go
+++ b/pkg/util/equality/podset_test.go
@@ -28,20 +28,13 @@ import (
 
 func TestComparePodSetSlices(t *testing.T) {
 	cases := map[string]struct {
-		a                   []kueue.PodSet
-		b                   []kueue.PodSet
-		checkCounts         bool
-		changePodSpecFields bool
-		wantEqual           bool
+		a         []kueue.PodSet
+		b         []kueue.PodSet
+		wantEqual bool
 	}{
 		"different name": {
 			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
 			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps2", 10).SetMinimumCount(5).Obj()},
-			wantEqual: true,
-		},
-		"different count": {
-			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
-			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 20).SetMinimumCount(5).Obj()},
 			wantEqual: true,
 		},
 		"different min count": {
@@ -91,14 +84,12 @@ func TestComparePodSetSlices(t *testing.T) {
 				Value:    "demand",
 				Effect:   corev1.TaintEffectNoSchedule,
 			}).Obj()},
-			changePodSpecFields: true,
-			wantEqual:           false,
+			wantEqual: false,
 		},
 		"different count when checked": {
-			a:           []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
-			b:           []kueue.PodSet{*utiltestting.MakePodSet("ps", 20).SetMinimumCount(5).Obj()},
-			checkCounts: true,
-			wantEqual:   false,
+			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
+			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 20).SetMinimumCount(5).Obj()},
+			wantEqual: false,
 		},
 		"different slice len": {
 			a:         []kueue.PodSet{{}, {}},
@@ -109,7 +100,7 @@ func TestComparePodSetSlices(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := ComparePodSetSlices(tc.a, tc.b, tc.checkCounts, tc.changePodSpecFields)
+			got := ComparePodSetSlices(tc.a, tc.b)
 			if got != tc.wantEqual {
 				t.Errorf("Unexpected result, want %v", tc.wantEqual)
 			}

--- a/pkg/util/equality/podset_test.go
+++ b/pkg/util/equality/podset_test.go
@@ -86,7 +86,7 @@ func TestComparePodSetSlices(t *testing.T) {
 			}).Obj()},
 			wantEqual: false,
 		},
-		"different count when checked": {
+		"different count": {
 			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
 			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 20).SetMinimumCount(5).Obj()},
 			wantEqual: false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1264

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adding toleration to a job leads to update workload
```