### PR TITLE
Adjust base timeouts for integration and E2E tests

### DIFF
--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	Timeout = time.Second * 30
+	Timeout = time.Second * 5
 	// LongTimeout is meant for E2E tests when waiting for complex operations
 	// such as running pods to completion.
 	LongTimeout = 45 * time.Second
@@ -31,6 +31,6 @@ const (
 	// need started and the time it takes for a change in ready probe response triggers
 	// a change in the deployment status.
 	StartUpTimeout     = 5 * time.Minute
-	ConsistentDuration = time.Second * 3
+	ConsistentDuration = time.Second
 	Interval           = time.Millisecond * 250
 )


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Based on experience fixing flaky tests, a timeout of 30s just adds to development time.
If Kueue doesn't react within 5 seconds, it likely won't in a longer time.

And for operations which require multiple pieces to interact (mainly E2E tests), we still have the `LongTimeout` variable which can be used on a case-by-case basis.

The duration for Consistent checks can also be limited, as these are more of sanity checks. We try not to use these checks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```