### PR TITLE
Flaky integration test "RayCluster Job controller interacting with scheduler" 

### DIFF
--- a/test/integration/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/controller/jobs/raycluster/raycluster_controller_test.go
@@ -602,7 +602,7 @@ var _ = ginkgo.Describe("RayCluster Job controller interacting with scheduler", 
 				Should(gomega.Succeed())
 			return *createdJob2.Spec.Suspend
 		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
+		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
 		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
 
 		ginkgo.By("deleting the job", func() {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind flake

#### What this PR does / why we need it:
When there's a no fit Job the inadmissible count for `ExpectPendingWorkloadsMetric()` should be 1

#### Which issue(s) this PR fixes:
Fixes #1829 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note

```