### PR TITLE
Add retriable-in-group annotation handling for pod groups

### DIFF
--- a/keps/976-plain-pods/README.md
+++ b/keps/976-plain-pods/README.md
@@ -585,9 +585,6 @@ Succeeded Pods will not be considered replaceable. In other words, the quota
 from Succeeded Pods will be released by filling [reclaimablePods](https://kueue.sigs.k8s.io/docs/concepts/workload/#dynamic-reclaim)
 in the Workload status.
 
-The quota from Failed Pods will also be released when there is a pod with
-the annotation `kueue.x-k8s.io/retriable-in-group` set to false.
-
 ### Metrics
 
 In addition to the existing metrics for workloads, it could be beneficial to track gated and

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -59,7 +59,7 @@ type GenericJob interface {
 
 type JobWithReclaimablePods interface {
 	// ReclaimablePods returns the list of reclaimable pods.
-	ReclaimablePods() []kueue.ReclaimablePod
+	ReclaimablePods() ([]kueue.ReclaimablePod, error)
 }
 
 type StopReason int

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -292,8 +292,14 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 
 	// 4. update reclaimable counts if implemented by the job
 	if jobRecl, implementsReclaimable := job.(JobWithReclaimablePods); implementsReclaimable {
-		if rp := jobRecl.ReclaimablePods(); !workload.ReclaimablePodsAreEqual(rp, wl.Status.ReclaimablePods) {
-			err = workload.UpdateReclaimablePods(ctx, r.client, wl, rp)
+		reclPods, err := jobRecl.ReclaimablePods()
+		if err != nil {
+			log.Error(err, "Getting reclaimable pods")
+			return ctrl.Result{}, err
+		}
+
+		if !workload.ReclaimablePodsAreEqual(reclPods, wl.Status.ReclaimablePods) {
+			err = workload.UpdateReclaimablePods(ctx, r.client, wl, reclPods)
 			if err != nil {
 				log.Error(err, "Updating reclaimable pods")
 				return ctrl.Result{}, err

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -188,21 +188,21 @@ func (j *Job) GVK() schema.GroupVersionKind {
 	return gvk
 }
 
-func (j *Job) ReclaimablePods() []kueue.ReclaimablePod {
+func (j *Job) ReclaimablePods() ([]kueue.ReclaimablePod, error) {
 	parallelism := ptr.Deref(j.Spec.Parallelism, 1)
 	if parallelism == 1 || j.Status.Succeeded == 0 {
-		return nil
+		return nil, nil
 	}
 
 	remaining := ptr.Deref(j.Spec.Completions, parallelism) - j.Status.Succeeded
 	if remaining >= parallelism {
-		return nil
+		return nil, nil
 	}
 
 	return []kueue.ReclaimablePod{{
 		Name:  kueue.DefaultPodSetName,
 		Count: parallelism - remaining,
-	}}
+	}}, nil
 }
 
 func (j *Job) PodSets() []kueue.PodSet {

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -178,9 +178,9 @@ func (j *JobSet) PodsReady() bool {
 	return replicas == readyReplicas
 }
 
-func (j *JobSet) ReclaimablePods() []kueue.ReclaimablePod {
+func (j *JobSet) ReclaimablePods() ([]kueue.ReclaimablePod, error) {
 	if len(j.Status.ReplicatedJobsStatus) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	ret := make([]kueue.ReclaimablePod, 0, len(j.Spec.ReplicatedJobs))
@@ -197,7 +197,7 @@ func (j *JobSet) ReclaimablePods() []kueue.ReclaimablePod {
 			}
 		}
 	}
-	return ret
+	return ret, nil
 }
 
 func podsCountPerReplica(rj *jobsetapi.ReplicatedJob) int32 {

--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -184,7 +184,10 @@ func TestReclaimablePods(t *testing.T) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			jobSet := (*JobSet)(tc.jobSet)
-			got := jobSet.ReclaimablePods()
+			got, err := jobSet.ReclaimablePods()
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("Unexpected Reclaimable pods (-want +got):\n%s", diff)
 			}

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -1886,7 +1886,6 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
 					Admitted(true).
 					ReclaimablePods(
-						kueue.ReclaimablePod{Name: "b990493b", Count: 1},
 						kueue.ReclaimablePod{Name: "4389b941", Count: 1},
 					).
 					Obj(),

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -1606,7 +1606,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads:   []kueue.Workload{},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
-		"pod group is considered finished if unretriable pod in group has failed": {
+		"pod group is considered finished if there is an unretriable pod and no running pods": {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1792,102 +1792,6 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
 					Admitted(true).
 					ReclaimablePods(kueue.ReclaimablePod{Name: "4389b941", Count: 1}).
-					Obj(),
-			},
-			workloadCmpOpts: defaultWorkloadCmpOpts,
-		},
-		"reclaimable pods updated for unretriable pod group": {
-			pods: []corev1.Pod{
-				*basePodWrapper.
-					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
-					KueueFinalizer().
-					Group("test-group").
-					GroupTotalCount("3").
-					StatusPhase(corev1.PodFailed).
-					Obj(),
-				*basePodWrapper.
-					Clone().
-					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
-					Annotation("kueue.x-k8s.io/retriable-in-group", "false").
-					KueueFinalizer().
-					Group("test-group").
-					GroupTotalCount("3").
-					StatusPhase(corev1.PodRunning).
-					Obj(),
-				*basePodWrapper.
-					Clone().
-					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
-					KueueFinalizer().
-					Group("test-group").
-					Image("test-image-role2", nil).
-					GroupTotalCount("3").
-					StatusPhase(corev1.PodSucceeded).
-					Obj(),
-			},
-			wantPods: []corev1.Pod{
-				*basePodWrapper.
-					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
-					KueueFinalizer().
-					Group("test-group").
-					GroupTotalCount("3").
-					StatusPhase(corev1.PodFailed).
-					Obj(),
-				*basePodWrapper.
-					Clone().
-					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
-					Annotation("kueue.x-k8s.io/retriable-in-group", "false").
-					KueueFinalizer().
-					Group("test-group").
-					GroupTotalCount("3").
-					StatusPhase(corev1.PodRunning).
-					Obj(),
-				*basePodWrapper.
-					Clone().
-					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
-					KueueFinalizer().
-					Group("test-group").
-					Image("test-image-role2", nil).
-					GroupTotalCount("3").
-					StatusPhase(corev1.PodSucceeded).
-					Obj(),
-			},
-			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("test-group", "ns").
-					PodSets(
-						*utiltesting.MakePodSet("4389b941", 1).
-							Request(corev1.ResourceCPU, "1").
-							Obj(),
-						*utiltesting.MakePodSet("b990493b", 2).
-							Request(corev1.ResourceCPU, "1").
-							Obj(),
-					).
-					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
-					Admitted(true).
-					Obj(),
-			},
-			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("test-group", "ns").
-					PodSets(
-						*utiltesting.MakePodSet("4389b941", 1).
-							Request(corev1.ResourceCPU, "1").
-							Obj(),
-						*utiltesting.MakePodSet("b990493b", 2).
-							Request(corev1.ResourceCPU, "1").
-							Obj(),
-					).
-					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
-					Admitted(true).
-					ReclaimablePods(
-						kueue.ReclaimablePod{Name: "4389b941", Count: 1},
-					).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -321,7 +321,7 @@ func TestGetRoleHash(t *testing.T) {
 
 			var previousHash string
 			for i := range tc.pods {
-				hash, err := getRoleHash(tc.pods[i])
+				hash, err := getRoleHash(tc.pods[i].pod)
 
 				if diff := cmp.Diff(tc.wantErr, err); diff != "" {
 					t.Errorf("Unexpected error (-want,+got):\n%s", diff)

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -536,6 +536,41 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
+		"retriable in group annotation is removed": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				Group("test-group").
+				GroupTotalCount("2").
+				Annotation("kueue.x-k8s.io/retriable-in-group", "false").
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				Group("test-group").
+				GroupTotalCount("2").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeForbidden,
+					Field: "metadata.annotations[kueue.x-k8s.io/retriable-in-group]",
+				},
+			}.ToAggregate(),
+		},
+		"retriable in group annotation is changed from false to true": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				Group("test-group").
+				GroupTotalCount("2").
+				Annotation("kueue.x-k8s.io/retriable-in-group", "false").
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				Group("test-group").
+				GroupTotalCount("2").
+				Annotation("kueue.x-k8s.io/retriable-in-group", "true").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeForbidden,
+					Field: "metadata.annotations[kueue.x-k8s.io/retriable-in-group]",
+				},
+			}.ToAggregate(),
+		},
 	}
 
 	for name, tc := range testCases {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -594,3 +594,13 @@ func ExpectPodUnsuspendedWithNodeSelectors(ctx context.Context, k8sClient client
 		g.Expect(createdPod.Spec.NodeSelector).To(gomega.BeComparableTo(ns))
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
+
+func ExpectPodsFinalized(ctx context.Context, k8sClient client.Client, keys ...types.NamespacedName) {
+	for _, key := range keys {
+		createdPod := &corev1.Pod{}
+		gomega.EventuallyWithOffset(1, func(g gomega.Gomega) []string {
+			g.Expect(k8sClient.Get(ctx, key, createdPod)).To(gomega.Succeed())
+			return createdPod.Finalizers
+		}, Timeout, Interval).Should(gomega.BeEmpty(), "Expected pod to be finalized")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

* A pod group is considered finished now if there are no running or pending pods, and at least one terminated pod has `retriable-in-group=false` annotation.

* Now pod groups support dynamically reclaiming quota. The quota from succeeded pods will always be released.

* The check of pod group total count in ConstructComposableWorkload was incorrect before. Failed pods should be filtered before checking if actual group total count is equal to the group total count annotation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related issue: #976 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```