### PR TITLE
Fix number of reconcilers for Pod integration

### DIFF
--- a/config/components/manager/controller_manager_config.yaml
+++ b/config/components/manager/controller_manager_config.yaml
@@ -13,7 +13,7 @@ leaderElection:
 controller:
   groupKindConcurrency:
     Job.batch: 5
-    Pod.: 5
+    Pod: 5
     Workload.kueue.x-k8s.io: 5
     LocalQueue.kueue.x-k8s.io: 1
     ClusterQueue.kueue.x-k8s.io: 1


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

There were 2 problems:
- The Pod reconciler doesn't use `For`, which controller-runtime uses to map to groupKindConcurrency.
- The GroupKind is actually just `Pod`, not `Pod.`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Thanks to @gabesaba for spotting the problem.
It's not easy to test this issue, but I did a manual run to verify the number of reconcilers.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix the configuration for the number of reconcilers for the Pod integration. It was only reconciling one group at a time.
```