### PR TITLE
Add workload finished event

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -152,13 +152,13 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			constants.KueueName)
 
 		if err == nil {
-			if own := metav1.GetControllerOf(&wl); own != nil {
+			for _, owner := range wl.OwnerReferences {
 				uowner := unstructured.Unstructured{}
-				uowner.SetKind(own.Kind)
-				uowner.SetAPIVersion(own.APIVersion)
-				uowner.SetName(own.Name)
+				uowner.SetKind(owner.Kind)
+				uowner.SetAPIVersion(owner.APIVersion)
+				uowner.SetName(owner.Name)
 				uowner.SetNamespace(wl.Namespace)
-				uowner.SetUID(own.UID)
+				uowner.SetUID(owner.UID)
 				r.recorder.Eventf(&uowner, corev1.EventTypeNormal, "WorkloadFinished", "Admission checks %v are rejected", rejectedChecks)
 			}
 		}

--- a/pkg/controller/jobframework/errors.go
+++ b/pkg/controller/jobframework/errors.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package jobframework
 
 import "errors"

--- a/pkg/controller/jobframework/events.go
+++ b/pkg/controller/jobframework/events.go
@@ -15,12 +15,12 @@ package jobframework
 
 // JobReconciler event reason list
 const (
-	Started            = "Started"
-	Suspended          = "Suspended"
-	Stopped            = "Stopped"
-	CreatedWorkload    = "CreatedWorkload"
-	DeletedWorkload    = "DeletedWorkload"
-	UpdatedWorkload    = "UpdatedWorkload"
-	FinishedWorkload   = "FinishedWorkload"
-	ErrWorkloadCompose = "ErrWorkloadCompose"
+	ReasonStarted            = "Started"
+	ReasonSuspended          = "Suspended"
+	ReasonStopped            = "Stopped"
+	ReasonCreatedWorkload    = "CreatedWorkload"
+	ReasonDeletedWorkload    = "DeletedWorkload"
+	ReasonUpdatedWorkload    = "UpdatedWorkload"
+	ReasonFinishedWorkload   = "FinishedWorkload"
+	ReasonErrWorkloadCompose = "ErrWorkloadCompose"
 )

--- a/pkg/controller/jobframework/events.go
+++ b/pkg/controller/jobframework/events.go
@@ -1,0 +1,13 @@
+package jobframework
+
+// JobReconciler event reason list
+const (
+	Started            = "Started"
+	Suspended          = "Suspended"
+	Stopped            = "Stopped"
+	CreatedWorkload    = "CreatedWorkload"
+	DeletedWorkload    = "DeletedWorkload"
+	UpdatedWorkload    = "UpdatedWorkload"
+	FinishedWorkload   = "FinishedWorkload"
+	ErrWorkloadCompose = "ErrWorkloadCompose"
+)

--- a/pkg/controller/jobframework/events.go
+++ b/pkg/controller/jobframework/events.go
@@ -1,3 +1,16 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package jobframework
 
 // JobReconciler event reason list

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -233,7 +233,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 					log.Error(err, "suspending child job failed")
 					return ctrl.Result{}, err
 				}
-				r.record.Eventf(object, corev1.EventTypeNormal, Suspended, "Kueue managed child job suspended")
+				r.record.Eventf(object, corev1.EventTypeNormal, ReasonSuspended, "Kueue managed child job suspended")
 			}
 		}
 		return ctrl.Result{}, nil
@@ -283,7 +283,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 			if err != nil && !apierrors.IsNotFound(err) {
 				return ctrl.Result{}, err
 			}
-			r.record.Eventf(object, corev1.EventTypeNormal, FinishedWorkload,
+			r.record.Eventf(object, corev1.EventTypeNormal, ReasonFinishedWorkload,
 				"Workload '%s' is declared finished", workload.Key(wl))
 		}
 
@@ -532,7 +532,7 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 		}
 		if err == nil {
 			existedWls++
-			r.record.Eventf(object, corev1.EventTypeNormal, DeletedWorkload,
+			r.record.Eventf(object, corev1.EventTypeNormal, ReasonDeletedWorkload,
 				"Deleted not matching Workload: %v", wlKey)
 		}
 	}
@@ -661,7 +661,7 @@ func (r *JobReconciler) updateWorkloadToMatchJob(ctx context.Context, job Generi
 		return nil, fmt.Errorf("updating existed workload: %w", err)
 	}
 
-	r.record.Eventf(object, corev1.EventTypeNormal, UpdatedWorkload,
+	r.record.Eventf(object, corev1.EventTypeNormal, ReasonUpdatedWorkload,
 		"Updated not matching Workload for suspended job: %v", klog.KObj(wl))
 	return newWl, nil
 }
@@ -687,7 +687,7 @@ func (r *JobReconciler) startJob(ctx context.Context, job GenericJob, object cli
 		}
 	}
 
-	r.record.Eventf(object, corev1.EventTypeNormal, Started,
+	r.record.Eventf(object, corev1.EventTypeNormal, ReasonStarted,
 		"Admitted by clusterQueue %v", wl.Status.Admission.ClusterQueue)
 
 	return nil
@@ -703,7 +703,7 @@ func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, wl *kueue.W
 	if jws, implements := job.(JobWithCustomStop); implements {
 		stoppedNow, err := jws.Stop(ctx, r.client, info, stopReason, eventMsg)
 		if stoppedNow {
-			r.record.Eventf(object, corev1.EventTypeNormal, Stopped, eventMsg)
+			r.record.Eventf(object, corev1.EventTypeNormal, ReasonStopped, eventMsg)
 		}
 
 		return err
@@ -721,7 +721,7 @@ func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, wl *kueue.W
 		return err
 	}
 
-	r.record.Eventf(object, corev1.EventTypeNormal, Stopped, eventMsg)
+	r.record.Eventf(object, corev1.EventTypeNormal, ReasonStopped, eventMsg)
 	return nil
 }
 
@@ -881,7 +881,7 @@ func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job Generic
 	if err = r.client.Create(ctx, wl); err != nil {
 		return err
 	}
-	r.record.Eventf(object, corev1.EventTypeNormal, CreatedWorkload,
+	r.record.Eventf(object, corev1.EventTypeNormal, ReasonCreatedWorkload,
 		"Created Workload: %v", workload.Key(wl))
 	return nil
 }

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -283,6 +283,8 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 			if err != nil && !apierrors.IsNotFound(err) {
 				return ctrl.Result{}, err
 			}
+			r.record.Eventf(object, corev1.EventTypeNormal, FinishedWorkload,
+				"Workload '%s' is declared finished", workload.Key(wl))
 		}
 
 		// Execute job finalization logic

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -233,7 +233,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 					log.Error(err, "suspending child job failed")
 					return ctrl.Result{}, err
 				}
-				r.record.Eventf(object, corev1.EventTypeNormal, "Suspended", "Kueue managed child job suspended")
+				r.record.Eventf(object, corev1.EventTypeNormal, Suspended, "Kueue managed child job suspended")
 			}
 		}
 		return ctrl.Result{}, nil
@@ -256,7 +256,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 			}
 		}
 
-		r.record.Eventf(object, corev1.EventTypeNormal, "FinishedWorkload",
+		r.record.Eventf(object, corev1.EventTypeNormal, FinishedWorkload,
 			"Workload '%s' is declared finished", workload.Key(wl))
 		return ctrl.Result{}, workload.RemoveFinalizer(ctx, r.client, wl)
 	}
@@ -530,7 +530,7 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 		}
 		if err == nil {
 			existedWls++
-			r.record.Eventf(object, corev1.EventTypeNormal, "DeletedWorkload",
+			r.record.Eventf(object, corev1.EventTypeNormal, DeletedWorkload,
 				"Deleted not matching Workload: %v", wlKey)
 		}
 	}
@@ -659,7 +659,7 @@ func (r *JobReconciler) updateWorkloadToMatchJob(ctx context.Context, job Generi
 		return nil, fmt.Errorf("updating existed workload: %w", err)
 	}
 
-	r.record.Eventf(object, corev1.EventTypeNormal, "UpdatedWorkload",
+	r.record.Eventf(object, corev1.EventTypeNormal, UpdatedWorkload,
 		"Updated not matching Workload for suspended job: %v", klog.KObj(wl))
 	return newWl, nil
 }
@@ -685,7 +685,7 @@ func (r *JobReconciler) startJob(ctx context.Context, job GenericJob, object cli
 		}
 	}
 
-	r.record.Eventf(object, corev1.EventTypeNormal, "Started",
+	r.record.Eventf(object, corev1.EventTypeNormal, Started,
 		"Admitted by clusterQueue %v", wl.Status.Admission.ClusterQueue)
 
 	return nil
@@ -701,7 +701,7 @@ func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, wl *kueue.W
 	if jws, implements := job.(JobWithCustomStop); implements {
 		stoppedNow, err := jws.Stop(ctx, r.client, info, stopReason, eventMsg)
 		if stoppedNow {
-			r.record.Eventf(object, corev1.EventTypeNormal, "Stopped", eventMsg)
+			r.record.Eventf(object, corev1.EventTypeNormal, Stopped, eventMsg)
 		}
 
 		return err
@@ -719,7 +719,7 @@ func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, wl *kueue.W
 		return err
 	}
 
-	r.record.Eventf(object, corev1.EventTypeNormal, "Stopped", eventMsg)
+	r.record.Eventf(object, corev1.EventTypeNormal, Stopped, eventMsg)
 	return nil
 }
 
@@ -879,7 +879,7 @@ func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job Generic
 	if err = r.client.Create(ctx, wl); err != nil {
 		return err
 	}
-	r.record.Eventf(object, corev1.EventTypeNormal, "CreatedWorkload",
+	r.record.Eventf(object, corev1.EventTypeNormal, CreatedWorkload,
 		"Created Workload: %v", workload.Key(wl))
 	return nil
 }

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -255,6 +256,8 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 			}
 		}
 
+		r.record.Eventf(object, corev1.EventTypeNormal, "FinishedWorkload",
+			"Workload '%s' is declared finished", workload.Key(wl))
 		return ctrl.Result{}, workload.RemoveFinalizer(ctx, r.client, wl)
 	}
 
@@ -657,7 +660,7 @@ func (r *JobReconciler) updateWorkloadToMatchJob(ctx context.Context, job Generi
 	}
 
 	r.record.Eventf(object, corev1.EventTypeNormal, "UpdatedWorkload",
-		"Updated not matching Workload for suspended job: %v", wl)
+		"Updated not matching Workload for suspended job: %v", klog.KObj(wl))
 	return newWl, nil
 }
 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -256,7 +256,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 			}
 		}
 
-		r.record.Eventf(object, corev1.EventTypeNormal, FinishedWorkload,
+		r.record.Eventf(object, corev1.EventTypeNormal, ReasonFinishedWorkload,
 			"Workload '%s' is declared finished", workload.Key(wl))
 		return ctrl.Result{}, workload.RemoveFinalizer(ctx, r.client, wl)
 	}

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -1874,6 +1874,14 @@ func TestReconciler(t *testing.T) {
 				Label(controllerconsts.PrebuiltWorkloadLabel, "missing-workload").
 				UID("test-uid").
 				Obj(),
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Stopped",
+					Message:   "missing workload",
+				},
+			},
 		},
 		"when the prebuilt workload exists its owner info is updated": {
 			job: *baseJobWrapper.
@@ -1909,6 +1917,14 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(batchv1.SchemeGroupVersion.String(), "Job", "job", "test-uid", true, true).
 					Obj(),
 			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Stopped",
+					Message:   "Not admitted by cluster queue",
+				},
+			},
 		},
 		"when the prebuilt workload is owned by another object": {
 			job: *baseJobWrapper.
@@ -1941,6 +1957,14 @@ func TestReconciler(t *testing.T) {
 					PriorityClassSource(constants.WorkloadPriorityClassSource).
 					OwnerReference(batchv1.SchemeGroupVersion.String(), "Job", "other-job", "other-uid", true, true).
 					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Stopped",
+					Message:   "missing workload",
+				},
 			},
 		},
 		"when the prebuilt workload is not equivalent to the job": {
@@ -1982,6 +2006,14 @@ func TestReconciler(t *testing.T) {
 						Message: "The prebuilt workload is out of sync with its user job",
 					}).
 					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Stopped",
+					Message:   "missing workload",
+				},
 			},
 		},
 	}

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -1717,6 +1717,14 @@ func TestReconciler(t *testing.T) {
 					}).
 					Obj(),
 			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "FinishedWorkload",
+					Message:   "Workload 'ns/a' is declared finished",
+				},
+			},
 		},
 		"the workload is created when queue name is set, with workloadPriorityClass": {
 			job: *baseJobWrapper.

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -1686,6 +1686,14 @@ func TestReconciler(t *testing.T) {
 					}).
 					Obj(),
 			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "FinishedWorkload",
+					Message:   "Workload 'ns/a' is declared finished",
+				},
+			},
 		},
 		"when the workload is finished, its finalizer is removed": {
 			job: *baseJobWrapper.Clone().Obj(),
@@ -1708,14 +1716,6 @@ func TestReconciler(t *testing.T) {
 						Status: metav1.ConditionTrue,
 					}).
 					Obj(),
-			},
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
-					EventType: "Normal",
-					Reason:    "FinishedWorkload",
-					Message:   "Workload 'ns/a' is declared finished",
-				},
 			},
 		},
 		"the workload is created when queue name is set, with workloadPriorityClass": {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -2015,7 +2015,6 @@ func TestReconciler(t *testing.T) {
 					t.Fatalf("Could not create workload: %v", err)
 				}
 			}
-			//recorder := record.NewBroadcaster().NewRecorder(kClient.Scheme(), corev1.EventSource{Component: "test"})
 			recorder := &utiltesting.EventRecorder{}
 			reconciler := NewReconciler(kClient, recorder, tc.reconcilerOptions...)
 

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -614,7 +614,7 @@ func (p *Pod) validatePodGroupMetadata(r record.EventRecorder, activePods []core
 
 	if len(activePods) < groupTotalCount {
 		errMsg := fmt.Sprintf("'%s' group total count is less than the actual number of pods in the cluster", podGroupName(p.pod))
-		r.Eventf(p.Object(), corev1.EventTypeWarning, "ErrWorkloadCompose", errMsg)
+		r.Eventf(p.Object(), corev1.EventTypeWarning, jobframework.ErrWorkloadCompose, errMsg)
 		return jobframework.UnretryableError(errMsg)
 	}
 
@@ -782,7 +782,7 @@ func (p *Pod) ConstructComposableWorkload(ctx context.Context, c client.Client, 
 	wl.Spec.PodSets, err = p.constructGroupPodSets()
 	if err != nil {
 		if jobframework.IsUnretryableError(err) {
-			r.Eventf(object, corev1.EventTypeWarning, "ErrWorkloadCompose", err.Error())
+			r.Eventf(object, corev1.EventTypeWarning, jobframework.ErrWorkloadCompose, err.Error())
 		}
 		return nil, err
 	}

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -614,7 +614,7 @@ func (p *Pod) validatePodGroupMetadata(r record.EventRecorder, activePods []core
 
 	if len(activePods) < groupTotalCount {
 		errMsg := fmt.Sprintf("'%s' group total count is less than the actual number of pods in the cluster", podGroupName(p.pod))
-		r.Eventf(p.Object(), corev1.EventTypeWarning, jobframework.ErrWorkloadCompose, errMsg)
+		r.Eventf(p.Object(), corev1.EventTypeWarning, jobframework.ReasonErrWorkloadCompose, errMsg)
 		return jobframework.UnretryableError(errMsg)
 	}
 
@@ -782,7 +782,7 @@ func (p *Pod) ConstructComposableWorkload(ctx context.Context, c client.Client, 
 	wl.Spec.PodSets, err = p.constructGroupPodSets()
 	if err != nil {
 		if jobframework.IsUnretryableError(err) {
-			r.Eventf(object, corev1.EventTypeWarning, jobframework.ErrWorkloadCompose, err.Error())
+			r.Eventf(object, corev1.EventTypeWarning, jobframework.ReasonErrWorkloadCompose, err.Error())
 		}
 		return nil, err
 	}

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -289,12 +289,6 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, lookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
 
-					gomega.Eventually(func(g gomega.Gomega) {
-						ok, err := testing.CheckLatestEvent(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name))
-						g.Expect(err).NotTo(gomega.HaveOccurred())
-						g.Expect(ok).To(gomega.BeTrue())
-					}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
 					gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 					gomega.Expect(createdWorkload.Status.Conditions).Should(gomega.BeComparableTo(
 						[]metav1.Condition{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

* Added workload finished event for the job reconciler.
* Added event reason constants for the job reconciler.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1387

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```