### PR TITLE
Fill the CreationTimestamp field in the visibility.PendingWorkload object

### DIFF
--- a/pkg/visibility/api/rest/pending_workloads_cq_test.go
+++ b/pkg/visibility/api/rest/pending_workloads_cq_test.go
@@ -73,15 +73,16 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 				utiltesting.MakeLocalQueue(lqNameA, nsName).ClusterQueue(cqNameA).Obj(),
 			},
 			workloads: []*kueue.Workload{
-				utiltesting.MakeWorkload("a", nsName).Queue(lqNameA).Priority(highPrio).Obj(),
-				utiltesting.MakeWorkload("b", nsName).Queue(lqNameA).Priority(lowPrio).Obj(),
+				utiltesting.MakeWorkload("a", nsName).Queue(lqNameA).Priority(highPrio).Creation(now).Obj(),
+				utiltesting.MakeWorkload("b", nsName).Queue(lqNameA).Priority(lowPrio).Creation(now).Obj(),
 			},
 			queryParams: defaultQueryParams,
 			wantPendingWorkloads: []visibility.PendingWorkload{
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "a",
-						Namespace: nsName,
+						Name:              "a",
+						Namespace:         nsName,
+						CreationTimestamp: v1.NewTime(now),
 					},
 					LocalQueueName:         lqNameA,
 					Priority:               highPrio,
@@ -90,8 +91,9 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 				},
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "b",
-						Namespace: nsName,
+						Name:              "b",
+						Namespace:         nsName,
+						CreationTimestamp: v1.NewTime(now),
 					},
 					LocalQueueName:         lqNameA,
 					Priority:               lowPrio,
@@ -118,8 +120,9 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 			wantPendingWorkloads: []visibility.PendingWorkload{
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "lqA-high-prio",
-						Namespace: nsName,
+						Name:              "lqA-high-prio",
+						Namespace:         nsName,
+						CreationTimestamp: v1.NewTime(now),
 					},
 					LocalQueueName:         lqNameA,
 					Priority:               highPrio,
@@ -128,8 +131,9 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 				},
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "lqB-high-prio",
-						Namespace: nsName,
+						Name:              "lqB-high-prio",
+						Namespace:         nsName,
+						CreationTimestamp: v1.NewTime(now.Add(time.Second)),
 					},
 					LocalQueueName:         lqNameB,
 					Priority:               highPrio,
@@ -138,8 +142,9 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 				},
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "lqA-low-prio",
-						Namespace: nsName,
+						Name:              "lqA-low-prio",
+						Namespace:         nsName,
+						CreationTimestamp: v1.NewTime(now),
 					},
 					LocalQueueName:         lqNameA,
 					Priority:               lowPrio,
@@ -148,8 +153,9 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 				},
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "lqB-low-prio",
-						Namespace: nsName,
+						Name:              "lqB-low-prio",
+						Namespace:         nsName,
+						CreationTimestamp: v1.NewTime(now.Add(time.Second)),
 					},
 					LocalQueueName:         lqNameB,
 					Priority:               lowPrio,
@@ -176,8 +182,9 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 			wantPendingWorkloads: []visibility.PendingWorkload{
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "a",
-						Namespace: nsName,
+						Name:              "a",
+						Namespace:         nsName,
+						CreationTimestamp: v1.NewTime(now),
 					},
 					LocalQueueName:         lqNameA,
 					Priority:               highPrio,
@@ -186,8 +193,9 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 				},
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "b",
-						Namespace: nsName,
+						Name:              "b",
+						Namespace:         nsName,
+						CreationTimestamp: v1.NewTime(now.Add(time.Second)),
 					},
 					LocalQueueName:         lqNameA,
 					Priority:               highPrio,
@@ -215,8 +223,9 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 			wantPendingWorkloads: []visibility.PendingWorkload{
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "b",
-						Namespace: nsName,
+						Name:              "b",
+						Namespace:         nsName,
+						CreationTimestamp: v1.NewTime(now.Add(time.Second)),
 					},
 					LocalQueueName:         lqNameA,
 					Priority:               highPrio,
@@ -225,8 +234,9 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 				},
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "c",
-						Namespace: nsName,
+						Name:              "c",
+						Namespace:         nsName,
+						CreationTimestamp: v1.NewTime(now.Add(time.Second * 2)),
 					},
 					LocalQueueName:         lqNameA,
 					Priority:               highPrio,
@@ -254,8 +264,9 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 			wantPendingWorkloads: []visibility.PendingWorkload{
 				{
 					ObjectMeta: v1.ObjectMeta{
-						Name:      "b",
-						Namespace: nsName,
+						Name:              "b",
+						Namespace:         nsName,
+						CreationTimestamp: v1.NewTime(now.Add(time.Second)),
 					},
 					LocalQueueName:         lqNameA,
 					Priority:               highPrio,

--- a/pkg/visibility/api/rest/pending_workloads_lq_test.go
+++ b/pkg/visibility/api/rest/pending_workloads_lq_test.go
@@ -84,7 +84,7 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 			},
 			workloads: []*kueue.Workload{
 				utiltesting.MakeWorkload("a", nsNameA).Queue(lqNameA).Priority(highPrio).Creation(now).Obj(),
-				utiltesting.MakeWorkload("b", nsNameA).Queue(lqNameA).Priority(lowPrio).Obj(),
+				utiltesting.MakeWorkload("b", nsNameA).Queue(lqNameA).Priority(lowPrio).Creation(now).Obj(),
 			},
 			wantResponse: map[req]*resp{
 				{
@@ -95,8 +95,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 					wantPendingWorkloads: []visibility.PendingWorkload{
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "a",
-								Namespace: nsNameA,
+								Name:              "a",
+								Namespace:         nsNameA,
+								CreationTimestamp: v1.NewTime(now),
 							},
 							LocalQueueName:         lqNameA,
 							Priority:               highPrio,
@@ -105,8 +106,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						},
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "b",
-								Namespace: nsNameA,
+								Name:              "b",
+								Namespace:         nsNameA,
+								CreationTimestamp: v1.NewTime(now),
 							},
 							LocalQueueName:         lqNameA,
 							Priority:               lowPrio,
@@ -139,8 +141,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 					wantPendingWorkloads: []visibility.PendingWorkload{
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "lqA-high-prio",
-								Namespace: nsNameA,
+								Name:              "lqA-high-prio",
+								Namespace:         nsNameA,
+								CreationTimestamp: v1.NewTime(now),
 							},
 							LocalQueueName:         lqNameA,
 							Priority:               highPrio,
@@ -149,8 +152,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						},
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "lqA-low-prio",
-								Namespace: nsNameA,
+								Name:              "lqA-low-prio",
+								Namespace:         nsNameA,
+								CreationTimestamp: v1.NewTime(now),
 							},
 							LocalQueueName:         lqNameA,
 							Priority:               lowPrio,
@@ -166,8 +170,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 					wantPendingWorkloads: []visibility.PendingWorkload{
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "lqB-high-prio",
-								Namespace: nsNameA,
+								Name:              "lqB-high-prio",
+								Namespace:         nsNameA,
+								CreationTimestamp: v1.NewTime(now.Add(time.Second)),
 							},
 							LocalQueueName:         lqNameB,
 							Priority:               highPrio,
@@ -176,8 +181,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						},
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "lqB-low-prio",
-								Namespace: nsNameA,
+								Name:              "lqB-low-prio",
+								Namespace:         nsNameA,
+								CreationTimestamp: v1.NewTime(now.Add(time.Second)),
 							},
 							LocalQueueName:         lqNameB,
 							Priority:               lowPrio,
@@ -211,8 +217,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 					wantPendingWorkloads: []visibility.PendingWorkload{
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "lqA-high-prio",
-								Namespace: nsNameA,
+								Name:              "lqA-high-prio",
+								Namespace:         nsNameA,
+								CreationTimestamp: v1.NewTime(now),
 							},
 							LocalQueueName:         lqNameA,
 							Priority:               highPrio,
@@ -221,8 +228,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						},
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "lqA-low-prio",
-								Namespace: nsNameA,
+								Name:              "lqA-low-prio",
+								Namespace:         nsNameA,
+								CreationTimestamp: v1.NewTime(now),
 							},
 							LocalQueueName:         lqNameA,
 							Priority:               lowPrio,
@@ -238,8 +246,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 					wantPendingWorkloads: []visibility.PendingWorkload{
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "lqB-high-prio",
-								Namespace: nsNameB,
+								Name:              "lqB-high-prio",
+								Namespace:         nsNameB,
+								CreationTimestamp: v1.NewTime(now.Add(time.Second)),
 							},
 							LocalQueueName:         lqNameB,
 							Priority:               highPrio,
@@ -248,8 +257,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						},
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "lqB-low-prio",
-								Namespace: nsNameB,
+								Name:              "lqB-low-prio",
+								Namespace:         nsNameB,
+								CreationTimestamp: v1.NewTime(now.Add(time.Second)),
 							},
 							LocalQueueName:         lqNameB,
 							Priority:               lowPrio,
@@ -283,8 +293,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 					wantPendingWorkloads: []visibility.PendingWorkload{
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "a",
-								Namespace: nsNameA,
+								Name:              "a",
+								Namespace:         nsNameA,
+								CreationTimestamp: v1.NewTime(now),
 							},
 							LocalQueueName:         lqNameA,
 							Priority:               highPrio,
@@ -293,8 +304,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						},
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "b",
-								Namespace: nsNameA,
+								Name:              "b",
+								Namespace:         nsNameA,
+								CreationTimestamp: v1.NewTime(now.Add(time.Second)),
 							},
 							LocalQueueName:         lqNameA,
 							Priority:               highPrio,
@@ -314,8 +326,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 					wantPendingWorkloads: []visibility.PendingWorkload{
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "b",
-								Namespace: nsNameA,
+								Name:              "b",
+								Namespace:         nsNameA,
+								CreationTimestamp: v1.NewTime(now.Add(time.Second)),
 							},
 							LocalQueueName:         lqNameA,
 							Priority:               highPrio,
@@ -324,8 +337,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						},
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "c",
-								Namespace: nsNameA,
+								Name:              "c",
+								Namespace:         nsNameA,
+								CreationTimestamp: v1.NewTime(now.Add(time.Second * 2)),
 							},
 							LocalQueueName:         lqNameA,
 							Priority:               highPrio,
@@ -345,8 +359,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 					wantPendingWorkloads: []visibility.PendingWorkload{
 						{
 							ObjectMeta: v1.ObjectMeta{
-								Name:      "b",
-								Namespace: nsNameA,
+								Name:              "b",
+								Namespace:         nsNameA,
+								CreationTimestamp: v1.NewTime(now.Add(time.Second)),
 							},
 							LocalQueueName:         lqNameA,
 							Priority:               highPrio,

--- a/pkg/visibility/api/rest/utils.go
+++ b/pkg/visibility/api/rest/utils.go
@@ -33,9 +33,10 @@ func newPendingWorkload(wlInfo *workload.Info, positionInLq int32, positionInCq 
 	}
 	return &v1alpha1.PendingWorkload{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            wlInfo.Obj.Name,
-			Namespace:       wlInfo.Obj.Namespace,
-			OwnerReferences: ownerReferences,
+			Name:              wlInfo.Obj.Name,
+			Namespace:         wlInfo.Obj.Namespace,
+			OwnerReferences:   ownerReferences,
+			CreationTimestamp: wlInfo.Obj.CreationTimestamp,
 		},
 		PositionInClusterQueue: int32(positionInCq),
 		Priority:               *wlInfo.Obj.Spec.Priority,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -45,9 +45,10 @@ import (
 var _ = ginkgo.Describe("Kueue visibility server", func() {
 	const defaultFlavor = "default-flavor"
 
-	// We do not check workload's Name and its OwnerReference's UID as they are generated at the server-side.
+	// We do not check workload's Name, CreationTimestamp, and its OwnerReference's UID as they are generated at the server-side.
 	var pendingWorkloadsCmpOpts = []cmp.Option{
 		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Name"),
+		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "CreationTimestamp"),
 		cmpopts.IgnoreFields(metav1.OwnerReference{}, "UID"),
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR continues the development of [KEP#168-2](https://github.com/kubernetes-sigs/kueue/pull/1300)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Visibility.PendingWorkload object has the metav1.CreationTimestamp field filled with the value of corresponding kueue.Workload
```