### PR TITLE
Suspend a running Job without requeueing - API doc update

### DIFF
--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -1607,6 +1607,20 @@ Workload's PriorityClass can accept the name of a pod priorityClass or a workloa
 When using pod PriorityClass, a priorityClassSource field has the scheduling.k8s.io/priorityclass value.</p>
 </td>
 </tr>
+<tr><td><code>active</code> <B>[Required]</B><br/>
+<code>bool</code>
+</td>
+<td>
+   <p>Active determines if a workload can be admitted into a queue.
+Changing active from true to false will evict any running workloads.
+Possible values are:</p>
+<ul>
+<li>false: indicates that a workload should never be admitted and evicts running workloads</li>
+<li>true: indicates that a workload can be evaluated for admission into it's respective queue.</li>
+</ul>
+<p>Defaults to true</p>
+</td>
+</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Regenerate the API doc after the addition of `wl.spec.active`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relate To  #1091

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```