### PR TITLE
docs: Fix broken link in Kubernetes Jobs guide

### DIFF
--- a/site/content/en/docs/tasks/run/flux_miniclusters.md
+++ b/site/content/en/docs/tasks/run/flux_miniclusters.md
@@ -13,7 +13,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 ## Before you begin
 
-Check [administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial cluster setup.
+Check [administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial cluster setup.
 
 Check [the Flux Operator installation guide](https://flux-framework.org/flux-operator/getting_started/user-guide.html#install).
 

--- a/site/content/en/docs/tasks/run/jobs.md
+++ b/site/content/en/docs/tasks/run/jobs.md
@@ -18,7 +18,7 @@ Make sure the following conditions are met:
 - A Kubernetes cluster is running.
 - The kubectl command-line tool has communication with your cluster.
 - [Kueue is installed](/docs/installation).
-- The cluster has [quotas configured](/docs/tasks/administer_cluster_quotas).
+- The cluster has [quotas configured](/docs/tasks/manage/administer_cluster_quotas).
 
 The following picture shows all the concepts you will interact with in this tutorial:
 

--- a/site/content/en/docs/tasks/run/jobsets.md
+++ b/site/content/en/docs/tasks/run/jobsets.md
@@ -13,7 +13,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 ## Before you begin
 
-1. Check [Administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial Kueue setup.
+1. Check [Administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial Kueue setup.
 
 2. See [JobSet Installation](https://github.com/kubernetes-sigs/jobset/blob/main/docs/setup/install.md) for installation and configuration details of JobSet Operator.
 

--- a/site/content/en/docs/tasks/run/kubeflow/mpijobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/mpijobs.md
@@ -12,7 +12,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 ## Before you begin
 
-Check [administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial cluster setup.
+Check [administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial cluster setup.
 
 Check [the MPI Operator installation guide](https://github.com/kubeflow/mpi-operator#installation).
 

--- a/site/content/en/docs/tasks/run/kubeflow/mxjobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/mxjobs.md
@@ -12,7 +12,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 ## Before you begin
 
-Check [administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial cluster setup.
+Check [administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial cluster setup.
 
 Check [the Training Operator installation guide](https://github.com/kubeflow/training-operator#installation).
 

--- a/site/content/en/docs/tasks/run/kubeflow/paddlejobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/paddlejobs.md
@@ -12,7 +12,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 ## Before you begin
 
-Check [administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial cluster setup.
+Check [administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial cluster setup.
 
 Check [the Training Operator installation guide](https://github.com/kubeflow/training-operator#installation).
 

--- a/site/content/en/docs/tasks/run/kubeflow/pytorchjobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/pytorchjobs.md
@@ -12,7 +12,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 ## Before you begin
 
-Check [administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial cluster setup.
+Check [administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial cluster setup.
 
 Check [the Training Operator installation guide](https://github.com/kubeflow/training-operator#installation).
 

--- a/site/content/en/docs/tasks/run/kubeflow/tfjobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/tfjobs.md
@@ -12,7 +12,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 ## Before you begin
 
-Check [administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial cluster setup.
+Check [administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial cluster setup.
 
 Check [the Training Operator installation guide](https://github.com/kubeflow/training-operator#installation).
 

--- a/site/content/en/docs/tasks/run/kubeflow/xgboostjobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/xgboostjobs.md
@@ -12,7 +12,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 ## Before you begin
 
-Check [administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial cluster setup.
+Check [administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial cluster setup.
 
 Check [the Training Operator installation guide](https://github.com/kubeflow/training-operator#installation).
 

--- a/site/content/en/docs/tasks/run/plain_pods.md
+++ b/site/content/en/docs/tasks/run/plain_pods.md
@@ -62,7 +62,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 3. Pods that belong to other API resources managed by Kueue are excluded from being queued by `pod` integration. 
    For example, pods managed by `batch/v1.Job` won't be managed by `pod` integration.
 
-4. Check [Administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial Kueue setup.
+4. Check [Administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial Kueue setup.
 
 ## Running a single Pod admitted by Kueue
 

--- a/site/content/en/docs/tasks/run/python_jobs.md
+++ b/site/content/en/docs/tasks/run/python_jobs.md
@@ -11,7 +11,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 ## Before you begin
 
-Check [administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial cluster setup.
+Check [administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial cluster setup.
 You'll also need kubernetes python installed. We recommend a virtual environment.
 
 ```bash

--- a/site/content/en/docs/tasks/run/rayclusters.md
+++ b/site/content/en/docs/tasks/run/rayclusters.md
@@ -15,7 +15,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 1. Make sure you are using Kueue v0.6.0 version or newer and KubeRay 1.1.0 or newer.
 
-2. Check [Administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial Kueue setup.
+2. Check [Administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial Kueue setup.
 
 3. See [KubeRay Installation](https://ray-project.github.io/kuberay/deploy/installation/) for installation and configuration details of KubeRay.
 

--- a/site/content/en/docs/tasks/run/rayjobs.md
+++ b/site/content/en/docs/tasks/run/rayjobs.md
@@ -14,7 +14,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 ## Before you begin
 
-1. Check [Administer cluster quotas](/docs/tasks/administer_cluster_quotas) for details on the initial Kueue setup.
+1. Check [Administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial Kueue setup.
 
 2. See [KubeRay Installation](https://ray-project.github.io/kuberay/deploy/installation/) for installation and configuration details of KubeRay.
 

--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -4,15 +4,15 @@
 # test at https://play.netlify.com/redirects  #
 ###############################################
 
-/docs/tasks/administer_cluster_quotas      /doc/tasks/manage/administer_cluster_quotas      301
-/docs/tasks/monitor_pending_workloads      /doc/tasks/manage/monitor_pending_workloads      301
-/docs/tasks/rbac                           /doc/tasks/manage/rbac                           301
-/docs/tasks/run_job_with_workload_priority /doc/tasks/manage/run_job_with_workload_priority 301
-/docs/tasks/setup_multikueue               /doc/tasks/manage/setup_multikueue               301
-/docs/tasks/setup_sequential_admission     /doc/tasks/manage/setup_sequential_admission     301
+/docs/tasks/administer_cluster_quotas      /docs/tasks/manage/administer_cluster_quotas      301
+/docs/tasks/monitor_pending_workloads      /docs/tasks/manage/monitor_pending_workloads      301
+/docs/tasks/rbac                           /docs/tasks/manage/rbac                           301
+/docs/tasks/run_job_with_workload_priority /docs/tasks/manage/run_job_with_workload_priority 301
+/docs/tasks/setup_multikueue               /docs/tasks/manage/setup_multikueue               301
+/docs/tasks/setup_sequential_admission     /docs/tasks/manage/setup_sequential_admission     301
 
-/docs/tasks/enabling_pprof_endpoints /doc/tasks/dev/enabling_pprof_endpoints 301
-/docs/tasks/integrate_a_custom_job   /doc/tasks/dev/integrate_a_custom_job   301
+/docs/tasks/enabling_pprof_endpoints /docs/tasks/dev/enabling_pprof_endpoints 301
+/docs/tasks/integrate_a_custom_job   /docs/tasks/dev/integrate_a_custom_job   301
 
 /docs/tasks/run_flux_minicluster /docs/tasks/run/flux_miniclusters 301
 /docs/tasks/run_jobs             /docs/tasks/run/jobs              301


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR fixes broken links to the [*Administer Cluster Quotas* page](https://kueue.sigs.k8s.io/docs/tasks/manage/administer_cluster_quotas/) throughout the docs, and in server-side redirect definitions.

The links in the latest documentation currently lead to a 404 page.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```