### PR TITLE
Preemption algorithm described

### DIFF
--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -452,9 +452,9 @@ within the cohort which satisfy the `reclaimWithinCohort` policy.
 
 The list of candidates is sorted based on the following preference checks for
 tie-breaking:
-- workloads from other cluster queues
-- workloads with the lowest priority
-- workloads which run the shortest
+- workloads from other cluster queues,
+- workloads with the lowest priority,
+- workloads which got admitted the most recently.
 
 #### Targets
 

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -443,7 +443,7 @@ cohort which satisfy the `reclaimWithinCohort` policy.
 
 The list of candidates is sorted based on the following preference checks for
 tie-breaking:
-- Workloads from other borrowing queues in the cohort,
+- Workloads from borrowing queues in the cohort,
 - Workloads with the lowest priority,
 - Workloads which got admitted the most recently.
 

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -430,7 +430,7 @@ Below we present a more detailed description of the algorithm.
 ### Preemption Algorithm overview
 
 An incoming Workload, which does not fit within the unused quota, is eligible
-for preemptions, within a flavor of the target queue, when one of the following
+to issue preemptions when one of the following
 is true:
 - the requests of the Workload are below the flavor's nominal quota, or
 - `borrowWithinCohort` is enabled.

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -424,6 +424,9 @@ The fields above do the following:
 Note that an incoming Workload can preempt Workloads both within the
 ClusterQueue and the cohort.
 
+Kueue implements heuristics to preempt as few Workloads as possible.
+Below we present a more detailed description of the algorithm.
+
 ### Preemption Algorithm overview
 
 An incoming Workload, which does not fit within the free capacity, is eligible
@@ -431,15 +434,6 @@ for preemptions, within a flavor of the target queue, when one of the following
 is true:
 - the requests of the Workload are below the flavor's nominal quota, or
 - `borrowWithinCohort` is enabled.
-
-Kueue implements heuristics to preempt as few Workloads as possible, preferring
-Workloads with these characteristics:
-
-- Workloads belonging to ClusterQueues that are borrowing quota.
-- Workloads with the lowest priority.
-- Workloads that have been admitted more recently.
-
-Below we present a more detailed description of the algorithm.
 
 #### Candidates
 

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -449,25 +449,29 @@ tie-breaking:
 
 #### Targets
 
-The algorithm qualifies the candidates as preemption targets using the following heuristics:
+The algorithm qualifies the candidates as preemption targets using the heuristics
+below:
 
 1. If all candidates belong to the target queue, then Kueue greedily
-qualifies candidates until the incoming Workload can fit, allowing for borrowing.
+qualifies candidates until the incoming Workload can fit, allowing the usage of
+the ClusterQueue to be above the nominal quota, up to the `borrowingLimit`.
+This is referred as "borrowing" in the points below.
 
 2. If `borrowWithinCohort` is enabled, then Kueue greedily qualifies
 candidates (respecting the `borrowWithinCohort.maxPriorityThreshold` threshold),
 until the incoming Workload can fit, allowing for borrowing.
 
 3. If the current usage of the target queue is below nominal quota, then
-Kueue greedily qualifies the candidates, until the incoming workload can fit
-without borrowing.
+Kueue greedily qualifies the candidates, until the incoming workload can fit,
+disallowing for borrowing.
 
 4. Kueue tries to greedily qualifies a subset of candidates which belong to the
 target Cluster Queue, until the incoming Workload can fit, allowing for borrowing.
 
 The last step of the algorithm is to optimize the set of targets. For this
 purpose Kueue greedily traverses the list of initial targets in reverse and
-removes them from the list of targets if the incoming Workload still can be admitted when they are accounted back for quota usage.
+removes them from the list of targets if the incoming Workload still can be
+admitted when they are accounted back for quota usage.
 
 ## FlavorFungibility
 

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -449,7 +449,7 @@ tie-breaking:
 
 #### Targets
 
-The algorithm qualifies the candidates as targets using the following heuristics:
+The algorithm qualifies the candidates as preemption targets using the following heuristics:
 
 1. If all candidates belong to the target queue, then Kueue greedily
 qualifies candidates until the incoming Workload can fit, allowing for borrowing.

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -466,7 +466,7 @@ without borrowing.
 target Cluster Queue, until the incoming Workload can fit, allowing for borrowing.
 
 The last step of the algorithm is to optimize the set of targets. For this
-purpose Kueue greedily traverses the list of initial targets (in reverse) and
+purpose Kueue greedily traverses the list of initial targets in reverse and
 removes them from the list of targets if the incoming Workload still can be admitted when they are accounted back for quota usage.
 
 ## FlavorFungibility

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -467,7 +467,7 @@ target Cluster Queue, until the incoming Workload can fit, allowing for borrowin
 
 The last step of the algorithm is to optimize the set of targets. For this
 purpose Kueue greedily traverses the list of initial targets (in reverse) and
-removes these without which the incoming Workload still can be admitted.
+removes them from the list of targets if the incoming Workload still can be admitted when they are accounted back for quota usage.
 
 ## FlavorFungibility
 

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -429,7 +429,7 @@ Below we present a more detailed description of the algorithm.
 
 ### Preemption Algorithm overview
 
-An incoming Workload, which does not fit within the free capacity, is eligible
+An incoming Workload, which does not fit within the unused quota, is eligible
 for preemptions, within a flavor of the target queue, when one of the following
 is true:
 - the requests of the Workload are below the flavor's nominal quota, or


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1974

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```