### PR TITLE
Fair share during admission

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -127,6 +127,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  10_000,
+							Lendable: 10_000,
+						},
+					},
 					Status:     active,
 					Preemption: defaultPreemption,
 				},
@@ -152,6 +158,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					},
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  15_000,
+							Lendable: 15_000,
+						},
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -197,6 +209,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					},
 					AdmittedUsage: FlavorResourceQuantities{
 						"nonexistent-flavor": {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  15_000,
+							Lendable: 15_000,
+						},
 					},
 					Status:     pending,
 					Preemption: defaultPreemption,
@@ -285,6 +303,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  10_000,
+							Lendable: 10_000,
+						},
+					},
 					Status:     active,
 					Preemption: defaultPreemption,
 				},
@@ -310,6 +334,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					},
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  15_000,
+							Lendable: 15_000,
+						},
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -357,6 +387,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					},
 					AdmittedUsage: FlavorResourceQuantities{
 						"nonexistent-flavor": {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  15_000,
+							Lendable: 15_000,
+						},
 					},
 					Status:     pending,
 					Preemption: defaultPreemption,
@@ -442,6 +478,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  5_000,
+							Lendable: 5_000,
+						},
+					},
 					Status:     active,
 					Preemption: defaultPreemption,
 				},
@@ -505,6 +547,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  5_000,
+							Lendable: 4_000,
+						},
+					},
 					Status:     active,
 					Preemption: defaultPreemption,
 				},
@@ -566,6 +614,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  15_000,
+							Lendable: 15_000,
+						},
+					},
 					Status:     active,
 					Preemption: defaultPreemption,
 				},
@@ -602,6 +656,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					},
 					AdmittedUsage: FlavorResourceQuantities{
 						"nonexistent-flavor": {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  15_000,
+							Lendable: 15_000,
+						},
 					},
 					Status:     pending,
 					Preemption: defaultPreemption,
@@ -662,6 +722,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  10_000,
+							Lendable: 10_000,
+						},
+					},
 					Status:     active,
 					Preemption: defaultPreemption,
 				},
@@ -687,6 +753,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					},
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  15_000,
+							Lendable: 15_000,
+						},
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -727,10 +799,20 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					}},
 					NamespaceSelector: labels.Nothing(),
 					FlavorFungibility: defaultFlavorFungibility,
-					Usage:             FlavorResourceQuantities{"nonexistent-flavor": {corev1.ResourceCPU: 0}},
-					AdmittedUsage:     FlavorResourceQuantities{"nonexistent-flavor": {corev1.ResourceCPU: 0}},
-					Status:            active,
-					Preemption:        defaultPreemption,
+					Usage: FlavorResourceQuantities{
+						"nonexistent-flavor": {corev1.ResourceCPU: 0},
+					},
+					AdmittedUsage: FlavorResourceQuantities{
+						"nonexistent-flavor": {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  15_000,
+							Lendable: 15_000,
+						},
+					},
+					Status:     active,
+					Preemption: defaultPreemption,
 				},
 				"f": {
 					Name:                          "f",
@@ -851,6 +933,11 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 						"gamma": {
 							"example.com/gpu": 0,
 						},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU:    {},
+						corev1.ResourceMemory: {},
+						"example.com/gpu":     {},
 					},
 					Status:     pending,
 					Preemption: defaultPreemption,
@@ -1012,6 +1099,13 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					FlavorFungibility:             defaultFlavorFungibility,
 					Usage:                         FlavorResourceQuantities{"f1": {corev1.ResourceCPU: 2000}},
 					AdmittedUsage:                 FlavorResourceQuantities{"f1": {corev1.ResourceCPU: 1000}},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: &QuotaStats{
+							Nominal:  10_000,
+							Lendable: 10_000,
+							Usage:    2_000,
+						},
+					},
 					Workloads: map[string]*workload.Info{
 						"ns/reserving": {
 							ClusterQueue: "cq1",
@@ -1147,6 +1241,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 	type result struct {
 		Workloads     sets.Set[string]
 		UsedResources FlavorResourceQuantities
+		ResourceStats ResourceStats
 	}
 
 	steps := []struct {
@@ -1181,12 +1276,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c", "/d"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
 					},
 				},
 			},
@@ -1210,12 +1315,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
 					},
 				},
 			},
@@ -1238,6 +1353,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
@@ -1245,11 +1365,16 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
+					},
 				},
 			},
 		},
 		{
-			name: "update",
+			name: "update cluster queue for a workload",
 			operation: func(cache *Cache) error {
 				old := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
@@ -1267,12 +1392,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/a", "/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
 					},
 				},
 			},
@@ -1296,12 +1431,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
 					},
 				},
 			},
@@ -1325,12 +1470,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
 					},
 				},
 			},
@@ -1353,12 +1508,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c", "/d"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
 					},
 				},
 			},
@@ -1378,12 +1543,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
 					},
 				},
 			},
@@ -1401,12 +1576,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
 					},
 				},
 			},
@@ -1425,12 +1610,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
 					},
 				},
 			},
@@ -1451,12 +1646,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
 					},
 				},
 			},
@@ -1476,12 +1681,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
 					},
 				},
 			},
@@ -1513,12 +1728,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 20},
 						"spot":      {corev1.ResourceCPU: 30},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 50,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c", "/e"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
 					},
 				},
 			},
@@ -1546,12 +1771,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
 					},
 				},
 			},
@@ -1586,12 +1821,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c", "/e"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
 					},
 				},
 			},
@@ -1618,12 +1863,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 0,
+						},
 					},
 				},
 			},
@@ -1660,12 +1915,22 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 20},
 						"spot":      {corev1.ResourceCPU: 30},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 50,
+						},
+					},
 				},
 				"two": {
 					Workloads: sets.New("/c", "/e"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Usage: 25,
+						},
 					},
 				},
 			},
@@ -1688,11 +1953,15 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			if diff := cmp.Diff(step.wantError, messageOrEmpty(gotError)); diff != "" {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}
-			gotWorkloads := make(map[string]result)
+			gotResult := make(map[string]result)
 			for name, cq := range cache.clusterQueues {
-				gotWorkloads[name] = result{Workloads: sets.KeySet(cq.Workloads), UsedResources: cq.Usage}
+				gotResult[name] = result{
+					Workloads:     sets.KeySet(cq.Workloads),
+					UsedResources: cq.Usage,
+					ResourceStats: cq.ResourceStats,
+				}
 			}
-			if diff := cmp.Diff(step.wantResults, gotWorkloads); diff != "" {
+			if diff := cmp.Diff(step.wantResults, gotResult); diff != "" {
 				t.Errorf("Unexpected clusterQueues (-want,+got):\n%s", diff)
 			}
 			if step.wantAssumedWorkloads == nil {

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -39,6 +39,16 @@ var (
 	errQueueAlreadyExists = errors.New("queue already exists")
 )
 
+// QuotaStats holds the nominal quota and usage for a resource.
+type QuotaStats struct {
+	Nominal  int64
+	Lendable int64
+	Usage    int64
+}
+
+// ResourceStats holds QuotaStats for resources.
+type ResourceStats map[corev1.ResourceName]*QuotaStats
+
 // ClusterQueue is the internal implementation of kueue.ClusterQueue that
 // holds admitted workloads.
 type ClusterQueue struct {
@@ -47,7 +57,6 @@ type ClusterQueue struct {
 	ResourceGroups    []ResourceGroup
 	RGByResource      map[corev1.ResourceName]*ResourceGroup
 	Usage             FlavorResourceQuantities
-	AdmittedUsage     FlavorResourceQuantities
 	Workloads         map[string]*workload.Info
 	WorkloadsNotReady sets.Set[string]
 	NamespaceSelector labels.Selector
@@ -62,9 +71,13 @@ type ClusterQueue struct {
 	// deleted, or the resource groups are changed.
 	AllocatableResourceGeneration int64
 
+	// ResourceStats holds nominal quota and usage for the resources of the ClusterQueue, independent of the flavor.
+	ResourceStats ResourceStats
+
 	// The following fields are not populated in a snapshot.
 
-	// Key is localQueue's key (namespace/name).
+	AdmittedUsage FlavorResourceQuantities
+	// localQueues by (namespace/name).
 	localQueues                                map[string]*queue
 	podsReadyTracking                          bool
 	hasMissingFlavors                          bool
@@ -79,11 +92,13 @@ type Cohort struct {
 	Name    string
 	Members sets.Set[*ClusterQueue]
 
-	// These fields are only populated for a snapshot. This field equals to
-	// the sum of LendingLimit when feature LendingLimit enabled.
+	// The next fields are only populated for a snapshot.
+
+	// RequestableResources equals to the sum of LendingLimit when feature LendingLimit enabled.
 	RequestableResources FlavorResourceQuantities
 	Usage                FlavorResourceQuantities
-	// This field will only be set in snapshot. This field equals to
+	ResourceStats        ResourceStats
+	// AllocatableResourceGeneration equals to
 	// the sum of allocatable generation among its members.
 	AllocatableResourceGeneration int64
 }
@@ -109,7 +124,8 @@ type ResourceQuota struct {
 	LendingLimit   *int64
 }
 
-type FlavorResourceQuantities map[kueue.ResourceFlavorReference]map[corev1.ResourceName]int64
+type ResourceQuantities map[corev1.ResourceName]int64
+type FlavorResourceQuantities map[kueue.ResourceFlavorReference]ResourceQuantities
 
 type queue struct {
 	key                string
@@ -185,8 +201,8 @@ func (c *ClusterQueue) update(in *kueue.ClusterQueue, resourceFlavors map[kueue.
 
 	c.AdmissionChecks = sets.New(in.Spec.AdmissionChecks...)
 
-	c.Usage = filterQuantities(c.Usage, in.Spec.ResourceGroups)
-	c.AdmittedUsage = filterQuantities(c.AdmittedUsage, in.Spec.ResourceGroups)
+	c.Usage = filterFlavorQuantities(c.Usage, in.Spec.ResourceGroups)
+	c.AdmittedUsage = filterFlavorQuantities(c.AdmittedUsage, in.Spec.ResourceGroups)
 	c.UpdateWithFlavors(resourceFlavors)
 	c.updateWithAdmissionChecks(admissionChecks)
 
@@ -231,7 +247,7 @@ func (c *ClusterQueue) update(in *kueue.ClusterQueue, resourceFlavors map[kueue.
 	return nil
 }
 
-func filterQuantities(orig FlavorResourceQuantities, resourceGroups []kueue.ResourceGroup) FlavorResourceQuantities {
+func filterFlavorQuantities(orig FlavorResourceQuantities, resourceGroups []kueue.ResourceGroup) FlavorResourceQuantities {
 	ret := make(FlavorResourceQuantities)
 	for _, rg := range resourceGroups {
 		for _, f := range rg.Flavors {
@@ -246,9 +262,29 @@ func filterQuantities(orig FlavorResourceQuantities, resourceGroups []kueue.Reso
 	return ret
 }
 
+// resetResourceStatsFromResourceGroups maintains the Usage stats for the given resource groups
+// and resets Nominal and Lendable values. They are calculated again in updateResourceGroups.
+func (c *ClusterQueue) resetResourceStatsFromResourceGroups(resourceGroups []kueue.ResourceGroup) {
+	updatedResourceStats := make(ResourceStats, len(resourceGroups))
+	for _, rg := range resourceGroups {
+		for _, res := range rg.CoveredResources {
+			if oStats := c.ResourceStats[res]; oStats != nil {
+				updatedResourceStats[res] = &QuotaStats{
+					Usage: c.ResourceStats[res].Usage,
+					// Reset Nominal and Lendable.
+				}
+			} else {
+				updatedResourceStats[res] = &QuotaStats{}
+			}
+		}
+	}
+	c.ResourceStats = updatedResourceStats
+}
+
 func (c *ClusterQueue) updateResourceGroups(in []kueue.ResourceGroup) {
 	oldRG := c.ResourceGroups
 	c.ResourceGroups = make([]ResourceGroup, len(in))
+	c.resetResourceStatsFromResourceGroups(in)
 	for i, rgIn := range in {
 		rg := &c.ResourceGroups[i]
 		*rg = ResourceGroup{
@@ -262,14 +298,19 @@ func (c *ClusterQueue) updateResourceGroups(in []kueue.ResourceGroup) {
 				Resources: make(map[corev1.ResourceName]*ResourceQuota, len(fIn.Resources)),
 			}
 			for _, rIn := range fIn.Resources {
+				nominal := workload.ResourceValue(rIn.Name, rIn.NominalQuota)
 				rQuota := ResourceQuota{
-					Nominal: workload.ResourceValue(rIn.Name, rIn.NominalQuota),
+					Nominal: nominal,
 				}
+				c.ResourceStats[rIn.Name].Nominal += nominal
 				if rIn.BorrowingLimit != nil {
 					rQuota.BorrowingLimit = ptr.To(workload.ResourceValue(rIn.Name, *rIn.BorrowingLimit))
 				}
 				if features.Enabled(features.LendingLimit) && rIn.LendingLimit != nil {
 					rQuota.LendingLimit = ptr.To(workload.ResourceValue(rIn.Name, *rIn.LendingLimit))
+					c.ResourceStats[rIn.Name].Lendable += *rQuota.LendingLimit
+				} else {
+					c.ResourceStats[rIn.Name].Lendable += nominal
 				}
 				fQuotas.Resources[rIn.Name] = &rQuota
 			}
@@ -454,23 +495,34 @@ func (c *ClusterQueue) reportActiveWorkloads() {
 // and the number of admitted workloads for local queues.
 func (c *ClusterQueue) updateWorkloadUsage(wi *workload.Info, m int64) {
 	admitted := workload.IsAdmitted(wi.Obj)
-	updateUsage(wi, c.Usage, m)
+	updateFlavorUsage(wi, c.Usage, m)
+	updateResourceStats(wi, c.ResourceStats, m)
 	if admitted {
-		updateUsage(wi, c.AdmittedUsage, m)
+		updateFlavorUsage(wi, c.AdmittedUsage, m)
 		c.admittedWorkloadsCount += int(m)
 	}
 	qKey := workload.QueueKey(wi.Obj)
 	if lq, ok := c.localQueues[qKey]; ok {
-		updateUsage(wi, lq.usage, m)
+		updateFlavorUsage(wi, lq.usage, m)
 		lq.reservingWorkloads += int(m)
 		if admitted {
-			updateUsage(wi, lq.admittedUsage, m)
+			updateFlavorUsage(wi, lq.admittedUsage, m)
 			lq.admittedWorkloads += int(m)
 		}
 	}
 }
 
-func updateUsage(wi *workload.Info, flvUsage FlavorResourceQuantities, m int64) {
+func updateResourceStats(wi *workload.Info, rStats ResourceStats, m int64) {
+	for _, ps := range wi.TotalRequests {
+		for res, v := range ps.Requests {
+			if _, exists := rStats[res]; exists {
+				rStats[res].Usage += v * m
+			}
+		}
+	}
+}
+
+func updateFlavorUsage(wi *workload.Info, flvUsage FlavorResourceQuantities, m int64) {
 	for _, ps := range wi.TotalRequests {
 		for wlRes, wlResFlv := range ps.Flavors {
 			v, wlResExist := ps.Requests[wlRes]
@@ -524,10 +576,10 @@ func (c *ClusterQueue) addLocalQueue(q *kueue.LocalQueue) error {
 	}
 	for _, wl := range c.Workloads {
 		if workloadBelongsToLocalQueue(wl.Obj, q) {
-			updateUsage(wl, qImpl.usage, 1)
+			updateFlavorUsage(wl, qImpl.usage, 1)
 			qImpl.reservingWorkloads++
 			if workload.IsAdmitted(wl.Obj) {
-				updateUsage(wl, qImpl.admittedUsage, 1)
+				updateFlavorUsage(wl, qImpl.admittedUsage, 1)
 				qImpl.admittedWorkloads++
 			}
 		}
@@ -626,4 +678,30 @@ func (c *ClusterQueue) UsedCohortQuota(fName kueue.ResourceFlavorReference, rNam
 	}
 
 	return cohortUsage
+}
+
+// DominantResourceShare returns a value from 0 to 100 representing the maximum of the ratios
+// of usage above nominal quota to the lendable resources in the cohort, among all the resources
+// provided by the ClusterQueue.
+// The function also returns the resource name that yielded this value.
+func (c *ClusterQueue) DominantResourceShare(w *workload.Info) (int, corev1.ResourceName) {
+	if c.Cohort == nil {
+		return 0, ""
+	}
+	var drs int64 = -1
+	var dRes corev1.ResourceName
+	wUsage := w.ResourceUsage()
+	for rName, rStats := range c.ResourceStats {
+		var ratio int64
+		if c.Cohort.ResourceStats[rName].Lendable > 0 {
+			ratio = max(rStats.Usage+wUsage[rName]-rStats.Nominal, 0) * 100 /
+				c.Cohort.ResourceStats[rName].Lendable
+		}
+		// Use alphabetical order to get a deterministic resource name.
+		if ratio > drs || (ratio == drs && rName < dRes) {
+			drs = ratio
+			dRes = rName
+		}
+	}
+	return int(drs), dRes
 }

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -223,6 +223,18 @@ func TestSnapshot(t *testing.T) {
 							"example.com/gpu": 15,
 						},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  400_000,
+							Lendable: 400_000,
+							Usage:    20_000,
+						},
+						"example.com/gpu": {
+							Nominal:  50,
+							Lendable: 50,
+							Usage:    15,
+						},
+					},
 				}
 				return Snapshot{
 					ClusterQueues: map[string]*ClusterQueue{
@@ -254,6 +266,13 @@ func TestSnapshot(t *testing.T) {
 							Usage: FlavorResourceQuantities{
 								"demand": {corev1.ResourceCPU: 10_000},
 								"spot":   {corev1.ResourceCPU: 0},
+							},
+							ResourceStats: ResourceStats{
+								corev1.ResourceCPU: {
+									Nominal:  300_000,
+									Lendable: 300_000,
+									Usage:    10_000,
+								},
 							},
 							Workloads: map[string]*workload.Info{
 								"/alpha": workload.NewInfo(utiltesting.MakeWorkload("alpha", "").
@@ -303,6 +322,18 @@ func TestSnapshot(t *testing.T) {
 									"example.com/gpu": 15,
 								},
 							},
+							ResourceStats: ResourceStats{
+								corev1.ResourceCPU: {
+									Nominal:  100_000,
+									Lendable: 100_000,
+									Usage:    10_000,
+								},
+								"example.com/gpu": {
+									Nominal:  50,
+									Lendable: 50,
+									Usage:    15,
+								},
+							},
 							Workloads: map[string]*workload.Info{
 								"/beta": workload.NewInfo(utiltesting.MakeWorkload("beta", "").
 									PodSets(*utiltesting.MakePodSet("main", 5).
@@ -350,6 +381,12 @@ func TestSnapshot(t *testing.T) {
 							Usage: FlavorResourceQuantities{
 								"default": {
 									corev1.ResourceCPU: 0,
+								},
+							},
+							ResourceStats: ResourceStats{
+								corev1.ResourceCPU: {
+									Nominal:  100_000,
+									Lendable: 100_000,
 								},
 							},
 							Preemption:        defaultPreemption,
@@ -455,6 +492,13 @@ func TestSnapshot(t *testing.T) {
 							corev1.ResourceCPU: 0,
 						},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  60_000,
+							Lendable: 30_000,
+							Usage:    25_000,
+						},
+					},
 				}
 				return Snapshot{
 					ClusterQueues: map[string]*ClusterQueue{
@@ -494,6 +538,13 @@ func TestSnapshot(t *testing.T) {
 							Usage: FlavorResourceQuantities{
 								"arm": {corev1.ResourceCPU: 15_000},
 								"x86": {corev1.ResourceCPU: 10_000},
+							},
+							ResourceStats: ResourceStats{
+								corev1.ResourceCPU: {
+									Nominal:  30_000,
+									Lendable: 15_000,
+									Usage:    25_000,
+								},
 							},
 							Workloads: map[string]*workload.Info{
 								"/alpha": workload.NewInfo(utiltesting.MakeWorkload("alpha", "").
@@ -566,6 +617,12 @@ func TestSnapshot(t *testing.T) {
 							Usage: FlavorResourceQuantities{
 								"arm": {corev1.ResourceCPU: 0},
 								"x86": {corev1.ResourceCPU: 0},
+							},
+							ResourceStats: ResourceStats{
+								corev1.ResourceCPU: {
+									Nominal:  30_000,
+									Lendable: 15_000,
+								},
 							},
 							Preemption:        defaultPreemption,
 							NamespaceSelector: labels.Everything(),
@@ -714,6 +771,16 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 						"alpha":   {corev1.ResourceMemory: 0},
 						"beta":    {corev1.ResourceMemory: 0},
 					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  12_000,
+							Lendable: 12_000,
+						},
+						corev1.ResourceMemory: {
+							Nominal:  12 * utiltesting.Gi,
+							Lendable: 12 * utiltesting.Gi,
+						},
+					},
 				}
 				return Snapshot{
 					ClusterQueues: map[string]*ClusterQueue{
@@ -729,6 +796,16 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								"alpha":   {corev1.ResourceMemory: 0},
 								"beta":    {corev1.ResourceMemory: 0},
 							},
+							ResourceStats: ResourceStats{
+								corev1.ResourceCPU: {
+									Nominal:  6_000,
+									Lendable: 6_000,
+								},
+								corev1.ResourceMemory: {
+									Nominal:  12 * utiltesting.Gi,
+									Lendable: 12 * utiltesting.Gi,
+								},
+							},
 						},
 						"c2": {
 							Name:                          "c2",
@@ -739,6 +816,12 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							AllocatableResourceGeneration: 1,
 							Usage: FlavorResourceQuantities{
 								"default": {corev1.ResourceCPU: 0},
+							},
+							ResourceStats: ResourceStats{
+								corev1.ResourceCPU: {
+									Nominal:  6_000,
+									Lendable: 6_000,
+								},
 							},
 						},
 					},
@@ -756,6 +839,18 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 						"default": {corev1.ResourceCPU: 2_000},
 						"alpha":   {corev1.ResourceMemory: utiltesting.Gi},
 						"beta":    {corev1.ResourceMemory: utiltesting.Gi},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  12_000,
+							Lendable: 12_000,
+							Usage:    2_000,
+						},
+						corev1.ResourceMemory: {
+							Nominal:  12 * utiltesting.Gi,
+							Lendable: 12 * utiltesting.Gi,
+							Usage:    2 * utiltesting.Gi,
+						},
 					},
 				}
 				return Snapshot{
@@ -775,6 +870,17 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								"alpha":   {corev1.ResourceMemory: utiltesting.Gi},
 								"beta":    {corev1.ResourceMemory: utiltesting.Gi},
 							},
+							ResourceStats: ResourceStats{
+								corev1.ResourceCPU: {
+									Nominal:  6_000,
+									Lendable: 6_000,
+								},
+								corev1.ResourceMemory: {
+									Nominal:  12 * utiltesting.Gi,
+									Lendable: 12 * utiltesting.Gi,
+									Usage:    2 * utiltesting.Gi,
+								},
+							},
 						},
 						"c2": {
 							Name:   "c2",
@@ -788,6 +894,13 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							AllocatableResourceGeneration: 1,
 							Usage: FlavorResourceQuantities{
 								"default": {corev1.ResourceCPU: 2_000},
+							},
+							ResourceStats: ResourceStats{
+								corev1.ResourceCPU: {
+									Nominal:  6_000,
+									Lendable: 6_000,
+									Usage:    2_000,
+								},
 							},
 						},
 					},
@@ -805,6 +918,18 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 						"default": {corev1.ResourceCPU: 3_000},
 						"alpha":   {corev1.ResourceMemory: 0},
 						"beta":    {corev1.ResourceMemory: utiltesting.Gi},
+					},
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  12_000,
+							Lendable: 12_000,
+							Usage:    3_000,
+						},
+						corev1.ResourceMemory: {
+							Nominal:  12 * utiltesting.Gi,
+							Lendable: 12 * utiltesting.Gi,
+							Usage:    utiltesting.Gi,
+						},
 					},
 				}
 				return Snapshot{
@@ -824,6 +949,18 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								"alpha":   {corev1.ResourceMemory: 0},
 								"beta":    {corev1.ResourceMemory: utiltesting.Gi},
 							},
+							ResourceStats: ResourceStats{
+								corev1.ResourceCPU: {
+									Nominal:  6_000,
+									Lendable: 6_000,
+									Usage:    1_000,
+								},
+								corev1.ResourceMemory: {
+									Nominal:  12 * utiltesting.Gi,
+									Lendable: 12 * utiltesting.Gi,
+									Usage:    utiltesting.Gi,
+								},
+							},
 						},
 						"c2": {
 							Name:   "c2",
@@ -837,6 +974,13 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							FlavorFungibility:             defaultFlavorFungibility,
 							Usage: FlavorResourceQuantities{
 								"default": {corev1.ResourceCPU: 2_000},
+							},
+							ResourceStats: ResourceStats{
+								corev1.ResourceCPU: {
+									Nominal:  6_000,
+									Lendable: 6_000,
+									Usage:    2_000,
+								},
 							},
 						},
 					},
@@ -951,6 +1095,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
+					ResourceStats: ResourceStats{
+						"cpu": {Nominal: 20_000, Lendable: 10_000},
+					},
 				}
 				return Snapshot{
 					ClusterQueues: map[string]*ClusterQueue{
@@ -969,6 +1116,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 4_000},
+							},
 						},
 						"lend-b": {
 							Name:                          "lend-b",
@@ -985,6 +1135,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 4_000,
 								},
 							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 6_000},
+							},
 						},
 					},
 				}
@@ -999,6 +1152,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					RequestableResources:          initialCohortResources,
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 1_000},
+					},
+					ResourceStats: ResourceStats{
+						"cpu": {Nominal: 20_000, Lendable: 10_000, Usage: 11_000},
 					},
 				}
 				return Snapshot{
@@ -1018,6 +1174,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 4_000, Usage: 7_000},
+							},
 						},
 						"lend-b": {
 							Name:                          "lend-b",
@@ -1034,6 +1193,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 4_000,
 								},
 							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 6_000, Usage: 4_000},
+							},
 						},
 					},
 				}
@@ -1048,6 +1210,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					RequestableResources:          initialCohortResources,
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						"cpu": {Nominal: 20_000, Lendable: 10_000, Usage: 10_000},
 					},
 				}
 				return Snapshot{
@@ -1067,6 +1232,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 4_000, Usage: 6_000},
+							},
 						},
 						"lend-b": {
 							Name:                          "lend-b",
@@ -1083,6 +1251,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 4_000,
 								},
 							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 6_000, Usage: 4_000},
+							},
 						},
 					},
 				}
@@ -1097,6 +1268,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					RequestableResources:          initialCohortResources,
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						"cpu": {Nominal: 20_000, Lendable: 10_000, Usage: 5_000},
 					},
 				}
 				return Snapshot{
@@ -1116,6 +1290,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 4_000, Usage: 1_000},
+							},
 						},
 						"lend-b": {
 							Name:                          "lend-b",
@@ -1131,6 +1308,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								"default": {
 									corev1.ResourceCPU: 4_000,
 								},
+							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 6_000, Usage: 4_000},
 							},
 						},
 					},
@@ -1148,6 +1328,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
+					ResourceStats: ResourceStats{
+						"cpu": {Nominal: 20_000, Lendable: 10_000, Usage: 1_000},
+					},
 				}
 				return Snapshot{
 					ClusterQueues: map[string]*ClusterQueue{
@@ -1166,6 +1349,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 4_000, Usage: 1_000},
+							},
 						},
 						"lend-b": {
 							Name:                          "lend-b",
@@ -1182,6 +1368,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 4_000,
 								},
 							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 6_000},
+							},
 						},
 					},
 				}
@@ -1197,6 +1386,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					RequestableResources:          initialCohortResources,
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
+					},
+					ResourceStats: ResourceStats{
+						"cpu": {Nominal: 20_000, Lendable: 10_000, Usage: 6_000},
 					},
 				}
 				return Snapshot{
@@ -1216,6 +1408,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 4_000, Usage: 6_000},
+							},
 						},
 						"lend-b": {
 							Name:                          "lend-b",
@@ -1232,6 +1427,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 4_000,
 								},
 							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 6_000},
+							},
 						},
 					},
 				}
@@ -1247,6 +1445,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					RequestableResources:          initialCohortResources,
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 3_000},
+					},
+					ResourceStats: ResourceStats{
+						"cpu": {Nominal: 20_000, Lendable: 10_000, Usage: 9_000},
 					},
 				}
 				return Snapshot{
@@ -1266,6 +1467,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 4_000, Usage: 9_000},
+							},
 						},
 						"lend-b": {
 							Name:                          "lend-b",
@@ -1281,6 +1485,9 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								"default": {
 									corev1.ResourceCPU: 4_000,
 								},
+							},
+							ResourceStats: ResourceStats{
+								"cpu": {Nominal: 10_000, Lendable: 6_000},
 							},
 						},
 					},

--- a/test/integration/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/scheduler/fairsharing/fair_sharing_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fairsharing
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("Scheduler", func() {
+
+	var (
+		defaultFlavor *kueue.ResourceFlavor
+		ns            *corev1.Namespace
+	)
+
+	ginkgo.BeforeEach(func() {
+		defaultFlavor = testing.MakeResourceFlavor("default").Obj()
+		gomega.Expect(k8sClient.Create(ctx, defaultFlavor)).To(gomega.Succeed())
+
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "core-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteResourceFlavor(ctx, k8sClient, defaultFlavor)).To(gomega.Succeed())
+	})
+
+	ginkgo.When("Preemption is disabled", func() {
+
+		var (
+			cqA      *kueue.ClusterQueue
+			lqA      *kueue.LocalQueue
+			cqB      *kueue.ClusterQueue
+			lqB      *kueue.LocalQueue
+			cqShared *kueue.ClusterQueue
+		)
+		ginkgo.BeforeEach(func() {
+			cqA = testing.MakeClusterQueue("a").
+				Cohort("all").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "3").Obj(),
+				).Obj()
+			gomega.Expect(k8sClient.Create(ctx, cqA)).To(gomega.Succeed())
+			lqA = testing.MakeLocalQueue("a", ns.Name).ClusterQueue("a").Obj()
+			gomega.Expect(k8sClient.Create(ctx, lqA)).To(gomega.Succeed())
+
+			cqB = testing.MakeClusterQueue("b").
+				Cohort("all").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
+				).Obj()
+			gomega.Expect(k8sClient.Create(ctx, cqB)).To(gomega.Succeed())
+			lqB = testing.MakeLocalQueue("b", ns.Name).ClusterQueue("b").Obj()
+			gomega.Expect(k8sClient.Create(ctx, lqB)).To(gomega.Succeed())
+
+			cqShared = testing.MakeClusterQueue("shared").
+				Cohort("all").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "4").Obj(),
+				).Obj()
+			gomega.Expect(k8sClient.Create(ctx, cqShared)).To(gomega.Succeed())
+		})
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteClusterQueue(ctx, k8sClient, cqA)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteClusterQueue(ctx, k8sClient, cqB)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteClusterQueue(ctx, k8sClient, cqShared)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("Admits workloads respecting fair share", func() {
+			ginkgo.By("Saturating cq-a")
+
+			aWorkloads := make([]*kueue.Workload, 10)
+			for i := range aWorkloads {
+				aWorkloads[i] = testing.MakeWorkload(fmt.Sprintf("a-%d", i), ns.Name).
+					Queue("a").
+					Request(corev1.ResourceCPU, "1").Obj()
+				gomega.Expect(k8sClient.Create(ctx, aWorkloads[i])).To(gomega.Succeed())
+			}
+			util.ExpectReservingActiveWorkloadsMetric(cqA, 8)
+			util.ExpectPendingWorkloadsMetric(cqA, 0, 2)
+
+			ginkgo.By("Creating newer workloads in cq-b")
+			// Ensure workloads in cqB have a newer timestamp.
+			time.Sleep(time.Second)
+			bWorkloads := make([]*kueue.Workload, 5)
+			for i := range bWorkloads {
+				bWorkloads[i] = testing.MakeWorkload(fmt.Sprintf("b-%d", i), ns.Name).
+					Queue("b").
+					Request(corev1.ResourceCPU, "1").Obj()
+				gomega.Expect(k8sClient.Create(ctx, bWorkloads[i])).To(gomega.Succeed())
+			}
+			util.ExpectPendingWorkloadsMetric(cqB, 0, 5)
+
+			ginkgo.By("Terminating 4 running workloads in cqA: shared quota is fair-shared")
+			finishRunningWorkloadsInCQ(cqA, 4)
+
+			// Admits 1 from cqA and 3 from cqB.
+			util.ExpectReservingActiveWorkloadsMetric(cqA, 5)
+			util.ExpectPendingWorkloadsMetric(cqA, 0, 1)
+			util.ExpectReservingActiveWorkloadsMetric(cqB, 3)
+			util.ExpectPendingWorkloadsMetric(cqB, 0, 2)
+
+			ginkgo.By("Terminating 2 more running workloads in cqA: cqB starts to take over shared quota")
+			finishRunningWorkloadsInCQ(cqA, 2)
+
+			// Admits last 1 from cqA and 1 from cqB.
+			util.ExpectReservingActiveWorkloadsMetric(cqA, 4)
+			util.ExpectPendingWorkloadsMetric(cqA, 0, 0)
+			util.ExpectReservingActiveWorkloadsMetric(cqB, 4)
+			util.ExpectPendingWorkloadsMetric(cqB, 0, 1)
+		})
+	})
+
+})
+
+func finishRunningWorkloadsInCQ(cq *kueue.ClusterQueue, n int) {
+	var wList kueue.WorkloadList
+	gomega.ExpectWithOffset(1, k8sClient.List(ctx, &wList)).To(gomega.Succeed())
+	finished := 0
+	for i := 0; i < len(wList.Items) && finished < n; i++ {
+		wl := wList.Items[i]
+		if wl.Status.Admission != nil && string(wl.Status.Admission.ClusterQueue) == cq.Name && !meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadFinished) {
+			util.FinishWorkloads(ctx, k8sClient, &wl)
+			finished++
+		}
+	}
+	gomega.ExpectWithOffset(1, finished).To(gomega.Equal(n), "Not enough workloads finished")
+}

--- a/test/integration/scheduler/fairsharing/suite_test.go
+++ b/test/integration/scheduler/fairsharing/suite_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fairsharing
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta1"
+	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	"sigs.k8s.io/kueue/pkg/queue"
+	"sigs.k8s.io/kueue/pkg/scheduler"
+	"sigs.k8s.io/kueue/pkg/webhooks"
+	"sigs.k8s.io/kueue/test/integration/framework"
+	// +kubebuilder:scaffold:imports
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
+)
+
+func TestScheduler(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	ginkgo.RunSpecs(t,
+		"Scheduler Fair Sharing Suite",
+	)
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	fwk = &framework.Framework{
+		CRDPath:     filepath.Join("..", "..", "..", "..", "config", "components", "crd", "bases"),
+		WebhookPath: filepath.Join("..", "..", "..", "..", "config", "components", "webhook"),
+	}
+	cfg = fwk.Init()
+	ctx, k8sClient = fwk.RunManager(cfg, managerAndSchedulerSetup)
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	fwk.Teardown()
+})
+
+func managerAndSchedulerSetup(mgr manager.Manager, ctx context.Context) {
+	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	cCache := cache.New(mgr.GetClient())
+	queues := queue.NewManager(mgr.GetClient(), cCache)
+
+	configuration := &config.Configuration{}
+	mgr.GetScheme().Default(configuration)
+
+	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+
+	failedWebhook, err := webhooks.Setup(mgr)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
+
+	err = workloadjob.SetupIndexes(ctx, mgr.GetFieldIndexer())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName),
+		scheduler.WithFairSharing(true))
+	err = sched.Start(ctx)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -929,7 +929,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		})
 	})
 
-	ginkgo.When("Using cohorts for fair-sharing", func() {
+	ginkgo.When("Using cohorts for sharing unused resources", func() {
 		var (
 			prodCQ *kueue.ClusterQueue
 			devCQ  *kueue.ClusterQueue


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Implements the concept of a "fair share" for a ClusterQueue or a ClusterQueue with an additional workload as defined in #1773:

```
For a given resource r provided by a ClusterQueue or cohort c, we calculate T_r as the total
requests consumed by the Workloads for that resource in that CQ or cohort, independent of the
flavor, that are above the nominal quota. The value for a resource is the ratio of T_r and the
total nominal quotas, or lendingLimits if defined, in the hierarchy of the parent of C.

The value for the CQ or cohort is the maximum among the values for each resource,
divided by the weight, if defined.
```

The fair share value is used for sorting the heads of the ClusterQueues during admission.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #1714

#### Special notes for your reviewer:

There is no API for this feature in this PR. That's because we don't want to release this behavior standalone, but accompany it with preemption support, which will come in a subsequent PR.

For reviewers convenience, I roughly divided the PR in 3 commits:
- Keeping stats for a ClusterQueue and cohort about total usage per resource and shareable resources.
- Calculate the share value for a ClusterQueue with or without a new workload
- Admission sorting + tests.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```