### PR TITLE
[e2e/multukueue] Retry creating test setup objects

### DIFF
--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -72,36 +72,36 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				GenerateName: "multikueue-",
 			},
 		}
-		gomega.Expect(k8sManagerClient.Create(ctx, managerNs)).To(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sManagerClient, managerNs)
 
 		worker1Ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: managerNs.Name,
 			},
 		}
-		gomega.Expect(k8sWorker1Client.Create(ctx, worker1Ns)).To(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sWorker1Client, worker1Ns)
 
 		worker2Ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: managerNs.Name,
 			},
 		}
-		gomega.Expect(k8sWorker2Client.Create(ctx, worker2Ns)).To(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sWorker2Client, worker2Ns)
 
 		workerCluster1 = utiltesting.MakeMultiKueueCluster("worker1").KubeConfig("multikueue1").Obj()
-		gomega.Expect(k8sManagerClient.Create(ctx, workerCluster1)).To(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sManagerClient, workerCluster1)
 
 		workerCluster2 = utiltesting.MakeMultiKueueCluster("worker2").KubeConfig("multikueue2").Obj()
-		gomega.Expect(k8sManagerClient.Create(ctx, workerCluster2)).To(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sManagerClient, workerCluster2)
 
 		multiKueueConfig = utiltesting.MakeMultiKueueConfig("multikueueconfig").Clusters("worker1", "worker2").Obj()
-		gomega.Expect(k8sManagerClient.Create(ctx, multiKueueConfig)).Should(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sManagerClient, multiKueueConfig)
 
 		multiKueueAc = utiltesting.MakeAdmissionCheck("ac1").
 			ControllerName(multikueue.ControllerName).
 			Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", multiKueueConfig.Name).
 			Obj()
-		gomega.Expect(k8sManagerClient.Create(ctx, multiKueueAc)).Should(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sManagerClient, multiKueueAc)
 
 		ginkgo.By("wait for check active", func() {
 			updatetedAc := kueue.AdmissionCheck{}
@@ -113,7 +113,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 
 		})
 		managerFlavor = utiltesting.MakeResourceFlavor("default").Obj()
-		gomega.Expect(k8sManagerClient.Create(ctx, managerFlavor)).Should(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sManagerClient, managerFlavor)
 
 		managerCq = utiltesting.MakeClusterQueue("q1").
 			ResourceGroup(
@@ -124,13 +124,13 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			).
 			AdmissionChecks(multiKueueAc.Name).
 			Obj()
-		gomega.Expect(k8sManagerClient.Create(ctx, managerCq)).Should(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sManagerClient, managerCq)
 
 		managerLq = utiltesting.MakeLocalQueue(managerCq.Name, managerNs.Name).ClusterQueue(managerCq.Name).Obj()
-		gomega.Expect(k8sManagerClient.Create(ctx, managerLq)).Should(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sManagerClient, managerLq)
 
 		worker1Flavor = utiltesting.MakeResourceFlavor("default").Obj()
-		gomega.Expect(k8sWorker1Client.Create(ctx, worker1Flavor)).Should(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sWorker1Client, worker1Flavor)
 
 		worker1Cq = utiltesting.MakeClusterQueue("q1").
 			ResourceGroup(
@@ -140,13 +140,13 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					Obj(),
 			).
 			Obj()
-		gomega.Expect(k8sWorker1Client.Create(ctx, worker1Cq)).Should(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sWorker1Client, worker1Cq)
 
 		worker1Lq = utiltesting.MakeLocalQueue(worker1Cq.Name, worker1Ns.Name).ClusterQueue(worker1Cq.Name).Obj()
-		gomega.Expect(k8sWorker1Client.Create(ctx, worker1Lq)).Should(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sWorker1Client, worker1Lq)
 
 		worker2Flavor = utiltesting.MakeResourceFlavor("default").Obj()
-		gomega.Expect(k8sWorker2Client.Create(ctx, worker2Flavor)).Should(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sWorker2Client, worker2Flavor)
 
 		worker2Cq = utiltesting.MakeClusterQueue("q1").
 			ResourceGroup(
@@ -156,10 +156,10 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					Obj(),
 			).
 			Obj()
-		gomega.Expect(k8sWorker2Client.Create(ctx, worker2Cq)).Should(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sWorker2Client, worker2Cq)
 
 		worker2Lq = utiltesting.MakeLocalQueue(worker2Cq.Name, worker2Ns.Name).ClusterQueue(worker2Cq.Name).Obj()
-		gomega.Expect(k8sWorker2Client.Create(ctx, worker2Lq)).Should(gomega.Succeed())
+		util.EventuallyCreate(ctx, k8sWorker2Client, worker2Lq)
 	})
 
 	ginkgo.AfterEach(func() {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -620,3 +620,9 @@ func ExpectPodsFinalized(ctx context.Context, k8sClient client.Client, keys ...t
 		}, Timeout, Interval).Should(gomega.BeEmpty(), "Expected pod to be finalized")
 	}
 }
+
+func EventuallyCreate(ctx context.Context, k8sClient client.Client, obj client.Object) {
+	gomega.EventuallyWithOffset(1, func() error {
+		return k8sClient.Create(ctx, obj)
+	}, Timeout, Interval).Should(gomega.Succeed())
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Retry the creation of the test setup objects in e2e multikueue suite.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1658

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```