### PR TITLE
Upgrade RayJob API to v1

### DIFF
--- a/config/components/webhook/manifests.yaml
+++ b/config/components/webhook/manifests.yaml
@@ -181,14 +181,14 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-ray-io-v1alpha1-rayjob
+      path: /mutate-ray-io-v1-rayjob
   failurePolicy: Fail
   name: mrayjob.kb.io
   rules:
   - apiGroups:
     - ray.io
     apiVersions:
-    - v1alpha1
+    - v1
     operations:
     - CREATE
     resources:
@@ -444,14 +444,14 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-ray-io-v1alpha1-rayjob
+      path: /validate-ray-io-v1-rayjob
   failurePolicy: Fail
   name: vrayjob.kb.io
   rules:
   - apiGroups:
     - ray.io
     apiVersions:
-    - v1alpha1
+    - v1
     operations:
     - CREATE
     - UPDATE

--- a/config/components/webhook/manifests.yaml
+++ b/config/components/webhook/manifests.yaml
@@ -183,12 +183,33 @@ webhooks:
       namespace: system
       path: /mutate-ray-io-v1-rayjob
   failurePolicy: Fail
+  matchPolicy: Equivalent
   name: mrayjob.kb.io
   rules:
   - apiGroups:
     - ray.io
     apiVersions:
     - v1
+    operations:
+    - CREATE
+    resources:
+    - rayjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-ray-io-v1alpha1-rayjob
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: mrayjobv1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1alpha1
     operations:
     - CREATE
     resources:
@@ -446,12 +467,34 @@ webhooks:
       namespace: system
       path: /validate-ray-io-v1-rayjob
   failurePolicy: Fail
+  matchPolicy: Equivalent
   name: vrayjob.kb.io
   rules:
   - apiGroups:
     - ray.io
     apiVersions:
     - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rayjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-ray-io-v1alpha1-rayjob
+  failurePolicy: Fail
+  matchPolicy: Exact
+  name: vrayjobv1alpha1.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1alpha1
     operations:
     - CREATE
     - UPDATE

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,24 +147,24 @@ func Encode(scheme *runtime.Scheme, cfg *configapi.Configuration) (string, error
 
 // Load returns a set of controller options and configuration from the given file, if the config file path is empty
 // it used the default configapi values.
-func Load(scheme *runtime.Scheme, configFile string) (ctrl.Options, configapi.Configuration, error) {
+func Load(scheme *runtime.Scheme, configFile string) (ctrl.Options, *configapi.Configuration, error) {
 	var err error
 	options := ctrl.Options{
 		Scheme: scheme,
 	}
 
-	cfg := configapi.Configuration{}
+	cfg := &configapi.Configuration{}
 	if configFile == "" {
-		scheme.Default(&cfg)
+		scheme.Default(cfg)
 	} else {
-		err := fromFile(configFile, scheme, &cfg)
+		err := fromFile(configFile, scheme, cfg)
 		if err != nil {
 			return options, cfg, err
 		}
 	}
-	if err := validate(&cfg).ToAggregate(); err != nil {
+	if err := validate(cfg).ToAggregate(); err != nil {
 		return options, cfg, err
 	}
-	addTo(&options, &cfg)
+	addTo(&options, cfg)
 	return options, cfg, err
 }

--- a/pkg/controller/jobframework/workload_names.go
+++ b/pkg/controller/jobframework/workload_names.go
@@ -60,5 +60,5 @@ func getHash(ownerName string, gvk schema.GroupVersionKind) string {
 }
 
 func getOwnerKey(ownerGVK schema.GroupVersionKind) string {
-	return fmt.Sprintf(".metadata.ownerReferences[%s.%s]", ownerGVK.Group, ownerGVK.Kind)
+	return fmt.Sprintf(".metadata.ownerReferences[%s.%s.%s]", ownerGVK.Group, ownerGVK.Kind, ownerGVK.Version)
 }

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -25,7 +25,6 @@ import (
 	"slices"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -814,7 +813,7 @@ func (p *Pod) ReclaimablePods() ([]kueue.ReclaimablePod, error) {
 
 func IsPodOwnerManagedByKueue(p *Pod) bool {
 	if owner := metav1.GetControllerOf(&p.pod); owner != nil {
-		return jobframework.IsOwnerManagedByKueue(owner) || (owner.Kind == "RayCluster" && (strings.HasPrefix(owner.APIVersion, "ray.io/v1alpha1") || strings.HasPrefix(owner.APIVersion, "ray.io/v1")))
+		return jobframework.IsOwnerManagedByKueue(owner)
 	}
 	return false
 }

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -814,7 +814,7 @@ func (p *Pod) ReclaimablePods() ([]kueue.ReclaimablePod, error) {
 
 func IsPodOwnerManagedByKueue(p *Pod) bool {
 	if owner := metav1.GetControllerOf(&p.pod); owner != nil {
-		return jobframework.IsOwnerManagedByKueue(owner) || (owner.Kind == "RayCluster" && strings.HasPrefix(owner.APIVersion, "ray.io/v1alpha1"))
+		return jobframework.IsOwnerManagedByKueue(owner) || (owner.Kind == "RayCluster" && (strings.HasPrefix(owner.APIVersion, "ray.io/v1alpha1") || strings.HasPrefix(owner.APIVersion, "ray.io/v1")))
 	}
 	return false
 }

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -40,6 +40,7 @@ import (
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	_ "sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
 	"sigs.k8s.io/kueue/pkg/podset"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -2280,9 +2280,9 @@ func TestIsPodOwnerManagedByQueue(t *testing.T) {
 			},
 			wantRes: false,
 		},
-		"ray.io/v1alpha1/RayCluster": {
+		"ray.io/v1/RayCluster": {
 			ownerReference: metav1.OwnerReference{
-				APIVersion: "ray.io/v1alpha1",
+				APIVersion: "ray.io/v1",
 				Controller: ptr.To(true),
 				Kind:       "RayCluster",
 			},

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -119,11 +119,11 @@ func TestDefault(t *testing.T) {
 			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				OwnerReference("parent-ray-cluster", rayjobapi.GroupVersion.WithKind("RayCluster")).
+				OwnerReference("parent-ray-cluster", rayv1.GroupVersion.WithKind("RayCluster")).
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				OwnerReference("parent-ray-cluster", rayjobapi.GroupVersion.WithKind("RayCluster")).
+				OwnerReference("parent-ray-cluster", rayv1.GroupVersion.WithKind("RayCluster")).
 				Obj(),
 		},
 		"pod with owner managed by kueue (MPIJob)": {

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -42,11 +42,12 @@ const (
 
 func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
-		SetupIndexes:  SetupIndexes,
-		NewReconciler: NewReconciler,
-		SetupWebhook:  SetupRayJobWebhook,
-		JobType:       &rayv1.RayJob{},
-		AddToScheme:   rayv1.AddToScheme,
+		SetupIndexes:           SetupIndexes,
+		NewReconciler:          NewReconciler,
+		SetupWebhook:           SetupRayJobWebhook,
+		JobType:                &rayv1.RayJob{},
+		AddToScheme:            rayv1.AddToScheme,
+		IsManagingObjectsOwner: isRayJob,
 	}))
 }
 
@@ -61,6 +62,12 @@ func init() {
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloadpriorityclasses,verbs=get;list;watch
 
 var NewReconciler = jobframework.NewGenericReconciler(func() jobframework.GenericJob { return &RayJob{} }, nil)
+
+func isRayJob(owner *metav1.OwnerReference) bool {
+	return owner.Kind == "RayCluster" &&
+		(strings.HasPrefix(owner.APIVersion, "ray.io/v1alpha1") ||
+			strings.HasPrefix(owner.APIVersion, "ray.io/v1"))
+}
 
 type RayJob rayv1.RayJob
 

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strings"
 
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	gvk = rayjobapi.GroupVersion.WithKind("RayJob")
+	gvk = rayv1.GroupVersion.WithKind("RayJob")
 )
 
 const (
@@ -45,8 +45,8 @@ func init() {
 		SetupIndexes:  SetupIndexes,
 		NewReconciler: NewReconciler,
 		SetupWebhook:  SetupRayJobWebhook,
-		JobType:       &rayjobapi.RayJob{},
-		AddToScheme:   rayjobapi.AddToScheme,
+		JobType:       &rayv1.RayJob{},
+		AddToScheme:   rayv1.AddToScheme,
 	}))
 }
 
@@ -62,12 +62,12 @@ func init() {
 
 var NewReconciler = jobframework.NewGenericReconciler(func() jobframework.GenericJob { return &RayJob{} }, nil)
 
-type RayJob rayjobapi.RayJob
+type RayJob rayv1.RayJob
 
 var _ jobframework.GenericJob = (*RayJob)(nil)
 
 func (j *RayJob) Object() client.Object {
-	return (*rayjobapi.RayJob)(j)
+	return (*rayv1.RayJob)(j)
 }
 
 func (j *RayJob) IsSuspended() bool {
@@ -75,7 +75,7 @@ func (j *RayJob) IsSuspended() bool {
 }
 
 func (j *RayJob) IsActive() bool {
-	return j.Status.JobDeploymentStatus != rayjobapi.JobDeploymentStatusSuspended
+	return j.Status.JobDeploymentStatus != rayv1.JobDeploymentStatusSuspended
 }
 
 func (j *RayJob) Suspend() {
@@ -166,11 +166,11 @@ func (j *RayJob) Finished() (metav1.Condition, bool) {
 		Message: j.Status.Message,
 	}
 
-	return condition, j.Status.JobStatus == rayjobapi.JobStatusFailed || j.Status.JobStatus == rayjobapi.JobStatusSucceeded
+	return condition, j.Status.JobStatus == rayv1.JobStatusFailed || j.Status.JobStatus == rayv1.JobStatusSucceeded
 }
 
 func (j *RayJob) PodsReady() bool {
-	return j.Status.RayClusterStatus.State == rayjobapi.Ready
+	return j.Status.RayClusterStatus.State == rayv1.Ready
 }
 
 func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
@@ -33,7 +33,7 @@ import (
 func TestPodSets(t *testing.T) {
 	job := testingrayutil.MakeJob("job", "ns").
 		WithHeadGroupSpec(
-			rayjobapi.HeadGroupSpec{
+			rayv1.HeadGroupSpec{
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -46,7 +46,7 @@ func TestPodSets(t *testing.T) {
 			},
 		).
 		WithWorkerGroups(
-			rayjobapi.WorkerGroupSpec{
+			rayv1.WorkerGroupSpec{
 				GroupName: "group1",
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
@@ -58,7 +58,7 @@ func TestPodSets(t *testing.T) {
 					},
 				},
 			},
-			rayjobapi.WorkerGroupSpec{
+			rayv1.WorkerGroupSpec{
 				GroupName: "group2",
 				Replicas:  ptr.To[int32](3),
 				Template: corev1.PodTemplateSpec{
@@ -125,14 +125,14 @@ func TestPodSets(t *testing.T) {
 
 func TestNodeSelectors(t *testing.T) {
 	baseJob := testingrayutil.MakeJob("job", "ns").
-		WithHeadGroupSpec(rayjobapi.HeadGroupSpec{
+		WithHeadGroupSpec(rayv1.HeadGroupSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{},
 				},
 			},
 		}).
-		WithWorkerGroups(rayjobapi.WorkerGroupSpec{
+		WithWorkerGroups(rayv1.WorkerGroupSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{
@@ -140,7 +140,7 @@ func TestNodeSelectors(t *testing.T) {
 					},
 				},
 			},
-		}, rayjobapi.WorkerGroupSpec{
+		}, rayv1.WorkerGroupSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{
@@ -152,12 +152,12 @@ func TestNodeSelectors(t *testing.T) {
 		Obj()
 
 	cases := map[string]struct {
-		job          *rayjobapi.RayJob
+		job          *rayv1.RayJob
 		runInfo      []podset.PodSetInfo
 		restoreInfo  []podset.PodSetInfo
 		wantRunError error
-		wantAfterRun *rayjobapi.RayJob
-		wantFinal    *rayjobapi.RayJob
+		wantAfterRun *rayv1.RayJob
+		wantFinal    *rayv1.RayJob
 	}{
 		"valid configuration": {
 			job: baseJob.DeepCopy(),
@@ -197,7 +197,7 @@ func TestNodeSelectors(t *testing.T) {
 			},
 			wantAfterRun: testingrayutil.MakeJob("job", "ns").
 				Suspend(false).
-				WithHeadGroupSpec(rayjobapi.HeadGroupSpec{
+				WithHeadGroupSpec(rayv1.HeadGroupSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{
@@ -206,7 +206,7 @@ func TestNodeSelectors(t *testing.T) {
 						},
 					},
 				}).
-				WithWorkerGroups(rayjobapi.WorkerGroupSpec{
+				WithWorkerGroups(rayv1.WorkerGroupSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{
@@ -214,7 +214,7 @@ func TestNodeSelectors(t *testing.T) {
 							},
 						},
 					},
-				}, rayjobapi.WorkerGroupSpec{
+				}, rayv1.WorkerGroupSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{

--- a/pkg/controller/jobs/rayjob/rayjob_controller_v1alpha1.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_v1alpha1.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rayjob
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	rayv1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/podset"
+)
+
+var (
+	gvkV1alpha1 = rayv1alpha1.GroupVersion.WithKind("RayJob")
+)
+
+var rayJobV1alpha1Callbacks = jobframework.IntegrationCallbacks{
+	SetupIndexes:           SetupIndexesV1alpha1,
+	NewReconciler:          NewReconcilerV1alpha1,
+	SetupWebhook:           SetupRayJobWebhookV1alpha1,
+	JobType:                &rayv1alpha1.RayJob{},
+	AddToScheme:            rayv1alpha1.AddToScheme,
+	IsManagingObjectsOwner: isRayJob,
+}
+
+var NewReconcilerV1alpha1 = jobframework.NewGenericReconciler(func() jobframework.GenericJob { return &RayJobV1alpha1{} }, nil)
+
+type RayJobV1alpha1 rayv1alpha1.RayJob
+
+var _ jobframework.GenericJob = (*RayJobV1alpha1)(nil)
+
+func (j *RayJobV1alpha1) Object() client.Object {
+	return (*rayv1alpha1.RayJob)(j)
+}
+
+func (j *RayJobV1alpha1) IsSuspended() bool {
+	return j.Spec.Suspend
+}
+
+func (j *RayJobV1alpha1) IsActive() bool {
+	return j.Status.JobDeploymentStatus != rayv1alpha1.JobDeploymentStatusSuspended
+}
+
+func (j *RayJobV1alpha1) Suspend() {
+	j.Spec.Suspend = true
+}
+
+func (j *RayJobV1alpha1) GVK() schema.GroupVersionKind {
+	return gvkV1alpha1
+}
+
+func (j *RayJobV1alpha1) PodSets() []kueue.PodSet {
+	// len = workerGroups + head
+	podSets := make([]kueue.PodSet, len(j.Spec.RayClusterSpec.WorkerGroupSpecs)+1)
+
+	// head
+	podSets[0] = kueue.PodSet{
+		Name:     headGroupPodSetName,
+		Template: *j.Spec.RayClusterSpec.HeadGroupSpec.Template.DeepCopy(),
+		Count:    1,
+	}
+
+	// workers
+	for index := range j.Spec.RayClusterSpec.WorkerGroupSpecs {
+		wgs := &j.Spec.RayClusterSpec.WorkerGroupSpecs[index]
+		replicas := int32(1)
+		if wgs.Replicas != nil {
+			replicas = *wgs.Replicas
+		}
+		podSets[index+1] = kueue.PodSet{
+			Name:     strings.ToLower(wgs.GroupName),
+			Template: *wgs.Template.DeepCopy(),
+			Count:    replicas,
+		}
+	}
+	return podSets
+}
+
+func (j *RayJobV1alpha1) RunWithPodSetsInfo(podSetsInfo []podset.PodSetInfo) error {
+	expectedLen := len(j.Spec.RayClusterSpec.WorkerGroupSpecs) + 1
+	if len(podSetsInfo) != expectedLen {
+		return podset.BadPodSetsInfoLenError(expectedLen, len(podSetsInfo))
+	}
+
+	j.Spec.Suspend = false
+
+	// head
+	headPod := &j.Spec.RayClusterSpec.HeadGroupSpec.Template
+	info := podSetsInfo[0]
+	if err := podset.Merge(&headPod.ObjectMeta, &headPod.Spec, info); err != nil {
+		return err
+	}
+
+	// workers
+	for index := range j.Spec.RayClusterSpec.WorkerGroupSpecs {
+		workerPod := &j.Spec.RayClusterSpec.WorkerGroupSpecs[index].Template
+		info := podSetsInfo[index+1]
+		if err := podset.Merge(&workerPod.ObjectMeta, &workerPod.Spec, info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (j *RayJobV1alpha1) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
+	if len(podSetsInfo) != len(j.Spec.RayClusterSpec.WorkerGroupSpecs)+1 {
+		return false
+	}
+
+	changed := false
+	// head
+	headPod := &j.Spec.RayClusterSpec.HeadGroupSpec.Template
+	changed = podset.RestorePodSpec(&headPod.ObjectMeta, &headPod.Spec, podSetsInfo[0]) || changed
+
+	// workers
+	for index := range j.Spec.RayClusterSpec.WorkerGroupSpecs {
+		workerPod := &j.Spec.RayClusterSpec.WorkerGroupSpecs[index].Template
+		info := podSetsInfo[index+1]
+		changed = podset.RestorePodSpec(&workerPod.ObjectMeta, &workerPod.Spec, info) || changed
+	}
+	return changed
+}
+
+func (j *RayJobV1alpha1) Finished() (metav1.Condition, bool) {
+	condition := metav1.Condition{
+		Type:    kueue.WorkloadFinished,
+		Status:  metav1.ConditionTrue,
+		Reason:  string(j.Status.JobStatus),
+		Message: j.Status.Message,
+	}
+
+	return condition, j.Status.JobStatus == rayv1alpha1.JobStatusFailed || j.Status.JobStatus == rayv1alpha1.JobStatusSucceeded
+}
+
+func (j *RayJobV1alpha1) PodsReady() bool {
+	return j.Status.RayClusterStatus.State == rayv1alpha1.Ready
+}
+
+func (j *RayJobV1alpha1) ValidateCreate() field.ErrorList {
+	var allErrors field.ErrorList
+
+	spec := &j.Spec
+	specPath := field.NewPath("spec")
+
+	// Should always delete the cluster after the sob has ended, otherwise it will continue to the queue's resources.
+	if !spec.ShutdownAfterJobFinishes {
+		allErrors = append(allErrors, field.Invalid(specPath.Child("shutdownAfterJobFinishes"), spec.ShutdownAfterJobFinishes, "a kueue managed job should delete the cluster after finishing"))
+	}
+
+	// Should not want existing cluster. Kueue (workload) should be able to control the admission of the actual work, not only the trigger.
+	if len(spec.ClusterSelector) > 0 {
+		allErrors = append(allErrors, field.Invalid(specPath.Child("clusterSelector"), spec.ClusterSelector, "a kueue managed job should not use an existing cluster"))
+	}
+
+	clusterSpec := spec.RayClusterSpec
+	clusterSpecPath := specPath.Child("rayClusterSpec")
+
+	// Should not use auto scaler. Once the resources are reserved by queue the cluster should do it's best to use them.
+	if ptr.Deref(clusterSpec.EnableInTreeAutoscaling, false) {
+		allErrors = append(allErrors, field.Invalid(clusterSpecPath.Child("enableInTreeAutoscaling"), clusterSpec.EnableInTreeAutoscaling, "a kueue managed job should not use autoscaling"))
+	}
+
+	// Should limit the worker count to 8 - 1 (max podSets num - cluster head)
+	if len(clusterSpec.WorkerGroupSpecs) > 7 {
+		allErrors = append(allErrors, field.TooMany(clusterSpecPath.Child("workerGroupSpecs"), len(clusterSpec.WorkerGroupSpecs), 7))
+	}
+
+	// None of the workerGroups should be named "head"
+	for i := range clusterSpec.WorkerGroupSpecs {
+		if clusterSpec.WorkerGroupSpecs[i].GroupName == headGroupPodSetName {
+			allErrors = append(allErrors, field.Forbidden(clusterSpecPath.Child("workerGroupSpecs").Index(i).Child("groupName"), fmt.Sprintf("%q is reserved for the head group", headGroupPodSetName)))
+		}
+	}
+
+	allErrors = append(allErrors, jobframework.ValidateCreateForQueueName(j)...)
+	return allErrors
+}
+
+func SetupIndexesV1alpha1(ctx context.Context, indexer client.FieldIndexer) error {
+	return jobframework.SetupWorkloadOwnerIndex(ctx, indexer, gvkV1alpha1)
+}

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
@@ -37,7 +37,7 @@ type RayJobWebhook struct {
 	manageJobsWithoutQueueName bool
 }
 
-// SetupRayJobWebhook configures the webhook for rayjobapi RayJob.
+// SetupRayJobWebhook configures the webhook for RayJob.
 func SetupRayJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.DefaultOptions
 	for _, opt := range opts {
@@ -47,38 +47,38 @@ func SetupRayJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		manageJobsWithoutQueueName: options.ManageJobsWithoutQueueName,
 	}
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(&rayjobapi.RayJob{}).
+		For(&rayv1.RayJob{}).
 		WithDefaulter(wh).
 		WithValidator(wh).
 		Complete()
 }
 
-// +kubebuilder:webhook:path=/mutate-ray-io-v1alpha1-rayjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayjobs,verbs=create,versions=v1alpha1,name=mrayjob.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-ray-io-v1-rayjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayjobs,verbs=create,versions=v1,name=mrayjob.kb.io,admissionReviewVersions=v1
 
 var _ webhook.CustomDefaulter = &RayJobWebhook{}
 
 // Default implements webhook.CustomDefaulter so a webhook will be registered for the type
 func (w *RayJobWebhook) Default(ctx context.Context, obj runtime.Object) error {
-	job := obj.(*rayjobapi.RayJob)
+	job := obj.(*rayv1.RayJob)
 	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
 	log.V(5).Info("Applying defaults", "job", klog.KObj(job))
 	jobframework.ApplyDefaultForSuspend((*RayJob)(job), w.manageJobsWithoutQueueName)
 	return nil
 }
 
-// +kubebuilder:webhook:path=/validate-ray-io-v1alpha1-rayjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayjobs,verbs=create;update,versions=v1alpha1,name=vrayjob.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-ray-io-v1-rayjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayjobs,verbs=create;update,versions=v1,name=vrayjob.kb.io,admissionReviewVersions=v1
 
 var _ webhook.CustomValidator = &RayJobWebhook{}
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
 func (w *RayJobWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
-	job := obj.(*rayjobapi.RayJob)
+	job := obj.(*rayv1.RayJob)
 	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
 	log.Info("Validating create", "job", klog.KObj(job))
 	return nil, w.validateCreate(job).ToAggregate()
 }
 
-func (w *RayJobWebhook) validateCreate(job *rayjobapi.RayJob) field.ErrorList {
+func (w *RayJobWebhook) validateCreate(job *rayv1.RayJob) field.ErrorList {
 	var allErrors field.ErrorList
 	kueueJob := (*RayJob)(job)
 
@@ -91,7 +91,7 @@ func (w *RayJobWebhook) validateCreate(job *rayjobapi.RayJob) field.ErrorList {
 			allErrors = append(allErrors, field.Invalid(specPath.Child("shutdownAfterJobFinishes"), spec.ShutdownAfterJobFinishes, "a kueue managed job should delete the cluster after finishing"))
 		}
 
-		// Should not want existing cluster. Keuue (workload) should be able to control the admission of the actual work, not only the trigger.
+		// Should not want existing cluster. Kueue (workload) should be able to control the admission of the actual work, not only the trigger.
 		if len(spec.ClusterSelector) > 0 {
 			allErrors = append(allErrors, field.Invalid(specPath.Child("clusterSelector"), spec.ClusterSelector, "a kueue managed job should not use an existing cluster"))
 		}
@@ -123,8 +123,8 @@ func (w *RayJobWebhook) validateCreate(job *rayjobapi.RayJob) field.ErrorList {
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
 func (w *RayJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	oldJob := oldObj.(*rayjobapi.RayJob)
-	newJob := newObj.(*rayjobapi.RayJob)
+	oldJob := oldObj.(*rayv1.RayJob)
+	newJob := newObj.(*rayv1.RayJob)
 	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
 	if w.manageJobsWithoutQueueName || jobframework.QueueName((*RayJob)(newJob)) != "" {
 		log.Info("Validating update", "job", klog.KObj(newJob))

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -38,8 +38,8 @@ var (
 
 func TestValidateDefault(t *testing.T) {
 	testcases := map[string]struct {
-		oldJob    *rayjobapi.RayJob
-		newJob    *rayjobapi.RayJob
+		oldJob    *rayv1.RayJob
+		newJob    *rayv1.RayJob
 		manageAll bool
 	}{
 		"unmanaged": {
@@ -88,11 +88,11 @@ func TestValidateDefault(t *testing.T) {
 }
 
 func TestValidateCreate(t *testing.T) {
-	worker := rayjobapi.WorkerGroupSpec{}
-	bigWorkerGroup := []rayjobapi.WorkerGroupSpec{worker, worker, worker, worker, worker, worker, worker, worker}
+	worker := rayv1.WorkerGroupSpec{}
+	bigWorkerGroup := []rayv1.WorkerGroupSpec{worker, worker, worker, worker, worker, worker, worker, worker}
 
 	testcases := map[string]struct {
-		job       *rayjobapi.RayJob
+		job       *rayv1.RayJob
 		manageAll bool
 		wantErr   error
 	}{
@@ -147,7 +147,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"worker group uses head name": {
 			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
-				WithWorkerGroups(rayjobapi.WorkerGroupSpec{
+				WithWorkerGroups(rayv1.WorkerGroupSpec{
 					GroupName: headGroupPodSetName,
 				}).
 				Obj(),
@@ -172,8 +172,8 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testcases := map[string]struct {
-		oldJob    *rayjobapi.RayJob
-		newJob    *rayjobapi.RayJob
+		oldJob    *rayv1.RayJob
+		newJob    *rayv1.RayJob
 		manageAll bool
 		wantErr   error
 	}{

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -34,12 +34,12 @@ const (
 	caOrganization = "kueue"
 )
 
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update
-//+kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs=get;list;watch;update
-//+kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=get;list;watch;update
 
 // ManageCerts creates all certs for webhooks. This function is called from main.go.
-func ManageCerts(mgr ctrl.Manager, cfg config.Configuration, setupFinished chan struct{}) error {
+func ManageCerts(mgr ctrl.Manager, cfg *config.Configuration, setupFinished chan struct{}) error {
 	// DNSName is <service name>.<namespace>.svc
 	var dnsName = fmt.Sprintf("%s.%s.svc", *cfg.InternalCertManagement.WebhookServiceName, *cfg.Namespace)
 

--- a/pkg/util/discovery/discovery.go
+++ b/pkg/util/discovery/discovery.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+)
+
+// HasAPIResourceForGVK checks whether the API resource is available for the provided GVK.
+func HasAPIResourceForGVK(dc discovery.DiscoveryInterface, gvk schema.GroupVersionKind) (bool, error) {
+	gv, kind := gvk.ToAPIVersionAndKind()
+	if resources, err := dc.ServerResourcesForGroupVersion(gv); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	} else {
+		for _, res := range resources.APIResources {
+			if res.Kind == kind {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/pkg/util/testingjobs/rayjob/wrappers.go
+++ b/pkg/util/testingjobs/rayjob/wrappers.go
@@ -17,7 +17,7 @@ limitations under the License.
 package rayjob
 
 import (
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,20 +27,20 @@ import (
 )
 
 // JobWrapper wraps a RayJob.
-type JobWrapper struct{ rayjobapi.RayJob }
+type JobWrapper struct{ rayv1.RayJob }
 
 // MakeJob creates a wrapper for a suspended rayJob
 func MakeJob(name, ns string) *JobWrapper {
-	return &JobWrapper{rayjobapi.RayJob{
+	return &JobWrapper{rayv1.RayJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   ns,
 			Annotations: make(map[string]string, 1),
 		},
-		Spec: rayjobapi.RayJobSpec{
+		Spec: rayv1.RayJobSpec{
 			ShutdownAfterJobFinishes: true,
-			RayClusterSpec: &rayjobapi.RayClusterSpec{
-				HeadGroupSpec: rayjobapi.HeadGroupSpec{
+			RayClusterSpec: &rayv1.RayClusterSpec{
+				HeadGroupSpec: rayv1.HeadGroupSpec{
 					RayStartParams: map[string]string{"p1": "v1"},
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
@@ -52,7 +52,7 @@ func MakeJob(name, ns string) *JobWrapper {
 						},
 					},
 				},
-				WorkerGroupSpecs: []rayjobapi.WorkerGroupSpec{
+				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
 						GroupName:      "workers-group-0",
 						Replicas:       ptr.To[int32](1),
@@ -77,7 +77,7 @@ func MakeJob(name, ns string) *JobWrapper {
 }
 
 // Obj returns the inner Job.
-func (j *JobWrapper) Obj() *rayjobapi.RayJob {
+func (j *JobWrapper) Obj() *rayv1.RayJob {
 	return &j.RayJob
 }
 
@@ -131,12 +131,12 @@ func (j *JobWrapper) WithEnableAutoscaling(value *bool) *JobWrapper {
 	return j
 }
 
-func (j *JobWrapper) WithWorkerGroups(workers ...rayjobapi.WorkerGroupSpec) *JobWrapper {
+func (j *JobWrapper) WithWorkerGroups(workers ...rayv1.WorkerGroupSpec) *JobWrapper {
 	j.Spec.RayClusterSpec.WorkerGroupSpecs = workers
 	return j
 }
 
-func (j *JobWrapper) WithHeadGroupSpec(value rayjobapi.HeadGroupSpec) *JobWrapper {
+func (j *JobWrapper) WithHeadGroupSpec(value rayv1.HeadGroupSpec) *JobWrapper {
 	j.Spec.RayClusterSpec.HeadGroupSpec = value
 	return j
 }

--- a/site/static/examples/jobs/ray-job-sample.yaml
+++ b/site/static/examples/jobs/ray-job-sample.yaml
@@ -1,4 +1,4 @@
-apiVersion: ray.io/v1alpha1
+apiVersion: ray.io/v1
 kind: RayJob
 metadata:
   name: ray-job-sample

--- a/test/integration/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/controller/jobs/rayjob/rayjob_controller_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -57,13 +57,13 @@ var (
 // +kubebuilder:docs-gen:collapse=Imports
 
 func setInitStatus(name, namespace string) {
-	createdJob := &rayjobapi.RayJob{}
+	createdJob := &rayv1.RayJob{}
 	nsName := types.NamespacedName{Name: name, Namespace: namespace}
 	gomega.EventuallyWithOffset(1, func() error {
 		if err := k8sClient.Get(ctx, nsName, createdJob); err != nil {
 			return err
 		}
-		createdJob.Status.JobDeploymentStatus = rayjobapi.JobDeploymentStatusSuspended
+		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusSuspended
 		return k8sClient.Status().Update(ctx, createdJob)
 	}, util.Timeout, util.Interval).Should(gomega.Succeed())
 }
@@ -112,7 +112,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			Obj()
 		err := k8sClient.Create(ctx, job)
 		gomega.Expect(err).To(gomega.Succeed())
-		createdJob := &rayjobapi.RayJob{}
+		createdJob := &rayv1.RayJob{}
 
 		setInitStatus(jobName, ns.Name)
 		gomega.Eventually(func() bool {
@@ -260,8 +260,8 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
 
 		ginkgo.By("checking the workload is finished when job is completed")
-		createdJob.Status.JobDeploymentStatus = rayjobapi.JobDeploymentStatusComplete
-		createdJob.Status.JobStatus = rayjobapi.JobStatusSucceeded
+		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusComplete
+		createdJob.Status.JobStatus = rayv1.JobStatusSucceeded
 		createdJob.Status.Message = "Job finished by test"
 
 		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
@@ -305,7 +305,7 @@ var _ = ginkgo.Describe("Job controller for workloads when only jobs with queue 
 		job := testingrayjob.MakeJob(jobName, ns.Name).Obj()
 		gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
 		lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
-		createdJob := &rayjobapi.RayJob{}
+		createdJob := &rayv1.RayJob{}
 		setInitStatus(jobName, ns.Name)
 		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 
@@ -332,9 +332,9 @@ var _ = ginkgo.Describe("Job controller for workloads when only jobs with queue 
 
 var _ = ginkgo.Describe("Job controller when waitForPodsReady enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	type podsReadyTestSpec struct {
-		beforeJobStatus *rayjobapi.RayJobStatus
+		beforeJobStatus *rayv1.RayJobStatus
 		beforeCondition *metav1.Condition
-		jobStatus       rayjobapi.RayJobStatus
+		jobStatus       rayv1.RayJobStatus
 		suspended       bool
 		wantCondition   *metav1.Condition
 	}
@@ -385,7 +385,7 @@ var _ = ginkgo.Describe("Job controller when waitForPodsReady enabled", ginkgo.O
 			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
 			lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
 			setInitStatus(jobName, ns.Name)
-			createdJob := &rayjobapi.RayJob{}
+			createdJob := &rayv1.RayJob{}
 			gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 
 			ginkgo.By("Fetch the workload created for the job")
@@ -466,10 +466,10 @@ var _ = ginkgo.Describe("Job controller when waitForPodsReady enabled", ginkgo.O
 			},
 		}),
 		ginkgo.Entry("Running RayJob", podsReadyTestSpec{
-			jobStatus: rayjobapi.RayJobStatus{
-				JobDeploymentStatus: rayjobapi.JobDeploymentStatusRunning,
-				RayClusterStatus: rayjobapi.RayClusterStatus{
-					State: rayjobapi.Ready,
+			jobStatus: rayv1.RayJobStatus{
+				JobDeploymentStatus: rayv1.JobDeploymentStatusRunning,
+				RayClusterStatus: rayv1.RayClusterStatus{
+					State: rayv1.Ready,
 				},
 			},
 			wantCondition: &metav1.Condition{
@@ -486,10 +486,10 @@ var _ = ginkgo.Describe("Job controller when waitForPodsReady enabled", ginkgo.O
 				Reason:  "PodsReady",
 				Message: "Not all pods are ready or succeeded",
 			},
-			jobStatus: rayjobapi.RayJobStatus{
-				JobDeploymentStatus: rayjobapi.JobDeploymentStatusRunning,
-				RayClusterStatus: rayjobapi.RayClusterStatus{
-					State: rayjobapi.Ready,
+			jobStatus: rayv1.RayJobStatus{
+				JobDeploymentStatus: rayv1.JobDeploymentStatusRunning,
+				RayClusterStatus: rayv1.RayClusterStatus{
+					State: rayv1.Ready,
 				},
 			},
 			wantCondition: &metav1.Condition{
@@ -500,10 +500,10 @@ var _ = ginkgo.Describe("Job controller when waitForPodsReady enabled", ginkgo.O
 			},
 		}),
 		ginkgo.Entry("Job suspended; PodsReady=True before", podsReadyTestSpec{
-			beforeJobStatus: &rayjobapi.RayJobStatus{
-				JobDeploymentStatus: rayjobapi.JobDeploymentStatusRunning,
-				RayClusterStatus: rayjobapi.RayClusterStatus{
-					State: rayjobapi.Ready,
+			beforeJobStatus: &rayv1.RayJobStatus{
+				JobDeploymentStatus: rayv1.JobDeploymentStatusRunning,
+				RayClusterStatus: rayv1.RayClusterStatus{
+					State: rayv1.Ready,
 				},
 			},
 			beforeCondition: &metav1.Condition{
@@ -512,8 +512,8 @@ var _ = ginkgo.Describe("Job controller when waitForPodsReady enabled", ginkgo.O
 				Reason:  "PodsReady",
 				Message: "All pods were ready or succeeded since the workload admission",
 			},
-			jobStatus: rayjobapi.RayJobStatus{
-				JobDeploymentStatus: rayjobapi.JobDeploymentStatusSuspended,
+			jobStatus: rayv1.RayJobStatus{
+				JobDeploymentStatus: rayv1.JobDeploymentStatusSuspended,
 			},
 			suspended: true,
 			wantCondition: &metav1.Condition{
@@ -587,7 +587,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 			Obj()
 		gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
 		setInitStatus(job.Name, job.Namespace)
-		createdJob := &rayjobapi.RayJob{}
+		createdJob := &rayv1.RayJob{}
 		gomega.Eventually(func() bool {
 			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, createdJob)).
 				Should(gomega.Succeed())
@@ -667,7 +667,7 @@ var _ = ginkgo.Describe("Job controller with preemption enabled", ginkgo.Ordered
 		setInitStatus(lowPriorityJob.Name, lowPriorityJob.Namespace)
 
 		ginkgo.By("Await for the low priority workload to be admitted")
-		createdJob := &rayjobapi.RayJob{}
+		createdJob := &rayv1.RayJob{}
 		gomega.Eventually(func() bool {
 			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lowPriorityJob.Name, Namespace: lowPriorityJob.Namespace}, createdJob)).
 				Should(gomega.Succeed())
@@ -702,7 +702,7 @@ var _ = ginkgo.Describe("Job controller with preemption enabled", ginkgo.Ordered
 		apimeta.IsStatusConditionFalse(createdWorkload.Status.Conditions, kueue.WorkloadAdmitted)
 
 		ginkgo.By("Low priority rayJob should be suspended")
-		createdJob = &rayjobapi.RayJob{}
+		createdJob = &rayv1.RayJob{}
 		gomega.Eventually(func() bool {
 			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lowPriorityJob.Name, Namespace: lowPriorityJob.Namespace}, createdJob)).
 				Should(gomega.Succeed())
@@ -712,7 +712,7 @@ var _ = ginkgo.Describe("Job controller with preemption enabled", ginkgo.Ordered
 		ginkgo.By("Delete high priority rayjob")
 		gomega.Expect(k8sClient.Delete(ctx, highPriorityJob)).To(gomega.Succeed())
 		gomega.EventuallyWithOffset(1, func() error {
-			rayjob := &rayjobapi.RayJob{}
+			rayjob := &rayv1.RayJob{}
 			return k8sClient.Get(ctx, client.ObjectKeyFromObject(highPriorityJob), rayjob)
 		}, util.Timeout, util.Interval).Should(testing.BeNotFoundError())
 		// Manually delete workload because no garbage collection controller.
@@ -730,7 +730,7 @@ var _ = ginkgo.Describe("Job controller with preemption enabled", ginkgo.Ordered
 		apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadAdmitted)
 
 		ginkgo.By("Low priority rayJob should be unsuspended")
-		createdJob = &rayjobapi.RayJob{}
+		createdJob = &rayv1.RayJob{}
 		gomega.Eventually(func() bool {
 			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lowPriorityJob.Name, Namespace: lowPriorityJob.Namespace}, createdJob)).
 				Should(gomega.Succeed())

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -27,7 +27,7 @@ import (
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	zaplog "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -89,7 +89,7 @@ func (f *Framework) RunManager(cfg *rest.Config, managerSetup ManagerSetup) (con
 	err = kubeflow.AddToScheme(scheme.Scheme)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
-	err = rayjobapi.AddToScheme(scheme.Scheme)
+	err = rayv1.AddToScheme(scheme.Scheme)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
 	err = jobsetapi.AddToScheme(scheme.Scheme)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
-->

#### What this PR does / why we need it:

KubeRay has promoted the RayJob API from v1alpha1 to v1 with KubeRay v1.0.0. While the v1alpha1 versions is still served, it'll eventually be removed.

#### Which issue(s) this PR fixes:

Fixes #1335.

#### Special notes for your reviewer:

This PR adds a mechanism that makes it possible to configure a framework integration dynamically, depending on the version of the framework API that is installed on the cluster for example.

That mechanism is used so both RayJob v1alpha1 and v1 can be supported. Specifically, v1alpha1-aware controller and webhooks are setup when the v1alpha1 API is installed. Otherwise, v1-aware ones are setup when the v1 API is installed, which works also for the v1alpha1 as it's fully round-trippable to v1. In the latter configuration, the v1alpha1 webhook is NOOP'ed. 

#### Does this PR introduce a user-facing change?

```release-note
Upgrade RayJob API to v1
```