### PR TITLE
Simplify quota reservation when preemption while borrowing

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -339,11 +339,7 @@ func resourcesToReserve(e *entry, cq *cache.ClusterQueue) cache.FlavorResourceQu
 			if !e.assignment.Borrowing {
 				reservedUsage[flavor][resource] = max(0, min(usage, cqQuota.Nominal-cq.Usage[flavor][resource]))
 			} else {
-				if cqQuota.BorrowingLimit == nil {
-					reservedUsage[flavor][resource] = usage
-				} else {
-					reservedUsage[flavor][resource] = min(usage, cqQuota.Nominal+*cqQuota.BorrowingLimit-cq.Usage[flavor][resource])
-				}
+				reservedUsage[flavor][resource] = usage
 			}
 
 		}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2025,7 +2025,7 @@ func TestResourcesToReserve(t *testing.T) {
 				kueue.ResourceFlavorReference("model-b"):   {"gpu": 10},
 			},
 			wantReserved: cache.FlavorResourceQuantities{
-				kueue.ResourceFlavorReference("spot"):    {corev1.ResourceMemory: 40},
+				kueue.ResourceFlavorReference("spot"):    {corev1.ResourceMemory: 50},
 				kueue.ResourceFlavorReference("model-b"): {"gpu": 2},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

It is a follow up to https://github.com/kubernetes-sigs/kueue/pull/1399 to narrow down the impact of that PR
to only the scenario which is tested by integration tests. See [discussion](https://github.com/kubernetes-sigs/kueue/pull/1399#discussion_r1447660199).

It is still not clear what should happen in the scenario when preemption with borrowing is used. In particular, there is a trade-off that letting the borrowing workload B get admitted may prolong waiting time for the workload A in the scenario depicted [here](https://github.com/kubernetes-sigs/kueue/assets/43413443/3ee2a4f6-d8ee-4bb4-96d8-2e9662e8869c).

So, I think it is better to simplify the code (which is already complicated) until we have feedback from users.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```