### PR TITLE
Count inflight workload as pending 

### DIFF
--- a/pkg/queue/cluster_queue_impl_test.go
+++ b/pkg/queue/cluster_queue_impl_test.go
@@ -101,8 +101,8 @@ func Test_PushOrUpdate(t *testing.T) {
 			updatedWl := tc.workload.Clone().ResourceVersion("1").Obj()
 			cq.PushOrUpdate(workload.NewInfo(updatedWl))
 			newWl := cq.Pop()
-			if newWl != nil && cq.Pending() != 0 {
-				t.Error("failed to update a workload in ClusterQueue")
+			if newWl != nil && cq.Pending() != 1 {
+				t.Errorf("unexpected count of pending workloads (want=%d, got=%d)", 1, cq.Pending())
 			}
 			if diff := cmp.Diff(tc.wantWorkload, newWl, cmpOpts...); len(diff) != 0 {
 				t.Errorf("Unexpected workloads in heap (-want,+got):\n%s", diff)

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -1726,31 +1726,31 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 	ginkgo.When("Queueing with StrictFIFO", func() {
 		var (
-			cq         *kueue.ClusterQueue
-			localQueue *kueue.LocalQueue
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
 		)
 
 		ginkgo.BeforeEach(func() {
 			gomega.Expect(k8sClient.Create(ctx, onDemandFlavor)).Should(gomega.Succeed())
-			cq = testing.MakeClusterQueue("cq").
+			clusterQueue = testing.MakeClusterQueue("cq").
 				QueueingStrategy(kueue.StrictFIFO).
 				ResourceGroup(*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj()).
 				Obj()
-			gomega.Expect(k8sClient.Create(ctx, cq)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).Should(gomega.Succeed())
 
-			localQueue = testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(cq.Name).Obj()
+			localQueue = testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
 			gomega.Expect(k8sClient.Create(ctx, localQueue)).Should(gomega.Succeed())
 		})
 
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, cq, true)
+			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, clusterQueue, true)
 			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
 		})
 
 		ginkgo.It("Should report pending workloads properly when blocked", func() {
 			var wl1, wl2, wl3 *kueue.Workload
-			ginkgo.By("Create two workloads and verify wl2 is counted properly as pending", func() {
+			ginkgo.By("Create two workloads", func() {
 				wl1 = testing.MakeWorkload("wl1", ns.Name).Queue(localQueue.
 					Name).Request(corev1.ResourceCPU, "2").Priority(100).Obj()
 				gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
@@ -1758,29 +1758,47 @@ var _ = ginkgo.Describe("Scheduler", func() {
 					Name).Request(corev1.ResourceCPU, "5").Priority(10).Obj()
 				gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
 
-				util.ExpectPendingWorkloadsMetric(cq, 1, 0)
+				util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+				util.ExpectPendingWorkloadsMetric(clusterQueue, 1, 0)
 				gomega.Eventually(func() int32 {
-					var clusterQueue kueue.ClusterQueue
-					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &clusterQueue)).To(gomega.Succeed())
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).To(gomega.Succeed())
 					return clusterQueue.Status.PendingWorkloads
 				}, util.Timeout, util.Interval).Should(gomega.Equal(int32(1)))
 			})
 
-			ginkgo.By("Create wl3 and verify the pending counter is incremented properly", func() {
+			ginkgo.By("Create wl3 which is now also pending", func() {
 				wl3 = testing.MakeWorkload("wl3", ns.Name).Queue(localQueue.
 					Name).Request(corev1.ResourceCPU, "1").Priority(1).Obj()
 				gomega.Expect(k8sClient.Create(ctx, wl3)).Should(gomega.Succeed())
 
-				util.ExpectPendingWorkloadsMetric(cq, 2, 0)
+				util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+				util.ExpectPendingWorkloadsMetric(clusterQueue, 2, 0)
 				gomega.Eventually(func() int32 {
-					var clusterQueue kueue.ClusterQueue
-					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &clusterQueue)).To(gomega.Succeed())
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).To(gomega.Succeed())
 					return clusterQueue.Status.PendingWorkloads
 				}, util.Timeout, util.Interval).Should(gomega.Equal(int32(2)))
 			})
 
-			ginkgo.By("Mark all workloads as finished", func() {
-				util.FinishWorkloads(ctx, k8sClient, wl1, wl2, wl3)
+			ginkgo.By("Mark wl1 as finished which allows wl2 to be admitted", func() {
+				util.FinishWorkloads(ctx, k8sClient, wl1)
+
+				util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+				util.ExpectPendingWorkloadsMetric(clusterQueue, 1, 0)
+				gomega.Eventually(func() int32 {
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).To(gomega.Succeed())
+					return clusterQueue.Status.PendingWorkloads
+				}, util.Timeout, util.Interval).Should(gomega.Equal(int32(1)))
+			})
+
+			ginkgo.By("Mark remaining workloads as finished", func() {
+				util.FinishWorkloads(ctx, k8sClient, wl2, wl3)
+
+				util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 0)
+				util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
+				gomega.Eventually(func() int32 {
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).To(gomega.Succeed())
+					return clusterQueue.Status.PendingWorkloads
+				}, util.Timeout, util.Interval).Should(gomega.Equal(int32(0)))
 			})
 		})
 	})

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -1723,4 +1723,65 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.FinishWorkloads(ctx, k8sClient, wl1, wl2)
 		})
 	})
+
+	ginkgo.When("Queueing with StrictFIFO", func() {
+		var (
+			cq         *kueue.ClusterQueue
+			localQueue *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			gomega.Expect(k8sClient.Create(ctx, onDemandFlavor)).Should(gomega.Succeed())
+			cq = testing.MakeClusterQueue("cq").
+				QueueingStrategy(kueue.StrictFIFO).
+				ResourceGroup(*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, cq)).Should(gomega.Succeed())
+
+			localQueue = testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(cq.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, localQueue)).Should(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, cq, true)
+			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
+		})
+
+		ginkgo.It("Should report pending workloads properly when blocked", func() {
+			var wl1, wl2, wl3 *kueue.Workload
+			ginkgo.By("Create two workloads and verify wl2 is counted properly as pending", func() {
+				wl1 = testing.MakeWorkload("wl1", ns.Name).Queue(localQueue.
+					Name).Request(corev1.ResourceCPU, "2").Priority(100).Obj()
+				gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
+				wl2 = testing.MakeWorkload("wl2", ns.Name).Queue(localQueue.
+					Name).Request(corev1.ResourceCPU, "5").Priority(10).Obj()
+				gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
+
+				util.ExpectPendingWorkloadsMetric(cq, 1, 0)
+				gomega.Eventually(func() int32 {
+					var clusterQueue kueue.ClusterQueue
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &clusterQueue)).To(gomega.Succeed())
+					return clusterQueue.Status.PendingWorkloads
+				}, util.Timeout, util.Interval).Should(gomega.Equal(int32(1)))
+			})
+
+			ginkgo.By("Create wl3 and verify the pending counter is incremented properly", func() {
+				wl3 = testing.MakeWorkload("wl3", ns.Name).Queue(localQueue.
+					Name).Request(corev1.ResourceCPU, "1").Priority(1).Obj()
+				gomega.Expect(k8sClient.Create(ctx, wl3)).Should(gomega.Succeed())
+
+				util.ExpectPendingWorkloadsMetric(cq, 2, 0)
+				gomega.Eventually(func() int32 {
+					var clusterQueue kueue.ClusterQueue
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &clusterQueue)).To(gomega.Succeed())
+					return clusterQueue.Status.PendingWorkloads
+				}, util.Timeout, util.Interval).Should(gomega.Equal(int32(2)))
+			})
+
+			ginkgo.By("Mark all workloads as finished", func() {
+				util.FinishWorkloads(ctx, k8sClient, wl1, wl2, wl3)
+			})
+		})
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1937

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Properly count the number of pending workloads in StrictFIFO queue, when the first workload cannot be admitted.
```