### PR TITLE
[jobframework] Return all errors when updating workload status

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,5 +25,6 @@ linters:
     - gocritic
     - goimports
     - govet
+    - loggercheck
     - misspell
     - unconvert

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -389,12 +389,14 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 			if err != nil {
 				log.Error(err, "Unsuspending job")
 				if podset.IsPermanent(err) {
+					allErrs := err
 					// Mark the workload as finished with failure since the is no point to retry.
 					errUpdateStatus := workload.UpdateStatus(ctx, r.client, wl, kueue.WorkloadFinished, metav1.ConditionTrue, FailedToStartFinishedReason, err.Error(), constants.JobControllerName)
 					if errUpdateStatus != nil {
-						log.Error(errUpdateStatus, "Updating workload status, on start failure %s", err.Error())
+						allErrs = errors.Join(err, errUpdateStatus)
+						log.Error(allErrs, "Could not mark Workload as finished after start failure")
 					}
-					return ctrl.Result{}, errUpdateStatus
+					return ctrl.Result{}, allErrs
 				}
 			}
 			return ctrl.Result{}, err

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -768,6 +768,7 @@ func TestReconciler(t *testing.T) {
 					}).
 					Obj(),
 			},
+			wantErr: podset.ErrInvalidPodSetUpdate,
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission checks on annotations, the workload is finished with failure": {
 			job: *baseJobWrapper.Clone().
@@ -839,6 +840,7 @@ func TestReconciler(t *testing.T) {
 					}).
 					Obj(),
 			},
+			wantErr: podset.ErrInvalidPodSetUpdate,
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission checks on nodeSelector, the workload is finished with failure": {
 			job: *baseJobWrapper.Clone().
@@ -910,6 +912,7 @@ func TestReconciler(t *testing.T) {
 					}).
 					Obj(),
 			},
+			wantErr: podset.ErrInvalidPodSetUpdate,
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission check nodeSelector and current node selector, the workload is finished with failure": {
 			job: *baseJobWrapper.Clone().
@@ -959,6 +962,7 @@ func TestReconciler(t *testing.T) {
 					}).
 					Obj(),
 			},
+			wantErr: podset.ErrInvalidPodSetUpdate,
 		},
 		"when workload is admitted the PodSetUpdates values matching for key": {
 			job: *baseJobWrapper.Clone().


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Extends the logic of `ReconcileGenericJob` to return all errors that occur when updating the status of the starting job fails.
This was prompted by a `loggercheck` lint issue found in the log message.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Initially, this PR only corrects the log message output and enables [`loggercheck`](https://golangci-lint.run/usage/linters/#loggercheck) linter to prevent similar mistakes in the future.

This PR arrose because [`log.Error`](https://pkg.go.dev/github.com/go-logr/logr@v1.4.1#Logger.Error) accepts key-value pairs, not format-value args:

```
func (l Logger) Error(err error, msg string, keysAndValues ...any)
```

The output from `loggercheck`:

```
pkg/controller/jobframework/reconciler.go:397:83: odd number of arguments passed as key-value pairs for logging (loggercheck)
                                                log.Error(errUpdateStatus, "Updating workload status, on start failure %s", err.Error())
                                                                                                                            ^
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```