### PR TITLE
Return 404 for non-existent queues for the visibility endpoints

### DIFF
--- a/pkg/visibility/api/rest/pending_workloads_cq.go
+++ b/pkg/visibility/api/rest/pending_workloads_cq.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -66,6 +67,10 @@ func (m *pendingWorkloadsInCqREST) Get(ctx context.Context, name string, opts ru
 
 	wls := make([]v1alpha1.PendingWorkload, 0, limit)
 	pendingWorkloadsInfo := m.queueMgr.PendingWorkloadsInfo(name)
+	if pendingWorkloadsInfo == nil {
+		return nil, errors.NewNotFound(v1alpha1.Resource("clusterqueue"), name)
+	}
+
 	localQueuePositions := make(map[string]int32, 0)
 
 	for index := 0; index < int(offset+limit) && index < len(pendingWorkloadsInfo); index++ {

--- a/pkg/visibility/api/rest/pending_workloads_lq.go
+++ b/pkg/visibility/api/rest/pending_workloads_lq.go
@@ -16,10 +16,10 @@ package rest
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -40,8 +40,6 @@ type pendingWorkloadsInLqREST struct {
 var _ rest.Storage = &pendingWorkloadsInLqREST{}
 var _ rest.GetterWithOptions = &pendingWorkloadsInLqREST{}
 var _ rest.Scoper = &pendingWorkloadsInLqREST{}
-
-var errQueueDoesNotExist = errors.New("queue doesn't exist")
 
 func NewPendingWorkloadsInLqREST(kueueMgr *queue.Manager) *pendingWorkloadsInLqREST {
 	return &pendingWorkloadsInLqREST{
@@ -71,7 +69,7 @@ func (m *pendingWorkloadsInLqREST) Get(ctx context.Context, name string, opts ru
 	namespace := genericapirequest.NamespaceValue(ctx)
 	cqName, err := m.queueMgr.ClusterQueueFromLocalQueue(fmt.Sprintf("%s/%s", namespace, name))
 	if err != nil {
-		return nil, errQueueDoesNotExist
+		return nil, errors.NewNotFound(v1alpha1.Resource("localqueue"), name)
 	}
 
 	wls := make([]v1alpha1.PendingWorkload, 0, limit)

--- a/pkg/visibility/api/rest/test_utils.go
+++ b/pkg/visibility/api/rest/test_utils.go
@@ -1,0 +1,30 @@
+// Copyright 2023 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rest
+
+import (
+	visibility "sigs.k8s.io/kueue/apis/visibility/v1alpha1"
+)
+
+type req struct {
+	nsName      string
+	queueName   string
+	queryParams *visibility.PendingWorkloadOptions
+}
+
+type resp struct {
+	wantErr              error
+	wantPendingWorkloads []visibility.PendingWorkload
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
Method `cmpopts.EquateErrors()` returned diff due to different addresses of errors.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Visibility endpoints return 404 code for non-existent queues
```