### PR TITLE
Passing parameters to ProvisioningRequest from annotations

### DIFF
--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -36,4 +36,7 @@ const (
 	// workloadPriorityClass name.
 	// This label is always mutable because it might be useful for the preemption.
 	WorkloadPriorityClassLabel = "kueue.x-k8s.io/priority-class"
+
+	// ProvReqAnnotationPrefix is the prefix for annotations that should be pass to ProvisioningRequest as Parameters.
+	ProvReqAnnotationPrefix = "provreq.kueue.x-k8s.io/"
 )

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/podset"
+	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	"sigs.k8s.io/kueue/pkg/util/equality"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	"sigs.k8s.io/kueue/pkg/util/maps"
@@ -803,10 +804,11 @@ func (r *JobReconciler) constructWorkload(ctx context.Context, job GenericJob, o
 
 	wl := &kueue.Workload{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       GetWorkloadNameForOwnerWithGVK(object.GetName(), object.GetUID(), job.GVK()),
-			Namespace:  object.GetNamespace(),
-			Labels:     map[string]string{},
-			Finalizers: []string{kueue.ResourceInUseFinalizerName},
+			Name:        GetWorkloadNameForOwnerWithGVK(object.GetName(), object.GetUID(), job.GVK()),
+			Namespace:   object.GetNamespace(),
+			Labels:      map[string]string{},
+			Finalizers:  []string{kueue.ResourceInUseFinalizerName},
+			Annotations: admissioncheck.FilterProvReqAnnotations(job.Object().GetAnnotations()),
 		},
 		Spec: kueue.WorkloadSpec{
 			PodSets:   podSets,

--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -30,6 +30,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/constants"
+	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingjobset "sigs.k8s.io/kueue/pkg/util/testingjobs/jobset"
@@ -202,7 +203,8 @@ var (
 	}
 	workloadCmpOpts = []cmp.Option{
 		cmpopts.EquateEmpty(),
-		cmpopts.IgnoreFields(kueue.Workload{}, "TypeMeta", "ObjectMeta"),
+		cmpopts.IgnoreFields(kueue.Workload{}, "TypeMeta"),
+		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Name", "Labels", "ResourceVersion", "OwnerReferences", "Finalizers"),
 		cmpopts.IgnoreFields(kueue.WorkloadSpec{}, "Priority"),
 		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
 		cmpopts.IgnoreFields(kueue.PodSet{}, "Template"),
@@ -223,7 +225,7 @@ func TestReconciler(t *testing.T) {
 		wantWorkloads     []kueue.Workload
 		wantErr           error
 	}{
-		"workload is created with podsets": {
+		"workload is created with podsets and a ProvReq annotation": {
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
 			},
@@ -239,8 +241,12 @@ func TestReconciler(t *testing.T) {
 					Replicas:    2,
 					Completions: 2,
 					Parallelism: 2,
-				},
-			).Obj(),
+				}).
+				Annotations(map[string]string{
+					controllerconsts.ProvReqAnnotationPrefix + "test-annotation": "test-val",
+					"invalid-provreq-prefix/test-annotation-2":                   "test-val-2",
+				}).
+				Obj(),
 			wantJob: testingjobset.MakeJobSet("jobset", "ns").ReplicatedJobs(
 				testingjobset.ReplicatedJobRequirements{
 					Name:        "replicated-job-1",
@@ -253,10 +259,15 @@ func TestReconciler(t *testing.T) {
 					Replicas:    2,
 					Completions: 2,
 					Parallelism: 2,
-				},
-			).Obj(),
+				}).
+				Annotations(map[string]string{
+					controllerconsts.ProvReqAnnotationPrefix + "test-annotation": "test-val",
+					"invalid-provreq-prefix/test-annotation-2":                   "test-val-2",
+				}).
+				Obj(),
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("jobset", "ns").
+					Annotations(map[string]string{controllerconsts.ProvReqAnnotationPrefix + "test-annotation": "test-val"}).
 					PodSets(
 						*utiltesting.MakePodSet("replicated-job-1", 1).Obj(),
 						*utiltesting.MakePodSet("replicated-job-2", 4).Obj(),

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -51,6 +51,7 @@ import (
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/podset"
+	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	"sigs.k8s.io/kueue/pkg/util/parallelize"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
@@ -897,9 +898,10 @@ func (p *Pod) ConstructComposableWorkload(ctx context.Context, c client.Client, 
 
 	wl := &kueue.Workload{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:  p.pod.GetNamespace(),
-			Labels:     map[string]string{},
-			Finalizers: []string{kueue.ResourceInUseFinalizerName},
+			Namespace:   p.pod.GetNamespace(),
+			Labels:      map[string]string{},
+			Finalizers:  []string{kueue.ResourceInUseFinalizerName},
+			Annotations: admissioncheck.FilterProvReqAnnotations(p.pod.GetAnnotations()),
 		},
 		Spec: kueue.WorkloadSpec{
 			QueueName: jobframework.QueueName(p),

--- a/pkg/util/admissioncheck/admissioncheck.go
+++ b/pkg/util/admissioncheck/admissioncheck.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 )
 
 var (
@@ -140,4 +142,15 @@ func FilterForController(ctx context.Context, c client.Client, states []kueue.Ad
 		}
 	}
 	return retActive, nil
+}
+
+// FilterProvReqAnnotations returns annotations containing the Provisioning Request annotation prefix.
+func FilterProvReqAnnotations(annotations map[string]string) map[string]string {
+	res := make(map[string]string)
+	for k, v := range annotations {
+		if strings.HasPrefix(k, controllerconsts.ProvReqAnnotationPrefix) {
+			res[k] = v
+		}
+	}
+	return res
 }

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -87,6 +87,11 @@ func (w *WorkloadWrapper) UID(uid types.UID) *WorkloadWrapper {
 	return w
 }
 
+func (w *WorkloadWrapper) Name(name string) *WorkloadWrapper {
+	w.Workload.Name = name
+	return w
+}
+
 func (w *WorkloadWrapper) Finalizers(fin ...string) *WorkloadWrapper {
 	w.ObjectMeta.Finalizers = fin
 	return w
@@ -277,8 +282,8 @@ func (w *WorkloadWrapper) appendOwnerReference(gvk schema.GroupVersionKind, name
 	return w
 }
 
-func (w *WorkloadWrapper) Annotations(kv map[string]string) *WorkloadWrapper {
-	w.ObjectMeta.Annotations = kv
+func (w *WorkloadWrapper) Annotations(annotations map[string]string) *WorkloadWrapper {
+	w.ObjectMeta.Annotations = annotations
 	return w
 }
 

--- a/pkg/util/testingjobs/jobset/wrappers.go
+++ b/pkg/util/testingjobs/jobset/wrappers.go
@@ -109,6 +109,12 @@ func (j *JobSetWrapper) Label(k, v string) *JobSetWrapper {
 	return j
 }
 
+// Annotation sets annotations to the JobSet.
+func (j *JobSetWrapper) Annotations(annotations map[string]string) *JobSetWrapper {
+	j.ObjectMeta.Annotations = annotations
+	return j
+}
+
 // Queue updates the queue name of the JobSet.
 func (j *JobSetWrapper) Queue(queue string) *JobSetWrapper {
 	return j.Label(constants.QueueLabel, queue)

--- a/pkg/util/testingjobs/mxjob/wrappers.go
+++ b/pkg/util/testingjobs/mxjob/wrappers.go
@@ -132,6 +132,12 @@ func (j *MXJobWrapper) Queue(queue string) *MXJobWrapper {
 	return j
 }
 
+// Annotations updates annotations of the job.
+func (j *MXJobWrapper) Annotations(annotations map[string]string) *MXJobWrapper {
+	j.ObjectMeta.Annotations = annotations
+	return j
+}
+
 // Request adds a resource request to the default container.
 func (j *MXJobWrapper) Request(replicaType kftraining.ReplicaType, r corev1.ResourceName, v string) *MXJobWrapper {
 	j.Spec.MXReplicaSpecs[replicaType].Template.Spec.Containers[0].Resources.Requests[r] = resource.MustParse(v)

--- a/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
@@ -119,6 +119,9 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 						Image("image").
 						Obj(),
 				).
+				Annotations(map[string]string{
+					"provreq.kueue.x-k8s.io/ValidUntilSeconds": "0",
+					"invalid-provreq-prefix/Foo":               "Bar"}).
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 			wlKey = client.ObjectKeyFromObject(wl)
@@ -225,8 +228,9 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			ginkgo.By("Checking that the provision requests content", func() {
 				gomega.Expect(createdRequest.Spec.ProvisioningClassName).To(gomega.Equal("provisioning-class"))
 				gomega.Expect(createdRequest.Spec.Parameters).To(gomega.BeComparableTo(map[string]autoscaling.Parameter{
-					"p1": "v1",
-					"p2": "v2",
+					"p1":                "v1",
+					"p2":                "v2",
+					"ValidUntilSeconds": "0",
 				}))
 				gomega.Expect(createdRequest.Spec.PodSets).To(gomega.HaveLen(2))
 
@@ -449,8 +453,9 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			ginkgo.By("Checking that the provision requests content", func() {
 				gomega.Expect(createdRequest.Spec.ProvisioningClassName).To(gomega.Equal("provisioning-class"))
 				gomega.Expect(createdRequest.Spec.Parameters).To(gomega.BeComparableTo(map[string]autoscaling.Parameter{
-					"p1": "v1",
-					"p2": "v2",
+					"p1":                "v1",
+					"p2":                "v2",
+					"ValidUntilSeconds": "0",
 				}))
 			})
 
@@ -477,8 +482,9 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 					g.Expect(err).To(gomega.Succeed())
 					g.Expect(createdRequest.Spec.ProvisioningClassName).To(gomega.Equal("provisioning-class-updated"))
 					g.Expect(createdRequest.Spec.Parameters).To(gomega.BeComparableTo(map[string]autoscaling.Parameter{
-						"p1": "v1updated",
-						"p3": "v3",
+						"p1":                "v1updated",
+						"p3":                "v3",
+						"ValidUntilSeconds": "0",
 					}))
 
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -503,8 +509,9 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 					g.Expect(err).To(gomega.Succeed())
 					g.Expect(createdRequest.Spec.ProvisioningClassName).To(gomega.Equal("provisioning-class2"))
 					g.Expect(createdRequest.Spec.Parameters).To(gomega.BeComparableTo(map[string]autoscaling.Parameter{
-						"p1": "v1.2",
-						"p2": "v2.2",
+						"p1":                "v1.2",
+						"p2":                "v2.2",
+						"ValidUntilSeconds": "0",
 					}))
 
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -115,7 +115,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 		ginkgo.When("Using single pod", func() {
 			ginkgo.It("Should reconcile the single pod with the queue name", func() {
-				pod := testingpod.MakePod(podName, ns.Name).Queue("test-queue").Obj()
+				pod := testingpod.MakePod(podName, ns.Name).
+					Queue("test-queue").
+					Annotation("provreq.kueue.x-k8s.io/ValidUntilSeconds", "0").
+					Annotation("invalid-provreq-prefix/Foo", "Bar").
+					Obj()
 				gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
 
 				createdPod := &corev1.Pod{}
@@ -147,6 +151,9 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"),
 					"The Workload should have .spec.queueName set")
+
+				ginkgo.By("checking that workload has ProvisioningRequest annotations")
+				gomega.Expect(createdWorkload.Annotations).Should(gomega.Equal(map[string]string{"provreq.kueue.x-k8s.io/ValidUntilSeconds": "0"}))
 
 				ginkgo.By("checking the pod is unsuspended when workload is assigned")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change 

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This implements changes introduced in #1788 and #1793 

#### Which issue(s) this PR fixes:
Fixes #1788
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
I've done manual e2e testing

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
User can now pass parameters to ProvisioningRequest using job's annotations
```