### PR TITLE
[doc] Add steps how to access VisibilityOnDemand via curl 

### DIFF
--- a/site/content/en/docs/tasks/monitor_pending_workloads/pending_workloads_on_demand.md
+++ b/site/content/en/docs/tasks/monitor_pending_workloads/pending_workloads_on_demand.md
@@ -26,6 +26,21 @@ Make sure the following conditions are met:
 
 VisibilityOnDemand is an `Alpha` feature disabled by default, check the [Change the feature gates configuration](/docs/installation/#change-the-feature-gates-configuration) section of the [Installation](/docs/installation/) for details.
 
+#### Accessing Cluster and Local Queue via curl
+
+To view pending workloads in ClusterQueue or LocalQueue via curl on kube-api, you first need to create a secret which holds authorization token
+as described here in [Directly accessing the REST API -> Without kubectl proxy](https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/#without-kubectl-proxy).
+
+You then need to create ClusterRole and ClusterRoleBinding for that same account
+
+{{< include "examples/admin/cluster-role-and-binding.yaml" "yaml" >}}
+
+using a command:
+
+```shell
+kubectl apply -f https://kueue.sigs.k8s.io/examples/admin/cluster-role-and-binding.yaml
+```
+
 ## Monitor pending workloads on demand
 
 > _Available in Kueue v0.6.0 and later_
@@ -44,13 +59,13 @@ Now, let's create 10 jobs
 
 {{< include "examples/jobs/sample-job.yaml" "yaml" >}}
 
-using a command: 
+using a command:
 
 ```shell
 for i in {1..6}; do kubectl create -f https://kueue.sigs.k8s.io/examples/jobs/sample-job.yaml; done
 ```
 
-### Cluster Queue visibility
+### Cluster Queue visibility via kubectl
 
 To view pending workloads in ClusterQueue `cluster-queue` run the following command:
 
@@ -139,7 +154,7 @@ To view only 1 pending workloads use, starting from position 1 in ClusterQueue r
 kubectl get --raw "/apis/visibility.kueue.x-k8s.io/v1alpha1/clusterqueues/cluster-queue/pendingworkloads?limit=1&offset=1"
 ```
 
-You should get results similar to 
+You should get results similar to
 
 ``` json
 {
@@ -172,7 +187,91 @@ You should get results similar to
 }
 ```
 
-### Local Queue visibility
+### Cluster Queue visibility via curl on kube-api
+
+If you followed steps described in [Accessing Cluster/Local Queue via curl](#accessing-cluster-and-local-queue-via-curl) above,
+you can use curl (and jq) to view pending workloads in ClusterQueue `cluster-queue` using following commands:
+
+```bash
+export CLUSTER_NAME="some_server_name"
+TOKEN=$(kubectl get secret default-token -o jsonpath='{.data.token}' | base64 --decode)
+APISERVER=$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"$CLUSTER_NAME\")].cluster.server}")
+
+curl -X GET $APISERVER/apis/visibility.kueue.x-k8s.io/v1alpha1/clusterqueues/cluster-queue/pendingworkloads --header "Authorization: Bearer $TOKEN | jq"
+```
+
+You should get results similar to:
+
+```json
+{
+  "kind": "PendingWorkloadsSummary",
+  "apiVersion": "visibility.kueue.x-k8s.io/v1alpha1",
+  "metadata": {
+    "creationTimestamp": null
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "job-sample-job-jrjfr-8d56e",
+        "namespace": "default",
+        "creationTimestamp": "2023-12-05T15:42:03Z",
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": "sample-job-jrjfr",
+            "uid": "5863cf0e-b0e7-43bf-a445-f41fa1abedfa"
+          }
+        ]
+      },
+      "priority": 0,
+      "localQueueName": "user-queue",
+      "positionInClusterQueue": 0,
+      "positionInLocalQueue": 0
+    },
+    {
+      "metadata": {
+        "name": "job-sample-job-jg9dw-5f1a3",
+        "namespace": "default",
+        "creationTimestamp": "2023-12-05T15:42:03Z",
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": "sample-job-jg9dw",
+            "uid": "fd5d1796-f61d-402f-a4c8-cbda646e2676"
+          }
+        ]
+      },
+      "priority": 0,
+      "localQueueName": "user-queue",
+      "positionInClusterQueue": 1,
+      "positionInLocalQueue": 1
+    },
+    {
+      "metadata": {
+        "name": "job-sample-job-t9b8m-4e770",
+        "namespace": "default",
+        "creationTimestamp": "2023-12-05T15:42:03Z",
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": "sample-job-t9b8m",
+            "uid": "64c26c73-6334-4d13-a1a8-38d99196baa5"
+          }
+        ]
+      },
+      "priority": 0,
+      "localQueueName": "user-queue",
+      "positionInClusterQueue": 2,
+      "positionInLocalQueue": 2
+    }
+  ]
+}
+```
+
+### Local Queue visibility via kubectl
 
 Similarly to ClusterQueue, to view pending workloads in LocalQueue `user-queue` run the following command:
 
@@ -259,9 +358,9 @@ To view only 1 pending workloads use, starting from position 1 in LocalQueue run
 
 ```shell
 kubectl get --raw "/apis/visibility.kueue.x-k8s.io/v1alpha1/localqueues/user-queue/pendingworkloads?limit=1&offset=1"
-
 ```
-You should get results similar to 
+
+You should get results similar to
 
 ``` json
 {
@@ -289,6 +388,90 @@ You should get results similar to
       "localQueueName": "user-queue",
       "positionInClusterQueue": 1,
       "positionInLocalQueue": 1
+    }
+  ]
+}
+```
+
+### Local Queue visibility via curl on kube-api
+
+If you followed steps described in Accessing Cluster/Local Queue via curl](#accessing-cluster-and-local-queue-via-curl) above,
+you can use curl (and jq) to view pending workloads in LocalQueue `user-queue` using following commands:
+
+```bash
+export CLUSTER_NAME="some_server_name"
+TOKEN=$(kubectl get secret default-token -o jsonpath='{.data.token}' | base64 --decode)
+APISERVER=$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"$CLUSTER_NAME\")].cluster.server}")
+
+curl -X GET $APISERVER/apis/visibility.kueue.x-k8s.io/v1alpha1/namespaces/default/localqueues/user-queue/pendingworkloads --header "Authorization: Bearer $TOKEN | jq"
+```
+
+You should get results similar to:
+
+``` json
+{
+  "kind": "PendingWorkloadsSummary",
+  "apiVersion": "visibility.kueue.x-k8s.io/v1alpha1",
+  "metadata": {
+    "creationTimestamp": null
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "job-sample-job-jrjfr-8d56e",
+        "namespace": "default",
+        "creationTimestamp": "2023-12-05T15:42:03Z",
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": "sample-job-jrjfr",
+            "uid": "5863cf0e-b0e7-43bf-a445-f41fa1abedfa"
+          }
+        ]
+      },
+      "priority": 0,
+      "localQueueName": "user-queue",
+      "positionInClusterQueue": 0,
+      "positionInLocalQueue": 0
+    },
+    {
+      "metadata": {
+        "name": "job-sample-job-jg9dw-5f1a3",
+        "namespace": "default",
+        "creationTimestamp": "2023-12-05T15:42:03Z",
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": "sample-job-jg9dw",
+            "uid": "fd5d1796-f61d-402f-a4c8-cbda646e2676"
+          }
+        ]
+      },
+      "priority": 0,
+      "localQueueName": "user-queue",
+      "positionInClusterQueue": 1,
+      "positionInLocalQueue": 1
+    },
+    {
+      "metadata": {
+        "name": "job-sample-job-t9b8m-4e770",
+        "namespace": "default",
+        "creationTimestamp": "2023-12-05T15:42:03Z",
+        "ownerReferences": [
+          {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "name": "sample-job-t9b8m",
+            "uid": "64c26c73-6334-4d13-a1a8-38d99196baa5"
+          }
+        ]
+      },
+      "priority": 0,
+      "localQueueName": "user-queue",
+      "positionInClusterQueue": 2,
+      "positionInLocalQueue": 2
     }
   ]
 }

--- a/site/static/examples/admin/cluster-role-and-binding.yaml
+++ b/site/static/examples/admin/cluster-role-and-binding.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kueue-api-get
+rules:
+- apiGroups:
+  - "visibility.kueue.x-k8s.io"
+  resources:
+  - "clusterqueues/pendingworkloads"
+  - "localqueues/pendingworkloads"
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kueue-api-get
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: ClusterRole
+  name: kueue-api-get
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Docs are missing a guide on how to access VisibilityOnDemand via curl, omitting `kubectl get --raw ....`. This is needed if you want to use it programmatically.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```