### PR TITLE
Fix test lint issues reported by ginkgolinter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,5 +18,6 @@ linters-settings:
 # Settings for enabling and disabling linters
 linters:
   enable:
+    - ginkgolinter
     - gocritic
     - goimports

--- a/cmd/experimental/podtaintstolerations/test/e2e/e2e_test.go
+++ b/cmd/experimental/podtaintstolerations/test/e2e/e2e_test.go
@@ -179,7 +179,7 @@ var _ = ginkgo.Describe("Kueue Pod-Taints-Tolerations Controller", func() {
 
 				gomega.EventuallyWithOffset(1, func() bool {
 					return apierrors.IsNotFound(k8sClient.Get(ctx, podKey, &corev1.Pod{}))
-				}, util.Timeout, util.Interval).Should(gomega.Equal(true))
+				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
 			})
 		})
 	})
@@ -190,7 +190,7 @@ func expectPodUnsuspendedWithTolerations(key types.NamespacedName, tolerations m
 	gomega.EventuallyWithOffset(1, func() bool {
 		gomega.Expect(k8sClient.Get(ctx, key, pod)).To(gomega.Succeed())
 		return isSuspended(pod)
-	}, util.Timeout, util.Interval).Should(gomega.Equal(false))
+	}, util.Timeout, util.Interval).Should(gomega.BeFalse())
 
 	gomega.EventuallyWithOffset(1, func() map[string]string {
 		gomega.Expect(k8sClient.Get(ctx, key, pod)).To(gomega.Succeed())

--- a/test/e2e/singlecluster/e2e_test.go
+++ b/test/e2e/singlecluster/e2e_test.go
@@ -216,7 +216,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 			gomega.Expect(k8sClient.Create(ctx, sampleJob)).Should(gomega.Succeed())
 
 			highPriorityClass := testing.MakePriorityClass("high").PriorityValue(100).Obj()
-			gomega.Expect(k8sClient.Create(ctx, highPriorityClass))
+			gomega.Expect(k8sClient.Create(ctx, highPriorityClass)).Should(gomega.Succeed())
 			ginkgo.DeferCleanup(func() {
 				gomega.Expect(k8sClient.Delete(ctx, highPriorityClass)).To(gomega.Succeed())
 			})

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -127,7 +127,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 					}
 					var wl kueue.Workload
 					g.Expect(k8sClient.Get(ctx, gKey, &wl)).Should(testing.BeNotFoundError())
-				}, util.Timeout, util.Interval)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 
@@ -300,7 +300,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 					}
 					var wl kueue.Workload
 					g.Expect(k8sClient.Get(ctx, gKey, &wl)).Should(testing.BeNotFoundError())
-				}, util.Timeout, util.Interval)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 
@@ -316,7 +316,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 			})
 
 			highPriorityClass := testing.MakePriorityClass("high").PriorityValue(100).Obj()
-			gomega.Expect(k8sClient.Create(ctx, highPriorityClass))
+			gomega.Expect(k8sClient.Create(ctx, highPriorityClass)).Should(gomega.Succeed())
 			ginkgo.DeferCleanup(func() {
 				gomega.Expect(k8sClient.Delete(ctx, highPriorityClass)).To(gomega.Succeed())
 			})

--- a/test/e2e/singlecluster/visibility_test.go
+++ b/test/e2e/singlecluster/visibility_test.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
-	"sigs.k8s.io/kueue/apis/visibility/v1alpha1"
 	visibility "sigs.k8s.io/kueue/apis/visibility/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
@@ -153,7 +152,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			})
 
 			ginkgo.By("Verify there is one pending workload", func() {
-				gomega.Eventually(func() []v1alpha1.PendingWorkload {
+				gomega.Eventually(func() []visibility.PendingWorkload {
 					info, err := visibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, clusterQueue.Name, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					return info.Items
@@ -173,7 +172,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			})
 
 			ginkgo.By("Verify there are zero pending workloads, after the second workload is admitted", func() {
-				gomega.Eventually(func() []v1alpha1.PendingWorkload {
+				gomega.Eventually(func() []visibility.PendingWorkload {
 					info, err := visibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, clusterQueue.Name, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					return info.Items

--- a/test/e2e/singlecluster/visibility_test.go
+++ b/test/e2e/singlecluster/visibility_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/apis/visibility/v1alpha1"
 	visibility "sigs.k8s.io/kueue/apis/visibility/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
@@ -100,13 +101,13 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			gomega.Expect(k8sClient.Create(ctx, localQueueB)).Should(gomega.Succeed())
 
 			highPriorityClass = testing.MakePriorityClass("high").PriorityValue(100).Obj()
-			gomega.Expect(k8sClient.Create(ctx, highPriorityClass))
+			gomega.Expect(k8sClient.Create(ctx, highPriorityClass)).Should(gomega.Succeed())
 
 			midPriorityClass = testing.MakePriorityClass("mid").PriorityValue(75).Obj()
-			gomega.Expect(k8sClient.Create(ctx, midPriorityClass))
+			gomega.Expect(k8sClient.Create(ctx, midPriorityClass)).Should(gomega.Succeed())
 
 			lowPriorityClass = testing.MakePriorityClass("low").PriorityValue(50).Obj()
-			gomega.Expect(k8sClient.Create(ctx, lowPriorityClass))
+			gomega.Expect(k8sClient.Create(ctx, lowPriorityClass)).Should(gomega.Succeed())
 
 			ginkgo.By("Schedule a job that when admitted workload blocks the queue", func() {
 				blockingJob = testingjob.MakeJob("test-job-1", nsA.Name).
@@ -138,7 +139,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			ginkgo.By("Verify there are zero pending workloads", func() {
 				info, err := visibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, clusterQueue.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(len(info.Items)).Should(gomega.Equal(0))
+				gomega.Expect(info.Items).Should(gomega.BeEmpty())
 			})
 
 			ginkgo.By("Schedule a job which is pending due to lower priority", func() {
@@ -152,11 +153,11 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			})
 
 			ginkgo.By("Verify there is one pending workload", func() {
-				gomega.Eventually(func() int {
+				gomega.Eventually(func() []v1alpha1.PendingWorkload {
 					info, err := visibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, clusterQueue.Name, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					return len(info.Items)
-				}, util.Timeout, util.Interval).Should(gomega.Equal(1))
+					return info.Items
+				}, util.Timeout, util.Interval).Should(gomega.HaveLen(1))
 			})
 
 			ginkgo.By("Await for pods to be running", func() {
@@ -172,11 +173,11 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			})
 
 			ginkgo.By("Verify there are zero pending workloads, after the second workload is admitted", func() {
-				gomega.Eventually(func() int {
+				gomega.Eventually(func() []v1alpha1.PendingWorkload {
 					info, err := visibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, clusterQueue.Name, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					return len(info.Items)
-				}, util.Timeout, util.Interval).Should(gomega.Equal(0))
+					return info.Items
+				}, util.Timeout, util.Interval).Should(gomega.BeEmpty())
 			})
 		})
 
@@ -259,7 +260,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			ginkgo.By("Verify there are zero pending workloads", func() {
 				info, err := visibilityClient.LocalQueues(nsA.Name).GetPendingWorkloadsSummary(ctx, localQueueA.Name, metav1.GetOptions{})
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				gomega.Expect(len(info.Items)).Should(gomega.Equal(0))
+				gomega.Expect(info.Items).Should(gomega.BeEmpty())
 			})
 
 			ginkgo.By("Schedule a job which is pending due to lower priority", func() {
@@ -273,11 +274,11 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			})
 
 			ginkgo.By("Verify there is one pending workload", func() {
-				gomega.Eventually(func() int {
+				gomega.Eventually(func() []visibility.PendingWorkload {
 					info, err := visibilityClient.LocalQueues(nsA.Name).GetPendingWorkloadsSummary(ctx, localQueueA.Name, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
-					return len(info.Items)
-				}, util.Timeout, util.Interval).Should(gomega.Equal(1))
+					return info.Items
+				}, util.Timeout, util.Interval).Should(gomega.HaveLen(1))
 			})
 
 			ginkgo.By("Await for pods to be running", func() {
@@ -503,13 +504,13 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			ginkgo.By("Returning a ResourceNotFound error for a nonexistent ClusterQueue", func() {
 				_, err := impersonatedVisibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
 				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.Equal(true))
+				gomega.Expect(ok).To(gomega.BeTrue())
 				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonNotFound))
 			})
 			ginkgo.By("Returning a ResourceNotFound error for a nonexistent LocalQueue", func() {
 				_, err := impersonatedVisibilityClient.LocalQueues(nsA.Name).GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
 				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.Equal(true))
+				gomega.Expect(ok).To(gomega.BeTrue())
 				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonNotFound))
 			})
 		})
@@ -537,19 +538,19 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			ginkgo.By("Returning a Forbidden error due to insufficient permissions for the ClusterQueue request", func() {
 				_, err := impersonatedVisibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
 				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.Equal(true))
+				gomega.Expect(ok).To(gomega.BeTrue())
 				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonForbidden))
 			})
 			ginkgo.By("Returning a ResourceNotFound error for a nonexistent LocalQueue", func() {
 				_, err := impersonatedVisibilityClient.LocalQueues(nsA.Name).GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
 				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.Equal(true))
+				gomega.Expect(ok).To(gomega.BeTrue())
 				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonNotFound))
 			})
 			ginkgo.By("Returning a Forbidden error due to insufficient permissions for the LocalQueue request in different namespace", func() {
 				_, err := impersonatedVisibilityClient.LocalQueues("default").GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
 				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.Equal(true))
+				gomega.Expect(ok).To(gomega.BeTrue())
 				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonForbidden))
 			})
 		})
@@ -560,13 +561,13 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			ginkgo.By("Returning a Forbidden error due to insufficient permissions for the ClusterQueue request", func() {
 				_, err := impersonatedVisibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
 				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.Equal(true))
+				gomega.Expect(ok).To(gomega.BeTrue())
 				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonForbidden))
 			})
 			ginkgo.By("Returning a Forbidden error due to insufficient permissions for the LocalQueue request", func() {
 				_, err := impersonatedVisibilityClient.LocalQueues(nsA.Name).GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
 				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.Equal(true))
+				gomega.Expect(ok).To(gomega.BeTrue())
 				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonForbidden))
 			})
 		})

--- a/test/integration/controller/jobs/job/job_controller_test.go
+++ b/test/integration/controller/jobs/job/job_controller_test.go
@@ -196,7 +196,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			ok, _ := testing.CheckLatestEvent(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name))
 			return ok
 		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		gomega.Expect(len(createdJob.Spec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		gomega.Consistently(func() bool {
 			if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
@@ -249,7 +249,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			}
 			return !*createdJob.Spec.Suspend
 		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		gomega.Expect(len(createdJob.Spec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
 		gomega.Consistently(func() bool {
 			if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
@@ -1510,7 +1510,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 		gomega.Expect(k8sClient.Create(ctx, devLocalQ)).Should(gomega.Succeed())
 
 		highPriorityClass := testing.MakePriorityClass("high").PriorityValue(100).Obj()
-		gomega.Expect(k8sClient.Create(ctx, highPriorityClass))
+		gomega.Expect(k8sClient.Create(ctx, highPriorityClass)).Should(gomega.Succeed())
 		ginkgo.DeferCleanup(func() {
 			gomega.Expect(k8sClient.Delete(ctx, highPriorityClass)).To(gomega.Succeed())
 		})
@@ -1557,7 +1557,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 		gomega.Expect(k8sClient.Create(ctx, devLocalQ)).Should(gomega.Succeed())
 
 		highWorkloadPriorityClass := testing.MakeWorkloadPriorityClass("high-workload").PriorityValue(100).Obj()
-		gomega.Expect(k8sClient.Create(ctx, highWorkloadPriorityClass))
+		gomega.Expect(k8sClient.Create(ctx, highWorkloadPriorityClass)).Should(gomega.Succeed())
 		ginkgo.DeferCleanup(func() {
 			gomega.Expect(k8sClient.Delete(ctx, highWorkloadPriorityClass)).To(gomega.Succeed())
 		})

--- a/test/integration/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/controller/jobs/jobset/jobset_controller_test.go
@@ -262,9 +262,9 @@ var _ = ginkgo.Describe("JobSet controller", ginkgo.Ordered, ginkgo.ContinueOnFa
 			return !*createdJobSet.Spec.Suspend
 		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
 
-		gomega.Expect(len(createdJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
-		gomega.Expect(len(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
 
 		ginkgo.By("checking the workload is finished when JobSet is completed")

--- a/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
@@ -194,9 +194,9 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			ok, _ := testing.CheckLatestEvent(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name))
 			return ok
 		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		gomega.Expect(len(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
-		gomega.Expect(len(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
 		gomega.Eventually(func() bool {
 			if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
@@ -258,9 +258,9 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			}
 			return !*createdJob.Spec.RunPolicy.Suspend
 		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		gomega.Expect(len(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
-		gomega.Expect(len(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
 		gomega.Eventually(func() bool {
 			if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
@@ -586,7 +586,7 @@ var _ = ginkgo.Describe("Job controller for workloads when only jobs with queue 
 
 		ginkgo.By("Checking that the child job isn't suspended")
 		gomega.Eventually(func() *bool {
-			gomega.Expect(k8sClient.Get(ctx, childLookupKey, childJob))
+			gomega.Expect(k8sClient.Get(ctx, childLookupKey, childJob)).Should(gomega.Succeed())
 			return childJob.Spec.Suspend
 		}, util.Timeout, util.Interval).Should(gomega.Equal(ptr.To(false)))
 	})

--- a/test/integration/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/controller/jobs/raycluster/raycluster_controller_test.go
@@ -194,9 +194,9 @@ var _ = ginkgo.Describe("RayCluster controller", ginkgo.Ordered, ginkgo.Continue
 			ok, _ := testing.CheckLatestEvent(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name))
 			return ok
 		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		gomega.Expect(len(createdJob.Spec.HeadGroupSpec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
-		gomega.Expect(len(createdJob.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
 		gomega.Eventually(func() bool {
 			if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
@@ -239,9 +239,9 @@ var _ = ginkgo.Describe("RayCluster controller", ginkgo.Ordered, ginkgo.Continue
 			}
 			return !*createdJob.Spec.Suspend
 		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		gomega.Expect(len(createdJob.Spec.HeadGroupSpec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
-		gomega.Expect(len(createdJob.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
 		gomega.Eventually(func() bool {
 			if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {

--- a/test/integration/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/controller/jobs/rayjob/rayjob_controller_test.go
@@ -202,9 +202,9 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			ok, _ := testing.CheckLatestEvent(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name))
 			return ok
 		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		gomega.Expect(len(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
-		gomega.Expect(len(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
 		gomega.Eventually(func() bool {
 			if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
@@ -247,9 +247,9 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			}
 			return !createdJob.Spec.Suspend
 		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		gomega.Expect(len(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
-		gomega.Expect(len(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
+		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
 		gomega.Eventually(func() bool {
 			if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {

--- a/test/integration/scheduler/podsready/scheduler_test.go
+++ b/test/integration/scheduler/podsready/scheduler_test.go
@@ -273,7 +273,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			util.ExpectWorkloadToHaveRequeueCount(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), ptr.To[int32](2))
 			ginkgo.By("the workload exceeded re-queue backoff limit should be deactivated")
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodWl), prodWl))
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodWl), prodWl)).Should(gomega.Succeed())
 				g.Expect(ptr.Deref(prodWl.Spec.Active, true)).Should(gomega.BeFalse())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
@@ -614,7 +614,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 2)
 			time.Sleep(podsReadyTimeout)
 			util.ExpectWorkloadToHaveRequeueCount(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), ptr.To[int32](2))
-			gomega.Expect(prodWl)
+			gomega.Expect(prodWl).NotTo(gomega.BeNil())
 			gomega.Expect(ptr.Deref(prodWl.Spec.Active, true)).Should(gomega.BeTrue())
 		})
 	})

--- a/test/integration/scheduler/podsready/scheduler_test.go
+++ b/test/integration/scheduler/podsready/scheduler_test.go
@@ -614,7 +614,6 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 2)
 			time.Sleep(podsReadyTimeout)
 			util.ExpectWorkloadToHaveRequeueCount(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), ptr.To[int32](2))
-			gomega.Expect(prodWl).NotTo(gomega.BeNil())
 			gomega.Expect(ptr.Deref(prodWl.Spec.Active, true)).Should(gomega.BeTrue())
 		})
 	})

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -863,7 +863,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				NodeSelector(map[string]string{instanceKey: onDemandFlavor.Name, "foo": "bar"}).
 				Request(corev1.ResourceCPU, "1").Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
-			gomega.Expect(len(wl2.Spec.PodSets[0].Template.Spec.NodeSelector)).Should(gomega.Equal(2))
+			gomega.Expect(wl2.Spec.PodSets[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(2))
 			expectAdmission = testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
@@ -1399,7 +1399,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				lookupKey := types.NamespacedName{Name: wl3.Name, Namespace: wl3.Namespace}
 				gomega.Expect(k8sClient.Get(ctx, lookupKey, wl3)).Should(gomega.Succeed())
 				return !workload.HasQuotaReservation(wl3)
-			}, util.ConsistentDuration, util.Interval).Should(gomega.Equal(true))
+			}, util.ConsistentDuration, util.Interval).Should(gomega.BeTrue())
 			util.ExpectPendingWorkloadsMetric(strictFIFOClusterQ, 2, 0)
 			util.ExpectReservingActiveWorkloadsMetric(strictFIFOClusterQ, 1)
 			util.ExpectAdmittedWorkloadsTotalMetric(strictFIFOClusterQ, 1)

--- a/test/integration/webhook/workload_test.go
+++ b/test/integration/webhook/workload_test.go
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("Workload defaulting webhook", func() {
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, workload)).Should(gomega.Succeed())
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), workload))
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), workload)).Should(gomega.Succeed())
 				workload.Status = kueue.WorkloadStatus{
 					Conditions: []metav1.Condition{{
 						Type:               kueue.WorkloadEvicted,
@@ -106,10 +106,10 @@ var _ = ginkgo.Describe("Workload defaulting webhook", func() {
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			ginkgo.By("Activate a Workload")
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), workload))
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), workload)).Should(gomega.Succeed())
 				workload.Spec.Active = ptr.To(true)
 				g.Expect(k8sClient.Update(ctx, workload)).Should(gomega.Succeed())
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), workload))
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), workload)).Should(gomega.Succeed())
 				g.Expect(workload.Status.RequeueState).Should(gomega.BeNil(), "re-queue state should be reset")
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fix and refactor e2e and integration tests according to the `ginkgolinter` suggestions.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Changes:

- Add missing assertion method statements.
- Replace `gomega.Equal(false)`/`gomega.Equal(true)` with `gomega.False()`/`gomega.True()`.
- Replace `gomega.Equal` with `gomega.HaveLen` for slices.
- Replace `gomega.Equal(0)` with `gomega.Empty` for slices.

The whole log of running golangci-lint:
```
❯ ./bin/golangci-lint run

test/integration/controller/jobs/mpijob/mpijob_controller_test.go:197:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/mpijob/mpijob_controller_test.go:199:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/mpijob/mpijob_controller_test.go:261:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/mpijob/mpijob_controller_test.go:263:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/mpijob/mpijob_controller_test.go:589:4: ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()" (ginkgolinter)
                        gomega.Expect(k8sClient.Get(ctx, childLookupKey, childJob))
                        ^
test/integration/controller/jobs/job/job_controller_test.go:199:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/job/job_controller_test.go:252:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/job/job_controller_test.go:1513:3: ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()" (ginkgolinter)
                gomega.Expect(k8sClient.Create(ctx, highPriorityClass))
                ^
test/integration/controller/jobs/job/job_controller_test.go:1560:3: ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()" (ginkgolinter)
                gomega.Expect(k8sClient.Create(ctx, highWorkloadPriorityClass))
                ^
test/integration/scheduler/podsready/scheduler_test.go:276:5: ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()" (ginkgolinter)
                                g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodWl), prodWl))
                                ^
test/integration/scheduler/podsready/scheduler_test.go:617:4: ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()" (ginkgolinter)
                        gomega.Expect(prodWl)
                        ^
test/integration/controller/jobs/jobset/jobset_controller_test.go:265:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/jobset/jobset_controller_test.go:267:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/webhook/workload_test.go:92:5: ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()" (ginkgolinter)
                                g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), workload))
                                ^
test/integration/webhook/workload_test.go:109:5: ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()" (ginkgolinter)
                                g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), workload))
                                ^
test/integration/webhook/workload_test.go:112:5: ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()" (ginkgolinter)
                                g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), workload))
                                ^
test/integration/controller/jobs/raycluster/raycluster_controller_test.go:197:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.HeadGroupSpec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/raycluster/raycluster_controller_test.go:199:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/raycluster/raycluster_controller_test.go:242:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.HeadGroupSpec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/raycluster/raycluster_controller_test.go:244:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.WorkerGroupSpecs[0].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/rayjob/rayjob_controller_test.go:205:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/rayjob/rayjob_controller_test.go:207:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/rayjob/rayjob_controller_test.go:250:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/controller/jobs/rayjob/rayjob_controller_test.go:252:3: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))` instead (ginkgolinter)
                gomega.Expect(len(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector)).Should(gomega.Equal(1))
                ^
test/integration/scheduler/scheduler_test.go:866:4: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(wl2.Spec.PodSets[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(2))` instead (ginkgolinter)
                        gomega.Expect(len(wl2.Spec.PodSets[0].Template.Spec.NodeSelector)).Should(gomega.Equal(2))
                        ^
test/integration/scheduler/scheduler_test.go:1398:4: ginkgo-linter: wrong boolean assertion; consider using `gomega.Consistently(func() bool {
        lookupKey := types.NamespacedName{Name: wl3.Name, Namespace: wl3.Namespace}
        gomega.Expect(k8sClient.Get(ctx, lookupKey, wl3)).Should(gomega.Succeed())
        return !workload.HasQuotaReservation(wl3)
}, util.ConsistentDuration, util.Interval).Should(gomega.BeTrue())` instead (ginkgolinter)
                        gomega.Consistently(func() bool {
                        ^
test/e2e/singlecluster/e2e_test.go:219:4: ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()" (ginkgolinter)
                        gomega.Expect(k8sClient.Create(ctx, highPriorityClass))
                        ^
test/e2e/singlecluster/pod_test.go:123:5: ginkgo-linter: "Eventually": missing assertion method. Expected "Should()" or "ShouldNot()" (ginkgolinter)
                                gomega.Eventually(func(g gomega.Gomega) {
                                ^
test/e2e/singlecluster/pod_test.go:296:5: ginkgo-linter: "Eventually": missing assertion method. Expected "Should()" or "ShouldNot()" (ginkgolinter)
                                gomega.Eventually(func(g gomega.Gomega) {
                                ^
test/e2e/singlecluster/pod_test.go:319:4: ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()" (ginkgolinter)
                        gomega.Expect(k8sClient.Create(ctx, highPriorityClass))
                        ^
test/e2e/singlecluster/visibility_test.go:103:4: ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()" (ginkgolinter)
                        gomega.Expect(k8sClient.Create(ctx, highPriorityClass))
                        ^
test/e2e/singlecluster/visibility_test.go:106:4: ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()" (ginkgolinter)
                        gomega.Expect(k8sClient.Create(ctx, midPriorityClass))
                        ^
test/e2e/singlecluster/visibility_test.go:109:4: ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()" (ginkgolinter)
                        gomega.Expect(k8sClient.Create(ctx, lowPriorityClass))
                        ^
test/e2e/singlecluster/visibility_test.go:141:5: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(info.Items).Should(gomega.BeEmpty())` instead (ginkgolinter)
                                gomega.Expect(len(info.Items)).Should(gomega.Equal(0))
                                ^
test/e2e/singlecluster/visibility_test.go:262:5: ginkgo-linter: wrong length assertion; consider using `gomega.Expect(info.Items).Should(gomega.BeEmpty())` instead (ginkgolinter)
                                gomega.Expect(len(info.Items)).Should(gomega.Equal(0))
                                ^
test/e2e/singlecluster/visibility_test.go:506:5: ginkgo-linter: wrong boolean assertion; consider using `gomega.Expect(ok).To(gomega.BeTrue())` instead (ginkgolinter)
                                gomega.Expect(ok).To(gomega.Equal(true))
                                ^
test/e2e/singlecluster/visibility_test.go:512:5: ginkgo-linter: wrong boolean assertion; consider using `gomega.Expect(ok).To(gomega.BeTrue())` instead (ginkgolinter)
                                gomega.Expect(ok).To(gomega.Equal(true))
                                ^
test/e2e/singlecluster/visibility_test.go:540:5: ginkgo-linter: wrong boolean assertion; consider using `gomega.Expect(ok).To(gomega.BeTrue())` instead (ginkgolinter)
                                gomega.Expect(ok).To(gomega.Equal(true))
                                ^
test/e2e/singlecluster/visibility_test.go:546:5: ginkgo-linter: wrong boolean assertion; consider using `gomega.Expect(ok).To(gomega.BeTrue())` instead (ginkgolinter)
                                gomega.Expect(ok).To(gomega.Equal(true))
                                ^
test/e2e/singlecluster/visibility_test.go:552:5: ginkgo-linter: wrong boolean assertion; consider using `gomega.Expect(ok).To(gomega.BeTrue())` instead (ginkgolinter)
                                gomega.Expect(ok).To(gomega.Equal(true))
                                ^
test/e2e/singlecluster/visibility_test.go:563:5: ginkgo-linter: wrong boolean assertion; consider using `gomega.Expect(ok).To(gomega.BeTrue())` instead (ginkgolinter)
                                gomega.Expect(ok).To(gomega.Equal(true))
                                ^
test/e2e/singlecluster/visibility_test.go:569:5: ginkgo-linter: wrong boolean assertion; consider using `gomega.Expect(ok).To(gomega.BeTrue())` instead (ginkgolinter)
                                gomega.Expect(ok).To(gomega.Equal(true))
                                ^
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```