### PR TITLE
Emit event when excess pods are deleted by Kueue [pod groups]

### DIFF
--- a/pkg/controller/jobframework/events.go
+++ b/pkg/controller/jobframework/events.go
@@ -23,5 +23,4 @@ const (
 	ReasonUpdatedWorkload    = "UpdatedWorkload"
 	ReasonFinishedWorkload   = "FinishedWorkload"
 	ReasonErrWorkloadCompose = "ErrWorkloadCompose"
-	ReasonExcessPodDeleted   = "ExcessPodDeleted"
 )

--- a/pkg/controller/jobframework/events.go
+++ b/pkg/controller/jobframework/events.go
@@ -23,4 +23,5 @@ const (
 	ReasonUpdatedWorkload    = "UpdatedWorkload"
 	ReasonFinishedWorkload   = "FinishedWorkload"
 	ReasonErrWorkloadCompose = "ErrWorkloadCompose"
+	ReasonExcessPodDeleted   = "ExcessPodDeleted"
 )

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -108,7 +108,7 @@ type ComposableJob interface {
 	// ListChildWorkloads returns all workloads related to the composable job
 	ListChildWorkloads(ctx context.Context, c client.Client, parent types.NamespacedName) (*kueue.WorkloadList, error)
 	// FindMatchingWorkloads returns all related workloads, workload that matches the ComposableJob and duplicates that has to be deleted.
-	FindMatchingWorkloads(ctx context.Context, c client.Client) (match *kueue.Workload, toDelete []*kueue.Workload, err error)
+	FindMatchingWorkloads(ctx context.Context, c client.Client, r record.EventRecorder) (match *kueue.Workload, toDelete []*kueue.Workload, err error)
 	// Stop implements the custom stop procedure for ComposableJob
 	Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, stopReason StopReason, eventMsg string) ([]client.Object, error)
 	// Ensure all members of the ComposableJob are owning the workload

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -509,7 +509,7 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 	var match *kueue.Workload
 	if cj, implements := job.(ComposableJob); implements {
 		var err error
-		match, toDelete, err = cj.FindMatchingWorkloads(ctx, r.client)
+		match, toDelete, err = cj.FindMatchingWorkloads(ctx, r.client, r.record)
 		if err != nil {
 			log.Error(err, "Composable job is unable to find matching workloads")
 			return nil, err

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -780,7 +780,7 @@ func (p *Pod) cleanupExcessPods(ctx context.Context, c client.Client, r record.E
 				p.excessPodExpectations.ObservedUID(log, p.key, pod.UID)
 				return err
 			}
-			r.Event(&pod, corev1.EventTypeNormal, jobframework.ReasonStopped, "Excess pod deleted")
+			r.Event(&pod, corev1.EventTypeNormal, jobframework.ReasonExcessPodDeleted, "Excess pod deleted")
 		}
 		return nil
 	})

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -65,6 +65,12 @@ const (
 	IsGroupWorkloadAnnotationValue = "true"
 )
 
+// Event reasons used by the pod controller
+const (
+	ReasonExcessPodDeleted     = "ExcessPodDeleted"
+	ReasonOwnerReferencesAdded = "OwnerReferencesAdded"
+)
+
 var (
 	gvk                          = corev1.SchemeGroupVersion.WithKind("Pod")
 	errIncorrectReconcileRequest = fmt.Errorf("event handler error: got a single pod reconcile request for a pod group")
@@ -780,7 +786,7 @@ func (p *Pod) cleanupExcessPods(ctx context.Context, c client.Client, r record.E
 				p.excessPodExpectations.ObservedUID(log, p.key, pod.UID)
 				return err
 			}
-			r.Event(&pod, corev1.EventTypeNormal, jobframework.ReasonExcessPodDeleted, "Excess pod deleted")
+			r.Event(&pod, corev1.EventTypeNormal, ReasonExcessPodDeleted, "Excess pod deleted")
 		}
 		return nil
 	})
@@ -824,7 +830,7 @@ func (p *Pod) EnsureWorkloadOwnedByAllMembers(ctx context.Context, c client.Clie
 		log.V(4).Info("Adding owner references for workload", "count", addedOwnersCnt)
 		err := c.Update(ctx, workload)
 		if err == nil {
-			r.Eventf(workload, corev1.EventTypeNormal, "OwnerReferencesAdded", fmt.Sprintf("Added %d owner reference(s)", addedOwnersCnt))
+			r.Eventf(workload, corev1.EventTypeNormal, ReasonOwnerReferencesAdded, fmt.Sprintf("Added %d owner reference(s)", addedOwnersCnt))
 		}
 		return err
 	}

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -2220,6 +2220,12 @@ func TestReconciler(t *testing.T) {
 					Reason:    "CreatedWorkload",
 					Message:   "Created Workload: ns/test-group",
 				},
+				{
+					Key:       types.NamespacedName{Name: "pod2", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Stopped",
+					Message:   "Excess pod deleted",
+				},
 			},
 		},
 		"excess pods before admission, youngest pods are deleted": {
@@ -2302,6 +2308,14 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "pod3", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Stopped",
+					Message:   "Excess pod deleted",
+				},
+			},
 		},
 		// In this case, group-total-count is equal to the number of pods in the cluster.
 		// But one of the roles is missing, and another role has an excess pod.
@@ -2373,6 +2387,14 @@ func TestReconciler(t *testing.T) {
 				key:  types.NamespacedName{Name: "another-group", Namespace: "ns"},
 				uids: []types.UID{"pod"},
 			}},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "pod2", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Stopped",
+					Message:   "Excess pod deleted",
+				},
+			},
 		},
 		"waiting to observe previous deletion of excess pod, no pods are deleted": {
 			pods: []corev1.Pod{
@@ -2549,6 +2571,14 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "pod3", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Stopped",
+					Message:   "Excess pod deleted",
+				},
+			},
 		},
 		// If an excess pod is already deleted and finalized, but an external finalizer blocks
 		// pod deletion, kueue should ignore such a pod, when creating a workload.

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -2223,7 +2223,7 @@ func TestReconciler(t *testing.T) {
 				{
 					Key:       types.NamespacedName{Name: "pod2", Namespace: "ns"},
 					EventType: "Normal",
-					Reason:    "Stopped",
+					Reason:    "ExcessPodDeleted",
 					Message:   "Excess pod deleted",
 				},
 			},
@@ -2312,7 +2312,7 @@ func TestReconciler(t *testing.T) {
 				{
 					Key:       types.NamespacedName{Name: "pod3", Namespace: "ns"},
 					EventType: "Normal",
-					Reason:    "Stopped",
+					Reason:    "ExcessPodDeleted",
 					Message:   "Excess pod deleted",
 				},
 			},
@@ -2391,7 +2391,7 @@ func TestReconciler(t *testing.T) {
 				{
 					Key:       types.NamespacedName{Name: "pod2", Namespace: "ns"},
 					EventType: "Normal",
-					Reason:    "Stopped",
+					Reason:    "ExcessPodDeleted",
 					Message:   "Excess pod deleted",
 				},
 			},
@@ -2575,7 +2575,7 @@ func TestReconciler(t *testing.T) {
 				{
 					Key:       types.NamespacedName{Name: "pod3", Namespace: "ns"},
 					EventType: "Normal",
-					Reason:    "Stopped",
+					Reason:    "ExcessPodDeleted",
 					Message:   "Excess pod deleted",
 				},
 			},

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -244,7 +244,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 							gomega.Expect(ok).To(gomega.BeTrue())
 							event, ok := evt.Object.(*v1.Event)
 							gomega.Expect(ok).To(gomega.BeTrue())
-							if event.InvolvedObject.Namespace == ns.Name && event.Reason == "Stopped" {
+							if event.InvolvedObject.Namespace == ns.Name && event.Reason == "ExcessPodDeleted" {
 								objKey := types.NamespacedName{Namespace: event.InvolvedObject.Namespace, Name: event.InvolvedObject.Name}
 								preemptedPods.Insert(objKey)
 							}

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -176,6 +176,16 @@ var _ = ginkgo.Describe("Pod groups", func() {
 		})
 
 		ginkgo.It("Failed Pod can be replaced in group", func() {
+			eventList := corev1.EventList{}
+			eventWatcher, err := k8sClient.Watch(ctx, &eventList, &client.ListOptions{
+				Namespace: ns.Name,
+			})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.DeferCleanup(func() {
+				eventWatcher.Stop()
+			})
+
 			group := podtesting.MakePod("group", ns.Name).
 				Image("gcr.io/k8s-staging-perf-tests/sleep:v0.1.0", []string{"1ms"}).
 				Queue(lq.Name).
@@ -222,10 +232,32 @@ var _ = ginkgo.Describe("Pod groups", func() {
 			ginkgo.By("Excess pod is deleted", func() {
 				excess := group[2].DeepCopy()
 				excess.Name = "excess"
-				gomega.Expect(k8sClient.Create(ctx, excess)).To(gomega.Succeed())
-				gomega.Eventually(func() error {
-					return k8sClient.Get(ctx, client.ObjectKeyFromObject(excess), &corev1.Pod{})
-				}, util.Timeout, util.Interval).Should(testing.BeNotFoundError())
+				excessPods := sets.New(client.ObjectKeyFromObject(excess))
+				ginkgo.By("Create the excess pod", func() {
+					gomega.Expect(k8sClient.Create(ctx, excess)).To(gomega.Succeed())
+				})
+				ginkgo.By("Use events to observe the excess pods are getting stopped", func() {
+					preemptedPods := sets.New[types.NamespacedName]()
+					gomega.Eventually(func(g gomega.Gomega) sets.Set[types.NamespacedName] {
+						select {
+						case evt, ok := <-eventWatcher.ResultChan():
+							gomega.Expect(ok).To(gomega.BeTrue())
+							event, ok := evt.Object.(*v1.Event)
+							gomega.Expect(ok).To(gomega.BeTrue())
+							if event.InvolvedObject.Namespace == ns.Name && event.Reason == "Stopped" {
+								objKey := types.NamespacedName{Namespace: event.InvolvedObject.Namespace, Name: event.InvolvedObject.Name}
+								preemptedPods.Insert(objKey)
+							}
+						default:
+						}
+						return preemptedPods
+					}, util.Timeout, util.Interval).Should(gomega.Equal(excessPods))
+				})
+				ginkgo.By("Verify the excess pod is deleted", func() {
+					gomega.Eventually(func() error {
+						return k8sClient.Get(ctx, client.ObjectKeyFromObject(excess), &corev1.Pod{})
+					}, util.Timeout, util.Interval).Should(testing.BeNotFoundError())
+				})
 			})
 
 			util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKey{Namespace: ns.Name, Name: "group"})
@@ -349,8 +381,8 @@ var _ = ginkgo.Describe("Pod groups", func() {
 						gomega.Expect(ok).To(gomega.BeTrue())
 						event, ok := evt.Object.(*v1.Event)
 						gomega.Expect(ok).To(gomega.BeTrue())
-						objKey := types.NamespacedName{Namespace: event.InvolvedObject.Namespace, Name: event.InvolvedObject.Name}
-						if defaultGroupPods.Has(objKey) && event.Reason == "Stopped" {
+						if event.InvolvedObject.Namespace == ns.Name && event.Reason == "Stopped" {
+							objKey := types.NamespacedName{Namespace: event.InvolvedObject.Namespace, Name: event.InvolvedObject.Name}
 							preemptedPods.Insert(objKey)
 						}
 					default:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This is a follow up to https://github.com/kubernetes-sigs/kueue/pull/1667

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```