### PR TITLE
[multikueue] Partially active admission check.

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/admissioncheck.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck.go
@@ -65,11 +65,20 @@ func (a *ACReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
-	inactiveReason := ""
-
 	log.V(2).Info("Reconcile AdmissionCheck")
+
+	newCondition := metav1.Condition{
+		Type:    kueue.AdmissionCheckActive,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Active",
+		Message: "The admission check is active",
+	}
+
 	if cfg, err := a.helper.ConfigFromRef(ctx, ac.Spec.Parameters); err != nil {
-		inactiveReason = fmt.Sprintf("Cannot load the AdmissionChecks parameters: %s", err.Error())
+		newCondition.Status = metav1.ConditionFalse
+		newCondition.Reason = "BadConfig"
+		newCondition.Message = fmt.Sprintf("Cannot load the AdmissionChecks parameters: %s", err.Error())
+
 	} else {
 		var missingClusters []string
 		var inactiveClusters []string
@@ -90,28 +99,25 @@ func (a *ACReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 				}
 			}
 		}
+		unusableClustersCount := len(missingClusters) + len(inactiveClusters)
+		if unusableClustersCount > 0 {
+			if unusableClustersCount < len(cfg.Spec.Clusters) {
+				// keep it partially active
+				newCondition.Reason = "PartiallyActive"
+			} else {
+				newCondition.Status = metav1.ConditionFalse
+				newCondition.Reason = "NoUsableClusters"
+			}
 
-		var messageParts []string
-		if len(missingClusters) > 0 {
-			messageParts = []string{fmt.Sprintf("Missing clusters: %v", missingClusters)}
+			var messageParts []string
+			if len(missingClusters) > 0 {
+				messageParts = []string{fmt.Sprintf("Missing clusters: %v", missingClusters)}
+			}
+			if len(inactiveClusters) > 0 {
+				messageParts = append(messageParts, fmt.Sprintf("Inactive clusters: %v", inactiveClusters))
+			}
+			newCondition.Message = strings.Join(messageParts, ", ")
 		}
-		if len(inactiveClusters) > 0 {
-			messageParts = append(messageParts, fmt.Sprintf("Inactive clusters: %v", inactiveClusters))
-		}
-		inactiveReason = strings.Join(messageParts, ", ")
-	}
-
-	newCondition := metav1.Condition{
-		Type: kueue.AdmissionCheckActive,
-	}
-	if len(inactiveReason) == 0 {
-		newCondition.Status = metav1.ConditionTrue
-		newCondition.Reason = "Active"
-		newCondition.Message = "The admission check is active"
-	} else {
-		newCondition.Status = metav1.ConditionFalse
-		newCondition.Reason = "Inactive"
-		newCondition.Message = inactiveReason
 	}
 
 	oldCondition := apimeta.FindStatusCondition(ac.Status.Conditions, kueue.AdmissionCheckActive)

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -187,7 +187,7 @@ var _ = ginkgo.Describe("Multikueue", func() {
 					g.Expect(updatetedAc.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.AdmissionCheckActive,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Inactive",
+						Reason:  "BadConfig",
 						Message: `Cannot load the AdmissionChecks parameters: MultiKueueConfig.kueue.x-k8s.io "testing-config" not found`,
 					}, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"))))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -213,7 +213,7 @@ var _ = ginkgo.Describe("Multikueue", func() {
 					g.Expect(updatetedAc.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.AdmissionCheckActive,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Inactive",
+						Reason:  "NoUsableClusters",
 						Message: `Missing clusters: [testing-cluster]`,
 					}, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"))))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -247,7 +247,7 @@ var _ = ginkgo.Describe("Multikueue", func() {
 					g.Expect(updatetedAc.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.AdmissionCheckActive,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Inactive",
+						Reason:  "NoUsableClusters",
 						Message: `Inactive clusters: [testing-cluster]`,
 					}, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"))))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[multikueue] Partially active admission check. Keep the AdmissionCheck Active even if not all it's clusters are usable.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relate to #693 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```