### PR TITLE
Automated cherry pick of #1613: Update latest version to v0.5.2

### DIFF
--- a/CHANGELOG/CHANGELOG-0.5.md
+++ b/CHANGELOG/CHANGELOG-0.5.md
@@ -1,3 +1,20 @@
+## v0.5.2
+
+Changes since `v0.5.1`:
+
+### Bug or Regression
+
+- Add Missing RBAC on integration finalizers sub-resources (#1486, @astefanutti)
+- Added event for QuotaReserved and fixed event for Admitted to trigger when admission checks complete (#1436, @trasc)
+- Avoid recreating a Workload for a finished Job and finalize a job when the workload is declared finished. (#1572, @alculquicondor)
+- Fix a bug in the pod integration where a Workload can be left with a finalizer when a pod is not found. (#1524, @achernevskii)
+- Remove finalizer from Workloads that are orphaned (have no owners). (#1523, @achernevskii, @woehrl01, @trasc)
+- Add Mutating WebhookConfigurations for the AdmissionCheck, RayJob, and JobSet to helm charts (#1570, @B1F030)
+- Add Validating/Mutating WebhookConfigurations for the KubeflowJobs like PyTorchJob (#1462, @tenzen-y)
+- Add events for transitions of the provisioning AdmissionCheck (#1394, @stuton)
+- Support for retry of provisioning request. (#1595, @mimowo)
+- Webhooks are served in non-leading replicas (#1511, @astefanutti)
+
 ## v0.5.1
 
 Changes since `v0.5.0`:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) to learn more.
 To install the latest release of Kueue in your cluster, run the following command:
 
 ```shell
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.5.1/manifests.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.5.2/manifests.yaml
 ```
 
 The controller runs in the `kueue-system` namespace.

--- a/charts/kueue/Chart.yaml
+++ b/charts/kueue/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.1"
+appVersion: "0.5.2"

--- a/site/config.toml
+++ b/site/config.toml
@@ -92,7 +92,7 @@ ignoreFiles = []
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
   # version number for this doc set.
-  version = "v0.5.1"
+  version = "v0.5.2"
 
   # Flag used in the "version-banner" partial to decide whether to display a
   # banner on every page indicating that this is an archived version of the docs.


### PR DESCRIPTION
Cherry pick of #1613 on website.
#1613: Update latest version to v0.5.2
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```