### PR TITLE
Distinguish preemption reasons

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -287,6 +287,13 @@ const (
 
 	// WorkloadEvicted means that the Workload was evicted by a ClusterQueue
 	WorkloadEvicted = "Evicted"
+
+	// WorkloadPreempted means that the Workload was preempted.
+	// The possible values of the reason field are "InClusterQueue", "InCohort".
+	// In the future more reasons can be introduced, including those conveying
+	// more detailed information. The more detailed reasons should be prefixed
+	// by one of the "base" reasons.
+	WorkloadPreempted = "Preempted"
 )
 
 const (

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -285,7 +285,9 @@ const (
 	// ready or have succeeded.
 	WorkloadPodsReady = "PodsReady"
 
-	// WorkloadEvicted means that the Workload was evicted by a ClusterQueue
+	// WorkloadEvicted means that the Workload was evicted by a ClusterQueue.
+	// When a workload is preempted this condition is accompanied by the "Preempted"
+	// condition which contains a more detailed reason for the preemption.
 	WorkloadEvicted = "Evicted"
 
 	// WorkloadPreempted means that the Workload was preempted.

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -285,8 +285,14 @@ const (
 	// ready or have succeeded.
 	WorkloadPodsReady = "PodsReady"
 
-	// WorkloadEvicted means that the Workload was evicted by a ClusterQueue.
-	// When a workload is preempted this condition is accompanied by the "Preempted"
+	// WorkloadEvicted means that the Workload was evicted. The possible reasons
+	// for this condition are:
+	// - "Preempted": the workload was preempted
+	// - "PodsReadyTimeout": the workload exceeded the PodsReady timeout
+	// - "AdmissionCheck": at least one admission check transitioned to False
+	// - "ClusterQueueStopped": the ClusterQueue is stopped
+	// - "InactiveWorkload": the workload has spec.active set to false
+	// When a workload is preempted, this condition is accompanied by the "Preempted"
 	// condition which contains a more detailed reason for the preemption.
 	WorkloadEvicted = "Evicted"
 

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -144,14 +144,14 @@ func (p *Preemptor) IssuePreemptions(ctx context.Context, preemptor *workload.In
 				reason = "InCohort"
 			}
 
-			message := fmt.Sprintf("Preempted to accommodate the workload (UID: %s) in the %s", preemptor.Obj.UID, origin)
+			message := fmt.Sprintf("Preempted to accommodate a workload (UID: %s) in the %s", preemptor.Obj.UID, origin)
 			err := p.applyPreemption(ctx, target.Obj, reason, message)
 			if err != nil {
 				errCh.SendErrorWithCancel(err, cancel)
 				return
 			}
 
-			log.V(3).Info("Preempted", "targetWorkload", klog.KObj(target.Obj))
+			log.V(3).Info("Preempted", "targetWorkload", klog.KObj(target.Obj), "reason", reason, "message", message)
 			p.recorder.Eventf(target.Obj, corev1.EventTypeNormal, "Preempted", message)
 		} else {
 			log.V(3).Info("Preemption ongoing", "targetWorkload", klog.KObj(target.Obj))

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -18,6 +18,7 @@ package preemption
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -50,7 +51,7 @@ type Preemptor struct {
 	workloadOrdering workload.Ordering
 
 	// stubs
-	applyPreemption func(context.Context, *kueue.Workload) error
+	applyPreemption func(context.Context, *kueue.Workload, string, string) error
 }
 
 func New(cl client.Client, workloadOrdering workload.Ordering, recorder record.EventRecorder) *Preemptor {
@@ -63,7 +64,7 @@ func New(cl client.Client, workloadOrdering workload.Ordering, recorder record.E
 	return p
 }
 
-func (p *Preemptor) OverrideApply(f func(context.Context, *kueue.Workload) error) {
+func (p *Preemptor) OverrideApply(f func(context.Context, *kueue.Workload, string, string) error) {
 	p.applyPreemption = f
 }
 
@@ -126,7 +127,7 @@ func (p *Preemptor) GetTargets(wl workload.Info, assignment flavorassigner.Assig
 }
 
 // IssuePreemptions marks the target workloads as evicted.
-func (p *Preemptor) IssuePreemptions(ctx context.Context, targets []*workload.Info, cq *cache.ClusterQueue) (int, error) {
+func (p *Preemptor) IssuePreemptions(ctx context.Context, preemptor *workload.Info, targets []*workload.Info, cq *cache.ClusterQueue) (int, error) {
 	log := ctrl.LoggerFrom(ctx)
 	errCh := routine.NewErrorChannel()
 	ctx, cancel := context.WithCancel(ctx)
@@ -135,18 +136,23 @@ func (p *Preemptor) IssuePreemptions(ctx context.Context, targets []*workload.In
 	workqueue.ParallelizeUntil(ctx, parallelPreemptions, len(targets), func(i int) {
 		target := targets[i]
 		if !meta.IsStatusConditionTrue(target.Obj.Status.Conditions, kueue.WorkloadEvicted) {
-			err := p.applyPreemption(ctx, target.Obj)
+
+			origin := "ClusterQueue"
+			reason := "InClusterQueue"
+			if cq.Name != target.ClusterQueue {
+				origin = "cohort"
+				reason = "InCohort"
+			}
+
+			message := fmt.Sprintf("Preempted to accommodate the workload (UID: %s) in the %s", preemptor.Obj.UID, origin)
+			err := p.applyPreemption(ctx, target.Obj, reason, message)
 			if err != nil {
 				errCh.SendErrorWithCancel(err, cancel)
 				return
 			}
 
-			origin := "ClusterQueue"
-			if cq.Name != target.ClusterQueue {
-				origin = "cohort"
-			}
 			log.V(3).Info("Preempted", "targetWorkload", klog.KObj(target.Obj))
-			p.recorder.Eventf(target.Obj, corev1.EventTypeNormal, "Preempted", "Preempted by another workload in the %s", origin)
+			p.recorder.Eventf(target.Obj, corev1.EventTypeNormal, "Preempted", message)
 		} else {
 			log.V(3).Info("Preemption ongoing", "targetWorkload", klog.KObj(target.Obj))
 		}
@@ -155,9 +161,10 @@ func (p *Preemptor) IssuePreemptions(ctx context.Context, targets []*workload.In
 	return int(successfullyPreempted), errCh.ReceiveError()
 }
 
-func (p *Preemptor) applyPreemptionWithSSA(ctx context.Context, w *kueue.Workload) error {
+func (p *Preemptor) applyPreemptionWithSSA(ctx context.Context, w *kueue.Workload, reason, message string) error {
 	w = w.DeepCopy()
-	workload.SetEvictedCondition(w, kueue.WorkloadEvictedByPreemption, "Preempted to accommodate a higher priority Workload")
+	workload.SetEvictedCondition(w, kueue.WorkloadEvictedByPreemption, message)
+	workload.SetPreemptedCondition(w, reason, message)
 	return workload.ApplyAdmissionStatus(ctx, p.client, w, false)
 }
 

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -1087,7 +1087,7 @@ func TestPreemption(t *testing.T) {
 			scheme := runtime.NewScheme()
 			recorder := broadcaster.NewRecorder(scheme, corev1.EventSource{Component: constants.AdmissionName})
 			preemptor := New(cl, workload.Ordering{}, recorder)
-			preemptor.applyPreemption = func(ctx context.Context, w *kueue.Workload) error {
+			preemptor.applyPreemption = func(ctx context.Context, w *kueue.Workload, _, _ string) error {
 				lock.Lock()
 				gotPreempted.Insert(workload.Key(w))
 				lock.Unlock()
@@ -1101,7 +1101,7 @@ func TestPreemption(t *testing.T) {
 			wlInfo.ClusterQueue = tc.targetCQ
 			targetClusterQueue := snapshot.ClusterQueues[wlInfo.ClusterQueue]
 			targets := preemptor.GetTargets(*wlInfo, tc.assignment, &snapshot)
-			preempted, err := preemptor.IssuePreemptions(ctx, targets, targetClusterQueue)
+			preempted, err := preemptor.IssuePreemptions(ctx, wlInfo, targets, targetClusterQueue)
 			if err != nil {
 				t.Fatalf("Failed doing preemption")
 			}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -248,7 +248,7 @@ func (s *Scheduler) schedule(ctx context.Context) {
 			if len(e.preemptionTargets) != 0 {
 				// If preemptions are issued, the next attempt should try all the flavors.
 				e.LastAssignment = nil
-				preempted, err := s.preemptor.IssuePreemptions(ctx, e.preemptionTargets, cq)
+				preempted, err := s.preemptor.IssuePreemptions(ctx, &e.Info, e.preemptionTargets, cq)
 				if err != nil {
 					log.Error(err, "Failed to preempt workloads")
 				}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1466,7 +1466,7 @@ func TestSchedule(t *testing.T) {
 				func() { wg.Done() },
 			))
 			gotPreempted := sets.New[string]()
-			scheduler.preemptor.OverrideApply(func(_ context.Context, w *kueue.Workload) error {
+			scheduler.preemptor.OverrideApply(func(_ context.Context, w *kueue.Workload, _, _ string) error {
 				mu.Lock()
 				gotPreempted.Insert(workload.Key(w))
 				mu.Unlock()
@@ -2042,7 +2042,7 @@ func TestLastSchedulingContext(t *testing.T) {
 				func() { wg.Done() },
 			))
 			gotPreempted := sets.New[string]()
-			scheduler.preemptor.OverrideApply(func(_ context.Context, w *kueue.Workload) error {
+			scheduler.preemptor.OverrideApply(func(_ context.Context, w *kueue.Workload, _, _ string) error {
 				mu.Lock()
 				gotPreempted.Insert(workload.Key(w))
 				mu.Unlock()

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -397,11 +397,15 @@ func SetQuotaReservation(w *kueue.Workload, admission *kueue.Admission) {
 	//reset Evicted condition if present.
 	if evictedCond := apimeta.FindStatusCondition(w.Status.Conditions, kueue.WorkloadEvicted); evictedCond != nil {
 		evictedCond.Status = metav1.ConditionFalse
+		evictedCond.Reason = "QuotaReserved"
+		evictedCond.Message = "Previously: " + evictedCond.Message
 		evictedCond.LastTransitionTime = metav1.Now()
 	}
 	// reset Preempted condition if present.
 	if preemptedCond := apimeta.FindStatusCondition(w.Status.Conditions, kueue.WorkloadPreempted); preemptedCond != nil {
 		preemptedCond.Status = metav1.ConditionFalse
+		preemptedCond.Reason = "QuotaReserved"
+		preemptedCond.Message = "Previously: " + preemptedCond.Message
 		preemptedCond.LastTransitionTime = metav1.Now()
 	}
 }

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -399,7 +399,7 @@ func SetQuotaReservation(w *kueue.Workload, admission *kueue.Admission) {
 		evictedCond.Status = metav1.ConditionFalse
 		evictedCond.LastTransitionTime = metav1.Now()
 	}
-	//reset Preempted condition if present.
+	// reset Preempted condition if present.
 	if preemptedCond := apimeta.FindStatusCondition(w.Status.Conditions, kueue.WorkloadPreempted); preemptedCond != nil {
 		preemptedCond.Status = metav1.ConditionFalse
 		preemptedCond.LastTransitionTime = metav1.Now()
@@ -408,11 +408,10 @@ func SetQuotaReservation(w *kueue.Workload, admission *kueue.Admission) {
 
 func SetPreemptedCondition(w *kueue.Workload, reason string, message string) {
 	condition := metav1.Condition{
-		Type:               kueue.WorkloadPreempted,
-		Status:             metav1.ConditionTrue,
-		LastTransitionTime: metav1.Now(),
-		Reason:             reason,
-		Message:            message,
+		Type:    kueue.WorkloadPreempted,
+		Status:  metav1.ConditionTrue,
+		Reason:  reason,
+		Message: message,
 	}
 	apimeta.SetStatusCondition(&w.Status.Conditions, condition)
 }

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -310,8 +310,8 @@ var _ = ginkgo.Describe("Preemption", func() {
 					g.Expect(apimeta.FindStatusCondition(alphaLowWl.Status.Conditions, kueue.WorkloadPreempted)).To(gomega.BeComparableTo(&metav1.Condition{
 						Type:    kueue.WorkloadPreempted,
 						Status:  metav1.ConditionFalse,
-						Reason:  "InClusterQueue",
-						Message: fmt.Sprintf("Preempted to accommodate a workload (UID: %s) in the ClusterQueue", alphaMidWl.UID),
+						Reason:  "QuotaReserved",
+						Message: fmt.Sprintf("Previously: Preempted to accommodate a workload (UID: %s) in the ClusterQueue", alphaMidWl.UID),
 					}, conditionCmpOpts))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -320,8 +320,8 @@ var _ = ginkgo.Describe("Preemption", func() {
 					g.Expect(apimeta.FindStatusCondition(betaMidWl.Status.Conditions, kueue.WorkloadPreempted)).To(gomega.BeComparableTo(&metav1.Condition{
 						Type:    kueue.WorkloadPreempted,
 						Status:  metav1.ConditionFalse,
-						Reason:  "InCohort",
-						Message: fmt.Sprintf("Preempted to accommodate a workload (UID: %s) in the cohort", alphaMidWl.UID),
+						Reason:  "QuotaReserved",
+						Message: fmt.Sprintf("Previously: Preempted to accommodate a workload (UID: %s) in the cohort", alphaMidWl.UID),
 					}, conditionCmpOpts))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1874

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
A new condition with type Preempted allows to distinguish different reasons for the preemption to happen
```