### PR TITLE
Finalize deleted gated Pods from groups without a Workload

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -135,12 +135,12 @@ func gateIndex(p *corev1.Pod) int {
 	return gateNotFound
 }
 
-func podActive(p *corev1.Pod) bool {
-	return p.Status.Phase != corev1.PodFailed && p.Status.Phase != corev1.PodSucceeded
+func isPodTerminated(p *corev1.Pod) bool {
+	return p.Status.Phase == corev1.PodFailed || p.Status.Phase == corev1.PodSucceeded
 }
 
 func podSuspended(p *corev1.Pod) bool {
-	return !podActive(p) || gateIndex(p) != gateNotFound
+	return isPodTerminated(p) || gateIndex(p) != gateNotFound
 }
 
 func isUnretriablePod(pod corev1.Pod) bool {
@@ -295,7 +295,7 @@ func (p *Pod) Finished() (metav1.Condition, bool) {
 			succeededCount++
 		}
 
-		if podActive(&pod) {
+		if !isPodTerminated(&pod) {
 			isActive = true
 		}
 	}
@@ -571,8 +571,7 @@ func (p *Pod) constructGroupPodSets() ([]kueue.PodSet, error) {
 	var resultPodSets []kueue.PodSet
 
 	for _, podInGroup := range p.list.Items {
-		// Skip failed pods
-		if podInGroup.Status.Phase == corev1.PodFailed {
+		if !isPodActive(&podInGroup) {
 			continue
 		}
 
@@ -648,17 +647,25 @@ func (p *Pod) validatePodGroupMetadata(r record.EventRecorder, activePods []core
 	return nil
 }
 
-// activePods returns a slice of non-failed pods in the group
+// activePods returns a slice of active pods in the group
 func (p *Pod) activePods() []corev1.Pod {
-	// Filter all failed pods
 	activePods := make([]corev1.Pod, 0, len(p.list.Items))
 	for _, pod := range p.list.Items {
-		if pod.Status.Phase != corev1.PodFailed {
+		if isPodActive(&pod) {
 			activePods = append(activePods, pod)
 		}
 	}
 
 	return activePods
+}
+
+// isPodActive returns whether the Pod can eventually run, is Running or Succeeded.
+// A Pod cannot run if it's gated and has a deletionTimestamp.
+func isPodActive(p *corev1.Pod) bool {
+	if p.DeletionTimestamp != nil && len(p.Spec.SchedulingGates) > 0 {
+		return false
+	}
+	return p.Status.Phase != corev1.PodFailed
 }
 
 // cleanupExcessPods will delete and finalize pods created last if the number of
@@ -753,6 +760,10 @@ func (p *Pod) ConstructComposableWorkload(ctx context.Context, c client.Client, 
 		}
 
 		return wl, nil
+	}
+
+	if err := p.finalizeInactivePods(ctx, c); err != nil {
+		return nil, err
 	}
 
 	activePods := p.activePods()
@@ -946,6 +957,20 @@ func (p *Pod) ReclaimablePods() ([]kueue.ReclaimablePod, error) {
 	}
 
 	return result, nil
+}
+
+func (p *Pod) finalizeInactivePods(ctx context.Context, c client.Client) error {
+	for _, p := range p.list.Items {
+		if isPodActive(&p) {
+			continue
+		}
+		if controllerutil.RemoveFinalizer(&p, PodFinalizer) {
+			if err := c.Update(ctx, &p); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func IsPodOwnerManagedByKueue(p *Pod) bool {

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -2157,8 +2157,8 @@ func TestReconciler(t *testing.T) {
 		"deleted pods in incomplete group are finalized": {
 			pods: []corev1.Pod{
 				*basePodWrapper.
-					Name("p1").
 					Clone().
+					Name("p1").
 					Label("kueue.x-k8s.io/managed", "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
@@ -2168,8 +2168,8 @@ func TestReconciler(t *testing.T) {
 					Delete().
 					Obj(),
 				*basePodWrapper.
-					Name("p2").
 					Clone().
+					Name("p2").
 					Label("kueue.x-k8s.io/managed", "true").
 					KueueFinalizer().
 					KueueSchedulingGate().

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -1389,7 +1389,7 @@ func TestReconciler(t *testing.T) {
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
-		"deleted pods in group should not be finalized if matching workload is not found": {
+		"deleted pods in group should not be finalized if the workload doesn't match": {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1670,7 +1670,7 @@ func TestReconciler(t *testing.T) {
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 		},
-		"if there's not enough non-failed pods in the group, workload should not be recreated": {
+		"if there's not enough non-failed pods in the group, workload should not be created": {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
@@ -1703,7 +1703,6 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					Label("kueue.x-k8s.io/managed", "true").
-					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
@@ -2154,6 +2153,32 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
+		},
+		"deleted pods in incomplete group are finalized": {
+			pods: []corev1.Pod{
+				*basePodWrapper.
+					Name("p1").
+					Clone().
+					Label("kueue.x-k8s.io/managed", "true").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					Group("group").
+					GroupTotalCount("3").
+					StatusPhase(corev1.PodPending).
+					Delete().
+					Obj(),
+				*basePodWrapper.
+					Name("p2").
+					Clone().
+					Label("kueue.x-k8s.io/managed", "true").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					Group("group").
+					GroupTotalCount("3").
+					StatusPhase(corev1.PodPending).
+					Delete().
+					Obj(),
+			},
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

If gated Pods are deleted before a Workload is created, they should be finalized.

This covers a scenario where a group was never complete and the user decides to delete the Pods.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No release note because this is an unreleased feature.

```release-note
NONE
```