### PR TITLE
Fill OwnerReferences field in PendingWorkload's metadata, so a user can easily identify the Job

### DIFF
--- a/keps/168-2-pending-workloads-visibility/README.md
+++ b/keps/168-2-pending-workloads-visibility/README.md
@@ -222,6 +222,8 @@ type PendingWorkloadsSummary struct {
 }
 ```
 
+A user can easily identify the Job that is an owner of the pending workload. To enable it, the API uses `metav1.OwnerReferences` field to indicate the owner, typically the job created by the user. 
+
 ### Future extensions
 
 The introduced API uses mechanism of subresources. It means, that in the future it can be easily extended by adding additional endpoints related e.g. to admitted workloads. Potentially the endpoint could look like this:

--- a/pkg/visibility/api/rest/pending_workloads_cq.go
+++ b/pkg/visibility/api/rest/pending_workloads_cq.go
@@ -19,12 +19,11 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	v1alpha1 "sigs.k8s.io/kueue/apis/visibility/v1alpha1"
+	"sigs.k8s.io/kueue/apis/visibility/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/queue"
 
@@ -78,16 +77,7 @@ func (m *pendingWorkloadsInCqREST) Get(ctx context.Context, name string, opts ru
 
 		if index >= int(offset) {
 			// Add a workload to results
-			wls = append(wls, v1alpha1.PendingWorkload{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      wlInfo.Obj.Name,
-					Namespace: wlInfo.Obj.Namespace,
-				},
-				PositionInClusterQueue: int32(index),
-				Priority:               *wlInfo.Obj.Spec.Priority,
-				LocalQueueName:         queueName,
-				PositionInLocalQueue:   positionInLocalQueue,
-			})
+			wls = append(wls, *newPendingWorkload(wlInfo, positionInLocalQueue, index))
 		}
 	}
 	return &v1alpha1.PendingWorkloadsSummary{Items: wls}, nil

--- a/pkg/visibility/api/rest/pending_workloads_cq_test.go
+++ b/pkg/visibility/api/rest/pending_workloads_cq_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -295,7 +294,7 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 				}
 				pendingWorkloadsInfo := info.(*visibility.PendingWorkloadsSummary)
 
-				if diff := cmp.Diff(tc.wantPendingWorkloads, pendingWorkloadsInfo.Items, cmpopts.IgnoreTypes(metav1.TypeMeta{})); diff != "" {
+				if diff := cmp.Diff(tc.wantPendingWorkloads, pendingWorkloadsInfo.Items, cmpopts.EquateEmpty()); diff != "" {
 					t.Errorf("Pending workloads differ: (-want,+got):\n%s", diff)
 				}
 			}

--- a/pkg/visibility/api/rest/pending_workloads_lq.go
+++ b/pkg/visibility/api/rest/pending_workloads_lq.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -86,16 +85,7 @@ func (m *pendingWorkloadsInLqREST) Get(ctx context.Context, name string, opts ru
 				skippedWls++
 			} else {
 				// Add a workload to results
-				wls = append(wls, v1alpha1.PendingWorkload{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      wlInfo.Obj.Name,
-						Namespace: wlInfo.Obj.Namespace,
-					},
-					PositionInClusterQueue: int32(index),
-					Priority:               *wlInfo.Obj.Spec.Priority,
-					LocalQueueName:         name,
-					PositionInLocalQueue:   int32(len(wls) + int(offset)),
-				})
+				wls = append(wls, *newPendingWorkload(wlInfo, int32(len(wls)+int(offset)), index))
 			}
 		}
 	}

--- a/pkg/visibility/api/rest/pending_workloads_lq_test.go
+++ b/pkg/visibility/api/rest/pending_workloads_lq_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -398,7 +397,7 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 					}
 				} else {
 					pendingWorkloadsInfo := info.(*visibility.PendingWorkloadsSummary)
-					if diff := cmp.Diff(resp.wantPendingWorkloads, pendingWorkloadsInfo.Items, cmpopts.IgnoreTypes(metav1.TypeMeta{})); diff != "" {
+					if diff := cmp.Diff(resp.wantPendingWorkloads, pendingWorkloadsInfo.Items, cmpopts.EquateEmpty()); diff != "" {
 						t.Errorf("Pending workloads differ: (-want,+got):\n%s", diff)
 					}
 				}

--- a/pkg/visibility/api/rest/utils.go
+++ b/pkg/visibility/api/rest/utils.go
@@ -1,0 +1,45 @@
+// Copyright 2023 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/kueue/apis/visibility/v1alpha1"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func newPendingWorkload(wlInfo *workload.Info, positionInLq int32, positionInCq int) *v1alpha1.PendingWorkload {
+	ownerReferences := make([]metav1.OwnerReference, 0, len(wlInfo.Obj.OwnerReferences))
+	for _, ref := range wlInfo.Obj.OwnerReferences {
+		ownerReferences = append(ownerReferences, metav1.OwnerReference{
+			APIVersion: ref.APIVersion,
+			Kind:       ref.Kind,
+			Name:       ref.Name,
+			UID:        ref.UID,
+		})
+	}
+	return &v1alpha1.PendingWorkload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            wlInfo.Obj.Name,
+			Namespace:       wlInfo.Obj.Namespace,
+			OwnerReferences: ownerReferences,
+		},
+		PositionInClusterQueue: int32(positionInCq),
+		Priority:               *wlInfo.Obj.Spec.Priority,
+		LocalQueueName:         wlInfo.Obj.Spec.QueueName,
+		PositionInLocalQueue:   positionInLq,
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR continues the development of [KEP#168-2](https://github.com/kubernetes-sigs/kueue/pull/1300)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```