### PR TITLE
Fix duplicated imports reported by gocritic linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,10 +9,14 @@ run:
 
 # Settings of specific linters
 linters-settings:
+  gocritic:
+    enabled-checks:
+      - dupImport
   goimports:
     local-prefixes: sigs.k8s.io/kueue
 
 # Settings for enabling and disabling linters
 linters:
   enable:
+    - gocritic
     - goimports

--- a/pkg/controller/jobs/kubeflow/jobs/mxjob/mxjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/mxjob/mxjob_controller_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -57,22 +56,22 @@ func TestPriorityClass(t *testing.T) {
 					},
 					MXReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.MXJobReplicaTypeScheduler: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "scheduler-priority",
 								},
 							},
 						},
 						kftraining.MXJobReplicaTypeServer: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "server-priority",
 								},
 							},
 						},
 						kftraining.MXJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -91,8 +90,8 @@ func TestPriorityClass(t *testing.T) {
 					},
 					MXReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.MXJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -108,22 +107,22 @@ func TestPriorityClass(t *testing.T) {
 					JobMode: kftraining.MXTrain,
 					MXReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.MXJobReplicaTypeScheduler: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "scheduler-priority",
 								},
 							},
 						},
 						kftraining.MXJobReplicaTypeTunerServer: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "server-priority",
 								},
 							},
 						},
 						kftraining.MXJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -139,18 +138,18 @@ func TestPriorityClass(t *testing.T) {
 					JobMode: kftraining.MXTune,
 					MXReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.MXJobReplicaTypeTunerTracker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{},
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{},
 							},
 						},
 						kftraining.MXJobReplicaTypeTunerServer: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{},
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{},
 							},
 						},
 						kftraining.MXJobReplicaTypeTuner: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "tuner-priority",
 								},
 							},
@@ -166,8 +165,8 @@ func TestPriorityClass(t *testing.T) {
 					JobMode: kftraining.MXTrain,
 					MXReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.MXJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -185,8 +184,8 @@ func TestPriorityClass(t *testing.T) {
 						kftraining.MXJobReplicaTypeScheduler: {},
 						kftraining.MXJobReplicaTypeServer:    {},
 						kftraining.MXJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{},
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{},
 							},
 						},
 					},
@@ -350,9 +349,9 @@ func TestReconciler(t *testing.T) {
 				Queue("foo").
 				Suspend(false).
 				Parallelism(10, 5).
-				Request(kftraining.MXJobReplicaTypeScheduler, v1.ResourceCPU, "1").
-				Request(kftraining.MXJobReplicaTypeServer, v1.ResourceCPU, "2").
-				Request(kftraining.MXJobReplicaTypeWorker, v1.ResourceCPU, "5").
+				Request(kftraining.MXJobReplicaTypeScheduler, corev1.ResourceCPU, "1").
+				Request(kftraining.MXJobReplicaTypeServer, corev1.ResourceCPU, "2").
+				Request(kftraining.MXJobReplicaTypeWorker, corev1.ResourceCPU, "5").
 				NodeSelector("provisioning", "spot").
 				Active(kftraining.MXJobReplicaTypeScheduler, 1).
 				Active(kftraining.MXJobReplicaTypeServer, 5).
@@ -361,30 +360,30 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("scheduler", 1).Request(v1.ResourceCPU, "1").Obj(),
-						*utiltesting.MakePodSet("server", 5).Request(v1.ResourceCPU, "2").Obj(),
-						*utiltesting.MakePodSet("worker", 10).Request(v1.ResourceCPU, "5").Obj(),
+						*utiltesting.MakePodSet("scheduler", 1).Request(corev1.ResourceCPU, "1").Obj(),
+						*utiltesting.MakePodSet("server", 5).Request(corev1.ResourceCPU, "2").Obj(),
+						*utiltesting.MakePodSet("worker", 10).Request(corev1.ResourceCPU, "5").Obj(),
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq").
 						PodSets(
 							kueue.PodSetAssignment{
 								Name: "scheduler",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](1),
 							},
 							kueue.PodSetAssignment{
 								Name: "server",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](2),
 							},
 							kueue.PodSetAssignment{
 								Name: "worker",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](5),
 							},
@@ -403,9 +402,9 @@ func TestReconciler(t *testing.T) {
 				Queue("foo").
 				Suspend(true).
 				Parallelism(10, 5).
-				Request(kftraining.MXJobReplicaTypeScheduler, v1.ResourceCPU, "1").
-				Request(kftraining.MXJobReplicaTypeServer, v1.ResourceCPU, "2").
-				Request(kftraining.MXJobReplicaTypeWorker, v1.ResourceCPU, "5").
+				Request(kftraining.MXJobReplicaTypeScheduler, corev1.ResourceCPU, "1").
+				Request(kftraining.MXJobReplicaTypeServer, corev1.ResourceCPU, "2").
+				Request(kftraining.MXJobReplicaTypeWorker, corev1.ResourceCPU, "5").
 				Active(kftraining.MXJobReplicaTypeScheduler, 1).
 				Active(kftraining.MXJobReplicaTypeServer, 5).
 				Active(kftraining.MXJobReplicaTypeWorker, 10).
@@ -413,30 +412,30 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("scheduler", 1).Request(v1.ResourceCPU, "1").Obj(),
-						*utiltesting.MakePodSet("server", 5).Request(v1.ResourceCPU, "2").Obj(),
-						*utiltesting.MakePodSet("worker", 10).Request(v1.ResourceCPU, "5").Obj(),
+						*utiltesting.MakePodSet("scheduler", 1).Request(corev1.ResourceCPU, "1").Obj(),
+						*utiltesting.MakePodSet("server", 5).Request(corev1.ResourceCPU, "2").Obj(),
+						*utiltesting.MakePodSet("worker", 10).Request(corev1.ResourceCPU, "5").Obj(),
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq").
 						PodSets(
 							kueue.PodSetAssignment{
 								Name: "scheduler",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](1),
 							},
 							kueue.PodSetAssignment{
 								Name: "server",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](2),
 							},
 							kueue.PodSetAssignment{
 								Name: "worker",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](5),
 							},
@@ -461,34 +460,34 @@ func TestReconciler(t *testing.T) {
 				Queue("foo").
 				Suspend(true).
 				Parallelism(1, 1).
-				Request(kftraining.MXJobReplicaTypeScheduler, v1.ResourceCPU, "1").
-				Request(kftraining.MXJobReplicaTypeServer, v1.ResourceCPU, "1").
-				Request(kftraining.MXJobReplicaTypeWorker, v1.ResourceCPU, "1").
+				Request(kftraining.MXJobReplicaTypeScheduler, corev1.ResourceCPU, "1").
+				Request(kftraining.MXJobReplicaTypeServer, corev1.ResourceCPU, "1").
+				Request(kftraining.MXJobReplicaTypeWorker, corev1.ResourceCPU, "1").
 				Obj(),
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("scheduler", 1).Request(v1.ResourceCPU, "1").Obj(),
-						*utiltesting.MakePodSet("server", 1).Request(v1.ResourceCPU, "1").Obj(),
-						*utiltesting.MakePodSet("worker", 1).Request(v1.ResourceCPU, "1").Obj(),
+						*utiltesting.MakePodSet("scheduler", 1).Request(corev1.ResourceCPU, "1").Obj(),
+						*utiltesting.MakePodSet("server", 1).Request(corev1.ResourceCPU, "1").Obj(),
+						*utiltesting.MakePodSet("worker", 1).Request(corev1.ResourceCPU, "1").Obj(),
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq").
 						PodSets(
 							kueue.PodSetAssignment{
 								Name: "scheduler",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "on-demand",
 								},
 							},
 							kueue.PodSetAssignment{
 								Name: "server",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "spot",
 								},
 							},
 							kueue.PodSetAssignment{
 								Name: "worker",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "default",
 								},
 							},
@@ -502,36 +501,36 @@ func TestReconciler(t *testing.T) {
 				Queue("foo").
 				Suspend(false).
 				Parallelism(1, 1).
-				Request(kftraining.MXJobReplicaTypeScheduler, v1.ResourceCPU, "1").
-				Request(kftraining.MXJobReplicaTypeServer, v1.ResourceCPU, "1").
-				Request(kftraining.MXJobReplicaTypeWorker, v1.ResourceCPU, "1").
+				Request(kftraining.MXJobReplicaTypeScheduler, corev1.ResourceCPU, "1").
+				Request(kftraining.MXJobReplicaTypeServer, corev1.ResourceCPU, "1").
+				Request(kftraining.MXJobReplicaTypeWorker, corev1.ResourceCPU, "1").
 				RoleNodeSelector(kftraining.MXJobReplicaTypeScheduler, "provisioning", "on-demand").
 				RoleNodeSelector(kftraining.MXJobReplicaTypeServer, "provisioning", "spot").
 				Obj(),
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("scheduler", 1).Request(v1.ResourceCPU, "1").Obj(),
-						*utiltesting.MakePodSet("server", 1).Request(v1.ResourceCPU, "1").Obj(),
-						*utiltesting.MakePodSet("worker", 1).Request(v1.ResourceCPU, "1").Obj(),
+						*utiltesting.MakePodSet("scheduler", 1).Request(corev1.ResourceCPU, "1").Obj(),
+						*utiltesting.MakePodSet("server", 1).Request(corev1.ResourceCPU, "1").Obj(),
+						*utiltesting.MakePodSet("worker", 1).Request(corev1.ResourceCPU, "1").Obj(),
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq").
 						PodSets(
 							kueue.PodSetAssignment{
 								Name: "scheduler",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "on-demand",
 								},
 							},
 							kueue.PodSetAssignment{
 								Name: "server",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "spot",
 								},
 							},
 							kueue.PodSetAssignment{
 								Name: "worker",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "default",
 								},
 							},
@@ -544,12 +543,12 @@ func TestReconciler(t *testing.T) {
 		"workload shouldn't be recreated for the completed mx job": {
 			job: testingmxjob.MakeMXJob("mxjob", "ns").
 				Queue("foo").
-				StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: v1.ConditionTrue}).
+				StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 				Obj(),
 			workloads: []kueue.Workload{},
 			wantJob: testingmxjob.MakeMXJob("mxjob", "ns").
 				Queue("foo").
-				StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: v1.ConditionTrue}).
+				StatusConditions(kftraining.JobCondition{Type: kftraining.JobSucceeded, Status: corev1.ConditionTrue}).
 				Obj(),
 			wantWorkloads: []kueue.Workload{},
 		},
@@ -577,7 +576,7 @@ func TestReconciler(t *testing.T) {
 					t.Fatalf("Could not create Workload: %v", err)
 				}
 			}
-			recorder := record.NewBroadcaster().NewRecorder(kClient.Scheme(), v1.EventSource{Component: "test"})
+			recorder := record.NewBroadcaster().NewRecorder(kClient.Scheme(), corev1.EventSource{Component: "test"})
 			reconciler := NewReconciler(kClient, recorder, tc.reconcilerOptions...)
 
 			jobKey := client.ObjectKeyFromObject(tc.job)

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -242,7 +241,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 						select {
 						case evt, ok := <-eventWatcher.ResultChan():
 							gomega.Expect(ok).To(gomega.BeTrue())
-							event, ok := evt.Object.(*v1.Event)
+							event, ok := evt.Object.(*corev1.Event)
 							gomega.Expect(ok).To(gomega.BeTrue())
 							if event.InvolvedObject.Namespace == ns.Name && event.Reason == "ExcessPodDeleted" {
 								objKey := types.NamespacedName{Namespace: event.InvolvedObject.Namespace, Name: event.InvolvedObject.Name}
@@ -379,7 +378,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 					select {
 					case evt, ok := <-eventWatcher.ResultChan():
 						gomega.Expect(ok).To(gomega.BeTrue())
-						event, ok := evt.Object.(*v1.Event)
+						event, ok := evt.Object.(*corev1.Event)
 						gomega.Expect(ok).To(gomega.BeTrue())
 						if event.InvolvedObject.Namespace == ns.Name && event.Reason == "Stopped" {
 							objKey := types.NamespacedName{Namespace: event.InvolvedObject.Namespace, Name: event.InvolvedObject.Name}
@@ -399,7 +398,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 						if _, found := replacementPods[origKey]; !found {
 							var p corev1.Pod
 							gomega.Expect(k8sClient.Get(ctx, origKey, &p)).To(gomega.Succeed())
-							if p.Status.Phase == v1.PodFailed {
+							if p.Status.Phase == corev1.PodFailed {
 								rep := origPod.DeepCopy()
 								// For replacement pods use args that let it complete fast.
 								rep.Name = "replacement-for-" + rep.Name
@@ -442,7 +441,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						var p corev1.Pod
 						g.Expect(k8sClient.Get(ctx, replKey, &p)).To(gomega.Succeed())
-						g.Expect(p.Status.Phase).To(gomega.Equal(v1.PodSucceeded))
+						g.Expect(p.Status.Phase).To(gomega.Equal(corev1.PodSucceeded))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				}
 			})

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -26,7 +26,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -144,7 +143,7 @@ func DeleteAllPodsInNamespace(ctx context.Context, c client.Client, ns *corev1.N
 	gomega.Eventually(func() error {
 		lst := corev1.PodList{}
 		err := c.List(ctx, &lst, client.InNamespace(ns.Name))
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("listing Pods with a finalizer in namespace %q: %w", ns.Name, err)
 		}
 
@@ -171,7 +170,7 @@ func DeleteWorkloadsInNamespace(ctx context.Context, c client.Client, ns *corev1
 	gomega.Eventually(func() error {
 		lst := kueue.WorkloadList{}
 		err := c.List(ctx, &lst, client.InNamespace(ns.Name))
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("listing Workloads with a finalizer in namespace %q: %w", ns.Name, err)
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The PR removes redundant duplicate imports in several files in tests. It enables the `gocritic` linter with the `dupImport` check to prevent such issues in the future.

#### Which issue(s) this PR fixes:

```
> make verify
...
pkg/controller/jobs/kubeflow/jobs/mxjob/mxjob_controller_test.go:25:2: dupImport: package is imported 2 times under different aliases on lines 25 and 26 (gocritic)
        corev1 "k8s.io/api/core/v1"
        ^
pkg/controller/jobs/kubeflow/jobs/mxjob/mxjob_controller_test.go:26:2: dupImport: package is imported 2 times under different aliases on lines 25 and 26 (gocritic)
        v1 "k8s.io/api/core/v1"
        ^
test/util/util.go:29:2: dupImport: package is imported 2 times under different aliases on lines 29 and 30 (gocritic)
        "k8s.io/apimachinery/pkg/api/errors"
        ^
test/util/util.go:30:2: dupImport: package is imported 2 times under different aliases on lines 29 and 30 (gocritic)
        apierrors "k8s.io/apimachinery/pkg/api/errors"
        ^
test/e2e/singlecluster/pod_test.go:22:2: dupImport: package is imported 2 times under different aliases on lines 22 and 23 (gocritic)
        corev1 "k8s.io/api/core/v1"
        ^
test/e2e/singlecluster/pod_test.go:23:2: dupImport: package is imported 2 times under different aliases on lines 22 and 23 (gocritic)
        v1 "k8s.io/api/core/v1"
        ^
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```