### PR TITLE
Automated cherry pick of #1561: Fix the borrowing while preemption when no borrowingLimit

### DIFF
--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -335,24 +335,21 @@ func workloadFits(wlReq cache.FlavorResourceQuantities, cq *cache.ClusterQueue, 
 			for rName, rReq := range flvReq {
 				resource := flvQuotas.Resources[rName]
 
-				if cq.Cohort != nil {
-					if allowBorrowing {
-						// When resource.BorrowingLimit == nil there is no borrowing
-						// limit, so we can skip the check.
-						if resource.BorrowingLimit != nil {
-							if cqResUsage[rName]+rReq > resource.Nominal+*resource.BorrowingLimit {
-								return false
-							}
-						}
-					}
-					if cohortResUsage[rName]+rReq > cohortResRequestable[rName] {
-						return false
-					}
-				}
 				if cq.Cohort == nil || !allowBorrowing {
 					if cqResUsage[rName]+rReq > resource.Nominal {
 						return false
 					}
+				} else {
+					// When resource.BorrowingLimit == nil there is no borrowing
+					// limit, so we can skip the check.
+					if resource.BorrowingLimit != nil {
+						if cqResUsage[rName]+rReq > resource.Nominal+*resource.BorrowingLimit {
+							return false
+						}
+					}
+				}
+				if cq.Cohort != nil && cohortResUsage[rName]+rReq > cohortResRequestable[rName] {
+					return false
 				}
 			}
 		}

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -101,6 +101,30 @@ func TestPreemption(t *testing.T) {
 				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
 			}).
 			Obj(),
+		utiltesting.MakeClusterQueue("d1").
+			Cohort("cohort-no-limits").
+			ResourceGroup(*utiltesting.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "6").
+				Resource(corev1.ResourceMemory, "3Gi").
+				Obj(),
+			).
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
+			}).
+			Obj(),
+		utiltesting.MakeClusterQueue("d2").
+			Cohort("cohort-no-limits").
+			ResourceGroup(*utiltesting.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "6").
+				Resource(corev1.ResourceMemory, "3Gi").
+				Obj(),
+			).
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue:  kueue.PreemptionPolicyNever,
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+			}).
+			Obj(),
 		utiltesting.MakeClusterQueue("l1").
 			Cohort("legion").
 			ResourceGroup(*utiltesting.MakeFlavorQuotas("default").
@@ -484,6 +508,37 @@ func TestPreemption(t *testing.T) {
 				},
 			}),
 			wantPreempted: sets.New("/c1-low"),
+		},
+		"preempting locally and borrowing same resource in cohort; no borrowing limit in the cohort": {
+			admitted: []kueue.Workload{
+				*utiltesting.MakeWorkload("d1-med", "").
+					Priority(0).
+					Request(corev1.ResourceCPU, "4").
+					ReserveQuota(utiltesting.MakeAdmission("d1").Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+					Obj(),
+				*utiltesting.MakeWorkload("d1-low", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "4").
+					ReserveQuota(utiltesting.MakeAdmission("d1").Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+					Obj(),
+				*utiltesting.MakeWorkload("d2-low-1", "").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "4").
+					ReserveQuota(utiltesting.MakeAdmission("d2").Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+					Obj(),
+			},
+			incoming: utiltesting.MakeWorkload("in", "").
+				Priority(1).
+				Request(corev1.ResourceCPU, "4").
+				Obj(),
+			targetCQ: "d1",
+			assignment: singlePodSetAssignment(flavorassigner.ResourceAssignment{
+				corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
+					Name: "default",
+					Mode: flavorassigner.Preempt,
+				},
+			}),
+			wantPreempted: sets.New("/d1-low"),
 		},
 		"preempting locally and borrowing other resources in cohort, with cohort candidates": {
 			admitted: []kueue.Workload{


### PR DESCRIPTION
Cherry pick of #1561 on release-0.5.
#1561: Fix the borrowing while preemption when no borrowingLimit
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```

Note: I had a conflict with https://github.com/kubernetes-sigs/kueue/commit/7aff0611ea52163b32b73d466bc621804459d8ae, but the other PR didn't contribute logic difference, so I resolved the conflict by using the new logic for the `workloadFits` function.