### PR TITLE
Use a uniquely identifying selector based on recommended labels for Kueue deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: update-helm
 update-helm: manifests yq
-	SED=${SED} ./hack/update-helm.sh
+	SED=$(SED) ./hack/update-helm.sh
 
 .PHONY: generate
 generate: gomod-download controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations and client-go libraries.

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,10 @@ INTEGRATION_NPROCS ?= 4
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+# Setting SED allows macos users to install GNU sed and use the latter
+# instead of the default BSD sed.
+SED ?= /usr/bin/sed
+
 version_pkg = sigs.k8s.io/kueue/pkg/version
 LD_FLAGS += -X '$(version_pkg).GitVersion=$(GIT_TAG)'
 LD_FLAGS += -X '$(version_pkg).GitCommit=$(shell git rev-parse HEAD)'
@@ -125,7 +129,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: update-helm
 update-helm: manifests yq
-	./hack/update-helm.sh
+	SED=${SED} ./hack/update-helm.sh
 
 .PHONY: generate
 generate: gomod-download controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations and client-go libraries.

--- a/charts/kueue/templates/_helpers.tpl
+++ b/charts/kueue/templates/_helpers.tpl
@@ -47,7 +47,7 @@ Selector labels
 */}}
 {{- define "kueue.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "kueue.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: controller
 {{- end }}
 
 {{/*

--- a/charts/kueue/templates/_helpers.tpl
+++ b/charts/kueue/templates/_helpers.tpl
@@ -47,6 +47,7 @@ Selector labels
 */}}
 {{- define "kueue.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "kueue.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: controller
 {{- end }}
 

--- a/charts/kueue/templates/certmanager/certificate.yaml
+++ b/charts/kueue/templates/certmanager/certificate.yaml
@@ -4,6 +4,8 @@ kind: Issuer
 metadata:
   name: {{ include "kueue.fullname" . }}-selfsigned-issuer
   namespace: '{{ .Release.Namespace }}'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 spec:
   selfSigned: {}
 ---
@@ -12,6 +14,8 @@ kind: Certificate
 metadata:
   name: {{ include "kueue.fullname" . }}-serving-cert
   namespace: '{{ .Release.Namespace }}'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 spec:
   dnsNames:
   - '{{ include "kueue.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc'

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -7,6 +7,8 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   name: admissionchecks.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -2,13 +2,13 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
-  labels:
-  {{- include "kueue.labels" . | nindent 4 }}
   name: admissionchecks.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -7,6 +7,8 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   name: clusterqueues.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -2,13 +2,13 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
-  labels:
-  {{- include "kueue.labels" . | nindent 4 }}
   name: clusterqueues.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
@@ -2,13 +2,13 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
-  labels:
-  {{- include "kueue.labels" . | nindent 4 }}
   name: localqueues.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
@@ -7,6 +7,8 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   name: localqueues.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
@@ -7,6 +7,8 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   name: multikueueclusters.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
@@ -2,13 +2,13 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
-  labels:
-  {{- include "kueue.labels" . | nindent 4 }}
   name: multikueueclusters.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
@@ -7,6 +7,8 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   name: multikueueconfigs.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
@@ -2,13 +2,13 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
-  labels:
-  {{- include "kueue.labels" . | nindent 4 }}
   name: multikueueconfigs.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -7,6 +7,8 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   name: provisioningrequestconfigs.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -2,13 +2,13 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
-  labels:
-  {{- include "kueue.labels" . | nindent 4 }}
   name: provisioningrequestconfigs.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
@@ -2,13 +2,13 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
-  labels:
-  {{- include "kueue.labels" . | nindent 4 }}
   name: resourceflavors.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
@@ -7,6 +7,8 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   name: resourceflavors.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
@@ -2,13 +2,13 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
-  labels:
-  {{- include "kueue.labels" . | nindent 4 }}
   name: workloadpriorityclasses.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
@@ -7,6 +7,8 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   name: workloadpriorityclasses.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -7,6 +7,8 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   name: workloads.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -2,13 +2,13 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.14.0
-  labels:
-  {{- include "kueue.labels" . | nindent 4 }}
   name: workloads.kueue.x-k8s.io
 spec:
   conversion:

--- a/charts/kueue/templates/internalcert/secret.yaml
+++ b/charts/kueue/templates/internalcert/secret.yaml
@@ -3,3 +3,5 @@ kind: Secret
 metadata:
   name: {{ include "kueue.fullname" . }}-webhook-server-cert
   namespace: '{{ .Release.Namespace }}'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}

--- a/charts/kueue/templates/manager/auth_proxy_service.yaml
+++ b/charts/kueue/templates/manager/auth_proxy_service.yaml
@@ -4,11 +4,10 @@ metadata:
   name: {{ include "kueue.fullname" . }}-controller-manager-metrics-service
   namespace: '{{ .Release.Namespace }}'
   labels:
-    control-plane: controller-manager
+  {{- include "kueue.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.metricsService.type }}
   selector:
-    control-plane: controller-manager
   {{- include "kueue.selectorLabels" . | nindent 4 }}
   ports:
   {{- .Values.metricsService.ports | toYaml | nindent 2 -}}

--- a/charts/kueue/templates/manager/manager-config.yaml
+++ b/charts/kueue/templates/manager/manager-config.yaml
@@ -3,5 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "kueue.fullname" . }}-manager-config
   namespace: '{{ .Release.Namespace }}'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 data:
   controller_manager_config.yaml: {{ .Values.managerConfig.controllerManagerConfigYaml | toYaml | indent 1 }}

--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -4,17 +4,15 @@ metadata:
   name: {{ include "kueue.fullname" . }}-controller-manager
   namespace: '{{ .Release.Namespace }}'
   labels:
-    control-plane: controller-manager
+  {{- include "kueue.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controllerManager.replicas }}
   selector:
     matchLabels:
-      control-plane: controller-manager
     {{- include "kueue.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        control-plane: controller-manager
       {{- include "kueue.selectorLabels" . | nindent 8 }}
       annotations:
         kubectl.kubernetes.io/default-container: manager

--- a/charts/kueue/templates/prometheus/monitor.yaml
+++ b/charts/kueue/templates/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "kueue.fullname" . }}-controller-manager-metrics-monitor
   labels:
-    control-plane: controller-manager
+  {{- include "kueue.labels" . | nindent 4 }}
   namespace: '{{ .Release.Namespace }}'
 spec:
   endpoints:
@@ -16,5 +16,5 @@ spec:
       insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+    {{- include "kueue.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/charts/kueue/templates/prometheus/monitor.yaml
+++ b/charts/kueue/templates/prometheus/monitor.yaml
@@ -16,5 +16,5 @@ spec:
       insecureSkipVerify: true
   selector:
     matchLabels:
-    {{- include "kueue.selectorLabels" . | nindent 6 }}
+    {{- include "kueue.labels" . | nindent 6 }}
 {{- end }}

--- a/charts/kueue/templates/prometheus/role.yaml
+++ b/charts/kueue/templates/prometheus/role.yaml
@@ -4,6 +4,8 @@ kind: Role
 metadata:
   name: {{ include "kueue.fullname" . }}-prometheus-k8s
   namespace: '{{ .Release.Namespace }}'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""
@@ -37,6 +39,8 @@ kind: RoleBinding
 metadata:
   name: {{ include "kueue.fullname" . }}-prometheus-k8s
   namespace: '{{ .Release.Namespace }}'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/kueue/templates/rbac/auth_proxy_client_clusterrole.yaml
+++ b/charts/kueue/templates/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-metrics-reader'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: '{{ include "kueue.fullname" . }}-metrics-reader'
 rules:
   - nonResourceURLs:
       - "/metrics"

--- a/charts/kueue/templates/rbac/auth_proxy_client_clusterrole.yaml
+++ b/charts/kueue/templates/rbac/auth_proxy_client_clusterrole.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-metrics-reader'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 rules:
   - nonResourceURLs:
       - "/metrics"

--- a/charts/kueue/templates/rbac/auth_proxy_role.yaml
+++ b/charts/kueue/templates/rbac/auth_proxy_role.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-proxy-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: '{{ include "kueue.fullname" . }}-proxy-role'
 rules:
   - apiGroups:
       - authentication.k8s.io

--- a/charts/kueue/templates/rbac/auth_proxy_role.yaml
+++ b/charts/kueue/templates/rbac/auth_proxy_role.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-proxy-role'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - authentication.k8s.io

--- a/charts/kueue/templates/rbac/auth_proxy_role_binding.yaml
+++ b/charts/kueue/templates/rbac/auth_proxy_role_binding.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: '{{ include "kueue.fullname" . }}-proxy-rolebinding'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: '{{ include "kueue.fullname" . }}-proxy-rolebinding'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kueue/templates/rbac/auth_proxy_role_binding.yaml
+++ b/charts/kueue/templates/rbac/auth_proxy_role_binding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: '{{ include "kueue.fullname" . }}-proxy-rolebinding'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kueue/templates/rbac/batch_admin_role.yaml
+++ b/charts/kueue/templates/rbac/batch_admin_role.yaml
@@ -2,9 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-batch-admin-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: '{{ include "kueue.fullname" . }}-batch-admin-role'
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:

--- a/charts/kueue/templates/rbac/batch_admin_role.yaml
+++ b/charts/kueue/templates/rbac/batch_admin_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-batch-admin-role'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:

--- a/charts/kueue/templates/rbac/batch_user_role.yaml
+++ b/charts/kueue/templates/rbac/batch_user_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-batch-user-role'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:

--- a/charts/kueue/templates/rbac/batch_user_role.yaml
+++ b/charts/kueue/templates/rbac/batch_user_role.yaml
@@ -2,9 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-batch-user-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: '{{ include "kueue.fullname" . }}-batch-user-role'
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:

--- a/charts/kueue/templates/rbac/clusterqueue_editor_role.yaml
+++ b/charts/kueue/templates/rbac/clusterqueue_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-clusterqueue-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/clusterqueue_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/clusterqueue_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-clusterqueue-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/job_editor_role.yaml
+++ b/charts/kueue/templates/rbac/job_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-job-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/job_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/job_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-job-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/jobset_editor_role.yaml
+++ b/charts/kueue/templates/rbac/jobset_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-jobset-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/jobset_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/jobset_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-jobset-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/leader_election_role.yaml
+++ b/charts/kueue/templates/rbac/leader_election_role.yaml
@@ -2,9 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: '{{ include "kueue.fullname" . }}-leader-election-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: '{{ include "kueue.fullname" . }}-leader-election-role'
 rules:
   - apiGroups:
       - ""

--- a/charts/kueue/templates/rbac/leader_election_role.yaml
+++ b/charts/kueue/templates/rbac/leader_election_role.yaml
@@ -3,6 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: '{{ include "kueue.fullname" . }}-leader-election-role'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/kueue/templates/rbac/leader_election_role_binding.yaml
+++ b/charts/kueue/templates/rbac/leader_election_role_binding.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: '{{ include "kueue.fullname" . }}-leader-election-rolebinding'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: '{{ include "kueue.fullname" . }}-leader-election-rolebinding'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/kueue/templates/rbac/leader_election_role_binding.yaml
+++ b/charts/kueue/templates/rbac/leader_election_role_binding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: '{{ include "kueue.fullname" . }}-leader-election-rolebinding'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/kueue/templates/rbac/localqueue_editor_role.yaml
+++ b/charts/kueue/templates/rbac/localqueue_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-localqueue-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/localqueue_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/localqueue_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-localqueue-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/mpijob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/mpijob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-mpijob-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/mpijob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/mpijob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-mpijob-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/mxjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/mxjob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-mxjob-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/mxjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/mxjob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-mxjob-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/paddlejob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/paddlejob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-paddlejob-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/paddlejob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/paddlejob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-paddlejob-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/pending_workloads_cq_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/pending_workloads_cq_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-pending-workloads-cq-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/pending_workloads_lq_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/pending_workloads_lq_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-pending-workloads-lq-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/pytorchjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/pytorchjob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-pytorchjob-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/pytorchjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/pytorchjob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-pytorchjob-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/raycluster_editor_role.yaml
+++ b/charts/kueue/templates/rbac/raycluster_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-raycluster-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/raycluster_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/raycluster_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-raycluster-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/rayjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/rayjob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-rayjob-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/rayjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/rayjob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-rayjob-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/resourceflavor_editor_role.yaml
+++ b/charts/kueue/templates/rbac/resourceflavor_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-resourceflavor-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/resourceflavor_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/resourceflavor_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-resourceflavor-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-manager-role'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: '{{ include "kueue.fullname" . }}-manager-role'
 rules:
   - apiGroups:
       - ""

--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-manager-role'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/kueue/templates/rbac/role_binding.yaml
+++ b/charts/kueue/templates/rbac/role_binding.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: '{{ include "kueue.fullname" . }}-manager-rolebinding'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: '{{ include "kueue.fullname" . }}-manager-rolebinding'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kueue/templates/rbac/role_binding.yaml
+++ b/charts/kueue/templates/rbac/role_binding.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: '{{ include "kueue.fullname" . }}-manager-rolebinding'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kueue/templates/rbac/service_account.yaml
+++ b/charts/kueue/templates/rbac/service_account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: '{{ include "kueue.fullname" . }}-controller-manager'
-  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: '{{ include "kueue.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/charts/kueue/templates/rbac/service_account.yaml
+++ b/charts/kueue/templates/rbac/service_account.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: '{{ include "kueue.fullname" . }}-controller-manager'
   namespace: '{{ .Release.Namespace }}'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}

--- a/charts/kueue/templates/rbac/tfjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/tfjob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-tfjob-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/tfjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/tfjob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-tfjob-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/workload_editor_role.yaml
+++ b/charts/kueue/templates/rbac/workload_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-workload-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
 rules:
   - apiGroups:

--- a/charts/kueue/templates/rbac/workload_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/workload_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-workload-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/xgboostjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/xgboostjob_editor_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-xgboostjob-editor-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/rbac/xgboostjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/xgboostjob_viewer_role.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 metadata:
   name: '{{ include "kueue.fullname" . }}-xgboostjob-viewer-role'
   labels:
+  {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"
     rbac.kueue.x-k8s.io/batch-user: "true"
 rules:

--- a/charts/kueue/templates/visibility/apiservice.yaml
+++ b/charts/kueue/templates/visibility/apiservice.yaml
@@ -3,6 +3,8 @@ apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1alpha1.visibility.kueue.x-k8s.io
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 spec:
   group: visibility.kueue.x-k8s.io
   groupPriorityMinimum: 100

--- a/charts/kueue/templates/visibility/apiservice.yaml
+++ b/charts/kueue/templates/visibility/apiservice.yaml
@@ -2,9 +2,9 @@
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1alpha1.visibility.kueue.x-k8s.io
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: v1alpha1.visibility.kueue.x-k8s.io
 spec:
   group: visibility.kueue.x-k8s.io
   groupPriorityMinimum: 100

--- a/charts/kueue/templates/visibility/role_binding.yaml
+++ b/charts/kueue/templates/visibility/role_binding.yaml
@@ -2,10 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: '{{ include "kueue.fullname" . }}-visibility-server-auth-reader'
-  namespace: kube-system
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: '{{ include "kueue.fullname" . }}-visibility-server-auth-reader'
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/kueue/templates/visibility/role_binding.yaml
+++ b/charts/kueue/templates/visibility/role_binding.yaml
@@ -2,10 +2,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-    control-plane: controller-manager
   name: '{{ include "kueue.fullname" . }}-visibility-server-auth-reader'
   namespace: kube-system
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/kueue/templates/visibility/service.yaml
+++ b/charts/kueue/templates/visibility/service.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   name: '{{ include "kueue.fullname" . }}-visibility-server'
   namespace: '{{ .Release.Namespace }}'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 spec:
   ports:
     - name: https
@@ -11,5 +13,5 @@ spec:
       protocol: TCP
       targetPort: 8082
   selector:
-    control-plane: controller-manager
+  {{- include "kueue.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/kueue/templates/visibility/service.yaml
+++ b/charts/kueue/templates/visibility/service.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: '{{ include "kueue.fullname" . }}-visibility-server'
-  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: '{{ include "kueue.fullname" . }}-visibility-server'
+  namespace: '{{ .Release.Namespace }}'
 spec:
   ports:
     - name: https

--- a/charts/kueue/templates/webhook/service.yaml
+++ b/charts/kueue/templates/webhook/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: '{{ include "kueue.fullname" . }}-webhook-service'
-  namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+  name: '{{ include "kueue.fullname" . }}-webhook-service'
+  namespace: '{{ .Release.Namespace }}'
 spec:
   type: {{ .Values.webhookService.type }}
   selector:

--- a/charts/kueue/templates/webhook/service.yaml
+++ b/charts/kueue/templates/webhook/service.yaml
@@ -3,10 +3,11 @@ kind: Service
 metadata:
   name: '{{ include "kueue.fullname" . }}-webhook-service'
   namespace: '{{ .Release.Namespace }}'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.webhookService.type }}
   selector:
-    control-plane: controller-manager
   {{- include "kueue.selectorLabels" . | nindent 4 }}
   ports:
   {{- .Values.webhookService.ports | toYaml | nindent 2 -}}

--- a/charts/kueue/templates/webhook/webhook.yaml
+++ b/charts/kueue/templates/webhook/webhook.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
   {{- end }}
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   namespace: '{{ .Release.Namespace }}'
 webhooks:
   - admissionReviewVersions:
@@ -301,6 +303,8 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
   {{- end }}
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   namespace: '{{ .Release.Namespace }}'
 webhooks:
   - admissionReviewVersions:

--- a/charts/kueue/templates/webhook/webhook.yaml
+++ b/charts/kueue/templates/webhook/webhook.yaml
@@ -2,13 +2,13 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   name: '{{ include "kueue.fullname" . }}-mutating-webhook-configuration'
   {{- if .Values.enableCertManager }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
   {{- end }}
-  labels:
-  {{- include "kueue.labels" . | nindent 4 }}
   namespace: '{{ .Release.Namespace }}'
 webhooks:
   - admissionReviewVersions:
@@ -298,13 +298,13 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
   name: '{{ include "kueue.fullname" . }}-validating-webhook-configuration'
   {{- if .Values.enableCertManager }}
   annotations:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
   {{- end }}
-  labels:
-  {{- include "kueue.labels" . | nindent 4 }}
   namespace: '{{ .Release.Namespace }}'
 webhooks:
   - admissionReviewVersions:

--- a/config/components/manager/auth_proxy_service.yaml
+++ b/config/components/manager/auth_proxy_service.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    control-plane: controller-manager
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -11,5 +9,3 @@ spec:
     port: 8443
     protocol: TCP
     targetPort: https
-  selector:
-    control-plane: controller-manager

--- a/config/components/manager/manager.yaml
+++ b/config/components/manager/manager.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  labels:
-    control-plane: controller-manager
   name: system
 ---
 apiVersion: apps/v1
@@ -10,19 +8,12 @@ kind: Deployment
 metadata:
   name: controller-manager
   namespace: system
-  labels:
-    control-plane: controller-manager
 spec:
-  selector:
-    matchLabels:
-      control-plane: controller-manager
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
-      labels:
-        control-plane: controller-manager
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/components/prometheus/monitor.yaml
+++ b/config/components/prometheus/monitor.yaml
@@ -1,10 +1,7 @@
-
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  labels:
-    control-plane: controller-manager
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +14,5 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/name: kueue

--- a/config/components/visibility/role_binding.yaml
+++ b/config/components/visibility/role_binding.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  labels:
-    control-plane: controller-manager
   name: visibility-server-auth-reader
   namespace: kube-system
 roleRef:

--- a/config/components/visibility/service.yaml
+++ b/config/components/visibility/service.yaml
@@ -9,6 +9,3 @@ spec:
     port: 443
     protocol: TCP
     targetPort: 8082
-  selector:
-    control-plane: controller-manager
-    

--- a/config/components/visibility/service.yaml
+++ b/config/components/visibility/service.yaml
@@ -9,3 +9,4 @@ spec:
     port: 443
     protocol: TCP
     targetPort: 8082
+

--- a/config/components/webhook/service.yaml
+++ b/config/components/webhook/service.yaml
@@ -8,5 +8,3 @@ spec:
     - port: 443
       protocol: TCP
       targetPort: 9443
-  selector:
-    control-plane: controller-manager

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -9,8 +9,9 @@ namespace: kueue-system
 namePrefix: kueue-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  app.kubernetes.io/name: kueue
+  app.kubernetes.io/component: controller
 
 resources:
 - ../components/crd


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR proposes to change the default label selector currently used by the Kueue deployment from:

```yaml
control-plane: controller-manager
```

to the following selector, that uses Kubernetes recommended labels to uniquely identify Kueue Pods:

```yaml
app.kubernetes.io/name: kueue
app.kubernetes.io/component: controller
```

#### Which issue(s) this PR fixes:

Fixes #1685

#### Special notes for your reviewer:

The script that updates the Helm charts has to be adapted to apply parameterised labels selectors.

#### Does this PR introduce a user-facing change?

```release-note
Use recommended labels and a uniquely identifying selector for Kueue deployment resources.

⚠️ This requires to recreate the Kueue deployment if you had it previously installed,
 as this label selector field is immutable.
```
