### PR TITLE
WIP: Add RequeuingStrategy to ClusterQueue

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -65,6 +65,9 @@ type ClusterQueueSpec struct {
 	// +kubebuilder:validation:Enum=StrictFIFO;BestEffortFIFO
 	QueueingStrategy QueueingStrategy `json:"queueingStrategy,omitempty"`
 
+	// RequeuingStrategy specifies how to requeue workloads that were evicted.
+	RequeuingStrategy *RequeuingStrategy `json:"requeuingStrategy,omitempty"`
+
 	// namespaceSelector defines which namespaces are allowed to submit workloads to
 	// this clusterQueue. Beyond this basic support for policy, an policy agent like
 	// Gatekeeper should be used to enforce more advanced policies.
@@ -358,6 +361,27 @@ type ClusterQueuePreemption struct {
 	// +kubebuilder:default=Never
 	// +kubebuilder:validation:Enum=Never;LowerPriority;LowerOrNewerEqualPriority
 	WithinClusterQueue PreemptionPolicy `json:"withinClusterQueue,omitempty"`
+}
+
+type QueueOrderingCriteria string
+
+const (
+	UseEvictionTimestamp = QueueOrderingCriteria("UseEvictionTimestamp")
+	UseCreationTimestamp = QueueOrderingCriteria("UseCreationTimestamp")
+)
+
+type RequeuingStrategy struct {
+	// OnPriorityPreemption specifies what criteria to sort on when a workload is
+	// being requeued after being preempted by a higher priority workload.
+	// +kubebuilder:default=UseCreationTimestamp
+	// +kubebuilder:validation:Enum=UseEvictionTimestamp,UseCreationTimestamp
+	OnPriorityPreemption QueueOrderingCriteria
+	// OnPodsReadyTimeout specifies what criteria to sort on when a workload is
+	// being requeued after being evicted due to some of its Pods failing to
+	// reach a Ready state.
+	// +kubebuilder:default=UseEvictionTimestamp
+	// +kubebuilder:validation:Enum=UseEvictionTimestamp,UseCreationTimestamp
+	OnPodsReadyTimeout QueueOrderingCriteria
 }
 
 //+genclient

--- a/pkg/queue/cluster_queue_best_effort_fifo.go
+++ b/pkg/queue/cluster_queue_best_effort_fifo.go
@@ -30,7 +30,7 @@ type ClusterQueueBestEffortFIFO struct {
 var _ ClusterQueue = &ClusterQueueBestEffortFIFO{}
 
 func newClusterQueueBestEffortFIFO(cq *kueue.ClusterQueue) (ClusterQueue, error) {
-	cqImpl := newClusterQueueImpl(keyFunc, queueOrdering)
+	cqImpl := newClusterQueueImpl(keyFunc, queueOrderingFunc(cq.Spec.RequeuingStrategy))
 	cqBE := &ClusterQueueBestEffortFIFO{
 		clusterQueueBase: cqImpl,
 	}

--- a/pkg/queue/cluster_queue_impl.go
+++ b/pkg/queue/cluster_queue_impl.go
@@ -55,6 +55,8 @@ type clusterQueueBase struct {
 	queueInadmissibleCycle int64
 
 	rwm sync.RWMutex
+
+	lessFunc func(a, b interface{}) bool
 }
 
 func newClusterQueueImpl(keyFunc func(obj interface{}) string, lessFunc func(a, b interface{}) bool) *clusterQueueBase {
@@ -63,6 +65,7 @@ func newClusterQueueImpl(keyFunc func(obj interface{}) string, lessFunc func(a, 
 		inadmissibleWorkloads:  make(map[string]*workload.Info),
 		queueInadmissibleCycle: -1,
 		rwm:                    sync.RWMutex{},
+		lessFunc:               lessFunc,
 	}
 }
 
@@ -247,7 +250,7 @@ func (c *clusterQueueBase) DumpInadmissible() (sets.Set[string], bool) {
 func (c *clusterQueueBase) Snapshot() []*workload.Info {
 	elements := c.totalElements()
 	sort.Slice(elements, func(i, j int) bool {
-		return queueOrdering(elements[i], elements[j])
+		return c.lessFunc(elements[i], elements[j])
 	})
 	return elements
 }

--- a/pkg/queue/cluster_queue_impl_test.go
+++ b/pkg/queue/cluster_queue_impl_test.go
@@ -37,7 +37,7 @@ const (
 )
 
 func Test_PushOrUpdate(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, queueOrdering)
+	cq := newClusterQueueImpl(keyFunc, queueOrderingFunc(nil))
 	wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 	if cq.Pending() != 0 {
 		t.Error("ClusterQueue should be empty")
@@ -57,7 +57,7 @@ func Test_PushOrUpdate(t *testing.T) {
 }
 
 func Test_Pop(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, queueOrdering)
+	cq := newClusterQueueImpl(keyFunc, queueOrderingFunc(nil))
 	now := time.Now()
 	wl1 := workload.NewInfo(utiltesting.MakeWorkload("workload-1", defaultNamespace).Creation(now).Obj())
 	wl2 := workload.NewInfo(utiltesting.MakeWorkload("workload-2", defaultNamespace).Creation(now.Add(time.Second)).Obj())
@@ -80,7 +80,7 @@ func Test_Pop(t *testing.T) {
 }
 
 func Test_Delete(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, queueOrdering)
+	cq := newClusterQueueImpl(keyFunc, queueOrderingFunc(nil))
 	wl1 := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 	wl2 := utiltesting.MakeWorkload("workload-2", defaultNamespace).Obj()
 	cq.PushOrUpdate(workload.NewInfo(wl1))
@@ -101,7 +101,7 @@ func Test_Delete(t *testing.T) {
 }
 
 func Test_Info(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, queueOrdering)
+	cq := newClusterQueueImpl(keyFunc, queueOrderingFunc(nil))
 	wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 	if info := cq.Info(keyFunc(workload.NewInfo(wl))); info != nil {
 		t.Error("workload doesn't exist")
@@ -113,7 +113,7 @@ func Test_Info(t *testing.T) {
 }
 
 func Test_AddFromLocalQueue(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, queueOrdering)
+	cq := newClusterQueueImpl(keyFunc, queueOrderingFunc(nil))
 	wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 	queue := &LocalQueue{
 		items: map[string]*workload.Info{
@@ -131,7 +131,7 @@ func Test_AddFromLocalQueue(t *testing.T) {
 }
 
 func Test_DeleteFromLocalQueue(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, queueOrdering)
+	cq := newClusterQueueImpl(keyFunc, queueOrderingFunc(nil))
 	q := utiltesting.MakeLocalQueue("foo", "").ClusterQueue("cq").Obj()
 	qImpl := newLocalQueue(q)
 	wl1 := utiltesting.MakeWorkload("wl1", "").Queue(q.Name).Obj()
@@ -174,12 +174,12 @@ func TestClusterQueueImpl(t *testing.T) {
 		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns3", Labels: map[string]string{"dep": "marketing"}}},
 	)
 
-	var workloads = []*kueue.Workload{
+	workloads := []*kueue.Workload{
 		utiltesting.MakeWorkload("w1", "ns1").Queue("q1").Obj(),
 		utiltesting.MakeWorkload("w2", "ns2").Queue("q2").Obj(),
 		utiltesting.MakeWorkload("w3", "ns3").Queue("q3").Obj(),
 	}
-	var updatedWorkloads = make([]*kueue.Workload, len(workloads))
+	updatedWorkloads := make([]*kueue.Workload, len(workloads))
 
 	updatedWorkloads[0] = workloads[0].DeepCopy()
 	updatedWorkloads[0].Spec.QueueName = "q2"
@@ -261,7 +261,7 @@ func TestClusterQueueImpl(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			cq := newClusterQueueImpl(keyFunc, queueOrdering)
+			cq := newClusterQueueImpl(keyFunc, queueOrderingFunc(nil))
 
 			err := cq.Update(utiltesting.MakeClusterQueue("cq").
 				NamespaceSelector(&metav1.LabelSelector{
@@ -315,7 +315,7 @@ func TestClusterQueueImpl(t *testing.T) {
 }
 
 func TestQueueInadmissibleWorkloadsDuringScheduling(t *testing.T) {
-	cq := newClusterQueueImpl(keyFunc, queueOrdering)
+	cq := newClusterQueueImpl(keyFunc, queueOrderingFunc(nil))
 	cq.namespaceSelector = labels.Everything()
 	wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 	cl := utiltesting.NewFakeClient(

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -228,7 +228,7 @@ func findCandidates(wl *kueue.Workload, cq *cache.ClusterQueue, resPerFlv resour
 
 	if cq.Preemption.WithinClusterQueue != kueue.PreemptionPolicyNever {
 		considerSamePrio := (cq.Preemption.WithinClusterQueue == kueue.PreemptionPolicyLowerOrNewerEqualPriority)
-		preemptorTS := workload.GetQueueOrderTimestamp(wl)
+		preemptorTS := workload.GetQueueOrderTimestamp(wl, cq.RequeuingStrategy)
 
 		for _, candidateWl := range cq.Workloads {
 			candidatePriority := priority.Priority(candidateWl.Obj)
@@ -236,7 +236,7 @@ func findCandidates(wl *kueue.Workload, cq *cache.ClusterQueue, resPerFlv resour
 				continue
 			}
 
-			if candidatePriority == wlPriority && !(considerSamePrio && preemptorTS.Before(workload.GetQueueOrderTimestamp(candidateWl.Obj))) {
+			if candidatePriority == wlPriority && !(considerSamePrio && preemptorTS.Before(workload.GetQueueOrderTimestamp(candidateWl.Obj, cq.RequeuingStrategy))) {
 				continue
 			}
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -68,8 +68,7 @@ type Scheduler struct {
 	applyAdmission func(context.Context, *kueue.Workload) error
 }
 
-type options struct {
-}
+type options struct{}
 
 // Option configures the reconciler.
 type Option func(*options)
@@ -353,11 +352,9 @@ func (s *Scheduler) getAssignments(log logr.Logger, wl *workload.Info, snap *cac
 			}
 			preemptionTargets := s.preemptor.GetTargets(*wl, assignment, snap)
 			if len(preemptionTargets) > 0 {
-
 				return &partialAssignment{assignment: assignment, preemptionTargets: preemptionTargets}, true
 			}
 			return nil, false
-
 		})
 		if pa, found := reducer.Search(); found {
 			return pa.assignment, pa.preemptionTargets
@@ -508,8 +505,8 @@ func (e entryOrdering) Less(i, j int) bool {
 	}
 
 	// 2. FIFO.
-	aComparisonTimestamp := workload.GetQueueOrderTimestamp(a.Obj)
-	bComparisonTimestamp := workload.GetQueueOrderTimestamp(b.Obj)
+	aComparisonTimestamp := workload.GetQueueOrderTimestamp(a.Obj, nil)
+	bComparisonTimestamp := workload.GetQueueOrderTimestamp(b.Obj, nil)
 	return aComparisonTimestamp.Before(bComparisonTimestamp)
 }
 

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -323,7 +323,7 @@ func TestGetQueueOrderTimestamp(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			gotTime := GetQueueOrderTimestamp(tc.wl)
+			gotTime := GetQueueOrderTimestamp(tc.wl, nil)
 			if diff := cmp.Diff(*gotTime, tc.want); diff != "" {
 				t.Errorf("Unexpected time (-want,+got):\n%s", diff)
 			}


### PR DESCRIPTION
#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:

See [KEP-1282](https://github.com/kubernetes-sigs/kueue/pull/1311). This PR implements the KEP however, it implements the configuration at the ClusterQueue level rather than in the controller-level ConfigMap.

#### Which issue(s) this PR fixes:

Fixes #1282

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add RequeuingStrategy configuration to ClusterQueue.
```