### PR TITLE
Fix syncing of the second provisioning request

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -168,8 +168,8 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 func (c *Controller) activeOrLastPRForChecks(ctx context.Context, wl *kueue.Workload, relevantChecks []string, ownedPrs []autoscaling.ProvisioningRequest) map[string]*autoscaling.ProvisioningRequest {
 	activeOrLastPRForChecks := make(map[string]*autoscaling.ProvisioningRequest)
 	for _, checkName := range relevantChecks {
-		for _, pr := range ownedPrs {
-			req := &pr
+		for i := range ownedPrs {
+			req := &ownedPrs[i]
 			// PRs relevant for the admission check
 			if matches(req, wl.Name, checkName) {
 				prc, err := c.helper.ConfigForAdmissionCheck(ctx, checkName)

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -661,7 +661,10 @@ func TestReconcile(t *testing.T) {
 
 			k8sclient := builder.Build()
 			recorder := &utiltesting.EventRecorder{}
-			controller, _ := NewController(k8sclient, recorder)
+			controller, err := NewController(k8sclient, recorder)
+			if err != nil {
+				t.Fatalf("Setting up the provisioning request controller: %v", err)
+			}
 
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{
@@ -845,7 +848,10 @@ func TestActiveOrLastPRForChecks(t *testing.T) {
 
 			k8sclient := builder.Build()
 			recorder := &utiltesting.EventRecorder{}
-			controller, _ := NewController(k8sclient, recorder)
+			controller, err := NewController(k8sclient, recorder)
+			if err != nil {
+				t.Fatalf("Setting up the provisioning request controller: %v", err)
+			}
 
 			gotResult := controller.activeOrLastPRForChecks(ctx, workload, relevantChecks, tc.requests)
 			if diff := cmp.Diff(tc.wantResult, gotResult, reqCmpOptions...); diff != "" {

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -724,3 +724,133 @@ func TestReconcile(t *testing.T) {
 	}
 
 }
+
+func TestActiveOrLastPRForChecks(t *testing.T) {
+	baseWorkload := utiltesting.MakeWorkload("wl", TestNamespace).
+		PodSets(
+			*utiltesting.MakePodSet("main", 4).
+				Request(corev1.ResourceCPU, "1").
+				Obj(),
+		).
+		ReserveQuota(utiltesting.MakeAdmission("q1").PodSets(
+			kueue.PodSetAssignment{
+				Name: "main",
+				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+					corev1.ResourceCPU: "flv1",
+				},
+				ResourceUsage: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				Count: ptr.To[int32](4),
+			},
+		).
+			Obj()).
+		AdmissionChecks(kueue.AdmissionCheckState{
+			Name:  "check",
+			State: kueue.CheckStatePending,
+		}, kueue.AdmissionCheckState{
+			Name:  "not-provisioning",
+			State: kueue.CheckStatePending,
+		}).
+		Obj()
+	baseConfig := &kueue.ProvisioningRequestConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config1",
+		},
+		Spec: kueue.ProvisioningRequestConfigSpec{
+			ProvisioningClassName: "class1",
+			Parameters: map[string]kueue.Parameter{
+				"p1": "v1",
+			},
+		},
+	}
+
+	baseRequest := autoscaling.ProvisioningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: TestNamespace,
+			Name:      "wl-check-1",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name: "wl",
+				},
+			},
+		},
+		Spec: autoscaling.ProvisioningRequestSpec{
+			PodSets: []autoscaling.PodSet{
+				{
+					PodTemplateRef: autoscaling.Reference{
+						Name: "ppt-wl-check-1-ps1",
+					},
+					Count: 4,
+				},
+			},
+			ProvisioningClassName: "class1",
+			Parameters: map[string]autoscaling.Parameter{
+				"p1": "v1",
+			},
+		},
+	}
+	pr1Failed := baseRequest.DeepCopy()
+	pr1Failed = requestWithCondition(pr1Failed, autoscaling.Failed, metav1.ConditionTrue)
+	pr2Created := baseRequest.DeepCopy()
+	pr2Created.Name = "wl-check-2"
+
+	baseCheck := utiltesting.MakeAdmissionCheck("check").
+		ControllerName(ControllerName).
+		Parameters(kueue.GroupVersion.Group, ConfigKind, "config1").
+		Obj()
+
+	cases := map[string]struct {
+		requests   []autoscaling.ProvisioningRequest
+		wantResult map[string]*autoscaling.ProvisioningRequest
+	}{
+		"no provisioning requests": {},
+		"two provisioning requests; 1 then 2": {
+			requests: []autoscaling.ProvisioningRequest{
+				*pr1Failed.DeepCopy(),
+				*pr2Created.DeepCopy(),
+			},
+			wantResult: map[string]*autoscaling.ProvisioningRequest{
+				"check": pr2Created.DeepCopy(),
+			},
+		},
+		"two provisioning requests; 2 then 1": {
+			requests: []autoscaling.ProvisioningRequest{
+				*pr2Created.DeepCopy(),
+				*pr1Failed.DeepCopy(),
+			},
+			wantResult: map[string]*autoscaling.ProvisioningRequest{
+				"check": pr2Created.DeepCopy(),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			workload := baseWorkload.DeepCopy()
+			relevantChecks := []string{"check"}
+			checks := []kueue.AdmissionCheck{*baseCheck.DeepCopy()}
+			configs := []kueue.ProvisioningRequestConfig{*baseConfig.DeepCopy()}
+
+			builder, ctx := getClientBuilder()
+
+			builder = builder.WithObjects(workload)
+			builder = builder.WithStatusSubresource(workload)
+
+			builder = builder.WithLists(
+				&autoscaling.ProvisioningRequestList{Items: tc.requests},
+				&kueue.ProvisioningRequestConfigList{Items: configs},
+				&kueue.AdmissionCheckList{Items: checks},
+			)
+
+			k8sclient := builder.Build()
+			recorder := &utiltesting.EventRecorder{}
+			controller, _ := NewController(k8sclient, recorder)
+
+			gotResult := controller.activeOrLastPRForChecks(ctx, workload, relevantChecks, tc.requests)
+			if diff := cmp.Diff(tc.wantResult, gotResult, reqCmpOptions...); diff != "" {
+				t.Errorf("unexpected request %q (-want/+got):\n%s", name, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1558

#### Special notes for your reviewer:

The root cause of the issue is that the returned map by `activeOrLastPRForChecks` could contain
the pr-1, instead of pr-2. This could happen when on the list of PRs passed to the function
we have [pr-2, pr-1]. I wanted to test `TestReconcile` but it appears that the order of PRs returned by the
List is always alphabetical in unit tests, even though it does not need to be from the production client.

The new unit test fails on the main branch consistently.

I assume it also fixes #1401, but will double check.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix the synchronization of the admission check state based on the second provisioning request
```