### PR TITLE
Load shellcheck configuration from the .shellcheckrc

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,31 @@
+# shellcheck configuration file
+# see: https://github.com/koalaman/shellcheck/wiki
+
+# Allow following sourced files that are not specified in the command,
+# we need this because we specify one file at a time in order to trivially
+# detect which files are failing
+external-sources=true
+
+# Currently disabled these errors will take care of them later
+
+# Not following: (error message here)
+# https://github.com/koalaman/shellcheck/wiki/SC1091
+disable=SC1091
+# Since you double quoted this, it will not word split, and the loop will only run once
+# https://github.com/koalaman/shellcheck/wiki/SC2066
+disable=SC2066
+# Double quote to prevent globbing and word splitting
+# https://github.com/koalaman/shellcheck/wiki/SC2086
+disable=SC2086
+# foo appears unused. Verify it or export it
+# https://github.com/koalaman/shellcheck/wiki/SC2034
+disable=SC2034
+# This {/} is literal. Check if ; is missing or quote the expression.
+# https://github.com/koalaman/shellcheck/wiki/SC1083
+disable=SC1083
+# Declare and assign separately to avoid masking return values
+# https://github.com/koalaman/shellcheck/wiki/SC2155
+disable=SC2155
+# Quote this to prevent word splitting
+# https://github.com/koalaman/shellcheck/wiki/SC2046
+disable=SC2046

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -21,21 +21,6 @@ DOCKER="${DOCKER:-docker}"
 SHELLCHECK_VERSION="0.9.0"
 SHELLCHECK_IMAGE="docker.io/koalaman/shellcheck-alpine:v0.9.0@sha256:e19ed93c22423970d56568e171b4512c9244fc75dd9114045016b4a0073ac4b7"
 
-SHELLCHECK_DISABLED="SC2002,SC3028,SC3054,SC3014,SC3040,SC3046,SC3030,SC3010,SC3037,SC3045,SC3006,SC3018,SC3016,SC3011,SC3044,SC3043,SC3060,SC3024,SC1091,SC2066,SC2086,SC2034,SC1083,SC1009,SC1073,SC1072,SC2155,SC2046"
-# common arguments we'll pass to shellcheck
-SHELLCHECK_OPTIONS=(
-  # allow following sourced files that are not specified in the command,
-  # we need this because we specify one file at a time in order to trivially
-  # detect which files are failing
-  "--external-sources"
-  # include our disabled lints
-  "--exclude=${SHELLCHECK_DISABLED}"
-  # set colorized output
-  "--color=${SHELLCHECK_COLORIZED_OUTPUT}"
-)
-
-# Currently disabled these errors will take care of them later
-
 scripts_to_check=("$@")
 if [[ "$#" == 0 ]]; then
   # Find all shell scripts excluding:
@@ -60,11 +45,12 @@ fi
 echo "Downloading ShellCheck Docker image..."
 "${DOCKER}" pull "${SHELLCHECK_IMAGE}"
 
-# Run ShellCheck on all shell script files, excluding those in the 'vendor' directory
+# Run ShellCheck on all shell script files, excluding those in the 'vendor' directory.
+# Configuration loaded from the .shelcheckrc file.
 echo "Running ShellCheck..."
 "${DOCKER}" run \
   --rm -v "$(pwd)" -w "$(pwd)" \
     "${SHELLCHECK_IMAGE}" \
-  shellcheck "${SHELLCHECK_OPTIONS[@]}" "${scripts_to_check[@]}" >&2 || res=$?
+  shellcheck "--color=${SHELLCHECK_COLORIZED_OUTPUT}" "${scripts_to_check[@]}" >&2 || res=$?
 
 echo "Shellcheck ran successfully"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add `.shelcheckrc` to store `shellcheck` configuration to improve readability and maintainability.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Updates #1518

#### Special notes for your reviewer:

I'm aware that the Kubernetes project uses the `SHELLCHECK_DISABLED` variable in [`hack/verify-shellcheck.sh`](https://github.com/kubernetes/kubernetes/blob/d1a2a134c532109540025c990697a6900c2e62fc/hack/verify-shellcheck.sh#L54) to ignore issues, rather than using a `.shellcheckrc` file. This is due to historical reasons: when Kubernetes first introduced `shellcheck`, it did not support config files.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```