### PR TITLE
Fair preemptions in a cohort, rule S2-a

### DIFF
--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -680,21 +681,30 @@ func (c *ClusterQueue) UsedCohortQuota(fName kueue.ResourceFlavorReference, rNam
 	return cohortUsage
 }
 
-// DominantResourceShare returns a value from 0 to 100 representing the maximum of the ratios
+// DominantResourceShare returns a value from -100 to 100 representing the maximum of the ratios
 // of usage above nominal quota to the lendable resources in the cohort, among all the resources
 // provided by the ClusterQueue.
+// If negative, it means that the usage of the ClusterQueue is below the nominal quota.
 // The function also returns the resource name that yielded this value.
 func (c *ClusterQueue) DominantResourceShare(w *workload.Info) (int, corev1.ResourceName) {
+	return c.dominantResourceShare(w, 1)
+}
+
+func (c *ClusterQueue) DominantResourceShareWithout(w *workload.Info) (int, corev1.ResourceName) {
+	return c.dominantResourceShare(w, -1)
+}
+
+func (c *ClusterQueue) dominantResourceShare(w *workload.Info, m int64) (int, corev1.ResourceName) {
 	if c.Cohort == nil {
 		return 0, ""
 	}
-	var drs int64 = -1
+	var drs int64 = math.MinInt64
 	var dRes corev1.ResourceName
 	wUsage := w.ResourceUsage()
 	for rName, rStats := range c.ResourceStats {
 		var ratio int64
 		if c.Cohort.ResourceStats[rName].Lendable > 0 {
-			ratio = max(rStats.Usage+wUsage[rName]-rStats.Nominal, 0) * 100 /
+			ratio = (rStats.Usage + wUsage[rName]*m - rStats.Nominal) * 100 /
 				c.Cohort.ResourceStats[rName].Lendable
 		}
 		// Use alphabetical order to get a deterministic resource name.

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -685,7 +685,11 @@ func (c *ClusterQueue) UsedCohortQuota(fName kueue.ResourceFlavorReference, rNam
 // provided by the ClusterQueue.
 // If zero, it means that the usage of the ClusterQueue is below the nominal quota.
 // The function also returns the resource name that yielded this value.
-func (c *ClusterQueue) DominantResourceShare(w *workload.Info) (int, corev1.ResourceName) {
+func (c *ClusterQueue) DominantResourceShare() (int, corev1.ResourceName) {
+	return c.dominantResourceShare(nil, 1)
+}
+
+func (c *ClusterQueue) DominantResourceShareWith(w *workload.Info) (int, corev1.ResourceName) {
 	return c.dominantResourceShare(w, 1)
 }
 

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -674,7 +674,8 @@ func TestDominantResourceShare(t *testing.T) {
 					},
 				},
 			},
-			wantDRName: corev1.ResourceCPU, // due to alphabetical order.
+			wantDRName:  corev1.ResourceCPU, // due to alphabetical order.
+			wantDRValue: -10,
 		},
 		"usage above nominal": {
 			cq: ClusterQueue{

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -821,7 +821,7 @@ func TestDominantResourceShare(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			drValue, drName := tc.cq.DominantResourceShare(tc.workload)
+			drValue, drName := tc.cq.DominantResourceShareWith(tc.workload)
 			if drValue != tc.wantDRValue {
 				t.Errorf("DominantResourceShare(_) returned value %d, want %d", drValue, tc.wantDRValue)
 			}

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -674,8 +674,7 @@ func TestDominantResourceShare(t *testing.T) {
 					},
 				},
 			},
-			wantDRName:  corev1.ResourceCPU, // due to alphabetical order.
-			wantDRValue: -10,
+			wantDRName: corev1.ResourceCPU, // due to alphabetical order.
 		},
 		"usage above nominal": {
 			cq: ClusterQueue{

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -30,13 +30,13 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
+	"sigs.k8s.io/kueue/pkg/util/heap"
 	"sigs.k8s.io/kueue/pkg/util/priority"
 	"sigs.k8s.io/kueue/pkg/util/routine"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -48,17 +48,19 @@ type Preemptor struct {
 	client   client.Client
 	recorder record.EventRecorder
 
-	workloadOrdering workload.Ordering
+	workloadOrdering  workload.Ordering
+	enableFairSharing bool
 
 	// stubs
 	applyPreemption func(context.Context, *kueue.Workload, string, string) error
 }
 
-func New(cl client.Client, workloadOrdering workload.Ordering, recorder record.EventRecorder) *Preemptor {
+func New(cl client.Client, workloadOrdering workload.Ordering, recorder record.EventRecorder, enableFairSharing bool) *Preemptor {
 	p := &Preemptor{
-		client:           cl,
-		recorder:         recorder,
-		workloadOrdering: workloadOrdering,
+		client:            cl,
+		recorder:          recorder,
+		workloadOrdering:  workloadOrdering,
+		enableFairSharing: enableFairSharing,
 	}
 	p.applyPreemption = p.applyPreemptionWithSSA
 	return p
@@ -103,18 +105,17 @@ func (p *Preemptor) GetTargets(wl workload.Info, assignment flavorassigner.Assig
 		return minimalPreemptions(wlReq, cq, snapshot, resPerFlv, candidates, true, nil)
 	}
 
+	borrowWithinCohort, thresholdPrio := canBorrowWithinCohort(cq, wl.Obj)
+	if p.enableFairSharing {
+		return fairPreemptions(&wl, assignment, snapshot, resPerFlv, candidates, thresholdPrio)
+	}
 	// There is a potential of preemption of workloads from the other queue in the
 	// cohort. We proceed with borrowing only if the dedicated policy
 	// (borrowWithinCohort) is enabled. This ensures the preempted workloads
 	// have lower priority, and so they will not preempt the preemptor when
 	// requeued.
-	borrowWithinCohort := cq.Preemption.BorrowWithinCohort
-	if borrowWithinCohort != nil && borrowWithinCohort.Policy != kueue.BorrowWithinCohortPolicyNever {
-		allowBorrowingBelowPriority := ptr.To(priority.Priority(wl.Obj))
-		if borrowWithinCohort.MaxPriorityThreshold != nil && *borrowWithinCohort.MaxPriorityThreshold < *allowBorrowingBelowPriority {
-			allowBorrowingBelowPriority = ptr.To(*borrowWithinCohort.MaxPriorityThreshold + 1)
-		}
-		return minimalPreemptions(wlReq, cq, snapshot, resPerFlv, candidates, true, allowBorrowingBelowPriority)
+	if borrowWithinCohort {
+		return minimalPreemptions(wlReq, cq, snapshot, resPerFlv, candidates, true, thresholdPrio)
 	}
 
 	// Only try preemptions in the cohort, without borrowing, if the target clusterqueue is still
@@ -128,6 +129,19 @@ func (p *Preemptor) GetTargets(wl workload.Info, assignment flavorassigner.Assig
 	// Final attempt. This time only candidates from the same queue, but
 	// with borrowing.
 	return minimalPreemptions(wlReq, cq, snapshot, resPerFlv, sameQueueCandidates, true, nil)
+}
+
+// canBorrowWithinCohort returns whether the behavior is enabled for the ClusterQueue and the threshold priority to use.
+func canBorrowWithinCohort(cq *cache.ClusterQueue, wl *kueue.Workload) (bool, *int32) {
+	borrowWithinCohort := cq.Preemption.BorrowWithinCohort
+	if borrowWithinCohort == nil || borrowWithinCohort.Policy == kueue.BorrowWithinCohortPolicyNever {
+		return false, nil
+	}
+	threshold := priority.Priority(wl)
+	if borrowWithinCohort.MaxPriorityThreshold != nil && *borrowWithinCohort.MaxPriorityThreshold < threshold {
+		threshold = *borrowWithinCohort.MaxPriorityThreshold + 1
+	}
+	return true, &threshold
 }
 
 // IssuePreemptions marks the target workloads as evicted.
@@ -212,13 +226,15 @@ func minimalPreemptions(wlReq cache.FlavorResourceQuantities, cq *cache.ClusterQ
 		}
 	}
 	if !fits {
-		// Reset changes to the snapshot.
-		for _, t := range targets {
-			snapshot.AddWorkload(t)
-		}
+		restoreSnapshot(snapshot, targets)
 		return nil
 	}
+	targets = fillBackWorkloads(targets, wlReq, cq, snapshot, allowBorrowing)
+	restoreSnapshot(snapshot, targets)
+	return targets
+}
 
+func fillBackWorkloads(targets []*workload.Info, wlReq cache.FlavorResourceQuantities, cq *cache.ClusterQueue, snapshot *cache.Snapshot, allowBorrowing bool) []*workload.Info {
 	// In the reverse order, check if any of the workloads can be added back.
 	for i := len(targets) - 2; i >= 0; i-- {
 		snapshot.AddWorkload(targets[i])
@@ -230,12 +246,99 @@ func minimalPreemptions(wlReq cache.FlavorResourceQuantities, cq *cache.ClusterQ
 			snapshot.RemoveWorkload(targets[i])
 		}
 	}
-	// Reset changes to the snapshot.
+	return targets
+}
+
+func restoreSnapshot(snapshot *cache.Snapshot, targets []*workload.Info) {
 	for _, t := range targets {
 		snapshot.AddWorkload(t)
 	}
+}
 
+func fairPreemptions(wl *workload.Info, assignment flavorassigner.Assignment, snapshot *cache.Snapshot, resPerFlv resourcesPerFlavor, candidates []*workload.Info, allowBorrowingBelowPriority *int32) []*workload.Info {
+	cqHeap := heap.New(
+		func(c *candidateCQ) string {
+			return c.cq.Name
+		},
+		func(c1, c2 *candidateCQ) bool {
+			return c1.share > c2.share
+		},
+	)
+	for _, cand := range candidates {
+		candCQ := cqHeap.GetByKey(cand.ClusterQueue)
+		if candCQ == nil {
+			cq := snapshot.ClusterQueues[cand.ClusterQueue]
+			share, _ := cq.DominantResourceShare(nil)
+			candCQ = &candidateCQ{
+				cq:        cq,
+				share:     share,
+				workloads: []*workload.Info{cand},
+			}
+			_ = cqHeap.PushIfNotPresent(candCQ)
+		} else {
+			candCQ.workloads = append(candCQ.workloads, cand)
+		}
+	}
+
+	nominatedCQ := snapshot.ClusterQueues[wl.ClusterQueue]
+	newNominatedShareValue, _ := nominatedCQ.DominantResourceShare(wl)
+	wlReq := totalRequestsForAssignment(wl, assignment)
+	var targets []*workload.Info
+	fits := false
+	for cqHeap.Len() > 0 && !fits {
+		candCQ := cqHeap.Pop()
+
+		if candCQ.cq == nominatedCQ {
+			candWl := candCQ.workloads[0]
+			snapshot.RemoveWorkload(candWl)
+			targets = append(targets, candWl)
+			if workloadFits(wlReq, nominatedCQ, true) {
+				fits = true
+				break
+			}
+			newNominatedShareValue, _ = nominatedCQ.DominantResourceShare(wl)
+			candCQ.workloads = candCQ.workloads[1:]
+			if len(candCQ.workloads) > 0 {
+				candCQ.share, _ = candCQ.cq.DominantResourceShare(nil)
+				cqHeap.PushIfNotPresent(candCQ)
+			}
+			continue
+		}
+
+		for i, candWl := range candCQ.workloads {
+			belowThreshold := allowBorrowingBelowPriority != nil && priority.Priority(candWl.Obj) < *allowBorrowingBelowPriority
+			// Rule S2-a in https://sigs.k8s.io/kueue/keps/1714-fair-sharing#choosing-workloads-from-clusterqueues-for-preemption
+			newCandShareVal, _ := candCQ.cq.DominantResourceShareWithout(candWl)
+			if belowThreshold || newNominatedShareValue <= newCandShareVal {
+				snapshot.RemoveWorkload(candWl)
+				targets = append(targets, candWl)
+				if workloadFits(wlReq, nominatedCQ, true) {
+					fits = true
+					break
+				}
+				candCQ.workloads = candCQ.workloads[i+1:]
+				if len(candCQ.workloads) > 0 && cqIsBorrowing(candCQ.cq, resPerFlv) {
+					candCQ.share = newCandShareVal
+					cqHeap.PushIfNotPresent(candCQ)
+				}
+				// Might need to pick a different CQ due to changing values.
+				break
+			}
+		}
+	}
+	if !fits {
+		restoreSnapshot(snapshot, targets)
+		return nil
+	}
+	targets = fillBackWorkloads(targets, wlReq, nominatedCQ, snapshot, true)
+	restoreSnapshot(snapshot, targets)
 	return targets
+}
+
+type candidateCQ struct {
+	cq        *cache.ClusterQueue
+	workloads []*workload.Info
+	share     int
 }
 
 type resourcesPerFlavor map[kueue.ResourceFlavorReference]sets.Set[corev1.ResourceName]

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -268,7 +268,7 @@ func fairPreemptions(wl *workload.Info, assignment flavorassigner.Assignment, sn
 		candCQ := cqHeap.GetByKey(cand.ClusterQueue)
 		if candCQ == nil {
 			cq := snapshot.ClusterQueues[cand.ClusterQueue]
-			share, _ := cq.DominantResourceShare(nil)
+			share, _ := cq.DominantResourceShare()
 			candCQ = &candidateCQ{
 				cq:        cq,
 				share:     share,
@@ -281,7 +281,7 @@ func fairPreemptions(wl *workload.Info, assignment flavorassigner.Assignment, sn
 	}
 
 	nominatedCQ := snapshot.ClusterQueues[wl.ClusterQueue]
-	newNominatedShareValue, _ := nominatedCQ.DominantResourceShare(wl)
+	newNominatedShareValue, _ := nominatedCQ.DominantResourceShareWith(wl)
 	wlReq := totalRequestsForAssignment(wl, assignment)
 	var targets []*workload.Info
 	fits := false
@@ -296,10 +296,10 @@ func fairPreemptions(wl *workload.Info, assignment flavorassigner.Assignment, sn
 				fits = true
 				break
 			}
-			newNominatedShareValue, _ = nominatedCQ.DominantResourceShare(wl)
+			newNominatedShareValue, _ = nominatedCQ.DominantResourceShareWith(wl)
 			candCQ.workloads = candCQ.workloads[1:]
 			if len(candCQ.workloads) > 0 {
-				candCQ.share, _ = candCQ.cq.DominantResourceShare(nil)
+				candCQ.share, _ = candCQ.cq.DominantResourceShare()
 				cqHeap.PushIfNotPresent(candCQ)
 			}
 			continue

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -37,6 +38,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
+	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -1313,7 +1315,7 @@ func TestPreemption(t *testing.T) {
 			broadcaster := record.NewBroadcaster()
 			scheme := runtime.NewScheme()
 			recorder := broadcaster.NewRecorder(scheme, corev1.EventSource{Component: constants.AdmissionName})
-			preemptor := New(cl, workload.Ordering{}, recorder)
+			preemptor := New(cl, workload.Ordering{}, recorder, false)
 			preemptor.applyPreemption = func(ctx context.Context, w *kueue.Workload, _, _ string) error {
 				lock.Lock()
 				gotPreempted.Insert(workload.Key(w))
@@ -1340,6 +1342,232 @@ func TestPreemption(t *testing.T) {
 			}
 			if diff := cmp.Diff(startingSnapshot, snapshot, snapCmpOpts...); diff != "" {
 				t.Errorf("Snapshot was modified (-initial,+end):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFairPreemption(t *testing.T) {
+	now := time.Now()
+	flavors := []*kueue.ResourceFlavor{
+		utiltesting.MakeResourceFlavor("default").Obj(),
+	}
+	clusterQueues := []*kueue.ClusterQueue{
+		utiltesting.MakeClusterQueue("a").
+			Cohort("all").
+			ResourceGroup(*utiltesting.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "3").Obj()).
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				BorrowWithinCohort: &kueue.BorrowWithinCohort{
+					Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
+					MaxPriorityThreshold: ptr.To[int32](-3),
+				},
+			}).
+			Obj(),
+		utiltesting.MakeClusterQueue("b").
+			Cohort("all").
+			ResourceGroup(*utiltesting.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "3").Obj()).
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				BorrowWithinCohort: &kueue.BorrowWithinCohort{
+					Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
+					MaxPriorityThreshold: ptr.To[int32](-3),
+				},
+			}).
+			Obj(),
+		utiltesting.MakeClusterQueue("c").
+			Cohort("all").
+			ResourceGroup(*utiltesting.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "3").Obj()).
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				BorrowWithinCohort: &kueue.BorrowWithinCohort{
+					Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
+					MaxPriorityThreshold: ptr.To[int32](-3),
+				},
+			}).
+			Obj(),
+		utiltesting.MakeClusterQueue("preemptible").
+			Cohort("all").
+			ResourceGroup(*utiltesting.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "0").Obj()).
+			Obj(),
+	}
+	unitWl := *utiltesting.MakeWorkload("unit", "").Request(corev1.ResourceCPU, "1")
+	cases := map[string]struct {
+		admitted      []kueue.Workload
+		incoming      *kueue.Workload
+		targetCQ      string
+		wantPreempted sets.Set[string]
+	}{
+		"reclaim nominal from user using the most": {
+			admitted: []kueue.Workload{
+				*unitWl.Clone().Name("a1").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a2").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a3").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("b1").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b2").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b3").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b4").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b5").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("c1").SimpleReserveQuota("c", "default", now).Obj(),
+			},
+			incoming:      unitWl.Clone().Name("c_incoming").Obj(),
+			targetCQ:      "c",
+			wantPreempted: sets.New("/b1"),
+		},
+		"reclaim borrowable quota from user using the most": {
+			admitted: []kueue.Workload{
+				*unitWl.Clone().Name("a1").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a2").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a3").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("b1").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b2").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b3").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b4").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b5").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("c1").SimpleReserveQuota("c", "default", now).Obj(),
+			},
+			incoming:      unitWl.Clone().Name("a_incoming").Obj(),
+			targetCQ:      "a",
+			wantPreempted: sets.New("/b1"),
+		},
+		"preempt one from each CQ borrowing": {
+			admitted: []kueue.Workload{
+				*utiltesting.MakeWorkload("a1", "").Request(corev1.ResourceCPU, "3").SimpleReserveQuota("a", "default", now).Obj(),
+				*utiltesting.MakeWorkload("a2", "").Request(corev1.ResourceCPU, "0.5").SimpleReserveQuota("a", "default", now).Obj(),
+				*utiltesting.MakeWorkload("a3", "").Request(corev1.ResourceCPU, "0.5").SimpleReserveQuota("a", "default", now).Obj(),
+				*utiltesting.MakeWorkload("b1", "").Request(corev1.ResourceCPU, "3").SimpleReserveQuota("b", "default", now).Obj(),
+				*utiltesting.MakeWorkload("b2", "").Request(corev1.ResourceCPU, "0.5").SimpleReserveQuota("b", "default", now).Obj(),
+				*utiltesting.MakeWorkload("b3", "").Request(corev1.ResourceCPU, "0.5").SimpleReserveQuota("b", "default", now).Obj(),
+			},
+			incoming:      utiltesting.MakeWorkload("c_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
+			targetCQ:      "c",
+			wantPreempted: sets.New("/a2", "/b2"),
+		},
+		"can't preempt when everyone under nominal": {
+			admitted: []kueue.Workload{
+				*unitWl.Clone().Name("a1").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a2").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a3").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("b1").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b2").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b3").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("c1").SimpleReserveQuota("c", "default", now).Obj(),
+				*unitWl.Clone().Name("c2").SimpleReserveQuota("c", "default", now).Obj(),
+				*unitWl.Clone().Name("c3").SimpleReserveQuota("c", "default", now).Obj(),
+			},
+			incoming: unitWl.Clone().Name("c_incoming").Obj(),
+			targetCQ: "c",
+		},
+		"can't preempt when it would switch the imbalance": {
+			admitted: []kueue.Workload{
+				*unitWl.Clone().Name("a1").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a2").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a3").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("b1").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b2").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b3").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b4").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b5").SimpleReserveQuota("b", "default", now).Obj(),
+			},
+			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
+			targetCQ: "a",
+		},
+		"can preempt lower priority workloads from same CQ": {
+			admitted: []kueue.Workload{
+				*unitWl.Clone().Name("a1_low").Priority(-1).SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a2_low").Priority(-1).SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a3").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a4").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("b1").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b2").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b3").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b4").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b5").SimpleReserveQuota("b", "default", now).Obj(),
+			},
+			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
+			targetCQ:      "a",
+			wantPreempted: sets.New("/a1_low", "/a2_low"),
+		},
+		"can preempt a combination of same CQ and highest user": {
+			admitted: []kueue.Workload{
+				*unitWl.Clone().Name("a_low").Priority(-1).SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a2").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a3").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("b1").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b2").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b3").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b4").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b5").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b6").SimpleReserveQuota("b", "default", now).Obj(),
+			},
+			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
+			targetCQ:      "a",
+			wantPreempted: sets.New("/a_low", "/b1"),
+		},
+		"workloads under priority threshold can always be preempted": {
+			admitted: []kueue.Workload{
+				*unitWl.Clone().Name("a1").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a2").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("a3").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("b1").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b2").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b3").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("preemptible1").Priority(-3).SimpleReserveQuota("preemptible", "default", now).Obj(),
+				*unitWl.Clone().Name("preemptible2").Priority(-3).SimpleReserveQuota("preemptible", "default", now).Obj(),
+				*unitWl.Clone().Name("preemptible3").Priority(-3).SimpleReserveQuota("preemptible", "default", now).Obj(),
+			},
+			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
+			targetCQ:      "a",
+			wantPreempted: sets.New("/preemptible1", "/preemptible2"),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			// Set name as UID so that candidates sorting is predictable.
+			for i := range tc.admitted {
+				tc.admitted[i].UID = types.UID(tc.admitted[i].Name)
+			}
+			cl := utiltesting.NewClientBuilder().
+				WithLists(&kueue.WorkloadList{Items: tc.admitted}).
+				Build()
+			cqCache := cache.New(cl)
+			for _, flv := range flavors {
+				cqCache.AddOrUpdateResourceFlavor(flv)
+			}
+			for _, cq := range clusterQueues {
+				if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
+					t.Fatalf("Couldn't add ClusterQueue to cache: %v", err)
+				}
+			}
+
+			broadcaster := record.NewBroadcaster()
+			scheme := runtime.NewScheme()
+			recorder := broadcaster.NewRecorder(scheme, corev1.EventSource{Component: constants.AdmissionName})
+			preemptor := New(cl, workload.Ordering{}, recorder, true)
+
+			snapshot := cqCache.Snapshot()
+			wlInfo := workload.NewInfo(tc.incoming)
+			wlInfo.ClusterQueue = tc.targetCQ
+			targets := preemptor.GetTargets(*wlInfo, singlePodSetAssignment(
+				flavorassigner.ResourceAssignment{
+					corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
+						Name: "default", Mode: flavorassigner.Preempt,
+					},
+				},
+			), &snapshot)
+			gotTargets := sets.New(slices.Map(targets, func(w **workload.Info) string {
+				return workload.Key((*w).Obj)
+			})...)
+			if diff := cmp.Diff(tc.wantPreempted, gotTargets, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Issued preemptions (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -1439,16 +1439,16 @@ func TestFairPreemption(t *testing.T) {
 		},
 		"preempt one from each CQ borrowing": {
 			admitted: []kueue.Workload{
-				*utiltesting.MakeWorkload("a1", "").Request(corev1.ResourceCPU, "3").SimpleReserveQuota("a", "default", now).Obj(),
+				*utiltesting.MakeWorkload("a1", "").Request(corev1.ResourceCPU, "0.5").SimpleReserveQuota("a", "default", now).Obj(),
 				*utiltesting.MakeWorkload("a2", "").Request(corev1.ResourceCPU, "0.5").SimpleReserveQuota("a", "default", now).Obj(),
-				*utiltesting.MakeWorkload("a3", "").Request(corev1.ResourceCPU, "0.5").SimpleReserveQuota("a", "default", now).Obj(),
-				*utiltesting.MakeWorkload("b1", "").Request(corev1.ResourceCPU, "3").SimpleReserveQuota("b", "default", now).Obj(),
+				*utiltesting.MakeWorkload("a3", "").Request(corev1.ResourceCPU, "3").SimpleReserveQuota("a", "default", now).Obj(),
+				*utiltesting.MakeWorkload("b1", "").Request(corev1.ResourceCPU, "0.5").SimpleReserveQuota("b", "default", now).Obj(),
 				*utiltesting.MakeWorkload("b2", "").Request(corev1.ResourceCPU, "0.5").SimpleReserveQuota("b", "default", now).Obj(),
-				*utiltesting.MakeWorkload("b3", "").Request(corev1.ResourceCPU, "0.5").SimpleReserveQuota("b", "default", now).Obj(),
+				*utiltesting.MakeWorkload("b3", "").Request(corev1.ResourceCPU, "3").SimpleReserveQuota("b", "default", now).Obj(),
 			},
 			incoming:      utiltesting.MakeWorkload("c_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ:      "c",
-			wantPreempted: sets.New("/a2", "/b2"),
+			wantPreempted: sets.New("/a1", "/b1"),
 		},
 		"can't preempt when everyone under nominal": {
 			admitted: []kueue.Workload{

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -114,7 +114,7 @@ func New(queues *queue.Manager, cache *cache.Cache, cl client.Client, recorder r
 		cache:                   cache,
 		client:                  cl,
 		recorder:                recorder,
-		preemptor:               preemption.New(cl, wo, recorder),
+		preemptor:               preemption.New(cl, wo, recorder, options.enableFairSharing),
 		admissionRoutineWrapper: routine.DefaultWrapper,
 		workloadOrdering:        wo,
 	}
@@ -405,7 +405,7 @@ type partialAssignment struct {
 
 func (s *Scheduler) getAssignments(log logr.Logger, wl *workload.Info, snap *cache.Snapshot) (flavorassigner.Assignment, []*workload.Info) {
 	cq := snap.ClusterQueues[wl.ClusterQueue]
-	flvAssigner := flavorassigner.New(wl, cq, snap.ResourceFlavors)
+	flvAssigner := flavorassigner.New(wl, cq, snap.ResourceFlavors, s.enableFairSharing)
 	fullAssignment := flvAssigner.Assign(log, nil)
 	var faPreemtionTargets []*workload.Info
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -358,7 +358,7 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 			e.inadmissibleMsg = e.assignment.Message()
 			e.Info.LastAssignment = &e.assignment.LastState
 			if s.enableFairSharing {
-				e.dominantResourceShare, e.dominantResourceName = cq.DominantResourceShare(&w)
+				e.dominantResourceShare, e.dominantResourceName = cq.DominantResourceShareWith(&w)
 			}
 		}
 		entries = append(entries, e)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1572,19 +1572,22 @@ func TestSchedule(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					SimpleReserveQuota("eng-alpha", "on-demand", now).Obj(),
 				*utiltesting.MakeWorkload("gamma1", "eng-gamma").UID("gamma1").
-					Request(corev1.ResourceCPU, "50").
+					Request(corev1.ResourceCPU, "10").
 					SimpleReserveQuota("eng-gamma", "on-demand", now).Obj(),
 				*utiltesting.MakeWorkload("gamma2", "eng-gamma").UID("gamma2").
-					Request(corev1.ResourceCPU, "10").
+					Request(corev1.ResourceCPU, "20").
 					SimpleReserveQuota("eng-gamma", "on-demand", now).Obj(),
 				*utiltesting.MakeWorkload("gamma3", "eng-gamma").UID("gamma3").
-					Request(corev1.ResourceCPU, "10").
+					Request(corev1.ResourceCPU, "20").
+					SimpleReserveQuota("eng-gamma", "on-demand", now).Obj(),
+				*utiltesting.MakeWorkload("gamma4", "eng-gamma").UID("gamma4").
+					Request(corev1.ResourceCPU, "20").
 					SimpleReserveQuota("eng-gamma", "on-demand", now).Obj(),
 				*utiltesting.MakeWorkload("preemptor", "eng-beta").
 					Queue("main").
 					Request(corev1.ResourceCPU, "30").Obj(),
 			},
-			wantPreempted: sets.New("eng-alpha/alpha1", "eng-gamma/gamma2"),
+			wantPreempted: sets.New("eng-alpha/alpha1", "eng-gamma/gamma1"),
 			wantLeft: map[string][]string{
 				// Preemptor is not admitted in this cycle.
 				"eng-beta": {"eng-beta/preemptor"},
@@ -1595,9 +1598,10 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/alpha2":   *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
 				"eng-alpha/alpha3":   *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
 				"eng-alpha/alpha4":   *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-gamma/gamma1":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj(),
-				"eng-gamma/gamma2":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
-				"eng-gamma/gamma3":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
+				"eng-gamma/gamma1":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
+				"eng-gamma/gamma2":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"eng-gamma/gamma3":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"eng-gamma/gamma4":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
 			},
 		},
 	}

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -124,6 +124,24 @@ func (w *WorkloadWrapper) Active(a bool) *WorkloadWrapper {
 	return w
 }
 
+// SimpleReserveQuota reserves the quota for all the requested resources in one flavor.
+// It assumes one podset with one container.
+func (w *WorkloadWrapper) SimpleReserveQuota(cq, flavor string, now time.Time) *WorkloadWrapper {
+	admission := MakeAdmission(cq, w.Spec.PodSets[0].Name)
+	resReq := make(corev1.ResourceList)
+	flavors := make(map[corev1.ResourceName]kueue.ResourceFlavorReference)
+	for res, val := range w.Spec.PodSets[0].Template.Spec.Containers[0].Resources.Requests {
+		val.Mul(int64(w.Spec.PodSets[0].Count))
+		resReq[res] = val
+		flavors[res] = kueue.ResourceFlavorReference(flavor)
+	}
+	admission.PodSetAssignments[0].Count = ptr.To(w.Spec.PodSets[0].Count)
+	admission.PodSetAssignments[0].Flavors = flavors
+	admission.PodSetAssignments[0].ResourceUsage = resReq
+
+	return w.ReserveQuotaAt(admission.Obj(), now)
+}
+
 // ReserveQuota sets workload admission and adds a "QuotaReserved" status condition
 func (w *WorkloadWrapper) ReserveQuota(a *kueue.Admission) *WorkloadWrapper {
 	return w.ReserveQuotaAt(a, time.Now())

--- a/test/integration/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/scheduler/fairsharing/fair_sharing_test.go
@@ -223,7 +223,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectPendingWorkloadsMetric(cqB, 5, 0)
 
 			ginkgo.By("Finishing eviction of 4 running workloads in cqA: shared quota is fair-shared")
-			finishEvictionofWorkloadsInCQ(cqA, 4)
+			finishEvictionOfWorkloadsInCQ(cqA, 4)
 			util.ExpectReservingActiveWorkloadsMetric(cqB, 4)
 
 			ginkgo.By("cq-c reclaims one unit, preemption happens in cq-a")
@@ -232,7 +232,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectPendingWorkloadsMetric(cqC, 1, 0)
 
 			ginkgo.By("Finishing eviction of 1 running workloads in the CQ with highest usage: cqA")
-			finishEvictionofWorkloadsInCQ(cqA, 1)
+			finishEvictionOfWorkloadsInCQ(cqA, 1)
 			util.ExpectReservingActiveWorkloadsMetric(cqC, 1)
 		})
 	})
@@ -253,7 +253,7 @@ func finishRunningWorkloadsInCQ(cq *kueue.ClusterQueue, n int) {
 	gomega.ExpectWithOffset(1, finished).To(gomega.Equal(n), "Not enough workloads finished")
 }
 
-func finishEvictionofWorkloadsInCQ(cq *kueue.ClusterQueue, n int) {
+func finishEvictionOfWorkloadsInCQ(cq *kueue.ClusterQueue, n int) {
 	finished := sets.New[types.UID]()
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) int {
 		var wList kueue.WorkloadList

--- a/test/integration/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/scheduler/fairsharing/fair_sharing_test.go
@@ -25,9 +25,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/test/util"
 )
 
@@ -142,6 +145,98 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		})
 	})
 
+	ginkgo.When("Preemption is enabled", func() {
+
+		var (
+			cqA *kueue.ClusterQueue
+			lqA *kueue.LocalQueue
+			cqB *kueue.ClusterQueue
+			lqB *kueue.LocalQueue
+			cqC *kueue.ClusterQueue
+			lqC *kueue.LocalQueue
+		)
+		ginkgo.BeforeEach(func() {
+			cqA = testing.MakeClusterQueue("a").
+				Cohort("all").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "3").Obj(),
+				).Preemption(kueue.ClusterQueuePreemption{
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+			}).Obj()
+			gomega.Expect(k8sClient.Create(ctx, cqA)).To(gomega.Succeed())
+			lqA = testing.MakeLocalQueue("a", ns.Name).ClusterQueue("a").Obj()
+			gomega.Expect(k8sClient.Create(ctx, lqA)).To(gomega.Succeed())
+
+			cqB = testing.MakeClusterQueue("b").
+				Cohort("all").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "3").Obj(),
+				).Preemption(kueue.ClusterQueuePreemption{
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+			}).Obj()
+			gomega.Expect(k8sClient.Create(ctx, cqB)).To(gomega.Succeed())
+			lqB = testing.MakeLocalQueue("b", ns.Name).ClusterQueue("b").Obj()
+			gomega.Expect(k8sClient.Create(ctx, lqB)).To(gomega.Succeed())
+
+			cqC = testing.MakeClusterQueue("c").
+				Cohort("all").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "3").Obj(),
+				).Preemption(kueue.ClusterQueuePreemption{
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+			}).Obj()
+			gomega.Expect(k8sClient.Create(ctx, cqC)).To(gomega.Succeed())
+			lqC = testing.MakeLocalQueue("c", ns.Name).ClusterQueue("c").Obj()
+			gomega.Expect(k8sClient.Create(ctx, lqC)).To(gomega.Succeed())
+		})
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteClusterQueue(ctx, k8sClient, cqA)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteClusterQueue(ctx, k8sClient, cqB)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteClusterQueue(ctx, k8sClient, cqC)).To(gomega.Succeed())
+		})
+
+		ginkgo.It("Admits workloads respecting fair share", func() {
+			ginkgo.By("Saturating cq-a")
+
+			aWorkloads := make([]*kueue.Workload, 10)
+			for i := range aWorkloads {
+				aWorkloads[i] = testing.MakeWorkload(fmt.Sprintf("a-%d", i), ns.Name).
+					Queue("a").
+					Request(corev1.ResourceCPU, "1").Obj()
+				gomega.Expect(k8sClient.Create(ctx, aWorkloads[i])).To(gomega.Succeed())
+			}
+			util.ExpectReservingActiveWorkloadsMetric(cqA, 9)
+			util.ExpectPendingWorkloadsMetric(cqA, 0, 1)
+
+			ginkgo.By("Creating newer workloads in cq-b")
+			bWorkloads := make([]*kueue.Workload, 5)
+			for i := range bWorkloads {
+				bWorkloads[i] = testing.MakeWorkload(fmt.Sprintf("b-%d", i), ns.Name).
+					Queue("b").
+					Request(corev1.ResourceCPU, "1").Obj()
+				gomega.Expect(k8sClient.Create(ctx, bWorkloads[i])).To(gomega.Succeed())
+			}
+			util.ExpectPendingWorkloadsMetric(cqB, 5, 0)
+
+			ginkgo.By("Finishing eviction of 4 running workloads in cqA: shared quota is fair-shared")
+			finishEvictionofWorkloadsInCQ(cqA, 4)
+			util.ExpectReservingActiveWorkloadsMetric(cqB, 4)
+
+			ginkgo.By("cq-c reclaims one unit, preemption happens in cq-a")
+			cWorkload := testing.MakeWorkload("c0", ns.Name).Queue("c").Request(corev1.ResourceCPU, "1").Obj()
+			gomega.Expect(k8sClient.Create(ctx, cWorkload)).To(gomega.Succeed())
+			util.ExpectPendingWorkloadsMetric(cqC, 1, 0)
+
+			ginkgo.By("Finishing eviction of 1 running workloads in the CQ with highest usage: cqA")
+			finishEvictionofWorkloadsInCQ(cqA, 1)
+			util.ExpectReservingActiveWorkloadsMetric(cqC, 1)
+		})
+	})
+
 })
 
 func finishRunningWorkloadsInCQ(cq *kueue.ClusterQueue, n int) {
@@ -156,4 +251,26 @@ func finishRunningWorkloadsInCQ(cq *kueue.ClusterQueue, n int) {
 		}
 	}
 	gomega.ExpectWithOffset(1, finished).To(gomega.Equal(n), "Not enough workloads finished")
+}
+
+func finishEvictionofWorkloadsInCQ(cq *kueue.ClusterQueue, n int) {
+	finished := sets.New[types.UID]()
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) int {
+		var wList kueue.WorkloadList
+		g.Expect(k8sClient.List(ctx, &wList)).To(gomega.Succeed())
+		for i := 0; i < len(wList.Items) && finished.Len() < n; i++ {
+			wl := wList.Items[i]
+			if wl.Status.Admission == nil || string(wl.Status.Admission.ClusterQueue) != cq.Name {
+				continue
+			}
+			evicted := meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted)
+			quotaReserved := meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
+			if evicted && quotaReserved {
+				workload.UnsetQuotaReservationWithCondition(&wl, "Pending", "Eviction finished by test")
+				g.Expect(workload.ApplyAdmissionStatus(ctx, k8sClient, &wl, true)).To(gomega.Succeed())
+				finished.Insert(wl.UID)
+			}
+		}
+		return finished.Len()
+	}, util.Timeout, util.Interval).Should(gomega.Equal(n), "Not enough workloads evicted")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is an implementation of rule S2-a of https://sigs.k8s.io/kueue/keps/1714-fair-sharing#choosing-workloads-from-clusterqueues-for-preemption

In simple terms:
Preempt if the CQ of the incoming workload doesn't obtain a share higher than the final share of the CQ being preempted.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #1714

#### Special notes for your reviewer:

WIP because I would still like to write an integration test that causes preemptions from multiple workloads to multiple workloads.

A follow up PR will include rule S2-b, which is not immediately obvious.

#### Does this PR introduce a user-facing change?

Not yet. The boolean that determines the use of fair sharing is not accessible through any API.

```release-note
NONE
```