### PR TITLE
[multikueue] Cluster connection monitoring and reconnect.

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/jobset_adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/jobset_adapter_test.go
@@ -331,7 +331,7 @@ func TestWlReconcileJobset(t *testing.T) {
 			worker1Builder = worker1Builder.WithLists(&kueue.WorkloadList{Items: tc.worker1Workloads}, &jobset.JobSetList{Items: tc.worker1JobSets})
 			worker1Client := worker1Builder.Build()
 
-			w1remoteClient := newRemoteClient(managerClient, nil, defaultOrigin)
+			w1remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "")
 			w1remoteClient.client = worker1Client
 
 			cRec.remoteClients["worker1"] = w1remoteClient

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,26 +37,47 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
+const (
+	eventChBufferSize = 10
+
+	// this set will provide waiting time between 5s to 5min
+	retryIncrement = 5 * time.Second
+	retryMaxSteps  = 6
+)
+
+// retryAfter returns an exponentially increasing interval between
+// retryIncrement and 2^retryMaxSteps * retryIncrement
+func retryAfter(failedAttempts uint) time.Duration {
+	return (1 << min(failedAttempts, retryMaxSteps)) * retryIncrement
+}
+
 type clientWithWatchBuilder func(config []byte, options client.Options) (client.WithWatch, error)
 
 type remoteClient struct {
-	localClient client.Client
-	client      client.WithWatch
-	wlUpdateCh  chan<- event.GenericEvent
-	watchCancel map[string]func()
-	kubeconfig  []byte
-	origin      string
+	clusterName  string
+	localClient  client.Client
+	client       client.WithWatch
+	wlUpdateCh   chan<- event.GenericEvent
+	watchEndedCh chan<- event.GenericEvent
+	watchCancel  func()
+	kubeconfig   []byte
+	origin       string
+
+	forceReconnect     atomic.Bool
+	failedConnAttempts uint
 
 	// For unit testing only. There is now need of creating fully functional remote clients in the unit tests
 	// and creating valid kubeconfig content is not trivial.
@@ -63,12 +85,13 @@ type remoteClient struct {
 	builderOverride clientWithWatchBuilder
 }
 
-func newRemoteClient(localClient client.Client, wlUpdateCh chan<- event.GenericEvent, origin string) *remoteClient {
+func newRemoteClient(localClient client.Client, wlUpdateCh, watchEndedCh chan<- event.GenericEvent, origin, clusterName string) *remoteClient {
 	rc := &remoteClient{
-		wlUpdateCh:  wlUpdateCh,
-		localClient: localClient,
-		origin:      origin,
-		watchCancel: map[string]func(){},
+		clusterName:  clusterName,
+		wlUpdateCh:   wlUpdateCh,
+		watchEndedCh: watchEndedCh,
+		localClient:  localClient,
+		origin:       origin,
 	}
 	return rc
 }
@@ -107,13 +130,19 @@ func (*workloadKueueWatcher) GetWorkloadKey(o runtime.Object) (types.NamespacedN
 }
 
 // setConfig - will try to recreate the k8s client and restart watching if the new config is different than
-// the one currently used.
-func (rc *remoteClient) setConfig(watchCtx context.Context, kubeconfig []byte) error {
-	if equality.Semantic.DeepEqual(kubeconfig, rc.kubeconfig) {
-		return nil
+// the one currently used or a reconnect was requested.
+// If the encountered error is not permanent the duration after which a retry should be done is returned.
+func (rc *remoteClient) setConfig(watchCtx context.Context, kubeconfig []byte) (*time.Duration, error) {
+	configChanged := !equality.Semantic.DeepEqual(kubeconfig, rc.kubeconfig)
+	if !configChanged && !rc.forceReconnect.Load() {
+		return nil, nil
 	}
 
 	rc.StopWatchers()
+	if configChanged {
+		rc.kubeconfig = kubeconfig
+		rc.failedConnAttempts = 0
+	}
 
 	builder := newClientWithWatch
 	if rc.builderOverride != nil {
@@ -121,13 +150,17 @@ func (rc *remoteClient) setConfig(watchCtx context.Context, kubeconfig []byte) e
 	}
 	remoteClient, err := builder(kubeconfig, client.Options{Scheme: rc.localClient.Scheme()})
 	if err != nil {
-		return err
+		return nil, err
 	}
+
 	rc.client = remoteClient
 
+	watchCtx, rc.watchCancel = context.WithCancel(watchCtx)
 	err = rc.startWatcher(watchCtx, kueue.GroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
 	if err != nil {
-		return err
+		retryIn := retryAfter(rc.failedConnAttempts)
+		rc.failedConnAttempts++
+		return &retryIn, err
 	}
 
 	// add a watch for all the adapters implementing multiKueueWatcher
@@ -141,12 +174,15 @@ func (rc *remoteClient) setConfig(watchCtx context.Context, kubeconfig []byte) e
 			// not being able to setup a watcher is not ideal but we can function with only the wl watcher.
 			ctrl.LoggerFrom(watchCtx).V(2).Error(err, "Unable to start the watcher", "kind", kind)
 			// however let's not accept this for now.
-			return err
+			retryIn := retryAfter(rc.failedConnAttempts)
+			rc.failedConnAttempts++
+			return &retryIn, err
 		}
 	}
 
-	rc.kubeconfig = kubeconfig
-	return nil
+	rc.forceReconnect.Store(false)
+	rc.failedConnAttempts = 0
+	return nil, nil
 }
 
 func (rc *remoteClient) startWatcher(ctx context.Context, kind string, w multiKueueWatcher) error {
@@ -158,7 +194,6 @@ func (rc *remoteClient) startWatcher(ctx context.Context, kind string, w multiKu
 
 	go func() {
 		log.V(2).Info("Starting watch")
-		defer log.V(2).Info("Watch ended")
 		for r := range newWatcher.ResultChan() {
 			wlKey, err := w.GetWorkloadKey(r.Object)
 			if err != nil {
@@ -167,16 +202,23 @@ func (rc *remoteClient) startWatcher(ctx context.Context, kind string, w multiKu
 				rc.queueWorkloadEvent(ctx, wlKey)
 			}
 		}
+		log.V(2).Info("Watch ended", "ctxErr", ctx.Err())
+		// If the context is not yet Done , queue a reconcile to attempt reconnection
+		if ctx.Err() == nil {
+			oldReconnect := rc.forceReconnect.Swap(true)
+			//reconnect if this is the first watch failing.
+			if !oldReconnect {
+				log.V(2).Info("Queue reconcile for reconnect", "cluster", rc.clusterName)
+				rc.queueWatchEndedEvent(ctx)
+			}
+		}
 	}()
-
-	rc.watchCancel[kind] = newWatcher.Stop
 	return nil
 }
 
 func (rc *remoteClient) StopWatchers() {
-	for kind, stop := range rc.watchCancel {
-		stop()
-		delete(rc.watchCancel, kind)
+	if rc.watchCancel != nil {
+		rc.watchCancel()
 	}
 }
 
@@ -188,6 +230,15 @@ func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.Name
 		if !apierrors.IsNotFound(err) {
 			ctrl.LoggerFrom(ctx).Error(err, "reading local workload")
 		}
+	}
+}
+
+func (rc *remoteClient) queueWatchEndedEvent(ctx context.Context) {
+	cluster := &kueuealpha.MultiKueueCluster{}
+	if err := rc.localClient.Get(ctx, types.NamespacedName{Name: rc.clusterName}, cluster); err == nil {
+		rc.watchEndedCh <- event.GenericEvent{Object: cluster}
+	} else {
+		ctrl.LoggerFrom(ctx).Error(err, "sending watch ended event")
 	}
 }
 
@@ -264,6 +315,10 @@ type clustersReconciler struct {
 	// and creating valid kubeconfig content is not trivial.
 	// The full client creation and usage is validated in the integration and e2e tests.
 	builderOverride clientWithWatchBuilder
+
+	// watchEndedCh - an event chan used to request the reconciliation of the clusters for which the watch loop
+	// has ended (connection lost).
+	watchEndedCh chan event.GenericEvent
 }
 
 var _ manager.Runnable = (*clustersReconciler)(nil)
@@ -284,13 +339,13 @@ func (c *clustersReconciler) stopAndRemoveCluster(clusterName string) {
 	}
 }
 
-func (c *clustersReconciler) setRemoteClientConfig(ctx context.Context, clusterName string, kubeconfig []byte, origin string) error {
+func (c *clustersReconciler) setRemoteClientConfig(ctx context.Context, clusterName string, kubeconfig []byte, origin string) (*time.Duration, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
 	client, found := c.remoteClients[clusterName]
 	if !found {
-		client = newRemoteClient(c.localClient, c.wlUpdateCh, origin)
+		client = newRemoteClient(c.localClient, c.wlUpdateCh, c.watchEndedCh, origin, clusterName)
 		if c.builderOverride != nil {
 			client.builderOverride = c.builderOverride
 		}
@@ -300,12 +355,11 @@ func (c *clustersReconciler) setRemoteClientConfig(ctx context.Context, clusterN
 	clientLog := ctrl.LoggerFrom(c.rootContext).WithValues("clusterName", clusterName)
 	clientCtx := ctrl.LoggerInto(c.rootContext, clientLog)
 
-	if err := client.setConfig(clientCtx, kubeconfig); err != nil {
+	if retryAfter, err := client.setConfig(clientCtx, kubeconfig); err != nil {
 		ctrl.LoggerFrom(ctx).Error(err, "failed to set kubeConfig in the remote client")
-		delete(c.remoteClients, clusterName)
-		return err
+		return retryAfter, err
 	}
-	return nil
+	return nil, nil
 }
 
 func (a *clustersReconciler) controllerFor(acName string) (*remoteClient, bool) {
@@ -343,9 +397,13 @@ func (c *clustersReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 		return reconcile.Result{}, c.updateStatus(ctx, cluster, false, "BadConfig", err.Error())
 	}
 
-	if err := c.setRemoteClientConfig(ctx, cluster.Name, kubeConfig, c.origin); err != nil {
-		log.Error(err, "setting kubeconfig")
-		return reconcile.Result{}, c.updateStatus(ctx, cluster, false, "ClientConnectionFailed", err.Error())
+	if retryAfter, err := c.setRemoteClientConfig(ctx, cluster.Name, kubeConfig, c.origin); err != nil {
+		log.Error(err, "setting kubeconfig", "retryAfter", retryAfter)
+		if err := c.updateStatus(ctx, cluster, false, "ClientConnectionFailed", err.Error()); err != nil {
+			return reconcile.Result{}, err
+		} else {
+			return reconcile.Result{RequeueAfter: ptr.Deref(retryAfter, 0)}, nil
+		}
 	}
 	return reconcile.Result{}, c.updateStatus(ctx, cluster, true, "Active", "Connected")
 }
@@ -433,9 +491,10 @@ func newClustersReconciler(c client.Client, namespace string, gcInterval time.Du
 		localClient:     c,
 		configNamespace: namespace,
 		remoteClients:   make(map[string]*remoteClient),
-		wlUpdateCh:      make(chan event.GenericEvent, 10),
+		wlUpdateCh:      make(chan event.GenericEvent, eventChBufferSize),
 		gcInterval:      gcInterval,
 		origin:          origin,
+		watchEndedCh:    make(chan event.GenericEvent, eventChBufferSize),
 	}
 }
 
@@ -445,9 +504,18 @@ func (c *clustersReconciler) setupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	syncHndl := handler.Funcs{
+		GenericFunc: func(_ context.Context, e event.GenericEvent, q workqueue.RateLimitingInterface) {
+			q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+				Name: e.Object.GetName(),
+			}})
+		},
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kueuealpha.MultiKueueCluster{}).
 		Watches(&corev1.Secret{}, &secretHandler{client: c.localClient}).
+		WatchesRawSource(&source.Channel{Source: c.watchEndedCh}, syncHndl).
 		Complete(c)
 }
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -74,7 +74,7 @@ func newTestClient(config string, watchCancel func()) *remoteClient {
 	return ret
 }
 
-func setForceReconnectandAttempts(rc *remoteClient, a uint) *remoteClient {
+func setReconnectState(rc *remoteClient, a uint) *remoteClient {
 	rc.failedConnAttempts = a
 	rc.forceReconnect.Store(true)
 	return rc
@@ -226,7 +226,7 @@ func TestUpdateConfig(t *testing.T) {
 				"worker1": newTestClient("worker1 old kubeconfig", cancelCalled),
 			},
 			wantRemoteClients: map[string]*remoteClient{
-				"worker1": setForceReconnectandAttempts(newTestClient("nowatch", nil), 1),
+				"worker1": setReconnectState(newTestClient("nowatch", nil), 1),
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Active(metav1.ConditionFalse, "ClientConnectionFailed", "client cannot watch").Obj(),
@@ -243,10 +243,10 @@ func TestUpdateConfig(t *testing.T) {
 				makeTestSecret("worker1", "nowatch"),
 			},
 			remoteClients: map[string]*remoteClient{
-				"worker1": setForceReconnectandAttempts(newTestClient("nowatch", cancelCalled), 2),
+				"worker1": setReconnectState(newTestClient("nowatch", cancelCalled), 2),
 			},
 			wantRemoteClients: map[string]*remoteClient{
-				"worker1": setForceReconnectandAttempts(newTestClient("nowatch", nil), 3),
+				"worker1": setReconnectState(newTestClient("nowatch", nil), 3),
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Active(metav1.ConditionFalse, "ClientConnectionFailed", "client cannot watch").Obj(),
@@ -266,7 +266,7 @@ func TestUpdateConfig(t *testing.T) {
 				makeTestSecret("worker1", "good config"),
 			},
 			remoteClients: map[string]*remoteClient{
-				"worker1": setForceReconnectandAttempts(newTestClient("nowatch", cancelCalled), 5),
+				"worker1": setReconnectState(newTestClient("nowatch", cancelCalled), 5),
 			},
 			wantRemoteClients: map[string]*remoteClient{
 				"worker1": newTestClient("good config", nil),
@@ -291,7 +291,7 @@ func TestUpdateConfig(t *testing.T) {
 				makeTestSecret("worker1", "invalid"),
 			},
 			remoteClients: map[string]*remoteClient{
-				"worker1": setForceReconnectandAttempts(newTestClient("nowatch", cancelCalled), 5),
+				"worker1": setReconnectState(newTestClient("nowatch", cancelCalled), 5),
 			},
 			wantRemoteClients: map[string]*remoteClient{
 				"worker1": newTestClient("invalid", nil),

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package multikueue
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -26,7 +28,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
@@ -38,6 +42,7 @@ import (
 
 var (
 	errInvalidConfig = errors.New("invalid kubeconfig")
+	errCannotWatch   = errors.New("client cannot watch")
 )
 
 func fakeClientBuilder(kubeconfig []byte, options client.Options) (client.WithWatch, error) {
@@ -45,24 +50,34 @@ func fakeClientBuilder(kubeconfig []byte, options client.Options) (client.WithWa
 		return nil, errInvalidConfig
 	}
 	b, _ := getClientBuilder()
+	b = b.WithInterceptorFuncs(interceptor.Funcs{
+		Watch: func(ctx context.Context, client client.WithWatch, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
+			if string(kubeconfig) == "nowatch" {
+				return nil, errCannotWatch
+			}
+			return client.Watch(ctx, obj, opts...)
+		},
+	})
 	return b.Build(), nil
 }
 
-func newTestClient(config string) *remoteClient {
+func newTestClient(config string, watchCancel func()) *remoteClient {
 	b, _ := getClientBuilder()
 	localClient := b.Build()
 	ret := &remoteClient{
 		kubeconfig:  []byte(config),
 		localClient: localClient,
+		watchCancel: watchCancel,
 
 		builderOverride: fakeClientBuilder,
 	}
-	ret.watchCancel = map[string]func(){
-		"test": func() {
-			ret.kubeconfig = []byte(string(ret.kubeconfig) + " canceled")
-		},
-	}
 	return ret
+}
+
+func setForceReconnectandAttempts(rc *remoteClient, a uint) *remoteClient {
+	rc.failedConnAttempts = a
+	rc.forceReconnect.Store(true)
+	return rc
 }
 
 func makeTestSecret(name string, kubeconfig string) corev1.Secret {
@@ -78,6 +93,9 @@ func makeTestSecret(name string, kubeconfig string) corev1.Secret {
 }
 
 func TestUpdateConfig(t *testing.T) {
+	cancelCalledCount := 0
+	cancelCalled := func() { cancelCalledCount++ }
+
 	cases := map[string]struct {
 		reconcileFor  string
 		remoteClients map[string]*remoteClient
@@ -86,6 +104,8 @@ func TestUpdateConfig(t *testing.T) {
 
 		wantRemoteClients map[string]*remoteClient
 		wantClusters      []kueuealpha.MultiKueueCluster
+		wantRequeueAfter  time.Duration
+		wantCancelCalled  int
 	}{
 		"new valid client is added": {
 			reconcileFor: "worker1",
@@ -113,7 +133,7 @@ func TestUpdateConfig(t *testing.T) {
 				makeTestSecret("worker1", "worker1 kubeconfig"),
 			},
 			remoteClients: map[string]*remoteClient{
-				"worker1": newTestClient("worker1 old kubeconfig"),
+				"worker1": newTestClient("worker1 old kubeconfig", cancelCalled),
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Active(metav1.ConditionTrue, "Active", "Connected").Obj(),
@@ -123,6 +143,7 @@ func TestUpdateConfig(t *testing.T) {
 					kubeconfig: []byte("worker1 kubeconfig"),
 				},
 			},
+			wantCancelCalled: 1,
 		},
 		"update client with valid path config": {
 			reconcileFor: "worker1",
@@ -130,7 +151,7 @@ func TestUpdateConfig(t *testing.T) {
 				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.PathLocationType, "testdata/worker1KubeConfig").Obj(),
 			},
 			remoteClients: map[string]*remoteClient{
-				"worker1": newTestClient("worker1 old kubeconfig"),
+				"worker1": newTestClient("worker1 old kubeconfig", cancelCalled),
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.PathLocationType, "testdata/worker1KubeConfig").Active(metav1.ConditionTrue, "Active", "Connected").Obj(),
@@ -140,6 +161,7 @@ func TestUpdateConfig(t *testing.T) {
 					kubeconfig: []byte("worker1 kubeconfig"),
 				},
 			},
+			wantCancelCalled: 1,
 		},
 		"update client with invalid secret config": {
 			reconcileFor: "worker1",
@@ -150,11 +172,15 @@ func TestUpdateConfig(t *testing.T) {
 				makeTestSecret("worker1", "invalid"),
 			},
 			remoteClients: map[string]*remoteClient{
-				"worker1": newTestClient("worker1 old kubeconfig"),
+				"worker1": newTestClient("worker1 old kubeconfig", cancelCalled),
+			},
+			wantRemoteClients: map[string]*remoteClient{
+				"worker1": newTestClient("invalid", nil),
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Active(metav1.ConditionFalse, "ClientConnectionFailed", "invalid kubeconfig").Obj(),
 			},
+			wantCancelCalled: 1,
 		},
 		"update client with invalid path config": {
 			reconcileFor: "worker1",
@@ -162,11 +188,12 @@ func TestUpdateConfig(t *testing.T) {
 				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.PathLocationType, "").Obj(),
 			},
 			remoteClients: map[string]*remoteClient{
-				"worker1": newTestClient("worker1 old kubeconfig"),
+				"worker1": newTestClient("worker1 old kubeconfig", cancelCalled),
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.PathLocationType, "").Active(metav1.ConditionFalse, "BadConfig", "open : no such file or directory").Obj(),
 			},
+			wantCancelCalled: 1,
 		},
 		"missing cluster is removed": {
 			reconcileFor: "worker2",
@@ -174,8 +201,8 @@ func TestUpdateConfig(t *testing.T) {
 				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Obj(),
 			},
 			remoteClients: map[string]*remoteClient{
-				"worker1": newTestClient("worker1 kubeconfig"),
-				"worker2": newTestClient("worker2 kubeconfig"),
+				"worker1": newTestClient("worker1 kubeconfig", cancelCalled),
+				"worker2": newTestClient("worker2 kubeconfig", cancelCalled),
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Obj(),
@@ -185,6 +212,97 @@ func TestUpdateConfig(t *testing.T) {
 					kubeconfig: []byte("worker1 kubeconfig"),
 				},
 			},
+			wantCancelCalled: 1,
+		},
+		"update client config, nowatch": {
+			reconcileFor: "worker1",
+			clusters: []kueuealpha.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Obj(),
+			},
+			secrets: []corev1.Secret{
+				makeTestSecret("worker1", "nowatch"),
+			},
+			remoteClients: map[string]*remoteClient{
+				"worker1": newTestClient("worker1 old kubeconfig", cancelCalled),
+			},
+			wantRemoteClients: map[string]*remoteClient{
+				"worker1": setForceReconnectandAttempts(newTestClient("nowatch", nil), 1),
+			},
+			wantClusters: []kueuealpha.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Active(metav1.ConditionFalse, "ClientConnectionFailed", "client cannot watch").Obj(),
+			},
+			wantRequeueAfter: 5 * time.Second,
+			wantCancelCalled: 1,
+		},
+		"update client config, nowatch 3rd try": {
+			reconcileFor: "worker1",
+			clusters: []kueuealpha.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Active(metav1.ConditionFalse, "ClientConnectionFailed", "client cannot watch").Obj(),
+			},
+			secrets: []corev1.Secret{
+				makeTestSecret("worker1", "nowatch"),
+			},
+			remoteClients: map[string]*remoteClient{
+				"worker1": setForceReconnectandAttempts(newTestClient("nowatch", cancelCalled), 2),
+			},
+			wantRemoteClients: map[string]*remoteClient{
+				"worker1": setForceReconnectandAttempts(newTestClient("nowatch", nil), 3),
+			},
+			wantClusters: []kueuealpha.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "worker1").Active(metav1.ConditionFalse, "ClientConnectionFailed", "client cannot watch").Obj(),
+			},
+			wantRequeueAfter: 20 * time.Second,
+			wantCancelCalled: 1,
+		},
+		"failed attempts are set to 0 on successful connection": {
+			reconcileFor: "worker1",
+			clusters: []kueuealpha.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").
+					KubeConfig(kueuealpha.SecretLocationType, "worker1").
+					Active(metav1.ConditionFalse, "ClientConnectionFailed", "client cannot watch").
+					Obj(),
+			},
+			secrets: []corev1.Secret{
+				makeTestSecret("worker1", "good config"),
+			},
+			remoteClients: map[string]*remoteClient{
+				"worker1": setForceReconnectandAttempts(newTestClient("nowatch", cancelCalled), 5),
+			},
+			wantRemoteClients: map[string]*remoteClient{
+				"worker1": newTestClient("good config", nil),
+			},
+			wantClusters: []kueuealpha.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").
+					KubeConfig(kueuealpha.SecretLocationType, "worker1").
+					Active(metav1.ConditionTrue, "Active", "Connected").
+					Obj(),
+			},
+			wantCancelCalled: 1,
+		},
+		"failed attempts are set to 0 on config change": {
+			reconcileFor: "worker1",
+			clusters: []kueuealpha.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").
+					KubeConfig(kueuealpha.SecretLocationType, "worker1").
+					Active(metav1.ConditionFalse, "ClientConnectionFailed", "client cannot watch").
+					Obj(),
+			},
+			secrets: []corev1.Secret{
+				makeTestSecret("worker1", "invalid"),
+			},
+			remoteClients: map[string]*remoteClient{
+				"worker1": setForceReconnectandAttempts(newTestClient("nowatch", cancelCalled), 5),
+			},
+			wantRemoteClients: map[string]*remoteClient{
+				"worker1": newTestClient("invalid", nil),
+			},
+			wantClusters: []kueuealpha.MultiKueueCluster{
+				*utiltesting.MakeMultiKueueCluster("worker1").
+					KubeConfig(kueuealpha.SecretLocationType, "worker1").
+					Active(metav1.ConditionFalse, "ClientConnectionFailed", "invalid kubeconfig").
+					Obj(),
+			},
+			wantCancelCalled: 1,
 		},
 	}
 
@@ -204,9 +322,18 @@ func TestUpdateConfig(t *testing.T) {
 			}
 			reconciler.builderOverride = fakeClientBuilder
 
-			_, gotErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.reconcileFor}})
+			cancelCalledCount = 0
+			res, gotErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.reconcileFor}})
 			if gotErr != nil {
 				t.Errorf("unexpected reconcile error: %s", gotErr)
+			}
+
+			if diff := cmp.Diff(tc.wantRequeueAfter, res.RequeueAfter); diff != "" {
+				t.Errorf("unexpected requeue after (-want/+got):\n%s", diff)
+			}
+
+			if tc.wantCancelCalled != cancelCalledCount {
+				t.Errorf("unexpected watch cancel call count want: %d,  got: %d", tc.wantCancelCalled, cancelCalledCount)
 			}
 
 			lst := &kueuealpha.MultiKueueClusterList{}
@@ -222,7 +349,12 @@ func TestUpdateConfig(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.wantRemoteClients, reconciler.remoteClients, cmpopts.EquateEmpty(),
-				cmp.Comparer(func(a, b remoteClient) bool { return string(a.kubeconfig) == string(b.kubeconfig) })); diff != "" {
+				cmp.Comparer(func(a, b *remoteClient) bool {
+					if a.failedConnAttempts != b.failedConnAttempts {
+						return false
+					}
+					return string(a.kubeconfig) == string(b.kubeconfig)
+				})); diff != "" {
 				t.Errorf("unexpected controllers (-want/+got):\n%s", diff)
 			}
 		})
@@ -341,7 +473,7 @@ func TestRemoteClientGC(t *testing.T) {
 			worker1Builder = worker1Builder.WithLists(&kueue.WorkloadList{Items: tc.workersWorkloads}, &batchv1.JobList{Items: tc.workersJobs})
 			worker1Client := worker1Builder.Build()
 
-			w1remoteClient := newRemoteClient(managerClient, nil, defaultOrigin)
+			w1remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "")
 			w1remoteClient.client = worker1Client
 
 			w1remoteClient.runGC(ctx)

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -451,7 +451,7 @@ func TestWlReconcile(t *testing.T) {
 			worker1Builder = worker1Builder.WithLists(&kueue.WorkloadList{Items: tc.worker1Workloads}, &batchv1.JobList{Items: tc.worker1Jobs})
 			worker1Client := worker1Builder.Build()
 
-			w1remoteClient := newRemoteClient(managerClient, nil, defaultOrigin)
+			w1remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "")
 			w1remoteClient.client = worker1Client
 			cRec.remoteClients["worker1"] = w1remoteClient
 
@@ -481,7 +481,7 @@ func TestWlReconcile(t *testing.T) {
 				})
 				worker2Client = worker2Builder.Build()
 
-				w2remoteClient := newRemoteClient(managerClient, nil, defaultOrigin)
+				w2remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "")
 				w2remoteClient.client = worker2Client
 				cRec.remoteClients["worker2"] = w2remoteClient
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

[multikueue] Cluster connection monitoring and reconnect.  Try to reconnect to the worker cluster when any of its watch loops ends.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fix #1787
Relates to #693 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added MultiKueue  worker connection monitoring and reconnect. 
```