### PR TITLE
Extend visibility ClusterQueue PendingWorkloads endpoint

### DIFF
--- a/apis/visibility/v1alpha1/openapi/zz_generated.openapi.go
+++ b/apis/visibility/v1alpha1/openapi/zz_generated.openapi.go
@@ -2631,7 +2631,40 @@ func schema_kueue_apis_visibility_v1alpha1_PendingWorkload(ref common.ReferenceC
 							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
+					"priority": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Priority indicates the workload's priority",
+							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"localQueueName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LocalQueueName indicates the name of the LocalQueue the workload is submitted to",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"positionInClusterQueue": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PositionInClusterQueue indicates the workload's position in the ClusterQueue, starting from 0",
+							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"positionInLocalQueue": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PositionInLocalQueue indicates the workload's position in the LocalQueue, starting from 0",
+							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 				},
+				Required: []string{"priority", "localQueueName", "positionInClusterQueue", "positionInLocalQueue"},
 			},
 		},
 		Dependencies: []string{
@@ -2662,7 +2695,7 @@ func schema_kueue_apis_visibility_v1alpha1_PendingWorkloadOptions(ref common.Ref
 					},
 					"offset": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Offset indicates position of the first pending workload that should be fetched starting from 0. 0 by default",
+							Description: "Offset indicates position of the first pending workload that should be fetched, starting from 0. 0 by default",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int64",

--- a/apis/visibility/v1alpha1/types.go
+++ b/apis/visibility/v1alpha1/types.go
@@ -27,6 +27,18 @@ import (
 type PendingWorkload struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// Priority indicates the workload's priority
+	Priority int32 `json:"priority"`
+
+	// LocalQueueName indicates the name of the LocalQueue the workload is submitted to
+	LocalQueueName string `json:"localQueueName"`
+
+	// PositionInClusterQueue indicates the workload's position in the ClusterQueue, starting from 0
+	PositionInClusterQueue int32 `json:"positionInClusterQueue"`
+
+	// PositionInLocalQueue indicates the workload's position in the LocalQueue, starting from 0
+	PositionInLocalQueue int32 `json:"positionInLocalQueue"`
 }
 
 // +genclient
@@ -78,7 +90,7 @@ type PendingWorkloadsSummaryList struct {
 type PendingWorkloadOptions struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// Offset indicates position of the first pending workload that should be fetched starting from 0. 0 by default
+	// Offset indicates position of the first pending workload that should be fetched, starting from 0. 0 by default
 	Offset int64 `json:"offset"`
 
 	// Limit indicates max number of pending workloads that should be fetched. 1000 by default

--- a/client-go/applyconfiguration/visibility/v1alpha1/pendingworkload.go
+++ b/client-go/applyconfiguration/visibility/v1alpha1/pendingworkload.go
@@ -28,6 +28,10 @@ import (
 type PendingWorkloadApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
+	Priority                         *int32  `json:"priority,omitempty"`
+	LocalQueueName                   *string `json:"localQueueName,omitempty"`
+	PositionInClusterQueue           *int32  `json:"positionInClusterQueue,omitempty"`
+	PositionInLocalQueue             *int32  `json:"positionInLocalQueue,omitempty"`
 }
 
 // PendingWorkloadApplyConfiguration constructs an declarative configuration of the PendingWorkload type for use with
@@ -195,4 +199,36 @@ func (b *PendingWorkloadApplyConfiguration) ensureObjectMetaApplyConfigurationEx
 	if b.ObjectMetaApplyConfiguration == nil {
 		b.ObjectMetaApplyConfiguration = &v1.ObjectMetaApplyConfiguration{}
 	}
+}
+
+// WithPriority sets the Priority field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Priority field is set to the value of the last call.
+func (b *PendingWorkloadApplyConfiguration) WithPriority(value int32) *PendingWorkloadApplyConfiguration {
+	b.Priority = &value
+	return b
+}
+
+// WithLocalQueueName sets the LocalQueueName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the LocalQueueName field is set to the value of the last call.
+func (b *PendingWorkloadApplyConfiguration) WithLocalQueueName(value string) *PendingWorkloadApplyConfiguration {
+	b.LocalQueueName = &value
+	return b
+}
+
+// WithPositionInClusterQueue sets the PositionInClusterQueue field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PositionInClusterQueue field is set to the value of the last call.
+func (b *PendingWorkloadApplyConfiguration) WithPositionInClusterQueue(value int32) *PendingWorkloadApplyConfiguration {
+	b.PositionInClusterQueue = &value
+	return b
+}
+
+// WithPositionInLocalQueue sets the PositionInLocalQueue field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PositionInLocalQueue field is set to the value of the last call.
+func (b *PendingWorkloadApplyConfiguration) WithPositionInLocalQueue(value int32) *PendingWorkloadApplyConfiguration {
+	b.PositionInLocalQueue = &value
+	return b
 }

--- a/pkg/visibility/api/rest/pending_workload_CQ_test.go
+++ b/pkg/visibility/api/rest/pending_workload_CQ_test.go
@@ -1,0 +1,304 @@
+// Copyright 2023 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	visibility "sigs.k8s.io/kueue/apis/visibility/v1alpha1"
+	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/queue"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+func TestPendingWorkloads(t *testing.T) {
+	const (
+		nsName   = "foo"
+		cqNameA  = "cqA"
+		cqNameB  = "cqB"
+		lqNameA  = "lqA"
+		lqNameB  = "lqB"
+		lowPrio  = 50
+		highPrio = 100
+	)
+
+	var (
+		defaultQueryParams = &visibility.PendingWorkloadOptions{
+			Offset: 0,
+			Limit:  constants.DefaultPendingWorkloadsLimit,
+		}
+	)
+
+	scheme := runtime.NewScheme()
+	if err := kueue.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed adding kueue scheme: %s", err)
+	}
+	if err := visibility.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed adding kueue scheme: %s", err)
+	}
+
+	now := time.Now()
+	cases := map[string]struct {
+		clusterQueues        []*kueue.ClusterQueue
+		queues               []*kueue.LocalQueue
+		workloads            []*kueue.Workload
+		queryParams          *visibility.PendingWorkloadOptions
+		wantPendingWorkloads []visibility.PendingWorkload
+	}{
+		"single ClusterQueue and single LocalQueue setup with two workloads and default query parameters": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltesting.MakeClusterQueue(cqNameA).Obj(),
+			},
+			queues: []*kueue.LocalQueue{
+				utiltesting.MakeLocalQueue(lqNameA, nsName).ClusterQueue(cqNameA).Obj(),
+			},
+			workloads: []*kueue.Workload{
+				utiltesting.MakeWorkload("a", nsName).Queue(lqNameA).Priority(highPrio).Obj(),
+				utiltesting.MakeWorkload("b", nsName).Queue(lqNameA).Priority(lowPrio).Obj(),
+			},
+			queryParams: defaultQueryParams,
+			wantPendingWorkloads: []visibility.PendingWorkload{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "a",
+						Namespace: nsName,
+					},
+					LocalQueueName:         lqNameA,
+					Priority:               highPrio,
+					PositionInClusterQueue: 0,
+					PositionInLocalQueue:   0,
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "b",
+						Namespace: nsName,
+					},
+					LocalQueueName:         lqNameA,
+					Priority:               lowPrio,
+					PositionInClusterQueue: 1,
+					PositionInLocalQueue:   1,
+				},
+			},
+		},
+		"single ClusterQueue and two LocalQueue setup with four workloads and default query parameters": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltesting.MakeClusterQueue(cqNameA).Obj(),
+			},
+			queues: []*kueue.LocalQueue{
+				utiltesting.MakeLocalQueue(lqNameA, nsName).ClusterQueue(cqNameA).Obj(),
+				utiltesting.MakeLocalQueue(lqNameB, nsName).ClusterQueue(cqNameA).Obj(),
+			},
+			workloads: []*kueue.Workload{
+				utiltesting.MakeWorkload("lqA-high-prio", nsName).Queue(lqNameA).Priority(highPrio).Creation(now).Obj(),
+				utiltesting.MakeWorkload("lqA-low-prio", nsName).Queue(lqNameA).Priority(lowPrio).Creation(now).Obj(),
+				utiltesting.MakeWorkload("lqB-high-prio", nsName).Queue(lqNameB).Priority(highPrio).Creation(now.Add(time.Second)).Obj(),
+				utiltesting.MakeWorkload("lqB-low-prio", nsName).Queue(lqNameB).Priority(lowPrio).Creation(now.Add(time.Second)).Obj(),
+			},
+			queryParams: defaultQueryParams,
+			wantPendingWorkloads: []visibility.PendingWorkload{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "lqA-high-prio",
+						Namespace: nsName,
+					},
+					LocalQueueName:         lqNameA,
+					Priority:               highPrio,
+					PositionInClusterQueue: 0,
+					PositionInLocalQueue:   0,
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "lqB-high-prio",
+						Namespace: nsName,
+					},
+					LocalQueueName:         lqNameB,
+					Priority:               highPrio,
+					PositionInClusterQueue: 1,
+					PositionInLocalQueue:   0,
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "lqA-low-prio",
+						Namespace: nsName,
+					},
+					LocalQueueName:         lqNameA,
+					Priority:               lowPrio,
+					PositionInClusterQueue: 2,
+					PositionInLocalQueue:   1,
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "lqB-low-prio",
+						Namespace: nsName,
+					},
+					LocalQueueName:         lqNameB,
+					Priority:               lowPrio,
+					PositionInClusterQueue: 3,
+					PositionInLocalQueue:   1,
+				},
+			},
+		},
+		"query parameters limit set": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltesting.MakeClusterQueue(cqNameA).Obj(),
+			},
+			queues: []*kueue.LocalQueue{
+				utiltesting.MakeLocalQueue(lqNameA, nsName).ClusterQueue(cqNameA).Obj(),
+			},
+			workloads: []*kueue.Workload{
+				utiltesting.MakeWorkload("a", nsName).Queue(lqNameA).Priority(highPrio).Creation(now).Obj(),
+				utiltesting.MakeWorkload("b", nsName).Queue(lqNameA).Priority(highPrio).Creation(now.Add(time.Second)).Obj(),
+				utiltesting.MakeWorkload("c", nsName).Queue(lqNameA).Priority(highPrio).Creation(now.Add(time.Second * 2)).Obj(),
+			},
+			queryParams: &visibility.PendingWorkloadOptions{
+				Limit: 2,
+			},
+			wantPendingWorkloads: []visibility.PendingWorkload{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "a",
+						Namespace: nsName,
+					},
+					LocalQueueName:         lqNameA,
+					Priority:               highPrio,
+					PositionInClusterQueue: 0,
+					PositionInLocalQueue:   0,
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "b",
+						Namespace: nsName,
+					},
+					LocalQueueName:         lqNameA,
+					Priority:               highPrio,
+					PositionInClusterQueue: 1,
+					PositionInLocalQueue:   1,
+				},
+			},
+		},
+		"query parameters offset set": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltesting.MakeClusterQueue(cqNameA).Obj(),
+			},
+			queues: []*kueue.LocalQueue{
+				utiltesting.MakeLocalQueue(lqNameA, nsName).ClusterQueue(cqNameA).Obj(),
+			},
+			workloads: []*kueue.Workload{
+				utiltesting.MakeWorkload("a", nsName).Queue(lqNameA).Priority(highPrio).Creation(now).Obj(),
+				utiltesting.MakeWorkload("b", nsName).Queue(lqNameA).Priority(highPrio).Creation(now.Add(time.Second)).Obj(),
+				utiltesting.MakeWorkload("c", nsName).Queue(lqNameA).Priority(highPrio).Creation(now.Add(time.Second * 2)).Obj(),
+			},
+			queryParams: &visibility.PendingWorkloadOptions{
+				Offset: 1,
+				Limit:  constants.DefaultPendingWorkloadsLimit,
+			},
+			wantPendingWorkloads: []visibility.PendingWorkload{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "b",
+						Namespace: nsName,
+					},
+					LocalQueueName:         lqNameA,
+					Priority:               highPrio,
+					PositionInClusterQueue: 1,
+					PositionInLocalQueue:   1,
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "c",
+						Namespace: nsName,
+					},
+					LocalQueueName:         lqNameA,
+					Priority:               highPrio,
+					PositionInClusterQueue: 2,
+					PositionInLocalQueue:   2,
+				},
+			},
+		},
+		"query parameters offset and limit set": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltesting.MakeClusterQueue(cqNameA).Obj(),
+			},
+			queues: []*kueue.LocalQueue{
+				utiltesting.MakeLocalQueue(lqNameA, nsName).ClusterQueue(cqNameA).Obj(),
+			},
+			workloads: []*kueue.Workload{
+				utiltesting.MakeWorkload("a", nsName).Queue(lqNameA).Priority(highPrio).Creation(now).Obj(),
+				utiltesting.MakeWorkload("b", nsName).Queue(lqNameA).Priority(highPrio).Creation(now.Add(time.Second)).Obj(),
+				utiltesting.MakeWorkload("c", nsName).Queue(lqNameA).Priority(highPrio).Creation(now.Add(time.Second * 2)).Obj(),
+			},
+			queryParams: &visibility.PendingWorkloadOptions{
+				Offset: 1,
+				Limit:  1,
+			},
+			wantPendingWorkloads: []visibility.PendingWorkload{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "b",
+						Namespace: nsName,
+					},
+					LocalQueueName:         lqNameA,
+					Priority:               highPrio,
+					PositionInClusterQueue: 1,
+					PositionInLocalQueue:   1,
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			manager := queue.NewManager(utiltesting.NewFakeClient(), nil)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go manager.CleanUpOnContext(ctx)
+
+			pendingWorkloadsInCqRest := NewPendingWorkloadsInCqREST(manager)
+			for _, cq := range tc.clusterQueues {
+				if err := manager.AddClusterQueue(ctx, cq); err != nil {
+					t.Fatalf("Adding cluster queue %s: %v", cq.Name, err)
+				}
+			}
+			for _, q := range tc.queues {
+				if err := manager.AddLocalQueue(ctx, q); err != nil {
+					t.Fatalf("Adding queue %q: %v", q.Name, err)
+				}
+			}
+			for _, w := range tc.workloads {
+				manager.AddOrUpdateWorkload(w)
+			}
+
+			for _, cq := range tc.clusterQueues {
+				info, err := pendingWorkloadsInCqRest.Get(ctx, cq.Name, tc.queryParams)
+				if err != nil {
+					t.Fatal(err)
+				}
+				pendingWorkloadsInfo := info.(*visibility.PendingWorkloadsSummary)
+
+				if diff := cmp.Diff(tc.wantPendingWorkloads, pendingWorkloadsInfo.Items, cmpopts.IgnoreTypes(metav1.TypeMeta{})); diff != "" {
+					t.Errorf("Pending workloads differ: (-want,+got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package e2e
 
 import (
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	visibility "sigs.k8s.io/kueue/apis/visibility/v1alpha1"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	"sigs.k8s.io/kueue/pkg/util/testing"
@@ -41,12 +44,16 @@ import (
 var _ = ginkgo.Describe("Kueue visibility server", func() {
 	const defaultFlavor = "default-flavor"
 	var (
-		defaultRF    *kueue.ResourceFlavor
-		localQueue   *kueue.LocalQueue
-		clusterQueue *kueue.ClusterQueue
-		ns           *corev1.Namespace
-		sampleJob1   *batchv1.Job
-		sampleJob2   *batchv1.Job
+		defaultRF         *kueue.ResourceFlavor
+		localQueueA       *kueue.LocalQueue
+		localQueueB       *kueue.LocalQueue
+		clusterQueue      *kueue.ClusterQueue
+		ns                *corev1.Namespace
+		sampleJob1        *batchv1.Job
+		sampleJob2        *batchv1.Job
+		highPriorityClass *schedulingv1.PriorityClass
+		midPriorityClass  *schedulingv1.PriorityClass
+		lowPriorityClass  *schedulingv1.PriorityClass
 	)
 
 	ginkgo.BeforeEach(func() {
@@ -75,12 +82,39 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).Should(gomega.Succeed())
 
-			localQueue = testing.MakeLocalQueue("main", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
-			gomega.Expect(k8sClient.Create(ctx, localQueue)).Should(gomega.Succeed())
+			localQueueA = testing.MakeLocalQueue("a", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, localQueueA)).Should(gomega.Succeed())
 
+			localQueueB = testing.MakeLocalQueue("b", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, localQueueB)).Should(gomega.Succeed())
+
+			highPriorityClass = testing.MakePriorityClass("high").PriorityValue(100).Obj()
+			gomega.Expect(k8sClient.Create(ctx, highPriorityClass))
+
+			midPriorityClass = testing.MakePriorityClass("mid").PriorityValue(75).Obj()
+			gomega.Expect(k8sClient.Create(ctx, midPriorityClass))
+
+			lowPriorityClass = testing.MakePriorityClass("low").PriorityValue(50).Obj()
+			gomega.Expect(k8sClient.Create(ctx, lowPriorityClass))
+
+			ginkgo.By("Schedule a job that when admitted workload blocks the queue", func() {
+				sampleJob1 = testingjob.MakeJob("test-job-1", ns.Name).
+					Queue(localQueueA.Name).
+					Image("gcr.io/k8s-staging-perf-tests/sleep:v0.0.3", []string{"60s", "-termination-grace-period", "0s"}).
+					Request(corev1.ResourceCPU, "1").
+					TerimnationGracePeriod(1).
+					BackoffLimit(0).
+					PriorityClass(highPriorityClass.Name).
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, sampleJob1)).Should(gomega.Succeed())
+			})
 		})
 		ginkgo.AfterEach(func() {
-			gomega.Expect(util.DeleteLocalQueue(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Delete(ctx, lowPriorityClass)).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Delete(ctx, midPriorityClass)).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Delete(ctx, highPriorityClass)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteLocalQueue(ctx, k8sClient, localQueueB)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteLocalQueue(ctx, k8sClient, localQueueA)).Should(gomega.Succeed())
 			gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
 			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, clusterQueue, true)
 			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, defaultRF, true)
@@ -95,33 +129,9 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Equal(0))
 			})
 
-			ginkgo.By("Schedule a job that when admitted workload blocks the queue", func() {
-				highPriorityClass := testing.MakePriorityClass("high").PriorityValue(100).Obj()
-				gomega.Expect(k8sClient.Create(ctx, highPriorityClass))
-				ginkgo.DeferCleanup(func() {
-					gomega.Expect(k8sClient.Delete(ctx, highPriorityClass)).To(gomega.Succeed())
-				})
-
-				sampleJob1 = testingjob.MakeJob("test-job-1", ns.Name).
-					Queue(localQueue.Name).
-					Image("gcr.io/k8s-staging-perf-tests/sleep:v0.0.3", []string{"60s", "-termination-grace-period", "0s"}).
-					Request(corev1.ResourceCPU, "1").
-					TerimnationGracePeriod(1).
-					BackoffLimit(0).
-					PriorityClass(highPriorityClass.Name).
-					Obj()
-				gomega.Expect(k8sClient.Create(ctx, sampleJob1)).Should(gomega.Succeed())
-			})
-
 			ginkgo.By("Schedule a job which is pending due to lower priority", func() {
-				lowPriorityClass := testing.MakePriorityClass("low").PriorityValue(50).Obj()
-				gomega.Expect(k8sClient.Create(ctx, lowPriorityClass))
-				ginkgo.DeferCleanup(func() {
-					gomega.Expect(k8sClient.Delete(ctx, lowPriorityClass)).To(gomega.Succeed())
-				})
-
 				sampleJob2 = testingjob.MakeJob("test-job-2", ns.Name).
-					Queue(localQueue.Name).
+					Queue(localQueueA.Name).
 					Image("gcr.io/k8s-staging-perf-tests/sleep:v0.0.3", []string{"1ms"}).
 					Request(corev1.ResourceCPU, "1").
 					PriorityClass(lowPriorityClass.Name).
@@ -155,6 +165,79 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					return len(info.Items)
 				}, util.Timeout, util.Interval).Should(gomega.Equal(0))
+			})
+		})
+
+		ginkgo.It("Should allow fetching information about position of pending workloads", func() {
+			ginkgo.By("Schedule three different jobs with different priorities and two different LocalQueues", func() {
+				jobCases := []struct {
+					JobName          string
+					JobPrioClassName string
+					LocalQueueName   string
+				}{
+					{
+						JobName:          "lq-a-high-prio",
+						JobPrioClassName: highPriorityClass.Name,
+						LocalQueueName:   localQueueA.Name,
+					},
+					{
+						JobName:          "lq-b-mid-prio",
+						JobPrioClassName: midPriorityClass.Name,
+						LocalQueueName:   localQueueB.Name,
+					},
+					{
+						JobName:          "lq-b-low-prio",
+						JobPrioClassName: lowPriorityClass.Name,
+						LocalQueueName:   localQueueB.Name,
+					},
+				}
+				for _, jobCase := range jobCases {
+					job := testingjob.MakeJob(jobCase.JobName, ns.Name).
+						Queue(jobCase.LocalQueueName).
+						Image("gcr.io/k8s-staging-perf-tests/sleep:v0.0.3", []string{"1ms"}).
+						Request(corev1.ResourceCPU, "1").
+						PriorityClass(jobCase.JobPrioClassName).
+						Obj()
+					gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+				}
+			})
+
+			ginkgo.By("Verify their positions and priorities", func() {
+				wantPendingWorkloads := []visibility.PendingWorkload{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: ns.Name,
+						},
+						Priority:               highPriorityClass.Value,
+						PositionInLocalQueue:   0,
+						PositionInClusterQueue: 0,
+						LocalQueueName:         localQueueA.Name,
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: ns.Name,
+						},
+						Priority:               midPriorityClass.Value,
+						PositionInLocalQueue:   0,
+						PositionInClusterQueue: 1,
+						LocalQueueName:         localQueueB.Name,
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: ns.Name,
+						},
+						Priority:               lowPriorityClass.Value,
+						PositionInLocalQueue:   1,
+						PositionInClusterQueue: 2,
+						LocalQueueName:         localQueueB.Name,
+					},
+				}
+				gomega.Eventually(func() []visibility.PendingWorkload {
+					info, err := visibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, clusterQueue.Name, metav1.GetOptions{})
+					gomega.Expect(err).NotTo(gomega.HaveOccurred())
+					return info.Items
+					// We do not check Name as it's generated for workloads
+				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(wantPendingWorkloads, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Name")))
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR continues the development of [KEP#168-2](https://github.com/kubernetes-sigs/kueue/pull/1300)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Extend the information returned for the pending workloads in cluster queue, that is used to determine the workload position, including the workload position itself.

```