### PR TITLE
fix some issue about lendingLimit docs

### DIFF
--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -305,7 +305,7 @@ can admit Workloads with resources adding up to `9+1=10` CPUs.
 If, for a given flavor/resource, the `borrowingLimit` field is empty or null,
 a ClusterQueue can borrow up to the sum of nominal quotas from all the
 ClusterQueues in the cohort. So for the yamls listed above, `team-b-cq` can
-borrow `12+9` CPUs.
+use up to `12+9` CPUs.
 
 ### LendingLimit
 
@@ -365,7 +365,7 @@ then ClusterQueue `team-a-cq` can admit Workloads with resources
 adding up to `9+1=10` CPUs.
 
 If the `lendingLimit` field is not specified, a ClusterQueue can lend out
-all of its resources. In this case, `team-a-cq` can use up to `9+12` CPUs.
+all of its resources. In this case, `team-b-cq` can use up to `9+12` CPUs.
 
 ## Preemption
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

the `lendingLimit` is limit quota can be lend to other ClusterQueues.
And `team-b-cq` set `lendingLimit` to 1 means `team-a-cq` can use up to 9+1 cpus.
And `team-a-cq` set `lendingLimit` as empty,  means all its quota can be lend out, so `team-b-cq` can use up to 12+9

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```