### PR TITLE
Non-admitted workloads with QuotaReserved condition are shown as Admitted by kubectl

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -330,9 +330,10 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Queue",JSONPath=".spec.queueName",type=string,description="Name of the queue this workload was submitted to"
-// +kubebuilder:printcolumn:name="Admitted by",JSONPath=".status.admission.clusterQueue",type=string,description="Name of the ClusterQueue that admitted this workload"
-// +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type=date,description="Time this workload was created"
+// +kubebuilder:printcolumn:name="Queue",JSONPath=".spec.queueName",type="string",priority=0,description="Name of the queue this workload was submitted to"
+// +kubebuilder:printcolumn:name="Reserving in",JSONPath=".status.admission.clusterQueue",type="string",priority=0,description="Name of the ClusterQueue where the workload is reserving quota"
+// +kubebuilder:printcolumn:name="Admitted",JSONPath=".status.conditions[?(@.type=='Admitted')].status",type="string",priority=10,description="Admission status"
+// +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",priority=0,description="Time this workload was created"
 // +kubebuilder:resource:shortName={wl}
 
 // Workload is the Schema for the workloads API

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -330,10 +330,10 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Queue",JSONPath=".spec.queueName",type="string",priority=0,description="Name of the queue this workload was submitted to"
-// +kubebuilder:printcolumn:name="Reserving in",JSONPath=".status.admission.clusterQueue",type="string",priority=0,description="Name of the ClusterQueue where the workload is reserving quota"
+// +kubebuilder:printcolumn:name="Queue",JSONPath=".spec.queueName",type="string",description="Name of the queue this workload was submitted to"
+// +kubebuilder:printcolumn:name="Reserving in",JSONPath=".status.admission.clusterQueue",type="string",description="Name of the ClusterQueue where the workload is reserving quota"
 // +kubebuilder:printcolumn:name="Admitted",JSONPath=".status.conditions[?(@.type=='Admitted')].status",type="string",description="Admission status"
-// +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",priority=0,description="Time this workload was created"
+// +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",description="Time this workload was created"
 // +kubebuilder:resource:shortName={wl}
 
 // Workload is the Schema for the workloads API

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -332,7 +332,7 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Queue",JSONPath=".spec.queueName",type="string",priority=0,description="Name of the queue this workload was submitted to"
 // +kubebuilder:printcolumn:name="Reserving in",JSONPath=".status.admission.clusterQueue",type="string",priority=0,description="Name of the ClusterQueue where the workload is reserving quota"
-// +kubebuilder:printcolumn:name="Admitted",JSONPath=".status.conditions[?(@.type=='Admitted')].status",type="string",priority=10,description="Admission status"
+// +kubebuilder:printcolumn:name="Admitted",JSONPath=".status.conditions[?(@.type=='Admitted')].status",type="string",description="Admission status"
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",priority=0,description="Time this workload was created"
 // +kubebuilder:resource:shortName={wl}
 

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -331,7 +331,7 @@ const (
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Queue",JSONPath=".spec.queueName",type="string",description="Name of the queue this workload was submitted to"
-// +kubebuilder:printcolumn:name="Reserving in",JSONPath=".status.admission.clusterQueue",type="string",description="Name of the ClusterQueue where the workload is reserving quota"
+// +kubebuilder:printcolumn:name="Reserved in",JSONPath=".status.admission.clusterQueue",type="string",description="Name of the ClusterQueue where the workload is reserving quota"
 // +kubebuilder:printcolumn:name="Admitted",JSONPath=".status.conditions[?(@.type=='Admitted')].status",type="string",description="Admission status"
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",description="Time this workload was created"
 // +kubebuilder:resource:shortName={wl}

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -38,7 +38,7 @@ spec:
       type: string
     - description: Name of the ClusterQueue where the workload is reserving quota
       jsonPath: .status.admission.clusterQueue
-      name: Reserving in
+      name: Reserved in
       type: string
     - description: Admission status
       jsonPath: .status.conditions[?(@.type=='Admitted')].status

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -43,7 +43,6 @@ spec:
     - description: Admission status
       jsonPath: .status.conditions[?(@.type=='Admitted')].status
       name: Admitted
-      priority: 10
       type: string
     - description: Time this workload was created
       jsonPath: .metadata.creationTimestamp

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -36,9 +36,14 @@ spec:
       jsonPath: .spec.queueName
       name: Queue
       type: string
-    - description: Name of the ClusterQueue that admitted this workload
+    - description: Name of the ClusterQueue where the workload is reserving quota
       jsonPath: .status.admission.clusterQueue
-      name: Admitted by
+      name: Reserving in
+      type: string
+    - description: Admission status
+      jsonPath: .status.conditions[?(@.type=='Admitted')].status
+      name: Admitted
+      priority: 10
       type: string
     - description: Time this workload was created
       jsonPath: .metadata.creationTimestamp

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -28,7 +28,6 @@ spec:
     - description: Admission status
       jsonPath: .status.conditions[?(@.type=='Admitted')].status
       name: Admitted
-      priority: 10
       type: string
     - description: Time this workload was created
       jsonPath: .metadata.creationTimestamp

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -21,9 +21,14 @@ spec:
       jsonPath: .spec.queueName
       name: Queue
       type: string
-    - description: Name of the ClusterQueue that admitted this workload
+    - description: Name of the ClusterQueue where the workload is reserving quota
       jsonPath: .status.admission.clusterQueue
-      name: Admitted by
+      name: Reserving in
+      type: string
+    - description: Admission status
+      jsonPath: .status.conditions[?(@.type=='Admitted')].status
+      name: Admitted
+      priority: 10
       type: string
     - description: Time this workload was created
       jsonPath: .metadata.creationTimestamp

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -23,7 +23,7 @@ spec:
       type: string
     - description: Name of the ClusterQueue where the workload is reserving quota
       jsonPath: .status.admission.clusterQueue
-      name: Reserving in
+      name: Reserved in
       type: string
     - description: Admission status
       jsonPath: .status.conditions[?(@.type=='Admitted')].status

--- a/site/content/en/docs/tasks/run/jobs.md
+++ b/site/content/en/docs/tasks/run/jobs.md
@@ -77,8 +77,8 @@ kubectl -n default get workloads
 The output will be similar to the following:
 
 ```shell
-NAME               QUEUE         ADMITTED BY     AGE
-sample-job-sl4bm   user-queue                    1s
+NAME               QUEUE         RESERVED IN   ADMITTED   AGE
+sample-job-sl4bm   user-queue                             1s
 ```
 
 ## 3. (Optional) Monitor the status of the workload
@@ -124,8 +124,8 @@ kubectl -n default get workloads
 The output is similar to the following:
 
 ```shell
-NAME               QUEUE         ADMITTED BY     AGE
-sample-job-sl4bm   user-queue    cluster-queue   45s
+NAME               QUEUE         RESERVED IN   ADMITTED   AGE
+sample-job-sl4bm   user-queue    cluster-queue True       1s
 ```
 
 To view the event for the Workload admission, run the following command:

--- a/site/content/en/docs/tasks/troubleshooting/troubleshooting_jobs.md
+++ b/site/content/en/docs/tasks/troubleshooting/troubleshooting_jobs.md
@@ -41,8 +41,8 @@ Job is called `my-job` in the `my-namespace` namespace.
    The output looks like the following:
 
    ```
-   NAME               QUEUE        ADMITTED BY     AGE
-   job-my-job-19797   user-queue   cluster-queue   9m45s
+   NAME               QUEUE         RESERVED IN   ADMITTED   AGE
+   job-my-job-19797   user-queue    cluster-queue True       9m45s
    ```
 
 3. You can list all of the workloads in the same namespace of your job and identify the one
@@ -56,8 +56,8 @@ Job is called `my-job` in the `my-namespace` namespace.
    The output looks like the following:
 
    ```
-   NAME               QUEUE        ADMITTED BY     AGE
-   job-my-job-19797   user-queue   cluster-queue   9m45s
+   NAME               QUEUE         RESERVED IN   ADMITTED   AGE
+   job-my-job-19797   user-queue    cluster-queue True       9m45s
    ```
 
 ## Is my Job running?


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
* Renames "Admitted by" to "Reserving in" printed column of `kubectl get workload`
* Adds "Admitted" printed column to `kubectl get workload`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1790

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Improve the kubectl output for workloads using admission checks.
```