### PR TITLE
Pod groups: add a note about not recreating pods deleted by kueue

### DIFF
--- a/keps/976-plain-pods/README.md
+++ b/keps/976-plain-pods/README.md
@@ -88,6 +88,9 @@ use of this API to implement queuing semantics for Pods.
 - Support for advanced Pod retry policies
 
   Kueue shouldn't re-implement core functionalities that are already available in the Job API.
+  In particular, Kueue does not re-create failed pods.
+  More specifically, in case of re-admission after preemption, it does not
+  re-create pods it deleted.
 
 - Tracking usage of Pods that were not queued through Kueue.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

To clarify the expected behavior. This is a follow up after the confusion discussed here: https://github.com/kubernetes-sigs/kueue/issues/1641. One might expect Kueue would re-create pods it deleted during preemption (so there is some asymmetry in handling of pod management).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

We should follow up with a docs page about the feature, but until that we can refer users to the KEP.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```