### PR TITLE
Remove unneeded loop variable copying

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,17 +1,20 @@
 # golangci-lint configuration file
 # see: https://golangci-lint.run/usage/configuration/
 
-# Options for analysis running
-run:
-  # Which dirs to skip: they won't be analyzed;
-  skip-dirs:
-    - bin
-
 # Settings of specific linters
 linters-settings:
   gocritic:
     enabled-checks:
       - dupImport
+    disabled-checks: # temporarily disabled checks, will fix them later
+      - appendAssign
+      - assignOp
+      - captLocal
+      - commentFormatting
+      - deprecatedComment
+      - elseif
+      - exitAfterDefer
+      - ifElseChain
   goimports:
     local-prefixes: sigs.k8s.io/kueue
   govet:
@@ -21,6 +24,7 @@ linters-settings:
 # Settings for enabling and disabling linters
 linters:
   enable:
+    - copyloopvar
     - dupword
     - ginkgolinter
     - gocritic
@@ -28,3 +32,13 @@ linters:
     - govet
     - misspell
     - unconvert
+
+# Settings related to issues
+issues:
+  # Which dirs to exclude: issues from them won't be reported
+  exclude-dirs:
+    - bin
+  # Show all issues from a linter
+  max-issues-per-linter: 0
+  # Show all issues with the same text
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 GOLANGCI_LINT = $(PROJECT_DIR)/bin/golangci-lint
 .PHONY: golangci-lint
 golangci-lint: ## Download golangci-lint locally if necessary.
-	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.56.2
+	@GOBIN=$(PROJECT_DIR)/bin GO111MODULE=on $(GO_CMD) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2
 
 CONTROLLER_GEN = $(PROJECT_DIR)/bin/controller-gen
 .PHONY: controller-gen

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -200,7 +200,6 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 		return fmt.Errorf("listing workloads that match the queue: %w", err)
 	}
 	for _, w := range workloads.Items {
-		w := w
 		if workload.HasQuotaReservation(&w) {
 			continue
 		}

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -460,7 +460,6 @@ func TestStatus(t *testing.T) {
 		}
 	}
 	for _, wl := range workloads {
-		wl := wl
 		manager.AddOrUpdateWorkload(&wl)
 	}
 

--- a/pkg/util/priority/priority.go
+++ b/pkg/util/priority/priority.go
@@ -87,9 +87,7 @@ func getDefaultPriorityClass(ctx context.Context, client client.Client) (*schedu
 	// In case more than one global default priority class is added as a result of a race condition,
 	// we pick the one with the lowest priority value.
 	var defaultPC *schedulingv1.PriorityClass
-	for _, pci := range pcs.Items {
-		item := pci
-
+	for _, item := range pcs.Items {
 		if item.GlobalDefault {
 			if defaultPC == nil || defaultPC.Value > item.Value {
 				defaultPC = &item

--- a/pkg/util/priority/priority_test.go
+++ b/pkg/util/priority/priority_test.go
@@ -135,7 +135,6 @@ func TestGetPriorityFromPriorityClass(t *testing.T) {
 	}
 
 	for desc, tt := range tests {
-		tt := tt
 		t.Run(desc, func(t *testing.T) {
 			t.Parallel()
 
@@ -200,7 +199,6 @@ func TestGetPriorityFromWorkloadPriorityClass(t *testing.T) {
 	}
 
 	for desc, tt := range tests {
-		tt := tt
 		t.Run(desc, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Clean up unnecessary loop variable copying and enable the `copyloopvar` linter for detecting this redundant variable copying.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

After the project upgraded to Go version 1.22 in #1895, copying variables inside a `for` loop became unnecessary. See this [blog post](https://go.dev/blog/loopvar-preview) for a detailed explanation.

The `copyloopvar` linter is only available from `golangci-lint` v1.57 onwards, so we also need to update this tool.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```