### PR TITLE
Automated cherry pick of #1723: Avoid reconciles without any meaningful changes when the

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -293,8 +293,8 @@ func syncAdmissionCheckConditions(conds []kueue.AdmissionCheckState, queueChecks
 func (r *WorkloadReconciler) reconcileNotReadyTimeout(ctx context.Context, req ctrl.Request, wl *kueue.Workload) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	if !ptr.Deref(wl.Spec.Active, true) || apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted) {
-		// the workload has already been evicted by the PodsReadyTimeout or been deactivated.
+	if apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted) {
+		// the workload has already been evicted by the PodsReadyTimeout.
 		return ctrl.Result{}, nil
 	}
 	countingTowardsTimeout, recheckAfter := r.admittedNotReadyWorkload(wl, realClock)

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -292,6 +292,11 @@ func syncAdmissionCheckConditions(conds []kueue.AdmissionCheckState, queueChecks
 
 func (r *WorkloadReconciler) reconcileNotReadyTimeout(ctx context.Context, req ctrl.Request, wl *kueue.Workload) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
+
+	if !ptr.Deref(wl.Spec.Active, true) || apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted) {
+		// the workload has already been evicted by the PodsReadyTimeout or been deactivated.
+		return ctrl.Result{}, nil
+	}
 	countingTowardsTimeout, recheckAfter := r.admittedNotReadyWorkload(wl, realClock)
 	if !countingTowardsTimeout {
 		return ctrl.Result{}, nil


### PR DESCRIPTION
Cherry pick of #1723 on release-0.5.
#1723: Avoid reconciles without any meaningful changes when the
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```