### PR TITLE
[test] Scalability runner metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,7 @@ run-scalability: envtest scalability-runner minimalkueue
 .PHONY: test-scalability
 test-scalability: gotestsum run-scalability
 	$(GOTESTSUM) --junitfile $(ARTIFACTS)/junit.xml -- $(GO_TEST_FLAGS) ./test/scalability/checker  \
+		--summary=$(SCALABILITY_RUN_DIR)/summary.yaml \
 		--cmdStats=$(SCALABILITY_RUN_DIR)/minimalkueue.stats.yaml \
 		--range=$(PROJECT_DIR)/test/scalability/default_rangespec.yaml
 

--- a/test/scalability/default_rangespec.yaml
+++ b/test/scalability/default_rangespec.yaml
@@ -5,3 +5,11 @@ cmd:
   maxUserMs: 3600_000
   maxSysMs: 3600_000
   maxrss: 1024_000 #1000MiB
+
+clusterQueueClassesMinUsage:
+  cq: 10  #10%
+
+wlClassesMaxAvgTimeToAdmissionMs:
+  large: 3600_000 #1h
+  medium: 3600_000
+  small: 3600_000

--- a/test/scalability/runner/main.go
+++ b/test/scalability/runner/main.go
@@ -196,6 +196,22 @@ func main() {
 		os.Exit(1)
 	}
 
+	err = recorder.WriteSummary(path.Join(*outputDir, "summary.yaml"))
+	if err != nil {
+		log.Error(err, "Writing summary")
+		os.Exit(1)
+	}
+	err = recorder.WriteCQCsv(path.Join(*outputDir, "cqStates.csv"))
+	if err != nil {
+		log.Error(err, "Writing cq csv")
+		os.Exit(1)
+	}
+	err = recorder.WriteWLCsv(path.Join(*outputDir, "wlStates.csv"))
+	if err != nil {
+		log.Error(err, "Writing wl csv")
+		os.Exit(1)
+	}
+
 	if *minimalKueuePath == "" {
 		c, err := client.New(cfg, client.Options{Scheme: scheme})
 		if err != nil {

--- a/test/scalability/runner/recorder/recorder.go
+++ b/test/scalability/runner/recorder/recorder.go
@@ -18,27 +18,138 @@ package recorder
 
 import (
 	"context"
+	"encoding/csv"
+	"os"
+	"strconv"
 	"sync/atomic"
 	"time"
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/yaml"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/test/scalability/runner/generator"
 )
 
+type event interface {
+	GetEventInfo() string
+}
+
 type CQStatus struct {
-	Name               string
+}
+
+type CQEvent struct {
+	Time      time.Time
+	Name      string
+	ClassName string
+	Cohort    string
+	UID       types.UID
+
+	CPUReservation     int64
+	CPUUsage           int64
+	CPUQuota           int64
 	PendingWorkloads   int32
 	ReservingWorkloads int32
+	AdmittedWorkloads  int32
 	Active             bool
 }
 
-type Store map[string]CQStatus
+func (e *CQEvent) GetEventInfo() string {
+	return ""
+}
+
+type CQState struct {
+	FirstEventTime  time.Time
+	FirstActiveTime time.Time
+	CPUUsed         int64
+	CPUMaxUsage     int64
+	LastEvent       *CQEvent
+}
+
+var CQStateCsvHeader = []string{
+	"name",
+	"cohort",
+	"class name",
+	"CPU quota (mCPU)",
+	"CPU used (mCPU * ms)",
+	"CPU max usage (mCPU)",
+	"monitor time (ms)",
+}
+
+func (cqs *CQState) CsvRecord() []string {
+	monitoringTimeMs := cqs.LastEvent.Time.Sub(cqs.FirstEventTime).Milliseconds()
+	return []string{
+		cqs.LastEvent.Name,
+		cqs.LastEvent.Cohort,
+		cqs.LastEvent.ClassName,
+		strconv.FormatInt(cqs.LastEvent.CPUQuota, 10),
+		strconv.FormatInt(cqs.CPUUsed, 10),
+		strconv.FormatInt(cqs.CPUMaxUsage, 10),
+		strconv.FormatInt(monitoringTimeMs, 10),
+	}
+}
+
+type CQStore map[string]*CQState
+
+type WLEvent struct {
+	Time time.Time
+	types.NamespacedName
+	UID       types.UID
+	ClassName string
+	Admitted  bool
+	Evicted   bool
+	Finished  bool
+}
+
+func (e *WLEvent) GetEventInfo() string {
+	return ""
+}
+
+type WLState struct {
+	Id int
+	types.NamespacedName
+	ClassName      string
+	FirstEventTime time.Time
+	MSToAdmitted   int64
+	MSToFinished   int64
+	EvictionCount  int32
+	LastEvent      *WLEvent
+}
+
+var WLStateCsvHeader = []string{
+	"id",
+	"class name",
+	"namespace",
+	"name",
+	"ms to admitted",
+	"ms to finish",
+	"num evictions",
+}
+
+func (wls *WLState) CsvRecord() []string {
+	return []string{
+		strconv.Itoa(wls.Id),
+		wls.ClassName,
+		wls.Namespace,
+		wls.Name,
+		strconv.FormatInt(wls.MSToAdmitted, 10),
+		strconv.FormatInt(wls.MSToFinished, 10),
+		strconv.FormatInt(int64(wls.EvictionCount), 10),
+	}
+}
+
+type WLStore map[types.UID]*WLState
+
+type Store struct {
+	CQ CQStore
+	WL WLStore
+}
 
 type Recorder struct {
 	maxRecording time.Duration
 	running      atomic.Bool
-	evChan       chan CQStatus
+	evChan       chan event
 
 	Store Store
 }
@@ -47,22 +158,251 @@ func New(maxRecording time.Duration) *Recorder {
 	return &Recorder{
 		maxRecording: maxRecording,
 		running:      atomic.Bool{},
-		evChan:       make(chan CQStatus, 10),
-		Store:        map[string]CQStatus{},
+		evChan:       make(chan event, 10),
+		Store: Store{
+			CQ: make(CQStore),
+			WL: make(WLStore),
+		},
 	}
 }
 
-func (r *Recorder) record(ev CQStatus) {
-	r.Store[ev.Name] = ev
+func (r *Recorder) recordCQEvent(ev *CQEvent) {
+	state, found := r.Store.CQ[ev.Name]
+	if !found {
+		state = &CQState{
+			FirstEventTime: ev.Time,
+			LastEvent:      ev,
+		}
+		r.Store.CQ[ev.Name] = state
+	} else {
+		if state.LastEvent.CPUUsage > 0 {
+			state.CPUUsed += state.LastEvent.CPUUsage * ev.Time.Sub(state.LastEvent.Time).Milliseconds()
+		}
+		state.LastEvent = ev
+	}
+
+	if ev.Active && state.FirstActiveTime.IsZero() {
+		state.FirstActiveTime = ev.Time
+	}
+	state.CPUMaxUsage = max(state.CPUMaxUsage, ev.CPUUsage)
+}
+
+func (r *Recorder) recordWLEvent(ev *WLEvent) {
+	state, found := r.Store.WL[ev.UID]
+	if !found {
+		state = &WLState{
+			Id:             len(r.Store.WL),
+			NamespacedName: ev.NamespacedName,
+			ClassName:      ev.ClassName,
+			FirstEventTime: ev.Time,
+			LastEvent:      &WLEvent{},
+		}
+		r.Store.WL[ev.UID] = state
+	}
+
+	if ev.Admitted && !state.LastEvent.Admitted {
+		state.MSToAdmitted = ev.Time.Sub(state.FirstEventTime).Milliseconds()
+	}
+
+	if ev.Evicted && !state.LastEvent.Evicted {
+		state.EvictionCount++
+	}
+
+	if ev.Finished && !state.LastEvent.Finished {
+		state.MSToFinished = ev.Time.Sub(state.FirstEventTime).Milliseconds()
+	}
+
+	state.LastEvent = ev
+}
+
+func (r *Recorder) record(ev event) {
+	switch v := ev.(type) {
+	case *CQEvent:
+		r.recordCQEvent(v)
+	case *WLEvent:
+		r.recordWLEvent(v)
+	}
+
 }
 
 func (r *Recorder) expectMoreEvents() bool {
-	for _, s := range r.Store {
+	for _, cqStatus := range r.Store.CQ {
+		s := cqStatus.LastEvent
 		if (s.PendingWorkloads > 0 || s.ReservingWorkloads > 0) && s.Active {
 			return true
 		}
 	}
 	return false
+}
+
+type CQGroupSummary struct {
+	CPUUsed         int64     `json:"cpuUsed"`
+	CPUAverageUsage int64     `json:"cpuAverageUsage"`
+	NominalQuota    int64     `json:"nominalQuota"`
+	FirstEventTime  time.Time `json:"firstEventTime"`
+	LastEventTime   time.Time `json:"lastEventTime"`
+}
+
+func (qgs *CQGroupSummary) AddQueueSummary(qs *CQState) {
+	qgs.CPUUsed += qs.CPUUsed
+	qgs.NominalQuota += qs.LastEvent.CPUQuota
+	if qs.FirstEventTime.Before(qgs.FirstEventTime) {
+		qgs.FirstEventTime = qs.FirstEventTime
+	}
+	if qs.LastEvent.Time.After(qgs.LastEventTime) {
+		qgs.LastEventTime = qs.LastEvent.Time
+	}
+}
+
+func (qgs *CQGroupSummary) refreshAverage() {
+	monitoringTime := qgs.LastEventTime.Sub(qgs.FirstEventTime).Milliseconds()
+	if monitoringTime > 0 {
+		qgs.CPUAverageUsage = qgs.CPUUsed / monitoringTime
+	}
+}
+
+func newCQGroupSummary(qs *CQState) *CQGroupSummary {
+	ret := &CQGroupSummary{
+		CPUUsed:         qs.CPUUsed,
+		CPUAverageUsage: 0,
+		NominalQuota:    qs.LastEvent.CPUQuota,
+		FirstEventTime:  qs.FirstEventTime,
+		LastEventTime:   qs.LastEvent.Time,
+	}
+	return ret
+}
+
+type WorkloadsClassSummary struct {
+	Count                    int32 `json:"count"`
+	totalTimeToAdmissionMs   int64 `json:"-"`
+	totalTimeToFinishMs      int64 `json:"-"`
+	TotalEvictions           int32 `json:"totalEvictions"`
+	AverageTimeToAdmissionMs int64 `json:"averageTimeToAdmissionMs"`
+	AverageTimeToFinishMs    int64 `json:"averageTimeToFinishMs"`
+}
+
+func (wcs *WorkloadsClassSummary) refreshAverage() {
+	if wcs == nil || wcs.Count == 0 {
+		return
+	}
+	wcs.AverageTimeToAdmissionMs = wcs.totalTimeToAdmissionMs / int64(wcs.Count)
+	wcs.AverageTimeToFinishMs = wcs.totalTimeToFinishMs / int64(wcs.Count)
+}
+
+type Summary struct {
+	ClusterQueueClasses map[string]*CQGroupSummary        `json:"clusterQueueClasses"`
+	WorkloadClasses     map[string]*WorkloadsClassSummary `json:"workloadClasses"`
+}
+
+func (r *Recorder) WriteSummary(path string) error {
+	summary := Summary{
+		ClusterQueueClasses: map[string]*CQGroupSummary{},
+		WorkloadClasses:     map[string]*WorkloadsClassSummary{},
+	}
+
+	for _, cqState := range r.Store.CQ {
+		if cqState.LastEvent == nil {
+			continue
+		}
+		if groupSummary, found := summary.ClusterQueueClasses[cqState.LastEvent.ClassName]; found {
+			groupSummary.AddQueueSummary(cqState)
+		} else {
+			summary.ClusterQueueClasses[cqState.LastEvent.ClassName] = newCQGroupSummary(cqState)
+		}
+	}
+
+	for _, group := range summary.ClusterQueueClasses {
+		group.refreshAverage()
+	}
+
+	for _, wlState := range r.Store.WL {
+		if class, found := summary.WorkloadClasses[wlState.ClassName]; !found {
+			summary.WorkloadClasses[wlState.ClassName] = &WorkloadsClassSummary{
+				Count:                  1,
+				totalTimeToAdmissionMs: wlState.MSToAdmitted,
+				totalTimeToFinishMs:    wlState.MSToFinished,
+				TotalEvictions:         wlState.EvictionCount,
+			}
+		} else {
+			class.Count++
+			class.totalTimeToAdmissionMs += wlState.MSToAdmitted
+			class.totalTimeToFinishMs += wlState.MSToFinished
+			class.TotalEvictions += wlState.EvictionCount
+		}
+	}
+
+	for _, class := range summary.WorkloadClasses {
+		class.refreshAverage()
+	}
+
+	bytes, err := yaml.Marshal(summary)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, bytes, 0666)
+}
+
+func (r *Recorder) WriteCQCsv(path string) (err error) {
+	var f *os.File
+	f, err = os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	cWriter := csv.NewWriter(f)
+
+	defer func() {
+		cWriter.Flush()
+		if err == nil {
+			err = cWriter.Error()
+		}
+	}()
+
+	err = cWriter.Write(CQStateCsvHeader)
+	if err != nil {
+		return err
+	}
+
+	for _, cqs := range r.Store.CQ {
+		err = cWriter.Write(cqs.CsvRecord())
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+
+func (r *Recorder) WriteWLCsv(path string) (err error) {
+	var f *os.File
+	f, err = os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	cWriter := csv.NewWriter(f)
+
+	defer func() {
+		cWriter.Flush()
+		if err == nil {
+			err = cWriter.Error()
+		}
+	}()
+
+	err = cWriter.Write(WLStateCsvHeader)
+	if err != nil {
+		return err
+	}
+
+	for _, ev := range r.Store.WL {
+		err = cWriter.Write(ev.CsvRecord())
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
 }
 
 func (r *Recorder) Run(ctx context.Context, genDone <-chan struct{}) error {
@@ -92,15 +432,55 @@ func (r *Recorder) Run(ctx context.Context, genDone <-chan struct{}) error {
 	}
 }
 
-func (r *Recorder) RecordCQStatus(cq *kueue.ClusterQueue) {
+func (r *Recorder) RecordWorkloadState(wl *kueue.Workload) {
+	if !r.running.Load() {
+		return
+	}
+	r.evChan <- &WLEvent{
+		Time: time.Now(),
+		NamespacedName: types.NamespacedName{
+			Namespace: wl.Namespace,
+			Name:      wl.Name,
+		},
+		UID:       wl.UID,
+		ClassName: wl.Labels[generator.ClassLabel],
+		Admitted:  apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadAdmitted),
+		Evicted:   apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted),
+		Finished:  apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadFinished),
+	}
+}
+
+func (r *Recorder) RecordCQState(cq *kueue.ClusterQueue) {
 	if !r.running.Load() {
 		return
 	}
 
-	r.evChan <- CQStatus{
-		Name:               cq.Name,
+	var cpuReserved, cpuUsed, cpuQuota int64
+	if len(cq.Status.FlavorsReservation) > 0 && len(cq.Status.FlavorsReservation[0].Resources) > 0 {
+		cpuReserved = cq.Status.FlavorsReservation[0].Resources[0].Total.MilliValue()
+	}
+
+	if len(cq.Status.FlavorsUsage) > 0 && len(cq.Status.FlavorsUsage[0].Resources) > 0 {
+		cpuUsed = cq.Status.FlavorsUsage[0].Resources[0].Total.MilliValue()
+	}
+
+	if len(cq.Spec.ResourceGroups) > 0 && len(cq.Spec.ResourceGroups[0].Flavors) > 0 && len(cq.Spec.ResourceGroups[0].Flavors[0].Resources) > 0 {
+		cpuQuota = cq.Spec.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota.MilliValue()
+	}
+
+	r.evChan <- &CQEvent{
+		Time:      time.Now(),
+		Name:      cq.Name,
+		ClassName: cq.Labels[generator.ClassLabel],
+		Cohort:    cq.Spec.Cohort,
+		UID:       cq.UID,
+
+		CPUReservation:     cpuReserved,
+		CPUUsage:           cpuUsed,
+		CPUQuota:           cpuQuota,
 		PendingWorkloads:   cq.Status.PendingWorkloads,
 		ReservingWorkloads: cq.Status.ReservingWorkloads,
+		AdmittedWorkloads:  cq.Status.AdmittedWorkloads,
 		Active:             apimeta.IsStatusConditionTrue(cq.Status.Conditions, kueue.AdmissionCheckActive),
 	}
 }

--- a/test/scalability/runner/recorder/recorder.go
+++ b/test/scalability/runner/recorder/recorder.go
@@ -36,9 +36,6 @@ type event interface {
 	GetEventInfo() string
 }
 
-type CQStatus struct {
-}
-
 type CQEvent struct {
 	Time      time.Time
 	Name      string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Adds scalability runner measured metrics, a set of measurements results extracted from the API events monitored by the runner which can be easily used to detect regressions in kueue's scheduling.

Currently a summary is generated like:

```yaml
clusterQueueClasses:
  cq:
    cpuAverageUsage: 358300
    cpuUsed: 123130721000
    firstEventTime: "2024-04-17T13:07:53.831208896+03:00"
    lastEventTime: "2024-04-17T13:13:37.48321136+03:00"
    nominalQuota: 600000
workloadClasses:
  large:
    averageTimeToAdmissionMs: 8288
    averageTimeToFinishMs: 9292
    count: 1500
    totalEvictions: 0
  medium:
    averageTimeToAdmissionMs: 77447
    averageTimeToFinishMs: 77951
    count: 3000
    totalEvictions: 1
  small:
    averageTimeToAdmissionMs: 214757
    averageTimeToFinishMs: 214962
    count: 10500
    totalEvictions: 8
```

The checker will  verify

```yaml
clusterQueueClassesMinUsage:
  cq: 10
# the value needs to be adapted based on a set of CI run results 
# computed as summary.clusterQueueClasses[<cq-class>].cpuAverageUsage * 100 / summary.clusterQueueClasses[<cq-class>].nominalQuota

wlClassesMaxAvgTimeToAdmissionMs:
  large: 3600_000 
  medium: 3600_000
  small: 3600_000 
# the value needs to be adapted based on a set of CI run results 
# compared against summary.workloadClasses[<wl-class>].averageTimeToAdmissionMs
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #1912

#### Special notes for your reviewer:

Please let me know if you can think of additional measurements we can do and worth monitoring in CI.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```