### PR TITLE
[slices] Optimize CmpNoOrder

### DIFF
--- a/pkg/util/slices/slices.go
+++ b/pkg/util/slices/slices.go
@@ -72,13 +72,14 @@ func CmpNoOrder[E comparable, S ~[]E](a, b S) bool {
 	counters := make(map[E]int, len(a))
 	for i := range a {
 		counters[a[i]]++
-		counters[b[i]]--
 	}
 
-	for _, v := range counters {
-		if v != 0 {
-			return false
+	for _, v := range b {
+		if counters[v] != 0 {
+			counters[v]--
+			continue
 		}
+		return false
 	}
 	return true
 }

--- a/pkg/util/slices/slices_test.go
+++ b/pkg/util/slices/slices_test.go
@@ -55,7 +55,7 @@ func TestToRefMap(t *testing.T) {
 	}
 }
 
-func TestToCmpNoOrder(t *testing.T) {
+func TestCmpNoOrder(t *testing.T) {
 	cases := map[string]struct {
 		sliceA []int
 		sliceB []int
@@ -95,7 +95,7 @@ func TestToCmpNoOrder(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			res := CmpNoOrder[int](tc.sliceA, tc.sliceB)
+			res := CmpNoOrder(tc.sliceA, tc.sliceB)
 			if res != tc.want {
 				t.Errorf("Unexpected result: want: %v, got: %v", tc.want, res)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Optimizes `slices.CmpNoOrder` by avoiding the decrement operation on the counters map for elements that are not present in the first slice. This can be achieved by checking if the element from the second slice exists in the counters map before decrementing its count.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

This simple micro-benchmark demonstrates that the new implementation is faster and results in fewer allocations:

```go
func BenchmarkCmpNoOrder(b *testing.B) {
	sliceA := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
	sliceB := []int{10, 9, 8, 7, 6, 5, 4, 3, 2, 1}

	for i := 0; i < b.N; i++ {
		CmpNoOrder(sliceA, sliceB)
	}
}
```

```sh
❯ go test -benchmem -run=^$ -bench ^BenchmarkCmpNoOrder$ sigs.k8s.io/kueue/pkg/util/slices -count=10 > old.txt
❯ git switch slices-improve-cmp-no-order
❯ go test -benchmem -run=^$ -bench ^BenchmarkCmpNoOrder$ sigs.k8s.io/kueue/pkg/util/slices -count=10 > new.txt
❯ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: sigs.k8s.io/kueue/pkg/util/slices
             │   old.txt   │               new.txt               │
             │   sec/op    │   sec/op     vs base                │
CmpNoOrder-8   414.1n ± 1%   336.5n ± 2%  -18.76% (p=0.000 n=10)

             │  old.txt   │              new.txt               │
             │    B/op    │    B/op     vs base                │
CmpNoOrder-8   339.0 ± 0%   291.0 ± 0%  -14.16% (p=0.000 n=10)

             │  old.txt   │              new.txt               │
             │ allocs/op  │ allocs/op   vs base                │
CmpNoOrder-8   3.000 ± 0%   1.000 ± 0%  -66.67% (p=0.000 n=10)
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```