### PR TITLE
[multikueue] Add file system kubeconfig watch.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module sigs.k8s.io/kueue
 go 1.22
 
 require (
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-logr/logr v1.4.1
 	github.com/google/go-cmp v0.6.0
 	github.com/kubeflow/mpi-operator v0.5.0
@@ -52,7 +53,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect

--- a/pkg/controller/admissionchecks/multikueue/controllers.go
+++ b/pkg/controller/admissionchecks/multikueue/controllers.go
@@ -76,7 +76,13 @@ func SetupControllers(mgr ctrl.Manager, namespace string, opts ...SetupOption) e
 		return err
 	}
 
-	cRec := newClustersReconciler(mgr.GetClient(), namespace, options.gcInterval, options.origin)
+	fsWaatcher := newKubeConfigFSWatcher()
+	err = mgr.Add(fsWaatcher)
+	if err != nil {
+		return err
+	}
+
+	cRec := newClustersReconciler(mgr.GetClient(), namespace, options.gcInterval, options.origin, fsWaatcher)
 	err = cRec.setupWithManager(mgr)
 	if err != nil {
 		return err

--- a/pkg/controller/admissionchecks/multikueue/controllers.go
+++ b/pkg/controller/admissionchecks/multikueue/controllers.go
@@ -76,13 +76,13 @@ func SetupControllers(mgr ctrl.Manager, namespace string, opts ...SetupOption) e
 		return err
 	}
 
-	fsWaatcher := newKubeConfigFSWatcher()
-	err = mgr.Add(fsWaatcher)
+	fsWatcher := newKubeConfigFSWatcher()
+	err = mgr.Add(fsWatcher)
 	if err != nil {
 		return err
 	}
 
-	cRec := newClustersReconciler(mgr.GetClient(), namespace, options.gcInterval, options.origin, fsWaatcher)
+	cRec := newClustersReconciler(mgr.GetClient(), namespace, options.gcInterval, options.origin, fsWatcher)
 	err = cRec.setupWithManager(mgr)
 	if err != nil {
 		return err

--- a/pkg/controller/admissionchecks/multikueue/fswatch.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multikueue
+
+import (
+	"context"
+	"errors"
+	"path"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/set"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+)
+
+var (
+	errNotStarted = errors.New("not started")
+)
+
+type KubeConfigFSWatcher struct {
+	watcher       *fsnotify.Watcher
+	lock          sync.RWMutex
+	clusterToFile map[string]string
+	// a single file can be potentially used by multiple clusters
+	fileToClusters map[string]set.Set[string]
+	parentDirs     map[string]set.Set[string]
+	reconcile      chan event.GenericEvent
+}
+
+var _ manager.Runnable = (*KubeConfigFSWatcher)(nil)
+
+func newKubeConfigFSWatcher() *KubeConfigFSWatcher {
+	return &KubeConfigFSWatcher{
+		clusterToFile:  map[string]string{},
+		fileToClusters: map[string]set.Set[string]{},
+		parentDirs:     map[string]set.Set[string]{},
+		reconcile:      make(chan event.GenericEvent),
+	}
+}
+
+func (w *KubeConfigFSWatcher) Start(ctx context.Context) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	var err error
+	w.watcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		log := ctrl.LoggerFrom(ctx).WithName("secret-fs-watcher")
+		defer func() {
+			err := w.watcher.Close()
+			if err != nil {
+				log.V(2).Error(err, "Closing kubeconfigs FS Watcher")
+			}
+		}()
+		watchedEvents := fsnotify.Write | fsnotify.Create | fsnotify.Remove | fsnotify.Rename
+		for {
+			select {
+			case ev := <-w.watcher.Events:
+				log.V(5).Info("Got event", "name", ev.Name, "op", ev.Op)
+				switch {
+				case (ev.Op & watchedEvents) != 0:
+					w.notifyPathWrite(ev.Name)
+				default:
+					log.V(2).Info("Ignore event", "name", ev.Name, "op", ev.Op)
+
+				}
+			case err := <-w.watcher.Errors:
+				log.V(2).Error(err, "Kubeconfigs FS Watch")
+			case <-ctx.Done():
+				log.V(2).Info("End kubeconfigs FS Watch")
+				return
+			}
+		}
+
+	}()
+	return nil
+}
+
+func (w *KubeConfigFSWatcher) notifyPathWrite(path string) {
+	w.lock.RLock()
+	clusters := w.fileToClusters[path].UnsortedList()
+	w.lock.RUnlock()
+	//TODO: maybe manage "..data" pattern
+	for _, c := range clusters {
+		w.reconcile <- event.GenericEvent{Object: &kueuealpha.MultiKueueCluster{ObjectMeta: metav1.ObjectMeta{Name: c}}}
+	}
+}
+
+func (w *KubeConfigFSWatcher) getClusterPath(cluster string) (string, bool) {
+	w.lock.RLock()
+	defer w.lock.RUnlock()
+	path, found := w.clusterToFile[cluster]
+	return path, found
+}
+
+func (w *KubeConfigFSWatcher) set(cluster, kcPath string) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	dir := path.Dir(kcPath)
+	if _, found := w.parentDirs[dir]; !found {
+		err := w.watcher.Add(dir)
+		if err != nil {
+			return err
+		}
+	}
+
+	w.clusterToFile[cluster] = kcPath
+	if _, found := w.fileToClusters[kcPath]; found {
+		w.fileToClusters[kcPath].Insert(cluster)
+	} else {
+		w.fileToClusters[kcPath] = set.New(cluster)
+	}
+	if _, found := w.parentDirs[dir]; found {
+		w.parentDirs[dir].Insert(kcPath)
+	} else {
+		w.parentDirs[dir] = set.New(kcPath)
+		return w.watcher.Add(dir)
+	}
+	return nil
+}
+
+func (w *KubeConfigFSWatcher) remove(cluster string) {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
+	kcPath := w.clusterToFile[cluster]
+	dir := path.Dir(kcPath)
+
+	file_removed := false
+	if s, found := w.fileToClusters[kcPath]; found {
+		s.Delete(cluster)
+		if s.Len() == 0 {
+			delete(w.fileToClusters, kcPath)
+			file_removed = true
+		}
+	}
+
+	if file_removed {
+		if s, found := w.parentDirs[dir]; found {
+			s.Delete(kcPath)
+			if s.Len() == 0 {
+				delete(w.parentDirs, dir)
+			}
+		}
+	}
+	delete(w.clusterToFile, cluster)
+}
+
+func (w *KubeConfigFSWatcher) cleanOldWatchDirs() error {
+	w.lock.RLock()
+	defer w.lock.RUnlock()
+
+	var errs []error
+	for _, dir := range w.watcher.WatchList() {
+		if _, found := w.parentDirs[dir]; !found {
+			err := w.watcher.Remove(dir)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (w *KubeConfigFSWatcher) Started() bool {
+	w.lock.RLock()
+	defer w.lock.RUnlock()
+	return w.watcher != nil
+}
+
+func (w *KubeConfigFSWatcher) AddOrUpdate(cluster, path string) error {
+	if !w.Started() {
+		return errNotStarted
+	}
+	cPath, found := w.getClusterPath(cluster)
+	if found && path == cPath {
+		return nil
+	}
+
+	if found {
+		w.remove(cluster)
+	}
+
+	err := w.set(cluster, path)
+	if err != nil {
+		return err
+	}
+
+	return w.cleanOldWatchDirs()
+}
+
+func (w *KubeConfigFSWatcher) Remove(cluster string) error {
+	if !w.Started() {
+		return errNotStarted
+	}
+	_, found := w.getClusterPath(cluster)
+	if !found {
+		return nil
+	}
+	w.remove(cluster)
+	return w.cleanOldWatchDirs()
+}

--- a/pkg/controller/admissionchecks/multikueue/fswatch.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch.go
@@ -99,11 +99,14 @@ func (w *KubeConfigFSWatcher) Start(ctx context.Context) error {
 	return nil
 }
 
-func (w *KubeConfigFSWatcher) notifyPathWrite(path string) {
+func (w *KubeConfigFSWatcher) clustersForPath(path string) []string {
 	w.lock.RLock()
-	clusters := w.fileToClusters[path].UnsortedList()
-	w.lock.RUnlock()
-	for _, c := range clusters {
+	defer w.lock.RUnlock()
+	return w.fileToClusters[path].UnsortedList()
+}
+
+func (w *KubeConfigFSWatcher) notifyPathWrite(path string) {
+	for _, c := range w.clustersForPath(path) {
 		w.reconcile <- event.GenericEvent{Object: &kueuealpha.MultiKueueCluster{ObjectMeta: metav1.ObjectMeta{Name: c}}}
 	}
 }

--- a/pkg/controller/admissionchecks/multikueue/fswatch_test.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch_test.go
@@ -1,0 +1,460 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multikueue
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/utils/set"
+)
+
+func TestFSWatch(t *testing.T) {
+	cases := map[string]struct {
+		prepareFnc func(basePath string) error
+		clusters   map[string]string
+		opFnc      func(basePath string) error
+
+		wantEventsForClusters set.Set[string]
+	}{
+		"empty": {},
+		"single cluster existing file": {
+			prepareFnc: func(basePath string) error {
+				return os.WriteFile(path.Join(basePath, "c1.kubeconfig"), []byte("123"), 0666)
+			},
+			clusters: map[string]string{
+				"c1": "c1.kubeconfig",
+			},
+			opFnc: func(basePath string) error {
+				return os.WriteFile(path.Join(basePath, "c1.kubeconfig"), []byte("123456"), 0666)
+			},
+			wantEventsForClusters: set.New("c1"),
+		},
+		"single cluster missing file": {
+			clusters: map[string]string{
+				"c1": "c1.kubeconfig",
+			},
+			opFnc: func(basePath string) error {
+				return os.WriteFile(path.Join(basePath, "c1.kubeconfig"), []byte("123456"), 0666)
+			},
+			wantEventsForClusters: set.New("c1"),
+		},
+		"single existing file deleted": {
+			prepareFnc: func(basePath string) error {
+				return os.WriteFile(path.Join(basePath, "c1.kubeconfig"), []byte("123"), 0666)
+			},
+			clusters: map[string]string{
+				"c1": "c1.kubeconfig",
+			},
+			opFnc: func(basePath string) error {
+				return os.Remove(path.Join(basePath, "c1.kubeconfig"))
+			},
+			wantEventsForClusters: set.New("c1"),
+		},
+		"single cluster file rename to": {
+			prepareFnc: func(basePath string) error {
+				return os.WriteFile(path.Join(basePath, "c1.kubeconfig.old"), []byte("123"), 0666)
+			},
+			clusters: map[string]string{
+				"c1": "c1.kubeconfig",
+			},
+			opFnc: func(basePath string) error {
+				return os.Rename(path.Join(basePath, "c1.kubeconfig.old"), path.Join(basePath, "c1.kubeconfig"))
+			},
+			wantEventsForClusters: set.New("c1"),
+		},
+		"single cluster file rename from": {
+			prepareFnc: func(basePath string) error {
+				return os.WriteFile(path.Join(basePath, "c1.kubeconfig"), []byte("123"), 0666)
+			},
+			clusters: map[string]string{
+				"c1": "c1.kubeconfig",
+			},
+			opFnc: func(basePath string) error {
+				return os.Rename(path.Join(basePath, "c1.kubeconfig"), path.Join(basePath, "c1.kubeconfig.new"))
+			},
+			wantEventsForClusters: set.New("c1"),
+		},
+		"single crete link": {
+			prepareFnc: func(basePath string) error {
+				return os.WriteFile(path.Join(basePath, "c1.kubeconfig.src"), []byte("123"), 0666)
+			},
+			clusters: map[string]string{
+				"c1": "c1.kubeconfig",
+			},
+			opFnc: func(basePath string) error {
+				return os.Symlink(path.Join(basePath, "c1.kubeconfig.src"), path.Join(basePath, "c1.kubeconfig"))
+			},
+			wantEventsForClusters: set.New("c1"),
+		},
+		"single remove link": {
+			prepareFnc: func(basePath string) error {
+				if err := os.WriteFile(path.Join(basePath, "c1.kubeconfig.src"), []byte("123"), 0666); err != nil {
+					return err
+				}
+				return os.Symlink(path.Join(basePath, "c1.kubeconfig.src"), path.Join(basePath, "c1.kubeconfig"))
+			},
+			clusters: map[string]string{
+				"c1": "c1.kubeconfig",
+			},
+			opFnc: func(basePath string) error {
+				return os.Remove(path.Join(basePath, "c1.kubeconfig"))
+			},
+			wantEventsForClusters: set.New("c1"),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			basePath := t.TempDir()
+			if tc.prepareFnc != nil {
+				if err := tc.prepareFnc(basePath); err != nil {
+					t.Fatalf("unexpected prepare error: %s", err)
+				}
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			watcher := newKubeConfigFSWatcher()
+
+			// start the recorder
+			gotEventsForClusters := set.New[string]()
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case ev := <-watcher.reconcile:
+						gotEventsForClusters.Insert(ev.Object.GetName())
+						if len(gotEventsForClusters) == len(tc.wantEventsForClusters) {
+							cancel()
+						}
+					case <-ctx.Done():
+						return
+					}
+				}
+			}()
+			_ = watcher.Start(ctx)
+
+			gotAddErrors := map[string]error{}
+			for c, p := range tc.clusters {
+				err := watcher.AddOrUpdate(c, path.Join(basePath, p))
+				if err != nil {
+					gotAddErrors[c] = err
+				}
+			}
+
+			if tc.opFnc != nil {
+				if err := tc.opFnc(basePath); err != nil {
+					t.Fatalf("unexpected op error: %s", err)
+				}
+			}
+			// wait
+			wg.Wait()
+
+			if len(gotAddErrors) > 0 {
+				t.Errorf("unexpected add errors:%s", gotAddErrors)
+			}
+
+			if diff := cmp.Diff(tc.wantEventsForClusters, gotEventsForClusters); diff != "" {
+				t.Errorf("unexpected events for clusters(-want/+got):\n%s", diff)
+			}
+
+		})
+	}
+}
+
+func TestFSWatchAddRm(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	basePath := t.TempDir()
+	f1Path := path.Join(basePath, "file.one")
+	f2Path := path.Join(basePath, "file.two")
+	f3Dir := path.Join(basePath, "d1")
+	f3Path := path.Join(f3Dir, "file.three")
+	steps := []struct {
+		name               string
+		opFnc              func(*KubeConfigFSWatcher) error
+		wantOpErr          error
+		wantClustersToFile map[string]string
+		wantFileToClusters map[string]set.Set[string]
+		wantParentDirs     map[string]set.Set[string]
+		wantWatchList      []string
+	}{
+		{
+			name: "add cluster before start",
+			opFnc: func(kcf *KubeConfigFSWatcher) error {
+				return kcf.AddOrUpdate("c1", f1Path)
+			},
+			wantOpErr: errNotStarted,
+		},
+		{
+			name: "start",
+			opFnc: func(kcf *KubeConfigFSWatcher) error {
+				return kcf.Start(ctx)
+			},
+			wantClustersToFile: map[string]string{},
+			wantFileToClusters: map[string]set.Set[string]{},
+			wantParentDirs:     map[string]set.Set[string]{},
+			wantWatchList:      []string{},
+		},
+		{
+			name: "add first cluster",
+			opFnc: func(kcf *KubeConfigFSWatcher) error {
+				return kcf.AddOrUpdate("c1", f1Path)
+			},
+			wantClustersToFile: map[string]string{
+				"c1": f1Path,
+			},
+			wantFileToClusters: map[string]set.Set[string]{
+				f1Path: set.New("c1"),
+			},
+			wantParentDirs: map[string]set.Set[string]{
+				basePath: set.New(f1Path),
+			},
+			wantWatchList: []string{
+				basePath,
+			},
+		},
+		{
+			name: "add second cluster same path",
+			opFnc: func(kcf *KubeConfigFSWatcher) error {
+				return kcf.AddOrUpdate("c2", f1Path)
+			},
+			wantClustersToFile: map[string]string{
+				"c1": f1Path,
+				"c2": f1Path,
+			},
+			wantFileToClusters: map[string]set.Set[string]{
+				f1Path: set.New("c1", "c2"),
+			},
+			wantParentDirs: map[string]set.Set[string]{
+				basePath: set.New(f1Path),
+			},
+			wantWatchList: []string{
+				basePath,
+			},
+		},
+		{
+			name: "add first cluster again",
+			opFnc: func(kcf *KubeConfigFSWatcher) error {
+				return kcf.AddOrUpdate("c1", f1Path)
+			},
+			wantClustersToFile: map[string]string{
+				"c1": f1Path,
+				"c2": f1Path,
+			},
+			wantFileToClusters: map[string]set.Set[string]{
+				f1Path: set.New("c1", "c2"),
+			},
+			wantParentDirs: map[string]set.Set[string]{
+				basePath: set.New(f1Path),
+			},
+			wantWatchList: []string{
+				basePath,
+			},
+		},
+		{
+			name: "add third cluster, different file ",
+			opFnc: func(kcf *KubeConfigFSWatcher) error {
+				return kcf.AddOrUpdate("c3", f2Path)
+			},
+			wantClustersToFile: map[string]string{
+				"c1": f1Path,
+				"c2": f1Path,
+				"c3": f2Path,
+			},
+			wantFileToClusters: map[string]set.Set[string]{
+				f1Path: set.New("c1", "c2"),
+				f2Path: set.New("c3"),
+			},
+			wantParentDirs: map[string]set.Set[string]{
+				basePath: set.New(f1Path, f2Path),
+			},
+			wantWatchList: []string{
+				basePath,
+			},
+		},
+		{
+			name: "add fourth cluster, missing dir ",
+			opFnc: func(kcf *KubeConfigFSWatcher) error {
+				return kcf.AddOrUpdate("c4", f3Path)
+			},
+			wantOpErr: os.ErrNotExist,
+			wantClustersToFile: map[string]string{
+				"c1": f1Path,
+				"c2": f1Path,
+				"c3": f2Path,
+			},
+			wantFileToClusters: map[string]set.Set[string]{
+				f1Path: set.New("c1", "c2"),
+				f2Path: set.New("c3"),
+			},
+			wantParentDirs: map[string]set.Set[string]{
+				basePath: set.New(f1Path, f2Path),
+			},
+			wantWatchList: []string{
+				basePath,
+			},
+		},
+		{
+			name: "create dir and add fourth cluster",
+			opFnc: func(kcf *KubeConfigFSWatcher) error {
+				err := os.Mkdir(f3Dir, os.ModePerm)
+				if err != nil {
+					return err
+				}
+				return kcf.AddOrUpdate("c4", f3Path)
+			},
+			wantClustersToFile: map[string]string{
+				"c1": f1Path,
+				"c2": f1Path,
+				"c3": f2Path,
+				"c4": f3Path,
+			},
+			wantFileToClusters: map[string]set.Set[string]{
+				f1Path: set.New("c1", "c2"),
+				f2Path: set.New("c3"),
+				f3Path: set.New("c4"),
+			},
+			wantParentDirs: map[string]set.Set[string]{
+				basePath: set.New(f1Path, f2Path),
+				f3Dir:    set.New(f3Path),
+			},
+			wantWatchList: []string{
+				basePath,
+				f3Dir,
+			},
+		},
+		{
+			name: "change the file for c3",
+			opFnc: func(kcf *KubeConfigFSWatcher) error {
+				return kcf.AddOrUpdate("c3", f3Path)
+			},
+			wantClustersToFile: map[string]string{
+				"c1": f1Path,
+				"c2": f1Path,
+				"c3": f3Path,
+				"c4": f3Path,
+			},
+			wantFileToClusters: map[string]set.Set[string]{
+				f1Path: set.New("c1", "c2"),
+				f3Path: set.New("c4", "c3"),
+			},
+			wantParentDirs: map[string]set.Set[string]{
+				basePath: set.New(f1Path),
+				f3Dir:    set.New(f3Path),
+			},
+			wantWatchList: []string{
+				basePath,
+				f3Dir,
+			},
+		},
+		{
+			name: "remove three clusters",
+			opFnc: func(kcf *KubeConfigFSWatcher) error {
+				return errors.Join(
+					kcf.Remove("c1"),
+					kcf.Remove("c3"),
+					kcf.Remove("c4"),
+				)
+			},
+			wantClustersToFile: map[string]string{
+				"c2": f1Path,
+			},
+			wantFileToClusters: map[string]set.Set[string]{
+				f1Path: set.New("c2"),
+			},
+			wantParentDirs: map[string]set.Set[string]{
+				basePath: set.New(f1Path),
+			},
+			wantWatchList: []string{
+				basePath,
+			},
+		},
+		{
+			name: "remove an unknown cluster",
+			opFnc: func(kcf *KubeConfigFSWatcher) error {
+				return kcf.Remove("c1")
+			},
+			wantClustersToFile: map[string]string{
+				"c2": f1Path,
+			},
+			wantFileToClusters: map[string]set.Set[string]{
+				f1Path: set.New("c2"),
+			},
+			wantParentDirs: map[string]set.Set[string]{
+				basePath: set.New(f1Path),
+			},
+			wantWatchList: []string{
+				basePath,
+			},
+		},
+		{
+			name: "remove the last cluster",
+			opFnc: func(kcf *KubeConfigFSWatcher) error {
+				return kcf.Remove("c2")
+			},
+			wantClustersToFile: map[string]string{},
+			wantFileToClusters: map[string]set.Set[string]{},
+			wantParentDirs:     map[string]set.Set[string]{},
+			wantWatchList:      []string{},
+		},
+	}
+
+	w := newKubeConfigFSWatcher()
+
+	for _, tc := range steps {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr := tc.opFnc(w)
+			if diff := cmp.Diff(tc.wantOpErr, gotErr, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("unexpected error(-want/+got):\n%s", diff)
+			}
+
+			if tc.wantClustersToFile != nil {
+				if diff := cmp.Diff(tc.wantClustersToFile, w.clusterToFile, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("unexpected clusterToFile(-want/+got):\n%s", diff)
+				}
+			}
+
+			if tc.wantFileToClusters != nil {
+				if diff := cmp.Diff(tc.wantFileToClusters, w.fileToClusters, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("unexpected fileToClusters(-want/+got):\n%s", diff)
+				}
+			}
+
+			if tc.wantParentDirs != nil {
+				if diff := cmp.Diff(tc.wantParentDirs, w.parentDirs, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("unexpected parent dir(-want/+got):\n%s", diff)
+				}
+			}
+
+			if tc.wantWatchList != nil {
+				if diff := cmp.Diff(tc.wantWatchList, w.watcher.WatchList(), cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+					t.Errorf("unexpected watch list(-want/+got):\n%s", diff)
+				}
+			}
+		})
+	}
+
+}

--- a/pkg/controller/admissionchecks/multikueue/fswatch_test.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch_test.go
@@ -444,7 +444,7 @@ func TestFSWatchAddRm(t *testing.T) {
 			}
 
 			if tc.wantParentDirs != nil {
-				if diff := cmp.Diff(tc.wantParentDirs, w.parentDirs, cmpopts.EquateEmpty()); diff != "" {
+				if diff := cmp.Diff(tc.wantParentDirs, w.parentDirToFiles, cmpopts.EquateEmpty()); diff != "" {
 					t.Errorf("unexpected parent dir(-want/+got):\n%s", diff)
 				}
 			}

--- a/pkg/controller/admissionchecks/multikueue/fswatch_test.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch_test.go
@@ -96,7 +96,7 @@ func TestFSWatch(t *testing.T) {
 			},
 			wantEventsForClusters: set.New("c1"),
 		},
-		"single crete link": {
+		"single create link": {
 			prepareFnc: func(basePath string) error {
 				return os.WriteFile(path.Join(basePath, "c1.kubeconfig.src"), []byte("123"), 0666)
 			},
@@ -158,8 +158,7 @@ func TestFSWatch(t *testing.T) {
 
 			gotAddErrors := map[string]error{}
 			for c, p := range tc.clusters {
-				err := watcher.AddOrUpdate(c, path.Join(basePath, p))
-				if err != nil {
+				if err := watcher.AddOrUpdate(c, path.Join(basePath, p)); err != nil {
 					gotAddErrors[c] = err
 				}
 			}

--- a/pkg/controller/admissionchecks/multikueue/jobset_adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/jobset_adapter_test.go
@@ -311,7 +311,7 @@ func TestWlReconcileJobset(t *testing.T) {
 
 			managerClient := manageBuilder.Build()
 
-			cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin)
+			cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil)
 
 			worker1Builder, _ := getClientBuilder()
 			worker1Builder = worker1Builder.WithLists(&kueue.WorkloadList{Items: tc.worker1Workloads}, &jobset.JobSetList{Items: tc.worker1JobSets})

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -374,7 +374,7 @@ func TestUpdateConfig(t *testing.T) {
 			builder = builder.WithStatusSubresource(slices.Map(tc.clusters, func(c *kueuealpha.MultiKueueCluster) client.Object { return c })...)
 			c := builder.Build()
 
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin)
+			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil)
 			reconciler.rootContext = ctx
 
 			if len(tc.remoteClients) > 0 {

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -662,7 +662,7 @@ func TestWlReconcile(t *testing.T) {
 
 			managerClient := manageBuilder.Build()
 
-			cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin)
+			cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil)
 
 			worker1Builder, _ := getClientBuilder()
 			worker1Builder = worker1Builder.WithLists(&kueue.WorkloadList{Items: tc.worker1Workloads}, &batchv1.JobList{Items: tc.worker1Jobs})

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -357,11 +357,6 @@ var _ = ginkgo.Describe("Multikueue", func() {
 			})
 		})
 
-		ginkgo.By("creating a config with duplicate clusters should fail", func() {
-			badConfig := utiltesting.MakeMultiKueueConfig("bad-config").Clusters("c1", "c2", "c1").Obj()
-			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, badConfig).Error()).Should(gomega.Equal(
-				`MultiKueueConfig.kueue.x-k8s.io "bad-config" is invalid: spec.clusters[2]: Duplicate value: "c1"`))
-		})
 		tempDir := ginkgo.GinkgoT().TempDir()
 		fsKubeConfig := path.Join(tempDir, "testing.kubeconfig")
 

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -175,7 +175,7 @@ var _ = ginkgo.Describe("Multikueue", func() {
 		gomega.Expect(managerTestCluster.client.Delete(managerTestCluster.ctx, managerMultikueueSecret1)).To(gomega.Succeed())
 		gomega.Expect(managerTestCluster.client.Delete(managerTestCluster.ctx, managerMultikueueSecret2)).To(gomega.Succeed())
 	})
-	ginkgo.It("Should properly manage the active condition of AdmissionChecks and MultiKueueClusters", func() {
+	ginkgo.It("Should properly manage the active condition of AdmissionChecks and MultiKueueClusters, kubeconfig provided by secret", func() {
 		ac := utiltesting.MakeAdmissionCheck("testing-ac").
 			ControllerName(multikueue.ControllerName).
 			Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "testing-config").
@@ -317,21 +317,78 @@ var _ = ginkgo.Describe("Multikueue", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
+	})
 
+	ginkgo.It("Should properly manage the active condition of AdmissionChecks and MultiKueueClusters, kubeconfig provided by file", func() {
+		ac := utiltesting.MakeAdmissionCheck("testing-ac").
+			ControllerName(multikueue.ControllerName).
+			Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "testing-config").
+			Obj()
+		ginkgo.By("creating the admission check with missing config, it's set inactive", func() {
+			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, ac)).Should(gomega.Succeed())
+			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, ac) })
+
+			ginkgo.By("wait for the check's active state update", func() {
+				updatedAc := kueue.AdmissionCheck{}
+				acKey := client.ObjectKeyFromObject(ac)
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatedAc)).To(gomega.Succeed())
+					g.Expect(updatedAc.Status.Conditions).To(gomega.ContainElements(
+						gomega.BeComparableTo(metav1.Condition{
+							Type:    kueue.AdmissionCheckActive,
+							Status:  metav1.ConditionFalse,
+							Reason:  "BadConfig",
+							Message: `Cannot load the AdmissionChecks parameters: MultiKueueConfig.kueue.x-k8s.io "testing-config" not found`,
+						}, util.IgnoreConditionTimestampsAndObservedGeneration),
+						gomega.BeComparableTo(metav1.Condition{
+							Type:    kueue.AdmissionChecksSingleInstanceInClusterQueue,
+							Status:  metav1.ConditionTrue,
+							Reason:  multikueue.SingleInstanceReason,
+							Message: multikueue.SingleInstanceMessage,
+						}, util.IgnoreConditionTimestampsAndObservedGeneration),
+						gomega.BeComparableTo(metav1.Condition{
+							Type:    kueue.FlavorIndependentAdmissionCheck,
+							Status:  metav1.ConditionTrue,
+							Reason:  multikueue.FlavorIndependentCheckReason,
+							Message: multikueue.FlavorIndependentCheckMessage,
+						}, util.IgnoreConditionTimestampsAndObservedGeneration),
+					))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.By("creating a config with duplicate clusters should fail", func() {
+			badConfig := utiltesting.MakeMultiKueueConfig("bad-config").Clusters("c1", "c2", "c1").Obj()
+			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, badConfig).Error()).Should(gomega.Equal(
+				`MultiKueueConfig.kueue.x-k8s.io "bad-config" is invalid: spec.clusters[2]: Duplicate value: "c1"`))
+		})
 		tempDir := ginkgo.GinkgoT().TempDir()
 		fsKubeConfig := path.Join(tempDir, "testing.kubeconfig")
 
-		ginkgo.By("setting the cluster's kubeconfig to a missing file, the cluster and admission check become inactive", func() {
-			ginkgo.By("change kubeconfig location", func() {
-				updatedCluster := kueuealpha.MultiKueueCluster{}
-				clusterKey := client.ObjectKeyFromObject(cluster)
+		config := utiltesting.MakeMultiKueueConfig("testing-config").Clusters("testing-cluster").Obj()
+		ginkgo.By("creating the config, the admission check's state is updated", func() {
+			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, config)).Should(gomega.Succeed())
+			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, config) })
+
+			ginkgo.By("wait for the check's active state update", func() {
+				updatedAc := kueue.AdmissionCheck{}
+				acKey := client.ObjectKeyFromObject(ac)
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, clusterKey, &updatedCluster)).To(gomega.Succeed())
-					updatedCluster.Spec.KubeConfig.LocationType = kueuealpha.PathLocationType
-					updatedCluster.Spec.KubeConfig.Location = fsKubeConfig
-					g.Expect(managerTestCluster.client.Update(managerTestCluster.ctx, &updatedCluster)).To(gomega.Succeed())
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatedAc)).To(gomega.Succeed())
+					g.Expect(updatedAc.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(metav1.Condition{
+						Type:    kueue.AdmissionCheckActive,
+						Status:  metav1.ConditionFalse,
+						Reason:  "NoUsableClusters",
+						Message: `Missing clusters: [testing-cluster]`,
+					}, util.IgnoreConditionTimestampsAndObservedGeneration)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
+		})
+
+		cluster := utiltesting.MakeMultiKueueCluster("testing-cluster").KubeConfig(kueuealpha.PathLocationType, fsKubeConfig).Obj()
+		ginkgo.By("creating the cluster, its Active state is updated, the admission check's state is updated", func() {
+			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, cluster)).Should(gomega.Succeed())
+			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, cluster) })
 
 			ginkgo.By("wait for the cluster's active state update", func() {
 				updatedCluster := kueuealpha.MultiKueueCluster{}
@@ -360,12 +417,13 @@ var _ = ginkgo.Describe("Multikueue", func() {
 					}, util.IgnoreConditionTimestampsAndObservedGeneration)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
-
 		})
+
+		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		ginkgo.By("creating the kubeconfig file, the cluster and admission check become active", func() {
 			gomega.Expect(os.WriteFile(fsKubeConfig, w1Kubeconfig, 0666)).Should(gomega.Succeed())
-
 			ginkgo.By("wait for the cluster's active state update", func() {
 				updatedCluster := kueuealpha.MultiKueueCluster{}
 				clusterKey := client.ObjectKeyFromObject(cluster)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add the watch for changes to kubeconfigs provided as `PathLocationType`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```