### PR TITLE
Add an event for when a ProvisioningRequest is created for a Workload

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -287,7 +287,7 @@ func (c *Controller) syncOwnedProvisionRequest(ctx context.Context, wl *kueue.Wo
 			if err := c.client.Create(ctx, req); err != nil {
 				return nil, err
 			}
-			c.record.Eventf(wl, corev1.EventTypeNormal, "ProvisioningRequestCreated", "A new provisioning request %q was created", req.Name)
+			c.record.Eventf(wl, corev1.EventTypeNormal, "ProvisioningRequestCreated", "Created ProvisioningRequest: %q", req.Name)
 			activeOrLastPRForChecks[checkName] = req
 		}
 		if err := c.syncProvisionRequestsPodTemplates(ctx, wl, requestName, prc); err != nil {

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -287,6 +287,7 @@ func (c *Controller) syncOwnedProvisionRequest(ctx context.Context, wl *kueue.Wo
 			if err := c.client.Create(ctx, req); err != nil {
 				return nil, err
 			}
+			c.record.Eventf(wl, corev1.EventTypeNormal, "ProvisioningRequestCreated", "A new provisioning request %q was created", req.Name)
 			activeOrLastPRForChecks[checkName] = req
 		}
 		if err := c.syncProvisionRequestsPodTemplates(ctx, wl, requestName, prc); err != nil {

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -299,7 +299,7 @@ func TestReconcile(t *testing.T) {
 					Key:       client.ObjectKeyFromObject(baseWorkload),
 					EventType: corev1.EventTypeNormal,
 					Reason:    "ProvisioningRequestCreated",
-					Message:   "A new provisioning request \"wl-check1-1\" was created",
+					Message:   "Created ProvisioningRequest: \"wl-check1-1\"",
 				},
 			},
 		},
@@ -328,7 +328,7 @@ func TestReconcile(t *testing.T) {
 					Key:       client.ObjectKeyFromObject(baseWorkload),
 					EventType: corev1.EventTypeNormal,
 					Reason:    "ProvisioningRequestCreated",
-					Message:   "A new provisioning request \"wl-check1-1\" was created",
+					Message:   "Created ProvisioningRequest: \"wl-check1-1\"",
 				},
 			},
 		},
@@ -397,7 +397,7 @@ func TestReconcile(t *testing.T) {
 					Key:       client.ObjectKeyFromObject(baseWorkload),
 					EventType: corev1.EventTypeNormal,
 					Reason:    "ProvisioningRequestCreated",
-					Message:   "A new provisioning request \"wl-check1-1\" was created",
+					Message:   "Created ProvisioningRequest: \"wl-check1-1\"",
 				},
 			},
 		},
@@ -610,7 +610,7 @@ func TestReconcile(t *testing.T) {
 					Key:       client.ObjectKeyFromObject(baseWorkload),
 					EventType: corev1.EventTypeNormal,
 					Reason:    "ProvisioningRequestCreated",
-					Message:   "A new provisioning request \"wl-check1-1\" was created",
+					Message:   "Created ProvisioningRequest: \"wl-check1-1\"",
 				},
 			},
 		},
@@ -636,7 +636,7 @@ func TestReconcile(t *testing.T) {
 					Key:       client.ObjectKeyFromObject(baseWorkload),
 					EventType: corev1.EventTypeNormal,
 					Reason:    "ProvisioningRequestCreated",
-					Message:   "A new provisioning request \"wl-check1-1\" was created",
+					Message:   "Created ProvisioningRequest: \"wl-check1-1\"",
 				},
 			},
 		},
@@ -670,7 +670,6 @@ func TestReconcile(t *testing.T) {
 				},
 			}
 			_, gotReconcileError := controller.Reconcile(ctx, req)
-
 			if diff := cmp.Diff(tc.wantReconcileError, gotReconcileError); diff != "" {
 				t.Errorf("unexpected reconcile error (-want/+got):\n%s", diff)
 			}

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -299,7 +299,7 @@ func TestReconcile(t *testing.T) {
 					Key:       client.ObjectKeyFromObject(baseWorkload),
 					EventType: corev1.EventTypeNormal,
 					Reason:    "ProvisioningRequestCreated",
-					Message:   "Created ProvisioningRequest: \"wl-check1-1\"",
+					Message:   `Created ProvisioningRequest: "wl-check1-1"`,
 				},
 			},
 		},
@@ -328,7 +328,7 @@ func TestReconcile(t *testing.T) {
 					Key:       client.ObjectKeyFromObject(baseWorkload),
 					EventType: corev1.EventTypeNormal,
 					Reason:    "ProvisioningRequestCreated",
-					Message:   "Created ProvisioningRequest: \"wl-check1-1\"",
+					Message:   `Created ProvisioningRequest: "wl-check1-1"`,
 				},
 			},
 		},
@@ -397,7 +397,7 @@ func TestReconcile(t *testing.T) {
 					Key:       client.ObjectKeyFromObject(baseWorkload),
 					EventType: corev1.EventTypeNormal,
 					Reason:    "ProvisioningRequestCreated",
-					Message:   "Created ProvisioningRequest: \"wl-check1-1\"",
+					Message:   `Created ProvisioningRequest: "wl-check1-1"`,
 				},
 			},
 		},
@@ -610,7 +610,7 @@ func TestReconcile(t *testing.T) {
 					Key:       client.ObjectKeyFromObject(baseWorkload),
 					EventType: corev1.EventTypeNormal,
 					Reason:    "ProvisioningRequestCreated",
-					Message:   "Created ProvisioningRequest: \"wl-check1-1\"",
+					Message:   `Created ProvisioningRequest: "wl-check1-1"`,
 				},
 			},
 		},
@@ -636,7 +636,7 @@ func TestReconcile(t *testing.T) {
 					Key:       client.ObjectKeyFromObject(baseWorkload),
 					EventType: corev1.EventTypeNormal,
 					Reason:    "ProvisioningRequestCreated",
-					Message:   "Created ProvisioningRequest: \"wl-check1-1\"",
+					Message:   `Created ProvisioningRequest: "wl-check1-1"`,
 				},
 			},
 		},
@@ -660,7 +660,7 @@ func TestReconcile(t *testing.T) {
 			)
 
 			k8sclient := builder.Build()
-			recorder := &utiltesting.EventTestRecorder{}
+			recorder := &utiltesting.EventRecorder{}
 			controller, _ := NewController(k8sclient, recorder)
 
 			req := reconcile.Request{

--- a/pkg/util/testing/client.go
+++ b/pkg/util/testing/client.go
@@ -75,19 +75,19 @@ type EventRecord struct {
 	// add annotations if ever needed
 }
 
-type EventTestRecorder struct {
+type EventRecorder struct {
 	RecordedEvents []EventRecord
 }
 
-func (tr *EventTestRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+func (tr *EventRecorder) Event(object runtime.Object, eventtype, reason, message string) {
 	tr.Eventf(object, eventtype, reason, message)
 }
 
-func (tr *EventTestRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+func (tr *EventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
 	tr.AnnotatedEventf(object, nil, eventtype, reason, messageFmt, args...)
 }
 
-func (tr *EventTestRecorder) AnnotatedEventf(targetObject runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+func (tr *EventRecorder) AnnotatedEventf(targetObject runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
 	key := types.NamespacedName{}
 	if cobj, iscobj := targetObject.(client.Object); iscobj {
 		key = client.ObjectKeyFromObject(cobj)

--- a/pkg/util/testing/client.go
+++ b/pkg/util/testing/client.go
@@ -18,8 +18,10 @@ package testing
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -63,4 +65,37 @@ func (b *builderIndexer) IndexField(ctx context.Context, obj client.Object, fiel
 
 func AsIndexer(builder *fake.ClientBuilder) client.FieldIndexer {
 	return &builderIndexer{ClientBuilder: builder}
+}
+
+type EventRecord struct {
+	Key       types.NamespacedName
+	EventType string
+	Reason    string
+	Message   string
+	// add annotations if ever needed
+}
+
+type EventTestRecorder struct {
+	RecordedEvents []EventRecord
+}
+
+func (tr *EventTestRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	tr.Eventf(object, eventtype, reason, message)
+}
+
+func (tr *EventTestRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	tr.AnnotatedEventf(object, nil, eventtype, reason, messageFmt, args...)
+}
+
+func (tr *EventTestRecorder) AnnotatedEventf(targetObject runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	key := types.NamespacedName{}
+	if cobj, iscobj := targetObject.(client.Object); iscobj {
+		key = client.ObjectKeyFromObject(cobj)
+	}
+	tr.RecordedEvents = append(tr.RecordedEvents, EventRecord{
+		Key:       key,
+		EventType: eventtype,
+		Reason:    reason,
+		Message:   fmt.Sprintf(messageFmt, args...),
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
An event associated to a Workload, for when the ProvisioningRequest is created, including it's name. Useful for debugging problems.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1393

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```