### PR TITLE
Increase reconcilers for Pod

### DIFF
--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -70,10 +70,11 @@ managerConfig:
     controller:
       groupKindConcurrency:
         Job.batch: 5
+        Pod.: 5
+        Workload.kueue.x-k8s.io: 5
         LocalQueue.kueue.x-k8s.io: 1
         ClusterQueue.kueue.x-k8s.io: 1
         ResourceFlavor.kueue.x-k8s.io: 1
-        Workload.kueue.x-k8s.io: 1
     clientConnection:
       qps: 50
       burst: 100

--- a/config/components/manager/controller_manager_config.yaml
+++ b/config/components/manager/controller_manager_config.yaml
@@ -13,10 +13,11 @@ leaderElection:
 controller:
   groupKindConcurrency:
     Job.batch: 5
+    Pod.: 5
+    Workload.kueue.x-k8s.io: 5
     LocalQueue.kueue.x-k8s.io: 1
     ClusterQueue.kueue.x-k8s.io: 1
     ResourceFlavor.kueue.x-k8s.io: 1
-    Workload.kueue.x-k8s.io: 1
 clientConnection:
   qps: 50
   burst: 100

--- a/test/e2e/config/controller_manager_config.yaml
+++ b/test/e2e/config/controller_manager_config.yaml
@@ -24,3 +24,8 @@ integrations:
   - "kubeflow.org/tfjob"
   - "kubeflow.org/xgboostjob"
   - "pod"
+controller:
+  groupKindConcurrency:
+    Job.batch: 5
+    Pod.: 5
+    Workload.kueue.x-k8s.io: 5


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Increase the number of reconcilers for Pod in the default configuration and E2E tests.

Also doing the same for Workload object, which are expected to be a significant number of objects.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Increase the default number of reconcilers for Pod and Workload objects to 5, each.
```