### PR TITLE
Cleanup unit test for events

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -2764,7 +2764,8 @@ func TestReconciler(t *testing.T) {
 			if diff := cmp.Diff(tc.wantWorkloads, gotWorkloads.Items, tc.workloadCmpOpts...); diff != "" {
 				t.Errorf("Workloads after reconcile (-want,+got):\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents, cmp.Transformer("sortedEvents", utiltesting.SortedEvents)); diff != "" {
+
+			if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents, cmpopts.SortSlices(utiltesting.SortEvents)); diff != "" {
 				t.Errorf("unexpected events (-want/+got):\n%s", diff)
 			}
 		})

--- a/pkg/util/testing/client.go
+++ b/pkg/util/testing/client.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"sync"
 
@@ -83,27 +82,20 @@ type EventRecorder struct {
 	RecordedEvents []EventRecord
 }
 
-func SortedEvents(events []EventRecord) []EventRecord {
-	sorted := make([]EventRecord, len(events))
-	copy(sorted, events)
-	sort.Slice(sorted, func(i, j int) bool {
-		ei := sorted[i]
-		ej := sorted[j]
-		if cmp := strings.Compare(ei.Key.String(), ej.Key.String()); cmp != 0 {
-			return cmp < 0
-		}
-		if cmp := strings.Compare(ei.EventType, ej.EventType); cmp != 0 {
-			return cmp < 0
-		}
-		if cmp := strings.Compare(ei.Reason, ej.Reason); cmp != 0 {
-			return cmp < 0
-		}
-		if cmp := strings.Compare(ei.Message, ej.Message); cmp != 0 {
-			return cmp < 0
-		}
-		return false
-	})
-	return sorted
+func SortEvents(ei, ej EventRecord) bool {
+	if cmp := strings.Compare(ei.Key.String(), ej.Key.String()); cmp != 0 {
+		return cmp < 0
+	}
+	if cmp := strings.Compare(ei.EventType, ej.EventType); cmp != 0 {
+		return cmp < 0
+	}
+	if cmp := strings.Compare(ei.Reason, ej.Reason); cmp != 0 {
+		return cmp < 0
+	}
+	if cmp := strings.Compare(ei.Message, ej.Message); cmp != 0 {
+		return cmp < 0
+	}
+	return false
 }
 
 func (tr *EventRecorder) Event(object runtime.Object, eventtype, reason, message string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

this is a follow up after https://github.com/kubernetes-sigs/kueue/pull/1667#discussion_r1478882245

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```