### PR TITLE
Fix preemption within cohort when there is no borrowingLimit

### DIFF
--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -361,20 +361,26 @@ func workloadFits(wlReq cache.FlavorResourceQuantities, cq *cache.ClusterQueue, 
 				cohortResRequestable = cq.Cohort.RequestableResources[flvQuotas.Name]
 			}
 			for rName, rReq := range flvReq {
-				limit := flvQuotas.Resources[rName].Nominal
+				resource := flvQuotas.Resources[rName]
 
-				// No need to check whether cohort is nil here because when borrowingLimit
-				// is non nil, cohort is always non nil.
-				if allowBorrowing && flvQuotas.Resources[rName].BorrowingLimit != nil {
-					limit += *flvQuotas.Resources[rName].BorrowingLimit
+				if cq.Cohort != nil {
+					if allowBorrowing {
+						// When resource.BorrowingLimit == nil there is no borrowing
+						// limit, so we can skip the check.
+						if resource.BorrowingLimit != nil {
+							if cqResUsage[rName]+rReq > resource.Nominal+*resource.BorrowingLimit {
+								return false
+							}
+						}
+					}
+					if cohortResUsage[rName]+rReq > cohortResRequestable[rName] {
+						return false
+					}
 				}
-
-				if cqResUsage[rName]+rReq > limit {
-					return false
-				}
-
-				if cq.Cohort != nil && cohortResUsage[rName]+rReq > cohortResRequestable[rName] {
-					return false
+				if cq.Cohort == nil || !allowBorrowing {
+					if cqResUsage[rName]+rReq > resource.Nominal {
+						return false
+					}
 				}
 			}
 		}

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -363,24 +363,21 @@ func workloadFits(wlReq cache.FlavorResourceQuantities, cq *cache.ClusterQueue, 
 			for rName, rReq := range flvReq {
 				resource := flvQuotas.Resources[rName]
 
-				if cq.Cohort != nil {
-					if allowBorrowing {
-						// When resource.BorrowingLimit == nil there is no borrowing
-						// limit, so we can skip the check.
-						if resource.BorrowingLimit != nil {
-							if cqResUsage[rName]+rReq > resource.Nominal+*resource.BorrowingLimit {
-								return false
-							}
-						}
-					}
-					if cohortResUsage[rName]+rReq > cohortResRequestable[rName] {
-						return false
-					}
-				}
 				if cq.Cohort == nil || !allowBorrowing {
 					if cqResUsage[rName]+rReq > resource.Nominal {
 						return false
 					}
+				} else {
+					// When resource.BorrowingLimit == nil there is no borrowing
+					// limit, so we can skip the check.
+					if resource.BorrowingLimit != nil {
+						if cqResUsage[rName]+rReq > resource.Nominal+*resource.BorrowingLimit {
+							return false
+						}
+					}
+				}
+				if cq.Cohort != nil && cohortResUsage[rName]+rReq > cohortResRequestable[rName] {
+					return false
 				}
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

To fix handling of preemption within a cohort when there is no borrowingLimit. In that case
during preemption the available resources coming from borrowing were calculated as if borrowingLimit=0.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix handling of preemption within a cohort when there is no borrowingLimit. In that case,
during preemption, the permitted resources to borrow were calculated as if borrowingLimit=0, instead of unlimited.

As a consequence, when using `reclaimWithinCohort`, it was possible that a workload, scheduled to ClusterQueue with no borrowingLimit, would preempt more workloads than needed, even though it could fit by borrowing.
```