### PR TITLE
Retry for ProvisioningRequests KEP

### DIFF
--- a/keps/1136-provisioning-request-support/README.md
+++ b/keps/1136-provisioning-request-support/README.md
@@ -107,9 +107,7 @@ OwnerReference).
 
 * Retry ProvisioningRequests with respect to the `RetryConfig` configuration in
 the `ProvisioningRequestConfig`. For each attempt a new provisioning request is
-created with the suffix indicating the attempt number. The attempt number will
-also be kept in ProvisioningRequest annotation:
-`kueue.x-k8s.io/provisioning-request-attempt`. The corresponding admission
+created with the suffix indicating the attempt number. The corresponding admission
 check will remain in the `Pending` state until the retries end.
 
 The definition of `ProvisioningRequestConfig` is relatively simple and is based on
@@ -153,26 +151,6 @@ type ProvisioningRequestConfigSpec struct {
 	// +listType=set
 	// +kubebuilder:validation:MaxItems=100
 	ManagedResources []corev1.ResourceName `json:"managedResources,omitempty"`
-
-	// RetryConfig defines the retry configuration for a provisioning request
-	//
-	// +optional
-	RetryConfig *ProvisioningRequestRetryConfig `json:"retryConfig,omitempty"`
-}
-
-// ProvisioningRequestRetryConfig defines the retry configuration for the provisioning requests
-type ProvisioningRequestRetryConfig struct {
-	// MaxRetries indicates the maximal number of retries for recreating the provisioning request.
-	//
-	// +optional
-	// +kubebuilder:default=3
-	MaxRetries *int32 `json:"maxRetries,omitempty"`
-
-	// DefaultBackoffSeconds indicates the default backoff in seconds. The intervals
-	// between consecutive attempts are determined by expotential growth up to 30min.
-	// +optional
-	// +kubebuilder:default=60
-	DefaultBackoffSeconds *int32 `json:"minBackoffSeconds,omitempty"`
 }
 ```
 

--- a/keps/1136-provisioning-request-support/README.md
+++ b/keps/1136-provisioning-request-support/README.md
@@ -105,6 +105,13 @@ If the `ProvisioningRequest` fails, fail the `AdmissionCheck`.
 the provisioning request should also be deleted (the last one can be achieved via
 OwnerReference).
 
+* Retry ProvisioningRequests with respect to the `RetryConfig` configuration in
+the `ProvisioningRequestConfig`. For each attempt a new provisioning request is
+created with the suffix indicating the attempt number. The attempt number will
+also be kept in ProvisioningRequest annotation:
+`kueue.x-k8s.io/provisioning-request-attempt`. The corresponding admission
+check will remain in the `Pending` state until the retries end.
+
 The definition of `ProvisioningRequestConfig` is relatively simple and is based on
 what can be set in `ProvisioningRequest`.
 
@@ -146,6 +153,26 @@ type ProvisioningRequestConfigSpec struct {
 	// +listType=set
 	// +kubebuilder:validation:MaxItems=100
 	ManagedResources []corev1.ResourceName `json:"managedResources,omitempty"`
+
+	// RetryConfig defines the retry configuration for a provisioning request
+	//
+	// +optional
+	RetryConfig *ProvisioningRequestRetryConfig `json:"retryConfig,omitempty"`
+}
+
+// ProvisioningRequestRetryConfig defines the retry configuration for the provisioning requests
+type ProvisioningRequestRetryConfig struct {
+	// MaxRetries indicates the maximal number of retries for recreating the provisioning request.
+	//
+	// +optional
+	// +kubebuilder:default=3
+	MaxRetries *int32 `json:"maxRetries,omitempty"`
+
+	// DefaultBackoffSeconds indicates the default backoff in seconds. The intervals
+	// between consecutive attempts are determined by expotential growth up to 30min.
+	// +optional
+	// +kubebuilder:default=60
+	DefaultBackoffSeconds *int32 `json:"minBackoffSeconds,omitempty"`
 }
 ```
 

--- a/keps/1136-provisioning-request-support/README.md
+++ b/keps/1136-provisioning-request-support/README.md
@@ -108,7 +108,9 @@ OwnerReference).
 * Retry ProvisioningRequests with respect to the `RetryConfig` configuration in
 the `ProvisioningRequestConfig`. For each attempt a new provisioning request is
 created with the suffix indicating the attempt number. The corresponding admission
-check will remain in the `Pending` state until the retries end.
+check will remain in the `Pending` state until the retries end. The max number
+of retries is 3, and the interval between attempts grows exponentially, starting
+from 1min (1, 2, 4 min).
 
 The definition of `ProvisioningRequestConfig` is relatively simple and is based on
 what can be set in `ProvisioningRequest`.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes-sigs/kueue/issues/1353

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```