### PR TITLE
Fix emitting events for pods preempted by Kueue [pod groups]

### DIFF
--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -75,7 +75,7 @@ type JobWithCustomStop interface {
 	// Stop implements a custom stop procedure.
 	// The function should be idempotent: not do any API calls if the job is already stopped.
 	// Returns whether the Job stopped with this call or an error
-	Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, stopReason StopReason, eventMsg string) (bool, error)
+	Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, stopReason StopReason, eventMsg string) ([]client.Object, error)
 }
 
 // JobWithFinalize interface should be implemented by generic jobs,

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -75,7 +75,7 @@ type JobWithCustomStop interface {
 	// Stop implements a custom stop procedure.
 	// The function should be idempotent: not do any API calls if the job is already stopped.
 	// Returns whether the Job stopped with this call or an error
-	Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, stopReason StopReason, eventMsg string) ([]client.Object, error)
+	Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, stopReason StopReason, eventMsg string) (bool, error)
 }
 
 // JobWithFinalize interface should be implemented by generic jobs,
@@ -109,6 +109,8 @@ type ComposableJob interface {
 	ListChildWorkloads(ctx context.Context, c client.Client, parent types.NamespacedName) (*kueue.WorkloadList, error)
 	// FindMatchingWorkloads returns all related workloads, workload that matches the ComposableJob and duplicates that has to be deleted.
 	FindMatchingWorkloads(ctx context.Context, c client.Client) (match *kueue.Workload, toDelete []*kueue.Workload, err error)
+	// Stop implements the custom stop procedure for ComposableJob
+	Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, stopReason StopReason, eventMsg string) ([]client.Object, error)
 }
 
 func ParentWorkloadName(job GenericJob) string {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -744,8 +744,8 @@ func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, wl *kueue.W
 
 	if jws, implements := job.(JobWithCustomStop); implements {
 		stoppedNow, err := jws.Stop(ctx, r.client, info, stopReason, eventMsg)
-		if stoppedNow {
-			r.record.Event(object, corev1.EventTypeNormal, ReasonStopped, eventMsg)
+		for _, objStoppedNow := range stoppedNow {
+			r.record.Event(objStoppedNow, corev1.EventTypeNormal, ReasonStopped, eventMsg)
 		}
 
 		return err

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -744,10 +744,17 @@ func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, wl *kueue.W
 
 	if jws, implements := job.(JobWithCustomStop); implements {
 		stoppedNow, err := jws.Stop(ctx, r.client, info, stopReason, eventMsg)
+		if stoppedNow {
+			r.record.Event(object, corev1.EventTypeNormal, ReasonStopped, eventMsg)
+		}
+		return err
+	}
+
+	if jws, implements := job.(ComposableJob); implements {
+		stoppedNow, err := jws.Stop(ctx, r.client, info, stopReason, eventMsg)
 		for _, objStoppedNow := range stoppedNow {
 			r.record.Event(objStoppedNow, corev1.EventTypeNormal, ReasonStopped, eventMsg)
 		}
-
 		return err
 	}
 

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -127,10 +127,9 @@ type Pod struct {
 }
 
 var (
-	_ jobframework.GenericJob        = (*Pod)(nil)
-	_ jobframework.JobWithCustomStop = (*Pod)(nil)
-	_ jobframework.JobWithFinalize   = (*Pod)(nil)
-	_ jobframework.ComposableJob     = (*Pod)(nil)
+	_ jobframework.GenericJob      = (*Pod)(nil)
+	_ jobframework.JobWithFinalize = (*Pod)(nil)
+	_ jobframework.ComposableJob   = (*Pod)(nil)
 )
 
 func fromObject(o runtime.Object) *Pod {

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -403,7 +403,7 @@ func (p *Pod) GVK() schema.GroupVersionKind {
 	return gvk
 }
 
-func (p *Pod) Stop(ctx context.Context, c client.Client, _ []podset.PodSetInfo, stopReason jobframework.StopReason, eventMsg string) (bool, error) {
+func (p *Pod) Stop(ctx context.Context, c client.Client, _ []podset.PodSetInfo, stopReason jobframework.StopReason, eventMsg string) ([]client.Object, error) {
 	var podsInGroup []corev1.Pod
 
 	if p.isGroup {
@@ -412,6 +412,7 @@ func (p *Pod) Stop(ctx context.Context, c client.Client, _ []podset.PodSetInfo, 
 		podsInGroup = []corev1.Pod{p.pod}
 	}
 
+	stoppedNow := make([]client.Object, 0)
 	for i := range podsInGroup {
 		// If the workload is being deleted, delete even finished Pods.
 		if !podsInGroup[i].DeletionTimestamp.IsZero() || (stopReason != jobframework.StopReasonWorkloadDeleted && podSuspended(&podsInGroup[i])) {
@@ -442,11 +443,12 @@ func (p *Pod) Stop(ctx context.Context, c client.Client, _ []podset.PodSetInfo, 
 			},
 		}
 		if err := c.Status().Patch(ctx, pCopy, client.Apply, client.FieldOwner(constants.KueueName)); err != nil && !apierrors.IsNotFound(err) {
-			return false, err
+			return stoppedNow, err
 		}
 		if err := c.Delete(ctx, podInGroup.Object()); err != nil && !apierrors.IsNotFound(err) {
-			return false, err
+			return stoppedNow, err
 		}
+		stoppedNow = append(stoppedNow, podInGroup.Object())
 	}
 
 	// If related workload is deleted, the generic reconciler will stop the pod group and finalize the workload.
@@ -455,11 +457,11 @@ func (p *Pod) Stop(ctx context.Context, c client.Client, _ []podset.PodSetInfo, 
 	if p.isGroup && stopReason == jobframework.StopReasonWorkloadDeleted {
 		err := p.Finalize(ctx, c)
 		if err != nil {
-			return false, err
+			return stoppedNow, err
 		}
 	}
 
-	return true, nil
+	return stoppedNow, nil
 }
 
 func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -2764,7 +2764,7 @@ func TestReconciler(t *testing.T) {
 			if diff := cmp.Diff(tc.wantWorkloads, gotWorkloads.Items, tc.workloadCmpOpts...); diff != "" {
 				t.Errorf("Workloads after reconcile (-want,+got):\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents); diff != "" {
+			if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents, cmp.Transformer("sortedEvents", utiltesting.SortedEvents)); diff != "" {
 				t.Errorf("unexpected events (-want/+got):\n%s", diff)
 			}
 		})

--- a/pkg/util/testing/client.go
+++ b/pkg/util/testing/client.go
@@ -19,6 +19,8 @@ package testing
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -79,6 +81,29 @@ type EventRecord struct {
 type EventRecorder struct {
 	lock           sync.Mutex
 	RecordedEvents []EventRecord
+}
+
+func SortedEvents(events []EventRecord) []EventRecord {
+	sorted := make([]EventRecord, len(events))
+	copy(sorted, events)
+	sort.Slice(sorted, func(i, j int) bool {
+		ei := sorted[i]
+		ej := sorted[j]
+		if cmp := strings.Compare(ei.Key.String(), ej.Key.String()); cmp != 0 {
+			return cmp < 0
+		}
+		if cmp := strings.Compare(ei.EventType, ej.EventType); cmp != 0 {
+			return cmp < 0
+		}
+		if cmp := strings.Compare(ei.Reason, ej.Reason); cmp != 0 {
+			return cmp < 0
+		}
+		if cmp := strings.Compare(ei.Message, ej.Message); cmp != 0 {
+			return cmp < 0
+		}
+		return false
+	})
+	return sorted
 }
 
 func (tr *EventRecorder) Event(object runtime.Object, eventtype, reason, message string) {

--- a/test/e2e/singlecluster/suite_test.go
+++ b/test/e2e/singlecluster/suite_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	k8sClient                    client.Client
+	k8sClient                    client.WithWatch
 	ctx                          context.Context
 	visibilityClient             visibilityv1alpha1.VisibilityV1alpha1Interface
 	impersonatedVisibilityClient visibilityv1alpha1.VisibilityV1alpha1Interface

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -17,7 +17,7 @@ import (
 	visibilityv1alpha1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/visibility/v1alpha1"
 )
 
-func CreateClientUsingCluster(kContext string) client.Client {
+func CreateClientUsingCluster(kContext string) client.WithWatch {
 	cfg, err := config.GetConfigWithContext(kContext)
 	if err != nil {
 		fmt.Printf("unable to get kubeconfig for context %q: %s", kContext, err)
@@ -37,7 +37,7 @@ func CreateClientUsingCluster(kContext string) client.Client {
 	err = jobset.AddToScheme(scheme.Scheme)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
-	client, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	client, err := client.NewWithWatch(cfg, client.Options{Scheme: scheme.Scheme})
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 	return client
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Solve two issues with events for pod groups:
1. the event indicating the a pod in pod group was emitted repeatedly, while the intention is to sent it once
2. the event was emitted only for the first pod in group, but because the Load function may return the pods in different order, we could get both pods covered with at least one event

This PR also adds e2e test to ensure the events are emitted per pod in the group.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Fix for unreleased feature
```release-note
NONE
```