### PR TITLE
[performance test] Fix cluster-queue template and update api version

### DIFF
--- a/test/performance/local-queue.yaml
+++ b/test/performance/local-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1alpha2
+apiVersion: kueue.x-k8s.io/v1beta1
 kind: LocalQueue
 metadata:
   name: {{.Name}}

--- a/test/performance/prerequisites/cluster-queue.template
+++ b/test/performance/prerequisites/cluster-queue.template
@@ -1,17 +1,15 @@
-apiVersion: kueue.x-k8s.io/v1alpha2
+apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
 metadata:
   name: default-cluster-queue
 spec:
   namespaceSelector: {}
-  resources:
-    - name: "cpu"
-      flavors:
-        - name: default
-          quota:
-            min: 100
-    - name: "memory"
-      flavors:
-        - name: default
-          quota:
-            min: 50Gi
+  resourceGroups:
+  - coveredResources: ["cpu", "memory"]
+    flavors:
+    - name: "default"
+      resources:
+      - name: "cpu"
+        nominalQuota: 100
+      - name: "memory"
+        nominalQuota: 50Gi

--- a/test/performance/prerequisites/resource-flavor.yaml
+++ b/test/performance/prerequisites/resource-flavor.yaml
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1alpha2
+apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor
 metadata:
   name: default

--- a/test/performance/run-test.sh
+++ b/test/performance/run-test.sh
@@ -78,8 +78,8 @@ for item in "${EXPERIMENTS[@]}"; do
     echo "Running an experiment with [$CL2_SMALL_JOBS, $CL2_MEDIUM_JOBS, $CL2_LARGE_JOBS, $CL2_JOB_RUNNING_TIME, $CL2_TEST_TIMEOUT, $cores, $memory]"
     if [[ "$USE_KUEUE" == true ]]; then
         cp prerequisites/cluster-queue.template prerequisites/cluster-queue.yaml        
-        yq -i e ".spec.resources[0].flavors[0].quota.min=$cores" prerequisites/cluster-queue.yaml
-        yq -i e ".spec.resources[1].flavors[0].quota.min=\"$memory\"" prerequisites/cluster-queue.yaml
+        yq -i e ".spec.resourceGroups[0].flavors[0].resources[0].nominalQuota=$cores" prerequisites/cluster-queue.yaml
+        yq -i e ".spec.resourceGroups[0].flavors[0].resources[1].nominalQuota=\"$memory\"" prerequisites/cluster-queue.yaml
         kubectl apply -f prerequisites/cluster-queue.yaml
     fi
     "$CL2_HOME_DIR/$CL2_BINARY_NAME" \


### PR DESCRIPTION
Update the api version from v1alpha2 to v1beta1, and update cluster-template as cluster-queue API has changed in the meantime

/kind cleanup
/kind failing-test

#### Does this PR introduce a user-facing change?
```release-note
NONE
```