### PR TITLE
Simplify tests by using T.TempDir

### DIFF
--- a/cmd/kueue/main_test.go
+++ b/cmd/kueue/main_test.go
@@ -32,12 +32,7 @@ import (
 )
 
 func TestValidateIntegrationsName(t *testing.T) {
-	// temp dir
-	tmpDir, err := os.MkdirTemp("", "temp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	integrationsConfig := filepath.Join(tmpDir, "integrations.yaml")
 	if err := os.WriteFile(integrationsConfig, []byte(`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -48,12 +48,7 @@ func TestLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// temp dir
-	tmpDir, err := os.MkdirTemp("", "temp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	namespaceOverWriteConfig := filepath.Join(tmpDir, "namespace-overwrite.yaml")
 	if err := os.WriteFile(namespaceOverWriteConfig, []byte(`


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor tests by replacing `os.MkdirTemp` with `t.TempDir`.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

[`T.TempDir`](https://pkg.go.dev/testing#T.TempDir)  automatically removes the temporary directory.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```