### PR TITLE
Add CEL rules to ClusterQueue

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -23,7 +23,7 @@ import (
 )
 
 // ClusterQueueSpec defines the desired state of ClusterQueue
-// +kubebuilder:validation:XValidation:rule="(!has(self.cohort) || size(self.cohort) == 0) && has(self.resourceGroups) ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r, !has(r.borrowingLimit)))) : true", message="resourceGroups[0].flavors[0].resources[0].borrowingLimit must be nil when cohort is empty"
+// +kubebuilder:validation:XValidation:rule="(!has(self.cohort) || size(self.cohort) == 0) && has(self.resourceGroups) ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r, !has(r.borrowingLimit)))) : true", message="borrowingLimit must be nil when cohort is empty"
 type ClusterQueueSpec struct {
 	// resourceGroups describes groups of resources.
 	// Each resource group defines the list of resources and a list of flavors

--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -23,6 +23,7 @@ import (
 )
 
 // ClusterQueueSpec defines the desired state of ClusterQueue
+// +kubebuilder:validation:XValidation:rule="(!has(self.cohort) || size(self.cohort) == 0) && has(self.resourceGroups) ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r, !has(r.borrowingLimit)))) : true", message="resourceGroups[0].flavors[0].resources[0].borrowingLimit must be nil when cohort is empty"
 type ClusterQueueSpec struct {
 	// resourceGroups describes groups of resources.
 	// Each resource group defines the list of resources and a list of flavors
@@ -48,6 +49,8 @@ type ClusterQueueSpec struct {
 	//
 	// Validation of a cohort name is equivalent to that of object names:
 	// subdomain in DNS (RFC 1123).
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 	Cohort string `json:"cohort,omitempty"`
 
 	// QueueingStrategy indicates the queueing strategy of the workloads
@@ -134,6 +137,7 @@ const (
 	Hold         StopPolicy = "Hold"
 )
 
+// +kubebuilder:validation:XValidation:rule="self.flavors.all(x, size(x.resources) == size(self.coveredResources))", message="flavors must have the same number of resources as the coveredResources"
 type ResourceGroup struct {
 	// coveredResources is the list of resources covered by the flavors in this
 	// group.
@@ -217,6 +221,8 @@ type ResourceQuota struct {
 }
 
 // ResourceFlavorReference is the name of the ResourceFlavor.
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 type ResourceFlavorReference string
 
 // ClusterQueueStatus defines the observed state of ClusterQueue
@@ -362,6 +368,7 @@ type FlavorFungibility struct {
 
 // ClusterQueuePreemption contains policies to preempt Workloads from this
 // ClusterQueue or the ClusterQueue's cohort.
+// +kubebuilder:validation:XValidation:rule="!(has(self.reclaimWithinCohort) && self.reclaimWithinCohort == 'Never' && has(self.borrowWithinCohort) &&  self.borrowWithinCohort.policy != 'Never')", message="reclaimWithinCohort=Never and borrowWithinCohort.Policy!=Never"
 type ClusterQueuePreemption struct {
 	// reclaimWithinCohort determines whether a pending Workload can preempt
 	// Workloads from other ClusterQueues in the cohort that are using more than

--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -23,7 +23,7 @@ import (
 )
 
 // ClusterQueueSpec defines the desired state of ClusterQueue
-// +kubebuilder:validation:XValidation:rule="(!has(self.cohort) || size(self.cohort) == 0) && has(self.resourceGroups) ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r, !has(r.borrowingLimit)))) : true", message="borrowingLimit must be nil when cohort is empty"
+// +kubebuilder:validation:XValidation:rule="!has(self.cohort) && has(self.resourceGroups) ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r, !has(r.borrowingLimit)))) : true", message="borrowingLimit must be nil when cohort is empty"
 type ClusterQueueSpec struct {
 	// resourceGroups describes groups of resources.
 	// Each resource group defines the list of resources and a list of flavors
@@ -370,7 +370,7 @@ type FlavorFungibility struct {
 
 // ClusterQueuePreemption contains policies to preempt Workloads from this
 // ClusterQueue or the ClusterQueue's cohort.
-// +kubebuilder:validation:XValidation:rule="!(has(self.reclaimWithinCohort) && self.reclaimWithinCohort == 'Never' && has(self.borrowWithinCohort) &&  self.borrowWithinCohort.policy != 'Never')", message="reclaimWithinCohort=Never and borrowWithinCohort.Policy!=Never"
+// +kubebuilder:validation:XValidation:rule="!(self.reclaimWithinCohort == 'Never' && has(self.borrowWithinCohort) &&  self.borrowWithinCohort.policy != 'Never')", message="reclaimWithinCohort=Never and borrowWithinCohort.Policy!=Never"
 type ClusterQueuePreemption struct {
 	// reclaimWithinCohort determines whether a pending Workload can preempt
 	// Workloads from other ClusterQueues in the cohort that are using more than

--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -77,6 +77,7 @@ type ClusterQueueSpec struct {
 
 	// flavorFungibility defines whether a workload should try the next flavor
 	// before borrowing or preempting in the flavor being evaluated.
+	// +kubebuilder:default={}
 	FlavorFungibility *FlavorFungibility `json:"flavorFungibility,omitempty"`
 
 	// preemption describes policies to preempt Workloads from this ClusterQueue
@@ -94,6 +95,7 @@ type ClusterQueueSpec struct {
 	// The preemption algorithm tries to find a minimal set of Workloads to
 	// preempt to accomomdate the pending Workload, preempting Workloads with
 	// lower priority first.
+	// +kubebuilder:default={}
 	Preemption *ClusterQueuePreemption `json:"preemption,omitempty"`
 
 	// admissionChecks lists the AdmissionChecks required by this ClusterQueue
@@ -388,6 +390,7 @@ type ClusterQueuePreemption struct {
 
 	// borrowWithinCohort provides configuration to allow preemption within
 	// cohort while borrowing.
+	// +kubebuilder:default={}
 	BorrowWithinCohort *BorrowWithinCohort `json:"borrowWithinCohort,omitempty"`
 
 	// withinClusterQueue determines whether a pending Workload that doesn't fit

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -103,6 +103,7 @@ spec:
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
               flavorFungibility:
+                default: {}
                 description: |-
                   flavorFungibility defines whether a workload should try the next flavor
                   before borrowing or preempting in the flavor being evaluated.
@@ -187,6 +188,7 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               preemption:
+                default: {}
                 description: |-
                   preemption describes policies to preempt Workloads from this ClusterQueue
                   or the ClusterQueue's cohort.
@@ -208,6 +210,7 @@ spec:
                   lower priority first.
                 properties:
                   borrowWithinCohort:
+                    default: {}
                     description: |-
                       borrowWithinCohort provides configuration to allow preemption within
                       cohort while borrowing.
@@ -453,8 +456,7 @@ spec:
                 type: string
             type: object
             x-kubernetes-validations:
-            - message: resourceGroups[0].flavors[0].resources[0].borrowingLimit must
-                be nil when cohort is empty
+            - message: borrowingLimit must be nil when cohort is empty
               rule: '(!has(self.cohort) || size(self.cohort) == 0) && has(self.resourceGroups)
                 ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r,
                 !has(r.borrowingLimit)))) : true'

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -99,6 +99,8 @@ spec:
 
                   Validation of a cohort name is equivalent to that of object names:
                   subdomain in DNS (RFC 1123).
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
               flavorFungibility:
                 description: |-
@@ -274,6 +276,11 @@ spec:
                     - LowerOrNewerEqualPriority
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: reclaimWithinCohort=Never and borrowWithinCohort.Policy!=Never
+                  rule: '!(has(self.reclaimWithinCohort) && self.reclaimWithinCohort
+                    == ''Never'' && has(self.borrowWithinCohort) &&  self.borrowWithinCohort.policy
+                    != ''Never'')'
               queueingStrategy:
                 default: BestEffortFIFO
                 description: |-
@@ -330,6 +337,8 @@ spec:
                               name of this flavor. The name should match the .metadata.name of a
                               ResourceFlavor. If a matching ResourceFlavor does not exist, the
                               ClusterQueue will have an Active condition set to False.
+                            maxLength: 253
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           resources:
                             description: |-
@@ -417,6 +426,10 @@ spec:
                   - coveredResources
                   - flavors
                   type: object
+                  x-kubernetes-validations:
+                  - message: flavors must have the same number of resources as the
+                      coveredResources
+                    rule: self.flavors.all(x, size(x.resources) == size(self.coveredResources))
                 maxItems: 16
                 type: array
                 x-kubernetes-list-type: atomic
@@ -439,6 +452,12 @@ spec:
                 - HoldAndDrain
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: resourceGroups[0].flavors[0].resources[0].borrowingLimit must
+                be nil when cohort is empty
+              rule: '(!has(self.cohort) || size(self.cohort) == 0) && has(self.resourceGroups)
+                ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r,
+                !has(r.borrowingLimit)))) : true'
           status:
             description: ClusterQueueStatus defines the observed state of ClusterQueue
             properties:
@@ -531,6 +550,8 @@ spec:
                   properties:
                     name:
                       description: name of the flavor.
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     resources:
                       description: resources lists the quota usage for the resources
@@ -583,6 +604,8 @@ spec:
                   properties:
                     name:
                       description: name of the flavor.
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     resources:
                       description: resources lists the quota usage for the resources

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -281,9 +281,8 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: reclaimWithinCohort=Never and borrowWithinCohort.Policy!=Never
-                  rule: '!(has(self.reclaimWithinCohort) && self.reclaimWithinCohort
-                    == ''Never'' && has(self.borrowWithinCohort) &&  self.borrowWithinCohort.policy
-                    != ''Never'')'
+                  rule: '!(self.reclaimWithinCohort == ''Never'' && has(self.borrowWithinCohort)
+                    &&  self.borrowWithinCohort.policy != ''Never'')'
               queueingStrategy:
                 default: BestEffortFIFO
                 description: |-
@@ -457,9 +456,8 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: borrowingLimit must be nil when cohort is empty
-              rule: '(!has(self.cohort) || size(self.cohort) == 0) && has(self.resourceGroups)
-                ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r,
-                !has(r.borrowingLimit)))) : true'
+              rule: '!has(self.cohort) && has(self.resourceGroups) ? self.resourceGroups.all(rg,
+                rg.flavors.all(f, f.resources.all(r, !has(r.borrowingLimit)))) : true'
           status:
             description: ClusterQueueStatus defines the observed state of ClusterQueue
             properties:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
@@ -172,6 +172,8 @@ spec:
                   properties:
                     name:
                       description: name of the flavor.
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     resources:
                       description: resources lists the quota usage for the resources
@@ -213,6 +215,8 @@ spec:
                   properties:
                     name:
                       description: name of the flavor.
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     resources:
                       description: resources lists the quota usage for the resources

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -7843,6 +7843,8 @@ spec:
                           additionalProperties:
                             description: ResourceFlavorReference is the name of the
                               ResourceFlavor.
+                            maxLength: 253
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           description: Flavors are the flavors assigned to the workload
                             for each resource.

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -84,6 +84,8 @@ spec:
 
                   Validation of a cohort name is equivalent to that of object names:
                   subdomain in DNS (RFC 1123).
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
               flavorFungibility:
                 description: |-
@@ -259,6 +261,11 @@ spec:
                     - LowerOrNewerEqualPriority
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: reclaimWithinCohort=Never and borrowWithinCohort.Policy!=Never
+                  rule: '!(has(self.reclaimWithinCohort) && self.reclaimWithinCohort
+                    == ''Never'' && has(self.borrowWithinCohort) &&  self.borrowWithinCohort.policy
+                    != ''Never'')'
               queueingStrategy:
                 default: BestEffortFIFO
                 description: |-
@@ -315,6 +322,8 @@ spec:
                               name of this flavor. The name should match the .metadata.name of a
                               ResourceFlavor. If a matching ResourceFlavor does not exist, the
                               ClusterQueue will have an Active condition set to False.
+                            maxLength: 253
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           resources:
                             description: |-
@@ -402,6 +411,10 @@ spec:
                   - coveredResources
                   - flavors
                   type: object
+                  x-kubernetes-validations:
+                  - message: flavors must have the same number of resources as the
+                      coveredResources
+                    rule: self.flavors.all(x, size(x.resources) == size(self.coveredResources))
                 maxItems: 16
                 type: array
                 x-kubernetes-list-type: atomic
@@ -424,6 +437,12 @@ spec:
                 - HoldAndDrain
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: resourceGroups[0].flavors[0].resources[0].borrowingLimit must
+                be nil when cohort is empty
+              rule: '(!has(self.cohort) || size(self.cohort) == 0) && has(self.resourceGroups)
+                ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r,
+                !has(r.borrowingLimit)))) : true'
           status:
             description: ClusterQueueStatus defines the observed state of ClusterQueue
             properties:
@@ -516,6 +535,8 @@ spec:
                   properties:
                     name:
                       description: name of the flavor.
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     resources:
                       description: resources lists the quota usage for the resources
@@ -568,6 +589,8 @@ spec:
                   properties:
                     name:
                       description: name of the flavor.
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     resources:
                       description: resources lists the quota usage for the resources

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -266,9 +266,8 @@ spec:
                 type: object
                 x-kubernetes-validations:
                 - message: reclaimWithinCohort=Never and borrowWithinCohort.Policy!=Never
-                  rule: '!(has(self.reclaimWithinCohort) && self.reclaimWithinCohort
-                    == ''Never'' && has(self.borrowWithinCohort) &&  self.borrowWithinCohort.policy
-                    != ''Never'')'
+                  rule: '!(self.reclaimWithinCohort == ''Never'' && has(self.borrowWithinCohort)
+                    &&  self.borrowWithinCohort.policy != ''Never'')'
               queueingStrategy:
                 default: BestEffortFIFO
                 description: |-
@@ -442,9 +441,8 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: borrowingLimit must be nil when cohort is empty
-              rule: '(!has(self.cohort) || size(self.cohort) == 0) && has(self.resourceGroups)
-                ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r,
-                !has(r.borrowingLimit)))) : true'
+              rule: '!has(self.cohort) && has(self.resourceGroups) ? self.resourceGroups.all(rg,
+                rg.flavors.all(f, f.resources.all(r, !has(r.borrowingLimit)))) : true'
           status:
             description: ClusterQueueStatus defines the observed state of ClusterQueue
             properties:

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -88,6 +88,7 @@ spec:
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
               flavorFungibility:
+                default: {}
                 description: |-
                   flavorFungibility defines whether a workload should try the next flavor
                   before borrowing or preempting in the flavor being evaluated.
@@ -172,6 +173,7 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               preemption:
+                default: {}
                 description: |-
                   preemption describes policies to preempt Workloads from this ClusterQueue
                   or the ClusterQueue's cohort.
@@ -193,6 +195,7 @@ spec:
                   lower priority first.
                 properties:
                   borrowWithinCohort:
+                    default: {}
                     description: |-
                       borrowWithinCohort provides configuration to allow preemption within
                       cohort while borrowing.
@@ -438,8 +441,7 @@ spec:
                 type: string
             type: object
             x-kubernetes-validations:
-            - message: resourceGroups[0].flavors[0].resources[0].borrowingLimit must
-                be nil when cohort is empty
+            - message: borrowingLimit must be nil when cohort is empty
               rule: '(!has(self.cohort) || size(self.cohort) == 0) && has(self.resourceGroups)
                 ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r,
                 !has(r.borrowingLimit)))) : true'

--- a/config/components/crd/bases/kueue.x-k8s.io_localqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_localqueues.yaml
@@ -157,6 +157,8 @@ spec:
                   properties:
                     name:
                       description: name of the flavor.
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     resources:
                       description: resources lists the quota usage for the resources
@@ -198,6 +200,8 @@ spec:
                   properties:
                     name:
                       description: name of the flavor.
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     resources:
                       description: resources lists the quota usage for the resources

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -7828,6 +7828,8 @@ spec:
                           additionalProperties:
                             description: ResourceFlavorReference is the name of the
                               ResourceFlavor.
+                            maxLength: 253
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                             type: string
                           description: Flavors are the flavors assigned to the workload
                             for each resource.

--- a/pkg/webhooks/clusterqueue_webhook.go
+++ b/pkg/webhooks/clusterqueue_webhook.go
@@ -63,23 +63,6 @@ func (w *ClusterQueueWebhook) Default(ctx context.Context, obj runtime.Object) e
 	if !controllerutil.ContainsFinalizer(cq, kueue.ResourceInUseFinalizerName) {
 		controllerutil.AddFinalizer(cq, kueue.ResourceInUseFinalizerName)
 	}
-	if cq.Spec.Preemption == nil {
-		cq.Spec.Preemption = &kueue.ClusterQueuePreemption{
-			WithinClusterQueue:  kueue.PreemptionPolicyNever,
-			ReclaimWithinCohort: kueue.PreemptionPolicyNever,
-		}
-	}
-	if cq.Spec.Preemption.BorrowWithinCohort == nil {
-		cq.Spec.Preemption.BorrowWithinCohort = &kueue.BorrowWithinCohort{
-			Policy: kueue.BorrowWithinCohortPolicyNever,
-		}
-	}
-	if cq.Spec.FlavorFungibility == nil {
-		cq.Spec.FlavorFungibility = &kueue.FlavorFungibility{
-			WhenCanBorrow:  kueue.Borrow,
-			WhenCanPreempt: kueue.TryNextFlavor,
-		}
-	}
 	return nil
 }
 

--- a/test/integration/webhook/clusterqueue_test.go
+++ b/test/integration/webhook/clusterqueue_test.go
@@ -175,26 +175,6 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("Should allow to update queueingStrategy with same value", func() {
-			ginkgo.By("Creating a new clusterQueue")
-			cq := testing.MakeClusterQueue("cluster-queue").
-				QueueingStrategy(kueue.BestEffortFIFO).
-				ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceMemory).Obj()).
-				Obj()
-			gomega.Expect(k8sClient.Create(ctx, cq)).Should(gomega.Succeed())
-
-			defer func() {
-				util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, cq, true)
-			}()
-
-			gomega.Eventually(func() error {
-				var updateCQ kueue.ClusterQueue
-				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &updateCQ)).Should(gomega.Succeed())
-				updateCQ.Spec.QueueingStrategy = kueue.BestEffortFIFO
-				return k8sClient.Update(ctx, &updateCQ)
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		})
-
 		ginkgo.DescribeTable("Validate ClusterQueue on creation", func(cq *kueue.ClusterQueue, errorType int) {
 			err := k8sClient.Create(ctx, cq)
 			if err == nil {

--- a/test/integration/webhook/clusterqueue_test.go
+++ b/test/integration/webhook/clusterqueue_test.go
@@ -152,7 +152,47 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &updateCQ)).Should(gomega.Succeed())
 				updateCQ.Spec.ResourceGroups[0].Flavors[0].Name = "@x86"
 				return k8sClient.Update(ctx, &updateCQ)
-			}, util.Timeout, util.Interval).Should(testing.BeForbiddenError())
+			}, util.Timeout, util.Interval).Should(testing.BeAPIError(testing.InvalidError))
+		})
+
+		ginkgo.It("Should allow to update queueingStrategy with different value", func() {
+			ginkgo.By("Creating a new clusterQueue")
+			cq := testing.MakeClusterQueue("cluster-queue").
+				QueueingStrategy(kueue.StrictFIFO).
+				ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceMemory).Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, cq)).Should(gomega.Succeed())
+
+			defer func() {
+				util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, cq, true)
+			}()
+
+			gomega.Eventually(func() error {
+				var updateCQ kueue.ClusterQueue
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &updateCQ)).Should(gomega.Succeed())
+				updateCQ.Spec.QueueingStrategy = kueue.BestEffortFIFO
+				return k8sClient.Update(ctx, &updateCQ)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("Should allow to update queueingStrategy with same value", func() {
+			ginkgo.By("Creating a new clusterQueue")
+			cq := testing.MakeClusterQueue("cluster-queue").
+				QueueingStrategy(kueue.BestEffortFIFO).
+				ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceMemory).Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, cq)).Should(gomega.Succeed())
+
+			defer func() {
+				util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, cq, true)
+			}()
+
+			gomega.Eventually(func() error {
+				var updateCQ kueue.ClusterQueue
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &updateCQ)).Should(gomega.Succeed())
+				updateCQ.Spec.QueueingStrategy = kueue.BestEffortFIFO
+				return k8sClient.Update(ctx, &updateCQ)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
 		ginkgo.DescribeTable("Validate ClusterQueue on creation", func(cq *kueue.ClusterQueue, errorType int) {
@@ -168,7 +208,7 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 				gomega.Expect(errors.IsForbidden(err)).Should(gomega.BeTrue(), "error: %v", err)
 			case isInvalid:
 				gomega.Expect(err).Should(gomega.HaveOccurred())
-				gomega.Expect(errors.IsInvalid(err)).Should(gomega.BeTrue(), "error: %v", err)
+				gomega.Expect(err).Should(testing.BeAPIError(testing.InvalidError), "error: %v", err)
 			default:
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				// Validating that defaults are set.
@@ -203,7 +243,7 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 				testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(*testing.MakeFlavorQuotas("invalid_name").Resource(corev1.ResourceCPU, "5").Obj()).
 					Obj(),
-				isForbidden),
+				isInvalid),
 			ginkgo.Entry("Should have qualified resource name",
 				testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource("@cpu", "5").Obj()).
@@ -255,6 +295,263 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 			ginkgo.Entry("Should forbid to create clusterQueue with unknown preemption.withinClusterQueue",
 				testing.MakeClusterQueue("cluster-queue").Preemption(kueue.ClusterQueuePreemption{WithinClusterQueue: "unknown"}).Obj(),
 				isInvalid),
+			ginkgo.Entry("Should allow to create clusterQueue with built-in resources with qualified names",
+				testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(*testing.MakeFlavorQuotas("default").Resource("cpu").Obj()).
+					Obj(),
+				isValid),
+			ginkgo.Entry("Should forbid to create clusterQueue with invalid resource name",
+				testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(*testing.MakeFlavorQuotas("default").Resource("@cpu").Obj()).
+					Obj(),
+				isForbidden),
+			ginkgo.Entry("Should allow to create clusterQueue with valid cohort",
+				testing.MakeClusterQueue("cluster-queue").Cohort("prod").Obj(),
+				isValid),
+			ginkgo.Entry("Should forbid to create clusterQueue with invalid cohort",
+				testing.MakeClusterQueue("cluster-queue").Cohort("@prod").Obj(),
+				isInvalid),
+			ginkgo.Entry("Should allow to create clusterQueue with extended resources with qualified names",
+				testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(*testing.MakeFlavorQuotas("default").Resource("example.com/gpu").Obj()).
+					Obj(),
+				isValid),
+			ginkgo.Entry("Should allow to create clusterQueue with flavor with qualified names",
+				testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource("cpu").Obj()).
+					Obj(),
+				isValid),
+			ginkgo.Entry("Should forbid to create clusterQueue with flavor with unqualified names",
+				testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(*testing.MakeFlavorQuotas("invalid_name").Obj()).
+					Obj(),
+				isInvalid),
+			ginkgo.Entry("Should forbid to create clusterQueue with flavor quota with negative value",
+				testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("x86").Resource("cpu", "-1").Obj()).
+					Obj(),
+				isForbidden),
+			ginkgo.Entry("Should allow to create clusterQueue with flavor quota with zero values",
+				testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("x86").Resource("cpu", "0").Obj()).
+					Obj(),
+				isValid),
+			ginkgo.Entry("Should allow to create clusterQueue with flavor quota with borrowingLimit 0",
+				testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("x86").Resource("cpu", "1", "0").Obj()).
+					Cohort("cohort").
+					Obj(),
+				isValid),
+			ginkgo.Entry("Should forbid to create clusterQueue with flavor quota with negative borrowingLimit",
+				testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("x86").Resource("cpu", "1", "-1").Obj()).
+					Cohort("cohort").
+					Obj(),
+				isForbidden),
+			ginkgo.Entry("Should forbid to create clusterQueue with flavor quota with borrowingLimit and empty cohort",
+				testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("x86").Resource("cpu", "1", "1").Obj()).
+					Obj(),
+				isInvalid),
+			ginkgo.Entry("Should allow to create clusterQueue with empty queueing strategy",
+				testing.MakeClusterQueue("cluster-queue").
+					QueueingStrategy("").
+					Obj(),
+				isValid),
+			ginkgo.Entry("Should forbid to create clusterQueue with namespaceSelector with invalid labels",
+				testing.MakeClusterQueue("cluster-queue").NamespaceSelector(&metav1.LabelSelector{
+					MatchLabels: map[string]string{"nospecialchars^=@": "bar"},
+				}).Obj(),
+				isForbidden),
+			ginkgo.Entry("Should forbid to create clusterQueue with namespaceSelector with invalid expressions",
+				testing.MakeClusterQueue("cluster-queue").NamespaceSelector(&metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "key",
+							Operator: "In",
+						},
+					},
+				}).Obj(),
+				isForbidden),
+			ginkgo.Entry("Should allow to create clusterQueue with multiple resource groups",
+				testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("alpha").
+							Resource("cpu", "0").
+							Resource("memory", "0").
+							Obj(),
+						*testing.MakeFlavorQuotas("beta").
+							Resource("cpu", "0").
+							Resource("memory", "0").
+							Obj(),
+					).
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("gamma").
+							Resource("example.com/gpu", "0").
+							Obj(),
+						*testing.MakeFlavorQuotas("omega").
+							Resource("example.com/gpu", "0").
+							Obj(),
+					).
+					Obj(),
+				isValid),
+			ginkgo.Entry("Should forbid to create clusterQueue with resources in a flavor in different order",
+				&kueue.ClusterQueue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-queue",
+					},
+					Spec: kueue.ClusterQueueSpec{
+						ResourceGroups: []kueue.ResourceGroup{
+							{
+								CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+								Flavors: []kueue.FlavorQuotas{
+									*testing.MakeFlavorQuotas("alpha").
+										Resource("cpu", "0").
+										Resource("memory", "0").
+										Obj(),
+									*testing.MakeFlavorQuotas("beta").
+										Resource("memory", "0").
+										Resource("cpu", "0").
+										Obj(),
+								},
+							},
+						},
+					},
+				},
+				isForbidden),
+			ginkgo.Entry("Should forbid to create clusterQueue missing resources in a flavor",
+				&kueue.ClusterQueue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-queue",
+					},
+					Spec: kueue.ClusterQueueSpec{
+						ResourceGroups: []kueue.ResourceGroup{
+							{
+								CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+								Flavors: []kueue.FlavorQuotas{
+									*testing.MakeFlavorQuotas("alpha").
+										Resource("cpu", "0").
+										Obj(),
+								},
+							},
+						},
+					},
+				},
+				isInvalid),
+			ginkgo.Entry("Should forbid to create clusterQueue missing resources in a flavor",
+				&kueue.ClusterQueue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-queue",
+					},
+					Spec: kueue.ClusterQueueSpec{
+						ResourceGroups: []kueue.ResourceGroup{
+							{
+								CoveredResources: []corev1.ResourceName{"cpu"},
+								Flavors: []kueue.FlavorQuotas{
+									*testing.MakeFlavorQuotas("alpha").
+										Resource("cpu", "0").
+										Resource("memory", "0").
+										Obj(),
+								},
+							},
+						},
+					},
+				},
+				isInvalid),
+			ginkgo.Entry("Should forbid to create clusterQueue missing resources in a flavor and mismatch",
+				&kueue.ClusterQueue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-queue",
+					},
+					Spec: kueue.ClusterQueueSpec{
+						ResourceGroups: []kueue.ResourceGroup{
+							{
+								CoveredResources: []corev1.ResourceName{"blah"},
+								Flavors: []kueue.FlavorQuotas{
+									*testing.MakeFlavorQuotas("alpha").
+										Resource("cpu", "0").
+										Resource("memory", "0").
+										Obj(),
+								},
+							},
+						},
+					},
+				},
+				isInvalid),
+			ginkgo.Entry("Should forbid to create clusterQueue with resource in more than one resource group",
+				testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("alpha").
+							Resource("cpu", "0").
+							Resource("memory", "0").
+							Obj(),
+					).
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("beta").
+							Resource("memory", "0").
+							Obj(),
+					).
+					Obj(),
+				isForbidden),
+			ginkgo.Entry("Should forbid to create clusterQueue with flavor in more than one resource group",
+				testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("alpha").Resource("cpu").Obj(),
+						*testing.MakeFlavorQuotas("beta").Resource("cpu").Obj(),
+					).
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("beta").Resource("memory").Obj(),
+					).
+					Obj(),
+				isForbidden),
+			ginkgo.Entry("Should forbid to create clusterQueue missing with invalid preemption due to reclaimWithinCohort=Never, while borrowWithinCohort!=nil",
+				&kueue.ClusterQueue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-queue",
+					},
+					Spec: kueue.ClusterQueueSpec{
+						Preemption: &kueue.ClusterQueuePreemption{
+							ReclaimWithinCohort: kueue.PreemptionPolicyNever,
+							BorrowWithinCohort: &kueue.BorrowWithinCohort{
+								Policy: kueue.BorrowWithinCohortPolicyLowerPriority,
+							},
+						},
+					},
+				},
+				isInvalid),
+			ginkgo.Entry("Should allow to create clusterQueue with valid preemption with borrowWithinCohort",
+				&kueue.ClusterQueue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-queue",
+					},
+					Spec: kueue.ClusterQueueSpec{
+						Preemption: &kueue.ClusterQueuePreemption{
+							ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
+							BorrowWithinCohort: &kueue.BorrowWithinCohort{
+								Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
+								MaxPriorityThreshold: ptr.To[int32](10),
+							},
+						},
+					},
+				},
+				isValid),
+			ginkgo.Entry("Should allow to create clusterQueue with existing cluster queue created with older Kueue version that has a nil borrowWithinCohort field",
+				&kueue.ClusterQueue{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "cluster-queue",
+					},
+					Spec: kueue.ClusterQueueSpec{
+						Preemption: &kueue.ClusterQueuePreemption{
+							ReclaimWithinCohort: kueue.PreemptionPolicyNever,
+						},
+					},
+				},
+				isValid),
 		)
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

It replaces some of the validations executed by webhooks for the `ClusterQueue` type with CRD validation rules.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #463 

#### Special notes for your reviewer:

Only validation rules with a cost within the API server limits have been added.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added CRD validation rules to ClusterQueue.

ACTION REQUIRED: Requires Kubernetes 1.25 or newer
```