### PR TITLE
Excess pods in group deletion

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -144,6 +144,8 @@ func TestReconciler(t *testing.T) {
 		Request(corev1.ResourceCPU, "1").
 		Image("", nil)
 
+	now := time.Now()
+
 	testCases := map[string]struct {
 		initObjects   []client.Object
 		pods          []corev1.Pod
@@ -1806,7 +1808,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Group("test-group").
 					GroupTotalCount("1").
-					CreationTimestamp(time.Date(2022, 9, 15, 11, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -1816,7 +1818,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Group("test-group").
 					GroupTotalCount("1").
-					CreationTimestamp(time.Date(2022, 9, 15, 15, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now.Add(time.Minute)).
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
@@ -1827,7 +1829,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Group("test-group").
 					GroupTotalCount("1").
-					CreationTimestamp(time.Date(2022, 9, 15, 11, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now).
 					Obj(),
 			},
 			workloads: []kueue.Workload{},
@@ -1854,7 +1856,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Date(2022, 9, 15, 11, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -1864,7 +1866,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Date(2022, 9, 15, 11, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now.Add(time.Minute)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -1873,7 +1875,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
-					CreationTimestamp(time.Date(2022, 9, 15, 15, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now.Add(time.Minute * 2)).
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -1885,7 +1887,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Date(2022, 9, 15, 11, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -1895,7 +1897,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Date(2022, 9, 15, 11, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now.Add(time.Minute)).
 					Obj(),
 			},
 			workloads: []kueue.Workload{
@@ -1928,7 +1930,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Date(2022, 9, 15, 11, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -1937,7 +1939,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Date(2022, 9, 15, 11, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now.Add(time.Minute)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -1946,7 +1948,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
-					CreationTimestamp(time.Date(2022, 9, 15, 15, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now.Add(time.Minute * 2)).
 					GroupTotalCount("2").
 					Obj(),
 			},
@@ -1957,7 +1959,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Date(2022, 9, 15, 11, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -1966,7 +1968,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Date(2022, 9, 15, 11, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now.Add(time.Minute)).
 					Obj(),
 			},
 			workloads: []kueue.Workload{
@@ -2004,7 +2006,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Group("test-group").
 					GroupTotalCount("1").
-					CreationTimestamp(time.Date(2022, 9, 15, 11, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -2014,7 +2016,7 @@ func TestReconciler(t *testing.T) {
 					Finalizer("kubernetes").
 					Group("test-group").
 					GroupTotalCount("1").
-					CreationTimestamp(time.Date(2022, 9, 15, 15, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now.Add(time.Minute)).
 					Delete().
 					Obj(),
 			},
@@ -2026,7 +2028,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Group("test-group").
 					GroupTotalCount("1").
-					CreationTimestamp(time.Date(2022, 9, 15, 11, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -2036,7 +2038,7 @@ func TestReconciler(t *testing.T) {
 					Finalizer("kubernetes").
 					Group("test-group").
 					GroupTotalCount("1").
-					CreationTimestamp(time.Date(2022, 9, 15, 15, 0, 0, 0, time.UTC)).
+					CreationTimestamp(now.Add(time.Minute)).
 					Delete().
 					Obj(),
 			},

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -121,13 +121,18 @@ func (p *PodWrapper) KueueSchedulingGate() *PodWrapper {
 	return p
 }
 
-// KueueFinalizer adds kueue finalizer to the Pod
-func (p *PodWrapper) KueueFinalizer() *PodWrapper {
+// Finalizer adds a finalizer to the Pod
+func (p *PodWrapper) Finalizer(f string) *PodWrapper {
 	if p.ObjectMeta.Finalizers == nil {
 		p.ObjectMeta.Finalizers = make([]string, 0)
 	}
-	p.ObjectMeta.Finalizers = append(p.ObjectMeta.Finalizers, "kueue.x-k8s.io/managed")
+	p.ObjectMeta.Finalizers = append(p.ObjectMeta.Finalizers, f)
 	return p
+}
+
+// KueueFinalizer adds kueue finalizer to the Pod
+func (p *PodWrapper) KueueFinalizer() *PodWrapper {
+	return p.Finalizer("kueue.x-k8s.io/managed")
 }
 
 // NodeSelector adds a node selector to the Pod.
@@ -183,6 +188,13 @@ func (p *PodWrapper) StatusConditions(conditions ...corev1.PodCondition) *PodWra
 // StatusPhase updates status phase of the Pod.
 func (p *PodWrapper) StatusPhase(ph corev1.PodPhase) *PodWrapper {
 	p.Pod.Status.Phase = ph
+	return p
+}
+
+// CreationTimestamp sets a creation timestamp for the pod object
+func (p *PodWrapper) CreationTimestamp(t time.Time) *PodWrapper {
+	timestamp := metav1.NewTime(t)
+	p.Pod.CreationTimestamp = timestamp
 	return p
 }
 

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -193,7 +193,7 @@ func (p *PodWrapper) StatusPhase(ph corev1.PodPhase) *PodWrapper {
 
 // CreationTimestamp sets a creation timestamp for the pod object
 func (p *PodWrapper) CreationTimestamp(t time.Time) *PodWrapper {
-	timestamp := metav1.NewTime(t)
+	timestamp := metav1.NewTime(t).Rfc3339Copy()
 	p.Pod.CreationTimestamp = timestamp
 	return p
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

* Move group metadata validation from `constructGroupPodSets`
  method into a separate `validatePodGroupMetadata` method.

* Add `cleanupExcessPods` method which will delete and
  finalize pods created last if the number of non-failed
  pods is greater than group-total-count annotation.

* Add integration/unit tests for excess pods deletion.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related issue: #976

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```