### PR TITLE
[doc] fix website broken links

### DIFF
--- a/site/content/en/docs/admission-check-controllers/provisioning.md
+++ b/site/content/en/docs/admission-check-controllers/provisioning.md
@@ -6,7 +6,7 @@ description: >
   An admission check controller providing kueue integration with cluster autoscaler.
 ---
 
-The Provisioning Admission Check Controller is an Admission Check Controller designed to integrate Kueue with [Kubernetes cluster-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler). Its primary function is to create [ProvisioningRequests](https://github.com/kubernetes/autoscaler/blob/4872bddce2bcc5b4a5f6a3d569111c11b8a2baf4/cluster-autoscaler/provisioningrequest/apis/autoscaling.x-k8s.io/v1beta1/types.go#L41) for the workloads holding [Quota Reservation](docs/concepts/#quota-reservation) and keeping the [AdmissionCheckState](/docs/concepts/admission_check/#admissioncheckstate) in sync.
+The Provisioning Admission Check Controller is an Admission Check Controller designed to integrate Kueue with [Kubernetes cluster-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler). Its primary function is to create [ProvisioningRequests](https://github.com/kubernetes/autoscaler/blob/4872bddce2bcc5b4a5f6a3d569111c11b8a2baf4/cluster-autoscaler/provisioningrequest/apis/autoscaling.x-k8s.io/v1beta1/types.go#L41) for the workloads holding [Quota Reservation](/docs/concepts/#quota-reservation) and keeping the [AdmissionCheckState](/docs/concepts/admission_check/#admissioncheckstate) in sync.
 
 The controller is part of kueue. You can enable it by setting the `ProvisioningACC` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
 

--- a/site/content/en/docs/concepts/workload.md
+++ b/site/content/en/docs/concepts/workload.md
@@ -48,7 +48,7 @@ spec:
 ```
 ## Active
 
-You can stop or resume a running workload by setting the [Active](/docs/reference/kueue.v1.beta1#kueue-x-k8s-io-v1beta1-WorkloadSpec) field. The active field determines if a workload can be admitted into a queue or continue running, if already admitted.
+You can stop or resume a running workload by setting the [Active](/docs/reference/kueue.v1beta1#kueue-x-k8s-io-v1beta1-WorkloadSpec) field. The active field determines if a workload can be admitted into a queue or continue running, if already admitted.
 Changing `.spec.Active` from true to false will cause a running workload to be evicted and not be requeued.
 
 ## Queue name

--- a/site/content/en/docs/contribution guidelines/_index.md
+++ b/site/content/en/docs/contribution guidelines/_index.md
@@ -6,7 +6,7 @@ description: >
   How to contribute to Kueue
 ---
 
-Welcome to Kubernetes. We are excited about the prospect of you joining our [community](https://git.k8s.io/community)! The Kubernetes community abides by the CNCF [code of conduct](code-of-conduct.md). Here is an excerpt:
+Welcome to Kubernetes. We are excited about the prospect of you joining our [community](https://git.k8s.io/community)! The Kubernetes community abides by the CNCF [code of conduct](https://git.k8s.io/community/code-of-conduct.md). Here is an excerpt:
 
 _As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities._
 

--- a/site/content/en/docs/tasks/_index.md
+++ b/site/content/en/docs/tasks/_index.md
@@ -26,7 +26,7 @@ As a batch administrator, you can learn how to:
 - As a batch administrator, you can learn how to
   [monitor pending workloads](/docs/tasks/monitor_pending_workloads).
 - As a batch administrator, you can learn how to [run a Kueue managed Jobs with a custom WorkloadPriority](/docs/tasks/run_job_with_workload_priority).
-- As a batch administrator, you can learn how to [setup a MultiKueue environment](/docs/tasks/setup_multikue).
+- As a batch administrator, you can learn how to [setup a MultiKueue environment](/docs/tasks/setup_multikueue).
 
 ### Batch user
 

--- a/site/content/en/docs/tasks/run_python_jobs.md
+++ b/site/content/en/docs/tasks/run_python_jobs.md
@@ -375,5 +375,5 @@ pi is approximately 3.1410376000000002
 ```
 
 That looks like pi! 🎉️🥧️
-If you are interested in running this same example with YAML outside of Python, see [Run an MPIJob](/docs/tasks/run_mpi_jobs/).
+If you are interested in running this same example with YAML outside of Python, see [Run an MPIJob](/docs/tasks/run_kubeflow_jobs/run_mpijobs/).
 

--- a/site/content/en/docs/tasks/setup_sequential_admission.md
+++ b/site/content/en/docs/tasks/setup_sequential_admission.md
@@ -91,7 +91,7 @@ you should set the timestamp to the `Creation`.
 Kueue will re-queue a Workload evicted by the `PodsReadyTimeout` reason until the number of re-queues reaches `backoffLimitCount`.
 If you don't specify any value for `backoffLimitCount`,
 a Workload is repeatedly and endlessly re-queued to the queue based on the `timestamp`.
-Once the number of re-queues reaches the limit, Kueue [deactivates the Workload](docs/concepts/workload/#active).
+Once the number of re-queues reaches the limit, Kueue [deactivates the Workload](/docs/concepts/workload/#active).
 
 ## Example
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Fixes broken URLs on https://kueue.sigs.k8s.io/

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Broken links found by the [linkchecker](https://linkchecker.github.io/linkchecker/).

<details>
<summary>linkchecker output</summary>

```
❯ linkchecker --no-warnings https://kueue.sigs.k8s.io/
INFO linkcheck.cmdline 2024-03-15 22:18:12,314 MainThread Checking intern URLs only; use --check-extern to check extern URLs.
LinkChecker 10.4.0
Copyright (C) 2000-2016 Bastian Kleineidam, 2010-2023 LinkChecker Authors
LinkChecker comes with ABSOLUTELY NO WARRANTY!
This is free software, and you are welcome to redistribute it under
certain conditions. Look at the file `COPYING' within this distribution.
Read the documentation at https://linkchecker.github.io/linkchecker/
Write comments and bugs to https://github.com/linkchecker/linkchecker/issues

Start checking at 2024-03-15 22:18:12+003
10 threads active,    10 links queued,   12 links in  32 URLs checked, runtime 1 seconds
10 threads active,     1 link queued,   41 links in  52 URLs checked, runtime 6 seconds
10 threads active,    34 links queued,   82 links in 126 URLs checked, runtime 11 seconds
10 threads active,    55 links queued,  175 links in 240 URLs checked, runtime 16 seconds
10 threads active,    63 links queued,  276 links in 349 URLs checked, runtime 21 seconds
10 threads active,    62 links queued,  399 links in 471 URLs checked, runtime 26 seconds
10 threads active,    50 links queued,  424 links in 484 URLs checked, runtime 31 seconds

URL        `/docs/reference/kueue.v1.beta1#kueue-x-k8s-io-v1beta1-WorkloadSpec'
Name       `Active'
Parent URL https://kueue.sigs.k8s.io/docs/concepts/workload/, line 324, col 61
Real URL   https://kueue.sigs.k8s.io/docs/reference/kueue.v1.beta1#kueue-x-k8s-io-v1beta1-WorkloadSpec
Check time 3.648 seconds
Result     Error: 404 Not Found

URL        `/docs/tasks/setup_multikue'
Name       `setup a MultiKueue environment'
Parent URL https://kueue.sigs.k8s.io/docs/tasks/, line 287, col 52
Real URL   https://kueue.sigs.k8s.io/docs/tasks/setup_multikue
Check time 3.583 seconds
Result     Error: 404 Not Found
10 threads active,    37 links queued,  437 links in 484 URLs checked, runtime 36 seconds

URL        `docs/concepts/workload/#active'
Name       `deactivates the Workload'
Parent URL https://kueue.sigs.k8s.io/docs/tasks/setup_sequential_admission/, line 357, col 55
Real URL   https://kueue.sigs.k8s.io/docs/tasks/setup_sequential_admission/docs/concepts/workload/#active
Check time 3.746 seconds
Result     Error: 404 Not Found
10 threads active,    22 links queued,  452 links in 484 URLs checked, runtime 41 seconds
10 threads active,     6 links queued,  468 links in 484 URLs checked, runtime 46 seconds

URL        `/docs/tasks/run_mpi_jobs/'
Name       `Run an MPIJob'
Parent URL https://kueue.sigs.k8s.io/docs/tasks/run_python_jobs/, line 1029, col 85
Real URL   https://kueue.sigs.k8s.io/docs/tasks/run_mpi_jobs/
Check time 4.050 seconds
Result     Error: 404 Not Found
 5 threads active,     0 links queued,  479 links in 484 URLs checked, runtime 51 seconds

URL        `docs/concepts/#quota-reservation'
Name       `Quota Reservation'
Parent URL https://kueue.sigs.k8s.io/docs/admission-check-controllers/provisioning/, line 280, col 495
Real URL   https://kueue.sigs.k8s.io/docs/admission-check-controllers/provisioning/docs/concepts/#quota-reservation
Check time 3.945 seconds
Result     Error: 404 Not Found

URL        `code-of-conduct.md'
Name       `code of conduct'
Parent URL https://kueue.sigs.k8s.io/docs/contribution-guidelines/, line 269, col 176
Real URL   https://kueue.sigs.k8s.io/docs/contribution-guidelines/code-of-conduct.md
Check time 3.874 seconds
Result     Error: 404 Not Found

Statistics:
Downloaded: 6.96MB.
Content types: 15 image, 93 text, 0 video, 0 audio, 30 application, 0 mail and 346 other.
URL lengths: min=15, max=1077, avg=169.

That's it. 484 links in 484 URLs checked. 0 warnings found (34 ignored or duplicates not printed). 6 errors found.
Stopped checking at 2024-03-15 22:19:05+003 (53 seconds)
```

</details>

It would be great if we could somehow implement URL checking into the CI pipeline to prevent broken links.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```