### PR TITLE
Trigger the workloads eviction on admission check rejection.

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -149,7 +149,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 
-	// If the workload is admitted, updating the status here will set the Admitted condition to
+	// If the workload is admitted, updating the status here would set the Admitted condition to
 	// false before the workloads eviction.
 	if !workload.IsAdmitted(&wl) && workload.SyncAdmittedCondition(&wl) {
 		if err := workload.ApplyAdmissionStatus(ctx, r.client, &wl, true); err != nil {

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -144,27 +144,27 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	// If the workload has rejected admission checks and is not admitted mark it as finished.
 	// If it has rejected admission checks and is admitted, continue the reconcile in  order to trigger its eviction.
-	if rejectedChecks := workload.GetRejectedChecks(&wl); len(rejectedChecks) > 0 && !workload.IsAdmitted(&wl) {
-		log.V(3).Info("Workload has Rejected admission checks, Finish with failure")
-		err := workload.UpdateStatus(ctx, r.client, &wl, kueue.WorkloadFinished,
-			metav1.ConditionTrue,
-			"AdmissionChecksRejected",
-			fmt.Sprintf("Admission checks %v are rejected", rejectedChecks),
-			constants.KueueName)
-
-		if err == nil {
-			for _, owner := range wl.OwnerReferences {
-				uowner := unstructured.Unstructured{}
-				uowner.SetKind(owner.Kind)
-				uowner.SetAPIVersion(owner.APIVersion)
-				uowner.SetName(owner.Name)
-				uowner.SetNamespace(wl.Namespace)
-				uowner.SetUID(owner.UID)
-				r.recorder.Eventf(&uowner, corev1.EventTypeNormal, "WorkloadFinished", "Admission checks %v are rejected", rejectedChecks)
+	if !workload.IsAdmitted(&wl) && (!apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted) || !workload.HasQuotaReservation(&wl)) {
+		if rejectedChecks := workload.GetRejectedChecks(&wl); len(rejectedChecks) > 0 {
+			log.V(3).Info("Workload has Rejected admission checks, Finish with failure")
+			err := workload.UpdateStatus(ctx, r.client, &wl, kueue.WorkloadFinished,
+				metav1.ConditionTrue,
+				"AdmissionChecksRejected",
+				fmt.Sprintf("Admission checks %v are rejected", rejectedChecks),
+				constants.KueueName)
+			if err == nil {
+				for _, owner := range wl.OwnerReferences {
+					uowner := unstructured.Unstructured{}
+					uowner.SetKind(owner.Kind)
+					uowner.SetAPIVersion(owner.APIVersion)
+					uowner.SetName(owner.Name)
+					uowner.SetNamespace(wl.Namespace)
+					uowner.SetUID(owner.UID)
+					r.recorder.Eventf(&uowner, corev1.EventTypeNormal, "WorkloadFinished", "Admission checks %v are rejected", rejectedChecks)
+				}
 			}
+			return ctrl.Result{}, err
 		}
-
-		return ctrl.Result{}, err
 	}
 
 	cqName, cqOk := r.queues.ClusterQueueForWorkload(&wl)
@@ -175,22 +175,22 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	if workload.SyncAdmittedCondition(&wl) {
-		if err := workload.ApplyAdmissionStatus(ctx, r.client, &wl, true); err != nil {
-			return ctrl.Result{}, err
-		}
-		if workload.IsAdmitted(&wl) {
+		//If it used to be admitted, don't update the status, trigger the eviction first
+		if !workload.IsAdmitted(&wl) {
+			if evictionTriggered, err := r.reconcileCheckBasedEviction(ctx, &wl); evictionTriggered || err != nil {
+				return ctrl.Result{}, err
+			}
+		} else {
+			if err := workload.ApplyAdmissionStatus(ctx, r.client, &wl, true); err != nil {
+				return ctrl.Result{}, err
+			}
 			c := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
 			r.recorder.Eventf(&wl, corev1.EventTypeNormal, "Admitted", "Admitted by ClusterQueue %v, wait time since reservation was %.0fs", wl.Status.Admission.ClusterQueue, time.Since(c.LastTransitionTime.Time).Seconds())
-
 		}
 		return ctrl.Result{}, nil
 	}
 
 	if workload.HasQuotaReservation(&wl) {
-		if evictionTriggered, err := r.reconcileCheckBasedEviction(ctx, &wl); evictionTriggered || err != nil {
-			return ctrl.Result{}, err
-		}
-
 		if updated, err := r.reconcileOnClusterQueueActiveState(ctx, &wl, cqName); updated || err != nil {
 			return ctrl.Result{}, err
 		}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -142,8 +142,9 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 	}
 
-	if rejectedChecks := workload.GetRejectedChecks(&wl); len(rejectedChecks) > 0 {
-		// Finish the workload
+	// If the workload has rejected admission checks and is not admitted mark it as finished.
+	// If it has rejected admission checks and is admitted, continue the reconcile in  order to trigger its eviction.
+	if rejectedChecks := workload.GetRejectedChecks(&wl); len(rejectedChecks) > 0 && !workload.IsAdmitted(&wl) {
 		log.V(3).Info("Workload has Rejected admission checks, Finish with failure")
 		err := workload.UpdateStatus(ctx, r.client, &wl, kueue.WorkloadFinished,
 			metav1.ConditionTrue,

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -310,6 +310,7 @@ func UnsetQuotaReservationWithCondition(wl *kueue.Workload, reason, message stri
 	}
 	apimeta.SetStatusCondition(&wl.Status.Conditions, condition)
 	wl.Status.Admission = nil
+	_ = SyncAdmittedCondition(wl)
 }
 
 // BaseSSAWorkload creates a new object based on the input workload that

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -310,6 +310,8 @@ func UnsetQuotaReservationWithCondition(wl *kueue.Workload, reason, message stri
 	}
 	apimeta.SetStatusCondition(&wl.Status.Conditions, condition)
 	wl.Status.Admission = nil
+
+	// Reset the admitted condition if necessary.
 	_ = SyncAdmittedCondition(wl)
 }
 

--- a/test/integration/controller/core/workload_controller_test.go
+++ b/test/integration/controller/core/workload_controller_test.go
@@ -150,11 +150,24 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Ordered, ginkgo.ContinueOn
 	})
 
 	ginkgo.When("the queue has admission checks", func() {
-		var flavor *kueue.ResourceFlavor
+		var (
+			flavor *kueue.ResourceFlavor
+			check1 *kueue.AdmissionCheck
+			check2 *kueue.AdmissionCheck
+		)
 
 		ginkgo.BeforeEach(func() {
 			flavor = testing.MakeResourceFlavor(flavorOnDemand).Obj()
 			gomega.Expect(k8sClient.Create(ctx, flavor)).Should(gomega.Succeed())
+
+			check1 = testing.MakeAdmissionCheck("check1").ControllerName("ctrl").Obj()
+			gomega.Expect(k8sClient.Create(ctx, check1)).Should(gomega.Succeed())
+			util.SetAdmissionCheckActive(ctx, k8sClient, check1, metav1.ConditionTrue)
+
+			check2 = testing.MakeAdmissionCheck("check2").ControllerName("ctrl").Obj()
+			gomega.Expect(k8sClient.Create(ctx, check2)).Should(gomega.Succeed())
+			util.SetAdmissionCheckActive(ctx, k8sClient, check2, metav1.ConditionTrue)
+
 			clusterQueue = testing.MakeClusterQueue("cluster-queue").
 				ResourceGroup(*testing.MakeFlavorQuotas(flavorOnDemand).
 					Resource(resourceGPU, "5", "5").Obj()).
@@ -168,6 +181,8 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Ordered, ginkgo.ContinueOn
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectAdmissionCheckToBeDeleted(ctx, k8sClient, check2, true)
+			util.ExpectAdmissionCheckToBeDeleted(ctx, k8sClient, check1, true)
 			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, flavor, true)
 		})
 
@@ -224,7 +239,7 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Ordered, ginkgo.ContinueOn
 				gomega.Expect(check2Cond).To(gomega.Equal(oldCheck2Cond))
 			})
 		})
-		ginkgo.It("should finish the workload with failure when a check is rejected", func() {
+		ginkgo.It("should finish an unadmitted workload with failure when a check is rejected", func() {
 			wl := testing.MakeWorkload("wl", ns.Name).Queue("queue").Obj()
 			wlKey := client.ObjectKeyFromObject(wl)
 			createdWl := kueue.Workload{}
@@ -250,6 +265,87 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Ordered, ginkgo.ContinueOn
 			})
 
 			ginkgo.By("checking the finish condition", func() {
+				gomega.Eventually(func() *metav1.Condition {
+					gomega.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					return apimeta.FindStatusCondition(createdWl.Status.Conditions, kueue.WorkloadFinished)
+				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(&metav1.Condition{
+					Type:    kueue.WorkloadFinished,
+					Status:  metav1.ConditionTrue,
+					Reason:  "AdmissionChecksRejected",
+					Message: "Admission checks [check1] are rejected",
+				}, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")))
+			})
+		})
+
+		ginkgo.It("should evict then finish with failure an admitted workload when a check is rejected", func() {
+			wl := testing.MakeWorkload("wl", ns.Name).Queue("queue").Obj()
+			wlKey := client.ObjectKeyFromObject(wl)
+			createdWl := kueue.Workload{}
+			ginkgo.By("creating the workload, the check conditions should be added", func() {
+				gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+				gomega.Eventually(func() []string {
+					gomega.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					return slices.Map(createdWl.Status.AdmissionChecks, func(c *kueue.AdmissionCheckState) string { return c.Name })
+				}, util.Timeout, util.Interval).Should(gomega.ConsistOf("check1", "check2"))
+			})
+
+			ginkgo.By("setting quota reservation and the checks ready, should admit the workload", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					g.Expect(util.SetQuotaReservation(ctx, k8sClient, &createdWl, testing.MakeAdmission(clusterQueue.Name).Obj())).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Eventually(func() error {
+					gomega.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					workload.SetAdmissionCheckState(&createdWl.Status.AdmissionChecks, kueue.AdmissionCheckState{
+						Name:    "check1",
+						State:   kueue.CheckStateReady,
+						Message: "check ready",
+					})
+					workload.SetAdmissionCheckState(&createdWl.Status.AdmissionChecks, kueue.AdmissionCheckState{
+						Name:    "check2",
+						State:   kueue.CheckStateReady,
+						Message: "check ready",
+					})
+					return k8sClient.Status().Update(ctx, &createdWl)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					g.Expect(createdWl.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
+						Type:    kueue.WorkloadAdmitted,
+						Status:  metav1.ConditionTrue,
+						Reason:  "Admitted",
+						Message: "The workload is admitted",
+					}, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"))))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("setting a rejected check conditions the workload should be evicted", func() {
+				gomega.Eventually(func() error {
+					gomega.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					workload.SetAdmissionCheckState(&createdWl.Status.AdmissionChecks, kueue.AdmissionCheckState{
+						Name:    "check1",
+						State:   kueue.CheckStateRejected,
+						Message: "check rejected",
+					})
+					return k8sClient.Status().Update(ctx, &createdWl)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					g.Expect(createdWl.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
+						Type:    kueue.WorkloadEvicted,
+						Status:  metav1.ConditionTrue,
+						Reason:  "AdmissionCheck",
+						Message: "At least one admission check is false",
+					}, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"))))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("finishing the eviction the finish condition should be set", func() {
+				util.FinishEvictionForWorkloads(ctx, k8sClient, &createdWl)
 				gomega.Eventually(func() *metav1.Condition {
 					gomega.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
 					return apimeta.FindStatusCondition(createdWl.Status.Conditions, kueue.WorkloadFinished)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Allow the workload reconciler to trigger the eviction of a workload that has `Rejected` admission checks and is `Admitted`, before making it as `Finished`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Trigger an eviction for an admitted Job after an admission check changed state to Rejected.
```