### PR TITLE
Add CEL rules to ResourceFlavor

### DIFF
--- a/apis/kueue/v1beta1/resourceflavor_types.go
+++ b/apis/kueue/v1beta1/resourceflavor_types.go
@@ -83,7 +83,7 @@ type ResourceFlavorSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self.all(x, has(x.tolerationSeconds) ? x.effect == 'NoExecute' : true)", message="effect must be 'NoExecute' when 'tolerationSeconds' is set"
 	// +kubebuilder:validation:XValidation:rule="self.all(x, !has(x.operator) || x.operator in ['Equal', 'Exists'])", message="supported toleration values: 'Equal'(default), 'Exists'"
 	// +kubebuilder:validation:XValidation:rule="self.all(x, has(x.operator) && x.operator == 'Exists' ? !has(x.value) : true)", message="a value must be empty when 'operator' is 'Exists'"
-	// +kubebuilder:validation:XValidation:rule="self.all(x, has(x.effect) ? x.effect in ['NoSchedule', 'PreferNoSchedule', 'NoExecute'] : true)", message="supported taint effect values: 'NoSchedule', 'PreferNoSchedule', 'NoExecute'"
+	// +kubebuilder:validation:XValidation:rule="self.all(x, !has(x.effect) || x.effect in ['NoSchedule', 'PreferNoSchedule', 'NoExecute'])", message="supported taint effect values: 'NoSchedule', 'PreferNoSchedule', 'NoExecute'"
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 

--- a/apis/kueue/v1beta1/resourceflavor_types.go
+++ b/apis/kueue/v1beta1/resourceflavor_types.go
@@ -65,6 +65,7 @@ type ResourceFlavorSpec struct {
 	// +optional
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=8
+	// +kubebuilder:validation:XValidation:rule="self.all(x, x.effect in ['NoSchedule', 'PreferNoSchedule', 'NoExecute'])", message="supported taint effect values: 'NoSchedule', 'PreferNoSchedule', 'NoExecute'"
 	NodeTaints []corev1.Taint `json:"nodeTaints,omitempty"`
 
 	// tolerations are extra tolerations that will be added to the pods admitted in
@@ -78,6 +79,11 @@ type ResourceFlavorSpec struct {
 	// +optional
 	// +listType=atomic
 	// +kubebuilder:validation:MaxItems=8
+	// +kubebuilder:validation:XValidation:rule="self.all(x, !has(x.key) ? x.operator == 'Exists' : true)", message="operator must be Exists when 'key' is empty, which means 'match all values and all keys'"
+	// +kubebuilder:validation:XValidation:rule="self.all(x, has(x.tolerationSeconds) ? x.effect == 'NoExecute' : true)", message="effect must be 'NoExecute' when 'tolerationSeconds' is set"
+	// +kubebuilder:validation:XValidation:rule="self.all(x, !has(x.operator) || x.operator in ['Equal', 'Exists'])", message="supported toleration values: 'Equal'(default), 'Exists'"
+	// +kubebuilder:validation:XValidation:rule="self.all(x, has(x.operator) && x.operator == 'Exists' ? !has(x.value) : true)", message="a value must be empty when 'operator' is 'Exists'"
+	// +kubebuilder:validation:XValidation:rule="self.all(x, has(x.effect) ? x.effect in ['NoSchedule', 'PreferNoSchedule', 'NoExecute'] : true)", message="supported taint effect values: 'NoSchedule', 'PreferNoSchedule', 'NoExecute'"
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 }
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
@@ -118,6 +118,11 @@ spec:
                 maxItems: 8
                 type: array
                 x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: 'supported taint effect values: ''NoSchedule'', ''PreferNoSchedule'',
+                    ''NoExecute'''
+                  rule: self.all(x, x.effect in ['NoSchedule', 'PreferNoSchedule',
+                    'NoExecute'])
               tolerations:
                 description: |-
                   tolerations are extra tolerations that will be added to the pods admitted in
@@ -168,6 +173,23 @@ spec:
                 maxItems: 8
                 type: array
                 x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: operator must be Exists when 'key' is empty, which means
+                    'match all values and all keys'
+                  rule: 'self.all(x, !has(x.key) ? x.operator == ''Exists'' : true)'
+                - message: effect must be 'NoExecute' when 'tolerationSeconds' is
+                    set
+                  rule: 'self.all(x, has(x.tolerationSeconds) ? x.effect == ''NoExecute''
+                    : true)'
+                - message: 'supported toleration values: ''Equal''(default), ''Exists'''
+                  rule: self.all(x, !has(x.operator) || x.operator in ['Equal', 'Exists'])
+                - message: a value must be empty when 'operator' is 'Exists'
+                  rule: 'self.all(x, has(x.operator) && x.operator == ''Exists'' ?
+                    !has(x.value) : true)'
+                - message: 'supported taint effect values: ''NoSchedule'', ''PreferNoSchedule'',
+                    ''NoExecute'''
+                  rule: 'self.all(x, has(x.effect) ? x.effect in [''NoSchedule'',
+                    ''PreferNoSchedule'', ''NoExecute''] : true)'
             type: object
         type: object
     served: true

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
@@ -188,8 +188,8 @@ spec:
                     !has(x.value) : true)'
                 - message: 'supported taint effect values: ''NoSchedule'', ''PreferNoSchedule'',
                     ''NoExecute'''
-                  rule: 'self.all(x, has(x.effect) ? x.effect in [''NoSchedule'',
-                    ''PreferNoSchedule'', ''NoExecute''] : true)'
+                  rule: self.all(x, !has(x.effect) || x.effect in ['NoSchedule', 'PreferNoSchedule',
+                    'NoExecute'])
             type: object
         type: object
     served: true

--- a/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
@@ -173,8 +173,8 @@ spec:
                     !has(x.value) : true)'
                 - message: 'supported taint effect values: ''NoSchedule'', ''PreferNoSchedule'',
                     ''NoExecute'''
-                  rule: 'self.all(x, has(x.effect) ? x.effect in [''NoSchedule'',
-                    ''PreferNoSchedule'', ''NoExecute''] : true)'
+                  rule: self.all(x, !has(x.effect) || x.effect in ['NoSchedule', 'PreferNoSchedule',
+                    'NoExecute'])
             type: object
         type: object
     served: true

--- a/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
@@ -103,6 +103,11 @@ spec:
                 maxItems: 8
                 type: array
                 x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: 'supported taint effect values: ''NoSchedule'', ''PreferNoSchedule'',
+                    ''NoExecute'''
+                  rule: self.all(x, x.effect in ['NoSchedule', 'PreferNoSchedule',
+                    'NoExecute'])
               tolerations:
                 description: |-
                   tolerations are extra tolerations that will be added to the pods admitted in
@@ -153,6 +158,23 @@ spec:
                 maxItems: 8
                 type: array
                 x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: operator must be Exists when 'key' is empty, which means
+                    'match all values and all keys'
+                  rule: 'self.all(x, !has(x.key) ? x.operator == ''Exists'' : true)'
+                - message: effect must be 'NoExecute' when 'tolerationSeconds' is
+                    set
+                  rule: 'self.all(x, has(x.tolerationSeconds) ? x.effect == ''NoExecute''
+                    : true)'
+                - message: 'supported toleration values: ''Equal''(default), ''Exists'''
+                  rule: self.all(x, !has(x.operator) || x.operator in ['Equal', 'Exists'])
+                - message: a value must be empty when 'operator' is 'Exists'
+                  rule: 'self.all(x, has(x.operator) && x.operator == ''Exists'' ?
+                    !has(x.value) : true)'
+                - message: 'supported taint effect values: ''NoSchedule'', ''PreferNoSchedule'',
+                    ''NoExecute'''
+                  rule: 'self.all(x, has(x.effect) ? x.effect in [''NoSchedule'',
+                    ''PreferNoSchedule'', ''NoExecute''] : true)'
             type: object
         type: object
     served: true

--- a/pkg/webhooks/resourceflavor_webhook.go
+++ b/pkg/webhooks/resourceflavor_webhook.go
@@ -112,7 +112,7 @@ func validateNodeTaints(taints []corev1.Taint, fldPath *field.Path) field.ErrorL
 			allErrors = append(allErrors, field.Invalid(idxPath.Child("value"), currTaint.Value, strings.Join(errs, ";")))
 		}
 		// validate the taint effect
-		allErrors = append(allErrors, validateTaintEffect(&currTaint.Effect, false, idxPath.Child("effect"))...)
+		// allErrors = append(allErrors, validateTaintEffect(&currTaint.Effect, false, idxPath.Child("effect"))...)
 
 		// validate if taint is unique by <key, effect>
 		if len(uniqueTaints[currTaint.Effect]) > 0 && uniqueTaints[currTaint.Effect].Has(currTaint.Key) {
@@ -131,6 +131,7 @@ func validateNodeTaints(taints []corev1.Taint, fldPath *field.Path) field.ErrorL
 	return allErrors
 }
 
+// TODO: Remove this function when add CEL validations to workload type
 // validateTaintEffect is extracted from git.k8s.io/kubernetes/pkg/apis/core/validation/validation.go
 func validateTaintEffect(effect *corev1.TaintEffect, allowEmpty bool, fldPath *field.Path) field.ErrorList {
 	if !allowEmpty && len(*effect) == 0 {

--- a/pkg/webhooks/resourceflavor_webhook.go
+++ b/pkg/webhooks/resourceflavor_webhook.go
@@ -111,8 +111,6 @@ func validateNodeTaints(taints []corev1.Taint, fldPath *field.Path) field.ErrorL
 		if errs := validation.IsValidLabelValue(currTaint.Value); len(errs) != 0 {
 			allErrors = append(allErrors, field.Invalid(idxPath.Child("value"), currTaint.Value, strings.Join(errs, ";")))
 		}
-		// validate the taint effect
-		// allErrors = append(allErrors, validateTaintEffect(&currTaint.Effect, false, idxPath.Child("effect"))...)
 
 		// validate if taint is unique by <key, effect>
 		if len(uniqueTaints[currTaint.Effect]) > 0 && uniqueTaints[currTaint.Effect].Has(currTaint.Key) {
@@ -131,7 +129,7 @@ func validateNodeTaints(taints []corev1.Taint, fldPath *field.Path) field.ErrorL
 	return allErrors
 }
 
-// TODO: Remove this function when add CEL validations to workload type
+// TODO: Remove this function when CEL validations are added to workload type
 // validateTaintEffect is extracted from git.k8s.io/kubernetes/pkg/apis/core/validation/validation.go
 func validateTaintEffect(effect *corev1.TaintEffect, allowEmpty bool, fldPath *field.Path) field.ErrorList {
 	if !allowEmpty && len(*effect) == 0 {

--- a/pkg/webhooks/resourceflavor_webhook.go
+++ b/pkg/webhooks/resourceflavor_webhook.go
@@ -129,7 +129,7 @@ func validateNodeTaints(taints []corev1.Taint, fldPath *field.Path) field.ErrorL
 	return allErrors
 }
 
-// TODO: Remove this function when CEL validations are added to workload type
+// TODO(#463): Remove this function when CEL validations are added to workload type
 // validateTaintEffect is extracted from git.k8s.io/kubernetes/pkg/apis/core/validation/validation.go
 func validateTaintEffect(effect *corev1.TaintEffect, allowEmpty bool, fldPath *field.Path) field.ErrorList {
 	if !allowEmpty && len(*effect) == 0 {

--- a/pkg/webhooks/resourceflavor_webhook_test.go
+++ b/pkg/webhooks/resourceflavor_webhook_test.go
@@ -50,16 +50,6 @@ func TestValidateResourceFlavor(t *testing.T) {
 				}).Obj(),
 		},
 		{
-			// Taint validation is not exhaustively tested, because the code was copied from upstream k8s.
-			name: "invalid taint",
-			rf: utiltesting.MakeResourceFlavor("resource-flavor").Taint(corev1.Taint{
-				Key: "skdajf",
-			}).Obj(),
-			wantErr: field.ErrorList{
-				field.Required(field.NewPath("spec", "nodeTaints").Index(0).Child("effect"), ""),
-			},
-		},
-		{
 			name: "invalid label name",
 			rf:   utiltesting.MakeResourceFlavor("resource-flavor").Label("@abc", "foo").Obj(),
 			wantErr: field.ErrorList{

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -236,7 +236,6 @@ func validateImmutablePodSetUpdates(newObj, oldObj *kueue.Workload, basePath *fi
 	return allErrs
 }
 
-// TODO: Refactor this function when add CEL validations to workload type
 // validateTolerations is extracted from git.k8s.io/kubernetes/pkg/apis/core/validation/validation.go
 // we do not import it as dependency, see the comment:
 // https://github.com/kubernetes/kubernetes/issues/79384#issuecomment-505627280

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -236,6 +236,7 @@ func validateImmutablePodSetUpdates(newObj, oldObj *kueue.Workload, basePath *fi
 	return allErrs
 }
 
+// TODO: Refactor this function when add CEL validations to workload type
 // validateTolerations is extracted from git.k8s.io/kubernetes/pkg/apis/core/validation/validation.go
 // we do not import it as dependency, see the comment:
 // https://github.com/kubernetes/kubernetes/issues/79384#issuecomment-505627280


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

This PR replaces some of the validations executed by webhooks for the `resourceflavor` type with CRD validation rules.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #463 

#### Special notes for your reviewer:

Due to the [resource constraints](https://kubernetes.io/docs/reference/using-api/cel/#resource-constraints) imposed by the API Server, only have been replaced those validations which costs don't exceed the limits.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added CRD validation rules to ResourceFlavor.

ACTION REQUIRED: Requires Kubernetes 1.25 or newer
```