### PR TITLE
Improve pod/wl cleanup for pod groups

### DIFF
--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -62,11 +62,20 @@ type JobWithReclaimablePods interface {
 	ReclaimablePods() []kueue.ReclaimablePod
 }
 
+type StopReason int
+
+const (
+	StopReasonWorkloadDeleted StopReason = iota
+	StopReasonWorkloadEvicted
+	StopReasonNoMatchingWorkload
+	StopReasonNotAdmitted
+)
+
 type JobWithCustomStop interface {
 	// Stop implements a custom stop procedure.
 	// The function should be idempotent: not do any API calls if the job is already stopped.
 	// Returns whether the Job stopped with this call or an error
-	Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, eventMsg string) (bool, error)
+	Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, stopReason StopReason, eventMsg string) (bool, error)
 }
 
 // JobWithFinalize interface should be implemented by generic jobs,

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -157,7 +157,7 @@ func (j *Job) Suspend() {
 	j.Spec.Suspend = ptr.To(true)
 }
 
-func (j *Job) Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, eventMsg string) (bool, error) {
+func (j *Job) Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, _ jobframework.StopReason, eventMsg string) (bool, error) {
 	stoppedNow := false
 	if !j.IsSuspended() {
 		j.Suspend()

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -122,7 +122,6 @@ func volumesShape(volumes []corev1.Volume) (result []corev1.Volume) {
 }
 
 func getRoleHash(p *Pod) (string, error) {
-
 	shape := map[string]interface{}{
 		"metadata": map[string]interface{}{
 			"labels": omitKueueLabels(p.pod.ObjectMeta.Labels),

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -192,3 +192,9 @@ func (p *PodWrapper) Delete() *PodWrapper {
 	p.Pod.DeletionTimestamp = &t
 	return p
 }
+
+// Volume adds a new volume for the pod object
+func (p *PodWrapper) Volume(v corev1.Volume) *PodWrapper {
+	p.Pod.Spec.Volumes = append(p.Pod.Spec.Volumes, v)
+	return p
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

* Add deletingWorkload for the Stop method of the JobWithCustomStop interface.

* Change Stop method for the pod controller to delete even suspended pods if workload is being deleted.

* Change pods in group finalization for the case of workload deletion. Now all pods in the group will be finalized right after the pod group has been stopped.

* Add new unit tests for the pod controller and webhook.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related issue: #976

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```