### PR TITLE
Remove duplicated word reported by dupword

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,6 +21,7 @@ linters-settings:
 # Settings for enabling and disabling linters
 linters:
   enable:
+    - dupword
     - ginkgolinter
     - gocritic
     - goimports

--- a/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
@@ -907,7 +907,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 				}, util.Timeout, util.Interval).Should(gomega.Equal(ptr.To(true)))
 			})
 
-			// backup the the node selectors
+			// backup the node selectors
 			originalNodeSelectors := nodeSelectors(createdJob)
 
 			ginkgo.By("create a localQueue", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes duplicated word `the` in the comment and enables [`dupword`](https://golangci-lint.run/usage/linters/#dupword) linter to prevent similar typos.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```