### PR TITLE
Increase startup timeout

### DIFF
--- a/test/e2e/singlecluster/e2e_test.go
+++ b/test/e2e/singlecluster/e2e_test.go
@@ -914,7 +914,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 					}
 					return slices.ToMap(createdWorkload.Status.AdmissionChecks, func(i int) (string, string) { return createdWorkload.Status.AdmissionChecks[i].Name, "" })
 
-				}, util.LongTimeout, util.Interval).Should(gomega.BeComparableTo(map[string]string{"check1": ""}))
+				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(map[string]string{"check1": ""}))
 			})
 
 			ginkgo.By("waiting for the workload to be assigned", func() {
@@ -981,7 +981,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 					}
 					return slices.ToMap(createdWorkload.Status.AdmissionChecks, func(i int) (string, string) { return createdWorkload.Status.AdmissionChecks[i].Name, "" })
 
-				}, util.LongTimeout, util.Interval).Should(gomega.BeComparableTo(map[string]string{"check1": ""}))
+				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(map[string]string{"check1": ""}))
 			})
 
 			ginkgo.By("setting the check as successful", func() {

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -24,7 +24,10 @@ const (
 	Timeout = time.Second * 30
 	// LongTimeout is meant for E2E tests when waiting for complex operations
 	// such as running pods to completion.
-	LongTimeout        = time.Second * 45
+	LongTimeout = 45 * time.Second
+	// StartupTimeout is meant to be used for waiting for Kueue to startup, given
+	// that cert updates can take up to 2 minutes to propagate to the filesystem.
+	StartUpTimeout     = 3 * time.Minute
 	ConsistentDuration = time.Second * 3
 	Interval           = time.Millisecond * 250
 )

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -62,6 +62,6 @@ func KueueReadyForTesting(ctx context.Context, client client.Client) {
 	resourceKueue := utiltesting.MakeResourceFlavor("default").Obj()
 	gomega.Eventually(func() error {
 		return client.Create(context.Background(), resourceKueue)
-	}, LongTimeout, Interval).Should(gomega.Succeed())
+	}, StartUpTimeout, Interval).Should(gomega.Succeed())
 	ExpectResourceFlavorToBeDeleted(ctx, client, resourceKueue, true)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Increase startup timeout to 3m (see https://ahmet.im/blog/kubernetes-secret-volumes-delay/ for rationale).

Downgraded some waits to simple Timeout, as they don't involve more than one controller.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1372

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```