### PR TITLE
Fix typos in unexported variable names

### DIFF
--- a/cmd/importer/pod/check_test.go
+++ b/cmd/importer/pod/check_test.go
@@ -43,11 +43,11 @@ func TestCheckNamespace(t *testing.T) {
 	baseClusterQueue := utiltesting.MakeClusterQueue("cq1")
 
 	cases := map[string]struct {
-		pods         []corev1.Pod
-		clusteQueues []kueue.ClusterQueue
-		localQueues  []kueue.LocalQueue
-		mapping      util.MappingRules
-		flavors      []kueue.ResourceFlavor
+		pods          []corev1.Pod
+		clusterQueues []kueue.ClusterQueue
+		localQueues   []kueue.LocalQueue
+		mapping       util.MappingRules
+		flavors       []kueue.ResourceFlavor
 
 		wantError error
 	}{
@@ -113,7 +113,7 @@ func TestCheckNamespace(t *testing.T) {
 			localQueues: []kueue.LocalQueue{
 				*baseLocalQueue.Obj(),
 			},
-			clusteQueues: []kueue.ClusterQueue{
+			clusterQueues: []kueue.ClusterQueue{
 				*baseClusterQueue.Obj(),
 			},
 			wantError: util.ErrCQInvalid,
@@ -136,7 +136,7 @@ func TestCheckNamespace(t *testing.T) {
 			localQueues: []kueue.LocalQueue{
 				*baseLocalQueue.Obj(),
 			},
-			clusteQueues: []kueue.ClusterQueue{
+			clusterQueues: []kueue.ClusterQueue{
 				*utiltesting.MakeClusterQueue("cq1").ResourceGroup(*utiltesting.MakeFlavorQuotas("rf1").Resource(corev1.ResourceCPU, "1").Obj()).Obj(),
 			},
 			flavors: []kueue.ResourceFlavor{
@@ -148,7 +148,7 @@ func TestCheckNamespace(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			podsList := corev1.PodList{Items: tc.pods}
-			cqList := kueue.ClusterQueueList{Items: tc.clusteQueues}
+			cqList := kueue.ClusterQueueList{Items: tc.clusterQueues}
 			lqList := kueue.LocalQueueList{Items: tc.localQueues}
 			rfList := kueue.ResourceFlavorList{Items: tc.flavors}
 

--- a/cmd/importer/pod/import_test.go
+++ b/cmd/importer/pod/import_test.go
@@ -83,11 +83,11 @@ func TestImportNamespace(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		pods         []corev1.Pod
-		clusteQueues []kueue.ClusterQueue
-		localQueues  []kueue.LocalQueue
-		mapping      util.MappingRules
-		addLabels    map[string]string
+		pods          []corev1.Pod
+		clusterQueues []kueue.ClusterQueue
+		localQueues   []kueue.LocalQueue
+		mapping       util.MappingRules
+		addLabels     map[string]string
 
 		wantPods      []corev1.Pod
 		wantWorkloads []kueue.Workload
@@ -112,7 +112,7 @@ func TestImportNamespace(t *testing.T) {
 			localQueues: []kueue.LocalQueue{
 				*baseLocalQueue.Obj(),
 			},
-			clusteQueues: []kueue.ClusterQueue{
+			clusterQueues: []kueue.ClusterQueue{
 				*baseClusterQueue.Obj(),
 			},
 
@@ -145,7 +145,7 @@ func TestImportNamespace(t *testing.T) {
 			localQueues: []kueue.LocalQueue{
 				*baseLocalQueue.Obj(),
 			},
-			clusteQueues: []kueue.ClusterQueue{
+			clusterQueues: []kueue.ClusterQueue{
 				*baseClusterQueue.Obj(),
 			},
 			addLabels: map[string]string{
@@ -171,7 +171,7 @@ func TestImportNamespace(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			podsList := corev1.PodList{Items: tc.pods}
-			cqList := kueue.ClusterQueueList{Items: tc.clusteQueues}
+			cqList := kueue.ClusterQueueList{Items: tc.clusterQueues}
 			lqList := kueue.LocalQueueList{Items: tc.localQueues}
 
 			builder := utiltesting.NewClientBuilder().

--- a/pkg/controller/admissionchecks/multikueue/controllers.go
+++ b/pkg/controller/admissionchecks/multikueue/controllers.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	defaultGCInterval       = time.Minute
-	defaultOrigin           = "multikueue"
-	defaulWorkerLostTimeout = 5 * time.Minute
+	defaultGCInterval        = time.Minute
+	defaultOrigin            = "multikueue"
+	defaultWorkerLostTimeout = 5 * time.Minute
 )
 
 type SetupOptions struct {
@@ -64,7 +64,7 @@ func SetupControllers(mgr ctrl.Manager, namespace string, opts ...SetupOption) e
 	options := &SetupOptions{
 		gcInterval:        defaultGCInterval,
 		origin:            defaultOrigin,
-		workerLostTimeout: defaulWorkerLostTimeout,
+		workerLostTimeout: defaultWorkerLostTimeout,
 	}
 
 	for _, o := range opts {

--- a/pkg/controller/admissionchecks/multikueue/jobset_adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/jobset_adapter_test.go
@@ -323,7 +323,7 @@ func TestWlReconcileJobset(t *testing.T) {
 			cRec.remoteClients["worker1"] = w1remoteClient
 
 			helper, _ := newMultiKueueStoreHelper(managerClient)
-			reconciler := newWlReconciler(managerClient, helper, cRec, defaultOrigin, defaulWorkerLostTimeout)
+			reconciler := newWlReconciler(managerClient, helper, cRec, defaultOrigin, defaultWorkerLostTimeout)
 
 			_, gotErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "wl1", Namespace: TestNamespace}})
 			if gotErr != nil {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -186,13 +186,13 @@ func (a *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		return reconcile.Result{}, a.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, rejectionMessage)
 	}
 
-	managed, unamagedReason, err := adapter.IsJobManagedByKueue(ctx, a.client, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace})
+	managed, unmanagedReason, err := adapter.IsJobManagedByKueue(ctx, a.client, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace})
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	if !managed {
-		return reconcile.Result{}, a.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("The owner is not managed by Kueue: %s", unamagedReason))
+		return reconcile.Result{}, a.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("The owner is not managed by Kueue: %s", unmanagedReason))
 	}
 
 	grp, err := a.readGroup(ctx, wl, mkAc.Name, adapter, owner.Name)

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -467,7 +467,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:               "ac1",
 						State:              kueue.CheckStateReady,
-						LastTransitionTime: metav1.NewTime(time.Now().Add(-defaulWorkerLostTimeout / 2)), //50% of the timeout
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-defaultWorkerLostTimeout / 2)), //50% of the timeout
 						Message:            `The workload got reservation on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -493,7 +493,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:               "ac1",
 						State:              kueue.CheckStateReady,
-						LastTransitionTime: metav1.NewTime(time.Now().Add(-defaulWorkerLostTimeout * 3 / 2)), // 150% of the timeout
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-defaultWorkerLostTimeout * 3 / 2)), // 150% of the timeout
 						Message:            `The workload got reservation on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -708,7 +708,7 @@ func TestWlReconcile(t *testing.T) {
 			}
 
 			helper, _ := newMultiKueueStoreHelper(managerClient)
-			reconciler := newWlReconciler(managerClient, helper, cRec, defaultOrigin, defaulWorkerLostTimeout)
+			reconciler := newWlReconciler(managerClient, helper, cRec, defaultOrigin, defaultWorkerLostTimeout)
 
 			_, gotErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.reconcileFor, Namespace: TestNamespace}})
 			if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -294,8 +294,8 @@ func TestMergeRestore(t *testing.T) {
 				}
 
 				restoreInfo := FromPodSet(orig)
-				gotRestoreChage := RestorePodSpec(&tc.podSet.Template.ObjectMeta, &tc.podSet.Template.Spec, restoreInfo)
-				if gotRestoreChage != tc.wantRestoreChanges {
+				gotRestoreChange := RestorePodSpec(&tc.podSet.Template.ObjectMeta, &tc.podSet.Template.Spec, restoreInfo)
+				if gotRestoreChange != tc.wantRestoreChanges {
 					t.Errorf("Unexpected restore change status want:%v", tc.wantRestoreChanges)
 				}
 				if diff := cmp.Diff(orig.Template, tc.podSet.Template, cmpopts.EquateEmpty()); diff != "" {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Corrects spelling mistakes in variable names.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

Safe to merge because only unexported or local variables are affected.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```