### PR TITLE
Skip recreating a workload for a finished job

### DIFF
--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -1374,6 +1374,16 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 			},
 		},
+		"the workload shouldn't be recreated for the completed job": {
+			job: *baseJobWrapper.Clone().
+				Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
+				Obj(),
+			workloads: []kueue.Workload{},
+			wantJob: *baseJobWrapper.Clone().
+				Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
+				Obj(),
+			wantWorkloads: []kueue.Workload{},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/controller/jobs/kubeflow/jobs/mxjob/mxjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/mxjob/mxjob_controller_test.go
@@ -407,6 +407,18 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 			},
 		},
+		"workload shouldn't be recreated for the completed mx job": {
+			job: testingmxjob.MakeMXJob("mxjob", "ns").
+				Queue("foo").
+				StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: v1.ConditionTrue}).
+				Obj(),
+			workloads: []kueue.Workload{},
+			wantJob: testingmxjob.MakeMXJob("mxjob", "ns").
+				Queue("foo").
+				StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: v1.ConditionTrue}).
+				Obj(),
+			wantWorkloads: []kueue.Workload{},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -406,7 +406,7 @@ func TestReconciler(t *testing.T) {
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
-		"finalizer is removed for finished pod without matching workload": {
+		"finalizer is removed for finished pod without matching workload, new workload shouldn't be created": {
 			pod: *basePodWrapper.
 				Clone().
 				Label("kueue.x-k8s.io/managed", "true").
@@ -418,15 +418,8 @@ func TestReconciler(t *testing.T) {
 				Label("kueue.x-k8s.io/managed", "true").
 				StatusPhase(corev1.PodSucceeded).
 				Obj(),
-			workloads: []kueue.Workload{},
-			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					Labels(map[string]string{"kueue.x-k8s.io/job-uid": "test-uid"}).
-					Queue("user-queue").
-					Priority(0).
-					Obj(),
-			},
+			workloads:       []kueue.Workload{},
+			wantWorkloads:   []kueue.Workload{},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
 	}
@@ -585,7 +578,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 	}
 
 	// Workload should be finished after the second reconcile
-	wantWl := *utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+	wantWl := *utiltesting.MakeWorkload("unit-test", "ns").
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 		ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
 		Admitted(true).

--- a/pkg/util/testingjobs/mxjob/wrappers.go
+++ b/pkg/util/testingjobs/mxjob/wrappers.go
@@ -197,3 +197,9 @@ func (j *MXJobWrapper) Active(rType kftraining.ReplicaType, c int32) *MXJobWrapp
 	}
 	return j
 }
+
+// StatusConditions updates status conditions of the MXJob.
+func (j *MXJobWrapper) StatusConditions(conditions ...kftraining.JobCondition) *MXJobWrapper {
+	j.Status.Conditions = conditions
+	return j
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

- Do not recreate workload for a finished Job
- Ensure finalization of job when workload is finished

#### Which issue(s) this PR fixes:

Ref #1383 and #1450

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Avoid recreating a Workload for a finished Job and finalize a job when the workload is declared finished.
```