### PR TITLE
Fix the flake preemption while borrowing unit test

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -58,6 +58,7 @@ var cmpDump = []cmp.Option{
 }
 
 func TestSchedule(t *testing.T) {
+	now := time.Now()
 	resourceFlavors := []*kueue.ResourceFlavor{
 		{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "on-demand"}},
@@ -733,21 +734,21 @@ func TestSchedule(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("new", "eng-beta").
 					Queue("main").
-					Creation(time.Now().Add(-2 * time.Second)).
+					Creation(now.Add(-2 * time.Second)).
 					PodSets(*utiltesting.MakePodSet("one", 50).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("new-alpha", "eng-alpha").
 					Queue("main").
-					Creation(time.Now().Add(-time.Second)).
+					Creation(now.Add(-time.Second)).
 					PodSets(*utiltesting.MakePodSet("one", 1).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("new-gamma", "eng-gamma").
 					Queue("main").
-					Creation(time.Now()).
+					Creation(now).
 					PodSets(*utiltesting.MakePodSet("one", 50).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
@@ -1158,14 +1159,14 @@ func TestSchedule(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "eng-alpha").
 					Queue("lq_a").
-					Creation(time.Now().Add(time.Second)).
+					Creation(now.Add(time.Second)).
 					PodSets(*utiltesting.MakePodSet("main", 1).
 						Request(corev1.ResourceCPU, "3").
 						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b", "eng-beta").
 					Queue("lq_b").
-					Creation(time.Now().Add(time.Second)).
+					Creation(now.Add(2 * time.Second)).
 					PodSets(*utiltesting.MakePodSet("main", 1).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1578

#### Special notes for your reviewer:

The test was added recently in https://github.com/kubernetes-sigs/kueue/pull/1576 to cover the logic modified in https://github.com/kubernetes-sigs/kueue/pull/1399.

The test used to flake as the order of considered workloads in a single scheduling cycle could be (A,B) or (B, A). The intention of the test is to cover scenario when (A,B). Thus adding 2*time.Second to the creation time of B.

Also, make sure all timestamps refer to the same `now`. Otherwise, it would be technically possible that `time.Now().Add(time.Second) > time.Now().Add(2*time.Second)` (though it would be super unlikely).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```