### PR TITLE
Remove .spec.volumes from role hash for pods

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -562,7 +562,6 @@ func getRoleHash(p corev1.Pod) (string, error) {
 			"preemptionPolicy":          p.Spec.PreemptionPolicy,
 			"topologySpreadConstraints": p.Spec.TopologySpreadConstraints,
 			"overhead":                  p.Spec.Overhead,
-			"volumes":                   volumesShape(p.Spec.Volumes),
 			"resourceClaims":            p.Spec.ResourceClaims,
 		},
 	}

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -532,7 +532,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -596,7 +596,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -610,7 +610,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -635,7 +635,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Group("test-group").
 					GroupTotalCount("2").
-					Annotation("kueue.x-k8s.io/role-hash", "b990493b").
+					Annotation("kueue.x-k8s.io/role-hash", "60bc72d3").
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -645,7 +645,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Group("test-group").
 					GroupTotalCount("2").
-					Annotation("kueue.x-k8s.io/role-hash", "b990493b").
+					Annotation("kueue.x-k8s.io/role-hash", "60bc72d3").
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
@@ -655,7 +655,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
-					Annotation("kueue.x-k8s.io/role-hash", "b990493b").
+					Annotation("kueue.x-k8s.io/role-hash", "60bc72d3").
 					NodeSelector("kubernetes.io/arch", "arm64").
 					Obj(),
 				*basePodWrapper.
@@ -665,17 +665,17 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
-					Annotation("kueue.x-k8s.io/role-hash", "b990493b").
+					Annotation("kueue.x-k8s.io/role-hash", "60bc72d3").
 					NodeSelector("kubernetes.io/arch", "arm64").
 					Obj(),
 			},
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(*utiltesting.MakePodSet("b990493b", 2).Request(corev1.ResourceCPU, "1").Obj()).
+					PodSets(*utiltesting.MakePodSet("60bc72d3", 2).Request(corev1.ResourceCPU, "1").Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", "b990493b").
+						utiltesting.MakeAdmission("cq", "60bc72d3").
 							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 							AssignmentPodCount(2).
 							Obj(),
@@ -685,11 +685,11 @@ func TestReconciler(t *testing.T) {
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(*utiltesting.MakePodSet("b990493b", 2).Request(corev1.ResourceCPU, "1").Obj()).
+					PodSets(*utiltesting.MakePodSet("60bc72d3", 2).Request(corev1.ResourceCPU, "1").Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", "b990493b").
+						utiltesting.MakeAdmission("cq", "60bc72d3").
 							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 							AssignmentPodCount(2).
 							Obj(),
@@ -754,7 +754,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -768,7 +768,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -777,7 +777,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Admitted(true).
-					ReclaimablePods(kueue.ReclaimablePod{Name: "b990493b", Count: 1}).
+					ReclaimablePods(kueue.ReclaimablePod{Name: "60bc72d3", Count: 1}).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -822,7 +822,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -836,7 +836,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -881,7 +881,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -894,7 +894,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -951,7 +951,7 @@ func TestReconciler(t *testing.T) {
 			},
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(*utiltesting.MakePodSet("b990493b", 2).Request(corev1.ResourceCPU, "1").Obj()).
+					PodSets(*utiltesting.MakePodSet("60bc72d3", 2).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue("test-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -966,7 +966,7 @@ func TestReconciler(t *testing.T) {
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(*utiltesting.MakePodSet("b990493b", 2).Request(corev1.ResourceCPU, "1").Obj()).
+					PodSets(*utiltesting.MakePodSet("60bc72d3", 2).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue("test-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1004,7 +1004,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1023,7 +1023,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1121,7 +1121,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{},
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(*utiltesting.MakePodSet("b990493b", 2).Request(corev1.ResourceCPU, "1").Obj()).
+					PodSets(*utiltesting.MakePodSet("60bc72d3", 2).Request(corev1.ResourceCPU, "1").Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Queue("test-queue").
@@ -1192,28 +1192,28 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", "b990493b").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", "60bc72d3").AssignmentPodCount(1).Obj()).
 					Admitted(true).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", "b990493b").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", "60bc72d3").AssignmentPodCount(1).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -1268,17 +1268,17 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 3).
+						*utiltesting.MakePodSet("60bc72d3", 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq", "b990493b").AssignmentPodCount(3).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", "60bc72d3").AssignmentPodCount(3).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReclaimablePods(kueue.ReclaimablePod{Name: "b990493b", Count: 1}).
+					ReclaimablePods(kueue.ReclaimablePod{Name: "60bc72d3", Count: 1}).
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
@@ -1320,14 +1320,14 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 3).
+						*utiltesting.MakePodSet("60bc72d3", 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq", "b990493b").AssignmentPodCount(3).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", "60bc72d3").AssignmentPodCount(3).Obj()).
 					ReclaimablePods(kueue.ReclaimablePod{
-						Name:  "b990493b",
+						Name:  "60bc72d3",
 						Count: 1,
 					}).
 					Admitted(true).
@@ -1335,7 +1335,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement", "test-uid").
-					ReclaimablePods(kueue.ReclaimablePod{Name: "b990493b", Count: 1}).
+					ReclaimablePods(kueue.ReclaimablePod{Name: "60bc72d3", Count: 1}).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -1411,7 +1411,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1426,7 +1426,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1480,7 +1480,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 1).
+						*utiltesting.MakePodSet("60bc72d3", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1500,7 +1500,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 1).
+						*utiltesting.MakePodSet("60bc72d3", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1545,7 +1545,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 1).
+						*utiltesting.MakePodSet("60bc72d3", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1565,7 +1565,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 1).
+						*utiltesting.MakePodSet("60bc72d3", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1655,7 +1655,7 @@ func TestReconciler(t *testing.T) {
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(*utiltesting.MakePodSet("b990493b", 2).Request(corev1.ResourceCPU, "1").Obj()).
+					PodSets(*utiltesting.MakePodSet("60bc72d3", 2).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue("test-queue").
 					Priority(0).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
@@ -1716,7 +1716,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1730,7 +1730,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1770,7 +1770,7 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("absent-pod-role", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
-						*utiltesting.MakePodSet("b990493b", 1).
+						*utiltesting.MakePodSet("60bc72d3", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1786,7 +1786,7 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("absent-pod-role", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
-						*utiltesting.MakePodSet("b990493b", 1).
+						*utiltesting.MakePodSet("60bc72d3", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1882,7 +1882,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
@@ -2018,7 +2018,7 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("4389b941", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2036,7 +2036,7 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("4389b941", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2128,10 +2128,10 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("4389b941", 1).
+						*utiltesting.MakePodSet("007b32e9", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2146,10 +2146,10 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("4389b941", 1).
+						*utiltesting.MakePodSet("007b32e9", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2159,7 +2159,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReclaimablePods(kueue.ReclaimablePod{Name: "4389b941", Count: 1}).
+					ReclaimablePods(kueue.ReclaimablePod{Name: "007b32e9", Count: 1}).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -2201,7 +2201,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 1).
+						*utiltesting.MakePodSet("60bc72d3", 1).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -2278,7 +2278,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2291,7 +2291,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2342,7 +2342,7 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("aaf269e6", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
-						*utiltesting.MakePodSet("b990493b", 1).
+						*utiltesting.MakePodSet("60bc72d3", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2358,7 +2358,7 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("aaf269e6", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
-						*utiltesting.MakePodSet("b990493b", 1).
+						*utiltesting.MakePodSet("60bc72d3", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2440,7 +2440,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 1).
+						*utiltesting.MakePodSet("60bc72d3", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2452,7 +2452,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 1).
+						*utiltesting.MakePodSet("60bc72d3", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2521,7 +2521,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2536,7 +2536,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 2).
+						*utiltesting.MakePodSet("60bc72d3", 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2601,7 +2601,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 1).
+						*utiltesting.MakePodSet("60bc72d3", 1).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -2730,7 +2730,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 3).
+						*utiltesting.MakePodSet("60bc72d3", 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2744,7 +2744,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 3).
+						*utiltesting.MakePodSet("60bc72d3", 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2836,7 +2836,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 3).
+						*utiltesting.MakePodSet("60bc72d3", 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2856,7 +2856,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("b990493b", 3).
+						*utiltesting.MakePodSet("60bc72d3", 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2955,7 +2955,14 @@ func TestReconciler(t *testing.T) {
 			if err := kClient.List(ctx, &gotWorkloads); err != nil {
 				t.Fatalf("Could not get Workloads after reconcile: %v", err)
 			}
+
 			if diff := cmp.Diff(tc.wantWorkloads, gotWorkloads.Items, tc.workloadCmpOpts...); diff != "" {
+				for i, p := range tc.pods {
+					// Make life easier when changing the hashing function.
+					hash, _ := getRoleHash(p)
+					t.Logf("note, the hash for pod[%v] = %s", i, hash)
+
+				}
 				t.Errorf("Workloads after reconcile (-want,+got):\n%s", diff)
 			}
 

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -130,15 +130,6 @@ func containersShape(containers []corev1.Container) (result []map[string]interfa
 	return result
 }
 
-func volumesShape(volumes []corev1.Volume) (result []corev1.Volume) {
-	for _, v := range volumes {
-		v.Name = ""
-		result = append(result, v)
-	}
-
-	return result
-}
-
 // addRoleHash calculates the role hash and adds it to the pod's annotations
 func (p *Pod) addRoleHash() error {
 	if p.pod.Annotations == nil {

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -233,7 +233,7 @@ func TestDefault(t *testing.T) {
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
 				Group("test-group").
-				RoleHash("90ce3e8a").
+				RoleHash("3b4907a8").
 				Label("kueue.x-k8s.io/managed", "true").
 				KueueSchedulingGate().
 				KueueFinalizer().
@@ -250,7 +250,7 @@ func TestDefault(t *testing.T) {
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
 				Group("test-group").
-				RoleHash("90ce3e8a").
+				RoleHash("3b4907a8").
 				Label("kueue.x-k8s.io/managed", "true").
 				KueueSchedulingGate().
 				KueueFinalizer().
@@ -315,6 +315,8 @@ func TestGetRoleHash(t *testing.T) {
 			},
 			wantEqualHash: true,
 		},
+		// NOTE: volumes used to be included in the role hash.
+		// https://github.com/kubernetes-sigs/kueue/issues/1697
 		"volumes with different claims shouldn't affect the role": {
 			pods: []*Pod{
 				{pod: *testingpod.MakePod("pod1", "test-ns").

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -315,6 +315,31 @@ func TestGetRoleHash(t *testing.T) {
 			},
 			wantEqualHash: true,
 		},
+		"volumes with different claims shouldn't affect the role": {
+			pods: []*Pod{
+				{pod: *testingpod.MakePod("pod1", "test-ns").
+					Volume(corev1.Volume{
+						Name: "volume",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "claim1",
+							},
+						},
+					}).
+					Obj()},
+				{pod: *testingpod.MakePod("pod1", "test-ns").
+					Volume(corev1.Volume{
+						Name: "volume",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "claim2",
+							},
+						},
+					}).
+					Obj()},
+			},
+			wantEqualHash: true,
+		},
 	}
 
 	for name, tc := range testCases {

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -525,10 +525,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(2))
 				gomega.Expect(createdWorkload.Spec.PodSets[0].Count).To(gomega.Equal(int32(1)))
 				gomega.Expect(createdWorkload.Spec.PodSets[1].Count).To(gomega.Equal(int32(1)))
+
 				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
 
 				ginkgo.By("checking that all pods in group are unsuspended when workload is admitted", func() {
-					admission := testing.MakeAdmission(clusterQueue.Name, "120fa2c0", "542d5455").
+					admission := testing.MakeAdmission(clusterQueue.Name, "7c214403", "41b86f81").
 						Assignment(corev1.ResourceCPU, "default", "1").
 						AssignmentPodCount(2).
 						Obj()
@@ -601,7 +602,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
 				originalWorkloadUID := createdWorkload.UID
 
-				admission := testing.MakeAdmission(clusterQueue.Name, "120fa2c0").
+				admission := testing.MakeAdmission(clusterQueue.Name, "7c214403").
 					Assignment(corev1.ResourceCPU, "default", "1").
 					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
 					Obj()
@@ -723,7 +724,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
 
 				ginkgo.By("checking that pod is unsuspended when workload is admitted")
-				admission := testing.MakeAdmission(clusterQueue.Name, "120fa2c0").
+				admission := testing.MakeAdmission(clusterQueue.Name, "7c214403").
 					Assignment(corev1.ResourceCPU, "default", "1").
 					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
 					Obj()
@@ -812,7 +813,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				createdPod := &corev1.Pod{}
 				ginkgo.By("checking that all pods in group are unsuspended when workload is admitted", func() {
-					admission := testing.MakeAdmission(clusterQueue.Name, "120fa2c0", "542d5455").
+					admission := testing.MakeAdmission(clusterQueue.Name, "7c214403", "41b86f81").
 						Assignment(corev1.ResourceCPU, "default", "1").
 						AssignmentPodCount(2).
 						Obj()
@@ -939,7 +940,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				})
 
 				ginkgo.By("checking that all pods in group are unsuspended when workload is admitted", func() {
-					admission := testing.MakeAdmission(clusterQueue.Name, "120fa2c0", "542d5455").
+					admission := testing.MakeAdmission(clusterQueue.Name, "7c214403", "41b86f81").
 						Assignment(corev1.ResourceCPU, "default", "1").
 						AssignmentPodCount(2).
 						Obj()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Removes `.spec.volumes` from pod role hash calculation. Allows for users to specify different volumes for pods in a pod group.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1697 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```