### PR TITLE
[cache] Don't assign finished workloads to newly add CQs.

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -317,7 +317,7 @@ func (c *Cache) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) err
 		return fmt.Errorf("listing workloads that match the queue: %w", err)
 	}
 	for i, w := range workloads.Items {
-		if !workload.HasQuotaReservation(&w) {
+		if !workload.HasQuotaReservation(&w) || workload.IsFinished(&w) {
 			continue
 		}
 		c.addOrUpdateWorkload(&workloads.Items[i])

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -91,6 +91,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 	cases := []struct {
 		name              string
 		operation         func(*Cache) error
+		clientObbjects    []client.Object
 		wantClusterQueues map[string]*ClusterQueue
 		wantCohorts       map[string]sets.Set[string]
 	}{
@@ -958,16 +959,93 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			},
 			wantCohorts: map[string]sets.Set[string]{},
 		},
+		{
+			name: "add cluster queue after finished workloads",
+			clientObbjects: []client.Object{
+				utiltesting.MakeLocalQueue("lq1", "ns").ClusterQueue("cq1").Obj(),
+				utiltesting.MakeWorkload("pending", "ns").Obj(),
+				utiltesting.MakeWorkload("reserving", "ns").ReserveQuota(
+					utiltesting.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj(),
+				).Obj(),
+				utiltesting.MakeWorkload("admitted", "ns").ReserveQuota(
+					utiltesting.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj(),
+				).Admitted(true).Obj(),
+				utiltesting.MakeWorkload("finished", "ns").ReserveQuota(
+					utiltesting.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj(),
+				).Admitted(true).Finished().Obj(),
+			},
+			operation: func(cache *Cache) error {
+				cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("f1").Obj())
+				err := cache.AddClusterQueue(context.Background(),
+					utiltesting.MakeClusterQueue("cq1").
+						ResourceGroup(kueue.FlavorQuotas{
+							Name: "f1",
+							Resources: []kueue.ResourceQuota{
+								{
+									Name:         corev1.ResourceCPU,
+									NominalQuota: resource.MustParse("10"),
+								},
+							},
+						}).
+						Obj())
+				if err != nil {
+					return fmt.Errorf("Adding ClusterQueue: %w", err)
+				}
+				return nil
+			},
+			wantClusterQueues: map[string]*ClusterQueue{
+				"cq1": {
+					Name:                          "cq1",
+					NamespaceSelector:             labels.Everything(),
+					Status:                        active,
+					Preemption:                    defaultPreemption,
+					AllocatableResourceGeneration: 1,
+					FlavorFungibility:             defaultFlavorFungibility,
+					Usage:                         FlavorResourceQuantities{"f1": {corev1.ResourceCPU: 2000}},
+					AdmittedUsage:                 FlavorResourceQuantities{"f1": {corev1.ResourceCPU: 1000}},
+					Workloads: map[string]*workload.Info{
+						"ns/reserving": {
+							ClusterQueue: "cq1",
+							TotalRequests: []workload.PodSetResources{
+								{
+									Name:     "main",
+									Requests: workload.Requests{corev1.ResourceCPU: 1000},
+									Count:    1,
+									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+										corev1.ResourceCPU: "f1",
+									},
+								},
+							},
+						},
+						"ns/admitted": {
+							ClusterQueue: "cq1",
+							TotalRequests: []workload.PodSetResources{
+								{
+									Name:     "main",
+									Requests: workload.Requests{corev1.ResourceCPU: 1000},
+									Count:    1,
+									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+										corev1.ResourceCPU: "f1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantCohorts: map[string]sets.Set[string]{},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cache := New(utiltesting.NewFakeClient())
+			cache := New(utiltesting.NewFakeClient(tc.clientObbjects...))
 			if err := tc.operation(cache); err != nil {
 				t.Errorf("Unexpected error during test operation: %s", err)
 			}
 			if diff := cmp.Diff(tc.wantClusterQueues, cache.clusterQueues,
-				cmpopts.IgnoreFields(ClusterQueue{}, "Cohort", "Workloads", "RGByResource"),
+				cmpopts.IgnoreFields(ClusterQueue{}, "Cohort", "RGByResource", "ResourceGroups"),
+				cmpopts.IgnoreFields(workload.Info{}, "Obj", "LastAssignment"),
 				cmpopts.IgnoreUnexported(ClusterQueue{}),
 				cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Unexpected clusterQueues (-want,+got):\n%s", diff)

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -141,6 +141,17 @@ func (w *WorkloadWrapper) Admitted(a bool) *WorkloadWrapper {
 	apimeta.SetStatusCondition(&w.Status.Conditions, cond)
 	return w
 }
+func (w *WorkloadWrapper) Finished() *WorkloadWrapper {
+	cond := metav1.Condition{
+		Type:               kueue.WorkloadFinished,
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             "ByTest",
+		Message:            "Finished by test",
+	}
+	apimeta.SetStatusCondition(&w.Status.Conditions, cond)
+	return w
+}
 
 func (w *WorkloadWrapper) Creation(t time.Time) *WorkloadWrapper {
 	w.CreationTimestamp = metav1.NewTime(t)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -448,6 +448,11 @@ func IsAdmitted(w *kueue.Workload) bool {
 	return apimeta.IsStatusConditionTrue(w.Status.Conditions, kueue.WorkloadAdmitted)
 }
 
+// IsFinished returns true if the workload is finished.
+func IsFinished(w *kueue.Workload) bool {
+	return apimeta.IsStatusConditionTrue(w.Status.Conditions, kueue.WorkloadFinished)
+}
+
 func RemoveFinalizer(ctx context.Context, c client.Client, wl *kueue.Workload) error {
 	if controllerutil.RemoveFinalizer(wl, kueue.ResourceInUseFinalizerName) {
 		return c.Update(ctx, wl)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Skips assigning Finished workloads to the newly added cluster queues in cache.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1654

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```