### PR TITLE
WaitForPodsReady: Reset the requeueState while reconciling

### DIFF
--- a/charts/kueue/templates/webhook/webhook.yaml
+++ b/charts/kueue/templates/webhook/webhook.yaml
@@ -289,10 +289,8 @@ webhooks:
           - v1beta1
         operations:
           - CREATE
-          - UPDATE
         resources:
           - workloads
-          - workloads/status
     sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/config/components/webhook/manifests.yaml
+++ b/config/components/webhook/manifests.yaml
@@ -267,10 +267,8 @@ webhooks:
     - v1beta1
     operations:
     - CREATE
-    - UPDATE
     resources:
     - workloads
-    - workloads/status
   sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -50,7 +50,7 @@ func setupWebhookForWorkload(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// +kubebuilder:webhook:path=/mutate-kueue-x-k8s-io-v1beta1-workload,mutating=true,failurePolicy=fail,sideEffects=None,groups=kueue.x-k8s.io,resources=workloads;workloads/status,verbs=create;update,versions=v1beta1,name=mworkload.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-kueue-x-k8s-io-v1beta1-workload,mutating=true,failurePolicy=fail,sideEffects=None,groups=kueue.x-k8s.io,resources=workloads,verbs=create,versions=v1beta1,name=mworkload.kb.io,admissionReviewVersions=v1
 
 var _ webhook.CustomDefaulter = &WorkloadWebhook{}
 
@@ -76,10 +76,6 @@ func (w *WorkloadWebhook) Default(ctx context.Context, obj runtime.Object) error
 		}
 	}
 
-	// If a deactivated workload is re-activated, we need to reset the RequeueState.
-	if ptr.Deref(wl.Spec.Active, true) && workload.IsEvictedByDeactivation(wl) && workload.HasRequeueState(wl) {
-		wl.Status.RequeueState = nil
-	}
 	return nil
 }
 

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -78,22 +78,6 @@ func TestWorkloadWebhookDefault(t *testing.T) {
 				},
 			},
 		},
-		"re-activated workload with re-queue state is reset the re-queue state": {
-			wl: *testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).
-				Condition(metav1.Condition{
-					Type:   kueue.WorkloadEvicted,
-					Status: metav1.ConditionTrue,
-					Reason: kueue.WorkloadEvictedByDeactivation,
-				}).RequeueState(ptr.To[int32](5), ptr.To(metav1.Now())).
-				Obj(),
-			wantWl: *testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).
-				Condition(metav1.Condition{
-					Type:   kueue.WorkloadEvicted,
-					Status: metav1.ConditionTrue,
-					Reason: kueue.WorkloadEvictedByDeactivation,
-				}).
-				Obj(),
-		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/test/integration/webhook/workload_test.go
+++ b/test/integration/webhook/workload_test.go
@@ -82,37 +82,6 @@ var _ = ginkgo.Describe("Workload defaulting webhook", func() {
 
 			gomega.Expect(created.Spec.PodSets[0].Name).Should(gomega.Equal(kueue.DefaultPodSetName))
 		})
-		ginkgo.It("Should reset re-queue state", func() {
-			ginkgo.By("Creating a new inactive Workload")
-			workload := testing.MakeWorkload(workloadName, ns.Name).
-				Active(false).
-				Obj()
-			gomega.Expect(k8sClient.Create(ctx, workload)).Should(gomega.Succeed())
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), workload)).Should(gomega.Succeed())
-				workload.Status = kueue.WorkloadStatus{
-					Conditions: []metav1.Condition{{
-						Type:               kueue.WorkloadEvicted,
-						Reason:             kueue.WorkloadEvictedByDeactivation,
-						Status:             metav1.ConditionTrue,
-						LastTransitionTime: metav1.Now(),
-					}},
-					RequeueState: &kueue.RequeueState{
-						Count:     ptr.To[int32](10),
-						RequeueAt: ptr.To(metav1.Now()),
-					},
-				}
-				g.Expect(k8sClient.Status().Update(ctx, workload)).Should(gomega.Succeed())
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			ginkgo.By("Activate a Workload")
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), workload)).Should(gomega.Succeed())
-				workload.Spec.Active = ptr.To(true)
-				g.Expect(k8sClient.Update(ctx, workload)).Should(gomega.Succeed())
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), workload)).Should(gomega.Succeed())
-				g.Expect(workload.Status.RequeueState).Should(gomega.BeNil(), "re-queue state should be reset")
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		})
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
As @alculquicondor mentioned https://github.com/kubernetes-sigs/kueue/issues/1821#issuecomment-1994761605, mutating webhooks seems not to be possible to update `spec` and `status` in a single webhook call.

So, we must reset requeueState while reconciling instead of webhooks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1821

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
WaitForPodsReady: Fix a bug that the requeueState isn't reset.
```