### PR TITLE
Parametrize CGO_ENABLED argument for container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG BASE_IMAGE
 # Build the manager binary
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
 
+ARG CGO_ENABLED
 ARG TARGETARCH
 
 WORKDIR /workspace
@@ -17,7 +18,7 @@ RUN go mod download
 COPY . .
 
 # Build
-RUN make build GO_BUILD_ENV='CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH}'
+RUN make build GO_BUILD_ENV='CGO_ENABLED=${CGO_ENABLED} GOOS=linux GOARCH=${TARGETARCH}'
 
 FROM --platform=${BUILDPLATFORM} ${BASE_IMAGE}
 WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ ARTIFACTS ?= $(PROJECT_DIR)/bin
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 BASE_IMAGE ?= gcr.io/distroless/static:nonroot
 BUILDER_IMAGE ?= golang:$(GO_VERSION)
+CGO_ENABLED ?= 0
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION ?= 1.28
@@ -211,6 +212,7 @@ image-build:
 		--platform=$(PLATFORMS) \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
+		--build-arg CGO_ENABLED=$(CGO_ENABLED) \
 		$(PUSH) \
 		$(IMAGE_BUILD_EXTRA_OPTS) ./
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

This PR parametrize's the CGO_ENABLED argument for the Kueue image build in both the dockerfile and makefile. This will make it easier for other consumers of Kueue to customize the image as needed.

#### Which issue(s) this PR fixes:

Fixes #1382

#### Special notes for your reviewer:

```release-note
Make the image build setting CGO_ENABLED configurable
```