### PR TITLE
Add a documentation note about borrowWithinCohort

### DIFF
--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -320,6 +320,9 @@ metadata:
 spec:
   preemption:
     reclaimWithinCohort: Any
+    borrowWithinCohort:
+      policy: LowerPriority
+      maxPriorityThreshold: 100
     withinClusterQueue: LowerPriority
 ```
 
@@ -335,6 +338,15 @@ The fields above do the following:
   - `Any`: if the pending Workload fits within the nominal quota of its
     ClusterQueue, preempt any Workload in the cohort, irrespective of
     priority.
+
+- `borrowWithinCohort` determines whether a pending Workload can preempt
+  Workloads from other ClusterQueues if the workload requires borrowing. This
+  field requires to specify `policy` sub-field with possible values:
+  - `Never` (default): do not preempt Workloads in the cohort if borrowing is required.
+  - `LowerPriority`: if the pending Workload requires borrowing, only preempt
+    Workloads in the cohort that have lower priority than the pending Workload.
+  Additionally, only workloads up to the priority indicated by
+  `maxPriorityThreshold` can be preempted in that scenario.
 
 - `withinClusterQueue` determines whether a pending Workload that doesn't fit
   within the nominal quota for its ClusterQueue, can preempt active Workloads in


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

To add some basic documentation about the feature.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1337

#### Special notes for your reviewer:

More extensive documentation about preemption is ticketed https://github.com/kubernetes-sigs/kueue/issues/1587

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```