### PR TITLE
Use leader election defaulting to set up controllers HA

### DIFF
--- a/pkg/controller/core/leader_aware_reconciler.go
+++ b/pkg/controller/core/leader_aware_reconciler.go
@@ -44,7 +44,7 @@ import (
 //     the leader election lease, in case the previously leading replica failed to renew it.
 func WithLeadingManager(mgr ctrl.Manager, reconciler reconcile.Reconciler, obj client.Object, cfg *config.Configuration) reconcile.Reconciler {
 	// Do not decorate the reconciler if leader election is disabled
-	if !ptr.Deref(cfg.LeaderElection.LeaderElect, false) {
+	if cfg.LeaderElection == nil || !ptr.Deref(cfg.LeaderElection.LeaderElect, false) {
 		return reconciler
 	}
 

--- a/test/integration/controller/core/suite_test.go
+++ b/test/integration/controller/core/suite_test.go
@@ -62,6 +62,8 @@ func managerSetup(mgr manager.Manager, ctx context.Context) {
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
 	controllersCfg := &config.Configuration{}
+	mgr.GetScheme().Default(controllersCfg)
+
 	controllersCfg.Metrics.EnableClusterQueueResources = true
 	controllersCfg.QueueVisibility = &config.QueueVisibility{
 		UpdateIntervalSeconds: 2,

--- a/test/integration/controller/jobs/job/suite_test.go
+++ b/test/integration/controller/jobs/job/suite_test.go
@@ -82,7 +82,10 @@ func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetu
 		cCache := cache.New(mgr.GetClient())
 		queues := queue.NewManager(mgr.GetClient(), cCache)
 
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+		configuration := &config.Configuration{}
+		mgr.GetScheme().Default(configuration)
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 		err = job.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/controller/jobs/jobset/suite_test.go
+++ b/test/integration/controller/jobs/jobset/suite_test.go
@@ -81,7 +81,10 @@ func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetu
 		cCache := cache.New(mgr.GetClient())
 		queues := queue.NewManager(mgr.GetClient(), cCache)
 
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+		configuration := &config.Configuration{}
+		mgr.GetScheme().Default(configuration)
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 		err = jobset.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/controller/jobs/mpijob/suite_test.go
+++ b/test/integration/controller/jobs/mpijob/suite_test.go
@@ -95,7 +95,10 @@ func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetu
 		cCache := cache.New(mgr.GetClient())
 		queues := queue.NewManager(mgr.GetClient(), cCache)
 
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+		configuration := &config.Configuration{}
+		mgr.GetScheme().Default(configuration)
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 		err = mpijob.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/controller/jobs/mxjob/suite_test.go
+++ b/test/integration/controller/jobs/mxjob/suite_test.go
@@ -79,7 +79,10 @@ func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetu
 		cCache := cache.New(mgr.GetClient())
 		queues := queue.NewManager(mgr.GetClient(), cCache)
 
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+		configuration := &config.Configuration{}
+		mgr.GetScheme().Default(configuration)
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 		err = mxjob.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/controller/jobs/paddlejob/suite_test.go
+++ b/test/integration/controller/jobs/paddlejob/suite_test.go
@@ -79,7 +79,10 @@ func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetu
 		cCache := cache.New(mgr.GetClient())
 		queues := queue.NewManager(mgr.GetClient(), cCache)
 
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+		configuration := &config.Configuration{}
+		mgr.GetScheme().Default(configuration)
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 		err = paddlejob.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/controller/jobs/pod/suite_test.go
+++ b/test/integration/controller/jobs/pod/suite_test.go
@@ -90,7 +90,10 @@ func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 		cCache := cache.New(mgr.GetClient())
 		queues := queue.NewManager(mgr.GetClient(), cCache)
 
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+		configuration := &config.Configuration{}
+		mgr.GetScheme().Default(configuration)
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 		err = pod.SetupWebhook(mgr, opts...)
@@ -118,7 +121,10 @@ func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetu
 		cCache := cache.New(mgr.GetClient())
 		queues := queue.NewManager(mgr.GetClient(), cCache)
 
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+		configuration := &config.Configuration{}
+		mgr.GetScheme().Default(configuration)
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 		err = pod.SetupWebhook(mgr, opts...)

--- a/test/integration/controller/jobs/pytorchjob/suite_test.go
+++ b/test/integration/controller/jobs/pytorchjob/suite_test.go
@@ -80,7 +80,10 @@ func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetu
 		cCache := cache.New(mgr.GetClient())
 		queues := queue.NewManager(mgr.GetClient(), cCache)
 
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+		configuration := &config.Configuration{}
+		mgr.GetScheme().Default(configuration)
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 		err = pytorchjob.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/controller/jobs/rayjob/suite_test.go
+++ b/test/integration/controller/jobs/rayjob/suite_test.go
@@ -81,7 +81,10 @@ func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetu
 		cCache := cache.New(mgr.GetClient())
 		queues := queue.NewManager(mgr.GetClient(), cCache)
 
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+		configuration := &config.Configuration{}
+		mgr.GetScheme().Default(configuration)
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 		err = rayjob.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/controller/jobs/tfjob/suite_test.go
+++ b/test/integration/controller/jobs/tfjob/suite_test.go
@@ -80,7 +80,10 @@ func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetu
 		cCache := cache.New(mgr.GetClient())
 		queues := queue.NewManager(mgr.GetClient(), cCache)
 
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+		configuration := &config.Configuration{}
+		mgr.GetScheme().Default(configuration)
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 		err = tfjob.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/controller/jobs/xgboostjob/suite_test.go
+++ b/test/integration/controller/jobs/xgboostjob/suite_test.go
@@ -80,7 +80,10 @@ func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetu
 		cCache := cache.New(mgr.GetClient())
 		queues := queue.NewManager(mgr.GetClient(), cCache)
 
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+		configuration := &config.Configuration{}
+		mgr.GetScheme().Default(configuration)
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 		err = xgboostjob.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
+	config "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
@@ -84,7 +85,10 @@ func (f *Framework) Init() *rest.Config {
 }
 
 func (f *Framework) RunManager(cfg *rest.Config, managerSetup ManagerSetup) (context.Context, client.Client) {
-	err := kueue.AddToScheme(scheme.Scheme)
+	err := config.AddToScheme(scheme.Scheme)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+
+	err = kueue.AddToScheme(scheme.Scheme)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
 	err = kueuealpha.AddToScheme(scheme.Scheme)

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -125,7 +125,10 @@ func managerSetup(mgr manager.Manager, ctx context.Context) {
 	cCache := cache.New(mgr.GetClient())
 	queues := queue.NewManager(mgr.GetClient(), cCache)
 
-	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+	configuration := &config.Configuration{}
+	mgr.GetScheme().Default(configuration)
+
+	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 	failedWebhook, err := webhooks.Setup(mgr)

--- a/test/integration/scheduler/podsready/suite_test.go
+++ b/test/integration/scheduler/podsready/suite_test.go
@@ -58,7 +58,7 @@ func TestSchedulerWithWaitForPodsReady(t *testing.T) {
 }
 
 func managerAndSchedulerSetupWithTimeoutAdmission(mgr manager.Manager, ctx context.Context, value time.Duration, blockAdmission bool, requeuingTimestamp config.RequeuingTimestamp) {
-	cfg := config.Configuration{
+	cfg := &config.Configuration{
 		WaitForPodsReady: &config.WaitForPodsReady{
 			Enable:             true,
 			BlockAdmission:     &blockAdmission,
@@ -66,6 +66,7 @@ func managerAndSchedulerSetupWithTimeoutAdmission(mgr manager.Manager, ctx conte
 			RequeuingTimestamp: ptr.To(requeuingTimestamp),
 		},
 	}
+	mgr.GetScheme().Default(cfg)
 
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -76,7 +77,7 @@ func managerAndSchedulerSetupWithTimeoutAdmission(mgr manager.Manager, ctx conte
 		queue.WithPodsReadyRequeuingTimestamp(requeuingTimestamp),
 	)
 
-	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &cfg)
+	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, cfg)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 	failedWebhook, err := webhooks.Setup(mgr)

--- a/test/integration/scheduler/suite_test.go
+++ b/test/integration/scheduler/suite_test.go
@@ -75,7 +75,10 @@ func managerAndSchedulerSetup(mgr manager.Manager, ctx context.Context) {
 	cCache := cache.New(mgr.GetClient())
 	queues := queue.NewManager(mgr.GetClient(), cCache)
 
-	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+	configuration := &config.Configuration{}
+	mgr.GetScheme().Default(configuration)
+
+	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 	failedWebhook, err := webhooks.Setup(mgr)

--- a/test/integration/webhook/suite_test.go
+++ b/test/integration/webhook/suite_test.go
@@ -66,7 +66,11 @@ var _ = ginkgo.BeforeSuite(func() {
 
 		cCache := cache.New(mgr.GetClient())
 		queues := queue.NewManager(mgr.GetClient(), cCache)
-		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+
+		configuration := &config.Configuration{}
+		mgr.GetScheme().Default(configuration)
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A quick follow-up on #1554 to incorporate #1598 as discussed here: https://github.com/kubernetes-sigs/kueue/pull/1554#discussion_r1448863168.

This avoids the duplication of the default leader election lease duration.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```