### PR TITLE
Fix Kueue startup by waiting for webhooks server using probes

### DIFF
--- a/cmd/experimental/podtaintstolerations/test/e2e/suite_test.go
+++ b/cmd/experimental/podtaintstolerations/test/e2e/suite_test.go
@@ -29,8 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
-	kueuetest "sigs.k8s.io/kueue/pkg/util/testing"
-	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
@@ -67,17 +65,7 @@ func CreateClientUsingCluster() client.Client {
 	return client
 }
 
-func KueueReadyForTesting(client client.Client) {
-	// To verify that webhooks are ready, let's create a simple resourceflavor
-	resourceKueue := kueuetest.MakeResourceFlavor("default").Obj()
-	gomega.Eventually(func() error {
-		return client.Create(context.Background(), resourceKueue)
-	}, Timeout, Interval).Should(gomega.Succeed())
-	util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, resourceKueue, true)
-}
-
 var _ = ginkgo.BeforeSuite(func() {
 	k8sClient = CreateClientUsingCluster()
 	ctx = context.Background()
-	KueueReadyForTesting(k8sClient)
 })

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"net/http"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -38,7 +39,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
@@ -274,11 +274,15 @@ func setupControllers(mgr ctrl.Manager, cCache *cache.Cache, queues *queue.Manag
 func setupProbeEndpoints(mgr ctrl.Manager) {
 	defer setupLog.Info("Probe endpoints are configured on healthz and readyz")
 
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+	readyz := func(req *http.Request) error {
+		return mgr.GetWebhookServer().StartedChecker()(req)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", readyz); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", readyz); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}

--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -55,5 +55,6 @@ function cluster_kueue_deploy {
     else
         kubectl apply --server-side -k test/e2e/config
     fi
+    kubectl wait --for=condition=available --timeout=3m deployment/kueue-controller-manager -n kueue-system
 }
 

--- a/test/e2e/multikueue/suite_test.go
+++ b/test/e2e/multikueue/suite_test.go
@@ -62,11 +62,4 @@ var _ = ginkgo.BeforeSuite(func() {
 	k8sWorker2Client = util.CreateClientUsingCluster("kind-" + worker2ClusterName)
 
 	ctx = context.Background()
-
-	//wait for the managers to start
-	// failing a this point might indicate a manifestation of
-	// https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
-	util.KueueReadyForTesting(ctx, k8sManagerClient)
-	util.KueueReadyForTesting(ctx, k8sWorker1Client)
-	util.KueueReadyForTesting(ctx, k8sWorker2Client)
 })

--- a/test/e2e/singlecluster/suite_test.go
+++ b/test/e2e/singlecluster/suite_test.go
@@ -54,5 +54,4 @@ var _ = ginkgo.BeforeSuite(func() {
 	visibilityClient = util.CreateVisibilityClient("")
 	impersonatedVisibilityClient = util.CreateVisibilityClient("system:serviceaccount:kueue-system:default")
 	ctx = context.Background()
-	// util.KueueReadyForTesting(ctx, k8sClient)
 })

--- a/test/e2e/singlecluster/suite_test.go
+++ b/test/e2e/singlecluster/suite_test.go
@@ -54,5 +54,5 @@ var _ = ginkgo.BeforeSuite(func() {
 	visibilityClient = util.CreateVisibilityClient("")
 	impersonatedVisibilityClient = util.CreateVisibilityClient("system:serviceaccount:kueue-system:default")
 	ctx = context.Background()
-	util.KueueReadyForTesting(ctx, k8sClient)
+	// util.KueueReadyForTesting(ctx, k8sClient)
 })

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -16,7 +15,6 @@ import (
 	visibility "sigs.k8s.io/kueue/apis/visibility/v1alpha1"
 	kueueclientset "sigs.k8s.io/kueue/client-go/clientset/versioned"
 	visibilityv1alpha1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/visibility/v1alpha1"
-	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
 func CreateClientUsingCluster(kContext string) client.Client {
@@ -63,13 +61,4 @@ func CreateVisibilityClient(user string) visibilityv1alpha1.VisibilityV1alpha1In
 	}
 	visibilityClient := kueueClient.VisibilityV1alpha1()
 	return visibilityClient
-}
-
-func KueueReadyForTesting(ctx context.Context, client client.Client) {
-	// To verify that webhooks are ready, let's create a simple resourceflavor
-	resourceKueue := utiltesting.MakeResourceFlavor("default").Obj()
-	gomega.Eventually(func() error {
-		return client.Create(context.Background(), resourceKueue)
-	}, StartUpTimeout, Interval).Should(gomega.Succeed())
-	ExpectResourceFlavorToBeDeleted(ctx, client, resourceKueue, true)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

To fix the flaky test.
To also let users wait for Kueue webhooks ready without the need for creating / deleting objects as in `KueueReadyForTesting`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1658

#### Special notes for your reviewer:

Tested locally, trying to see what will happen on GH CI.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```