### PR TITLE
Fix deprecated comment for constants.QueueAnnotation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,7 +11,6 @@ linters-settings:
       - assignOp
       - captLocal
       - commentFormatting
-      - deprecatedComment
       - elseif
       - exitAfterDefer
       - ifElseChain
@@ -38,6 +37,12 @@ issues:
   # Which dirs to exclude: issues from them won't be reported
   exclude-dirs:
     - bin
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - linters:
+      - staticcheck
+      # TODO(#768): Drop when incrementing the API version.
+      text: "SA1019: constants.QueueAnnotation is deprecated"
   # Show all issues from a linter
   max-issues-per-linter: 0
   # Show all issues with the same text

--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -22,7 +22,7 @@ const (
 
 	// QueueAnnotation is the annotation key in the workload that holds the queue name.
 	//
-	// DEPRECATED: Use QueueLabel as a label key.
+	// Deprecated: Use QueueLabel as a label key.
 	QueueAnnotation = QueueLabel
 
 	// PrebuiltWorkloadLabel is the label key of the job holding the name of the pre-built workload to use.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Changes deprecation comment format for `constants.QueueAnnotation` according to the https://go.dev/wiki/Deprecated.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

The wrong format of the deprecation comment for the `constants.QueueAnnotation` is found with `gocritic`'s `deprecatedComment` check.

Can't replace `constants.QueueAnnotation` with `constants.QueueLabel`, see the discussion below https://github.com/kubernetes-sigs/kueue/pull/1976#discussion_r1566379045

#### Does this PR introduce a user-facing change?

```release-note
NONE
```