### PR TITLE
Automated cherry pick of #1351: Support retry for provisioning requests

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -159,8 +159,8 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 func (c *Controller) activeOrLastPRForChecks(ctx context.Context, wl *kueue.Workload, relevantChecks []string, ownedPrs []autoscaling.ProvisioningRequest) map[string]*autoscaling.ProvisioningRequest {
 	activeOrLastPRForChecks := make(map[string]*autoscaling.ProvisioningRequest)
 	for _, checkName := range relevantChecks {
-		for _, pr := range ownedPrs {
-			req := &pr
+		for i := range ownedPrs {
+			req := &ownedPrs[i]
 			// PRs relevant for the admission check
 			if matches(req, wl.Name, checkName) {
 				prc, err := c.helper.ProvReqConfigForAdmissionCheck(ctx, checkName)

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -23,6 +23,9 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"regexp"
+	"strconv"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -38,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -56,6 +60,11 @@ const (
 
 var (
 	errInconsistentPodSetAssignments = errors.New("inconsistent podSet assignments")
+)
+
+var (
+	MaxRetries        int32 = 3
+	MinBackoffSeconds int32 = 60
 )
 
 type Controller struct {
@@ -110,20 +119,78 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
+	list := &autoscaling.ProvisioningRequestList{}
+	if err := c.client.List(ctx, list, client.InNamespace(wl.Namespace), client.MatchingFields{RequestsOwnedByWorkloadKey: wl.Name}); client.IgnoreNotFound(err) != nil {
+		return reconcile.Result{}, err
+	}
+	ownedPrs := list.Items
+	activeOrLastPRForChecks := c.activeOrLastPRForChecks(ctx, wl, relevantChecks, ownedPrs)
+
 	if workload.IsAdmitted(wl) {
 		// check the state of the provision requests, eventually toggle the checks to false
 		// otherwise there is nothing to here
 		log.V(5).Info("workload admitted, sync checks")
-		return reconcile.Result{}, c.syncCheckStates(ctx, wl, relevantChecks)
+		return reconcile.Result{}, c.syncCheckStates(ctx, wl, relevantChecks, activeOrLastPRForChecks)
 	}
 
-	if err := c.syncOwnedProvisionRequest(ctx, wl, relevantChecks); err != nil {
+	err = c.deleteUnusedProvisioningRequests(ctx, ownedPrs, activeOrLastPRForChecks)
+	if err != nil {
+		log.V(2).Error(err, "syncOwnedProvisionRequest failed to delete unused provisioning requests")
+		return reconcile.Result{}, err
+	}
+
+	requeAfter, err := c.syncOwnedProvisionRequest(ctx, wl, relevantChecks, activeOrLastPRForChecks)
+	if err != nil {
 		// this can also delete unneeded checks
 		log.V(2).Error(err, "syncOwnedProvisionRequest failed")
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{}, c.syncCheckStates(ctx, wl, relevantChecks)
+	err = c.syncCheckStates(ctx, wl, relevantChecks, activeOrLastPRForChecks)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if requeAfter != nil {
+		return reconcile.Result{RequeueAfter: *requeAfter}, nil
+	}
+	return reconcile.Result{}, nil
+}
+
+func (c *Controller) activeOrLastPRForChecks(ctx context.Context, wl *kueue.Workload, relevantChecks []string, ownedPrs []autoscaling.ProvisioningRequest) map[string]*autoscaling.ProvisioningRequest {
+	activeOrLastPRForChecks := make(map[string]*autoscaling.ProvisioningRequest)
+	for _, checkName := range relevantChecks {
+		for _, pr := range ownedPrs {
+			req := &pr
+			// PRs relevant for the admission check
+			if matches(req, wl.Name, checkName) {
+				prc, err := c.helper.ProvReqConfigForAdmissionCheck(ctx, checkName)
+				if err == nil && c.reqIsNeeded(ctx, wl, prc) && requestHasParamaters(req, prc) {
+					if currPr, exists := activeOrLastPRForChecks[checkName]; !exists || getAttempt(ctx, currPr, wl.Name, checkName) < getAttempt(ctx, req, wl.Name, checkName) {
+						activeOrLastPRForChecks[checkName] = req
+					}
+				}
+			}
+		}
+	}
+	return activeOrLastPRForChecks
+}
+
+func (c *Controller) deleteUnusedProvisioningRequests(ctx context.Context, ownedPrs []autoscaling.ProvisioningRequest, activeOrLastPRForChecks map[string]*autoscaling.ProvisioningRequest) error {
+	log := ctrl.LoggerFrom(ctx)
+	prNames := sets.New[string]()
+	for _, pr := range activeOrLastPRForChecks {
+		prNames.Insert(pr.Name)
+	}
+	for _, pr := range ownedPrs {
+		req := &pr
+		if !prNames.Has(req.Name) {
+			if err := c.client.Delete(ctx, req); client.IgnoreNotFound(err) != nil {
+				log.V(5).Error(err, "deleting the request", "req", klog.KObj(req))
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (c *Controller) deleteOwnedProvisionRequests(ctx context.Context, namespace string, name string) error {
@@ -140,54 +207,42 @@ func (c *Controller) deleteOwnedProvisionRequests(ctx context.Context, namespace
 	return nil
 }
 
-func (c *Controller) syncOwnedProvisionRequest(ctx context.Context, wl *kueue.Workload, relevantChecks []string) error {
+func (c *Controller) syncOwnedProvisionRequest(ctx context.Context, wl *kueue.Workload, relevantChecks []string, activeOrLastPRForChecks map[string]*autoscaling.ProvisioningRequest) (*time.Duration, error) {
 	log := ctrl.LoggerFrom(ctx)
-	list := &autoscaling.ProvisioningRequestList{}
-	if err := c.client.List(ctx, list, client.InNamespace(wl.Namespace), client.MatchingFields{RequestsOwnedByWorkloadKey: wl.Name}); client.IgnoreNotFound(err) != nil {
-		return err
-	}
-
-	requestExists := slices.ToMap(relevantChecks, func(i int) (string, bool) { return GetProvisioningRequestName(wl.Name, relevantChecks[i]), false })
-	requestNeededForCheck := slices.ToMap(relevantChecks, func(i int) (string, bool) { return relevantChecks[i], c.requestIsNeeded(ctx, wl, relevantChecks[i]) })
-	requestToCheckName := slices.ToMap(relevantChecks, func(i int) (string, string) {
-		return GetProvisioningRequestName(wl.Name, relevantChecks[i]), relevantChecks[i]
-	})
-
-	for i := range list.Items {
-		req := &list.Items[i]
-		if _, needed := requestExists[req.Name]; !needed {
-			if err := c.client.Delete(ctx, req); client.IgnoreNotFound(err) != nil {
-				return err
-			}
-		} else {
-			// get the parameters
-			checkName := requestToCheckName[req.Name]
-			prc, err := c.helper.ProvReqConfigForAdmissionCheck(ctx, checkName)
-			if err != nil || !requestNeededForCheck[checkName] || !requestHasParamaters(req, prc) {
-				// the check is not active or the parameters are out of sync
-				if err := c.client.Delete(ctx, req); client.IgnoreNotFound(err) != nil {
-					log.V(5).Error(err, "deleting the request", "check", checkName)
-					return err
-				}
-			} else {
-				requestExists[req.Name] = true
-			}
-		}
-	}
-
-	// create the missing ones
-	for requestName, exists := range requestExists {
-		checkName := requestToCheckName[requestName]
-		if !requestNeededForCheck[checkName] {
-			continue
-		}
+	var requeAfter *time.Duration
+	for _, checkName := range relevantChecks {
 		//get the config
 		prc, err := c.helper.ProvReqConfigForAdmissionCheck(ctx, checkName)
 		if err != nil {
 			// the check is not active
 			continue
 		}
-		if !exists {
+		if !c.reqIsNeeded(ctx, wl, prc) {
+			continue
+		}
+		oldPr, exists := activeOrLastPRForChecks[checkName]
+		attempt := int32(1)
+		shouldCreatePr := false
+		if exists {
+			attempt = getAttempt(ctx, oldPr, wl.Name, checkName)
+			if apimeta.IsStatusConditionTrue(oldPr.Status.Conditions, autoscaling.Failed) {
+				if attempt <= MaxRetries {
+					prFailed := apimeta.FindStatusCondition(oldPr.Status.Conditions, autoscaling.Failed)
+					remainingTime := remainingTime(prc, attempt, prFailed.LastTransitionTime.Time)
+					if remainingTime <= 0 {
+						shouldCreatePr = true
+						attempt += 1
+					} else if requeAfter == nil || remainingTime < *requeAfter {
+						requeAfter = &remainingTime
+					}
+				}
+			}
+		} else {
+			shouldCreatePr = true
+		}
+		requestName := GetProvisioningRequestName(wl.Name, checkName, attempt)
+		if shouldCreatePr {
+			log.V(3).Info("Creating ProvisioningRequest", "requestName", requestName, "attempt", attempt)
 			req := &autoscaling.ProvisioningRequest{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      requestName,
@@ -206,35 +261,36 @@ func (c *Controller) syncOwnedProvisionRequest(ctx context.Context, wl *kueue.Wo
 				ps, psFound := podSetMap[psName]
 				psa, psaFound := psaMap[psName]
 				if !psFound || !psaFound {
-					return errInconsistentPodSetAssignments
+					return nil, errInconsistentPodSetAssignments
 				}
 				req.Spec.PodSets = append(req.Spec.PodSets, autoscaling.PodSet{
 					PodTemplateRef: autoscaling.Reference{
-						Name: getProvisioningRequestPodTemplateName(wl.Name, checkName, psName),
+						Name: getProvisioningRequestPodTemplateName(requestName, psName),
 					},
 					Count: ptr.Deref(psa.Count, ps.Count),
 				})
 			}
 
 			if err := ctrl.SetControllerReference(wl, req, c.client.Scheme()); err != nil {
-				return err
+				return nil, err
 			}
 
 			if err := c.client.Create(ctx, req); err != nil {
-				return err
+				return nil, err
 			}
+			activeOrLastPRForChecks[checkName] = req
 		}
-		if err := c.syncProvisionRequestsPodTemplates(ctx, wl, checkName, prc); err != nil {
-			return err
+		if err := c.syncProvisionRequestsPodTemplates(ctx, wl, requestName, prc); err != nil {
+			return nil, err
 		}
 	}
-	return nil
+	return requeAfter, nil
 }
 
-func (c *Controller) syncProvisionRequestsPodTemplates(ctx context.Context, wl *kueue.Workload, checkName string, prc *kueue.ProvisioningRequestConfig) error {
+func (c *Controller) syncProvisionRequestsPodTemplates(ctx context.Context, wl *kueue.Workload, prName string, prc *kueue.ProvisioningRequestConfig) error {
 	request := &autoscaling.ProvisioningRequest{}
 	requestKey := types.NamespacedName{
-		Name:      GetProvisioningRequestName(wl.Name, checkName),
+		Name:      prName,
 		Namespace: wl.Namespace,
 	}
 	err := c.client.Get(ctx, requestKey, request)
@@ -244,7 +300,7 @@ func (c *Controller) syncProvisionRequestsPodTemplates(ctx context.Context, wl *
 
 	expectedPodSets := requiredPodSets(wl.Spec.PodSets, prc.Spec.ManagedResources)
 	podsetRefsMap := slices.ToMap(expectedPodSets, func(i int) (string, string) {
-		return getProvisioningRequestPodTemplateName(wl.Name, checkName, expectedPodSets[i]), expectedPodSets[i]
+		return getProvisioningRequestPodTemplateName(prName, expectedPodSets[i]), expectedPodSets[i]
 	})
 
 	// the order of the podSets should be the same in the workload and prov. req.
@@ -312,13 +368,8 @@ func (c *Controller) syncProvisionRequestsPodTemplates(ctx context.Context, wl *
 	return nil
 }
 
-func (c *Controller) requestIsNeeded(ctx context.Context, wl *kueue.Workload, checkName string) bool {
-	prc, err := c.helper.ProvReqConfigForAdmissionCheck(ctx, checkName)
-	if err != nil {
-		return false
-	}
-	expectdPodsets := requiredPodSets(wl.Spec.PodSets, prc.Spec.ManagedResources)
-	return len(expectdPodsets) > 0
+func (c *Controller) reqIsNeeded(ctx context.Context, wl *kueue.Workload, prc *kueue.ProvisioningRequestConfig) bool {
+	return len(requiredPodSets(wl.Spec.PodSets, prc.Spec.ManagedResources)) > 0
 }
 
 func requiredPodSets(podSets []kueue.PodSet, resources []corev1.ResourceName) []string {
@@ -383,21 +434,22 @@ func requestHasParamaters(req *autoscaling.ProvisioningRequest, prc *kueue.Provi
 	return true
 }
 
-func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, checks []string) error {
+func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, checks []string, activeOrLastPRForChecks map[string]*autoscaling.ProvisioningRequest) error {
+	log := ctrl.LoggerFrom(ctx)
 	checksMap := slices.ToRefMap(wl.Status.AdmissionChecks, func(c *kueue.AdmissionCheckState) string { return c.Name })
 	wlPatch := workload.BaseSSAWorkload(wl)
 	recorderMessages := make([]string, 0, len(checks))
 	updated := false
 	for _, check := range checks {
 		checkState := *checksMap[check]
-		if _, err := c.helper.ProvReqConfigForAdmissionCheck(ctx, check); err != nil {
+		if prc, err := c.helper.ProvReqConfigForAdmissionCheck(ctx, check); err != nil {
 			// the check is not active
 			if checkState.State != kueue.CheckStatePending || checkState.Message != CheckInactiveMessage {
 				updated = true
 				checkState.State = kueue.CheckStatePending
 				checkState.Message = CheckInactiveMessage
 			}
-		} else if !c.requestIsNeeded(ctx, wl, check) {
+		} else if !c.reqIsNeeded(ctx, wl, prc) {
 			if checkState.State != kueue.CheckStateReady {
 				updated = true
 				checkState.State = kueue.CheckStateReady
@@ -405,28 +457,37 @@ func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, ch
 				checkState.PodSetUpdates = nil
 			}
 		} else {
-			pr := &autoscaling.ProvisioningRequest{}
-			if err := c.client.Get(ctx, types.NamespacedName{Namespace: wl.Namespace, Name: GetProvisioningRequestName(wl.Name, check)}, pr); err != nil {
-				return client.IgnoreNotFound(err)
+			pr := activeOrLastPRForChecks[check]
+			if pr == nil {
+				return nil
 			}
 
 			prFailed := apimeta.IsStatusConditionTrue(pr.Status.Conditions, autoscaling.Failed)
 			prAccepted := apimeta.IsStatusConditionTrue(pr.Status.Conditions, autoscaling.Provisioned)
 			prAvailable := apimeta.IsStatusConditionTrue(pr.Status.Conditions, autoscaling.CapacityAvailable)
+			log.V(3).Info("Synchronizing admission check state based on provisioning request", "wl", klog.KObj(wl), "check", check, "prName", pr.Name, "failed", prFailed, "accepted", prAccepted, "available", prAvailable)
 
 			switch {
 			case prFailed:
 				if checkState.State != kueue.CheckStateRejected {
-					updated = true
-					checkState.State = kueue.CheckStateRejected
-					checkState.Message = apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Failed).Message
+					if attempt := getAttempt(ctx, pr, wl.Name, check); attempt <= MaxRetries {
+						// it is going to be retried
+						message := fmt.Sprintf("Retrying after failure: %s", apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Failed).Message)
+						updated = updated || checkState.State != kueue.CheckStatePending || checkState.Message != message
+						checkState.State = kueue.CheckStatePending
+						checkState.Message = message
+					} else {
+						updated = true
+						checkState.State = kueue.CheckStateRejected
+						checkState.Message = apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Failed).Message
+					}
 				}
 			case prAccepted || prAvailable:
 				if checkState.State != kueue.CheckStateReady {
 					updated = true
 					checkState.State = kueue.CheckStateReady
 					// add the pod podSetUpdates
-					checkState.PodSetUpdates = podSetUpdates(wl, pr, check)
+					checkState.PodSetUpdates = podSetUpdates(wl, pr)
 				}
 			default:
 				if checkState.State != kueue.CheckStatePending {
@@ -458,10 +519,10 @@ func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, ch
 	return nil
 }
 
-func podSetUpdates(wl *kueue.Workload, pr *autoscaling.ProvisioningRequest, checkName string) []kueue.PodSetUpdate {
+func podSetUpdates(wl *kueue.Workload, pr *autoscaling.ProvisioningRequest) []kueue.PodSetUpdate {
 	podSets := wl.Spec.PodSets
 	refMap := slices.ToMap(podSets, func(i int) (string, string) {
-		return getProvisioningRequestPodTemplateName(wl.Name, checkName, podSets[i].Name), podSets[i].Name
+		return getProvisioningRequestPodTemplateName(pr.Name, podSets[i].Name), podSets[i].Name
 	})
 	return slices.Map(pr.Spec.PodSets, func(ps *autoscaling.PodSet) kueue.PodSetUpdate {
 		return kueue.PodSetUpdate{
@@ -646,13 +707,18 @@ func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(acReconciler)
 }
 
-func GetProvisioningRequestName(workloadName, checkName string) string {
-	fullName := fmt.Sprintf("%s-%s", workloadName, checkName)
+func GetProvisioningRequestName(workloadName, checkName string, attempt int32) string {
+	fullName := fmt.Sprintf("%s-%s-%d", workloadName, checkName, int(attempt))
 	return limitObjectName(fullName)
 }
 
-func getProvisioningRequestPodTemplateName(workloadName, checkName, podsetName string) string {
-	fullName := fmt.Sprintf("%s-%s-%s-%s", podTemplatesPrefix, workloadName, checkName, podsetName)
+func getProvisioningRequestNamePrefix(workloadName, checkName string) string {
+	fullName := fmt.Sprintf("%s-%s-", workloadName, checkName)
+	return limitObjectName(fullName)
+}
+
+func getProvisioningRequestPodTemplateName(prName, podsetName string) string {
+	fullName := fmt.Sprintf("%s-%s-%s", podTemplatesPrefix, prName, podsetName)
 	return limitObjectName(fullName)
 }
 
@@ -664,4 +730,49 @@ func limitObjectName(fullName string) string {
 	h.Write([]byte(fullName))
 	hashBytes := hex.EncodeToString(h.Sum(nil))
 	return fmt.Sprintf("%s-%s", fullName[:objNameMaxPrefixLength], hashBytes[:objNameHashLength])
+}
+
+func matches(pr *autoscaling.ProvisioningRequest, workloadName, checkName string) bool {
+	attemptRegex := getAttemptRegex(workloadName, checkName)
+	matches := attemptRegex.FindStringSubmatch(pr.Name)
+	return len(matches) > 0
+}
+
+func getAttempt(ctx context.Context, pr *autoscaling.ProvisioningRequest, workloadName, checkName string) int32 {
+	logger := log.FromContext(ctx)
+	attemptRegex := getAttemptRegex(workloadName, checkName)
+	matches := attemptRegex.FindStringSubmatch(pr.Name)
+	if len(matches) > 0 {
+		number, err := strconv.Atoi(matches[1])
+		if err != nil {
+			logger.Error(err, "Parsing the attempt number from provisioning request", "requestName", pr.Name)
+			return 1
+		} else {
+			return int32(number)
+		}
+	} else {
+		logger.Info("No attempt suffix in provisioning request", "requestName", pr.Name)
+		return 1
+	}
+}
+
+func getAttemptRegex(workloadName, checkName string) *regexp.Regexp {
+	prefix := getProvisioningRequestNamePrefix(workloadName, checkName)
+	escapedPrefix := regexp.QuoteMeta(prefix)
+	return regexp.MustCompile("^" + escapedPrefix + "([0-9]+)$")
+}
+
+func remainingTime(prc *kueue.ProvisioningRequestConfig, failuresCount int32, lastFailureTime time.Time) time.Duration {
+	defaultBackoff := time.Duration(MinBackoffSeconds) * time.Second
+	maxBackoff := 30 * time.Minute
+	backoffDuration := defaultBackoff
+	for i := 1; i < int(failuresCount); i++ {
+		backoffDuration = backoffDuration * 2
+		if backoffDuration >= maxBackoff {
+			backoffDuration = maxBackoff
+			break
+		}
+	}
+	timeElapsedSinceLastFailure := time.Since(lastFailureTime)
+	return backoffDuration - timeElapsedSinceLastFailure
 }

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -126,7 +126,7 @@ func TestReconcile(t *testing.T) {
 	baseRequest := &autoscaling.ProvisioningRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: TestNamespace,
-			Name:      "wl-check1",
+			Name:      "wl-check1-1",
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Name: "wl",
@@ -137,13 +137,13 @@ func TestReconcile(t *testing.T) {
 			PodSets: []autoscaling.PodSet{
 				{
 					PodTemplateRef: autoscaling.Reference{
-						Name: "ppt-wl-check1-ps1",
+						Name: "ppt-wl-check1-1-ps1",
 					},
 					Count: 4,
 				},
 				{
 					PodTemplateRef: autoscaling.Reference{
-						Name: "ppt-wl-check1-ps2",
+						Name: "ppt-wl-check1-1-ps2",
 					},
 					Count: 3,
 				},
@@ -158,10 +158,10 @@ func TestReconcile(t *testing.T) {
 	baseTemplate1 := &corev1.PodTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: TestNamespace,
-			Name:      "ppt-wl-check1-ps1",
+			Name:      "ppt-wl-check1-1-ps1",
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					Name: "wl-check1",
+					Name: "wl-check1-1",
 				},
 			},
 		},
@@ -193,10 +193,10 @@ func TestReconcile(t *testing.T) {
 	baseTemplate2 := &corev1.PodTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: TestNamespace,
-			Name:      "ppt-wl-check1-ps2",
+			Name:      "ppt-wl-check1-1-ps2",
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					Name: "wl-check1",
+					Name: "wl-check1-1",
 				},
 			},
 		},
@@ -241,6 +241,7 @@ func TestReconcile(t *testing.T) {
 		configs              []kueue.ProvisioningRequestConfig
 		flavors              []kueue.ResourceFlavor
 		workload             *kueue.Workload
+		maxRetries           int32
 		wantReconcileError   error
 		wantWorkloads        map[string]*kueue.Workload
 		wantRequests         map[string]*autoscaling.ProvisioningRequest
@@ -341,7 +342,7 @@ func TestReconcile(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: TestNamespace,
-						Name:      "wl-check1",
+						Name:      "wl-check1-1",
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Name: "wl",
@@ -352,7 +353,7 @@ func TestReconcile(t *testing.T) {
 						PodSets: []autoscaling.PodSet{
 							{
 								PodTemplateRef: autoscaling.Reference{
-									Name: "ppt-wl-check1-main",
+									Name: "ppt-wl-check1-1-main",
 								},
 								Count: 1,
 							},
@@ -390,11 +391,46 @@ func TestReconcile(t *testing.T) {
 			templates:            []corev1.PodTemplate{*baseTemplate1.DeepCopy(), *baseTemplate2.DeepCopy()},
 			wantRequestsNotFound: []string{"wl-check1"},
 		},
-		"when request fails": {
+		"when request fails and is retried": {
 			workload: baseWorkload.DeepCopy(),
 			checks:   []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
 			flavors:  []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
 			configs:  []kueue.ProvisioningRequestConfig{*baseConfig.DeepCopy()},
+			requests: []autoscaling.ProvisioningRequest{
+				*requestWithCondition(baseRequest, autoscaling.Failed, metav1.ConditionTrue),
+			},
+			maxRetries: 2,
+			templates:  []corev1.PodTemplate{*baseTemplate1.DeepCopy(), *baseTemplate2.DeepCopy()},
+			wantWorkloads: map[string]*kueue.Workload{
+				baseWorkload.Name: (&utiltesting.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).
+					AdmissionChecks(kueue.AdmissionCheckState{
+						Name:    "check1",
+						State:   kueue.CheckStatePending,
+						Message: "Retrying after failure: ",
+					}, kueue.AdmissionCheckState{
+						Name:  "not-provisioning",
+						State: kueue.CheckStatePending,
+					}).
+					Obj(),
+			},
+		},
+		"when request fails, and there is no retry": {
+			workload: baseWorkload.DeepCopy(),
+			checks:   []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
+			flavors:  []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
+			configs: []kueue.ProvisioningRequestConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config1",
+					},
+					Spec: kueue.ProvisioningRequestConfigSpec{
+						ProvisioningClassName: "class1",
+						Parameters: map[string]kueue.Parameter{
+							"p1": "v1",
+						},
+					},
+				},
+			},
 			requests: []autoscaling.ProvisioningRequest{
 				*requestWithCondition(baseRequest, autoscaling.Failed, metav1.ConditionTrue),
 			},
@@ -428,11 +464,11 @@ func TestReconcile(t *testing.T) {
 						PodSetUpdates: []kueue.PodSetUpdate{
 							{
 								Name:        "ps1",
-								Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1"},
+								Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1-1"},
 							},
 							{
 								Name:        "ps2",
-								Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1"},
+								Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1-1"},
 							},
 						},
 					}, kueue.AdmissionCheckState{
@@ -459,11 +495,11 @@ func TestReconcile(t *testing.T) {
 						PodSetUpdates: []kueue.PodSetUpdate{
 							{
 								Name:        "ps1",
-								Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1"},
+								Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1-1"},
 							},
 							{
 								Name:        "ps2",
-								Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1"},
+								Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1-1"},
 							},
 						},
 					}, kueue.AdmissionCheckState{
@@ -524,12 +560,12 @@ func TestReconcile(t *testing.T) {
 				baseWorkload.Name: baseWorkload.DeepCopy(),
 			},
 			wantRequests: map[string]*autoscaling.ProvisioningRequest{
-				"wl-check1": {
+				"wl-check1-1": {
 					Spec: autoscaling.ProvisioningRequestSpec{
 						PodSets: []autoscaling.PodSet{
 							{
 								PodTemplateRef: autoscaling.Reference{
-									Name: "ppt-wl-check1-ps2",
+									Name: "ppt-wl-check1-1-ps2",
 								},
 								Count: 3,
 							},
@@ -567,6 +603,8 @@ func TestReconcile(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Cleanup(utiltesting.SetDuringTest(&MaxRetries, tc.maxRetries))
+
 			builder, ctx := getClientBuilder()
 
 			builder = builder.WithObjects(tc.workload)

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -680,3 +680,133 @@ func TestReconcile(t *testing.T) {
 	}
 
 }
+
+func TestActiveOrLastPRForChecks(t *testing.T) {
+	baseWorkload := utiltesting.MakeWorkload("wl", TestNamespace).
+		PodSets(
+			*utiltesting.MakePodSet("main", 4).
+				Request(corev1.ResourceCPU, "1").
+				Obj(),
+		).
+		ReserveQuota(utiltesting.MakeAdmission("q1").PodSets(
+			kueue.PodSetAssignment{
+				Name: "main",
+				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+					corev1.ResourceCPU: "flv1",
+				},
+				ResourceUsage: map[corev1.ResourceName]resource.Quantity{
+					corev1.ResourceCPU: resource.MustParse("4"),
+				},
+				Count: ptr.To[int32](4),
+			},
+		).
+			Obj()).
+		AdmissionChecks(kueue.AdmissionCheckState{
+			Name:  "check",
+			State: kueue.CheckStatePending,
+		}, kueue.AdmissionCheckState{
+			Name:  "not-provisioning",
+			State: kueue.CheckStatePending,
+		}).
+		Obj()
+	baseConfig := &kueue.ProvisioningRequestConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "config1",
+		},
+		Spec: kueue.ProvisioningRequestConfigSpec{
+			ProvisioningClassName: "class1",
+			Parameters: map[string]kueue.Parameter{
+				"p1": "v1",
+			},
+		},
+	}
+
+	baseRequest := autoscaling.ProvisioningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: TestNamespace,
+			Name:      "wl-check-1",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name: "wl",
+				},
+			},
+		},
+		Spec: autoscaling.ProvisioningRequestSpec{
+			PodSets: []autoscaling.PodSet{
+				{
+					PodTemplateRef: autoscaling.Reference{
+						Name: "ppt-wl-check-1-ps1",
+					},
+					Count: 4,
+				},
+			},
+			ProvisioningClassName: "class1",
+			Parameters: map[string]autoscaling.Parameter{
+				"p1": "v1",
+			},
+		},
+	}
+	pr1Failed := baseRequest.DeepCopy()
+	pr1Failed = requestWithCondition(pr1Failed, autoscaling.Failed, metav1.ConditionTrue)
+	pr2Created := baseRequest.DeepCopy()
+	pr2Created.Name = "wl-check-2"
+
+	baseCheck := utiltesting.MakeAdmissionCheck("check").
+		ControllerName(ControllerName).
+		Parameters(kueue.GroupVersion.Group, ConfigKind, "config1").
+		Obj()
+
+	cases := map[string]struct {
+		requests   []autoscaling.ProvisioningRequest
+		wantResult map[string]*autoscaling.ProvisioningRequest
+	}{
+		"no provisioning requests": {},
+		"two provisioning requests; 1 then 2": {
+			requests: []autoscaling.ProvisioningRequest{
+				*pr1Failed.DeepCopy(),
+				*pr2Created.DeepCopy(),
+			},
+			wantResult: map[string]*autoscaling.ProvisioningRequest{
+				"check": pr2Created.DeepCopy(),
+			},
+		},
+		"two provisioning requests; 2 then 1": {
+			requests: []autoscaling.ProvisioningRequest{
+				*pr2Created.DeepCopy(),
+				*pr1Failed.DeepCopy(),
+			},
+			wantResult: map[string]*autoscaling.ProvisioningRequest{
+				"check": pr2Created.DeepCopy(),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			workload := baseWorkload.DeepCopy()
+			relevantChecks := []string{"check"}
+			checks := []kueue.AdmissionCheck{*baseCheck.DeepCopy()}
+			configs := []kueue.ProvisioningRequestConfig{*baseConfig.DeepCopy()}
+
+			builder, ctx := getClientBuilder()
+
+			builder = builder.WithObjects(workload)
+			builder = builder.WithStatusSubresource(workload)
+
+			builder = builder.WithLists(
+				&autoscaling.ProvisioningRequestList{Items: tc.requests},
+				&kueue.ProvisioningRequestConfigList{Items: configs},
+				&kueue.AdmissionCheckList{Items: checks},
+			)
+
+			k8sclient := builder.Build()
+			recorder := &utiltesting.EventRecorder{}
+			controller := NewController(k8sclient, recorder)
+
+			gotResult := controller.activeOrLastPRForChecks(ctx, workload, relevantChecks, tc.requests)
+			if diff := cmp.Diff(tc.wantResult, gotResult, reqCmpOptions...); diff != "" {
+				t.Errorf("unexpected request %q (-want/+got):\n%s", name, diff)
+			}
+		})
+	}
+}

--- a/pkg/util/testing/util.go
+++ b/pkg/util/testing/util.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+func SetDuringTest[T any](val *T, newVal T) func() {
+	origVal := *val
+	*val = newVal
+	return func() {
+		*val = origVal
+	}
+}

--- a/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 package provisioning
 
 import (
+	"time"
+
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -40,7 +42,12 @@ const (
 	customResourceTwo = "example.org/res2"
 )
 
-var _ = ginkgo.Describe("Provisioning", func() {
+var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+
+	var (
+		defaultMaxRetries        = provisioning.MaxRetries
+		defaultMinBackoffSeconds = provisioning.MinBackoffSeconds
+	)
 
 	ginkgo.When("A workload is using a provision admission check", func() {
 		var (
@@ -53,6 +60,8 @@ var _ = ginkgo.Describe("Provisioning", func() {
 			admission *kueue.Admission
 		)
 		ginkgo.BeforeEach(func() {
+			provisioning.MaxRetries = 0
+
 			ns = &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "provisioning-",
@@ -142,6 +151,8 @@ var _ = ginkgo.Describe("Provisioning", func() {
 		})
 
 		ginkgo.AfterEach(func() {
+			provisioning.MaxRetries = defaultMaxRetries
+			provisioning.MinBackoffSeconds = defaultMinBackoffSeconds
 			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, rf, true)
 			util.ExpectAdmissionCheckToBeDeleted(ctx, k8sClient, ac, true)
 			util.ExpectProvisioningRequestConfigToBeDeleted(ctx, k8sClient, prc2, true)
@@ -165,7 +176,7 @@ var _ = ginkgo.Describe("Provisioning", func() {
 			ginkgo.By("Checking no provision request is created", func() {
 				provReqKey := types.NamespacedName{
 					Namespace: wlKey.Namespace,
-					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name),
+					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name, 1),
 				}
 				gomega.Consistently(func() error {
 					request := &autoscaling.ProvisioningRequest{}
@@ -203,7 +214,7 @@ var _ = ginkgo.Describe("Provisioning", func() {
 			ginkgo.By("Checking that the provision request is created", func() {
 				provReqKey := types.NamespacedName{
 					Namespace: wlKey.Namespace,
-					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name),
+					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name, 1),
 				}
 				gomega.Eventually(func() error {
 					return k8sClient.Get(ctx, provReqKey, createdRequest)
@@ -264,7 +275,7 @@ var _ = ginkgo.Describe("Provisioning", func() {
 			ginkgo.By("Checking provision request is deleted", func() {
 				provReqKey := types.NamespacedName{
 					Namespace: wlKey.Namespace,
-					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name),
+					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name, 1),
 				}
 				gomega.Eventually(func() error {
 					request := &autoscaling.ProvisioningRequest{}
@@ -300,7 +311,7 @@ var _ = ginkgo.Describe("Provisioning", func() {
 
 			provReqKey := types.NamespacedName{
 				Namespace: wlKey.Namespace,
-				Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name),
+				Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name, 1),
 			}
 			ginkgo.By("Setting the provision request as Provisioned", func() {
 				createdRequest := &autoscaling.ProvisioningRequest{}
@@ -372,7 +383,7 @@ var _ = ginkgo.Describe("Provisioning", func() {
 				createdRequest := &autoscaling.ProvisioningRequest{}
 				provReqKey := types.NamespacedName{
 					Namespace: wlKey.Namespace,
-					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name),
+					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name, 1),
 				}
 				gomega.Eventually(func() error {
 					err := k8sClient.Get(ctx, provReqKey, createdRequest)
@@ -427,7 +438,7 @@ var _ = ginkgo.Describe("Provisioning", func() {
 			createdRequest := &autoscaling.ProvisioningRequest{}
 			provReqKey := types.NamespacedName{
 				Namespace: wlKey.Namespace,
-				Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name),
+				Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name, 1),
 			}
 			ginkgo.By("Checking that the provision request is created", func() {
 				gomega.Eventually(func() error {
@@ -515,7 +526,7 @@ var _ = ginkgo.Describe("Provisioning", func() {
 			ginkgo.By("Checking no provision request is deleted", func() {
 				provReqKey := types.NamespacedName{
 					Namespace: wlKey.Namespace,
-					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name),
+					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name, 1),
 				}
 				gomega.Eventually(func() error {
 					request := &autoscaling.ProvisioningRequest{}
@@ -529,6 +540,278 @@ var _ = ginkgo.Describe("Provisioning", func() {
 					state := workload.FindAdmissionCheck(updatedWl.Status.AdmissionChecks, ac.Name)
 					g.Expect(state).NotTo(gomega.BeNil())
 					g.Expect(state.Message).To(gomega.Equal(provisioning.CheckInactiveMessage))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+
+	ginkgo.When("A workload is using a provision admission check with retry", func() {
+		var (
+			ns        *corev1.Namespace
+			wlKey     types.NamespacedName
+			ac        *kueue.AdmissionCheck
+			prc       *kueue.ProvisioningRequestConfig
+			rf        *kueue.ResourceFlavor
+			admission *kueue.Admission
+		)
+		ginkgo.BeforeEach(func() {
+			provisioning.MaxRetries = 1
+			provisioning.MinBackoffSeconds = 1
+
+			ns = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "provisioning-",
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+			prc = &kueue.ProvisioningRequestConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "prov-config",
+				},
+				Spec: kueue.ProvisioningRequestConfigSpec{
+					ProvisioningClassName: "provisioning-class",
+					Parameters: map[string]kueue.Parameter{
+						"p1": "v1",
+						"p2": "v2",
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, prc)).To(gomega.Succeed())
+
+			ac = testing.MakeAdmissionCheck("ac-prov").
+				ControllerName(provisioning.ControllerName).
+				Parameters(kueue.GroupVersion.Group, "ProvisioningRequestConfig", prc.Name).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, ac)).To(gomega.Succeed())
+
+			rf = testing.MakeResourceFlavor("rf1").Label("ns1", "ns1v").Obj()
+			gomega.Expect(k8sClient.Create(ctx, rf)).To(gomega.Succeed())
+
+			wl := testing.MakeWorkload("wl", ns.Name).
+				PodSets(
+					*testing.MakePodSet("ps1", 3).
+						Request(corev1.ResourceCPU, "1").
+						Image("iamge").
+						Obj(),
+					*testing.MakePodSet("ps2", 6).
+						Request(corev1.ResourceCPU, "500m").
+						Request(customResourceOne, "1").
+						Limit(customResourceOne, "1").
+						Image("iamge").
+						Obj(),
+				).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+			wlKey = client.ObjectKeyFromObject(wl)
+
+			admission = testing.MakeAdmission("q").
+				PodSets(
+					kueue.PodSetAssignment{
+						Name: "ps1",
+						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+							corev1.ResourceCPU: kueue.ResourceFlavorReference(rf.Name),
+						},
+						ResourceUsage: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceCPU: resource.MustParse("3"),
+						},
+						Count: ptr.To[int32](3),
+					},
+					kueue.PodSetAssignment{
+						Name: "ps2",
+						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+							corev1.ResourceCPU: kueue.ResourceFlavorReference(rf.Name),
+						},
+						ResourceUsage: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+						Count: ptr.To[int32](4),
+					},
+				).
+				Obj()
+
+		})
+
+		ginkgo.AfterEach(func() {
+			provisioning.MaxRetries = defaultMaxRetries
+			provisioning.MinBackoffSeconds = defaultMinBackoffSeconds
+			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, rf, true)
+			util.ExpectAdmissionCheckToBeDeleted(ctx, k8sClient, ac, true)
+			util.ExpectProvisioningRequestConfigToBeDeleted(ctx, k8sClient, prc, true)
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("Should retry when ProvisioningRequestConfig has MaxRetries=2, the succeeded if the second Provisioning request succeeds", func() {
+			ginkgo.By("Setting the admission check to the workload", func() {
+				updatedWl := &kueue.Workload{}
+				gomega.Eventually(func() error {
+					err := k8sClient.Get(ctx, wlKey, updatedWl)
+					if err != nil {
+						return err
+					}
+					util.SetWorkloadsAdmissionCheck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
+					return nil
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Setting the quota reservation to the workload", func() {
+				updatedWl := &kueue.Workload{}
+				gomega.Eventually(func() error {
+					err := k8sClient.Get(ctx, wlKey, updatedWl)
+					if err != nil {
+						return err
+					}
+					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, updatedWl, admission)).To(gomega.Succeed())
+					return nil
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Setting the provision request-1 as Failed", func() {
+				createdRequest := &autoscaling.ProvisioningRequest{}
+				provReqKey := types.NamespacedName{
+					Namespace: wlKey.Namespace,
+					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name, 1),
+				}
+				gomega.Eventually(func() error {
+					err := k8sClient.Get(ctx, provReqKey, createdRequest)
+					if err != nil {
+						return err
+					}
+					apimeta.SetStatusCondition(&createdRequest.Status.Conditions, metav1.Condition{
+						Type:   autoscaling.Failed,
+						Status: metav1.ConditionTrue,
+						Reason: autoscaling.Failed,
+					})
+					return k8sClient.Status().Update(ctx, createdRequest)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking the admission check is pending", func() {
+				updatedWl := &kueue.Workload{}
+				// use consistently with short interval to make sure it does not
+				// flip to a short period of time.
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, updatedWl)).To(gomega.Succeed())
+					state := workload.FindAdmissionCheck(updatedWl.Status.AdmissionChecks, ac.Name)
+					g.Expect(state).NotTo(gomega.BeNil())
+					g.Expect(state.State).To(gomega.Equal(kueue.CheckStatePending))
+				}, time.Second, 10*time.Millisecond).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Setting the provision request-2 as Provisioned", func() {
+				createdRequest := &autoscaling.ProvisioningRequest{}
+				provReqKey := types.NamespacedName{
+					Namespace: wlKey.Namespace,
+					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name, 2),
+				}
+				gomega.Eventually(func() error {
+					err := k8sClient.Get(ctx, provReqKey, createdRequest)
+					if err != nil {
+						return err
+					}
+					apimeta.SetStatusCondition(&createdRequest.Status.Conditions, metav1.Condition{
+						Type:   autoscaling.Provisioned,
+						Status: metav1.ConditionTrue,
+						Reason: autoscaling.Provisioned,
+					})
+					return k8sClient.Status().Update(ctx, createdRequest)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking the admission check is ready", func() {
+				updatedWl := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, updatedWl)).To(gomega.Succeed())
+					state := workload.FindAdmissionCheck(updatedWl.Status.AdmissionChecks, ac.Name)
+					g.Expect(state).NotTo(gomega.BeNil())
+					g.Expect(state.State).To(gomega.Equal(kueue.CheckStateReady))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("Should retry when ProvisioningRequestConfig has MaxRetries>o, and every Provisioning request retry fails", func() {
+
+			ginkgo.By("Setting the admission check to the workload", func() {
+				updatedWl := &kueue.Workload{}
+				gomega.Eventually(func() error {
+					err := k8sClient.Get(ctx, wlKey, updatedWl)
+					if err != nil {
+						return err
+					}
+					util.SetWorkloadsAdmissionCheck(ctx, k8sClient, updatedWl, ac.Name, kueue.CheckStatePending, false)
+					return nil
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Setting the quota reservation to the workload", func() {
+				updatedWl := &kueue.Workload{}
+				gomega.Eventually(func() error {
+					err := k8sClient.Get(ctx, wlKey, updatedWl)
+					if err != nil {
+						return err
+					}
+					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, updatedWl, admission)).To(gomega.Succeed())
+					return nil
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Setting the provision request-1 as Failed", func() {
+				createdRequest := &autoscaling.ProvisioningRequest{}
+				provReqKey := types.NamespacedName{
+					Namespace: wlKey.Namespace,
+					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name, 1),
+				}
+				gomega.Eventually(func() error {
+					err := k8sClient.Get(ctx, provReqKey, createdRequest)
+					if err != nil {
+						return err
+					}
+					apimeta.SetStatusCondition(&createdRequest.Status.Conditions, metav1.Condition{
+						Type:   autoscaling.Failed,
+						Status: metav1.ConditionTrue,
+						Reason: autoscaling.Failed,
+					})
+					return k8sClient.Status().Update(ctx, createdRequest)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking the admission check is pending", func() {
+				updatedWl := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, updatedWl)).To(gomega.Succeed())
+					state := workload.FindAdmissionCheck(updatedWl.Status.AdmissionChecks, ac.Name)
+					g.Expect(state).NotTo(gomega.BeNil())
+					g.Expect(state.State).To(gomega.Equal(kueue.CheckStatePending))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Setting the provision request-2 as Failed", func() {
+				createdRequest := &autoscaling.ProvisioningRequest{}
+				provReqKey := types.NamespacedName{
+					Namespace: wlKey.Namespace,
+					Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name, 2),
+				}
+				gomega.Eventually(func() error {
+					err := k8sClient.Get(ctx, provReqKey, createdRequest)
+					if err != nil {
+						return err
+					}
+					apimeta.SetStatusCondition(&createdRequest.Status.Conditions, metav1.Condition{
+						Type:   autoscaling.Failed,
+						Status: metav1.ConditionTrue,
+						Reason: autoscaling.Failed,
+					})
+					return k8sClient.Status().Update(ctx, createdRequest)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking the admission check is rejected", func() {
+				updatedWl := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, updatedWl)).To(gomega.Succeed())
+					state := workload.FindAdmissionCheck(updatedWl.Status.AdmissionChecks, ac.Name)
+					g.Expect(state).NotTo(gomega.BeNil())
+					g.Expect(state.State).To(gomega.Equal(kueue.CheckStateRejected))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})


### PR DESCRIPTION
Cherry pick of #1351 on release-0.5.
#1351: Support retry for provisioning requests
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
Support for retry of provisioning request.
```
It includes the fix PR https://github.com/kubernetes-sigs/kueue/pull/1585 (except for the commit https://github.com/kubernetes-sigs/kueue/pull/1585/commits/916bddb28c9bf4c2811d7a3aa78e0e4e2ab424ab, because on the release-0.5 branch `NewController` does not return `err`). 