### PR TITLE
When preempting in a flavor, retry all flavors in the next iteration

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -208,6 +208,8 @@ func (s *Scheduler) schedule(ctx context.Context) {
 		ctx := ctrl.LoggerInto(ctx, log)
 		if e.assignment.RepresentativeMode() != flavorassigner.Fit {
 			if len(e.preemptionTargets) != 0 {
+				// If preemptions are issued, the next attempt should try all the flavors.
+				e.LastAssignment = nil
 				preempted, err := s.preemptor.IssuePreemptions(ctx, e.preemptionTargets, cq)
 				if err != nil {
 					log.Error(err, "Failed to preempt workloads")

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -1147,17 +1147,17 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wl2 := testing.MakeWorkload("wl-2", ns.Name).Priority(1).Queue(devQueue.Name).Request(corev1.ResourceCPU, "9").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
 			gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
-			util.ExpectPendingWorkloadsMetric(devCQ, 0, 0)
-			util.ExpectReservingActiveWorkloadsMetric(devCQ, 2)
-			util.ExpectAdmittedWorkloadsTotalMetric(devCQ, 2)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
 
 			ginkgo.By("Creating another workload")
 			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "5").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl3)).Should(gomega.Succeed())
 			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, wl1)
-			util.ExpectPendingWorkloadsMetric(prodCQ, 0, 0)
-			util.ExpectReservingActiveWorkloadsMetric(prodCQ, 1)
-			util.ExpectAdmittedWorkloadsTotalMetric(prodCQ, 1)
+
+			util.FinishEvictionForWorkloads(ctx, k8sClient, wl1)
+
+			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3,
+				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj())
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Wipe the last assignment information when issuing preemptions, as the scheduler should retry all flavors in the next admission attempt.

Also ensure that the integration test checks for the admission flavor, not just that a workload was preempted.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed fungiblity policy `whenCanPreempt: Preempt`. The admission should happen in the flavor for which preemptions were issued.
```