### PR TITLE
Fix flaky test: add a dedicated finalizer to verify the pod's status after the workload is evicted

### DIFF
--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -26,9 +26,11 @@ import (
 	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
@@ -235,80 +237,98 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				}, util.Timeout, util.Interval).Should(testing.BeNotFoundError())
 			})
 
-			ginkgo.It("Should stop the single pod with the queue name if workload is evicted", func() {
-				ginkgo.By("Creating a pod with queue name")
-				pod := testingpod.MakePod(podName, ns.Name).Queue("test-queue").Obj()
-				gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
+			ginkgo.When("A workload is evicted", func() {
+				const finalizerName = "kueue.x-k8s.io/integration-test"
+				var pod *corev1.Pod
 
-				createdPod := &corev1.Pod{}
-				gomega.Eventually(func() error {
-					return k8sClient.Get(ctx, lookupKey, createdPod)
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				ginkgo.BeforeEach(func() {
+					// A pod must have a dedicated finalizer since we need to verify the pod status
+					// after a workload is evicted.
+					pod = testingpod.MakePod(podName, ns.Name).Queue("test-queue").Finalizer(finalizerName).Obj()
+					ginkgo.By("Creating a pod with queue name")
+					gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
+				})
+				ginkgo.AfterEach(func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, lookupKey, pod)).Should(gomega.Succeed())
+						controllerutil.RemoveFinalizer(pod, finalizerName)
+						g.Expect(k8sClient.Update(ctx, pod)).Should(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					gomega.Eventually(func() bool {
+						return apierrors.IsNotFound(k8sClient.Get(ctx, lookupKey, &corev1.Pod{}))
+					}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+				})
 
-				ginkgo.By("checking that workload is created for pod with the queue name")
-				createdWorkload := &kueue.Workload{}
-				gomega.Eventually(func() error {
-					return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				ginkgo.It("Should stop the single pod with the queue name", func() {
+					createdPod := &corev1.Pod{}
+					gomega.Eventually(func() error {
+						return k8sClient.Get(ctx, lookupKey, createdPod)
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(1))
+					ginkgo.By("checking that workload is created for pod with the queue name")
+					createdWorkload := &kueue.Workload{}
+					gomega.Eventually(func() error {
+						return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
+					gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(1))
 
-				ginkgo.By("checking that pod is unsuspended when workload is admitted")
-				clusterQueue := testing.MakeClusterQueue("cluster-queue").
-					ResourceGroup(
-						*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
-					).Obj()
-				admission := testing.MakeAdmission(clusterQueue.Name).
-					Assignment(corev1.ResourceCPU, "default", "1").
-					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
-					Obj()
-				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
-				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+					gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
 
-				util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, lookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
+					ginkgo.By("checking that pod is unsuspended when workload is admitted")
+					clusterQueue := testing.MakeClusterQueue("cluster-queue").
+						ResourceGroup(
+							*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
+						).Obj()
+					admission := testing.MakeAdmission(clusterQueue.Name).
+						Assignment(corev1.ResourceCPU, "default", "1").
+						AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+						Obj()
+					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
+					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
 
-				gomega.Eventually(func(g gomega.Gomega) {
-					ok, err := testing.CheckLatestEvent(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name))
-					g.Expect(err).NotTo(gomega.HaveOccurred())
-					g.Expect(ok).To(gomega.BeTrue())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, lookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
 
-				gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-				gomega.Expect(createdWorkload.Status.Conditions).Should(gomega.BeComparableTo(
-					[]metav1.Condition{
-						{Type: kueue.WorkloadQuotaReserved, Status: metav1.ConditionTrue},
-						{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue},
-					},
-					wlConditionCmpOpts...,
-				))
+					gomega.Eventually(func(g gomega.Gomega) {
+						ok, err := testing.CheckLatestEvent(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name))
+						g.Expect(err).NotTo(gomega.HaveOccurred())
+						g.Expect(ok).To(gomega.BeTrue())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-				ginkgo.By("checking that pod is stopped when workload is evicted")
-
-				gomega.Expect(
-					workload.UpdateStatus(ctx, k8sClient, createdWorkload, kueue.WorkloadEvicted, metav1.ConditionTrue,
-						kueue.WorkloadEvictedByPreemption, "By test", "evict"),
-				).Should(gomega.Succeed())
-				util.FinishEvictionForWorkloads(ctx, k8sClient, createdWorkload)
-
-				gomega.Eventually(func(g gomega.Gomega) bool {
-					g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).To(gomega.Succeed())
-					return createdPod.DeletionTimestamp.IsZero()
-				}, util.Timeout, util.Interval).Should(gomega.BeFalse(), "Expected pod to be deleted")
-
-				gomega.Expect(createdPod.Status.Conditions).Should(gomega.ContainElement(
-					gomega.BeComparableTo(
-						corev1.PodCondition{
-							Type:    "TerminationTarget",
-							Status:  "True",
-							Reason:  "StoppedByKueue",
-							Message: "By test",
+					gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					gomega.Expect(createdWorkload.Status.Conditions).Should(gomega.BeComparableTo(
+						[]metav1.Condition{
+							{Type: kueue.WorkloadQuotaReserved, Status: metav1.ConditionTrue},
+							{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue},
 						},
-						cmpopts.IgnoreFields(corev1.PodCondition{}, "LastTransitionTime"),
-					),
-				))
+						wlConditionCmpOpts...,
+					))
 
+					ginkgo.By("checking that pod is stopped when workload is evicted")
+
+					gomega.Expect(
+						workload.UpdateStatus(ctx, k8sClient, createdWorkload, kueue.WorkloadEvicted, metav1.ConditionTrue,
+							kueue.WorkloadEvictedByPreemption, "By test", "evict"),
+					).Should(gomega.Succeed())
+					util.FinishEvictionForWorkloads(ctx, k8sClient, createdWorkload)
+
+					gomega.Eventually(func(g gomega.Gomega) bool {
+						g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).To(gomega.Succeed())
+						return createdPod.DeletionTimestamp.IsZero()
+					}, util.Timeout, util.Interval).Should(gomega.BeFalse(), "Expected pod to be deleted")
+
+					gomega.Expect(createdPod.Status.Conditions).Should(gomega.ContainElement(
+						gomega.BeComparableTo(
+							corev1.PodCondition{
+								Type:    "TerminationTarget",
+								Status:  "True",
+								Reason:  "StoppedByKueue",
+								Message: "By test",
+							},
+							cmpopts.IgnoreFields(corev1.PodCondition{}, "LastTransitionTime"),
+						),
+					))
+				})
 			})
 
 			ginkgo.When("Pod owner is managed by Kueue", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:
I added a dedicated finalizer to verify if the pod has an expected eviction status after the workload is evicted.

Please see the root cause: https://github.com/kubernetes-sigs/kueue/issues/1501#issuecomment-1878114456

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1501

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```