### PR TITLE
Fix run make target: update path to main.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ build:
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	$(GO_CMD) run ./main.go
+	$(GO_CMD) run cmd/kueue/main.go
 
 # Build the multiplatform container image locally.
 .PHONY: image-local-build


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fix the path to `main.go` in the `run` make target.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

The `run` target has become broken since https://github.com/kubernetes-sigs/kueue/pull/1088.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```