### PR TITLE
Add support for pod groups

### DIFF
--- a/pkg/controller/jobframework/errors.go
+++ b/pkg/controller/jobframework/errors.go
@@ -1,0 +1,22 @@
+package jobframework
+
+import "errors"
+
+// UnretryableError is an error that doesn't require reconcile retry
+// and will not be returned by the JobReconciler.
+func UnretryableError(msg string) error {
+	return &unretryableError{msg: msg}
+}
+
+type unretryableError struct {
+	msg string
+}
+
+func (e *unretryableError) Error() string {
+	return e.msg
+}
+
+func IsUnretryableError(e error) bool {
+	var unretryableError *unretryableError
+	return errors.As(e, &unretryableError)
+}

--- a/pkg/controller/jobframework/indexer.go
+++ b/pkg/controller/jobframework/indexer.go
@@ -16,7 +16,6 @@ package jobframework
 import (
 	"context"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -27,15 +26,16 @@ func SetupWorkloadOwnerIndex(ctx context.Context, indexer client.FieldIndexer, g
 	return indexer.IndexField(ctx, &kueue.Workload{}, getOwnerKey(gvk), func(o client.Object) []string {
 		// grab the Workload object, extract the owner...
 		wl := o.(*kueue.Workload)
-		owner := metav1.GetControllerOf(wl)
-		if owner == nil {
+		if len(wl.OwnerReferences) == 0 {
 			return nil
 		}
-		// ...make sure it's the job with matching GVK...
-		if owner.Kind != gvk.Kind || owner.APIVersion != gvk.GroupVersion().String() {
-			return nil
+		owners := make([]string, 0, len(wl.OwnerReferences))
+		for i := range wl.OwnerReferences {
+			owner := &wl.OwnerReferences[i]
+			if owner.Kind == gvk.Kind && owner.APIVersion == gvk.GroupVersion().String() {
+				owners = append(owners, owner.Name)
+			}
 		}
-		// ...and if so, return it
-		return []string{owner.Name}
+		return owners
 	})
 }

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -27,6 +28,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -132,12 +134,22 @@ func NewReconciler(
 	}
 }
 
-func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Request, job GenericJob) (ctrl.Result, error) {
+func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Request, job GenericJob) (result ctrl.Result, err error) {
 	object := job.Object()
 	log := ctrl.LoggerFrom(ctx).WithValues("job", req.String(), "gvk", job.GVK())
 	ctx = ctrl.LoggerInto(ctx, log)
 
-	err := r.client.Get(ctx, req.NamespacedName, object)
+	defer func() {
+		err = r.ignoreUnretryableError(log, err)
+	}()
+
+	dropFinalizers := false
+	if cJob, isComposable := job.(ComposableJob); isComposable {
+		dropFinalizers, err = cJob.Load(ctx, r.client, req.NamespacedName)
+	} else {
+		err = r.client.Get(ctx, req.NamespacedName, object)
+		dropFinalizers = apierrors.IsNotFound(err) || !object.GetDeletionTimestamp().IsZero()
+	}
 
 	if jws, implements := job.(JobWithSkip); implements {
 		if jws.Skip() {
@@ -145,7 +157,8 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	if apierrors.IsNotFound(err) || !object.GetDeletionTimestamp().IsZero() {
+	if dropFinalizers {
+		// Remove workload finalizer
 		workloads := kueue.WorkloadList{}
 		if err := r.client.List(ctx, &workloads, client.InNamespace(req.Namespace),
 			client.MatchingFields{getOwnerKey(job.GVK()): req.Name}); err != nil {
@@ -159,6 +172,8 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 				return ctrl.Result{}, err
 			}
 		}
+
+		// Remove job finalizer
 		if !object.GetDeletionTimestamp().IsZero() {
 			if err = r.finalizeJob(ctx, job); err != nil {
 				return ctrl.Result{}, err
@@ -309,8 +324,8 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 					return ctrl.Result{}, fmt.Errorf("clearing admission: %w", err)
 				}
 			}
-			return ctrl.Result{}, nil
 		}
+		return ctrl.Result{}, nil
 	}
 
 	// 7. handle job is suspended.
@@ -402,19 +417,19 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 	// Find a matching workload first if there is one.
 	var toDelete []*kueue.Workload
 	var match *kueue.Workload
-	var workloads kueue.WorkloadList
-	if err := r.client.List(ctx, &workloads, client.InNamespace(object.GetNamespace()),
-		client.MatchingFields{getOwnerKey(job.GVK()): object.GetName()}); err != nil {
-		log.Error(err, "Unable to list child workloads")
-		return nil, err
-	}
-
-	for i := range workloads.Items {
-		w := &workloads.Items[i]
-		if match == nil && r.equivalentToWorkload(job, object, w) {
-			match = w
-		} else {
-			toDelete = append(toDelete, w)
+	if cj, implements := job.(ComposableJob); implements {
+		var err error
+		match, toDelete, err = cj.FindMatchingWorkloads(ctx, r.client)
+		if err != nil {
+			log.Error(err, "Composable job is unable to find matching workloads")
+			return nil, err
+		}
+	} else {
+		var err error
+		match, toDelete, err = FindMatchingWorkloads(ctx, r.client, job)
+		if err != nil {
+			log.Error(err, "Unable to list child workloads")
+			return nil, err
 		}
 	}
 
@@ -428,11 +443,11 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 	if match == nil && !job.IsSuspended() {
 		log.V(2).Info("job with no matching workload, suspending")
 		var w *kueue.Workload
-		if len(workloads.Items) == 1 {
+		if len(toDelete) == 1 {
 			// The job may have been modified and hence the existing workload
 			// doesn't match the job anymore. All bets are off if there are more
 			// than one workload...
-			w = &workloads.Items[0]
+			w = toDelete[0]
 		}
 
 		if _, finished := job.Finished(); finished {
@@ -480,16 +495,37 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 	return match, nil
 }
 
+func FindMatchingWorkloads(ctx context.Context, c client.Client, job GenericJob) (match *kueue.Workload, toDelete []*kueue.Workload, err error) {
+	object := job.Object()
+
+	workloads := &kueue.WorkloadList{}
+	if err := c.List(ctx, workloads, client.InNamespace(object.GetNamespace()),
+		client.MatchingFields{getOwnerKey(job.GVK()): object.GetName()}); err != nil {
+		return nil, nil, err
+	}
+
+	for i := range workloads.Items {
+		w := &workloads.Items[i]
+		if match == nil && equivalentToWorkload(job, w) {
+			match = w
+		} else {
+			toDelete = append(toDelete, w)
+		}
+	}
+
+	return match, toDelete, nil
+}
+
 // equivalentToWorkload checks if the job corresponds to the workload
-func (r *JobReconciler) equivalentToWorkload(job GenericJob, object client.Object, wl *kueue.Workload) bool {
+func equivalentToWorkload(job GenericJob, wl *kueue.Workload) bool {
 	owner := metav1.GetControllerOf(wl)
 	// Indexes don't work in unit tests, so we explicitly check for the
 	// owner here.
-	if owner.Name != object.GetName() {
+	if owner.Name != job.Object().GetName() {
 		return false
 	}
 
-	jobPodSets := resetMinCounts(job.PodSets())
+	jobPodSets := clearMinCountsIfFeatureDisabled(job.PodSets())
 
 	if !workload.CanBePartiallyAdmitted(wl) || !workload.HasQuotaReservation(wl) {
 		// the two sets should fully match.
@@ -522,6 +558,10 @@ func (r *JobReconciler) equivalentToWorkload(job GenericJob, object client.Objec
 
 func (r *JobReconciler) updateWorkloadToMatchJob(ctx context.Context, job GenericJob, object client.Object, wl *kueue.Workload) (*kueue.Workload, error) {
 	newWl, err := r.constructWorkload(ctx, job, object)
+	if err != nil {
+		return nil, fmt.Errorf("can't construct workload for update: %w", err)
+	}
+	err = r.prepareWorkload(ctx, job, newWl)
 	if err != nil {
 		return nil, fmt.Errorf("can't construct workload for update: %w", err)
 	}
@@ -558,7 +598,7 @@ func (r *JobReconciler) startJob(ctx context.Context, job GenericJob, object cli
 // stopJob will suspend the job, and also restore node affinity, reset job status if needed.
 // Returns whether any operation was done to stop the job or an error.
 func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, object client.Object, wl *kueue.Workload, eventMsg string) error {
-	info := getPodSetsInfoFromWorkload(wl)
+	info := GetPodSetsInfoFromWorkload(wl)
 
 	if jws, implements := job.(JobWithCustomStop); implements {
 		stoppedNow, err := jws.Stop(ctx, r.client, info, eventMsg)
@@ -605,6 +645,15 @@ func (r *JobReconciler) removeFinalizer(ctx context.Context, wl *kueue.Workload)
 func (r *JobReconciler) constructWorkload(ctx context.Context, job GenericJob, object client.Object) (*kueue.Workload, error) {
 	log := ctrl.LoggerFrom(ctx)
 
+	if cj, implements := job.(ComposableJob); implements {
+		wl, err := cj.ConstructComposableWorkload(ctx, r.client, r.record)
+		if err != nil {
+			return nil, err
+		}
+
+		return wl, nil
+	}
+
 	podSets := job.PodSets()
 
 	wl := &kueue.Workload{
@@ -615,7 +664,7 @@ func (r *JobReconciler) constructWorkload(ctx context.Context, job GenericJob, o
 			Finalizers: []string{kueue.ResourceInUseFinalizerName},
 		},
 		Spec: kueue.WorkloadSpec{
-			PodSets:   resetMinCounts(podSets),
+			PodSets:   podSets,
 			QueueName: QueueName(job),
 		},
 	}
@@ -631,19 +680,26 @@ func (r *JobReconciler) constructWorkload(ctx context.Context, job GenericJob, o
 		)
 	}
 
-	priorityClassName, source, p, err := r.extractPriority(ctx, podSets, job)
-	if err != nil {
+	if err := ctrl.SetControllerReference(object, wl, r.client.Scheme()); err != nil {
 		return nil, err
+	}
+	return wl, nil
+}
+
+// prepareWorkload adds the priority information for the constructed workload
+func (r *JobReconciler) prepareWorkload(ctx context.Context, job GenericJob, wl *kueue.Workload) error {
+	priorityClassName, source, p, err := r.extractPriority(ctx, wl.Spec.PodSets, job)
+	if err != nil {
+		return err
 	}
 
 	wl.Spec.PriorityClassName = priorityClassName
 	wl.Spec.Priority = &p
 	wl.Spec.PriorityClassSource = source
 
-	if err := ctrl.SetControllerReference(object, wl, r.client.Scheme()); err != nil {
-		return nil, err
-	}
-	return wl, nil
+	wl.Spec.PodSets = clearMinCountsIfFeatureDisabled(wl.Spec.PodSets)
+
+	return nil
 }
 
 func (r *JobReconciler) extractPriority(ctx context.Context, podSets []kueue.PodSet, job GenericJob) (string, string, int32, error) {
@@ -711,12 +767,24 @@ func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job Generic
 	if err != nil {
 		return err
 	}
+	err = r.prepareWorkload(ctx, job, wl)
+	if err != nil {
+		return err
+	}
 	if err = r.client.Create(ctx, wl); err != nil {
 		return err
 	}
 	r.record.Eventf(object, corev1.EventTypeNormal, "CreatedWorkload",
 		"Created Workload: %v", workload.Key(wl))
 	return nil
+}
+
+func (r *JobReconciler) ignoreUnretryableError(log logr.Logger, err error) error {
+	if IsUnretryableError(err) {
+		log.V(2).Info("Received an unretryable error", "error", err)
+		return nil
+	}
+	return err
 }
 
 func generatePodsReadyCondition(job GenericJob, wl *kueue.Workload) metav1.Condition {
@@ -739,9 +807,9 @@ func generatePodsReadyCondition(job GenericJob, wl *kueue.Workload) metav1.Condi
 	}
 }
 
-// getPodSetsInfoFromWorkload retrieve the podSetsInfo slice from the
+// GetPodSetsInfoFromWorkload retrieve the podSetsInfo slice from the
 // provided workload's spec
-func getPodSetsInfoFromWorkload(wl *kueue.Workload) []podset.PodSetInfo {
+func GetPodSetsInfoFromWorkload(wl *kueue.Workload) []podset.PodSetInfo {
 	if wl == nil {
 		return nil
 	}
@@ -774,17 +842,17 @@ func (r *genericReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 }
 
 func (r *genericReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	builder := ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(r.newJob().Object()).
-		Owns(&kueue.Workload{})
+		Owns(&kueue.Workload{}, builder.MatchEveryOwner)
 	if r.newWorkloadHandler != nil {
-		builder = builder.Watches(&kueue.Workload{}, r.newWorkloadHandler(mgr.GetClient()))
+		b = b.Watches(&kueue.Workload{}, r.newWorkloadHandler(mgr.GetClient()))
 	}
-	return builder.Complete(r)
+	return b.Complete(r)
 }
 
-// resets the minCount for all podSets if the PartialAdmission feature is not enabled
-func resetMinCounts(in []kueue.PodSet) []kueue.PodSet {
+// clearMinCountsIfFeatureDisabled sets the minCount for all podSets to nil if the PartialAdmission feature is not enabled
+func clearMinCountsIfFeatureDisabled(in []kueue.PodSet) []kueue.PodSet {
 	if features.Enabled(features.PartialAdmission) || len(in) == 0 {
 		return in
 	}

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -33,7 +33,7 @@ var (
 
 func ValidateCreateForQueueName(job GenericJob) field.ErrorList {
 	var allErrs field.ErrorList
-	allErrs = append(allErrs, validateLabelAsCRDName(job, constants.QueueLabel)...)
+	allErrs = append(allErrs, ValidateLabelAsCRDName(job, constants.QueueLabel)...)
 	allErrs = append(allErrs, ValidateAnnotationAsCRDName(job, constants.QueueAnnotation)...)
 	return allErrs
 }
@@ -48,7 +48,7 @@ func ValidateAnnotationAsCRDName(job GenericJob, crdNameAnnotation string) field
 	return allErrs
 }
 
-func validateLabelAsCRDName(job GenericJob, crdNameLabel string) field.ErrorList {
+func ValidateLabelAsCRDName(job GenericJob, crdNameLabel string) field.ErrorList {
 	var allErrs field.ErrorList
 	if value, exists := job.Object().GetLabels()[crdNameLabel]; exists {
 		if errs := validation.IsDNS1123Subdomain(value); len(errs) > 0 {

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -20,11 +20,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -61,7 +63,6 @@ func TestDefault(t *testing.T) {
 		namespaceSelector          *metav1.LabelSelector
 		podSelector                *metav1.LabelSelector
 		want                       *corev1.Pod
-		wantError                  error
 	}{
 		"pod with queue nil ns selector": {
 			initObjects: []client.Object{defaultNamespace},
@@ -220,6 +221,40 @@ func TestDefault(t *testing.T) {
 				).
 				Obj(),
 		},
+		"pod with a group name label, but without group total count label": {
+			initObjects:       []client.Object{defaultNamespace},
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				Group("test-group").
+				Obj(),
+			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				Group("test-group").
+				RoleHash("90ce3e8a").
+				Label("kueue.x-k8s.io/managed", "true").
+				KueueSchedulingGate().
+				KueueFinalizer().
+				Obj(),
+		},
+		"pod with a group name label": {
+			initObjects:       []client.Object{defaultNamespace},
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				Group("test-group").
+				Obj(),
+			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				Group("test-group").
+				RoleHash("90ce3e8a").
+				Label("kueue.x-k8s.io/managed", "true").
+				KueueSchedulingGate().
+				KueueFinalizer().
+				Obj(),
+		},
 	}
 
 	for name, tc := range testCases {
@@ -250,6 +285,7 @@ func TestDefault(t *testing.T) {
 func TestValidateCreate(t *testing.T) {
 	testCases := map[string]struct {
 		pod       *corev1.Pod
+		wantErr   error
 		wantWarns admission.Warnings
 	}{
 		"pod owner is managed by kueue": {
@@ -260,6 +296,69 @@ func TestValidateCreate(t *testing.T) {
 			wantWarns: admission.Warnings{
 				"pod owner is managed by kueue, label 'kueue.x-k8s.io/managed=true' might lead to unexpected behaviour",
 			},
+		},
+		"pod with group name and no group total count": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				Label("kueue.x-k8s.io/managed", "true").
+				Group("test-group").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeRequired,
+					Field: "metadata.annotations[kueue.x-k8s.io/pod-group-total-count]",
+				},
+			}.ToAggregate(),
+		},
+		"pod with group total count and no group name": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				Label("kueue.x-k8s.io/managed", "true").
+				GroupTotalCount("3").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeRequired,
+					Field: "metadata.labels[kueue.x-k8s.io/pod-group-name]",
+				},
+			}.ToAggregate(),
+		},
+		"pod with 0 group total count": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				Label("kueue.x-k8s.io/managed", "true").
+				Group("test-group").
+				GroupTotalCount("0").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/pod-group-total-count]",
+				},
+			}.ToAggregate(),
+		},
+		"pod with empty group total count": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				Label("kueue.x-k8s.io/managed", "true").
+				Group("test-group").
+				GroupTotalCount("").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/pod-group-total-count]",
+				},
+			}.ToAggregate(),
+		},
+		"pod with incorrect group name": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				Label("kueue.x-k8s.io/managed", "true").
+				Group("notAdns1123Subdomain*").
+				GroupTotalCount("2").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.labels[kueue.x-k8s.io/pod-group-name]",
+				},
+			}.ToAggregate(),
 		},
 	}
 
@@ -275,8 +374,8 @@ func TestValidateCreate(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 
 			warns, err := w.ValidateCreate(ctx, tc.pod)
-			if err != nil {
-				t.Errorf("failed to set validate create for v1/pod: %s", err)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}
 			if diff := cmp.Diff(warns, tc.wantWarns); diff != "" {
 				t.Errorf("Expected different list of warnings (-want,+got):\n%s", diff)
@@ -289,6 +388,7 @@ func TestValidateUpdate(t *testing.T) {
 	testCases := map[string]struct {
 		oldPod    *corev1.Pod
 		newPod    *corev1.Pod
+		wantErr   error
 		wantWarns admission.Warnings
 	}{
 		"pods owner is managed by kueue, managed label is set for both pods": {
@@ -316,6 +416,63 @@ func TestValidateUpdate(t *testing.T) {
 				"pod owner is managed by kueue, label 'kueue.x-k8s.io/managed=true' might lead to unexpected behaviour",
 			},
 		},
+		"pod with group name and no group total count": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").Group("test-group").Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				Label("kueue.x-k8s.io/managed", "true").
+				Group("test-group").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeRequired,
+					Field: "metadata.annotations[kueue.x-k8s.io/pod-group-total-count]",
+				},
+			}.ToAggregate(),
+		},
+		"pod with 0 group total count": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").Group("test-group").Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				Label("kueue.x-k8s.io/managed", "true").
+				Group("test-group").
+				GroupTotalCount("0").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/pod-group-total-count]",
+				},
+			}.ToAggregate(),
+		},
+		"pod with empty group total count": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").Group("test-group").Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				Label("kueue.x-k8s.io/managed", "true").
+				Group("test-group").
+				GroupTotalCount("").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/pod-group-total-count]",
+				},
+			}.ToAggregate(),
+		},
+		"pod group name is changed": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				Group("test-group").
+				GroupTotalCount("2").
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				Group("test-group-new").
+				GroupTotalCount("2").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.labels[kueue.x-k8s.io/pod-group-name]",
+				},
+			}.ToAggregate(),
+		},
 	}
 
 	for name, tc := range testCases {
@@ -330,8 +487,8 @@ func TestValidateUpdate(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 
 			warns, err := w.ValidateUpdate(ctx, tc.oldPod, tc.newPod)
-			if err != nil {
-				t.Errorf("failed to set validate create for v1/pod: %s", err)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}
 			if diff := cmp.Diff(warns, tc.wantWarns); diff != "" {
 				t.Errorf("Expected different list of warnings (-want,+got):\n%s", diff)

--- a/pkg/util/testing/core.go
+++ b/pkg/util/testing/core.go
@@ -65,5 +65,5 @@ func CheckLatestEvent(ctx context.Context, k8sClient client.Client,
 		return true, nil
 	}
 
-	return false, fmt.Errorf("mismatch with the latest event")
+	return false, fmt.Errorf("mismatch with the latest event: got r:%v t:%v n:%v, reg %v", item.Reason, item.Type, item.Note, item.Regarding)
 }

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -102,6 +102,7 @@ func (w *WorkloadWrapper) Queue(q string) *WorkloadWrapper {
 	return w
 }
 
+// ReserveQuota sets workload admission and adds a "QuotaReserved" status condition
 func (w *WorkloadWrapper) ReserveQuota(a *kueue.Admission) *WorkloadWrapper {
 	w.Status.Admission = a
 	w.Status.Conditions = []metav1.Condition{{

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package testing
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,12 +67,24 @@ func (p *PodWrapper) Clone() *PodWrapper {
 }
 
 // Queue updates the queue name of the Pod
-func (p *PodWrapper) Queue(queue string) *PodWrapper {
-	if p.Labels == nil {
-		p.Labels = make(map[string]string)
-	}
-	p.Labels[constants.QueueLabel] = queue
+func (p *PodWrapper) Queue(q string) *PodWrapper {
+	return p.Label(constants.QueueLabel, q)
+}
+
+// Name updated the name of the pod
+func (p *PodWrapper) Name(n string) *PodWrapper {
+	p.ObjectMeta.Name = n
 	return p
+}
+
+// Group updates the pod.GroupNameLabel of the Pod
+func (p *PodWrapper) Group(g string) *PodWrapper {
+	return p.Label("kueue.x-k8s.io/pod-group-name", g)
+}
+
+// GroupTotalCount updates the pod.GroupTotalCountAnnotation of the Pod
+func (p *PodWrapper) GroupTotalCount(gtc string) *PodWrapper {
+	return p.Annotation("kueue.x-k8s.io/pod-group-total-count", gtc)
 }
 
 // Label sets the label of the Pod
@@ -85,6 +99,11 @@ func (p *PodWrapper) Label(k, v string) *PodWrapper {
 func (p *PodWrapper) Annotation(key, content string) *PodWrapper {
 	p.Annotations[key] = content
 	return p
+}
+
+// RoleHash updates the pod.RoleHashAnnotation of the pod
+func (p *PodWrapper) RoleHash(h string) *PodWrapper {
+	return p.Annotation("kueue.x-k8s.io/role-hash", h)
 }
 
 // ParentWorkload sets the parent-workload annotation
@@ -164,5 +183,12 @@ func (p *PodWrapper) StatusConditions(conditions ...corev1.PodCondition) *PodWra
 // StatusPhase updates status phase of the Pod.
 func (p *PodWrapper) StatusPhase(ph corev1.PodPhase) *PodWrapper {
 	p.Pod.Status.Phase = ph
+	return p
+}
+
+// Delete sets a deletion timestamp for the pod object
+func (p *PodWrapper) Delete() *PodWrapper {
+	t := metav1.NewTime(time.Now())
+	p.Pod.DeletionTimestamp = &t
 	return p
 }

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,6 +53,10 @@ var (
 var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	ginkgo.When("manageJobsWithoutQueueName is disabled", func() {
 		var defaultFlavor = testing.MakeResourceFlavor("default").Label("kubernetes.io/arch", "arm64").Obj()
+		var clusterQueue = testing.MakeClusterQueue("cluster-queue").
+			ResourceGroup(
+				*testing.MakeFlavorQuotas(defaultFlavor.Name).Resource(corev1.ResourceCPU, "1").Obj(),
+			).Obj()
 
 		ginkgo.BeforeAll(func() {
 			fwk = &framework.Framework{
@@ -76,8 +79,10 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				}),
 			))
 			gomega.Expect(k8sClient.Create(ctx, defaultFlavor)).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
 		})
 		ginkgo.AfterAll(func() {
+			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, clusterQueue, true)
 			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, defaultFlavor, true)
 			fwk.Teardown()
 		})
@@ -103,236 +108,9 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		})
 
-		ginkgo.It("Should reconcile the single pod with the queue name", func() {
-			pod := testingpod.MakePod(podName, ns.Name).Queue("test-queue").Obj()
-			gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
-
-			createdPod := &corev1.Pod{}
-			gomega.Eventually(func() error {
-				return k8sClient.Get(ctx, lookupKey, createdPod)
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			gomega.Expect(createdPod.Spec.SchedulingGates).To(
-				gomega.ContainElement(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}),
-				"Pod should have scheduling gate",
-			)
-
-			gomega.Expect(createdPod.Labels).To(
-				gomega.HaveKeyWithValue("kueue.x-k8s.io/managed", "true"),
-				"Pod should have the label",
-			)
-
-			gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement("kueue.x-k8s.io/managed"),
-				"Pod should have finalizer")
-
-			ginkgo.By("checking that workload is created for pod with the queue name")
-			createdWorkload := &kueue.Workload{}
-			gomega.Eventually(func() error {
-				return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(1))
-
-			gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"),
-				"The Workload should have .spec.queueName set")
-
-			ginkgo.By("checking the pod is unsuspended when workload is assigned")
-
-			clusterQueue := testing.MakeClusterQueue("cluster-queue").
-				ResourceGroup(
-					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
-				).Obj()
-			admission := testing.MakeAdmission(clusterQueue.Name).
-				Assignment(corev1.ResourceCPU, "default", "1").
-				AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
-				Obj()
-			gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
-			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
-
-			gomega.Eventually(func() []corev1.PodSchedulingGate {
-				if err := k8sClient.Get(ctx, lookupKey, createdPod); err != nil {
-					return nil
-				}
-				return createdPod.Spec.SchedulingGates
-			}, util.Timeout, util.Interval).Should(gomega.BeEmpty())
-			gomega.Eventually(func(g gomega.Gomega) bool {
-				ok, err := testing.CheckLatestEvent(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name))
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				return ok
-			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-			gomega.Expect(createdPod.Spec.NodeSelector).Should(gomega.HaveLen(1))
-			gomega.Expect(createdPod.Spec.NodeSelector["kubernetes.io/arch"]).Should(gomega.Equal("arm64"))
-
-			gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-			gomega.Expect(createdWorkload.Status.Conditions).To(gomega.BeComparableTo(
-				[]metav1.Condition{
-					{Type: kueue.WorkloadQuotaReserved, Status: metav1.ConditionTrue},
-					{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue},
-				},
-				wlConditionCmpOpts...,
-			))
-
-			ginkgo.By("checking the workload is finished and the pod finalizer is removed when pod is succeeded")
-			createdPod.Status.Phase = corev1.PodSucceeded
-			gomega.Expect(k8sClient.Status().Update(ctx, createdPod)).Should(gomega.Succeed())
-			gomega.Eventually(func() []metav1.Condition {
-				err := k8sClient.Get(ctx, wlLookupKey, createdWorkload)
-				if err != nil {
-					return nil
-				}
-				return createdWorkload.Status.Conditions
-			}, util.Timeout, util.Interval).Should(gomega.ContainElement(
-				gomega.BeComparableTo(
-					metav1.Condition{Type: kueue.WorkloadFinished, Status: metav1.ConditionTrue},
-					wlConditionCmpOpts...,
-				),
-			), "Expected 'Finished' workload condition")
-
-			gomega.Eventually(func(g gomega.Gomega) []string {
-				g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).To(gomega.Succeed())
-				return createdPod.Finalizers
-			}, util.Timeout, util.Interval).ShouldNot(gomega.ContainElement("kueue.x-k8s.io/managed"),
-				"Pod shouldn't have finalizer set")
-		})
-
-		ginkgo.It("Should remove finalizers from Pods that are actively deleted after being admitted", func() {
-			pod := testingpod.MakePod(podName, ns.Name).Queue("test-queue").Obj()
-			gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
-
-			createdPod := &corev1.Pod{}
-			gomega.Eventually(func() error {
-				return k8sClient.Get(ctx, lookupKey, createdPod)
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement("kueue.x-k8s.io/managed"),
-				"Pod should have finalizer")
-
-			ginkgo.By("checking that workload is created for pod with the queue name")
-			createdWorkload := &kueue.Workload{}
-			gomega.Eventually(func() error {
-				return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			ginkgo.By("checking the pod is unsuspended when workload is assigned")
-			clusterQueue := testing.MakeClusterQueue("cluster-queue").
-				ResourceGroup(
-					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
-				).Obj()
-			admission := testing.MakeAdmission(clusterQueue.Name).
-				Assignment(corev1.ResourceCPU, "default", "1").
-				AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
-				Obj()
-			gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
-			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
-
-			gomega.Eventually(func() []corev1.PodSchedulingGate {
-				if err := k8sClient.Get(ctx, lookupKey, createdPod); err != nil {
-					return nil
-				}
-				return createdPod.Spec.SchedulingGates
-			}, util.Timeout, util.Interval).Should(gomega.BeEmpty())
-
-			ginkgo.By("checking that the finalizer is removed when the Pod is deleted early")
-			gomega.Expect(k8sClient.Delete(ctx, createdPod)).Should(gomega.Succeed())
-			gomega.Eventually(func(g gomega.Gomega) bool {
-				return apierrors.IsNotFound(k8sClient.Get(ctx, lookupKey, createdPod))
-			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		})
-
-		ginkgo.It("Should stop the single pod with the queue name if workload is evicted", func() {
-			ginkgo.By("Creating a pod with queue name")
-			pod := testingpod.MakePod(podName, ns.Name).Queue("test-queue").Obj()
-			gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
-
-			createdPod := &corev1.Pod{}
-			gomega.Eventually(func() error {
-				return k8sClient.Get(ctx, lookupKey, createdPod)
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			ginkgo.By("checking that workload is created for pod with the queue name")
-			createdWorkload := &kueue.Workload{}
-			gomega.Eventually(func() error {
-				return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(1))
-
-			gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
-
-			ginkgo.By("checking that pod is unsuspended when workload is admitted")
-			clusterQueue := testing.MakeClusterQueue("cluster-queue").
-				ResourceGroup(
-					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
-				).Obj()
-			admission := testing.MakeAdmission(clusterQueue.Name).
-				Assignment(corev1.ResourceCPU, "default", "1").
-				AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
-				Obj()
-			gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
-			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
-
-			gomega.Eventually(func() []corev1.PodSchedulingGate {
-				if err := k8sClient.Get(ctx, lookupKey, createdPod); err != nil {
-					return createdPod.Spec.SchedulingGates
-				}
-				return createdPod.Spec.SchedulingGates
-			}, util.Timeout, util.Interval).ShouldNot(
-				gomega.ContainElement(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}),
-			)
-			gomega.Eventually(func(g gomega.Gomega) bool {
-				ok, err := testing.CheckLatestEvent(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name))
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				return ok
-			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-			gomega.Expect(len(createdPod.Spec.NodeSelector)).Should(gomega.Equal(1))
-			gomega.Expect(createdPod.Spec.NodeSelector["kubernetes.io/arch"]).Should(gomega.Equal("arm64"))
-
-			gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-			gomega.Expect(createdWorkload.Status.Conditions).Should(gomega.BeComparableTo(
-				[]metav1.Condition{
-					{Type: kueue.WorkloadQuotaReserved, Status: metav1.ConditionTrue},
-					{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue},
-				},
-				wlConditionCmpOpts...,
-			))
-
-			ginkgo.By("checking that pod is stopped when workload is evicted")
-
-			gomega.Expect(
-				workload.UpdateStatus(ctx, k8sClient, createdWorkload, kueue.WorkloadEvicted, metav1.ConditionTrue,
-					kueue.WorkloadEvictedByPreemption, "By test", "evict"),
-			).Should(gomega.Succeed())
-			util.FinishEvictionForWorkloads(ctx, k8sClient, createdWorkload)
-
-			gomega.Eventually(func(g gomega.Gomega) bool {
-				g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).To(gomega.Succeed())
-				return createdPod.DeletionTimestamp.IsZero()
-			}, util.Timeout, util.Interval).Should(gomega.BeFalse(), "Expected pod to be deleted")
-
-			gomega.Expect(createdPod.Status.Conditions).Should(gomega.ContainElement(
-				gomega.BeComparableTo(
-					corev1.PodCondition{
-						Type:    "TerminationTarget",
-						Status:  "True",
-						Reason:  "StoppedByKueue",
-						Message: "By test",
-					},
-					cmpopts.IgnoreFields(corev1.PodCondition{}, "LastTransitionTime"),
-				),
-			))
-
-		})
-
-		ginkgo.When("Pod owner is managed by Kueue", func() {
-			var pod *corev1.Pod
-			ginkgo.BeforeEach(func() {
-				pod = testingpod.MakePod(podName, ns.Name).
-					Queue("test-queue").
-					OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
-					Obj()
-			})
-
-			ginkgo.It("Should skip the pod", func() {
+		ginkgo.When("Using single pod", func() {
+			ginkgo.It("Should reconcile the single pod with the queue name", func() {
+				pod := testingpod.MakePod(podName, ns.Name).Queue("test-queue").Obj()
 				gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
 
 				createdPod := &corev1.Pod{}
@@ -340,143 +118,660 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					return k8sClient.Get(ctx, lookupKey, createdPod)
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-				gomega.Expect(createdPod.Spec.SchedulingGates).NotTo(
+				gomega.Expect(createdPod.Spec.SchedulingGates).To(
 					gomega.ContainElement(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}),
-					"Pod shouldn't have scheduling gate",
+					"Pod should have scheduling gate",
 				)
 
-				gomega.Expect(createdPod.Labels).NotTo(
+				gomega.Expect(createdPod.Labels).To(
 					gomega.HaveKeyWithValue("kueue.x-k8s.io/managed", "true"),
-					"Pod shouldn't have the label",
+					"Pod should have the label",
 				)
 
-				gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement("kueue.x-k8s.io/managed"),
-					"Pod shouldn't have finalizer")
+				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement("kueue.x-k8s.io/managed"),
+					"Pod should have finalizer")
 
-				ginkgo.By(fmt.Sprintf("checking that workload '%s' is not created", wlLookupKey))
+				ginkgo.By("checking that workload is created for pod with the queue name")
 				createdWorkload := &kueue.Workload{}
+				gomega.Eventually(func() error {
+					return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-				gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(testing.BeNotFoundError())
+				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(1))
+
+				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"),
+					"The Workload should have .spec.queueName set")
+
+				ginkgo.By("checking the pod is unsuspended when workload is assigned")
+
+				clusterQueue := testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
+					).Obj()
+				admission := testing.MakeAdmission(clusterQueue.Name).
+					Assignment(corev1.ResourceCPU, "default", "1").
+					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					Obj()
+				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
+				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+
+				gomega.Eventually(func(g gomega.Gomega) bool {
+					ok, err := testing.CheckLatestEvent(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name))
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					return ok
+				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+
+				util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, lookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+
+				gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				gomega.Expect(createdWorkload.Status.Conditions).To(gomega.BeComparableTo(
+					[]metav1.Condition{
+						{Type: kueue.WorkloadQuotaReserved, Status: metav1.ConditionTrue},
+						{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue},
+					},
+					wlConditionCmpOpts...,
+				))
+
+				ginkgo.By("checking the workload is finished and the pod finalizer is removed when pod is succeeded")
+				util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, pod)
+				gomega.Eventually(func() []metav1.Condition {
+					err := k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+					if err != nil {
+						return nil
+					}
+					return createdWorkload.Status.Conditions
+				}, util.Timeout, util.Interval).Should(gomega.ContainElement(
+					gomega.BeComparableTo(
+						metav1.Condition{Type: kueue.WorkloadFinished, Status: metav1.ConditionTrue},
+						wlConditionCmpOpts...,
+					),
+				), "Expected 'Finished' workload condition")
+
+				gomega.Eventually(func(g gomega.Gomega) []string {
+					g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).To(gomega.Succeed())
+					return createdPod.Finalizers
+				}, util.Timeout, util.Interval).ShouldNot(gomega.ContainElement("kueue.x-k8s.io/managed"),
+					"Pod shouldn't have finalizer set")
+			})
+
+			ginkgo.It("Should remove finalizers from Pods that are actively deleted after being admitted", func() {
+				pod := testingpod.MakePod(podName, ns.Name).Queue("test-queue").Obj()
+				gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
+
+				createdPod := &corev1.Pod{}
+				gomega.Eventually(func() error {
+					return k8sClient.Get(ctx, lookupKey, createdPod)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement("kueue.x-k8s.io/managed"),
+					"Pod should have finalizer")
+
+				ginkgo.By("checking that workload is created for pod with the queue name")
+				createdWorkload := &kueue.Workload{}
+				gomega.Eventually(func() error {
+					return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("checking the pod is unsuspended when workload is assigned")
+				clusterQueue := testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
+					).Obj()
+				admission := testing.MakeAdmission(clusterQueue.Name).
+					Assignment(corev1.ResourceCPU, "default", "1").
+					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					Obj()
+				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
+				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+
+				gomega.Eventually(func() []corev1.PodSchedulingGate {
+					if err := k8sClient.Get(ctx, lookupKey, createdPod); err != nil {
+						return nil
+					}
+					return createdPod.Spec.SchedulingGates
+				}, util.Timeout, util.Interval).Should(gomega.BeEmpty())
+
+				ginkgo.By("checking that the finalizer is removed when the Pod is deleted early")
+				gomega.Expect(k8sClient.Delete(ctx, createdPod)).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) error {
+					return k8sClient.Get(ctx, lookupKey, createdPod)
+				}, util.Timeout, util.Interval).Should(testing.BeNotFoundError())
+			})
+
+			ginkgo.It("Should stop the single pod with the queue name if workload is evicted", func() {
+				ginkgo.By("Creating a pod with queue name")
+				pod := testingpod.MakePod(podName, ns.Name).Queue("test-queue").Obj()
+				gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
+
+				createdPod := &corev1.Pod{}
+				gomega.Eventually(func() error {
+					return k8sClient.Get(ctx, lookupKey, createdPod)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("checking that workload is created for pod with the queue name")
+				createdWorkload := &kueue.Workload{}
+				gomega.Eventually(func() error {
+					return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(1))
+
+				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
+
+				ginkgo.By("checking that pod is unsuspended when workload is admitted")
+				clusterQueue := testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
+					).Obj()
+				admission := testing.MakeAdmission(clusterQueue.Name).
+					Assignment(corev1.ResourceCPU, "default", "1").
+					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					Obj()
+				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
+				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+
+				util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, lookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					ok, err := testing.CheckLatestEvent(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name))
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					g.Expect(ok).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				gomega.Expect(createdWorkload.Status.Conditions).Should(gomega.BeComparableTo(
+					[]metav1.Condition{
+						{Type: kueue.WorkloadQuotaReserved, Status: metav1.ConditionTrue},
+						{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue},
+					},
+					wlConditionCmpOpts...,
+				))
+
+				ginkgo.By("checking that pod is stopped when workload is evicted")
+
+				gomega.Expect(
+					workload.UpdateStatus(ctx, k8sClient, createdWorkload, kueue.WorkloadEvicted, metav1.ConditionTrue,
+						kueue.WorkloadEvictedByPreemption, "By test", "evict"),
+				).Should(gomega.Succeed())
+				util.FinishEvictionForWorkloads(ctx, k8sClient, createdWorkload)
+
+				gomega.Eventually(func(g gomega.Gomega) bool {
+					g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).To(gomega.Succeed())
+					return createdPod.DeletionTimestamp.IsZero()
+				}, util.Timeout, util.Interval).Should(gomega.BeFalse(), "Expected pod to be deleted")
+
+				gomega.Expect(createdPod.Status.Conditions).Should(gomega.ContainElement(
+					gomega.BeComparableTo(
+						corev1.PodCondition{
+							Type:    "TerminationTarget",
+							Status:  "True",
+							Reason:  "StoppedByKueue",
+							Message: "By test",
+						},
+						cmpopts.IgnoreFields(corev1.PodCondition{}, "LastTransitionTime"),
+					),
+				))
+
+			})
+
+			ginkgo.When("Pod owner is managed by Kueue", func() {
+				var pod *corev1.Pod
+				ginkgo.BeforeEach(func() {
+					pod = testingpod.MakePod(podName, ns.Name).
+						Queue("test-queue").
+						OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
+						Obj()
+				})
+
+				ginkgo.It("Should skip the pod", func() {
+					gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
+
+					createdPod := &corev1.Pod{}
+					gomega.Eventually(func() error {
+						return k8sClient.Get(ctx, lookupKey, createdPod)
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+					gomega.Expect(createdPod.Spec.SchedulingGates).NotTo(
+						gomega.ContainElement(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}),
+						"Pod shouldn't have scheduling gate",
+					)
+
+					gomega.Expect(createdPod.Labels).NotTo(
+						gomega.HaveKeyWithValue("kueue.x-k8s.io/managed", "true"),
+						"Pod shouldn't have the label",
+					)
+
+					gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement("kueue.x-k8s.io/managed"),
+						"Pod shouldn't have finalizer")
+
+					ginkgo.By(fmt.Sprintf("checking that workload '%s' is not created", wlLookupKey))
+					createdWorkload := &kueue.Workload{}
+
+					gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(testing.BeNotFoundError())
+				})
+			})
+
+			ginkgo.When("the queue has admission checks", func() {
+				var (
+					ns             *corev1.Namespace
+					clusterQueueAc *kueue.ClusterQueue
+					localQueue     *kueue.LocalQueue
+					testFlavor     *kueue.ResourceFlavor
+					podLookupKey   *types.NamespacedName
+					wlLookupKey    *types.NamespacedName
+					admissionCheck *kueue.AdmissionCheck
+				)
+
+				ginkgo.BeforeEach(func() {
+					ns = &corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							GenerateName: "pod-ac-namespace-",
+						},
+					}
+					gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+					admissionCheck = testing.MakeAdmissionCheck("check").ControllerName("ac-controller").Obj()
+					gomega.Expect(k8sClient.Create(ctx, admissionCheck)).To(gomega.Succeed())
+					util.SetAdmissionCheckActive(ctx, k8sClient, admissionCheck, metav1.ConditionTrue)
+					clusterQueueAc = testing.MakeClusterQueue("prod-cq-with-checks").
+						ResourceGroup(
+							*testing.MakeFlavorQuotas("test-flavor").Resource(corev1.ResourceCPU, "5").Obj(),
+						).AdmissionChecks("check").Obj()
+					gomega.Expect(k8sClient.Create(ctx, clusterQueueAc)).Should(gomega.Succeed())
+					localQueue = testing.MakeLocalQueue("queue", ns.Name).ClusterQueue(clusterQueueAc.Name).Obj()
+					gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
+					testFlavor = testing.MakeResourceFlavor("test-flavor").Label(instanceKey, "test-flavor").Obj()
+					gomega.Expect(k8sClient.Create(ctx, testFlavor)).Should(gomega.Succeed())
+
+					podLookupKey = &types.NamespacedName{Name: podName, Namespace: ns.Name}
+					wlLookupKey = &types.NamespacedName{Name: podcontroller.GetWorkloadNameForPod(podName), Namespace: ns.Name}
+				})
+
+				ginkgo.AfterEach(func() {
+					gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+					util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, clusterQueueAc, true)
+					util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, testFlavor, true)
+					util.ExpectAdmissionCheckToBeDeleted(ctx, k8sClient, admissionCheck, true)
+				})
+
+				ginkgo.It("labels and annotations should be propagated from admission check to job", func() {
+					createdPod := &corev1.Pod{}
+					createdWorkload := &kueue.Workload{}
+
+					ginkgo.By("creating the job with pod labels & annotations", func() {
+						job := testingpod.MakePod(podName, ns.Name).
+							Queue(localQueue.Name).
+							Request(corev1.ResourceCPU, "5").
+							Annotation("old-ann-key", "old-ann-value").
+							Label("old-label-key", "old-label-value").
+							Obj()
+						gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+					})
+
+					ginkgo.By("fetch the job and verify it is suspended as the checks are not ready", func() {
+						gomega.Eventually(func(g gomega.Gomega) []corev1.PodSchedulingGate {
+							g.Expect(k8sClient.Get(ctx, *podLookupKey, createdPod)).To(gomega.Succeed())
+							return createdPod.Spec.SchedulingGates
+						}, util.Timeout, util.Interval).Should(
+							gomega.ContainElement(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}),
+						)
+					})
+
+					ginkgo.By("fetch the created workload", func() {
+						gomega.Eventually(func() error {
+							return k8sClient.Get(ctx, *wlLookupKey, createdWorkload)
+						}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					})
+
+					ginkgo.By("add labels & annotations to the admission check", func() {
+						gomega.Eventually(func() error {
+							var newWL kueue.Workload
+							gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdWorkload), &newWL)).To(gomega.Succeed())
+							workload.SetAdmissionCheckState(&newWL.Status.AdmissionChecks, kueue.AdmissionCheckState{
+								Name:  "check",
+								State: kueue.CheckStateReady,
+								PodSetUpdates: []kueue.PodSetUpdate{
+									{
+										Name: "main",
+										Labels: map[string]string{
+											"label1": "label-value1",
+										},
+										Annotations: map[string]string{
+											"ann1": "ann-value1",
+										},
+										NodeSelector: map[string]string{
+											"selector1": "selector-value1",
+										},
+									},
+								},
+							})
+							return k8sClient.Status().Update(ctx, &newWL)
+						}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					})
+
+					ginkgo.By("admit the workload", func() {
+						admission := testing.MakeAdmission(clusterQueueAc.Name).
+							Assignment(corev1.ResourceCPU, "test-flavor", "1").
+							AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+							Obj()
+						gomega.Expect(k8sClient.Get(ctx, *wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+						gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
+						util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+					})
+
+					ginkgo.By("await for the job to be admitted", func() {
+						gomega.Eventually(func(g gomega.Gomega) []corev1.PodSchedulingGate {
+							g.Expect(k8sClient.Get(ctx, *podLookupKey, createdPod)).
+								To(gomega.Succeed())
+							return createdPod.Spec.SchedulingGates
+						}, util.Timeout, util.Interval).Should(gomega.BeEmpty())
+					})
+
+					ginkgo.By("verify the PodSetUpdates are propagated to the running job", func() {
+						gomega.Expect(createdPod.Annotations).Should(gomega.HaveKeyWithValue("ann1", "ann-value1"))
+						gomega.Expect(createdPod.Annotations).Should(gomega.HaveKeyWithValue("old-ann-key", "old-ann-value"))
+						gomega.Expect(createdPod.Labels).Should(gomega.HaveKeyWithValue("label1", "label-value1"))
+						gomega.Expect(createdPod.Labels).Should(gomega.HaveKeyWithValue("old-label-key", "old-label-value"))
+						gomega.Expect(createdPod.Spec.NodeSelector).Should(gomega.HaveKeyWithValue(instanceKey, "test-flavor"))
+						gomega.Expect(createdPod.Spec.NodeSelector).Should(gomega.HaveKeyWithValue("selector1", "selector-value1"))
+					})
+				})
 			})
 		})
 
-		ginkgo.When("the queue has admission checks", func() {
-			var (
-				clusterQueueAc *kueue.ClusterQueue
-				localQueue     *kueue.LocalQueue
-				testFlavor     *kueue.ResourceFlavor
-				podLookupKey   *types.NamespacedName
-				wlLookupKey    *types.NamespacedName
-				admissionCheck *kueue.AdmissionCheck
-			)
+		ginkgo.When("Using pod group", func() {
+			ginkgo.It("Should ungate pods when admitted and finalize Pods when succeeded", func() {
+				ginkgo.By("Creating pods with queue name")
+				pod1 := testingpod.MakePod("test-pod1", ns.Name).
+					Group("test-group").
+					GroupTotalCount("2").
+					Queue("test-queue").
+					Obj()
+				pod2 := testingpod.MakePod("test-pod2", ns.Name).
+					Group("test-group").
+					GroupTotalCount("2").
+					Image("test-image", nil).
+					Queue("test-queue").
+					Obj()
+				pod1LookupKey := client.ObjectKeyFromObject(pod1)
+				pod2LookupKey := client.ObjectKeyFromObject(pod2)
 
-			ginkgo.BeforeEach(func() {
-				admissionCheck = testing.MakeAdmissionCheck("check").ControllerName("ac-controller").Obj()
-				gomega.Expect(k8sClient.Create(ctx, admissionCheck)).To(gomega.Succeed())
-				util.SetAdmissionCheckActive(ctx, k8sClient, admissionCheck, metav1.ConditionTrue)
-				clusterQueueAc = testing.MakeClusterQueue("prod-cq-with-checks").
-					ResourceGroup(
-						*testing.MakeFlavorQuotas("test-flavor").Resource(corev1.ResourceCPU, "5").Obj(),
-					).AdmissionChecks("check").Obj()
-				gomega.Expect(k8sClient.Create(ctx, clusterQueueAc)).Should(gomega.Succeed())
-				localQueue = testing.MakeLocalQueue("queue", ns.Name).ClusterQueue(clusterQueueAc.Name).Obj()
-				gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
-				testFlavor = testing.MakeResourceFlavor("test-flavor").Label(instanceKey, "test-flavor").Obj()
-				gomega.Expect(k8sClient.Create(ctx, testFlavor)).Should(gomega.Succeed())
+				gomega.Expect(k8sClient.Create(ctx, pod1)).Should(gomega.Succeed())
+				gomega.Expect(k8sClient.Create(ctx, pod2)).Should(gomega.Succeed())
 
-				podLookupKey = &types.NamespacedName{Name: podName, Namespace: ns.Name}
-				wlLookupKey = &types.NamespacedName{Name: podcontroller.GetWorkloadNameForPod(podName), Namespace: ns.Name}
-			})
-
-			ginkgo.AfterEach(func() {
-				gomega.Expect(util.DeleteLocalQueue(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
-				gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-				gomega.Expect(util.DeleteAdmissionCheck(ctx, k8sClient, admissionCheck)).To(gomega.Succeed())
-				util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, clusterQueueAc, true)
-				util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, testFlavor, true)
-			})
-
-			ginkgo.It("labels and annotations should be propagated from admission check to job", func() {
-				createdPod := &corev1.Pod{}
+				ginkgo.By("checking that workload is created for the pod group with the queue name")
+				wlLookupKey := types.NamespacedName{
+					Namespace: pod1.Namespace,
+					Name:      "test-group",
+				}
 				createdWorkload := &kueue.Workload{}
+				gomega.Eventually(func() error {
+					return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-				ginkgo.By("creating the job with pod labels & annotations", func() {
-					job := testingpod.MakePod(podName, ns.Name).
-						Queue(localQueue.Name).
-						Request(corev1.ResourceCPU, "5").
-						Annotation("old-ann-key", "old-ann-value").
-						Label("old-label-key", "old-label-value").
+				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(2))
+				gomega.Expect(createdWorkload.Spec.PodSets[0].Count).To(gomega.Equal(int32(1)))
+				gomega.Expect(createdWorkload.Spec.PodSets[1].Count).To(gomega.Equal(int32(1)))
+				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
+
+				createdPod := &corev1.Pod{}
+				ginkgo.By("checking that all pods in group are unsuspended when workload is admitted", func() {
+					admission := testing.MakeAdmission(clusterQueue.Name, "120fa2c0", "542d5455").
+						Assignment(corev1.ResourceCPU, "default", "1").
+						AssignmentPodCount(2).
 						Obj()
-					gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
-				})
-
-				ginkgo.By("fetch the job and verify it is suspended as the checks are not ready", func() {
-					gomega.Eventually(func(g gomega.Gomega) []corev1.PodSchedulingGate {
-						g.Expect(k8sClient.Get(ctx, *podLookupKey, createdPod)).To(gomega.Succeed())
-						return createdPod.Spec.SchedulingGates
-					}, util.Timeout, util.Interval).Should(
-						gomega.ContainElement(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}),
-					)
-				})
-
-				ginkgo.By("fetch the created workload", func() {
-					gomega.Eventually(func() error {
-						return k8sClient.Get(ctx, *wlLookupKey, createdWorkload)
-					}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				})
-
-				ginkgo.By("add labels & annotations to the admission check", func() {
-					gomega.Eventually(func() error {
-						var newWL kueue.Workload
-						gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdWorkload), &newWL)).To(gomega.Succeed())
-						workload.SetAdmissionCheckState(&newWL.Status.AdmissionChecks, kueue.AdmissionCheckState{
-							Name:  "check",
-							State: kueue.CheckStateReady,
-							PodSetUpdates: []kueue.PodSetUpdate{
-								{
-									Name: "main",
-									Labels: map[string]string{
-										"label1": "label-value1",
-									},
-									Annotations: map[string]string{
-										"ann1": "ann-value1",
-									},
-									NodeSelector: map[string]string{
-										"selector1": "selector-value1",
-									},
-								},
-							},
-						})
-						return k8sClient.Status().Update(ctx, &newWL)
-					}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				})
-
-				ginkgo.By("admit the workload", func() {
-					admission := testing.MakeAdmission(clusterQueueAc.Name).
-						Assignment(corev1.ResourceCPU, "test-flavor", "1").
-						AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
-						Obj()
-					gomega.Expect(k8sClient.Get(ctx, *wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+
+					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod1LookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod2LookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+
+					gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					gomega.Expect(createdWorkload.Status.Conditions).Should(gomega.BeComparableTo(
+						[]metav1.Condition{
+							{Type: kueue.WorkloadQuotaReserved, Status: metav1.ConditionTrue},
+							{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue},
+						},
+						wlConditionCmpOpts...,
+					))
 				})
 
-				ginkgo.By("await for the job to be admitted", func() {
-					gomega.Eventually(func(g gomega.Gomega) []corev1.PodSchedulingGate {
-						g.Expect(k8sClient.Get(ctx, *podLookupKey, createdPod)).
-							To(gomega.Succeed())
-						return createdPod.Spec.SchedulingGates
-					}, util.Timeout, util.Interval).Should(gomega.BeEmpty())
+				ginkgo.By("checking that pod group is finalized when all pods in the group succeed", func() {
+					util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, pod1, pod2)
+
+					gomega.Eventually(func() []metav1.Condition {
+						err := k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+						if err != nil {
+							return nil
+						}
+						return createdWorkload.Status.Conditions
+					}, util.Timeout, util.Interval).Should(gomega.ContainElement(
+						gomega.BeComparableTo(
+							metav1.Condition{Type: kueue.WorkloadFinished, Status: metav1.ConditionTrue},
+							wlConditionCmpOpts...,
+						),
+					), "Expected 'Finished' workload condition")
+
+					gomega.Eventually(func(g gomega.Gomega) []string {
+						g.Expect(k8sClient.Get(ctx, pod1LookupKey, createdPod)).To(gomega.Succeed())
+						return createdPod.Finalizers
+					}, util.Timeout, util.Interval).Should(gomega.BeEmpty(), "Expected pod to be finalized")
+
+					gomega.Eventually(func(g gomega.Gomega) []string {
+						g.Expect(k8sClient.Get(ctx, pod2LookupKey, createdPod)).To(gomega.Succeed())
+						return createdPod.Finalizers
+					}, util.Timeout, util.Interval).Should(gomega.BeEmpty(), "Expected pod to be finalized")
+				})
+			})
+
+			ginkgo.It("Should keep the running pod group with the queue name if workload is evicted", func() {
+				ginkgo.By("Creating pods with queue name")
+				pod1 := testingpod.MakePod("test-pod1", ns.Name).
+					Group("test-group").
+					GroupTotalCount("2").
+					Queue("test-queue").
+					Obj()
+				pod2 := testingpod.MakePod("test-pod2", ns.Name).
+					Group("test-group").
+					GroupTotalCount("2").
+					Queue("test-queue").
+					Obj()
+				pod1LookupKey := client.ObjectKeyFromObject(pod1)
+				pod2LookupKey := client.ObjectKeyFromObject(pod2)
+
+				gomega.Expect(k8sClient.Create(ctx, pod1)).Should(gomega.Succeed())
+				gomega.Expect(k8sClient.Create(ctx, pod2)).Should(gomega.Succeed())
+
+				ginkgo.By("checking that workload is created for the pod group with the queue name")
+				wlLookupKey := types.NamespacedName{
+					Namespace: pod1.Namespace,
+					Name:      "test-group",
+				}
+				createdWorkload := &kueue.Workload{}
+				gomega.Eventually(func() error {
+					return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(1))
+				gomega.Expect(createdWorkload.Spec.PodSets[0].Count).To(gomega.Equal(int32(2)))
+				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
+				originalWorkloadUID := createdWorkload.UID
+
+				admission := testing.MakeAdmission(clusterQueue.Name, "120fa2c0").
+					Assignment(corev1.ResourceCPU, "default", "1").
+					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					Obj()
+				ginkgo.By("checking that all pods in group are unsuspended when workload is admitted", func() {
+					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
+					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+
+					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod1LookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod2LookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+
+					gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					gomega.Expect(createdWorkload.Status.Conditions).Should(gomega.BeComparableTo(
+						[]metav1.Condition{
+							{Type: kueue.WorkloadQuotaReserved, Status: metav1.ConditionTrue},
+							{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue},
+						},
+						wlConditionCmpOpts...,
+					))
 				})
 
-				ginkgo.By("verify the PodSetUpdates are propagated to the running job", func() {
-					gomega.Expect(createdPod.Annotations).Should(gomega.HaveKeyWithValue("ann1", "ann-value1"))
-					gomega.Expect(createdPod.Annotations).Should(gomega.HaveKeyWithValue("old-ann-key", "old-ann-value"))
-					gomega.Expect(createdPod.Labels).Should(gomega.HaveKeyWithValue("label1", "label-value1"))
-					gomega.Expect(createdPod.Labels).Should(gomega.HaveKeyWithValue("old-label-key", "old-label-value"))
-					gomega.Expect(createdPod.Spec.NodeSelector).Should(gomega.HaveKeyWithValue(instanceKey, "test-flavor"))
-					gomega.Expect(createdPod.Spec.NodeSelector).Should(gomega.HaveKeyWithValue("selector1", "selector-value1"))
+				ginkgo.By("set the pods as running", func() {
+					util.SetPodsPhase(ctx, k8sClient, corev1.PodRunning, pod1, pod2)
 				})
+
+				createdPod := &corev1.Pod{}
+				ginkgo.By("checking that the Pods get a deletion timestamp when the workload is evicted", func() {
+					gomega.Expect(func() error {
+						w := createdWorkload.DeepCopy()
+						workload.SetEvictedCondition(w, "ByTest", "by test")
+						return workload.ApplyAdmissionStatus(ctx, k8sClient, w, false)
+					}()).Should(gomega.Succeed())
+
+					gomega.Eventually(func(g gomega.Gomega) bool {
+						g.Expect(k8sClient.Get(ctx, pod1LookupKey, createdPod)).To(gomega.Succeed())
+						return createdPod.DeletionTimestamp.IsZero()
+					}, util.ConsistentDuration, util.Interval).Should(gomega.BeFalse())
+
+					gomega.Eventually(func(g gomega.Gomega) bool {
+						g.Expect(k8sClient.Get(ctx, pod2LookupKey, createdPod)).To(gomega.Succeed())
+						return createdPod.DeletionTimestamp.IsZero()
+					}, util.ConsistentDuration, util.Interval).Should(gomega.BeFalse())
+				})
+
+				ginkgo.By("finish one pod and fail the other, the eviction should end", func() {
+					util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, pod1)
+					util.SetPodsPhase(ctx, k8sClient, corev1.PodFailed, pod2)
+
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+						g.Expect(createdWorkload.Status.Conditions).Should(gomega.ContainElement(
+							gomega.BeComparableTo(metav1.Condition{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionFalse}, wlConditionCmpOpts...),
+						))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				replacementPod := testingpod.MakePod("test-pod2-replace", ns.Name).
+					Group("test-group").
+					GroupTotalCount("2").
+					Queue("test-queue").
+					Obj()
+				replacementPodLookupKey := client.ObjectKeyFromObject(pod2)
+
+				ginkgo.By("creating the replacement pod and readmitting the workload will unsuspended the replacement", func() {
+					gomega.Expect(k8sClient.Create(ctx, replacementPod)).Should(gomega.Succeed())
+
+					gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					gomega.Expect(createdWorkload.UID).To(gomega.Equal(originalWorkloadUID))
+					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
+					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+
+					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, replacementPodLookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+
+					gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					gomega.Expect(createdWorkload.Status.Conditions).Should(gomega.ContainElement(
+						gomega.BeComparableTo(metav1.Condition{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue}, wlConditionCmpOpts...),
+					))
+				})
+
+				ginkgo.By("finishing the replacement pod the workload should be finished", func() {
+					util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, replacementPod)
+
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+						g.Expect(createdWorkload.Status.Conditions).Should(gomega.ContainElement(
+							gomega.BeComparableTo(metav1.Condition{Type: kueue.WorkloadFinished, Status: metav1.ConditionTrue}, wlConditionCmpOpts...),
+						))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+
+			ginkgo.It("Should keep the existing workload for pod replacement", func() {
+				ginkgo.By("Creating a single pod with queue and group names")
+
+				pod := testingpod.MakePod("test-pod", ns.Name).
+					Group("test-group").
+					GroupTotalCount("1").
+					Queue("test-queue").
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
+
+				ginkgo.By("checking that workload is created for the pod group with the queue name")
+				wlLookupKey := types.NamespacedName{
+					Namespace: pod.Namespace,
+					Name:      "test-group",
+				}
+				createdWorkload := &kueue.Workload{}
+				gomega.Eventually(func() error {
+					return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(1))
+				gomega.Expect(createdWorkload.Spec.PodSets[0].Count).To(gomega.Equal(int32(1)))
+				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
+
+				ginkgo.By("checking that pod is unsuspended when workload is admitted")
+				clusterQueue := testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
+					).Obj()
+				admission := testing.MakeAdmission(clusterQueue.Name, "120fa2c0").
+					Assignment(corev1.ResourceCPU, "default", "1").
+					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					Obj()
+				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
+				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+
+				podLookupKey := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
+				util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, podLookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+
+				ginkgo.By("Failing the running pod")
+
+				util.SetPodsPhase(ctx, k8sClient, corev1.PodFailed, pod)
+				createdPod := &corev1.Pod{}
+				gomega.Consistently(func(g gomega.Gomega) []string {
+					g.Expect(k8sClient.Get(ctx, podLookupKey, createdPod)).To(gomega.Succeed())
+					return createdPod.Finalizers
+				}, util.ConsistentDuration, util.Interval).Should(gomega.ContainElement("kueue.x-k8s.io/managed"), "Pod should have finalizer")
+				gomega.Expect(createdPod.Status.Phase).To(gomega.Equal(corev1.PodFailed))
+
+				gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+				gomega.Expect(createdWorkload.DeletionTimestamp.IsZero()).Should(gomega.BeTrue())
+
+				ginkgo.By("Creating a replacement pod in the group")
+				replacementPod := testingpod.MakePod("replacement-test-pod", ns.Name).
+					Group("test-group").
+					GroupTotalCount("1").
+					Queue("test-queue").
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, replacementPod)).Should(gomega.Succeed())
+				replacementPodLookupKey := client.ObjectKeyFromObject(replacementPod)
+
+				// Workload shouldn't be deleted after replacement pod has been created
+				gomega.Consistently(func() error {
+					return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+
+				util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, replacementPodLookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+
+				util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, replacementPod)
+				gomega.Eventually(func(g gomega.Gomega) []string {
+					g.Expect(k8sClient.Get(ctx, replacementPodLookupKey, createdPod)).To(gomega.Succeed())
+					return createdPod.Finalizers
+				}, util.Timeout, util.Interval).ShouldNot(gomega.ContainElement("kueue.x-k8s.io/managed"),
+					"Pod shouldn't have the kueue finalizer")
+				gomega.Expect(createdPod.Status.Phase).To(gomega.Equal(corev1.PodSucceeded))
+
+				gomega.Eventually(func(g gomega.Gomega) []metav1.Condition {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					return createdWorkload.Status.Conditions
+				}, util.Timeout, util.Interval).Should(gomega.ContainElement(
+					gomega.BeComparableTo(
+						metav1.Condition{Type: kueue.WorkloadFinished, Status: metav1.ConditionTrue},
+						wlConditionCmpOpts...,
+					),
+				), "Expected 'Finished' workload condition")
 			})
 		})
 	})
@@ -509,19 +804,6 @@ var _ = ginkgo.Describe("Pod controller interacting with scheduler", ginkgo.Orde
 				},
 			}),
 		))
-	})
-	ginkgo.AfterAll(func() {
-		fwk.Teardown()
-	})
-
-	ginkgo.BeforeEach(func() {
-		ns = &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "pod-namespace-",
-			},
-		}
-		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
-
 		spotUntaintedFlavor = testing.MakeResourceFlavor("spot-untainted").Label(instanceKey, "spot-untainted").Obj()
 		gomega.Expect(k8sClient.Create(ctx, spotUntaintedFlavor)).Should(gomega.Succeed())
 
@@ -531,10 +813,32 @@ var _ = ginkgo.Describe("Pod controller interacting with scheduler", ginkgo.Orde
 			).Obj()
 		gomega.Expect(k8sClient.Create(ctx, clusterQueue)).Should(gomega.Succeed())
 	})
-	ginkgo.AfterEach(func() {
-		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	ginkgo.AfterAll(func() {
 		util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, clusterQueue, true)
 		util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, spotUntaintedFlavor, true)
+		fwk.Teardown()
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "pod-sched-namespace-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+	})
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+
+		gomega.Eventually(func(g gomega.Gomega) []kueue.Workload {
+			var workloads kueue.WorkloadList
+			g.Expect(k8sClient.List(ctx, &workloads, client.InNamespace(ns.Name))).To(gomega.Succeed())
+			return workloads.Items
+		}, util.Timeout, util.Interval).Should(
+			gomega.BeEmpty(),
+			"All workloads have to be finalized and deleted before the next test starts",
+		)
 	})
 
 	ginkgo.It("Should schedule pods as they fit in their ClusterQueue", func() {
@@ -556,6 +860,104 @@ var _ = ginkgo.Describe("Pod controller interacting with scheduler", ginkgo.Orde
 		gomega.Expect(createdPod.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+	})
+
+	ginkgo.It("Should schedule pod groups as they fit in their ClusterQueue", func() {
+		ginkgo.By("creating localQueue")
+		localQueue = testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		gomega.Expect(k8sClient.Create(ctx, localQueue)).Should(gomega.Succeed())
+
+		basePod := testingpod.MakePod("pod", ns.Name).
+			Group("dev-pods").
+			GroupTotalCount("4").
+			Queue(localQueue.Name).
+			Request(corev1.ResourceCPU, "1")
+
+		role1Pod1 := basePod.
+			Clone().
+			Name("role1-pod1").
+			Image("role1-image", nil).
+			Obj()
+		role1Pod2 := basePod.
+			Clone().
+			Name("role1-pod2").
+			Image("role1-image", nil).
+			Obj()
+		role2Pod1 := basePod.
+			Clone().
+			Name("role2-pod1").
+			Image("role2-image", nil).
+			Obj()
+		role2Pod2 := basePod.
+			Clone().
+			Name("role2-pod2").
+			Image("role2-image", nil).
+			Obj()
+
+		ginkgo.By("creating the pods", func() {
+			gomega.Expect(k8sClient.Create(ctx, role1Pod1)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, role1Pod2)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, role2Pod1)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, role2Pod2)).Should(gomega.Succeed())
+		})
+
+		// the composed workload is created
+		wlKey := types.NamespacedName{
+			Namespace: role1Pod1.Namespace,
+			Name:      "dev-pods",
+		}
+		wl := &kueue.Workload{}
+
+		ginkgo.By("checking the composed workload is created", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		createdPod := &corev1.Pod{}
+		ginkgo.By("check the pods are unsuspended", func() {
+			gomega.Eventually(func(g gomega.Gomega) []corev1.PodSchedulingGate {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: role1Pod1.Name, Namespace: role1Pod1.Namespace}, createdPod)).
+					To(gomega.Succeed())
+				return createdPod.Spec.SchedulingGates
+			}, util.Timeout, util.Interval).Should(gomega.BeEmpty())
+			gomega.Expect(createdPod.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
+			gomega.Eventually(func(g gomega.Gomega) []corev1.PodSchedulingGate {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: role1Pod2.Name, Namespace: role1Pod2.Namespace}, createdPod)).
+					To(gomega.Succeed())
+				return createdPod.Spec.SchedulingGates
+			}, util.Timeout, util.Interval).Should(gomega.BeEmpty())
+			gomega.Expect(createdPod.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
+			gomega.Eventually(func(g gomega.Gomega) []corev1.PodSchedulingGate {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: role2Pod1.Name, Namespace: role2Pod1.Namespace}, createdPod)).
+					To(gomega.Succeed())
+				return createdPod.Spec.SchedulingGates
+			}, util.Timeout, util.Interval).Should(gomega.BeEmpty())
+			gomega.Expect(createdPod.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
+			gomega.Eventually(func(g gomega.Gomega) []corev1.PodSchedulingGate {
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: role2Pod2.Name, Namespace: role2Pod2.Namespace}, createdPod)).
+					To(gomega.Succeed())
+				return createdPod.Spec.SchedulingGates
+			}, util.Timeout, util.Interval).Should(gomega.BeEmpty())
+			gomega.Expect(createdPod.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotUntaintedFlavor.Name))
+		})
+		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
+		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+
+		util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, role1Pod1, role1Pod2, role2Pod1, role2Pod2)
+
+		ginkgo.By("checking pods are finalized", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(role1Pod1), createdPod)).Should(gomega.Succeed())
+				g.Expect(createdPod.Finalizers).To(gomega.BeEmpty(), "Pod should be finalized")
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(role1Pod2), createdPod)).Should(gomega.Succeed())
+				g.Expect(createdPod.Finalizers).To(gomega.BeEmpty(), "Pod should be finalized")
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(role2Pod1), createdPod)).Should(gomega.Succeed())
+				g.Expect(createdPod.Finalizers).To(gomega.BeEmpty(), "Pod should be finalized")
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(role2Pod2), createdPod)).Should(gomega.Succeed())
+				g.Expect(createdPod.Finalizers).To(gomega.BeEmpty(), "Pod should be finalized")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
 	})
 
 	ginkgo.When("The workload's admission is removed", func() {
@@ -601,7 +1003,6 @@ var _ = ginkgo.Describe("Pod controller interacting with scheduler", ginkgo.Orde
 					return createdPod.Spec.NodeSelector
 				}, util.Timeout, util.Interval).ShouldNot(gomega.Equal(originalNodeSelector))
 			})
-			updatedNodeSelector := createdPod.Spec.NodeSelector
 
 			ginkgo.By("deleting the localQueue to prevent readmission", func() {
 				gomega.Expect(util.DeleteLocalQueue(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
@@ -615,11 +1016,10 @@ var _ = ginkgo.Describe("Pod controller interacting with scheduler", ginkgo.Orde
 				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
 			})
 
-			ginkgo.By("checking if the node selectors are not restored", func() {
-				gomega.Eventually(func() map[string]string {
-					gomega.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).Should(gomega.Succeed())
-					return createdPod.Spec.NodeSelector
-				}, util.Timeout, util.Interval).Should(gomega.Equal(updatedNodeSelector))
+			ginkgo.By("checking if pods are deleted", func() {
+				gomega.Eventually(func(g gomega.Gomega) error {
+					return k8sClient.Get(ctx, lookupKey, createdPod)
+				}, util.Timeout, util.Interval).Should(testing.BeNotFoundError())
 			})
 		})
 	})

--- a/test/integration/controller/jobs/pod/suite_test.go
+++ b/test/integration/controller/jobs/pod/suite_test.go
@@ -77,6 +77,9 @@ func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Job reconciler is enabled for "pod parent managed by queue" tests
+		err = job.SetupIndexes(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		jobReconciler := job.NewReconciler(
 			mgr.GetClient(),
 			mgr.GetEventRecorderFor(constants.JobControllerName),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

* Introduce new ComposableJob interface for jobs which has to be composed of different API objects.

* Add ComposableJob implementation for pod groups.

* Add webhook checks for pod group labels and annotations.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related issue: #976

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for groups of plain Pods.
```