### PR TITLE
Fix the issue where namespaceSelector never takes effect when podSelector is nil

### DIFF
--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -145,14 +145,14 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		log.V(5).Info("Pod owner is managed by kueue, skipping")
 		return nil
 	}
-
+	podMatch := false
 	// Check for pod label selector match
 	podSelector, err := metav1.LabelSelectorAsSelector(w.podSelector)
 	if err != nil {
 		return fmt.Errorf("failed to parse pod selector: %w", err)
 	}
-	if !podSelector.Matches(labels.Set(pod.pod.GetLabels())) {
-		return nil
+	if podSelector.Matches(labels.Set(pod.pod.GetLabels())) {
+		podMatch = true
 	}
 
 	// Get pod namespace and check for namespace label selector match
@@ -169,7 +169,10 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse namespace selector: %w", err)
 	}
-	if !nsSelector.Matches(labels.Set(ns.GetLabels())) {
+	if nsSelector.Matches(labels.Set(ns.GetLabels())) {
+		podMatch = true
+	}
+	if !podMatch {
 		return nil
 	}
 

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -73,6 +73,19 @@ func TestDefault(t *testing.T) {
 				Queue("test-queue").
 				Obj(),
 		},
+		"pod with queue nil pod selector": {
+			initObjects: []client.Object{defaultNamespace},
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				Obj(),
+			namespaceSelector: defaultNamespaceSelector,
+			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				Label("kueue.x-k8s.io/managed", "true").
+				KueueSchedulingGate().
+				KueueFinalizer().
+				Obj(),
+		},
 		"pod with queue matching ns selector": {
 			initObjects: []client.Object{defaultNamespace},
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix the issue where namespaceSelector never takes effect when podSelector is nil
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```