### PR TITLE
Fix kueue crashing when clearing outdated assignment on log level 6

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -238,7 +238,6 @@ func lastAssignmentOutdated(wl *workload.Info, cq *cache.ClusterQueue) bool {
 // FlavorAssignmentMode.
 func AssignFlavors(log logr.Logger, wl *workload.Info, resourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor, cq *cache.ClusterQueue, counts []int32) Assignment {
 	if wl.LastAssignment != nil && lastAssignmentOutdated(wl, cq) {
-		wl.LastAssignment = nil
 		if logV := log.V(6); logV.Enabled() {
 			keysValues := []any{
 				"cq.AllocatableResourceGeneration", cq.AllocatableResourceGeneration,
@@ -250,8 +249,9 @@ func AssignFlavors(log logr.Logger, wl *workload.Info, resourceFlavors map[kueue
 					"wl.LastAssignment.CohortGeneration", wl.LastAssignment.CohortGeneration,
 				)
 			}
-			logV.Info("Cleared Worload's last assignment becaused it was outdated", keysValues...)
+			logV.Info("Clearing Workload's last assignment because it was outdated", keysValues...)
 		}
+		wl.LastAssignment = nil
 	}
 
 	if len(counts) == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind regression
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Kueue is crashing currently when the log is at level 6.

This is the error log: 
```
goroutine 481 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x175e3ae?})
	/go/pkg/mod/k8s.io/apimachinery@v0.28.6/pkg/util/runtime/runtime.go:56 +0xcd
panic({0x22b8780?, 0x3fa68e0?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
sigs.k8s.io/kueue/pkg/scheduler/flavorassigner.AssignFlavors({{0x2a96818?, 0xc000a64360?}, 0x14?}, 0xc000f9bc00, 0x4?, 0xc0011541e0, {0x0, 0x0, 0xc001805880?})
	/workspace/pkg/scheduler/flavorassigner/flavorassigner.go:245 +0x220
sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).getAssignments(0xc0007c6780, {{0x2a96818?, 0xc000a64360?}, 0xc000a64270?}, 0xc000f9bc00, 0xc000ebb838)
	/workspace/pkg/scheduler/scheduler.go:382 +0xf5
sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).nominate(0xc0007c6780, {0x2a8fac8, 0xc000c9e090}, {0xc001513ac0, 0x1, 0xd?}, {0xc000a64060, 0xc000a64090, 0xc000a640c0})
	/workspace/pkg/scheduler/scheduler.go:334 +0x931
sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).schedule(0xc0007c6780, {0x2a8fac8, 0xc000c9e090})
	/workspace/pkg/scheduler/scheduler.go:191 +0x166
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1()
	/go/pkg/mod/k8s.io/apimachinery@v0.28.6/pkg/util/wait/backoff.go:259 +0x22
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000ebbe80?)
	/go/pkg/mod/k8s.io/apimachinery@v0.28.6/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x0?, {0x2a69100, 0xc000c9e0c0}, 0x1, 0xc000c2e000)
	/go/pkg/mod/k8s.io/apimachinery@v0.28.6/pkg/util/wait/backoff.go:227 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x2a8fb00?, 0x0, 0x0, 0x0?, 0x0?)
	/go/pkg/mod/k8s.io/apimachinery@v0.28.6/pkg/util/wait/backoff.go:204 +0x7f
k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext({0x2a8fac8, 0xc000c9e090}, 0xc000ca0000, 0xc0007c42d0?, 0xcc516e?, 0xd0?)
	/go/pkg/mod/k8s.io/apimachinery@v0.28.6/pkg/util/wait/backoff.go:259 +0x93
k8s.io/apimachinery/pkg/util/wait.UntilWithContext({0x2a8fac8?, 0xc000c9e090?}, 0x17d4907?, 0xc0006b2240?)
	/go/pkg/mod/k8s.io/apimachinery@v0.28.6/pkg/util/wait/backoff.go:170 +0x25
created by sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).Start in goroutine 394
	/workspace/pkg/scheduler/scheduler.go:119 +0x13a
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix Kueue crashing at the log level 6 when re-admitting workloads
```