### PR TITLE
add a metric for eviction number in cluster queue

### DIFF
--- a/pkg/controller/core/clusterqueue_controller_test.go
+++ b/pkg/controller/core/clusterqueue_controller_test.go
@@ -224,9 +224,9 @@ func TestUpdateCqStatusIfChanged(t *testing.T) {
 }
 
 type cqMetrics struct {
-	NominalDPs   []testingmetrics.GaugeDataPoint
-	BorrowingDPs []testingmetrics.GaugeDataPoint
-	UsageDPs     []testingmetrics.GaugeDataPoint
+	NominalDPs   []testingmetrics.MetricDataPoint
+	BorrowingDPs []testingmetrics.MetricDataPoint
+	UsageDPs     []testingmetrics.MetricDataPoint
 }
 
 func allMetricsForQueue(name string) cqMetrics {
@@ -237,8 +237,8 @@ func allMetricsForQueue(name string) cqMetrics {
 	}
 }
 
-func resourceDataPoint(cohort, name, flavor, res string, v float64) testingmetrics.GaugeDataPoint {
-	return testingmetrics.GaugeDataPoint{
+func resourceDataPoint(cohort, name, flavor, res string, v float64) testingmetrics.MetricDataPoint {
+	return testingmetrics.MetricDataPoint{
 		Labels: map[string]string{
 			"cohort":        cohort,
 			"cluster_queue": name,
@@ -299,13 +299,13 @@ func TestRecordResourceMetrics(t *testing.T) {
 		"no change": {
 			queue: baseQueue.DeepCopy(),
 			wantMetrics: cqMetrics{
-				NominalDPs: []testingmetrics.GaugeDataPoint{
+				NominalDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 1),
 				},
-				BorrowingDPs: []testingmetrics.GaugeDataPoint{
+				BorrowingDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
-				UsageDPs: []testingmetrics.GaugeDataPoint{
+				UsageDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
 			},
@@ -313,13 +313,13 @@ func TestRecordResourceMetrics(t *testing.T) {
 		"update-in-place": {
 			queue: baseQueue.DeepCopy(),
 			wantMetrics: cqMetrics{
-				NominalDPs: []testingmetrics.GaugeDataPoint{
+				NominalDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 1),
 				},
-				BorrowingDPs: []testingmetrics.GaugeDataPoint{
+				BorrowingDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
-				UsageDPs: []testingmetrics.GaugeDataPoint{
+				UsageDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
 			},
@@ -331,13 +331,13 @@ func TestRecordResourceMetrics(t *testing.T) {
 				return ret
 			}(),
 			wantUpdatedMetrics: cqMetrics{
-				NominalDPs: []testingmetrics.GaugeDataPoint{
+				NominalDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
-				BorrowingDPs: []testingmetrics.GaugeDataPoint{
+				BorrowingDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 1),
 				},
-				UsageDPs: []testingmetrics.GaugeDataPoint{
+				UsageDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 3),
 				},
 			},
@@ -345,13 +345,13 @@ func TestRecordResourceMetrics(t *testing.T) {
 		"change-cohort": {
 			queue: baseQueue.DeepCopy(),
 			wantMetrics: cqMetrics{
-				NominalDPs: []testingmetrics.GaugeDataPoint{
+				NominalDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 1),
 				},
-				BorrowingDPs: []testingmetrics.GaugeDataPoint{
+				BorrowingDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
-				UsageDPs: []testingmetrics.GaugeDataPoint{
+				UsageDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
 			},
@@ -361,13 +361,13 @@ func TestRecordResourceMetrics(t *testing.T) {
 				return ret
 			}(),
 			wantUpdatedMetrics: cqMetrics{
-				NominalDPs: []testingmetrics.GaugeDataPoint{
+				NominalDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort2", "name", "flavor", string(corev1.ResourceCPU), 1),
 				},
-				BorrowingDPs: []testingmetrics.GaugeDataPoint{
+				BorrowingDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort2", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
-				UsageDPs: []testingmetrics.GaugeDataPoint{
+				UsageDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort2", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
 			},
@@ -375,13 +375,13 @@ func TestRecordResourceMetrics(t *testing.T) {
 		"add-rm-flavor": {
 			queue: baseQueue.DeepCopy(),
 			wantMetrics: cqMetrics{
-				NominalDPs: []testingmetrics.GaugeDataPoint{
+				NominalDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 1),
 				},
-				BorrowingDPs: []testingmetrics.GaugeDataPoint{
+				BorrowingDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
-				UsageDPs: []testingmetrics.GaugeDataPoint{
+				UsageDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
 			},
@@ -392,13 +392,13 @@ func TestRecordResourceMetrics(t *testing.T) {
 				return ret
 			}(),
 			wantUpdatedMetrics: cqMetrics{
-				NominalDPs: []testingmetrics.GaugeDataPoint{
+				NominalDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor2", string(corev1.ResourceCPU), 1),
 				},
-				BorrowingDPs: []testingmetrics.GaugeDataPoint{
+				BorrowingDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor2", string(corev1.ResourceCPU), 2),
 				},
-				UsageDPs: []testingmetrics.GaugeDataPoint{
+				UsageDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor2", string(corev1.ResourceCPU), 2),
 				},
 			},
@@ -406,13 +406,13 @@ func TestRecordResourceMetrics(t *testing.T) {
 		"add-rm-resource": {
 			queue: baseQueue.DeepCopy(),
 			wantMetrics: cqMetrics{
-				NominalDPs: []testingmetrics.GaugeDataPoint{
+				NominalDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 1),
 				},
-				BorrowingDPs: []testingmetrics.GaugeDataPoint{
+				BorrowingDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
-				UsageDPs: []testingmetrics.GaugeDataPoint{
+				UsageDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
 			},
@@ -423,13 +423,13 @@ func TestRecordResourceMetrics(t *testing.T) {
 				return ret
 			}(),
 			wantUpdatedMetrics: cqMetrics{
-				NominalDPs: []testingmetrics.GaugeDataPoint{
+				NominalDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceMemory), 1),
 				},
-				BorrowingDPs: []testingmetrics.GaugeDataPoint{
+				BorrowingDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceMemory), 2),
 				},
-				UsageDPs: []testingmetrics.GaugeDataPoint{
+				UsageDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceMemory), 2),
 				},
 			},
@@ -437,13 +437,13 @@ func TestRecordResourceMetrics(t *testing.T) {
 		"drop-usage": {
 			queue: baseQueue.DeepCopy(),
 			wantMetrics: cqMetrics{
-				NominalDPs: []testingmetrics.GaugeDataPoint{
+				NominalDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 1),
 				},
-				BorrowingDPs: []testingmetrics.GaugeDataPoint{
+				BorrowingDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
-				UsageDPs: []testingmetrics.GaugeDataPoint{
+				UsageDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
 			},
@@ -453,10 +453,10 @@ func TestRecordResourceMetrics(t *testing.T) {
 				return ret
 			}(),
 			wantUpdatedMetrics: cqMetrics{
-				NominalDPs: []testingmetrics.GaugeDataPoint{
+				NominalDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 1),
 				},
-				BorrowingDPs: []testingmetrics.GaugeDataPoint{
+				BorrowingDPs: []testingmetrics.MetricDataPoint{
 					resourceDataPoint("cohort", "name", "flavor", string(corev1.ResourceCPU), 2),
 				},
 			},
@@ -464,7 +464,7 @@ func TestRecordResourceMetrics(t *testing.T) {
 	}
 
 	opts := []cmp.Option{
-		cmpopts.SortSlices(func(a, b testingmetrics.GaugeDataPoint) bool { return a.Less(&b) }),
+		cmpopts.SortSlices(func(a, b testingmetrics.MetricDataPoint) bool { return a.Less(&b) }),
 		cmpopts.EquateEmpty(),
 	}
 

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -194,10 +194,12 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, workload.ApplyAdmissionStatus(ctx, r.client, &wl, true)
 		}
 	} else if !workload.IsEvictedByDeactivation(&wl) {
+		// if job is not active and does not have condition reason of WorkloadEvictedByDeactivation, update its condition
 		workload.SetEvictedCondition(&wl, kueue.WorkloadEvictedByDeactivation, "The workload is deactivated")
 		if err := workload.ApplyAdmissionStatus(ctx, r.client, &wl, true); err != nil {
 			return ctrl.Result{}, fmt.Errorf("setting eviction: %w", err)
 		}
+		metrics.ReportEvictedWorkloads(string(wl.Status.Admission.ClusterQueue), kueue.WorkloadEvictedByDeactivation)
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -38,7 +38,6 @@ import (
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
-	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/podset"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	"sigs.k8s.io/kueue/pkg/util/equality"

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -568,6 +568,7 @@ func (m *Manager) PendingWorkloadsInfo(cqName string) []*workload.Info {
 	return cq.Snapshot()
 }
 
+// ClusterQueueFromLocalQueue returns ClusterQueue name, with a QueueKey(namespace/localQueueName) as the parameter
 func (m *Manager) ClusterQueueFromLocalQueue(lqName string) (string, error) {
 	m.RLock()
 	defer m.RUnlock()

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -35,6 +35,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
 	"sigs.k8s.io/kueue/pkg/util/heap"
 	"sigs.k8s.io/kueue/pkg/util/priority"
@@ -185,6 +186,7 @@ func (p *Preemptor) IssuePreemptions(ctx context.Context, preemptor *workload.In
 
 			log.V(3).Info("Preempted", "targetWorkload", klog.KObj(target.Obj), "reason", reason, "message", message)
 			p.recorder.Eventf(target.Obj, corev1.EventTypeNormal, "Preempted", message)
+			metrics.ReportEvictedWorkloads(target.ClusterQueue, kueue.WorkloadEvictedByPreemption)
 		} else {
 			log.V(3).Info("Preemption ongoing", "targetWorkload", klog.KObj(target.Obj))
 		}

--- a/pkg/util/testing/metrics/metrics.go
+++ b/pkg/util/testing/metrics/metrics.go
@@ -26,12 +26,12 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/slices"
 )
 
-type GaugeDataPoint struct {
+type MetricDataPoint struct {
 	Labels map[string]string
 	Value  float64
 }
 
-func (a *GaugeDataPoint) Less(b *GaugeDataPoint) bool {
+func (a *MetricDataPoint) Less(b *MetricDataPoint) bool {
 
 	keys := maps.Keys(a.Labels)
 	sort.Strings(keys)
@@ -61,13 +61,13 @@ func (a *GaugeDataPoint) Less(b *GaugeDataPoint) bool {
 
 }
 
-func CollectFilteredGaugeVec(v *prometheus.GaugeVec, labels map[string]string) []GaugeDataPoint {
+func CollectFilteredGaugeVec(v prometheus.Collector, labels map[string]string) []MetricDataPoint {
 	if v == nil {
 		return nil
 	}
 
 	ch := make(chan prometheus.Metric)
-	ret := []GaugeDataPoint{}
+	ret := []MetricDataPoint{}
 
 	go func() {
 		v.Collect(ch)
@@ -79,9 +79,14 @@ func CollectFilteredGaugeVec(v *prometheus.GaugeVec, labels map[string]string) [
 		if m.Write(&dtoMetric) == nil {
 			metricLabelsMap := slices.ToMap(dtoMetric.Label, func(i int) (string, string) { return *dtoMetric.Label[i].Name, *dtoMetric.Label[i].Value })
 			if maps.Contains(metricLabelsMap, labels) {
-				dp := GaugeDataPoint{
+				dp := MetricDataPoint{
 					Labels: metricLabelsMap,
-					Value:  *dtoMetric.Gauge.Value,
+				}
+				if dtoMetric.Gauge != nil {
+					dp.Value = *dtoMetric.Gauge.Value
+				}
+				if dtoMetric.Counter != nil {
+					dp.Value = *dtoMetric.Counter.Value
 				}
 				ret = append(ret, dp)
 			}

--- a/pkg/util/testing/metrics/metrics_test.go
+++ b/pkg/util/testing/metrics/metrics_test.go
@@ -34,11 +34,21 @@ func getTestGaugeVec() *prometheus.GaugeVec {
 	return ret
 }
 
+func getTestCounterVec() *prometheus.CounterVec {
+	ret := prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"c1", "c2"})
+	ret.With(prometheus.Labels{"c1": "l1v1", "c2": "l2v1"}).Inc()
+	ret.With(prometheus.Labels{"c1": "l1v1", "c2": "l2v2"}).Inc()
+	ret.With(prometheus.Labels{"c1": "l1v1", "c2": "l2v3"}).Inc()
+	ret.With(prometheus.Labels{"c1": "l1v2", "c2": "l2v1"}).Inc()
+	ret.With(prometheus.Labels{"c1": "l1v2", "c2": "l2v2"}).Inc()
+	return ret
+}
+
 func TestCollect(t *testing.T) {
 	cases := map[string]struct {
-		vec    *prometheus.GaugeVec
+		vec    prometheus.Collector
 		labels map[string]string
-		want   []GaugeDataPoint
+		want   []MetricDataPoint
 	}{
 		"nil": {
 			vec:    nil,
@@ -48,12 +58,12 @@ func TestCollect(t *testing.T) {
 		"empty": {
 			vec:    prometheus.NewGaugeVec(prometheus.GaugeOpts{}, nil),
 			labels: nil,
-			want:   []GaugeDataPoint{},
+			want:   []MetricDataPoint{},
 		},
 		"filter l1": {
 			vec:    getTestGaugeVec(),
 			labels: map[string]string{"l1": "l1v1"},
-			want: []GaugeDataPoint{
+			want: []MetricDataPoint{
 				{Labels: map[string]string{"l1": "l1v1", "l2": "l2v1"}, Value: 1},
 				{Labels: map[string]string{"l1": "l1v1", "l2": "l2v2"}, Value: 2},
 				{Labels: map[string]string{"l1": "l1v1", "l2": "l2v3"}, Value: 3},
@@ -62,7 +72,7 @@ func TestCollect(t *testing.T) {
 		"filter l2": {
 			vec:    getTestGaugeVec(),
 			labels: map[string]string{"l2": "l2v1"},
-			want: []GaugeDataPoint{
+			want: []MetricDataPoint{
 				{Labels: map[string]string{"l1": "l1v1", "l2": "l2v1"}, Value: 1},
 				{Labels: map[string]string{"l1": "l1v2", "l2": "l2v1"}, Value: 4},
 			},
@@ -70,19 +80,19 @@ func TestCollect(t *testing.T) {
 		"filter both": {
 			vec:    getTestGaugeVec(),
 			labels: map[string]string{"l1": "l1v2", "l2": "l2v1"},
-			want: []GaugeDataPoint{
+			want: []MetricDataPoint{
 				{Labels: map[string]string{"l1": "l1v2", "l2": "l2v1"}, Value: 4},
 			},
 		},
 		"filter no match": {
 			vec:    getTestGaugeVec(),
 			labels: map[string]string{"l3": "l3v1"},
-			want:   []GaugeDataPoint{},
+			want:   []MetricDataPoint{},
 		},
 		"empty filter": {
 			vec:    getTestGaugeVec(),
 			labels: nil,
-			want: []GaugeDataPoint{
+			want: []MetricDataPoint{
 				{Labels: map[string]string{"l1": "l1v2", "l2": "l2v1"}, Value: 4},
 				{Labels: map[string]string{"l1": "l1v2", "l2": "l2v2"}, Value: 5},
 				{Labels: map[string]string{"l1": "l1v1", "l2": "l2v1"}, Value: 1},
@@ -90,12 +100,32 @@ func TestCollect(t *testing.T) {
 				{Labels: map[string]string{"l1": "l1v1", "l2": "l2v3"}, Value: 3},
 			},
 		},
+		"empty filter for counter metrics": {
+			vec:    getTestCounterVec(),
+			labels: nil,
+			want: []MetricDataPoint{
+				{Labels: map[string]string{"c1": "l1v1", "c2": "l2v1"}, Value: 1},
+				{Labels: map[string]string{"c1": "l1v1", "c2": "l2v2"}, Value: 1},
+				{Labels: map[string]string{"c1": "l1v1", "c2": "l2v3"}, Value: 1},
+				{Labels: map[string]string{"c1": "l1v2", "c2": "l2v1"}, Value: 1},
+				{Labels: map[string]string{"c1": "l1v2", "c2": "l2v2"}, Value: 1},
+			},
+		},
+		"filter c1 for counter metrics": {
+			vec:    getTestCounterVec(),
+			labels: map[string]string{"c1": "l1v1"},
+			want: []MetricDataPoint{
+				{Labels: map[string]string{"c1": "l1v1", "c2": "l2v1"}, Value: 1},
+				{Labels: map[string]string{"c1": "l1v1", "c2": "l2v2"}, Value: 1},
+				{Labels: map[string]string{"c1": "l1v1", "c2": "l2v3"}, Value: 1},
+			},
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := CollectFilteredGaugeVec(tc.vec, tc.labels)
-			if diff := cmp.Diff(tc.want, got, cmpopts.SortSlices(func(a, b GaugeDataPoint) bool { return a.Less(&b) })); len(diff) != 0 {
+			if diff := cmp.Diff(tc.want, got, cmpopts.SortSlices(func(a, b MetricDataPoint) bool { return a.Less(&b) })); len(diff) != 0 {
 				t.Errorf("Unexpected data points (-want,+got):\n%s", diff)
 			}
 		})

--- a/site/content/en/docs/reference/metrics.md
+++ b/site/content/en/docs/reference/metrics.md
@@ -28,6 +28,7 @@ Use the following metrics to monitor the status of your ClusterQueues:
 | `kueue_quota_reserved_workloads_total` | Counter | The total number of quota reserved workloads. | `cluster_queue`: the name of the ClusterQueue |
 | `kueue_quota_reserved_wait_time_seconds` | Histogram | The time between a workload was created or requeued until it got quota reservation. | `cluster_queue`: the name of the ClusterQueue |
 | `kueue_admitted_workloads_total` | Counter | The total number of admitted workloads. | `cluster_queue`: the name of the ClusterQueue |
+| `kueue_evicted_workloads_total` | Counter | The total number of evicted workloads. | `cluster_queue`: the name of the ClusterQueue<br> `reason`: Possible values are `Preempted`, `PodsReadyTimeout`, `AdmissionCheck`, `ClusterQueueStopped` or `InactiveWorkload` |
 | `kueue_admission_wait_time_seconds` | Histogram | The time between a workload was created or requeued until admission. | `cluster_queue`: the name of the ClusterQueue |
 | `kueue_admission_checks_wait_time_seconds` | Histogram | The time from when a workload got the quota reservation until admission. | `cluster_queue`: the name of the ClusterQueue |
 | `kueue_admitted_active_workloads` | Gauge | The number of admitted Workloads that are active (unsuspended and not finished) | `cluster_queue`: the name of the ClusterQueue |

--- a/test/integration/controller/core/workload_controller_test.go
+++ b/test/integration/controller/core/workload_controller_test.go
@@ -357,6 +357,8 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Ordered, ginkgo.ContinueOn
 					return k8sClient.Status().Update(ctx, &createdWl)
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
+				util.ExpectEvictedWorkloadsTotalMetric(clusterQueue.Name, kueue.WorkloadEvictedByAdmissionCheck, 1)
+
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
 					g.Expect(createdWl.Status.Conditions).To(gomega.ContainElements(

--- a/test/integration/scheduler/podsready/scheduler_test.go
+++ b/test/integration/scheduler/podsready/scheduler_test.go
@@ -295,8 +295,8 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 				g.Expect(k8sClient.Status().Update(ctx, prodWl)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed(), "Job reconciler should add an Evicted condition with InactiveWorkload to the Workload")
 
-			// ReconcileGenericJob didn't run here
-			// util.ExpectEvictedWorkloadsTotalMetric(prodClusterQ.Name, kueue.WorkloadEvictedByDeactivation, 1)
+			// should observe a metrics of WorkloadEvictedByDeactivation
+			util.ExpectEvictedWorkloadsTotalMetric(prodClusterQ.Name, kueue.WorkloadEvictedByDeactivation, 1)
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodWl), prodWl)).Should(gomega.Succeed())
 				prodWl.Spec.Active = ptr.To(true)

--- a/test/integration/scheduler/podsready/scheduler_test.go
+++ b/test/integration/scheduler/podsready/scheduler_test.go
@@ -242,6 +242,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			}, util.Timeout, util.Interval).Should(gomega.Succeed(), "the workload should be evicted after the timeout expires")
 
 			util.FinishEvictionForWorkloads(ctx, k8sClient, prodWl1)
+			util.ExpectEvictedWorkloadsTotalMetric(prodClusterQ.Name, kueue.WorkloadEvictedByPodsReadyTimeout, 1)
 
 			ginkgo.By("verify the 'prod2' workload gets admitted and the 'prod1' is pending by backoff")
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, prodWl2)
@@ -293,6 +294,9 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 				})
 				g.Expect(k8sClient.Status().Update(ctx, prodWl)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed(), "Job reconciler should add an Evicted condition with InactiveWorkload to the Workload")
+
+			// ReconcileGenericJob didn't run here
+			// util.ExpectEvictedWorkloadsTotalMetric(prodClusterQ.Name, kueue.WorkloadEvictedByDeactivation, 1)
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodWl), prodWl)).Should(gomega.Succeed())
 				prodWl.Spec.Active = ptr.To(true)

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -136,6 +136,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 			gomega.Expect(k8sClient.Create(ctx, highWl2)).To(gomega.Succeed())
 
 			util.FinishEvictionForWorkloads(ctx, k8sClient, lowWl1, lowWl2)
+			util.ExpectEvictedWorkloadsTotalMetric(cq.Name, kueue.WorkloadEvictedByPreemption, 2)
 
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, highWl2)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, lowWl1, lowWl2)

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -1775,6 +1775,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			util.ExpectClusterQueueStatusMetric(cq, metrics.CQStatusPending)
+			util.ExpectEvictedWorkloadsTotalMetric(clusterQueue.Name, kueue.WorkloadEvictedByClusterQueueStopped, 1)
 
 			ginkgo.By("Checking the condition of workload is evicted", func() {
 				createdWl := kueue.Workload{}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -448,6 +448,15 @@ func ExpectAdmittedWorkloadsTotalMetric(cq *kueue.ClusterQueue, v int) {
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
+func ExpectEvictedWorkloadsTotalMetric(cqName string, reason string, v int) {
+	metric := metrics.EvictedWorkloadsTotal.WithLabelValues(cqName, reason)
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+		count, err := testutil.GetCounterMetricValue(metric)
+		g.Expect(err).ToNot(gomega.HaveOccurred())
+		g.Expect(int(count)).Should(gomega.Equal(v))
+	}, Timeout, Interval).Should(gomega.Succeed())
+}
+
 func ExpectQuotaReservedWorkloadsTotalMetric(cq *kueue.ClusterQueue, v int) {
 	metric := metrics.QuotaReservedWorkloadsTotal.WithLabelValues(cq.Name)
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Expose a metrics to record workloads eviction number in cluster queue

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1741

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
metric `evicted_workloads` is  number of evicted workloads per 'cluster_queue'
```