### PR TITLE
Use constant gvk for pod owner index

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -834,7 +834,7 @@ func (p *Pod) ListChildWorkloads(ctx context.Context, c client.Client, key types
 
 	// List related workloads for the single pod
 	if err := c.List(ctx, workloads, client.InNamespace(key.Namespace),
-		client.MatchingFields{jobframework.GetOwnerKey(p.pod.GroupVersionKind()): key.Name}); err != nil {
+		client.MatchingFields{jobframework.GetOwnerKey(gvk): key.Name}); err != nil {
 		log.Error(err, "Unable to get related workload for the single pod")
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

The combination of #1524 and #1502 causes `p.pod` to be empty, leading to a nonexistent owner key. 

This could lead to infinite reconcile attempts for this key, and an unfinalized Workload if previous reconcile attempts failed to remove the finalizer.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Fixes unreleased feature.

```release-note
NONE
```