### PR TITLE
Pod group concurrent reconciles

### DIFF
--- a/pkg/controller/jobframework/indexer.go
+++ b/pkg/controller/jobframework/indexer.go
@@ -23,7 +23,7 @@ import (
 )
 
 func SetupWorkloadOwnerIndex(ctx context.Context, indexer client.FieldIndexer, gvk schema.GroupVersionKind) error {
-	return indexer.IndexField(ctx, &kueue.Workload{}, getOwnerKey(gvk), func(o client.Object) []string {
+	return indexer.IndexField(ctx, &kueue.Workload{}, GetOwnerKey(gvk), func(o client.Object) []string {
 		// grab the Workload object, extract the owner...
 		wl := o.(*kueue.Workload)
 		if len(wl.OwnerReferences) == 0 {

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -99,12 +99,14 @@ type JobWithPriorityClass interface {
 // are composed out of multiple API objects.
 type ComposableJob interface {
 	// Load loads all members of the composable job. If removeFinalizers == true, workload and job finalizers should be removed.
-	Load(ctx context.Context, c client.Client, key types.NamespacedName) (removeFinalizers bool, err error)
+	Load(ctx context.Context, c client.Client, key *types.NamespacedName) (removeFinalizers bool, err error)
 	// Run unsuspends all members of the ComposableJob and injects the node affinity with podSet
 	// counts extracting from workload to all members of the ComposableJob.
 	Run(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo) error
 	// ConstructComposableWorkload returns a new Workload that's assembled out of all members of the ComposableJob.
 	ConstructComposableWorkload(ctx context.Context, c client.Client, r record.EventRecorder) (*kueue.Workload, error)
+	// ListChildWorkloads returns all workloads related to the composable job
+	ListChildWorkloads(ctx context.Context, c client.Client, parent types.NamespacedName) (*kueue.WorkloadList, error)
 	// FindMatchingWorkloads returns all related workloads, workload that matches the ComposableJob and duplicates that has to be deleted.
 	FindMatchingWorkloads(ctx context.Context, c client.Client) (match *kueue.Workload, toDelete []*kueue.Workload, err error)
 }

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -100,6 +100,9 @@ type JobWithPriorityClass interface {
 type ComposableJob interface {
 	// Load loads all members of the composable job. If removeFinalizers == true, workload and job finalizers should be removed.
 	Load(ctx context.Context, c client.Client, key types.NamespacedName) (removeFinalizers bool, err error)
+	// Run unsuspends all members of the ComposableJob and injects the node affinity with podSet
+	// counts extracting from workload to all members of the ComposableJob.
+	Run(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo) error
 	// ConstructComposableWorkload returns a new Workload that's assembled out of all members of the ComposableJob.
 	ConstructComposableWorkload(ctx context.Context, c client.Client, r record.EventRecorder) (*kueue.Workload, error)
 	// FindMatchingWorkloads returns all related workloads, workload that matches the ComposableJob and duplicates that has to be deleted.

--- a/pkg/controller/jobframework/workload_names.go
+++ b/pkg/controller/jobframework/workload_names.go
@@ -59,6 +59,6 @@ func getHash(ownerName string, gvk schema.GroupVersionKind) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func getOwnerKey(ownerGVK schema.GroupVersionKind) string {
+func GetOwnerKey(ownerGVK schema.GroupVersionKind) string {
 	return fmt.Sprintf(".metadata.ownerReferences[%s.%s]", ownerGVK.Group, ownerGVK.Kind)
 }

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -78,7 +78,7 @@ func init() {
 var NewReconciler = jobframework.NewGenericReconciler(
 	func() jobframework.GenericJob {
 		return &Job{}
-	}, func(c client.Client) handler.EventHandler {
+	}, nil, func(c client.Client) handler.EventHandler {
 		return &parentWorkloadHandler{client: c}
 	},
 )

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -62,7 +62,7 @@ func init() {
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=resourceflavors,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloadpriorityclasses,verbs=get;list;watch
 
-var NewReconciler = jobframework.NewGenericReconciler(func() jobframework.GenericJob { return &JobSet{} }, nil)
+var NewReconciler = jobframework.NewGenericReconciler(func() jobframework.GenericJob { return &JobSet{} }, nil, nil)
 
 func isJobSet(owner *metav1.OwnerReference) bool {
 	return owner.Kind == "JobSet" && strings.HasPrefix(owner.APIVersion, "jobset.x-k8s.io/v1")

--- a/pkg/controller/jobs/kubeflow/jobs/mxjob/mxjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/jobs/mxjob/mxjob_controller.go
@@ -60,7 +60,7 @@ func init() {
 
 var NewReconciler = jobframework.NewGenericReconciler(func() jobframework.GenericJob {
 	return &kubeflowjob.KubeflowJob{KFJobControl: (*JobControl)(&kftraining.MXJob{})}
-}, nil)
+}, nil, nil)
 
 func isMXJob(owner *metav1.OwnerReference) bool {
 	return owner.Kind == kftraining.MXJobKind && strings.HasPrefix(owner.APIVersion, kftraining.SchemeGroupVersion.Group)

--- a/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller.go
+++ b/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller.go
@@ -60,7 +60,7 @@ func init() {
 
 var NewReconciler = jobframework.NewGenericReconciler(func() jobframework.GenericJob {
 	return &kubeflowjob.KubeflowJob{KFJobControl: (*JobControl)(&kftraining.PaddleJob{})}
-}, nil)
+}, nil, nil)
 
 func isPaddleJob(owner *metav1.OwnerReference) bool {
 	return owner.Kind == kftraining.PaddleJobKind && strings.HasPrefix(owner.APIVersion, kftraining.SchemeGroupVersion.Group)

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller.go
@@ -60,7 +60,7 @@ func init() {
 
 var NewReconciler = jobframework.NewGenericReconciler(func() jobframework.GenericJob {
 	return &kubeflowjob.KubeflowJob{KFJobControl: (*JobControl)(&kftraining.PyTorchJob{})}
-}, nil)
+}, nil, nil)
 
 func isPyTorchJob(owner *metav1.OwnerReference) bool {
 	return owner.Kind == kftraining.PyTorchJobKind && strings.HasPrefix(owner.APIVersion, kftraining.SchemeGroupVersion.Group)

--- a/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller.go
@@ -60,7 +60,7 @@ func init() {
 
 var NewReconciler = jobframework.NewGenericReconciler(func() jobframework.GenericJob {
 	return &kubeflowjob.KubeflowJob{KFJobControl: (*JobControl)(&kftraining.TFJob{})}
-}, nil)
+}, nil, nil)
 
 func isTFJob(owner *metav1.OwnerReference) bool {
 	return owner.Kind == kftraining.TFJobKind && strings.HasPrefix(owner.APIVersion, kftraining.SchemeGroupVersion.Group)

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller.go
@@ -60,7 +60,7 @@ func init() {
 
 var NewReconciler = jobframework.NewGenericReconciler(func() jobframework.GenericJob {
 	return &kubeflowjob.KubeflowJob{KFJobControl: (*JobControl)(&kftraining.XGBoostJob{})}
-}, nil)
+}, nil, nil)
 
 func isXGBoostJob(owner *metav1.OwnerReference) bool {
 	return owner.Kind == kftraining.XGBoostJobKind && strings.HasPrefix(owner.APIVersion, kftraining.SchemeGroupVersion.Group)

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -62,7 +62,7 @@ func init() {
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=resourceflavors,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloadpriorityclasses,verbs=get;list;watch
 
-var NewReconciler = jobframework.NewGenericReconciler(func() jobframework.GenericJob { return &MPIJob{} }, nil)
+var NewReconciler = jobframework.NewGenericReconciler(func() jobframework.GenericJob { return &MPIJob{} }, nil, nil)
 
 func isMPIJob(owner *metav1.OwnerReference) bool {
 	return owner.Kind == "MPIJob" && strings.HasPrefix(owner.APIVersion, "kubeflow.org/v2")

--- a/pkg/controller/jobs/pod/event_handlers.go
+++ b/pkg/controller/jobs/pod/event_handlers.go
@@ -118,7 +118,7 @@ func (h *parentWorkloadHandler) queueReconcileForChildPod(ctx context.Context, o
 			return
 		}
 
-		if groupName := fromObject(&parentPod).groupName(); groupName == "" {
+		if groupName := podGroupName(parentPod); groupName == "" {
 			log.V(5).Info("Queueing reconcile for the single pod", "pod", klog.KObj(&parentPod))
 			q.Add(reconcile.Request{
 				NamespacedName: types.NamespacedName{

--- a/pkg/controller/jobs/pod/event_handlers.go
+++ b/pkg/controller/jobs/pod/event_handlers.go
@@ -69,7 +69,6 @@ func (h *podEventHandler) queueReconcileForPod(ctx context.Context, object clien
 	}
 
 	log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(p))
-	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(5).Info("Queueing reconcile for pod")
 
 	q.Add(reconcileRequestForPod(p))

--- a/pkg/controller/jobs/pod/event_handlers.go
+++ b/pkg/controller/jobs/pod/event_handlers.go
@@ -1,0 +1,145 @@
+package pod
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+)
+
+var (
+	errWlOwnersNotFound = fmt.Errorf("unable to find any workload owners")
+)
+
+func reconcileRequestForPod(p *corev1.Pod) reconcile.Request {
+	groupName := p.GetLabels()[GroupNameLabel]
+
+	if groupName == "" {
+		return reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: p.Namespace,
+				Name:      p.Name,
+			},
+		}
+	}
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      groupName,
+			Namespace: fmt.Sprintf("group/%s", p.Namespace),
+		},
+	}
+}
+
+// podEventHandler will convert reconcile requests for pods in group from "<namespace>/<pod-name>" to
+// "group/<namespace>/<group-name>".
+type podEventHandler struct {
+	client client.Client
+}
+
+func (h *podEventHandler) Create(ctx context.Context, e event.CreateEvent, q workqueue.RateLimitingInterface) {
+	h.queueReconcileForPod(ctx, e.Object, q)
+}
+
+func (h *podEventHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	h.queueReconcileForPod(ctx, e.ObjectNew, q)
+}
+
+func (h *podEventHandler) Delete(ctx context.Context, e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	h.queueReconcileForPod(ctx, e.Object, q)
+}
+
+func (h *podEventHandler) Generic(ctx context.Context, e event.GenericEvent, q workqueue.RateLimitingInterface) {
+	h.queueReconcileForPod(ctx, e.Object, q)
+}
+
+func (h *podEventHandler) queueReconcileForPod(ctx context.Context, object client.Object, q workqueue.RateLimitingInterface) {
+	p, ok := object.(*corev1.Pod)
+	if !ok {
+		return
+	}
+
+	log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(p))
+	ctx = ctrl.LoggerInto(ctx, log)
+	log.V(5).Info("Queueing reconcile for pod")
+
+	q.Add(reconcileRequestForPod(p))
+}
+
+type parentWorkloadHandler struct {
+	client client.Client
+}
+
+func (h *parentWorkloadHandler) Create(ctx context.Context, e event.CreateEvent, q workqueue.RateLimitingInterface) {
+	h.queueReconcileForChildPod(ctx, e.Object, q)
+}
+
+func (h *parentWorkloadHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	h.queueReconcileForChildPod(ctx, e.ObjectNew, q)
+}
+
+func (h *parentWorkloadHandler) Delete(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface) {
+}
+
+func (h *parentWorkloadHandler) Generic(ctx context.Context, e event.GenericEvent, q workqueue.RateLimitingInterface) {
+}
+
+func (h *parentWorkloadHandler) queueReconcileForChildPod(ctx context.Context, object client.Object, q workqueue.RateLimitingInterface) {
+	w, ok := object.(*kueue.Workload)
+	if !ok {
+		return
+	}
+	log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(w))
+	ctx = ctrl.LoggerInto(ctx, log)
+
+	if len(w.ObjectMeta.OwnerReferences) == 0 {
+		return
+	}
+	log.V(5).Info("Queueing reconcile for parent pods")
+
+	for _, ownerRef := range w.ObjectMeta.OwnerReferences {
+		var parentPod corev1.Pod
+
+		err := h.client.Get(ctx, types.NamespacedName{Name: ownerRef.Name, Namespace: w.ObjectMeta.Namespace}, &parentPod)
+
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			log.Error(err, "Unable to get parent pod")
+			return
+		}
+
+		if groupName := fromObject(&parentPod).groupName(); groupName == "" {
+			log.V(5).Info("Queueing reconcile for the single pod", "pod", klog.KObj(&parentPod))
+			q.Add(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      parentPod.Name,
+					Namespace: w.Namespace,
+				},
+			})
+			return
+		} else {
+			log.V(5).Info("Queueing reconcile for the pod group", "groupName", groupName, "namespace", w.Namespace)
+			q.Add(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      groupName,
+					Namespace: fmt.Sprintf("group/%s", w.Namespace),
+				},
+			})
+			return
+		}
+
+	}
+
+	log.Error(errWlOwnersNotFound, "Unable to queue reconcile for workload parent pods")
+}

--- a/pkg/controller/jobs/pod/event_handlers.go
+++ b/pkg/controller/jobs/pod/event_handlers.go
@@ -134,6 +134,4 @@ func (h *parentWorkloadHandler) queueReconcileForChildPod(ctx context.Context, o
 			return
 		}
 	}
-
-	return
 }

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -1104,8 +1104,9 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(3).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", "b990493b").AssignmentPodCount(3).Obj()).
 					Admitted(true).
+					ReclaimablePods(kueue.ReclaimablePod{Name: "b990493b", Count: 1}).
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
@@ -1152,12 +1153,13 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(3).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", "b990493b").AssignmentPodCount(3).Obj()).
 					ReclaimablePods(kueue.ReclaimablePod{
 						Name:  "b990493b",
 						Count: 1,
 					}).
 					Admitted(true).
+					ReclaimablePods(kueue.ReclaimablePod{Name: "b990493b", Count: 1}).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -464,6 +464,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					Priority(0).
+					Annotations(map[string]string{"kueue.x-k8s.io/is-group-workload": "true"}).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -1450,6 +1451,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("b990493b", 2).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue("test-queue").
 					Priority(0).
+					Annotations(map[string]string{"kueue.x-k8s.io/is-group-workload": "true"}).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -1664,6 +1666,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					Priority(0).
+					Annotations(map[string]string{"kueue.x-k8s.io/is-group-workload": "true"}).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -1949,6 +1952,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					Priority(0).
+					Annotations(map[string]string{"kueue.x-k8s.io/is-group-workload": "true"}).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -2151,6 +2155,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					Priority(0).
+					Annotations(map[string]string{"kueue.x-k8s.io/is-group-workload": "true"}).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -186,7 +186,7 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 			pod.pod.Spec.SchedulingGates = append(pod.pod.Spec.SchedulingGates, corev1.PodSchedulingGate{Name: SchedulingGateName})
 		}
 
-		if pod.groupName() != "" {
+		if podGroupName(pod.pod) != "" {
 			if err := pod.addRoleHash(); err != nil {
 				return err
 			}
@@ -232,7 +232,7 @@ func (w *PodWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.
 
 	allErrs = append(allErrs, validateManagedLabel(newPod)...)
 
-	allErrs = append(allErrs, validation.ValidateImmutableField(newPod.groupName(), oldPod.groupName(), groupNameLabelPath)...)
+	allErrs = append(allErrs, validation.ValidateImmutableField(podGroupName(newPod.pod), podGroupName(oldPod.pod), groupNameLabelPath)...)
 
 	allErrs = append(allErrs, validatePodGroupMetadata(newPod)...)
 
@@ -274,7 +274,7 @@ func validatePodGroupMetadata(p *Pod) field.ErrorList {
 
 	gtc, gtcExists := p.pod.GetAnnotations()[GroupTotalCountAnnotation]
 
-	if p.groupName() == "" {
+	if podGroupName(p.pod) == "" {
 		if gtcExists {
 			return append(allErrs, field.Required(
 				groupNameLabelPath,
@@ -304,7 +304,7 @@ func validatePodGroupMetadata(p *Pod) field.ErrorList {
 }
 
 func validateUpdateForRetriableInGroupAnnotation(oldPod, newPod *Pod) field.ErrorList {
-	if newPod.groupName() != "" && isUnretriablePod(oldPod.pod) && !isUnretriablePod(newPod.pod) {
+	if podGroupName(newPod.pod) != "" && isUnretriablePod(oldPod.pod) && !isUnretriablePod(newPod.pod) {
 		return field.ErrorList{
 			field.Forbidden(retriableInGroupAnnotationPath, "unretriable pod group can't be converted to retriable"),
 		}

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -60,7 +60,7 @@ func init() {
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=resourceflavors,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloadpriorityclasses,verbs=get;list;watch
 
-var NewReconciler = jobframework.NewGenericReconciler(func() jobframework.GenericJob { return &RayJob{} }, nil)
+var NewReconciler = jobframework.NewGenericReconciler(func() jobframework.GenericJob { return &RayJob{} }, nil, nil)
 
 type RayJob rayjobapi.RayJob
 

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -226,6 +226,11 @@ func (w *WorkloadWrapper) OwnerReference(apiVersion, kind, name, uid string, con
 	return w
 }
 
+func (w *WorkloadWrapper) Annotations(kv map[string]string) *WorkloadWrapper {
+	w.ObjectMeta.Annotations = kv
+	return w
+}
+
 type PodSetWrapper struct{ kueue.PodSet }
 
 func MakePodSet(name string, count int) *PodSetWrapper {

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -539,7 +539,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
 
 					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod1LookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
-					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod2LookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod2LookupKey, nil)
 
 					gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 					gomega.Expect(createdWorkload.Status.Conditions).Should(gomega.BeComparableTo(
@@ -817,7 +817,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
 
 					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod1LookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
-					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod2LookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod2LookupKey, nil)
 
 					gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 					gomega.Expect(createdWorkload.Status.Conditions).Should(gomega.BeComparableTo(
@@ -835,13 +835,13 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					gomega.Consistently(func(g gomega.Gomega) []string {
 						g.Expect(k8sClient.Get(ctx, pod1LookupKey, createdPod)).To(gomega.Succeed())
 						return createdPod.Finalizers
-					}, util.Timeout, util.Interval).Should(gomega.ContainElement("kueue.x-k8s.io/managed"),
+					}, util.ConsistentDuration, util.Interval).Should(gomega.ContainElement("kueue.x-k8s.io/managed"),
 						"Pod should have finalizer")
 
 					gomega.Consistently(func(g gomega.Gomega) []string {
 						g.Expect(k8sClient.Get(ctx, pod2LookupKey, createdPod)).To(gomega.Succeed())
 						return createdPod.Finalizers
-					}, util.Timeout, util.Interval).Should(gomega.ContainElement("kueue.x-k8s.io/managed"),
+					}, util.ConsistentDuration, util.Interval).Should(gomega.ContainElement("kueue.x-k8s.io/managed"),
 						"Pod should have finalizer")
 				})
 
@@ -857,7 +857,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				replacementPod2LookupKey := client.ObjectKeyFromObject(replacementPod2)
 
 				ginkgo.By("checking that unretriable replacement pod is allowed to run", func() {
-					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, replacementPod2LookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, replacementPod2LookupKey, nil)
 				})
 
 				ginkgo.By("checking that pod group is finalized when unretriable pod has failed", func() {
@@ -944,7 +944,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
 
 					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod1LookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
-					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod2LookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, pod2LookupKey, nil)
 
 					gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 					gomega.Expect(createdWorkload.Status.Conditions).Should(gomega.BeComparableTo(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

* Add new method Run for the ComposableJob interface. Same as RunWithPodSetsInfo, but unsuspends all members of the composable job.

* And new job event handler for the generic reconciler.

* Implement Run for the pod groups.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related issue: #976

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```