### PR TITLE
[website] Custom Jobs integrations documentation cleanup

### DIFF
--- a/site/content/en/docs/tasks/run_jobsets.md
+++ b/site/content/en/docs/tasks/run_jobsets.md
@@ -12,18 +12,9 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 ## Before you begin
 
-1. By default, the integration for `jobset.x-k8s.io/jobset` is not enabled.
-  Learn how to [install Kueue with a custom manager configuration](/docs/installation/#install-a-custom-configured-released-version). `jobset.x-k8s.io/jobset` integration should be specified in the `integrations.frameworks` section of the custom manager configuration.
+1. Check [Administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial Kueue setup.
 
-```yaml
-integrations:
-  frameworks:
-  - "jobset.x-k8s.io/jobset"
-```
-
-2. Check [Administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial Kueue setup.
-
-3. See [JobSet Installation](https://github.com/kubernetes-sigs/jobset/blob/main/docs/setup/install.md) for installation and configuration details of JobSet Operator.
+2. See [JobSet Installation](https://github.com/kubernetes-sigs/jobset/blob/main/docs/setup/install.md) for installation and configuration details of JobSet Operator.
 
 ## JobSet definition
 

--- a/site/content/en/docs/tasks/run_kubeflow_jobs/run_mpijobs.md
+++ b/site/content/en/docs/tasks/run_kubeflow_jobs/run_mpijobs.md
@@ -16,14 +16,6 @@ Check [administer cluster quotas](/docs/tasks/administer_cluster_quotas) for det
 
 Check [the MPI Operator installation guide](https://github.com/kubeflow/mpi-operator#installation).
 
-Set MPIJobs as an allowed workload in Kueue Configuration.
-
-```yaml
-integrations:
-  frameworks:
-  - "kubeflow.org/mpijob"
-```
-
 You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include MPIJobs as an allowed workload.  
 
 ## MPI Operator definition

--- a/site/content/en/docs/tasks/run_kubeflow_jobs/run_mxjobs.md
+++ b/site/content/en/docs/tasks/run_kubeflow_jobs/run_mxjobs.md
@@ -18,14 +18,6 @@ Check [the Training Operator installation guide](https://github.com/kubeflow/tra
 
 Note that the minimum requirement training-operator version is v1.7.0.
 
-Set MXJobs as an allowed workload in Kueue Configuration.
-
-```yaml
-integrations:
-  frameworks:
-  - "kubeflow.org/mxjob" 
-```
-
 You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include MXJobs as an allowed workload.
 
 ## MXJob definition

--- a/site/content/en/docs/tasks/run_kubeflow_jobs/run_paddlejobs.md
+++ b/site/content/en/docs/tasks/run_kubeflow_jobs/run_paddlejobs.md
@@ -18,14 +18,6 @@ Check [the Training Operator installation guide](https://github.com/kubeflow/tra
 
 Note that the minimum requirement training-operator version is v1.7.0.
 
-Set PaddleJobs as an allowed workload in Kueue Configuration.
-
-```yaml
-integrations:
-  frameworks:
-    - "kubeflow.org/paddlejob" 
-```
-
 You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include PaddleJobs as an allowed workload.
 
 ## PaddleJob definition

--- a/site/content/en/docs/tasks/run_kubeflow_jobs/run_pytorchjobs.md
+++ b/site/content/en/docs/tasks/run_kubeflow_jobs/run_pytorchjobs.md
@@ -18,14 +18,6 @@ Check [the Training Operator installation guide](https://github.com/kubeflow/tra
 
 Note that the minimum requirement training-operator version is v1.7.0.
 
-Set PyTorchJobs as an allowed workload in Kueue Configuration.
-
-```yaml
-integrations:
-  frameworks:
-  - "kubeflow.org/pytorchjob" 
-```
-
 You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include PyTorchJobs as an allowed workload.
 
 ## PyTorchJob definition

--- a/site/content/en/docs/tasks/run_kubeflow_jobs/run_tfjobs.md
+++ b/site/content/en/docs/tasks/run_kubeflow_jobs/run_tfjobs.md
@@ -18,14 +18,6 @@ Check [the Training Operator installation guide](https://github.com/kubeflow/tra
 
 Note that the minimum requirement training-operator version is v1.7.0.
 
-Set TFJobs as an allowed workload in Kueue Configuration.
-
-```yaml
-integrations:
-  frameworks:
-  - "kubeflow.org/tfjob" 
-```
-
 You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include TFJobs as an allowed workload.
 
 ## TFJob definition

--- a/site/content/en/docs/tasks/run_kubeflow_jobs/run_xgboostjobs.md
+++ b/site/content/en/docs/tasks/run_kubeflow_jobs/run_xgboostjobs.md
@@ -18,14 +18,6 @@ Check [the Training Operator installation guide](https://github.com/kubeflow/tra
 
 Note that the minimum requirement training-operator version is v1.7.0.
 
-Set XGBoostJobs as an allowed workload in Kueue Configuration.
-
-```yaml
-integrations:
-  frameworks:
-  - "kubeflow.org/xgboostjob" 
-```
-
 You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include XGBoostJobs as an allowed workload.
 
 ## XGBoostJob definition


### PR DESCRIPTION
#### What type of PR is this?
Add one of the following kinds:
/kind documentation
/kind cleanup

#### What this PR does / why we need it:
Related to this comment (https://github.com/kubernetes-sigs/kueue/pull/1678#pullrequestreview-1856548892), documentation for other custom job frameworks indicate that you need to enable the integration when it's already enabled by default according to this: https://github.com/kubernetes-sigs/kueue/blob/main/config/components/manager/controller_manager_config.yaml

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```