### PR TITLE
E2e extend startup interval

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -55,6 +55,5 @@ function cluster_kueue_deploy {
     else
         kubectl apply --server-side -k test/e2e/config
     fi
-    kubectl wait --for=condition=available --timeout=3m deployment/kueue-controller-manager -n kueue-system
 }
 

--- a/hack/multikueue/manager-cluster.kind.yaml
+++ b/hack/multikueue/manager-cluster.kind.yaml
@@ -1,2 +1,18 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    scheduler:
+      extraArgs:
+        v: "2"
+    controllerManager:
+      extraArgs:
+        v: "2"
+    apiServer:
+      extraArgs:
+        enable-aggregator-routing: "true"
+        v: "2"

--- a/hack/multikueue/worker-cluster.kind.yaml
+++ b/hack/multikueue/worker-cluster.kind.yaml
@@ -2,3 +2,19 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   apiServerAddress: "FILLED_AT_RUNTIME"
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiVersion: kubeadm.k8s.io/v1beta3
+    scheduler:
+      extraArgs:
+        v: "2"
+    controllerManager:
+      extraArgs:
+        v: "2"
+    apiServer:
+      extraArgs:
+        enable-aggregator-routing: "true"
+        v: "2"

--- a/test/e2e/multikueue/suite_test.go
+++ b/test/e2e/multikueue/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -62,4 +63,10 @@ var _ = ginkgo.BeforeSuite(func() {
 	k8sWorker2Client = util.CreateClientUsingCluster("kind-" + worker2ClusterName)
 
 	ctx = context.Background()
+
+	waitForAvailableStart := time.Now()
+	util.WaitForKueueAvailability(ctx, k8sManagerClient)
+	util.WaitForKueueAvailability(ctx, k8sWorker1Client)
+	util.WaitForKueueAvailability(ctx, k8sWorker2Client)
+	ginkgo.GinkgoLogr.Info("Kueue is Available in all the clusters", "waitingTime", time.Since(waitForAvailableStart))
 })

--- a/test/e2e/singlecluster/suite_test.go
+++ b/test/e2e/singlecluster/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -54,4 +55,8 @@ var _ = ginkgo.BeforeSuite(func() {
 	visibilityClient = util.CreateVisibilityClient("")
 	impersonatedVisibilityClient = util.CreateVisibilityClient("system:serviceaccount:kueue-system:default")
 	ctx = context.Background()
+
+	waitForAvailableStart := time.Now()
+	util.WaitForKueueAvailability(ctx, k8sClient)
+	ginkgo.GinkgoLogr.Info("Kueue is Available in the cluster", "waitingTime", time.Since(waitForAvailableStart))
 })

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -30,7 +30,7 @@ const (
 	// Taken into account that after the certificates are ready, all Kueue's components
 	// need started and the time it takes for a change in ready probe response triggers
 	// a change in the deployment status.
-	StartUpTimeout     = 4 * time.Minute
+	StartUpTimeout     = 5 * time.Minute
 	ConsistentDuration = time.Second * 3
 	Interval           = time.Millisecond * 250
 )

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -26,8 +26,11 @@ const (
 	// such as running pods to completion.
 	LongTimeout = 45 * time.Second
 	// StartupTimeout is meant to be used for waiting for Kueue to startup, given
-	// that cert updates can take up to 2 minutes to propagate to the filesystem.
-	StartUpTimeout     = 3 * time.Minute
+	// that cert updates can take up to 3 minutes to propagate to the filesystem.
+	// Taken into account that after the certificates are ready, all Kueue's components
+	// need started and the time it takes for a change in ready probe response triggers
+	// a change in the deployment status.
+	StartUpTimeout     = 4 * time.Minute
 	ConsistentDuration = time.Second * 3
 	Interval           = time.Millisecond * 250
 )

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -1,10 +1,15 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"os"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -61,4 +66,21 @@ func CreateVisibilityClient(user string) visibilityv1alpha1.VisibilityV1alpha1In
 	}
 	visibilityClient := kueueClient.VisibilityV1alpha1()
 	return visibilityClient
+}
+
+func WaitForKueueAvailability(ctx context.Context, k8sClient client.Client) {
+	kcmKey := types.NamespacedName{
+		Namespace: "kueue-system",
+		Name:      "kueue-controller-manager",
+	}
+	deployment := &appsv1.Deployment{}
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, kcmKey, deployment)).To(gomega.Succeed())
+		g.Expect(deployment.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(
+			appsv1.DeploymentCondition{
+				Type:   appsv1.DeploymentAvailable,
+				Status: corev1.ConditionTrue,
+			},
+			cmpopts.IgnoreFields(appsv1.DeploymentCondition{}, "Reason", "Message", "LastUpdateTime", "LastTransitionTime"))))
+	}, StartUpTimeout, Interval).Should(gomega.Succeed())
 }

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -74,13 +74,24 @@ func WaitForKueueAvailability(ctx context.Context, k8sClient client.Client) {
 		Name:      "kueue-controller-manager",
 	}
 	deployment := &appsv1.Deployment{}
-	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+	pods := corev1.PodList{}
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) error {
 		g.Expect(k8sClient.Get(ctx, kcmKey, deployment)).To(gomega.Succeed())
+		g.Expect(k8sClient.List(ctx, &pods, client.InNamespace("kueue-system"), client.MatchingLabels(deployment.Spec.Selector.MatchLabels))).To(gomega.Succeed())
+		for _, pod := range pods.Items {
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.RestartCount > 0 {
+					return gomega.StopTrying(fmt.Sprintf("%q in %q has restarted %d times", cs.Name, pod.Name, cs.RestartCount))
+				}
+			}
+		}
 		g.Expect(deployment.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(
 			appsv1.DeploymentCondition{
 				Type:   appsv1.DeploymentAvailable,
 				Status: corev1.ConditionTrue,
 			},
 			cmpopts.IgnoreFields(appsv1.DeploymentCondition{}, "Reason", "Message", "LastUpdateTime", "LastTransitionTime"))))
+		return nil
+
 	}, StartUpTimeout, Interval).Should(gomega.Succeed())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

E2e extend startup interval.
Move availability checks in the test suite.
Improve k8s components logging in multikueue clusters.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1700 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```