### PR TITLE
Prevent cluster queue webhook from panicking for existing resources

### DIFF
--- a/pkg/webhooks/clusterqueue_webhook.go
+++ b/pkg/webhooks/clusterqueue_webhook.go
@@ -140,7 +140,9 @@ func ValidateClusterQueueUpdate(newObj, oldObj *kueue.ClusterQueue) field.ErrorL
 
 func validatePreemption(preemption *kueue.ClusterQueuePreemption, path *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
-	if preemption.ReclaimWithinCohort == kueue.PreemptionPolicyNever && preemption.BorrowWithinCohort.Policy != kueue.BorrowWithinCohortPolicyNever {
+	if preemption.ReclaimWithinCohort == kueue.PreemptionPolicyNever &&
+		preemption.BorrowWithinCohort != nil &&
+		preemption.BorrowWithinCohort.Policy != kueue.BorrowWithinCohortPolicyNever {
 		allErrs = append(allErrs, field.Invalid(path, preemption, "reclaimWithinCohort=Never and borrowWithinCohort.Policy!=Never"))
 	}
 	return allErrs

--- a/pkg/webhooks/clusterqueue_webhook_test.go
+++ b/pkg/webhooks/clusterqueue_webhook_test.go
@@ -356,6 +356,19 @@ func TestValidateClusterQueue(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "existing cluster queue created with older Kueue version that has a nil borrowWithinCohort field",
+			clusterQueue: &kueue.ClusterQueue{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-queue",
+				},
+				Spec: kueue.ClusterQueueSpec{
+					Preemption: &kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyNever,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Prevent the cluster queue validation webhook from panicking for existing resources, whose `.spec.preemption.borrowWithinCohort` field haven't been defaulted yet.

#### Which issue(s) this PR fixes:

Fixes #1669

#### Does this PR introduce a user-facing change?

```release-note
NONE
```