### PR TITLE
Fix fungibility: Try next flavor if can't preempt on first

### DIFF
--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -200,6 +201,7 @@ func filterQuantities(orig FlavorResourceQuantities, resourceGroups []kueue.Reso
 }
 
 func (c *ClusterQueue) updateResourceGroups(in []kueue.ResourceGroup) {
+	oldRG := c.ResourceGroups
 	c.ResourceGroups = make([]ResourceGroup, len(in))
 	for i, rgIn := range in {
 		rg := &c.ResourceGroups[i]
@@ -225,7 +227,9 @@ func (c *ClusterQueue) updateResourceGroups(in []kueue.ResourceGroup) {
 			rg.Flavors = append(rg.Flavors, fQuotas)
 		}
 	}
-	c.AllocatableResourceGeneration++
+	if !reflect.DeepEqual(oldRG, c.ResourceGroups) {
+		c.AllocatableResourceGeneration++
+	}
 	c.UpdateRGByResource()
 }
 

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -3,9 +3,9 @@ package cache
 import (
 	"errors"
 	"fmt"
-	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -227,7 +227,8 @@ func (c *ClusterQueue) updateResourceGroups(in []kueue.ResourceGroup) {
 			rg.Flavors = append(rg.Flavors, fQuotas)
 		}
 	}
-	if !reflect.DeepEqual(oldRG, c.ResourceGroups) {
+	// Start at 1, for backwards compatibility.
+	if c.AllocatableResourceGeneration == 0 || !equality.Semantic.DeepEqual(oldRG, c.ResourceGroups) {
 		c.AllocatableResourceGeneration++
 	}
 	c.UpdateRGByResource()

--- a/pkg/queue/cluster_queue_impl.go
+++ b/pkg/queue/cluster_queue_impl.go
@@ -142,7 +142,7 @@ func (c *clusterQueueBase) requeueIfNotPresent(wInfo *workload.Info, immediate b
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
 	key := workload.Key(wInfo.Obj)
-	if immediate || c.queueInadmissibleCycle >= c.popCycle {
+	if immediate || c.queueInadmissibleCycle >= c.popCycle || wInfo.LastAssignment.PendingFlavors() {
 		// If the workload was inadmissible, move it back into the queue.
 		inadmissibleWl := c.inadmissibleWorkloads[key]
 		if inadmissibleWl != nil {

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -220,10 +220,10 @@ func (m FlavorAssignmentMode) String() string {
 }
 
 type FlavorAssignment struct {
-	Name      kueue.ResourceFlavorReference
-	Mode      FlavorAssignmentMode
-	FlavorIdx int
-	borrow    int64
+	Name           kueue.ResourceFlavorReference
+	Mode           FlavorAssignmentMode
+	TriedFlavorIdx int
+	borrow         int64
 }
 
 func lastAssignmentOutdated(wl *workload.Info, cq *cache.ClusterQueue) bool {
@@ -237,24 +237,20 @@ func lastAssignmentOutdated(wl *workload.Info, cq *cache.ClusterQueue) bool {
 // FlavorAssignmentMode.
 func AssignFlavors(log logr.Logger, wl *workload.Info, resourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor, cq *cache.ClusterQueue, counts []int32) Assignment {
 	if wl.LastAssignment != nil && lastAssignmentOutdated(wl, cq) {
-		log.V(6).Info("workload's last assignment is outdated, set wl.LastAssignment to nil",
-			"cq.AllocatableResourceGeneration", cq.AllocatableResourceGeneration,
-			"wl.LastAssignment.ClusterQueueGeneration", wl.LastAssignment.ClusterQueueGeneration)
-		if cq.Cohort != nil {
-			log.V(6).Info("", "cq.Cohort.AllocatableResourceGeneration", cq.Cohort.AllocatableResourceGeneration,
-				"wl.LastAssignment.CohortGeneration", wl.LastAssignment.CohortGeneration)
-		}
 		wl.LastAssignment = nil
-	} else if wl.LastAssignment != nil {
-		log.V(6).Info("workload's last assignment is up to date",
-			"cq.AllocatableResourceGeneration", cq.AllocatableResourceGeneration,
-			"wl.LastAssignment.ClusterQueueGeneration", wl.LastAssignment.ClusterQueueGeneration)
-		if cq.Cohort != nil {
-			log.V(6).Info("", "cq.Cohort.AllocatableResourceGeneration", cq.Cohort.AllocatableResourceGeneration,
-				"wl.LastAssignment.CohortGeneration", wl.LastAssignment.CohortGeneration)
+		if logV := log.V(6); logV.Enabled() {
+			keysValues := []any{
+				"cq.AllocatableResourceGeneration", cq.AllocatableResourceGeneration,
+				"wl.LastAssignment.ClusterQueueGeneration", wl.LastAssignment.ClusterQueueGeneration,
+			}
+			if cq.Cohort != nil {
+				keysValues = append(keysValues,
+					"cq.Cohort.AllocatableResourceGeneration", cq.Cohort.AllocatableResourceGeneration,
+					"wl.LastAssignment.CohortGeneration", wl.LastAssignment.CohortGeneration,
+				)
+			}
+			logV.Info("Cleared Worload's last assignment becaused it was outdated", keysValues...)
 		}
-	} else {
-		log.V(4).Info("workload's last assignment is nil")
 	}
 
 	if len(counts) == 0 {
@@ -273,18 +269,14 @@ func assignFlavors(log logr.Logger, requests []workload.PodSetResources, podSets
 		TotalBorrow: make(cache.FlavorResourceQuantities),
 		PodSets:     make([]PodSetAssignment, 0, len(requests)),
 		Usage:       make(cache.FlavorResourceQuantities),
-	}
-	if lastAssignment != nil {
-		assignment.LastState = *lastAssignment
-	} else {
-		assignment.LastState = workload.AssigmentClusterQueueState{
-			LastAssignedFlavorIdx:  make([]map[corev1.ResourceName]int, 0, len(podSets)),
+		LastState: workload.AssigmentClusterQueueState{
+			LastTriedFlavorIdx:     make([]map[corev1.ResourceName]int, 0, len(podSets)),
 			CohortGeneration:       0,
 			ClusterQueueGeneration: cq.AllocatableResourceGeneration,
-		}
-		if cq.Cohort != nil {
-			assignment.LastState.CohortGeneration = cq.Cohort.AllocatableResourceGeneration
-		}
+		},
+	}
+	if cq.Cohort != nil {
+		assignment.LastState.CohortGeneration = cq.Cohort.AllocatableResourceGeneration
 	}
 
 	for i, podSet := range requests {
@@ -314,8 +306,8 @@ func assignFlavors(log logr.Logger, requests []workload.PodSetResources, podSets
 				break
 			}
 			lastFlavorAssignment := -1
-			if lastAssignment != nil && len(lastAssignment.LastAssignedFlavorIdx) > i {
-				idx, ok := lastAssignment.LastAssignedFlavorIdx[i][resName]
+			if lastAssignment != nil && len(lastAssignment.LastTriedFlavorIdx) > i {
+				idx, ok := lastAssignment.LastTriedFlavorIdx[i][resName]
 				if ok {
 					lastFlavorAssignment = idx
 				}
@@ -369,9 +361,9 @@ func (a *Assignment) append(requests workload.Requests, psAssignment *PodSetAssi
 			a.Usage[flvAssignment.Name] = make(map[corev1.ResourceName]int64)
 		}
 		a.Usage[flvAssignment.Name][resource] += requests[resource]
-		flavorIdx[resource] = flvAssignment.FlavorIdx
+		flavorIdx[resource] = flvAssignment.TriedFlavorIdx
 	}
-	a.LastState.LastAssignedFlavorIdx = append(a.LastState.LastAssignedFlavorIdx, flavorIdx)
+	a.LastState.LastTriedFlavorIdx = append(a.LastState.LastTriedFlavorIdx, flavorIdx)
 }
 
 // findFlavorForResourceGroup finds the flavor which can satisfy the resource
@@ -475,9 +467,9 @@ func (a *Assignment) findFlavorForResourceGroup(
 		for _, assignment := range bestAssignment {
 			if flavorIdx == len(rg.Flavors)-1 {
 				// we have reach the last flavor, try from the first flavor next time
-				assignment.FlavorIdx = -1
+				assignment.TriedFlavorIdx = -1
 			} else {
-				assignment.FlavorIdx = flavorIdx
+				assignment.TriedFlavorIdx = flavorIdx
 			}
 		}
 		if bestAssignmentMode == Fit {

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -237,7 +237,24 @@ func lastAssignmentOutdated(wl *workload.Info, cq *cache.ClusterQueue) bool {
 // FlavorAssignmentMode.
 func AssignFlavors(log logr.Logger, wl *workload.Info, resourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor, cq *cache.ClusterQueue, counts []int32) Assignment {
 	if wl.LastAssignment != nil && lastAssignmentOutdated(wl, cq) {
+		log.V(6).Info("workload's last assignment is outdated, set wl.LastAssignment to nil",
+			"cq.AllocatableResourceGeneration", cq.AllocatableResourceGeneration,
+			"wl.LastAssignment.ClusterQueueGeneration", wl.LastAssignment.ClusterQueueGeneration)
+		if cq.Cohort != nil {
+			log.V(6).Info("", "cq.Cohort.AllocatableResourceGeneration", cq.Cohort.AllocatableResourceGeneration,
+				"wl.LastAssignment.CohortGeneration", wl.LastAssignment.CohortGeneration)
+		}
 		wl.LastAssignment = nil
+	} else if wl.LastAssignment != nil {
+		log.V(6).Info("workload's last assignment is up to date",
+			"cq.AllocatableResourceGeneration", cq.AllocatableResourceGeneration,
+			"wl.LastAssignment.ClusterQueueGeneration", wl.LastAssignment.ClusterQueueGeneration)
+		if cq.Cohort != nil {
+			log.V(6).Info("", "cq.Cohort.AllocatableResourceGeneration", cq.Cohort.AllocatableResourceGeneration,
+				"wl.LastAssignment.CohortGeneration", wl.LastAssignment.CohortGeneration)
+		}
+	} else {
+		log.V(4).Info("workload's last assignment is nil")
 	}
 
 	if len(counts) == 0 {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -1874,7 +1874,7 @@ func TestAssignFlavors(t *testing.T) {
 				t.Errorf("e.assignFlavors(_).RepresentativeMode()=%s, want %s", repMode, tc.wantRepMode)
 			}
 
-			if diff := cmp.Diff(tc.wantAssignment, assignment, cmpopts.IgnoreUnexported(Assignment{}, FlavorAssignment{}), cmpopts.IgnoreFields(Assignment{}, "LastState"), cmpopts.IgnoreFields(FlavorAssignment{}, "FlavorIdx")); diff != "" {
+			if diff := cmp.Diff(tc.wantAssignment, assignment, cmpopts.IgnoreUnexported(Assignment{}, FlavorAssignment{}), cmpopts.IgnoreFields(Assignment{}, "LastState"), cmpopts.IgnoreFields(FlavorAssignment{}, "TriedFlavorIdx")); diff != "" {
 				t.Errorf("Unexpected assignment (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -117,22 +117,6 @@ func TestSchedule(t *testing.T) {
 			ResourceGroup(*utiltesting.MakeFlavorQuotas("nonexistent-flavor").
 				Resource(corev1.ResourceCPU, "50").Obj()).
 			Obj(),
-		*utiltesting.MakeClusterQueue("cq-with-2-flavor").
-			QueueingStrategy(kueue.StrictFIFO).
-			Preemption(kueue.ClusterQueuePreemption{
-				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
-				WithinClusterQueue:  kueue.PreemptionPolicyLowerOrNewerEqualPriority,
-			}).
-			FlavorFungibility(kueue.FlavorFungibility{
-				WhenCanBorrow:  kueue.Borrow,
-				WhenCanPreempt: kueue.Preempt,
-			}).
-			ResourceGroup(
-				*utiltesting.MakeFlavorQuotas("on-demand").
-					Resource(corev1.ResourceCPU, "2").Obj(),
-				*utiltesting.MakeFlavorQuotas("spot").
-					Resource(corev1.ResourceCPU, "2").Obj()).
-			Obj(),
 	}
 	queues := []kueue.LocalQueue{
 		{
@@ -189,20 +173,10 @@ func TestSchedule(t *testing.T) {
 				ClusterQueue: "nonexistent-cq",
 			},
 		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "sales",
-				Name:      "local-queue-cq-with-2-flavor",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "cq-with-2-flavor",
-			},
-		},
 	}
 	cases := map[string]struct {
-		workloads         []kueue.Workload
-		needScheduleTwice bool
-		admissionError    error
+		workloads      []kueue.Workload
+		admissionError error
 		// wantAssignments is a summary of all the admissions in the cache after this cycle.
 		wantAssignments map[string]kueue.Admission
 		// wantScheduled is the subset of workloads that got scheduled/admitted in this cycle.
@@ -221,79 +195,6 @@ func TestSchedule(t *testing.T) {
 		// disable partial admission
 		disablePartialAdmission bool
 	}{
-		"two flavors to schedule": {
-			needScheduleTwice: true,
-			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("sample-job1", "sales").
-					Queue("local-queue-cq-with-2-flavor").
-					PodSets(*utiltesting.MakePodSet("main", 1).
-						Request(corev1.ResourceCPU, "1").
-						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq-with-2-flavor").Assignment(corev1.ResourceCPU, "on-demand", "1000m").Obj()).
-					Obj(),
-				*utiltesting.MakeWorkload("sample-job2", "sales").
-					Queue("local-queue-cq-with-2-flavor").
-					PodSets(*utiltesting.MakePodSet("main", 1).
-						Request(corev1.ResourceCPU, "1").
-						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq-with-2-flavor").Assignment(corev1.ResourceCPU, "on-demand", "1000m").Obj()).
-					Obj(),
-				*utiltesting.MakeWorkload("sample-job3", "sales").
-					Queue("local-queue-cq-with-2-flavor").
-					PodSets(*utiltesting.MakePodSet("main", 1).
-						Request(corev1.ResourceCPU, "1").
-						Obj()).
-					Obj(),
-			},
-			wantScheduled: []string{"sales/sample-job3"},
-			wantAssignments: map[string]kueue.Admission{
-				"sales/sample-job1": {
-					ClusterQueue: "cq-with-2-flavor",
-					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "main",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("1000m"),
-							},
-							Count: ptr.To[int32](1),
-						},
-					},
-				},
-				"sales/sample-job2": {
-					ClusterQueue: "cq-with-2-flavor",
-					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "main",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("1000m"),
-							},
-							Count: ptr.To[int32](1),
-						},
-					},
-				},
-				"sales/sample-job3": {
-					ClusterQueue: "cq-with-2-flavor",
-					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "main",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "spot",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("1000m"),
-							},
-							Count: ptr.To[int32](1),
-						},
-					},
-				},
-			},
-		},
 		"workload fits in single clusterQueue": {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("foo", "sales").
@@ -1209,9 +1110,6 @@ func TestSchedule(t *testing.T) {
 			defer cancel()
 
 			scheduler.schedule(ctx)
-			if tc.needScheduleTwice {
-				scheduler.schedule(ctx)
-			}
 			wg.Wait()
 
 			wantScheduled := make(map[string]kueue.Admission)
@@ -1386,100 +1284,6 @@ func TestEntryOrdering(t *testing.T) {
 	}
 }
 
-func TestClusterQueueUpdate(t *testing.T) {
-	resourceFlavors := []*kueue.ResourceFlavor{
-		{ObjectMeta: metav1.ObjectMeta{Name: "on-demand"}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "spot"}},
-	}
-	clusterQueue :=
-		*utiltesting.MakeClusterQueue("eng-alpha").
-			QueueingStrategy(kueue.StrictFIFO).
-			Preemption(kueue.ClusterQueuePreemption{
-				WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
-			}).
-			FlavorFungibility(kueue.FlavorFungibility{
-				WhenCanPreempt: kueue.Preempt,
-			}).
-			ResourceGroup(
-				*utiltesting.MakeFlavorQuotas("on-demand").
-					Resource(corev1.ResourceCPU, "50", "50").Obj(),
-				*utiltesting.MakeFlavorQuotas("spot").
-					Resource(corev1.ResourceCPU, "100", "0").Obj(),
-			).Obj()
-	newClusterQueue1 :=
-		*utiltesting.MakeClusterQueue("eng-alpha").
-			QueueingStrategy(kueue.StrictFIFO).
-			Preemption(kueue.ClusterQueuePreemption{
-				WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
-			}).
-			FlavorFungibility(kueue.FlavorFungibility{
-				WhenCanPreempt: kueue.Preempt,
-			}).
-			ResourceGroup(
-				*utiltesting.MakeFlavorQuotas("on-demand").
-					Resource(corev1.ResourceCPU, "50", "50").Obj(),
-				*utiltesting.MakeFlavorQuotas("spot").
-					Resource(corev1.ResourceCPU, "100", "0").Obj(),
-			).Obj()
-	newClusterQueue2 :=
-		*utiltesting.MakeClusterQueue("eng-alpha").
-			QueueingStrategy(kueue.StrictFIFO).
-			Preemption(kueue.ClusterQueuePreemption{
-				WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
-			}).
-			FlavorFungibility(kueue.FlavorFungibility{
-				WhenCanPreempt: kueue.Preempt,
-			}).
-			ResourceGroup(
-				*utiltesting.MakeFlavorQuotas("on-demand").
-					Resource(corev1.ResourceCPU, "100", "50").Obj(),
-				*utiltesting.MakeFlavorQuotas("spot").
-					Resource(corev1.ResourceCPU, "100", "0").Obj(),
-			).Obj()
-	cases := []struct {
-		name                         string
-		cqs                          *kueue.ClusterQueue
-		newcq                        *kueue.ClusterQueue
-		wantLastAssignmentGeneration int64
-	}{
-		{
-			name:                         "RGs not change",
-			cqs:                          &clusterQueue,
-			newcq:                        &newClusterQueue1,
-			wantLastAssignmentGeneration: 1,
-		},
-		{
-			name:                         "RGs changed",
-			cqs:                          &clusterQueue,
-			newcq:                        &newClusterQueue2,
-			wantLastAssignmentGeneration: 2,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			clientBuilder := utiltesting.NewClientBuilder().
-				WithObjects(
-					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
-					tc.cqs,
-				)
-			cl := clientBuilder.Build()
-			cqCache := cache.New(cl)
-			// Workloads are loaded into queues or clusterQueues as we add them.
-			for _, rf := range resourceFlavors {
-				cqCache.AddOrUpdateResourceFlavor(rf)
-			}
-			cqCache.AddClusterQueue(context.Background(), tc.cqs)
-			cqCache.UpdateClusterQueue(tc.newcq)
-			snapshot := cqCache.Snapshot()
-			if diff := cmp.Diff(
-				tc.wantLastAssignmentGeneration,
-				snapshot.ClusterQueues["eng-alpha"].AllocatableResourceGeneration); diff != "" {
-				t.Errorf("Unexpected assigned clusterQueues in cache (-want,+got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestLastSchedulingContext(t *testing.T) {
 	resourceFlavors := []*kueue.ResourceFlavor{
 		{ObjectMeta: metav1.ObjectMeta{Name: "on-demand"}},
@@ -1487,7 +1291,7 @@ func TestLastSchedulingContext(t *testing.T) {
 	}
 	clusterQueue := []kueue.ClusterQueue{
 		*utiltesting.MakeClusterQueue("eng-alpha").
-			QueueingStrategy(kueue.StrictFIFO).
+			QueueingStrategy(kueue.BestEffortFIFO).
 			Preemption(kueue.ClusterQueuePreemption{
 				WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
 			}).
@@ -1594,6 +1398,7 @@ func TestLastSchedulingContext(t *testing.T) {
 		},
 	}
 	wl := utiltesting.MakeWorkload("low-1", "default").
+		Queue("main").
 		Request(corev1.ResourceCPU, "50").
 		ReserveQuota(utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
 		Admitted(true).
@@ -1603,29 +1408,29 @@ func TestLastSchedulingContext(t *testing.T) {
 		cqs                            []kueue.ClusterQueue
 		admittedWorkloads              []kueue.Workload
 		workloads                      []kueue.Workload
-		deletedWorkloads               []kueue.Workload
+		deleteWorkloads                []kueue.Workload
 		wantPreempted                  sets.Set[string]
 		wantAdmissionsOnFirstSchedule  map[string]kueue.Admission
 		wantAdmissionsOnSecondSchedule map[string]kueue.Admission
 	}{
 		{
-			name: "scheduling context not changed",
+			name: "scheduling context not changed: use next flavor if can't preempt",
 			cqs:  clusterQueue,
 			admittedWorkloads: []kueue.Workload{
 				*wl,
 			},
 			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("preemptor", "default").
+				*utiltesting.MakeWorkload("new", "default").
 					Queue("main").
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deletedWorkloads:              []kueue.Workload{},
+			deleteWorkloads:               []kueue.Workload{},
 			wantPreempted:                 sets.Set[string]{},
 			wantAdmissionsOnFirstSchedule: map[string]kueue.Admission{},
 			wantAdmissionsOnSecondSchedule: map[string]kueue.Admission{
-				"default/preemptor": *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "spot", "20").Obj(),
-				"default/low-1":     *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj(),
+				"default/new":   *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "spot", "20").Obj(),
+				"default/low-1": *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj(),
 			},
 		},
 		{
@@ -1640,7 +1445,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deletedWorkloads: []kueue.Workload{
+			deleteWorkloads: []kueue.Workload{
 				*wl,
 			},
 			wantPreempted:                 sets.Set[string]{},
@@ -1669,8 +1474,8 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deletedWorkloads: []kueue.Workload{},
-			wantPreempted:    sets.Set[string]{},
+			deleteWorkloads: []kueue.Workload{},
+			wantPreempted:   sets.Set[string]{},
 			wantAdmissionsOnFirstSchedule: map[string]kueue.Admission{
 				"default/workload1": *utiltesting.MakeAdmission("eng-cohort-beta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
 				"default/borrower":  *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
@@ -1702,8 +1507,8 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deletedWorkloads: []kueue.Workload{},
-			wantPreempted:    sets.Set[string]{},
+			deleteWorkloads: []kueue.Workload{},
+			wantPreempted:   sets.Set[string]{},
 			wantAdmissionsOnFirstSchedule: map[string]kueue.Admission{
 				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "20").Obj(),
 			},
@@ -1714,7 +1519,7 @@ func TestLastSchedulingContext(t *testing.T) {
 			},
 		},
 		{
-			name: "when the next flavor is full",
+			name: "when the next flavor is full, but can borrow on first",
 			cqs:  clusterQueue_cohort,
 			admittedWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder", "default").
@@ -1739,8 +1544,8 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deletedWorkloads: []kueue.Workload{},
-			wantPreempted:    sets.Set[string]{},
+			deleteWorkloads: []kueue.Workload{},
+			wantPreempted:   sets.Set[string]{},
 			wantAdmissionsOnFirstSchedule: map[string]kueue.Admission{
 				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
 			},
@@ -1749,6 +1554,36 @@ func TestLastSchedulingContext(t *testing.T) {
 				"default/placeholder1": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "40").Obj(),
 				"default/placeholder2": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "100").Obj(),
 				"default/workload":     *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+			},
+		},
+		{
+			name: "when the next flavor is full, but can preempt on first",
+			cqs:  clusterQueue_cohort,
+			admittedWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("placeholder-alpha", "default").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "150").
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "150").Obj()).
+					Admitted(true).
+					Obj(),
+				*utiltesting.MakeWorkload("placeholder-theta-spot", "default").
+					Request(corev1.ResourceCPU, "100").
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "100").Obj()).
+					Admitted(true).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("new", "default").
+					Queue("main-theta").
+					Request(corev1.ResourceCPU, "20").
+					Obj(),
+			},
+			deleteWorkloads:               []kueue.Workload{*utiltesting.MakeWorkload("placeholder-alpha", "default").Obj()},
+			wantPreempted:                 sets.New("default/placeholder-alpha"),
+			wantAdmissionsOnFirstSchedule: map[string]kueue.Admission{},
+			wantAdmissionsOnSecondSchedule: map[string]kueue.Admission{
+				"default/placeholder-theta-spot": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "100").Obj(),
+				"default/new":                    *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
 			},
 		},
 	}
@@ -1825,7 +1660,7 @@ func TestLastSchedulingContext(t *testing.T) {
 				t.Errorf("Unexpected scheduled workloads (-want,+got):\n%s", diff)
 			}
 
-			for _, wl := range tc.deletedWorkloads {
+			for _, wl := range tc.deleteWorkloads {
 				err := cl.Delete(ctx, &wl)
 				if err != nil {
 					t.Errorf("Delete workload failed: %v", err)
@@ -1834,6 +1669,7 @@ func TestLastSchedulingContext(t *testing.T) {
 				if err != nil {
 					t.Errorf("Delete workload failed: %v", err)
 				}
+				qManager.QueueAssociatedInadmissibleWorkloadsAfter(ctx, &wl, nil)
 			}
 
 			scheduler.schedule(ctx)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -40,21 +40,38 @@ var (
 )
 
 type AssigmentClusterQueueState struct {
-	LastAssignedFlavorIdx  []map[corev1.ResourceName]int
+	LastTriedFlavorIdx     []map[corev1.ResourceName]int
 	CohortGeneration       int64
 	ClusterQueueGeneration int64
 }
 
 func (s *AssigmentClusterQueueState) Clone() *AssigmentClusterQueueState {
 	c := AssigmentClusterQueueState{
-		LastAssignedFlavorIdx:  make([]map[corev1.ResourceName]int, len(s.LastAssignedFlavorIdx)),
+		LastTriedFlavorIdx:     make([]map[corev1.ResourceName]int, len(s.LastTriedFlavorIdx)),
 		CohortGeneration:       s.CohortGeneration,
 		ClusterQueueGeneration: s.ClusterQueueGeneration,
 	}
-	for ps, flavorIdx := range s.LastAssignedFlavorIdx {
-		c.LastAssignedFlavorIdx[ps] = maps.Clone(flavorIdx)
+	for ps, flavorIdx := range s.LastTriedFlavorIdx {
+		c.LastTriedFlavorIdx[ps] = maps.Clone(flavorIdx)
 	}
 	return &c
+}
+
+// PendingFlavors returns whether there are pending flavors to try
+// after the last attempt.
+func (s *AssigmentClusterQueueState) PendingFlavors() bool {
+	if s == nil {
+		// This is only reached in unit tests.
+		return false
+	}
+	for _, podSetIdxs := range s.LastTriedFlavorIdx {
+		for _, idx := range podSetIdxs {
+			if idx != -1 {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Info holds a Workload object and some pre-processing.

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -1075,31 +1075,40 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, devCQ.Name, dWl1)
 		})
 
-		ginkgo.It("Should try next flavor instead of pending", func() {
+		ginkgo.It("Should try next flavor if can't preempt on first", func() {
 			prodCQ = testing.MakeClusterQueue("prod-cq").
+				QueueingStrategy(kueue.StrictFIFO).
 				Cohort("all").
 				ResourceGroup(
 					*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "2").Obj(),
 					*testing.MakeFlavorQuotas("spot-untainted").Resource(corev1.ResourceCPU, "2").Obj()).
+				Preemption(kueue.ClusterQueuePreemption{
+					WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+				}).
+				FlavorFungibility(kueue.FlavorFungibility{
+					WhenCanPreempt: kueue.Preempt,
+				}).
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, prodCQ)).Should(gomega.Succeed())
 
 			prodQueue := testing.MakeLocalQueue("prod-queue", ns.Name).ClusterQueue(prodCQ.Name).Obj()
 			gomega.Expect(k8sClient.Create(ctx, prodQueue)).Should(gomega.Succeed())
 
-			ginkgo.By("Creating 3 workloads")
+			ginkgo.By("Creating 2 workloads and ensuring they are admitted")
 			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
 			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
-			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
 			gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
+			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1,
+				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj())
+			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2,
+				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj())
+
+			ginkgo.By("Creating an additional workload that can't fit in the first flavor")
+			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl3)).Should(gomega.Succeed())
-			prodWl1Admission := testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()
-			prodWl2Admission := testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()
-			prodWl3Admission := testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "spot-untainted", "1").Obj()
-			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, prodWl1Admission)
-			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, prodWl2Admission)
-			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3, prodWl3Admission)
+			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3,
+				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "spot-untainted", "1").Obj())
 			util.ExpectPendingWorkloadsMetric(prodCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(prodCQ, 3)
 			util.ExpectAdmittedWorkloadsTotalMetric(prodCQ, 3)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes 3 problems:
- The AllocatableResourceGeneration for a ClusterQueue was changing for unrelated status updates (Thanks to @KunWuLuan for this fix)
- Needed to requeue immediately if there are pending flavors to try.
- The indexes for the lastattempt were accumulating across scheduling attempts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1344

#### Special notes for your reviewer:

This supersedes #1356.

I want to add more tests before merging.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix fungibility policy `Preempt` where it was not able to utilize the next flavor if preemption was not possible.
```