### PR TITLE
Avoid to override e2e manifests

### DIFF
--- a/test/e2e/config/kustomization.yaml
+++ b/test/e2e/config/kustomization.yaml
@@ -6,3 +6,9 @@ resources:
 
 patches:
 - path: manager_e2e_patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: kueue-controller-manager
+    namespace: kueue-system

--- a/test/e2e/config/manager_e2e_patch.yaml
+++ b/test/e2e/config/manager_e2e_patch.yaml
@@ -1,13 +1,6 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: controller-manager
-  namespace: system
-spec:
-  template:
-    spec:
-      containers:
-      - name: manager
-        imagePullPolicy: IfNotPresent
-        args:
-          - "--feature-gates=VisibilityOnDemand=true"
+- op: replace
+  path: /spec/template/spec/containers/0/imagePullPolicy
+  value: IfNotPresent
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --feature-gates=VisibilityOnDemand=true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The following args will be removed since the current patch file will override container args.
So the queue-controller-manager doesn't load KueueConfig from ConfigMap and then uses default values.

https://github.com/kubernetes-sigs/kueue/blob/e21fabbd66499f862b70d3db274aa5cb107c903e/config/default/manager_config_patch.yaml#L11-L13

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```