### PR TITLE
Dereference StopPolicy before equality check

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -750,7 +750,7 @@ func (w *workloadCqHandler) Update(ctx context.Context, ev event.UpdateEvent, wq
 
 	if !newCq.DeletionTimestamp.IsZero() ||
 		!slices.CmpNoOrder(oldCq.Spec.AdmissionChecks, newCq.Spec.AdmissionChecks) ||
-		ptr.Equal(oldCq.Spec.StopPolicy, newCq.Spec.StopPolicy) {
+		!ptr.Equal(oldCq.Spec.StopPolicy, newCq.Spec.StopPolicy) {
 		w.queueReconcileForWorkloads(ctx, newCq.Name, wq)
 	}
 }

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -750,7 +750,7 @@ func (w *workloadCqHandler) Update(ctx context.Context, ev event.UpdateEvent, wq
 
 	if !newCq.DeletionTimestamp.IsZero() ||
 		!slices.CmpNoOrder(oldCq.Spec.AdmissionChecks, newCq.Spec.AdmissionChecks) ||
-		ptr.Deref(oldCq.Spec.StopPolicy, kueue.None) != ptr.Deref(newCq.Spec.StopPolicy, kueue.None) {
+		ptr.Equal(oldCq.Spec.StopPolicy, newCq.Spec.StopPolicy) {
 		w.queueReconcileForWorkloads(ctx, newCq.Name, wq)
 	}
 }

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -750,7 +750,7 @@ func (w *workloadCqHandler) Update(ctx context.Context, ev event.UpdateEvent, wq
 
 	if !newCq.DeletionTimestamp.IsZero() ||
 		!slices.CmpNoOrder(oldCq.Spec.AdmissionChecks, newCq.Spec.AdmissionChecks) ||
-		oldCq.Spec.StopPolicy != newCq.Spec.StopPolicy {
+		ptr.Deref(oldCq.Spec.StopPolicy, kueue.None) != ptr.Deref(newCq.Spec.StopPolicy, kueue.None) {
 		w.queueReconcileForWorkloads(ctx, newCq.Name, wq)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
/kind bug
-->

#### What this PR does / why we need it:
I was investigating why we were doing a large amount of workload reconciles, and found that this equality check wasn't working as intended.

Compare workload reconciles before/after (1k jobs, 10k pods)

![workload_reconciles](https://github.com/kubernetes-sigs/kueue/assets/15304068/33b707c3-f059-4472-a91b-9d8875207e6c)

#### Does this PR introduce a user-facing change?
```release-note
None
```