### PR TITLE
Debug image and cache dump script

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,6 +13,15 @@ steps:
       - GIT_TAG=$_GIT_TAG
       - EXTRA_TAG=$_PULL_BASE_REF
       - DOCKER_BUILDX_CMD=/buildx-entrypoint
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221214-1b4dd4d69a'
+    entrypoint: make
+    args:
+      - debug-image-push
+    env:
+      - IMAGE_REGISTRY=gcr.io/$PROJECT_ID
+      - GIT_TAG=$_GIT_TAG
+      - EXTRA_TAG=$_PULL_BASE_REF
+      - DOCKER_BUILDX_CMD=/buildx-entrypoint
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution

--- a/hack/debugpod/Dockerfile
+++ b/hack/debugpod/Dockerfile
@@ -1,0 +1,2 @@
+FROM debian:stable
+USER 65532:65532

--- a/hack/dump_cache.sh
+++ b/hack/dump_cache.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script sends a USR2 signal to a running kueue binary in the kueue-system namespace
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAMESPACE=${NAMESPACE:-kueue-system}
+LEASE_NAME=${LEASE_NAME:-c1f6bfd2.kueue.x-k8s.io}
+DEBUG_IMAGE=${DEBUG_IMAGE:-gcr.io/k8s-staging-kueue/debug:main}
+
+leader=$(kubectl get lease -n ${NAMESPACE} ${LEASE_NAME} -o jsonpath='{.spec.holderIdentity}' | cut -d '_' -f 1)
+
+# When the FOLLOW environment variable is set, output the logs.
+if [ -v FOLLOW ]; then
+    kubectl logs -n ${NAMESPACE} ${leader} -f --tail=1 &
+fi
+
+kubectl debug -n ${NAMESPACE} ${leader} --image=${DEBUG_IMAGE} --target=manager --profile=restricted --image-pull-policy=IfNotPresent -- sh -c 'kill -USR2 1'


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Configuration to build a debug image in the pipeline.
- A script to produce a dump of the cache into the kueue Pod logs

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fix #1437

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The image gcr.io/k8s-staging-kueue/debug:main, along with the script ./hack/dump_cache.sh can be used to trigger a dump of the internal cache into the logs.
```