### PR TITLE
Remove deleted pending workloads from the cache so the visibility API results are correct

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -403,9 +403,8 @@ func (r *WorkloadReconciler) Delete(e event.DeleteEvent) bool {
 
 	// Even if the state is unknown, the last cached state tells us whether the
 	// workload was in the queues and should be cleared from them.
-	if workload.HasQuotaReservation(wl) {
-		r.queues.DeleteWorkload(wl)
-	}
+	r.queues.DeleteWorkload(wl)
+
 	return true
 }
 


### PR DESCRIPTION
This fixes #1555 and also adds an integration test as suggested in https://github.com/kubernetes-sigs/kueue/issues/1555#issuecomment-1912423532.

#### What type of PR is this?

/kind bug

#### Which issue(s) this PR fixes:

Fixes #1555

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Remove deleted pending workloads from the cache
```