### PR TITLE
Enable govet linter; disable vet in make verify

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,9 @@ linters-settings:
       - dupImport
   goimports:
     local-prefixes: sigs.k8s.io/kueue
+  govet:
+    enable:
+      - nilness
 
 # Settings for enabling and disabling linters
 linters:
@@ -21,5 +24,6 @@ linters:
     - ginkgolinter
     - gocritic
     - goimports
+    - govet
     - misspell
     - unconvert

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ ci-lint: golangci-lint
 	$(GOLANGCI_LINT) run --timeout 15m0s
 
 .PHONY: verify
-verify: gomod-verify vet ci-lint fmt-verify shell-lint toc-verify manifests generate update-helm generate-apiref prepare-release-branch
+verify: gomod-verify ci-lint fmt-verify shell-lint toc-verify manifests generate update-helm generate-apiref prepare-release-branch
 	git --no-pager diff --exit-code config/components apis charts/kueue/templates client-go site/
 
 ##@ Build

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -292,9 +292,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		err := r.stopJob(ctx, job, wl, StopReasonWorkloadDeleted, "Workload is deleted")
 		if err != nil {
 			log.Error(err, "Suspending job with deleted workload")
-		}
-
-		if err == nil && wl != nil {
+		} else {
 			err = workload.RemoveFinalizer(ctx, r.client, wl)
 		}
 		return ctrl.Result{}, err


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The PR enables `govet`, removes `vet` from `verify` make target; fixes `govet.nilness` issue.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

`govet` is enabled in the https://github.com/kubernetes/kubernetes/blob/e0621034bedeeabe83383e5c300cf2d4fb616f36/hack/golangci.yaml#L136, so I've also enabled it here with all default analyzers and `nilness` analyzer.

So, the whole enabled `govet` analyzers list looks like this:
```
❯ GL_DEBUG=govet ./golangci-lint run
...
DEBU [govet] Enabled by config analyzers (33): [appends asmdecl assign atomic bools buildtag cgocall composites copylocks defers directive errorsas framepointer httpresponse ifaceassert loopclosure lostcancel nilfunc nilness printf shift sigchanyzer slog stdmethods stringintconv structtag testinggoroutine tests timeformat unmarshal unreachable unsafeptr unusedresult] 
```

*Note, that debug flag `GL_DEBUG=govet` was added to golangci-lint [today](https://github.com/golangci/golangci-lint/pull/4465) and will be available with golangci-lint v1.57.0 (not yet released)*.

To speed up CI, the PR removes `vet` make target from `verify`. This is because running `go vet ./...` is equivalent to  running golangci-lint with the `govet` linter. 

Additionally, this PR removes the unnecessary check for `nil` detected by the `govet.nilness`:
```
pkg/controller/jobframework/reconciler.go:297:23: nilness: tautological condition: non-nil != nil (govet)
                if err == nil && wl != nil {
                                    ^
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```