### PR TITLE
Do not cleanup excess pods when awaiting to observe previous clean ups

### DIFF
--- a/pkg/controller/jobs/pod/expectations.go
+++ b/pkg/controller/jobs/pod/expectations.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"sync"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type uids = sets.Set[types.UID]
+
+// expectationsStore contains UIDs for which we are waiting to observe some change through event handlers.
+type expectationsStore struct {
+	sync.Mutex
+	name string
+
+	store map[types.NamespacedName]uids
+}
+
+func newUIDExpectations(name string) *expectationsStore {
+	return &expectationsStore{
+		name:  name,
+		store: make(map[types.NamespacedName]uids),
+	}
+}
+
+func (e *expectationsStore) ExpectUIDs(log logr.Logger, key types.NamespacedName, UIDs []types.UID) {
+	log.V(3).Info("Expecting UIDs", "store", e.name, "key", key, "uids", UIDs)
+	expectedUIDs := sets.New[types.UID](UIDs...)
+	e.Lock()
+	defer e.Unlock()
+
+	stored, found := e.store[key]
+	if !found {
+		e.store[key] = expectedUIDs
+	} else {
+		e.store[key] = stored.Union(expectedUIDs)
+	}
+}
+
+func (e *expectationsStore) ObservedUID(log logr.Logger, key types.NamespacedName, uid types.UID) {
+	log.V(3).Info("Observed UID", "store", e.name, "key", key, "uid", uid)
+	e.Lock()
+	defer e.Unlock()
+
+	stored, found := e.store[key]
+	if !found {
+		return
+	}
+	stored.Delete(uid)
+
+	// clean up key if empty.
+	if stored.Len() == 0 {
+		delete(e.store, key)
+	}
+}
+
+func (e *expectationsStore) Satisfied(log logr.Logger, key types.NamespacedName) bool {
+	e.Lock()
+	_, found := e.store[key]
+	e.Unlock()
+
+	if logV := log.V(4); logV.Enabled() {
+		log.V(4).Info("Retrieved satisfied expectations", "store", e.name, "key", key, "satisfied", !found)
+	}
+	return !found
+}

--- a/pkg/controller/jobs/pod/expectations_test.go
+++ b/pkg/controller/jobs/pod/expectations_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/kueue/pkg/util/parallelize"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+type keyUIDs struct {
+	key  types.NamespacedName
+	uids []types.UID
+}
+
+func TestExpectations(t *testing.T) {
+	ctx, log := utiltesting.ContextWithLog(t)
+	initial := []keyUIDs{
+		{
+			key:  types.NamespacedName{Name: "g1"},
+			uids: []types.UID{"a", "b", "c"},
+		},
+		{
+			key:  types.NamespacedName{Name: "g2"},
+			uids: []types.UID{"x", "y", "z"},
+		},
+		{
+
+			key:  types.NamespacedName{Name: "g3"},
+			uids: []types.UID{"a", "b", "c", "x", "y", "z"},
+		},
+	}
+	expectations := newUIDExpectations("test")
+	err := parallelize.Until(ctx, len(initial), func(i int) error {
+		e := initial[i]
+		expectations.ExpectUIDs(log, e.key, e.uids)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Inserting initial UIDs: %v", err)
+	}
+
+	observe := []keyUIDs{
+		{
+			key:  types.NamespacedName{Name: "g1"},
+			uids: []types.UID{"a", "b", "c"},
+		},
+		{
+			key:  types.NamespacedName{Name: "g2"},
+			uids: []types.UID{"x", "y", "z", "x", "y", "z"},
+		},
+		{
+			key:  types.NamespacedName{Name: "g3"},
+			uids: []types.UID{"a", "b", "c", "x", "y"},
+		},
+	}
+	err = parallelize.Until(ctx, len(observe), func(i int) error {
+		e := observe[i]
+		return parallelize.Until(ctx, len(e.uids), func(j int) error {
+			expectations.ObservedUID(log, e.key, e.uids[j])
+			return nil
+		})
+	})
+	if err != nil {
+		t.Fatalf("Observing UIDs: %v", err)
+	}
+
+	wantSatisfied := map[types.NamespacedName]bool{
+		{Name: "g1"}: true,
+		{Name: "g2"}: true,
+		{Name: "g3"}: false,
+	}
+	for key, want := range wantSatisfied {
+		got := expectations.Satisfied(log, key)
+		if got != want {
+			t.Errorf("Got key %s satisfied: %t, want %t", key, got, want)
+		}
+	}
+}

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -50,6 +50,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/podset"
 	"sigs.k8s.io/kueue/pkg/util/parallelize"
+	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 )
 
 const (
@@ -65,6 +66,7 @@ const (
 var (
 	gvk                          = corev1.SchemeGroupVersion.WithKind("Pod")
 	errIncorrectReconcileRequest = fmt.Errorf("event handler error: got a single pod reconcile request for a pod group")
+	errPendingOps                = jobframework.UnretryableError("waiting to observe previous operations on pods")
 )
 
 func init() {
@@ -88,31 +90,36 @@ func init() {
 
 type Reconciler struct {
 	*jobframework.JobReconciler
+	expectationsStore *expectationsStore
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.ReconcileGenericJob(ctx, req, &Pod{})
+	return r.ReconcileGenericJob(ctx, req, &Pod{excessPodExpectations: r.expectationsStore})
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		Watches(&corev1.Pod{}, &podEventHandler{}).Named("v1_pod").
+		Watches(&corev1.Pod{}, &podEventHandler{cleanedUpPodsExpectations: r.expectationsStore}).Named("v1_pod").
 		Watches(&kueue.Workload{}, &workloadHandler{}).
 		Complete(r)
 }
 
 func NewReconciler(c client.Client, record record.EventRecorder, opts ...jobframework.Option) jobframework.JobReconcilerInterface {
 	return &Reconciler{
-		JobReconciler: jobframework.NewReconciler(c, record, opts...),
+		JobReconciler:     jobframework.NewReconciler(c, record, opts...),
+		expectationsStore: newUIDExpectations("finalizedPods"),
 	}
 }
 
 type Pod struct {
-	pod              corev1.Pod
-	isFound          bool
-	isGroup          bool
-	unretriableGroup *bool
-	list             corev1.PodList
+	pod                   corev1.Pod
+	key                   types.NamespacedName
+	isFound               bool
+	isGroup               bool
+	unretriableGroup      *bool
+	list                  corev1.PodList
+	excessPodExpectations *expectationsStore
+	satisfiedExcessPods   bool
 }
 
 var (
@@ -576,6 +583,11 @@ func (p *Pod) Load(ctx context.Context, c client.Client, key *types.NamespacedNa
 	p.isGroup = true
 
 	key.Namespace = nsKey[1]
+	p.key = *key
+
+	// Check the expectations before listing pods, otherwise a new pod can sneak in
+	// and update the expectations after we've retrieved active pods from the store.
+	p.satisfiedExcessPods = p.excessPodExpectations.Satisfied(ctrl.LoggerFrom(ctx), *key)
 
 	if err := c.List(ctx, &p.list, client.MatchingLabels{
 		GroupNameLabel: key.Name,
@@ -705,14 +717,34 @@ func (p *Pod) cleanupExcessPods(ctx context.Context, c client.Client, totalCount
 	if extraPodsCount <= 0 {
 		return nil
 	}
+	// Do not clean up more pods until observing previous operations
+	if !p.satisfiedExcessPods {
+		return errPendingOps
+	}
 
 	// Sort active pods by creation timestamp
 	sort.Slice(activePods, func(i, j int) bool {
-		return activePods[i].ObjectMeta.CreationTimestamp.Before(&activePods[j].ObjectMeta.CreationTimestamp)
+		pi := &activePods[i]
+		pj := &activePods[j]
+		iFin := slices.Contains(pi.Finalizers, PodFinalizer)
+		jFin := slices.Contains(pj.Finalizers, PodFinalizer)
+		// Keep pods that have a finalizer
+		if iFin != jFin {
+			return iFin
+		}
+		iGated := gateIndex(pi) != gateNotFound
+		jGated := gateIndex(pj) != gateNotFound
+		// keep pods that aren't gated.
+		if iGated != jGated {
+			return !iGated
+		}
+		return pi.ObjectMeta.CreationTimestamp.Before(&pj.ObjectMeta.CreationTimestamp)
 	})
 
 	// Extract all the latest created extra pods
 	extraPods := activePods[len(activePods)-extraPodsCount:]
+	extraPodsUIDs := utilslices.Map(extraPods, func(p *corev1.Pod) types.UID { return p.UID })
+	p.excessPodExpectations.ExpectUIDs(log, p.key, extraPodsUIDs)
 
 	// Finalize and delete the active pods created last
 
@@ -721,12 +753,18 @@ func (p *Pod) cleanupExcessPods(ctx context.Context, c client.Client, totalCount
 		if controllerutil.RemoveFinalizer(&pod, PodFinalizer) {
 			log.V(3).Info("Finalizing excess pod in group", "excessPod", klog.KObj(&pod))
 			if err := c.Update(ctx, &pod); err != nil {
+				// We won't observe this cleanup in the event handler.
+				p.excessPodExpectations.ObservedUID(log, p.key, pod.UID)
 				return err
 			}
 		}
 		if pod.ObjectMeta.DeletionTimestamp.IsZero() {
 			log.V(3).Info("Deleting excess pod in group", "excessPod", klog.KObj(&pod))
-			return c.Delete(ctx, &pod)
+			if err := c.Delete(ctx, &pod); err != nil {
+				// We won't observe this cleanup in the event handler.
+				p.excessPodExpectations.ObservedUID(log, p.key, pod.UID)
+				return err
+			}
 		}
 		return nil
 	})

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -728,13 +728,13 @@ func (p *Pod) cleanupExcessPods(ctx context.Context, c client.Client, totalCount
 		pj := &activePods[j]
 		iFin := slices.Contains(pi.Finalizers, PodFinalizer)
 		jFin := slices.Contains(pj.Finalizers, PodFinalizer)
-		// Keep pods that have a finalizer
+		// Prefer to keep pods that have a finalizer.
 		if iFin != jFin {
 			return iFin
 		}
 		iGated := gateIndex(pi) != gateNotFound
 		jGated := gateIndex(pj) != gateNotFound
-		// keep pods that aren't gated.
+		// Prefer to keep pods that aren't gated.
 		if iGated != jGated {
 			return !iGated
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

- After cleaning up pods, await to observe them in the event handlers before cleaning up more pods.
- When sorting pods for clean up, prefer the ones that are still gated or have lost their finalizer.

This prevents unnecessary cleanups in two scenarios:
- The user creates an excess pod when the group just was started. Previously, the reconciler might not have observed the pods that it ungated, deleting one of these pods.
- The user creates two replacement pods to fill up a Failed Pod. Previously, the reconciler might delete one the Pods in the first reconcile, and the other one in the second reconcile.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1593

#### Special notes for your reviewer:

Adding parallelism simplified handling of expectations when there are failures. But I extracted the changes specific to parallelism into a separate PR #1632

#### Does this PR introduce a user-facing change?

Unreleased feature

```release-note
NONE
```