### PR TITLE
Fix the equivalentToWorkload method for pod groups

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -575,14 +575,22 @@ func (p *Pod) equivalentToWorkload(wl *kueue.Workload, jobPodSets []kueue.PodSet
 		return false
 	}
 
-	for i := range wl.Spec.PodSets {
-		if i >= len(jobPodSets) {
-			return true
+	// Match the current state of pod sets
+	// to the pod set info in the workload
+	j := -1
+	for i := range jobPodSets {
+		for j++; j < len(wl.Spec.PodSets); j++ {
+			if jobPodSets[i].Name == wl.Spec.PodSets[j].Name {
+				break
+			}
 		}
-		if !workloadFinished && wl.Spec.PodSets[i].Count < jobPodSets[i].Count {
+		// If actual pod set info has a role that workload doesn't have,
+		// consider workload not an equivalent to the pod group
+		if j == len(wl.Spec.PodSets) {
 			return false
 		}
-		if wl.Spec.PodSets[i].Name != jobPodSets[i].Name {
+		// Check counts for found pod sets
+		if !workloadFinished && wl.Spec.PodSets[j].Count < jobPodSets[i].Count {
 			return false
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

* Update equivalentToWorkload to consider workload equivalent to the pod group if any of the "first" roles in the group are absent from the cluster.

* Example of the case in which the previous implementation was failing: https://github.com/kubernetes-sigs/kueue/pull/1319#discussion_r1404471430.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #976

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```