### PR TITLE
Upgrade RayJob API to v1

### DIFF
--- a/charts/kueue/templates/webhook/webhook.yaml
+++ b/charts/kueue/templates/webhook/webhook.yaml
@@ -222,14 +222,14 @@ webhooks:
       service:
         name: '{{ include "kueue.fullname" . }}-webhook-service'
         namespace: '{{ .Release.Namespace }}'
-        path: /mutate-ray-io-v1alpha1-rayjob
+        path: /mutate-ray-io-v1-rayjob
     failurePolicy: Fail
     name: mrayjob.kb.io
     rules:
       - apiGroups:
           - ray.io
         apiVersions:
-          - v1alpha1
+          - v1
         operations:
           - CREATE
         resources:
@@ -526,14 +526,14 @@ webhooks:
       service:
         name: '{{ include "kueue.fullname" . }}-webhook-service'
         namespace: '{{ .Release.Namespace }}'
-        path: /validate-ray-io-v1alpha1-rayjob
+        path: /validate-ray-io-v1-rayjob
     failurePolicy: Fail
     name: vrayjob.kb.io
     rules:
       - apiGroups:
           - ray.io
         apiVersions:
-          - v1alpha1
+          - v1
         operations:
           - CREATE
           - UPDATE

--- a/config/components/webhook/manifests.yaml
+++ b/config/components/webhook/manifests.yaml
@@ -200,14 +200,14 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-ray-io-v1alpha1-rayjob
+      path: /mutate-ray-io-v1-rayjob
   failurePolicy: Fail
   name: mrayjob.kb.io
   rules:
   - apiGroups:
     - ray.io
     apiVersions:
-    - v1alpha1
+    - v1
     operations:
     - CREATE
     resources:
@@ -482,14 +482,14 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-ray-io-v1alpha1-rayjob
+      path: /validate-ray-io-v1-rayjob
   failurePolicy: Fail
   name: vrayjob.kb.io
   rules:
   - apiGroups:
     - ray.io
     apiVersions:
-    - v1alpha1
+    - v1
     operations:
     - CREATE
     - UPDATE

--- a/pkg/controller/jobframework/setup_test.go
+++ b/pkg/controller/jobframework/setup_test.go
@@ -26,7 +26,6 @@ import (
 	kubeflow "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -75,7 +74,7 @@ func TestSetupControllers(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			_, logger := utiltesting.ContextWithLog(t)
-			k8sClient := utiltesting.NewClientBuilder(jobset.AddToScheme, kubeflow.AddToScheme, rayjobapi.AddToScheme, kftraining.AddToScheme, rayv1.AddToScheme).Build()
+			k8sClient := utiltesting.NewClientBuilder(jobset.AddToScheme, kubeflow.AddToScheme, kftraining.AddToScheme, rayv1.AddToScheme).Build()
 
 			mgrOpts := ctrlmgr.Options{
 				Scheme: k8sClient.Scheme(),

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -1171,7 +1171,7 @@ func (p *Pod) ReclaimablePods() ([]kueue.ReclaimablePod, error) {
 
 func IsPodOwnerManagedByKueue(p *Pod) bool {
 	if owner := metav1.GetControllerOf(&p.pod); owner != nil {
-		return jobframework.IsOwnerManagedByKueue(owner) || (owner.Kind == "RayCluster" && strings.HasPrefix(owner.APIVersion, "ray.io/v1alpha1"))
+		return jobframework.IsOwnerManagedByKueue(owner) || (owner.Kind == "RayCluster" && (strings.HasPrefix(owner.APIVersion, "ray.io/v1alpha1") || strings.HasPrefix(owner.APIVersion, "ray.io/v1")))
 	}
 	return false
 }

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,11 +120,11 @@ func TestDefault(t *testing.T) {
 			namespaceSelector: defaultNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				OwnerReference("parent-ray-cluster", rayjobapi.GroupVersion.WithKind("RayCluster")).
+				OwnerReference("parent-ray-cluster", rayv1.GroupVersion.WithKind("RayCluster")).
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				OwnerReference("parent-ray-cluster", rayjobapi.GroupVersion.WithKind("RayCluster")).
+				OwnerReference("parent-ray-cluster", rayv1.GroupVersion.WithKind("RayCluster")).
 				Obj(),
 		},
 		"pod with owner managed by kueue (MPIJob)": {

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"strings"
 
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,7 +33,7 @@ import (
 )
 
 var (
-	gvk = rayjobapi.GroupVersion.WithKind("RayJob")
+	gvk = rayv1.GroupVersion.WithKind("RayJob")
 )
 
 const (
@@ -46,8 +46,8 @@ func init() {
 		SetupIndexes:           SetupIndexes,
 		NewReconciler:          NewReconciler,
 		SetupWebhook:           SetupRayJobWebhook,
-		JobType:                &rayjobapi.RayJob{},
-		AddToScheme:            rayjobapi.AddToScheme,
+		JobType:                &rayv1.RayJob{},
+		AddToScheme:            rayv1.AddToScheme,
 		IsManagingObjectsOwner: isRayJob,
 	}))
 }
@@ -64,12 +64,12 @@ func init() {
 
 var NewReconciler = jobframework.NewGenericReconcilerFactory(func() jobframework.GenericJob { return &RayJob{} })
 
-type RayJob rayjobapi.RayJob
+type RayJob rayv1.RayJob
 
 var _ jobframework.GenericJob = (*RayJob)(nil)
 
 func (j *RayJob) Object() client.Object {
-	return (*rayjobapi.RayJob)(j)
+	return (*rayv1.RayJob)(j)
 }
 
 func (j *RayJob) IsSuspended() bool {
@@ -77,7 +77,7 @@ func (j *RayJob) IsSuspended() bool {
 }
 
 func (j *RayJob) IsActive() bool {
-	return j.Status.JobDeploymentStatus != rayjobapi.JobDeploymentStatusSuspended
+	return j.Status.JobDeploymentStatus != rayv1.JobDeploymentStatusSuspended
 }
 
 func (j *RayJob) Suspend() {
@@ -168,11 +168,11 @@ func (j *RayJob) Finished() (metav1.Condition, bool) {
 		Message: j.Status.Message,
 	}
 
-	return condition, j.Status.JobStatus == rayjobapi.JobStatusFailed || j.Status.JobStatus == rayjobapi.JobStatusSucceeded
+	return condition, j.Status.JobStatus == rayv1.JobStatusFailed || j.Status.JobStatus == rayv1.JobStatusSucceeded
 }
 
 func (j *RayJob) PodsReady() bool {
-	return j.Status.RayClusterStatus.State == rayjobapi.Ready
+	return j.Status.RayClusterStatus.State == rayv1.Ready
 }
 
 func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
@@ -33,7 +33,7 @@ import (
 func TestPodSets(t *testing.T) {
 	job := testingrayutil.MakeJob("job", "ns").
 		WithHeadGroupSpec(
-			rayjobapi.HeadGroupSpec{
+			rayv1.HeadGroupSpec{
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -46,7 +46,7 @@ func TestPodSets(t *testing.T) {
 			},
 		).
 		WithWorkerGroups(
-			rayjobapi.WorkerGroupSpec{
+			rayv1.WorkerGroupSpec{
 				GroupName: "group1",
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
@@ -58,7 +58,7 @@ func TestPodSets(t *testing.T) {
 					},
 				},
 			},
-			rayjobapi.WorkerGroupSpec{
+			rayv1.WorkerGroupSpec{
 				GroupName: "group2",
 				Replicas:  ptr.To[int32](3),
 				Template: corev1.PodTemplateSpec{
@@ -125,14 +125,14 @@ func TestPodSets(t *testing.T) {
 
 func TestNodeSelectors(t *testing.T) {
 	baseJob := testingrayutil.MakeJob("job", "ns").
-		WithHeadGroupSpec(rayjobapi.HeadGroupSpec{
+		WithHeadGroupSpec(rayv1.HeadGroupSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{},
 				},
 			},
 		}).
-		WithWorkerGroups(rayjobapi.WorkerGroupSpec{
+		WithWorkerGroups(rayv1.WorkerGroupSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{
@@ -140,7 +140,7 @@ func TestNodeSelectors(t *testing.T) {
 					},
 				},
 			},
-		}, rayjobapi.WorkerGroupSpec{
+		}, rayv1.WorkerGroupSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{
@@ -152,12 +152,12 @@ func TestNodeSelectors(t *testing.T) {
 		Obj()
 
 	cases := map[string]struct {
-		job          *rayjobapi.RayJob
+		job          *rayv1.RayJob
 		runInfo      []podset.PodSetInfo
 		restoreInfo  []podset.PodSetInfo
 		wantRunError error
-		wantAfterRun *rayjobapi.RayJob
-		wantFinal    *rayjobapi.RayJob
+		wantAfterRun *rayv1.RayJob
+		wantFinal    *rayv1.RayJob
 	}{
 		"valid configuration": {
 			job: baseJob.DeepCopy(),
@@ -197,7 +197,7 @@ func TestNodeSelectors(t *testing.T) {
 			},
 			wantAfterRun: testingrayutil.MakeJob("job", "ns").
 				Suspend(false).
-				WithHeadGroupSpec(rayjobapi.HeadGroupSpec{
+				WithHeadGroupSpec(rayv1.HeadGroupSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{
@@ -206,7 +206,7 @@ func TestNodeSelectors(t *testing.T) {
 						},
 					},
 				}).
-				WithWorkerGroups(rayjobapi.WorkerGroupSpec{
+				WithWorkerGroups(rayv1.WorkerGroupSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{
@@ -214,7 +214,7 @@ func TestNodeSelectors(t *testing.T) {
 							},
 						},
 					},
-				}, rayjobapi.WorkerGroupSpec{
+				}, rayv1.WorkerGroupSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -38,8 +38,8 @@ var (
 
 func TestValidateDefault(t *testing.T) {
 	testcases := map[string]struct {
-		oldJob    *rayjobapi.RayJob
-		newJob    *rayjobapi.RayJob
+		oldJob    *rayv1.RayJob
+		newJob    *rayv1.RayJob
 		manageAll bool
 	}{
 		"unmanaged": {
@@ -88,11 +88,11 @@ func TestValidateDefault(t *testing.T) {
 }
 
 func TestValidateCreate(t *testing.T) {
-	worker := rayjobapi.WorkerGroupSpec{}
-	bigWorkerGroup := []rayjobapi.WorkerGroupSpec{worker, worker, worker, worker, worker, worker, worker, worker}
+	worker := rayv1.WorkerGroupSpec{}
+	bigWorkerGroup := []rayv1.WorkerGroupSpec{worker, worker, worker, worker, worker, worker, worker, worker}
 
 	testcases := map[string]struct {
-		job       *rayjobapi.RayJob
+		job       *rayv1.RayJob
 		manageAll bool
 		wantErr   error
 	}{
@@ -147,7 +147,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"worker group uses head name": {
 			job: testingrayutil.MakeJob("job", "ns").Queue("queue").
-				WithWorkerGroups(rayjobapi.WorkerGroupSpec{
+				WithWorkerGroups(rayv1.WorkerGroupSpec{
 					GroupName: headGroupPodSetName,
 				}).
 				Obj(),
@@ -172,8 +172,8 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testcases := map[string]struct {
-		oldJob    *rayjobapi.RayJob
-		newJob    *rayjobapi.RayJob
+		oldJob    *rayv1.RayJob
+		newJob    *rayv1.RayJob
 		manageAll bool
 		wantErr   error
 	}{

--- a/pkg/util/testingjobs/rayjob/wrappers.go
+++ b/pkg/util/testingjobs/rayjob/wrappers.go
@@ -17,7 +17,7 @@ limitations under the License.
 package rayjob
 
 import (
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,20 +27,20 @@ import (
 )
 
 // JobWrapper wraps a RayJob.
-type JobWrapper struct{ rayjobapi.RayJob }
+type JobWrapper struct{ rayv1.RayJob }
 
 // MakeJob creates a wrapper for a suspended rayJob
 func MakeJob(name, ns string) *JobWrapper {
-	return &JobWrapper{rayjobapi.RayJob{
+	return &JobWrapper{rayv1.RayJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   ns,
 			Annotations: make(map[string]string, 1),
 		},
-		Spec: rayjobapi.RayJobSpec{
+		Spec: rayv1.RayJobSpec{
 			ShutdownAfterJobFinishes: true,
-			RayClusterSpec: &rayjobapi.RayClusterSpec{
-				HeadGroupSpec: rayjobapi.HeadGroupSpec{
+			RayClusterSpec: &rayv1.RayClusterSpec{
+				HeadGroupSpec: rayv1.HeadGroupSpec{
 					RayStartParams: map[string]string{"p1": "v1"},
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
@@ -52,7 +52,7 @@ func MakeJob(name, ns string) *JobWrapper {
 						},
 					},
 				},
-				WorkerGroupSpecs: []rayjobapi.WorkerGroupSpec{
+				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
 						GroupName:      "workers-group-0",
 						Replicas:       ptr.To[int32](1),
@@ -77,7 +77,7 @@ func MakeJob(name, ns string) *JobWrapper {
 }
 
 // Obj returns the inner Job.
-func (j *JobWrapper) Obj() *rayjobapi.RayJob {
+func (j *JobWrapper) Obj() *rayv1.RayJob {
 	return &j.RayJob
 }
 
@@ -131,12 +131,12 @@ func (j *JobWrapper) WithEnableAutoscaling(value *bool) *JobWrapper {
 	return j
 }
 
-func (j *JobWrapper) WithWorkerGroups(workers ...rayjobapi.WorkerGroupSpec) *JobWrapper {
+func (j *JobWrapper) WithWorkerGroups(workers ...rayv1.WorkerGroupSpec) *JobWrapper {
 	j.Spec.RayClusterSpec.WorkerGroupSpecs = workers
 	return j
 }
 
-func (j *JobWrapper) WithHeadGroupSpec(value rayjobapi.HeadGroupSpec) *JobWrapper {
+func (j *JobWrapper) WithHeadGroupSpec(value rayv1.HeadGroupSpec) *JobWrapper {
 	j.Spec.RayClusterSpec.HeadGroupSpec = value
 	return j
 }

--- a/site/static/examples/jobs/ray-job-sample.yaml
+++ b/site/static/examples/jobs/ray-job-sample.yaml
@@ -1,4 +1,4 @@
-apiVersion: ray.io/v1alpha1
+apiVersion: ray.io/v1
 kind: RayJob
 metadata:
   name: ray-job-sample

--- a/test/integration/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/test/integration/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -16,7 +16,7 @@ package raycluster
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	rayv1alpha1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -111,7 +111,7 @@ var _ = ginkgo.Describe("RayCluster Webhook", func() {
 			lookupKey := types.NamespacedName{Name: parentJob.Name, Namespace: ns.Name}
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, lookupKey, parentJob)).To(gomega.Succeed())
-				parentJob.Status.JobDeploymentStatus = rayv1alpha1.JobDeploymentStatusSuspended
+				parentJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusSuspended
 				g.Expect(k8sClient.Status().Update(ctx, parentJob)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -28,7 +28,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	rayjobapi "github.com/ray-project/kuberay/ray-operator/apis/ray/v1alpha1"
 	zaplog "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -98,7 +97,7 @@ func (f *Framework) SetupClient(cfg *rest.Config) (context.Context, client.Clien
 	err = kubeflow.AddToScheme(scheme.Scheme)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
-	err = rayjobapi.AddToScheme(scheme.Scheme)
+	err = rayv1.AddToScheme(scheme.Scheme)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
 	err = rayv1.AddToScheme(scheme.Scheme)


### PR DESCRIPTION
#### What this PR does / why we need it:

KubeRay has promoted the RayJob API from v1alpha1 to v1 with KubeRay v1.0.0. While the v1alpha1 version is still served in KubeRay v1.1.0, it'll be removed in v1.2.0.

#### Which issue(s) this PR fixes:

Fixes #1335.

#### Special notes for your reviewer:

Supersedes #1435.

#### Does this PR introduce a user-facing change?

```release-note
Upgrade RayJob API to v1

ACTION REQUIRED
If you use KubeRay older than v1.0.0, you'll have to upgrade your existing installation
to KubeRay v1.0.0, or any more recent version, that supports KubeRay v1 APIs, for it to
remain compatible with Kueue.
```