### PR TITLE
Do not (re)create ProvReq is the state of admission check is Ready

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -229,6 +229,11 @@ func (c *Controller) syncOwnedProvisionRequest(ctx context.Context, wl *kueue.Wo
 		if !c.reqIsNeeded(ctx, wl, prc) {
 			continue
 		}
+		if ac := workload.FindAdmissionCheck(wl.Status.AdmissionChecks, checkName); ac != nil && ac.State == kueue.CheckStateReady {
+			log.V(2).Info("Skip syncing of the ProvReq for admission check which is Ready", "workload", klog.KObj(wl), "admissionCheck", checkName)
+			continue
+		}
+
 		oldPr, exists := activeOrLastPRForChecks[checkName]
 		attempt := int32(1)
 		shouldCreatePr := false

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -34,6 +34,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 var (
@@ -112,6 +113,12 @@ func TestReconcile(t *testing.T) {
 			State: kueue.CheckStatePending,
 		}).
 		Obj()
+
+	baseWorkloadWithCheck1Ready := baseWorkload.DeepCopy()
+	workload.SetAdmissionCheckState(&baseWorkloadWithCheck1Ready.Status.AdmissionChecks, kueue.AdmissionCheckState{
+		Name:  "check1",
+		State: kueue.CheckStateReady,
+	})
 
 	baseFlavor1 := utiltesting.MakeResourceFlavor("flv1").Label("f1l1", "v1").
 		Toleration(corev1.Toleration{
@@ -614,30 +621,17 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
-		"when the request is removed while the check is ready": {
-			workload: (&utiltesting.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).
-				AdmissionChecks(kueue.AdmissionCheckState{
-					Name:  "check1",
-					State: kueue.CheckStateReady,
-				}, kueue.AdmissionCheckState{
-					Name:  "not-provisioning",
-					State: kueue.CheckStatePending,
-				}).
-				Obj(),
-
-			checks:  []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
-			flavors: []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
-			configs: []kueue.ProvisioningRequestConfig{*baseConfig.DeepCopy()},
+		"when the request is removed while the check is ready; don't create the ProvReq and keep Ready state": {
+			workload: baseWorkloadWithCheck1Ready.DeepCopy(),
+			checks:   []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
+			flavors:  []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
+			configs:  []kueue.ProvisioningRequestConfig{*baseConfig.DeepCopy()},
 			wantWorkloads: map[string]*kueue.Workload{
-				baseWorkload.Name: baseWorkload.DeepCopy(),
+				baseWorkload.Name: baseWorkloadWithCheck1Ready.DeepCopy(),
 			},
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       client.ObjectKeyFromObject(baseWorkload),
-					EventType: corev1.EventTypeNormal,
-					Reason:    "ProvisioningRequestCreated",
-					Message:   `Created ProvisioningRequest: "wl-check1-1"`,
-				},
+			wantRequestsNotFound: []string{
+				GetProvisioningRequestName("wl", "check1", 1),
+				GetProvisioningRequestName("wl", "check2", 1),
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1605

#### Special notes for your reviewer:

I tested this in a loop and already >2500 repeats passed, which makes me confident the test is fixed.

A potential drawback scenario is when the check is flipped to Ready, but the workload awaits long (>10min) for other checks, if in the meantime the ProvReq is manually deleted then it will not be recreated. As a consequence the nodes might be collected by CA (Cluster Autoscaler) before the workload is admitted. Not sure we want to support the scenario.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Do not (re)create ProvReq is the state of admission check is Ready
```