### PR TITLE
[jobframework] Fix logging of error message

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,5 +25,6 @@ linters:
     - gocritic
     - goimports
     - govet
+    - loggercheck
     - misspell
     - unconvert

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -392,7 +392,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 					// Mark the workload as finished with failure since the is no point to retry.
 					errUpdateStatus := workload.UpdateStatus(ctx, r.client, wl, kueue.WorkloadFinished, metav1.ConditionTrue, FailedToStartFinishedReason, err.Error(), constants.JobControllerName)
 					if errUpdateStatus != nil {
-						log.Error(errUpdateStatus, "Updating workload status, on start failure %s", err.Error())
+						log.Error(errUpdateStatus, "Updating workload status, on start failure", "err", err)
 					}
 					return ctrl.Result{}, errUpdateStatus
 				}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The PR corrects the log message output and enables [loggercheck](https://golangci-lint.run/usage/linters/#loggercheck) linter to prevent similar mistakes in the future.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

We can't return all errors `log.Error` is needed here. See #1907 and #1940 for details.

This PR arrose because [log.Error](https://pkg.go.dev/github.com/go-logr/logr@v1.4.1#Logger.Error) accepts key-value pairs, not format-value args:

```
func (l Logger) Error(err error, msg string, keysAndValues ...any)
```

The output from loggercheck:

```
pkg/controller/jobframework/reconciler.go:397:83: odd number of arguments passed as key-value pairs for logging (loggercheck)
                                                log.Error(errUpdateStatus, "Updating workload status, on start failure %s", err.Error())
                                                                                                                            ^
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```