### PR TITLE
Remove redundant RayCluster logic from Pod controller

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -1171,7 +1171,7 @@ func (p *Pod) ReclaimablePods() ([]kueue.ReclaimablePod, error) {
 
 func IsPodOwnerManagedByKueue(p *Pod) bool {
 	if owner := metav1.GetControllerOf(&p.pod); owner != nil {
-		return jobframework.IsOwnerManagedByKueue(owner) || (owner.Kind == "RayCluster" && (strings.HasPrefix(owner.APIVersion, "ray.io/v1alpha1") || strings.HasPrefix(owner.APIVersion, "ray.io/v1")))
+		return jobframework.IsOwnerManagedByKueue(owner)
 	}
 	return false
 }

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -41,6 +41,7 @@ import (
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	_ "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	"sigs.k8s.io/kueue/pkg/podset"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -3594,9 +3595,9 @@ func TestIsPodOwnerManagedByQueue(t *testing.T) {
 			},
 			wantRes: false,
 		},
-		"ray.io/v1alpha1/RayCluster": {
+		"ray.io/v1/RayCluster": {
 			ownerReference: metav1.OwnerReference{
-				APIVersion: "ray.io/v1alpha1",
+				APIVersion: "ray.io/v1",
 				Controller: ptr.To(true),
 				Kind:       "RayCluster",
 			},

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -33,6 +33,7 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs"
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
+	_ "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 )

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -184,5 +184,5 @@ func GetWorkloadNameForRayJob(jobName string, jobUID types.UID) string {
 }
 
 func isRayJob(owner *metav1.OwnerReference) bool {
-	return owner.Kind == "RayJob" && (strings.HasPrefix(owner.APIVersion, "ray.io/v1alpha1") || strings.HasPrefix(owner.APIVersion, "ray.io/v1"))
+	return owner.Kind == "RayJob" && strings.HasPrefix(owner.APIVersion, "ray.io/v1")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

A quick follow up after  #1802 to remove duplicated custom logic for Pods ownership by RayClusters.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```