### PR TITLE
[multikueue] Add Path kubeConfig location type

### DIFF
--- a/apis/kueue/v1alpha1/multikueue_types.go
+++ b/apis/kueue/v1alpha1/multikueue_types.go
@@ -28,6 +28,9 @@ const (
 type LocationType string
 
 const (
+	// Location is the path on the disk of kueue-controller-manager.
+	PathLocationType LocationType = "Path"
+
 	// Location is the name of the secret inside the namespace in which the kueue controller
 	// manager is running. The config should be stored in the "kubeconfig" key.
 	SecretLocationType LocationType = "Secret"
@@ -43,7 +46,7 @@ type KubeConfig struct {
 	// Type of the KubeConfig location.
 	//
 	// +kubebuilder:default=Secret
-	// +kubebuilder:validation:Enum=Secret
+	// +kubebuilder:validation:Enum=Secret;Path
 	LocationType LocationType `json:"locationType"`
 }
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
@@ -60,6 +60,7 @@ spec:
                     description: Type of the KubeConfig location.
                     enum:
                     - Secret
+                    - Path
                     type: string
                 required:
                 - location

--- a/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
@@ -47,6 +47,7 @@ spec:
                     description: Type of the KubeConfig location.
                     enum:
                     - Secret
+                    - Path
                     type: string
                 required:
                 - location

--- a/keps/693-multikueue/README.md
+++ b/keps/693-multikueue/README.md
@@ -160,7 +160,7 @@ type MultiKueueCluster struct {
 type LocationType string
 
 const (
-    // Location is the path on the disk.
+    // Location is the path on the disk of kueue-controller-manager.
     PathLocationType LocationType = "Path"
     
     // Location is the name of the secret inside the namespace in which the kueue controller
@@ -180,7 +180,7 @@ type KubeConfig struct {
     // Type of the KubeConfig location.
     //
     // +kubebuilder:default=Secret
-    // +kubebuilder:validation:Enum=Secret
+    // +kubebuilder:validation:Enum=Secret;Path
     LocationType LocationType `json:"locationType"`
 }
 

--- a/pkg/controller/admissionchecks/multikueue/indexer_test.go
+++ b/pkg/controller/admissionchecks/multikueue/indexer_test.go
@@ -77,21 +77,21 @@ func TestListMultiKueueClustersUsingKubeConfig(t *testing.T) {
 		},
 		"single cluster, single match": {
 			clusters: []*kueuealpha.MultiKueueCluster{
-				utiltesting.MakeMultiKueueCluster("cluster1").KubeConfig("secret1").Obj(),
+				utiltesting.MakeMultiKueueCluster("cluster1").KubeConfig(kueuealpha.SecretLocationType, "secret1").Obj(),
 			},
 			filter:   client.MatchingFields{UsingKubeConfigs: TestNamespace + "/secret1"},
 			wantList: []string{"cluster1"},
 		},
 		"single cluster, no match": {
 			clusters: []*kueuealpha.MultiKueueCluster{
-				utiltesting.MakeMultiKueueCluster("cluster2").KubeConfig("secret2").Obj(),
+				utiltesting.MakeMultiKueueCluster("cluster2").KubeConfig(kueuealpha.SecretLocationType, "secret2").Obj(),
 			},
 			filter: client.MatchingFields{UsingKubeConfigs: TestNamespace + "/secret1"},
 		},
 		"multiple clusters, single match": {
 			clusters: []*kueuealpha.MultiKueueCluster{
-				utiltesting.MakeMultiKueueCluster("cluster1").KubeConfig("secret1").Obj(),
-				utiltesting.MakeMultiKueueCluster("cluster2").KubeConfig("secret2").Obj(),
+				utiltesting.MakeMultiKueueCluster("cluster1").KubeConfig(kueuealpha.SecretLocationType, "secret1").Obj(),
+				utiltesting.MakeMultiKueueCluster("cluster2").KubeConfig(kueuealpha.SecretLocationType, "secret2").Obj(),
 			},
 			filter:   client.MatchingFields{UsingKubeConfigs: TestNamespace + "/secret1"},
 			wantList: []string{"cluster1"},

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -85,13 +85,13 @@ func TestUpdateConfig(t *testing.T) {
 		"new valid client is added": {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
-				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig("worker1").Obj(),
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Obj(),
 			},
 			secrets: []corev1.Secret{
 				makeTestSecret("worker1", "worker1 kubeconfig"),
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
-				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig("worker1").Active(metav1.ConditionTrue, "Active", "Connected").Obj(),
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Active(metav1.ConditionTrue, "Active", "Connected").Obj(),
 			},
 			wantRemoteClients: map[string]*remoteClient{
 				"worker1": {
@@ -102,7 +102,7 @@ func TestUpdateConfig(t *testing.T) {
 		"update client with valid secret config": {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
-				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig("worker1").Obj(),
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Obj(),
 			},
 			secrets: []corev1.Secret{
 				makeTestSecret("worker1", "worker1 kubeconfig"),
@@ -111,7 +111,7 @@ func TestUpdateConfig(t *testing.T) {
 				"worker1": newTestClient("worker1 old kubeconfig"),
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
-				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig("worker1").Active(metav1.ConditionTrue, "Active", "Connected").Obj(),
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Active(metav1.ConditionTrue, "Active", "Connected").Obj(),
 			},
 			wantRemoteClients: map[string]*remoteClient{
 				"worker1": {
@@ -122,13 +122,13 @@ func TestUpdateConfig(t *testing.T) {
 		"update client with valid path config": {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
-				*utiltesting.MakeMultiKueueCluster("worker1").Path("w1", "testdata/worker1KubeConfig").Obj(),
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.PathLocationType, "testdata/worker1KubeConfig").Obj(),
 			},
 			remoteClients: map[string]*remoteClient{
 				"worker1": newTestClient("worker1 old kubeconfig"),
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
-				*utiltesting.MakeMultiKueueCluster("worker1").Path("w1", "testdata/worker1KubeConfig").Active(metav1.ConditionTrue, "Active", "Connected").Obj(),
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.PathLocationType, "testdata/worker1KubeConfig").Active(metav1.ConditionTrue, "Active", "Connected").Obj(),
 			},
 			wantRemoteClients: map[string]*remoteClient{
 				"worker1": {
@@ -139,7 +139,7 @@ func TestUpdateConfig(t *testing.T) {
 		"update client with invalid secret config": {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
-				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig("worker1").Obj(),
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Obj(),
 			},
 			secrets: []corev1.Secret{
 				makeTestSecret("worker1", "invalid"),
@@ -148,32 +148,32 @@ func TestUpdateConfig(t *testing.T) {
 				"worker1": newTestClient("worker1 old kubeconfig"),
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
-				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig("worker1").Active(metav1.ConditionFalse, "ClientConnectionFailed", "invalid kubeconfig").Obj(),
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Active(metav1.ConditionFalse, "ClientConnectionFailed", "invalid kubeconfig").Obj(),
 			},
 		},
 		"update client with invalid path config": {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
-				*utiltesting.MakeMultiKueueCluster("worker1").Path("w1", "").Obj(),
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.PathLocationType, "").Obj(),
 			},
 			remoteClients: map[string]*remoteClient{
 				"worker1": newTestClient("worker1 old kubeconfig"),
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
-				*utiltesting.MakeMultiKueueCluster("worker1").Path("w1", "").Active(metav1.ConditionFalse, "BadConfig", "open : no such file or directory").Obj(),
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.PathLocationType, "").Active(metav1.ConditionFalse, "BadConfig", "open : no such file or directory").Obj(),
 			},
 		},
 		"missing cluster is removed": {
 			reconcileFor: "worker2",
 			clusters: []kueuealpha.MultiKueueCluster{
-				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig("worker1").Obj(),
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Obj(),
 			},
 			remoteClients: map[string]*remoteClient{
 				"worker1": newTestClient("worker1 kubeconfig"),
 				"worker2": newTestClient("worker2 kubeconfig"),
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
-				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig("worker1").Obj(),
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Obj(),
 			},
 			wantRemoteClients: map[string]*remoteClient{
 				"worker1": {

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -99,7 +99,7 @@ func TestUpdateConfig(t *testing.T) {
 				},
 			},
 		},
-		"update client with valid config": {
+		"update client with valid secret config": {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig("worker1").Obj(),
@@ -119,7 +119,24 @@ func TestUpdateConfig(t *testing.T) {
 				},
 			},
 		},
-		"update client with invalid config": {
+		"update client with valid path config": {
+			reconcileFor: "worker1",
+			clusters: []kueuealpha.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").Path("w1", "testdata/worker1KubeConfig").Obj(),
+			},
+			remoteClients: map[string]*remoteClient{
+				"worker1": newTestClient("worker1 old kubeconfig"),
+			},
+			wantClusters: []kueuealpha.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").Path("w1", "testdata/worker1KubeConfig").Active(metav1.ConditionTrue, "Active", "Connected").Obj(),
+			},
+			wantRemoteClients: map[string]*remoteClient{
+				"worker1": {
+					kubeconfig: []byte("worker1 kubeconfig"),
+				},
+			},
+		},
+		"update client with invalid secret config": {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig("worker1").Obj(),
@@ -132,6 +149,18 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig("worker1").Active(metav1.ConditionFalse, "ClientConnectionFailed", "invalid kubeconfig").Obj(),
+			},
+		},
+		"update client with invalid path config": {
+			reconcileFor: "worker1",
+			clusters: []kueuealpha.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").Path("w1", "").Obj(),
+			},
+			remoteClients: map[string]*remoteClient{
+				"worker1": newTestClient("worker1 old kubeconfig"),
+			},
+			wantClusters: []kueuealpha.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").Path("w1", "").Active(metav1.ConditionFalse, "BadConfig", "open : no such file or directory").Obj(),
 			},
 		},
 		"missing cluster is removed": {

--- a/pkg/controller/admissionchecks/multikueue/testdata/worker1KubeConfig
+++ b/pkg/controller/admissionchecks/multikueue/testdata/worker1KubeConfig
@@ -1,0 +1,1 @@
+worker1 kubeconfig

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -789,19 +789,10 @@ func (mkc *MultiKueueClusterWrapper) Obj() *kueuealpha.MultiKueueCluster {
 	return &mkc.MultiKueueCluster
 }
 
-func (mkc *MultiKueueClusterWrapper) KubeConfig(secretName string) *MultiKueueClusterWrapper {
+func (mkc *MultiKueueClusterWrapper) KubeConfig(LocationType kueuealpha.LocationType, location string) *MultiKueueClusterWrapper {
 	mkc.Spec.KubeConfig = kueuealpha.KubeConfig{
-		Location:     secretName,
-		LocationType: kueuealpha.SecretLocationType,
-	}
-	return mkc
-}
-
-func (mkc *MultiKueueClusterWrapper) Path(name, path string) *MultiKueueClusterWrapper {
-	mkc.Spec.KubeConfig = kueuealpha.KubeConfig{
-		Name:         name,
-		Location:     path,
-		LocationType: kueuealpha.PathLocationType,
+		Location:     location,
+		LocationType: LocationType,
 	}
 	return mkc
 }

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -797,6 +797,15 @@ func (mkc *MultiKueueClusterWrapper) KubeConfig(secretName string) *MultiKueueCl
 	return mkc
 }
 
+func (mkc *MultiKueueClusterWrapper) Path(name, path string) *MultiKueueClusterWrapper {
+	mkc.Spec.KubeConfig = kueuealpha.KubeConfig{
+		Name:         name,
+		Location:     path,
+		LocationType: kueuealpha.PathLocationType,
+	}
+	return mkc
+}
+
 func (mkc *MultiKueueClusterWrapper) Active(state metav1.ConditionStatus, reason, message string) *MultiKueueClusterWrapper {
 	cond := metav1.Condition{
 		Type:    kueuealpha.MultiKueueClusterActive,

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -88,10 +88,10 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		}
 		gomega.Expect(k8sWorker2Client.Create(ctx, worker2Ns)).To(gomega.Succeed())
 
-		workerCluster1 = utiltesting.MakeMultiKueueCluster("worker1").KubeConfig("multikueue1").Obj()
+		workerCluster1 = utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "multikueue1").Obj()
 		gomega.Expect(k8sManagerClient.Create(ctx, workerCluster1)).To(gomega.Succeed())
 
-		workerCluster2 = utiltesting.MakeMultiKueueCluster("worker2").KubeConfig("multikueue2").Obj()
+		workerCluster2 = utiltesting.MakeMultiKueueCluster("worker2").KubeConfig(kueuealpha.SecretLocationType, "multikueue2").Obj()
 		gomega.Expect(k8sManagerClient.Create(ctx, workerCluster2)).To(gomega.Succeed())
 
 		multiKueueConfig = utiltesting.MakeMultiKueueConfig("multikueueconfig").Clusters("worker1", "worker2").Obj()

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -111,10 +111,10 @@ var _ = ginkgo.Describe("Multikueue", func() {
 		}
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerMultikueueSecret2)).To(gomega.Succeed())
 
-		workerCluster1 = utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(managerMultikueueSecret1.Name).Obj()
+		workerCluster1 = utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, managerMultikueueSecret1.Name).Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, workerCluster1)).To(gomega.Succeed())
 
-		workerCluster2 = utiltesting.MakeMultiKueueCluster("worker2").KubeConfig(managerMultikueueSecret2.Name).Obj()
+		workerCluster2 = utiltesting.MakeMultiKueueCluster("worker2").KubeConfig(kueuealpha.SecretLocationType, managerMultikueueSecret2.Name).Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, workerCluster2)).To(gomega.Succeed())
 
 		managerMultiKueueConfig = utiltesting.MakeMultiKueueConfig("multikueueconfig").Clusters(workerCluster1.Name, workerCluster2.Name).Obj()
@@ -220,7 +220,7 @@ var _ = ginkgo.Describe("Multikueue", func() {
 			})
 		})
 
-		cluster := utiltesting.MakeMultiKueueCluster("testing-cluster").KubeConfig("testing-secret").Obj()
+		cluster := utiltesting.MakeMultiKueueCluster("testing-cluster").KubeConfig(kueuealpha.SecretLocationType, "testing-secret").Obj()
 		ginkgo.By("creating the cluster, its Active state is updated, the admission check's state is updated", func() {
 			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, cluster)).Should(gomega.Succeed())
 			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, cluster) })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add Path location type for MultiKueue cluster KubeConfigs
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #693

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Add Path location type for MultiKueue cluster KubeConfigs
```