### PR TITLE
Fixes typos in variables, comments, and tests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,3 +21,4 @@ linters:
     - ginkgolinter
     - gocritic
     - goimports
+    - misspell

--- a/apis/visibility/v1alpha1/conversion_test.go
+++ b/apis/visibility/v1alpha1/conversion_test.go
@@ -74,7 +74,7 @@ func TestPendingWorkloadsOptions(t *testing.T) {
 				t.Fatal(err)
 			}
 			if d := cmp.Diff(actualParameters, tc.wantQueryParams); d != "" {
-				t.Fatalf("Unxpected serialization:\n%s", diff.ObjectGoPrintSideBySide(tc.wantQueryParams, actualParameters))
+				t.Fatalf("Unexpected serialization:\n%s", diff.ObjectGoPrintSideBySide(tc.wantQueryParams, actualParameters))
 			}
 
 			// query params -> versioned

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -92,7 +92,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 	cases := []struct {
 		name               string
 		operation          func(*Cache) error
-		clientObbjects     []client.Object
+		clientObjects      []client.Object
 		wantClusterQueues  map[string]*ClusterQueue
 		wantCohorts        map[string]sets.Set[string]
 		enableLendingLimit bool
@@ -970,7 +970,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "add cluster queue after finished workloads",
-			clientObbjects: []client.Object{
+			clientObjects: []client.Object{
 				utiltesting.MakeLocalQueue("lq1", "ns").ClusterQueue("cq1").Obj(),
 				utiltesting.MakeWorkload("pending", "ns").Obj(),
 				utiltesting.MakeWorkload("reserving", "ns").ReserveQuota(
@@ -1049,7 +1049,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			defer features.SetFeatureGateDuringTest(t, features.LendingLimit, tc.enableLendingLimit)()
-			cache := New(utiltesting.NewFakeClient(tc.clientObbjects...))
+			cache := New(utiltesting.NewFakeClient(tc.clientObjects...))
 			if err := tc.operation(cache); err != nil {
 				t.Errorf("Unexpected error during test operation: %s", err)
 			}
@@ -3173,11 +3173,11 @@ func TestClusterQueuesUsingAdmissionChecks(t *testing.T) {
 }
 
 func TestClusterQueueReadiness(t *testing.T) {
-	baseFalvor := utiltesting.MakeResourceFlavor("flavor1").Obj()
+	baseFlavor := utiltesting.MakeResourceFlavor("flavor1").Obj()
 	baseCheck := utiltesting.MakeAdmissionCheck("check1").Active(metav1.ConditionTrue).Obj()
 	baseQueue := utiltesting.MakeClusterQueue("queue1").
 		ResourceGroup(
-			*utiltesting.MakeFlavorQuotas(baseFalvor.Name).
+			*utiltesting.MakeFlavorQuotas(baseFlavor.Name).
 				Resource(corev1.ResourceCPU, "10", "10").Obj()).
 		AdmissionChecks(baseCheck.Name).
 		Obj()
@@ -3210,7 +3210,7 @@ func TestClusterQueueReadiness(t *testing.T) {
 		},
 		"check not found": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
-			resourceFlavors:  []*kueue.ResourceFlavor{baseFalvor},
+			resourceFlavors:  []*kueue.ResourceFlavor{baseFlavor},
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
 			wantReason:       "CheckNotFoundOrInactive",
@@ -3218,7 +3218,7 @@ func TestClusterQueueReadiness(t *testing.T) {
 		},
 		"check inactive": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
-			resourceFlavors:  []*kueue.ResourceFlavor{baseFalvor},
+			resourceFlavors:  []*kueue.ResourceFlavor{baseFlavor},
 			admissionChecks:  []*kueue.AdmissionCheck{utiltesting.MakeAdmissionCheck("check1").Obj()},
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
@@ -3235,7 +3235,7 @@ func TestClusterQueueReadiness(t *testing.T) {
 		"terminating": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
 			admissionChecks:  []*kueue.AdmissionCheck{baseCheck},
-			resourceFlavors:  []*kueue.ResourceFlavor{baseFalvor},
+			resourceFlavors:  []*kueue.ResourceFlavor{baseFlavor},
 			clusterQueueName: "queue1",
 			terminate:        true,
 			wantStatus:       metav1.ConditionFalse,
@@ -3246,7 +3246,7 @@ func TestClusterQueueReadiness(t *testing.T) {
 		"ready": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
 			admissionChecks:  []*kueue.AdmissionCheck{baseCheck},
-			resourceFlavors:  []*kueue.ResourceFlavor{baseFalvor},
+			resourceFlavors:  []*kueue.ResourceFlavor{baseFlavor},
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionTrue,
 			wantReason:       "Ready",

--- a/pkg/controller/admissionchecks/multikueue/jobset_adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/jobset_adapter_test.go
@@ -344,24 +344,24 @@ func TestWlReconcileJobset(t *testing.T) {
 				t.Errorf("unexpected error: %s", gotErr)
 			}
 
-			gotManagersWokloads := &kueue.WorkloadList{}
-			err := managerClient.List(ctx, gotManagersWokloads)
+			gotManagersWorkloads := &kueue.WorkloadList{}
+			err := managerClient.List(ctx, gotManagersWorkloads)
 			if err != nil {
 				t.Error("unexpected list managers workloads error")
 			}
 
-			if diff := cmp.Diff(tc.wantManagersWorkloads, gotManagersWokloads.Items, objCheckOpts...); diff != "" {
-				t.Errorf("unexpected manangers workloads (-want/+got):\n%s", diff)
+			if diff := cmp.Diff(tc.wantManagersWorkloads, gotManagersWorkloads.Items, objCheckOpts...); diff != "" {
+				t.Errorf("unexpected managers workloads (-want/+got):\n%s", diff)
 			}
 
-			gotWorker1Wokloads := &kueue.WorkloadList{}
-			err = worker1Client.List(ctx, gotWorker1Wokloads)
+			gotWorker1Workloads := &kueue.WorkloadList{}
+			err = worker1Client.List(ctx, gotWorker1Workloads)
 			if err != nil {
 				t.Error("unexpected list managers workloads error")
 			}
 
-			if diff := cmp.Diff(tc.wantWorker1Workloads, gotWorker1Wokloads.Items, objCheckOpts...); diff != "" {
-				t.Errorf("unexpected manangers workloads (-want/+got):\n%s", diff)
+			if diff := cmp.Diff(tc.wantWorker1Workloads, gotWorker1Workloads.Items, objCheckOpts...); diff != "" {
+				t.Errorf("unexpected managers workloads (-want/+got):\n%s", diff)
 			}
 			gotManagersJobs := &jobset.JobSetList{}
 			err = managerClient.List(ctx, gotManagersJobs)
@@ -370,7 +370,7 @@ func TestWlReconcileJobset(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.wantManagersJobsSets, gotManagersJobs.Items, objCheckOpts...); diff != "" {
-				t.Errorf("unexpected manangers jobs (-want/+got):\n%s", diff)
+				t.Errorf("unexpected managers jobs (-want/+got):\n%s", diff)
 			}
 
 			gotWorker1Job := &jobset.JobSetList{}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -82,7 +82,7 @@ func newClientWithWatch(kubeconfig []byte, options client.Options) (client.WithW
 }
 
 type multiKueueWatcher interface {
-	// returns an empty list of objets
+	// returns an empty list of objects
 	GetEmptyList() client.ObjectList
 	// returns the key of the workload of interest
 	// - the object name for workloads

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -346,13 +346,13 @@ func TestRemoteClientGC(t *testing.T) {
 
 			w1remoteClient.runGC(ctx)
 
-			gotWorker1Wokloads := &kueue.WorkloadList{}
-			err := worker1Client.List(ctx, gotWorker1Wokloads)
+			gotWorker1Workloads := &kueue.WorkloadList{}
+			err := worker1Client.List(ctx, gotWorker1Workloads)
 			if err != nil {
 				t.Error("unexpected list worker's workloads error")
 			}
 
-			if diff := cmp.Diff(tc.wantWorkersWorkloads, gotWorker1Wokloads.Items, objCheckOpts...); diff != "" {
+			if diff := cmp.Diff(tc.wantWorkersWorkloads, gotWorker1Workloads.Items, objCheckOpts...); diff != "" {
 				t.Errorf("unexpected worker's workloads (-want/+got):\n%s", diff)
 			}
 

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -495,20 +495,20 @@ func TestWlReconcile(t *testing.T) {
 				t.Errorf("unexpected error (-want/+got):\n%s", diff)
 			}
 
-			gotManagersWokloads := &kueue.WorkloadList{}
-			if err := managerClient.List(ctx, gotManagersWokloads); err != nil {
+			gotManagersWorkloads := &kueue.WorkloadList{}
+			if err := managerClient.List(ctx, gotManagersWorkloads); err != nil {
 				t.Errorf("unexpected list manager's workloads error: %s", err)
 			} else {
-				if diff := cmp.Diff(tc.wantManagersWorkloads, gotManagersWokloads.Items, objCheckOpts...); diff != "" {
+				if diff := cmp.Diff(tc.wantManagersWorkloads, gotManagersWorkloads.Items, objCheckOpts...); diff != "" {
 					t.Errorf("unexpected manager's workloads (-want/+got):\n%s", diff)
 				}
 			}
 
-			gotWorker1Wokloads := &kueue.WorkloadList{}
-			if err := worker1Client.List(ctx, gotWorker1Wokloads); err != nil {
+			gotWorker1Workloads := &kueue.WorkloadList{}
+			if err := worker1Client.List(ctx, gotWorker1Workloads); err != nil {
 				t.Errorf("unexpected list worker's workloads error: %s", err)
 			} else {
-				if diff := cmp.Diff(tc.wantWorker1Workloads, gotWorker1Wokloads.Items, objCheckOpts...); diff != "" {
+				if diff := cmp.Diff(tc.wantWorker1Workloads, gotWorker1Workloads.Items, objCheckOpts...); diff != "" {
 					t.Errorf("unexpected worker's workloads (-want/+got):\n%s", diff)
 				}
 			}
@@ -532,11 +532,11 @@ func TestWlReconcile(t *testing.T) {
 			}
 
 			if tc.useSecondWorker {
-				gotWorker2Wokloads := &kueue.WorkloadList{}
-				if err := worker2Client.List(ctx, gotWorker2Wokloads); err != nil {
+				gotWorker2Workloads := &kueue.WorkloadList{}
+				if err := worker2Client.List(ctx, gotWorker2Workloads); err != nil {
 					t.Errorf("unexpected list worker2 workloads error: %s", err)
 				} else {
-					if diff := cmp.Diff(tc.wantWorker2Workloads, gotWorker2Wokloads.Items, objCheckOpts...); diff != "" {
+					if diff := cmp.Diff(tc.wantWorker2Workloads, gotWorker2Workloads.Items, objCheckOpts...); diff != "" {
 						t.Errorf("unexpected worker2 workloads (-want/+got):\n%s", diff)
 					}
 				}

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -173,7 +173,7 @@ func (c *Controller) activeOrLastPRForChecks(ctx context.Context, wl *kueue.Work
 			// PRs relevant for the admission check
 			if matches(req, wl.Name, checkName) {
 				prc, err := c.helper.ConfigForAdmissionCheck(ctx, checkName)
-				if err == nil && c.reqIsNeeded(ctx, wl, prc) && requestHasParamaters(req, prc) {
+				if err == nil && c.reqIsNeeded(ctx, wl, prc) && requestHasParameters(req, prc) {
 					if currPr, exists := activeOrLastPRForChecks[checkName]; !exists || getAttempt(ctx, currPr, wl.Name, checkName) < getAttempt(ctx, req, wl.Name, checkName) {
 						activeOrLastPRForChecks[checkName] = req
 					}
@@ -434,7 +434,7 @@ func parametersKueueToProvisioning(in map[string]kueue.Parameter) map[string]aut
 	return out
 }
 
-func requestHasParamaters(req *autoscaling.ProvisioningRequest, prc *kueue.ProvisioningRequestConfig) bool {
+func requestHasParameters(req *autoscaling.ProvisioningRequest, prc *kueue.ProvisioningRequestConfig) bool {
 	if req.Spec.ProvisioningClassName != prc.Spec.ProvisioningClassName {
 		return false
 	}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -452,7 +452,7 @@ func (r *WorkloadReconciler) Delete(e event.DeleteEvent) bool {
 		// trigger the move of associated inadmissibleWorkloads if required.
 		r.queues.QueueAssociatedInadmissibleWorkloadsAfter(ctx, wl, func() {
 			// Delete the workload from cache while holding the queues lock
-			// to guarantee that requeueued workloads are taken into account before
+			// to guarantee that requeued workloads are taken into account before
 			// the next scheduling cycle.
 			if err := r.cache.DeleteWorkload(wl); err != nil {
 				if !e.DeleteStateUnknown {
@@ -514,7 +514,7 @@ func (r *WorkloadReconciler) Update(e event.UpdateEvent) bool {
 		// trigger the move of associated inadmissibleWorkloads, if there are any.
 		r.queues.QueueAssociatedInadmissibleWorkloadsAfter(ctx, wl, func() {
 			// Delete the workload from cache while holding the queues lock
-			// to guarantee that requeueued workloads are taken into account before
+			// to guarantee that requeued workloads are taken into account before
 			// the next scheduling cycle.
 			if err := r.cache.DeleteWorkload(oldWl); err != nil && prevStatus == admitted {
 				log.Error(err, "Failed to delete workload from cache")
@@ -535,7 +535,7 @@ func (r *WorkloadReconciler) Update(e event.UpdateEvent) bool {
 		// trigger the move of associated inadmissibleWorkloads, if there are any.
 		r.queues.QueueAssociatedInadmissibleWorkloadsAfter(ctx, wl, func() {
 			// Delete the workload from cache while holding the queues lock
-			// to guarantee that requeueued workloads are taken into account before
+			// to guarantee that requeued workloads are taken into account before
 			// the next scheduling cycle.
 			if err := r.cache.DeleteWorkload(wl); err != nil {
 				log.Error(err, "Failed to delete workload from cache")

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -42,7 +42,7 @@ func ValidateCreateForQueueName(job GenericJob) field.ErrorList {
 	allErrs = append(allErrs, ValidateLabelAsCRDName(job, constants.PrebuiltWorkloadLabel)...)
 	allErrs = append(allErrs, ValidateAnnotationAsCRDName(job, constants.QueueAnnotation)...)
 
-	// this rule should be relaxed when its confirmed that running wit a prebuilt wl is fully supported by each integration
+	// this rule should be relaxed when its confirmed that running with a prebuilt wl is fully supported by each integration
 	if _, hasPrebuilt := job.Object().GetLabels()[constants.PrebuiltWorkloadLabel]; hasPrebuilt {
 		gvk := job.GVK().String()
 		if !supportedPrebuiltWlJobGVKs.Has(gvk) {

--- a/pkg/queue/cluster_queue_impl_test.go
+++ b/pkg/queue/cluster_queue_impl_test.go
@@ -105,10 +105,10 @@ func Test_PushOrUpdate(t *testing.T) {
 				t.Error("failed to update a workload in ClusterQueue")
 			}
 			if diff := cmp.Diff(tc.wantWorkload, newWl, cmpOpts...); len(diff) != 0 {
-				t.Errorf("Unexpectd workloads in heap (-want,+got):\n%s", diff)
+				t.Errorf("Unexpected workloads in heap (-want,+got):\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.wantInAdmissibleWorkloads, cq.inadmissibleWorkloads, cmpOpts...); len(diff) != 0 {
-				t.Errorf("Unexpectd inadmissibleWorkloads (-want,+got):\n%s", diff)
+				t.Errorf("Unexpected inadmissibleWorkloads (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -496,7 +496,7 @@ func shouldTryNextFlavor(representativeMode FlavorAssignmentMode, flavorFungibil
 }
 
 func flavorSelector(spec *corev1.PodSpec, allowedKeys sets.Set[string]) nodeaffinity.RequiredNodeAffinity {
-	// This function generally replicates the implementation of kube-scheduler's NodeAffintiy
+	// This function generally replicates the implementation of kube-scheduler's NodeAffinity
 	// Filter plugin as of v1.24.
 	var specCopy corev1.PodSpec
 

--- a/pkg/util/maps/maps_test.go
+++ b/pkg/util/maps/maps_test.go
@@ -105,7 +105,7 @@ func TestContains(t *testing.T) {
 			},
 			wantResult: true,
 		},
-		"missmatch": {
+		"mismatch": {
 			a: map[string]int{
 				"v1": 1,
 				"v2": 3,

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -553,7 +553,7 @@ func (c *ClusterQueueWrapper) NamespaceSelector(s *metav1.LabelSelector) *Cluste
 	return c
 }
 
-// Preemption sets the preeemption policies.
+// Preemption sets the preemption policies.
 func (c *ClusterQueueWrapper) Preemption(p kueue.ClusterQueuePreemption) *ClusterQueueWrapper {
 	c.Spec.Preemption = &p
 	return c

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -420,7 +420,7 @@ type Ordering struct {
 // be the workload creation time or the last time a PodsReady timeout has occurred.
 func (o Ordering) GetQueueOrderTimestamp(w *kueue.Workload) *metav1.Time {
 	if o.PodsReadyRequeuingTimestamp == config.EvictionTimestamp {
-		if evictedCond, evictedByTimout := IsEvictedByPodsReadyTimeout(w); evictedByTimout {
+		if evictedCond, evictedByTimeout := IsEvictedByPodsReadyTimeout(w); evictedByTimeout {
 			return &evictedCond.LastTransitionTime
 		}
 	}
@@ -432,7 +432,7 @@ func HasQuotaReservation(w *kueue.Workload) bool {
 	return apimeta.IsStatusConditionTrue(w.Status.Conditions, kueue.WorkloadQuotaReserved)
 }
 
-// UpdateReclaimablePods updates the ReclaimablePods list for the workload wit SSA.
+// UpdateReclaimablePods updates the ReclaimablePods list for the workload with SSA.
 func UpdateReclaimablePods(ctx context.Context, c client.Client, w *kueue.Workload, reclaimablePods []kueue.ReclaimablePod) error {
 	patch := BaseSSAWorkload(w)
 	patch.Status.ReclaimablePods = reclaimablePods

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -365,17 +365,17 @@ func TestReclaimablePodsAreEqual(t *testing.T) {
 			b:          []kueue.ReclaimablePod{{Name: "rp1", Count: 1}},
 			wantResult: false,
 		},
-		"one value missmatch": {
+		"one value mismatch": {
 			a:          []kueue.ReclaimablePod{{Name: "rp1", Count: 1}, {Name: "rp2", Count: 2}},
 			b:          []kueue.ReclaimablePod{{Name: "rp2", Count: 1}, {Name: "rp1", Count: 1}},
 			wantResult: false,
 		},
-		"one name missmatch": {
+		"one name mismatch": {
 			a:          []kueue.ReclaimablePod{{Name: "rp1", Count: 1}, {Name: "rp2", Count: 2}},
 			b:          []kueue.ReclaimablePod{{Name: "rp3", Count: 3}, {Name: "rp1", Count: 1}},
 			wantResult: false,
 		},
-		"length missmatch": {
+		"length mismatch": {
 			a:          []kueue.ReclaimablePod{{Name: "rp1", Count: 1}, {Name: "rp2", Count: 2}},
 			b:          []kueue.ReclaimablePod{{Name: "rp1", Count: 1}},
 			wantResult: false,
@@ -474,7 +474,7 @@ func TestHasRequeueState(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := HasRequeueState(tc.workload)
 			if tc.want != got {
-				t.Errorf("Unexpected result from HasRequeuState\nwant:%v\ngot:%v\n", tc.want, got)
+				t.Errorf("Unexpected result from HasRequeueState\nwant:%v\ngot:%v\n", tc.want, got)
 			}
 		})
 	}

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -104,11 +104,11 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		gomega.Expect(k8sManagerClient.Create(ctx, multiKueueAc)).Should(gomega.Succeed())
 
 		ginkgo.By("wait for check active", func() {
-			updatetedAc := kueue.AdmissionCheck{}
+			updatedAc := kueue.AdmissionCheck{}
 			acKey := client.ObjectKeyFromObject(multiKueueAc)
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sManagerClient.Get(ctx, acKey, &updatetedAc)).To(gomega.Succeed())
-				g.Expect(apimeta.IsStatusConditionTrue(updatetedAc.Status.Conditions, kueue.AdmissionCheckActive)).To(gomega.BeTrue())
+				g.Expect(k8sManagerClient.Get(ctx, acKey, &updatedAc)).To(gomega.Succeed())
+				g.Expect(apimeta.IsStatusConditionTrue(updatedAc.Status.Conditions, kueue.AdmissionCheckActive)).To(gomega.BeTrue())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		})

--- a/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
@@ -110,13 +110,13 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 				PodSets(
 					*testing.MakePodSet("ps1", 3).
 						Request(corev1.ResourceCPU, "1").
-						Image("iamge").
+						Image("image").
 						Obj(),
 					*testing.MakePodSet("ps2", 6).
 						Request(corev1.ResourceCPU, "500m").
 						Request(customResourceOne, "1").
 						Limit(customResourceOne, "1").
-						Image("iamge").
+						Image("image").
 						Obj(),
 				).
 				Obj()
@@ -701,13 +701,13 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 				PodSets(
 					*testing.MakePodSet("ps1", 3).
 						Request(corev1.ResourceCPU, "1").
-						Image("iamge").
+						Image("image").
 						Obj(),
 					*testing.MakePodSet("ps2", 6).
 						Request(corev1.ResourceCPU, "500m").
 						Request(customResourceOne, "1").
 						Limit(customResourceOne, "1").
-						Image("iamge").
+						Image("image").
 						Obj(),
 				).
 				Obj()

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -127,11 +127,11 @@ var _ = ginkgo.Describe("Multikueue", func() {
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, multikueueAC)).Should(gomega.Succeed())
 
 		ginkgo.By("wait for check active", func() {
-			updatetedAc := kueue.AdmissionCheck{}
+			updatedAc := kueue.AdmissionCheck{}
 			acKey := client.ObjectKeyFromObject(multikueueAC)
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatetedAc)).To(gomega.Succeed())
-				cond := apimeta.FindStatusCondition(updatetedAc.Status.Conditions, kueue.AdmissionCheckActive)
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatedAc)).To(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(updatedAc.Status.Conditions, kueue.AdmissionCheckActive)
 				g.Expect(cond).NotTo(gomega.BeNil())
 				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue), "Reason: %s, Message: %q", cond.Reason, cond.Message)
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -180,11 +180,11 @@ var _ = ginkgo.Describe("Multikueue", func() {
 			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, ac) })
 
 			ginkgo.By("wait for the check's active state update", func() {
-				updatetedAc := kueue.AdmissionCheck{}
+				updatedAc := kueue.AdmissionCheck{}
 				acKey := client.ObjectKeyFromObject(ac)
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatetedAc)).To(gomega.Succeed())
-					g.Expect(updatetedAc.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatedAc)).To(gomega.Succeed())
+					g.Expect(updatedAc.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.AdmissionCheckActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "Inactive",
@@ -206,11 +206,11 @@ var _ = ginkgo.Describe("Multikueue", func() {
 			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, config) })
 
 			ginkgo.By("wait for the check's active state update", func() {
-				updatetedAc := kueue.AdmissionCheck{}
+				updatedAc := kueue.AdmissionCheck{}
 				acKey := client.ObjectKeyFromObject(ac)
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatetedAc)).To(gomega.Succeed())
-					g.Expect(updatetedAc.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatedAc)).To(gomega.Succeed())
+					g.Expect(updatedAc.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.AdmissionCheckActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "Inactive",
@@ -226,11 +226,11 @@ var _ = ginkgo.Describe("Multikueue", func() {
 			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, cluster) })
 
 			ginkgo.By("wait for the cluster's active state update", func() {
-				updatetedCluster := kueuealpha.MultiKueueCluster{}
+				updatedCluster := kueuealpha.MultiKueueCluster{}
 				clusterKey := client.ObjectKeyFromObject(cluster)
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, clusterKey, &updatetedCluster)).To(gomega.Succeed())
-					g.Expect(updatetedCluster.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, clusterKey, &updatedCluster)).To(gomega.Succeed())
+					g.Expect(updatedCluster.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
 						Type:    kueuealpha.MultiKueueClusterActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "BadConfig",
@@ -240,11 +240,11 @@ var _ = ginkgo.Describe("Multikueue", func() {
 			})
 
 			ginkgo.By("wait for the check's active state update", func() {
-				updatetedAc := kueue.AdmissionCheck{}
+				updatedAc := kueue.AdmissionCheck{}
 				acKey := client.ObjectKeyFromObject(ac)
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatetedAc)).To(gomega.Succeed())
-					g.Expect(updatetedAc.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatedAc)).To(gomega.Succeed())
+					g.Expect(updatedAc.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.AdmissionCheckActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "Inactive",
@@ -271,11 +271,11 @@ var _ = ginkgo.Describe("Multikueue", func() {
 			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, secret) })
 
 			ginkgo.By("wait for the cluster's active state update", func() {
-				updatetedCluster := kueuealpha.MultiKueueCluster{}
+				updatedCluster := kueuealpha.MultiKueueCluster{}
 				clusterKey := client.ObjectKeyFromObject(cluster)
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, clusterKey, &updatetedCluster)).To(gomega.Succeed())
-					g.Expect(updatetedCluster.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, clusterKey, &updatedCluster)).To(gomega.Succeed())
+					g.Expect(updatedCluster.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
 						Type:    kueuealpha.MultiKueueClusterActive,
 						Status:  metav1.ConditionTrue,
 						Reason:  "Active",
@@ -285,11 +285,11 @@ var _ = ginkgo.Describe("Multikueue", func() {
 			})
 
 			ginkgo.By("wait for the check's active state update", func() {
-				updatetedAc := kueue.AdmissionCheck{}
+				updatedAc := kueue.AdmissionCheck{}
 				acKey := client.ObjectKeyFromObject(ac)
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatetedAc)).To(gomega.Succeed())
-					g.Expect(updatetedAc.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatedAc)).To(gomega.Succeed())
+					g.Expect(updatedAc.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.AdmissionCheckActive,
 						Status:  metav1.ConditionTrue,
 						Reason:  "Active",

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -1578,13 +1578,13 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		})
 
 		type testParams struct {
-			reqCPU          string
-			limitCPU        string
-			minCPU          string
-			maxCPU          string
-			limitType       corev1.LimitType
-			wantedStatus    string
-			shouldBeAdmited bool
+			reqCPU           string
+			limitCPU         string
+			minCPU           string
+			maxCPU           string
+			limitType        corev1.LimitType
+			wantedStatus     string
+			shouldBeAdmitted bool
 		}
 
 		ginkgo.DescribeTable("", func(tp testParams) {
@@ -1613,7 +1613,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wl := wlBuilder.Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-			if tp.shouldBeAdmited {
+			if tp.shouldBeAdmitted {
 				util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl)
 			} else {
 				gomega.Eventually(func() string {
@@ -1637,7 +1637,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.Entry("request under container limits", testParams{reqCPU: "2", limitCPU: "3", minCPU: "3", wantedStatus: "didn't satisfy LimitRange constraints:"}),
 			ginkgo.Entry("request over pod limits", testParams{reqCPU: "2", limitCPU: "3", maxCPU: "1", limitType: corev1.LimitTypePod, wantedStatus: "didn't satisfy LimitRange constraints:"}),
 			ginkgo.Entry("request under pod limits", testParams{reqCPU: "2", limitCPU: "3", minCPU: "3", limitType: corev1.LimitTypePod, wantedStatus: "didn't satisfy LimitRange constraints:"}),
-			ginkgo.Entry("valid", testParams{reqCPU: "2", limitCPU: "3", minCPU: "1", maxCPU: "4", shouldBeAdmited: true}),
+			ginkgo.Entry("valid", testParams{reqCPU: "2", limitCPU: "3", minCPU: "1", maxCPU: "4", shouldBeAdmitted: true}),
 		)
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The PR fixes typos in unexported variable/function/field names, test messages, and comments. Additionally, the PR enables `misspell` linter that can catch some mistakes.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```