### PR TITLE
Verbose logging of cache and queues

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -54,6 +54,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/noop"
+	"sigs.k8s.io/kueue/pkg/debugger"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/queue"
@@ -160,6 +161,7 @@ func main() {
 		setupLog.Error(err, "Unable to setup indexes")
 		os.Exit(1)
 	}
+	debugger.NewDumper(cCache, queues).ListenForSignal(ctx)
 
 	serverVersionFetcher := setupServerVersionFetcher(mgr, kubeConfig)
 

--- a/pkg/debugger/debugger.go
+++ b/pkg/debugger/debugger.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debugger
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/queue"
+)
+
+type Dumper struct {
+	cache  *cache.Cache
+	queues *queue.Manager
+}
+
+func NewDumper(c *cache.Cache, q *queue.Manager) *Dumper {
+	return &Dumper{cache: c, queues: q}
+}
+
+// ListenForSignal starts a goroutine that will trigger the Dumper's
+// behavior when the process receives SIGUSR2.
+func (d *Dumper) ListenForSignal(ctx context.Context) {
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, syscall.SIGUSR2)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-signalCh:
+				d.DumpAll(ctx)
+			}
+		}
+	}()
+}
+
+func (d *Dumper) DumpAll(ctx context.Context) {
+	log := ctrl.LoggerFrom(ctx).WithName("dumper")
+	log.Info("Started dump")
+	snap := d.cache.Snapshot()
+	snap.Log(log)
+	d.queues.LogDump(log)
+	log.Info("Ended dump")
+}

--- a/pkg/queue/cluster_queue_impl.go
+++ b/pkg/queue/cluster_queue_impl.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -221,29 +220,29 @@ func (c *clusterQueueBase) Pop() *workload.Info {
 	return info.(*workload.Info)
 }
 
-func (c *clusterQueueBase) Dump() (sets.Set[string], bool) {
+func (c *clusterQueueBase) Dump() ([]string, bool) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
 	if c.heap.Len() == 0 {
 		return nil, false
 	}
-	elements := make(sets.Set[string], c.heap.Len())
-	for _, e := range c.heap.List() {
+	elements := make([]string, c.heap.Len())
+	for i, e := range c.heap.List() {
 		info := e.(*workload.Info)
-		elements.Insert(workload.Key(info.Obj))
+		elements[i] = workload.Key(info.Obj)
 	}
 	return elements, true
 }
 
-func (c *clusterQueueBase) DumpInadmissible() (sets.Set[string], bool) {
+func (c *clusterQueueBase) DumpInadmissible() ([]string, bool) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
 	if len(c.inadmissibleWorkloads) == 0 {
 		return nil, false
 	}
-	elements := make(sets.Set[string], len(c.inadmissibleWorkloads))
+	elements := make([]string, 0, len(c.inadmissibleWorkloads))
 	for _, info := range c.inadmissibleWorkloads {
-		elements.Insert(workload.Key(info.Obj))
+		elements = append(elements, workload.Key(info.Obj))
 	}
 	return elements, true
 }

--- a/pkg/queue/cluster_queue_interface.go
+++ b/pkg/queue/cluster_queue_interface.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -90,8 +89,8 @@ type ClusterQueue interface {
 	// Dump produces a dump of the current workloads in the heap of
 	// this ClusterQueue. It returns false if the queue is empty,
 	// otherwise returns true.
-	Dump() (sets.Set[string], bool)
-	DumpInadmissible() (sets.Set[string], bool)
+	Dump() ([]string, bool)
+	DumpInadmissible() ([]string, bool)
 	// Snapshot returns a copy of the current workloads in the heap of
 	// this ClusterQueue.
 	Snapshot() []*workload.Info

--- a/pkg/queue/dumper.go
+++ b/pkg/queue/dumper.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"github.com/go-logr/logr"
+	"k8s.io/klog/v2"
+)
+
+// LogDump dumps the pending and inadmissible workloads for each ClusterQueue into the log,
+// one line per ClusterQueue.
+func (m *Manager) LogDump(log logr.Logger) {
+	m.Lock()
+	defer m.Unlock()
+	for name, cq := range m.clusterQueues {
+		pending, _ := cq.Dump()
+		inadmissible, _ := cq.DumpInadmissible()
+		log.Info("Found pending and inadmissible workloads in ClusterQueue",
+			"clusterQueue", klog.KRef("", name),
+			"pending", pending,
+			"inadmissible", inadmissible)
+	}
+}
+
+// Dump is a dump of the queues and it's elements (unordered).
+// Only use for testing purposes.
+func (m *Manager) Dump() map[string][]string {
+	m.Lock()
+	defer m.Unlock()
+	if len(m.clusterQueues) == 0 {
+		return nil
+	}
+	dump := make(map[string][]string, len(m.clusterQueues))
+	for key, cq := range m.clusterQueues {
+		if elements, ok := cq.Dump(); ok {
+			dump[key] = elements
+		}
+	}
+	if len(dump) == 0 {
+		return nil
+	}
+	return dump
+}
+
+// DumpInadmissible is a dump of the inadmissible workloads list.
+// Only use for testing purposes.
+func (m *Manager) DumpInadmissible() map[string][]string {
+	m.Lock()
+	defer m.Unlock()
+	if len(m.clusterQueues) == 0 {
+		return nil
+	}
+	dump := make(map[string][]string, len(m.clusterQueues))
+	for key, cq := range m.clusterQueues {
+		if elements, ok := cq.DumpInadmissible(); ok {
+			dump[key] = elements
+		}
+	}
+	if len(dump) == 0 {
+		return nil
+	}
+	return dump
+}

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -457,46 +457,6 @@ func (m *Manager) Heads(ctx context.Context) []workload.Info {
 	}
 }
 
-// Dump is a dump of the queues and it's elements (unordered).
-// Only use for testing purposes.
-func (m *Manager) Dump() map[string]sets.Set[string] {
-	m.Lock()
-	defer m.Unlock()
-	if len(m.clusterQueues) == 0 {
-		return nil
-	}
-	dump := make(map[string]sets.Set[string], len(m.clusterQueues))
-	for key, cq := range m.clusterQueues {
-		if elements, ok := cq.Dump(); ok {
-			dump[key] = elements
-		}
-	}
-	if len(dump) == 0 {
-		return nil
-	}
-	return dump
-}
-
-// DumpInadmissible is a dump of the inadmissible workloads list.
-// Only use for testing purposes.
-func (m *Manager) DumpInadmissible() map[string]sets.Set[string] {
-	m.Lock()
-	defer m.Unlock()
-	if len(m.clusterQueues) == 0 {
-		return nil
-	}
-	dump := make(map[string]sets.Set[string], len(m.clusterQueues))
-	for key, cq := range m.clusterQueues {
-		if elements, ok := cq.DumpInadmissible(); ok {
-			dump[key] = elements
-		}
-	}
-	if len(dump) == 0 {
-		return nil
-	}
-	return dump
-}
-
 func (m *Manager) heads() []workload.Info {
 	var workloads []workload.Info
 	for cqName, cq := range m.clusterQueues {

--- a/pkg/scheduler/logging.go
+++ b/pkg/scheduler/logging.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"github.com/go-logr/logr"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/kueue/pkg/cache"
+)
+
+func logAdmissionAttemptIfVerbose(log logr.Logger, e *entry) {
+	logV := log.V(3)
+	if !logV.Enabled() {
+		return
+	}
+	args := []any{
+		"workload", klog.KObj(e.Obj),
+		"clusterQueue", klog.KRef("", e.ClusterQueue),
+		"status", e.status,
+		"reason", e.inadmissibleMsg,
+	}
+	if log.V(6).Enabled() {
+		args = append(args, "nominatedAssignment", e.assignment)
+	}
+	logV.Info("Workload evaluated for admission", args...)
+}
+
+func logSnapshotIfVerbose(log logr.Logger, s *cache.Snapshot) {
+	if logV := log.V(6); logV.Enabled() {
+		s.Log(logV)
+	}
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -167,6 +167,7 @@ func (s *Scheduler) schedule(ctx context.Context) {
 
 	// 2. Take a snapshot of the cache.
 	snapshot := s.cache.Snapshot()
+	logSnapshotIfVerbose(log, &snapshot)
 
 	// 3. Calculate requirements (resource flavors, borrowing) for admitting workloads.
 	entries := s.nominate(ctx, headWorkloads, snapshot)
@@ -245,11 +246,7 @@ func (s *Scheduler) schedule(ctx context.Context) {
 	// 6. Requeue the heads that were not scheduled.
 	result := metrics.AdmissionResultInadmissible
 	for _, e := range entries {
-		log.V(3).Info("Workload evaluated for admission",
-			"workload", klog.KObj(e.Obj),
-			"clusterQueue", klog.KRef("", e.ClusterQueue),
-			"status", e.status,
-			"reason", e.inadmissibleMsg)
+		logAdmissionAttemptIfVerbose(log, &e)
 		if e.status != assumed {
 			s.requeueAndUpdate(log, ctx, e)
 		} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Produces a dump of the cache into the logs at log level 5.

A dump of the cache and queues can be logged on demand using SIGUSR2, regardless of the log level.

Refactored some existing dump methods used for testing to use slices for better performance and simpler formatting.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1438 #1437

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
At log level 6, the usage of ClusterQueues and cohorts is included in logs.

The status of the internal cache and queues is also logged on demand when a SIGUSR2 is sent to kueue, regardless of the log level.
```