### PR TITLE
Automated cherry pick of #1617: Do not (re)create ProvReq is the state of admission check is

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -220,6 +220,11 @@ func (c *Controller) syncOwnedProvisionRequest(ctx context.Context, wl *kueue.Wo
 		if !c.reqIsNeeded(ctx, wl, prc) {
 			continue
 		}
+		if ac := workload.FindAdmissionCheck(wl.Status.AdmissionChecks, checkName); ac != nil && ac.State == kueue.CheckStateReady {
+			log.V(2).Info("Skip syncing of the ProvReq for admission check which is Ready", "workload", klog.KObj(wl), "admissionCheck", checkName)
+			continue
+		}
+
 		oldPr, exists := activeOrLastPRForChecks[checkName]
 		attempt := int32(1)
 		shouldCreatePr := false


### PR DESCRIPTION
Cherry pick of #1617 on release-0.5.
#1617: Do not (re)create ProvReq is the state of admission check is
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```