### PR TITLE
Make ClusterQueue's AdmissionCheckStrategy a pointer, avoid type casting

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -106,7 +106,7 @@ type ClusterQueueSpec struct {
 	// admissionCheckStrategy defines a list of strategies to determine which ResourceFlavors require AdmissionChecks.
 	// This property cannot be used in conjunction with the 'admissionChecks' property.
 	// +optional
-	AdmissionChecksStrategy AdmissionChecksStrategy `json:"admissionChecksStrategy,omitempty"`
+	AdmissionChecksStrategy *AdmissionChecksStrategy `json:"admissionChecksStrategy,omitempty"`
 
 	// stopPolicy - if set to a value different from None, the ClusterQueue is considered Inactive, no new reservation being
 	// made.
@@ -137,7 +137,7 @@ type AdmissionCheckStrategyRule struct {
 	// onFlavors is a list of ResourceFlavors' names that this AdmissionCheck should run for.
 	// If empty, the AdmissionCheck will run for all workloads submitted to the ClusterQueue.
 	// +optional
-	OnFlavors []ResourceFlavorReference `json:"onFlavors"`
+	OnFlavors []ResourceFlavorReference `json:"onFlavors,omitempty"`
 }
 
 type QueueingStrategy string

--- a/apis/kueue/v1beta1/zz_generated.deepcopy.go
+++ b/apis/kueue/v1beta1/zz_generated.deepcopy.go
@@ -399,7 +399,11 @@ func (in *ClusterQueueSpec) DeepCopyInto(out *ClusterQueueSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	in.AdmissionChecksStrategy.DeepCopyInto(&out.AdmissionChecksStrategy)
+	if in.AdmissionChecksStrategy != nil {
+		in, out := &in.AdmissionChecksStrategy, &out.AdmissionChecksStrategy
+		*out = new(AdmissionChecksStrategy)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.StopPolicy != nil {
 		in, out := &in.StopPolicy, &out.StopPolicy
 		*out = new(StopPolicy)

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -964,9 +964,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					Preemption:                    defaultPreemption,
 					AllocatableResourceGeneration: 1,
 					FlavorFungibility:             defaultFlavorFungibility,
-					AdmissionChecks: map[string]sets.Set[string]{
-						"check1": sets.New[string](),
-						"check2": sets.New[string](),
+					AdmissionChecks: map[string]sets.Set[kueue.ResourceFlavorReference]{
+						"check1": sets.New[kueue.ResourceFlavorReference](),
+						"check2": sets.New[kueue.ResourceFlavorReference](),
 					},
 				},
 			},
@@ -995,9 +995,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					Preemption:                    defaultPreemption,
 					AllocatableResourceGeneration: 1,
 					FlavorFungibility:             defaultFlavorFungibility,
-					AdmissionChecks: map[string]sets.Set[string]{
-						"check1": sets.New[string](),
-						"check2": sets.New[string](),
+					AdmissionChecks: map[string]sets.Set[kueue.ResourceFlavorReference]{
+						"check1": sets.New[kueue.ResourceFlavorReference](),
+						"check2": sets.New[kueue.ResourceFlavorReference](),
 					}},
 			},
 			wantCohorts: map[string]sets.Set[string]{},
@@ -1026,9 +1026,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					Preemption:                    defaultPreemption,
 					AllocatableResourceGeneration: 1,
 					FlavorFungibility:             defaultFlavorFungibility,
-					AdmissionChecks: map[string]sets.Set[string]{
-						"check1": sets.New[string](),
-						"check2": sets.New[string](),
+					AdmissionChecks: map[string]sets.Set[kueue.ResourceFlavorReference]{
+						"check1": sets.New[kueue.ResourceFlavorReference](),
+						"check2": sets.New[kueue.ResourceFlavorReference](),
 					}},
 			},
 			wantCohorts: map[string]sets.Set[string]{},
@@ -1057,9 +1057,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					Preemption:                    defaultPreemption,
 					AllocatableResourceGeneration: 1,
 					FlavorFungibility:             defaultFlavorFungibility,
-					AdmissionChecks: map[string]sets.Set[string]{
-						"check1": sets.New[string](),
-						"check2": sets.New[string](),
+					AdmissionChecks: map[string]sets.Set[kueue.ResourceFlavorReference]{
+						"check1": sets.New[kueue.ResourceFlavorReference](),
+						"check2": sets.New[kueue.ResourceFlavorReference](),
 					}},
 			},
 			wantCohorts: map[string]sets.Set[string]{},

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -66,7 +66,7 @@ type ClusterQueue struct {
 	// Aggregates AdmissionChecks from both .spec.AdmissionChecks and .spec.AdmissionCheckStrategy
 	// Sets hold ResourceFlavors to which an AdmissionCheck should apply.
 	// In case its empty, it means an AdmissionCheck should apply to all ResourceFlavor
-	AdmissionChecks map[string]sets.Set[string]
+	AdmissionChecks map[string]sets.Set[kueue.ResourceFlavorReference]
 	Status          metrics.ClusterQueueStatus
 	// GuaranteedQuota records how much resource quota the ClusterQueue reserved
 	// when feature LendingLimit is enabled and flavor's lendingLimit is not nil.

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -143,7 +143,7 @@ func (c *ClusterQueue) snapshot() *ClusterQueue {
 		Preemption:                    c.Preemption,
 		NamespaceSelector:             c.NamespaceSelector,
 		Status:                        c.Status,
-		AdmissionChecks:               utilmaps.DeepCopySets[string](c.AdmissionChecks),
+		AdmissionChecks:               utilmaps.DeepCopySets[kueue.ResourceFlavorReference](c.AdmissionChecks),
 	}
 
 	for fName, rUsage := range c.Usage {

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -566,6 +566,9 @@ func (c *ClusterQueueWrapper) Cohort(cohort string) *ClusterQueueWrapper {
 }
 
 func (c *ClusterQueueWrapper) AdmissionCheckStrategy(acs ...kueue.AdmissionCheckStrategyRule) *ClusterQueueWrapper {
+	if c.Spec.AdmissionChecksStrategy == nil {
+		c.Spec.AdmissionChecksStrategy = &kueue.AdmissionChecksStrategy{}
+	}
 	c.Spec.AdmissionChecksStrategy.AdmissionChecks = acs
 	return c
 }

--- a/pkg/webhooks/clusterqueue_webhook.go
+++ b/pkg/webhooks/clusterqueue_webhook.go
@@ -127,7 +127,7 @@ func validatePreemption(preemption *kueue.ClusterQueuePreemption, path *field.Pa
 
 func validateCQAdmissionChecks(spec *kueue.ClusterQueueSpec, path *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
-	if len(spec.AdmissionChecksStrategy.AdmissionChecks) != 0 && len(spec.AdmissionChecks) != 0 {
+	if spec.AdmissionChecksStrategy != nil && len(spec.AdmissionChecks) != 0 {
 		allErrs = append(allErrs, field.Invalid(path, spec, "Either AdmissionChecks or AdmissionCheckStrategy can be set, but not both"))
 	}
 

--- a/pkg/webhooks/clusterqueue_webhook_test.go
+++ b/pkg/webhooks/clusterqueue_webhook_test.go
@@ -73,9 +73,7 @@ func TestValidateClusterQueue(t *testing.T) {
 			name: "both admissionChecks and admissionCheckStrategy is defined",
 			clusterQueue: testingutil.MakeClusterQueue("cluster-queue").
 				AdmissionChecks("ac1").
-				AdmissionCheckStrategy(
-					*testingutil.MakeAdmissionCheckStrategyRule("ac1", "flavor1").Obj(),
-				).Obj(),
+				AdmissionCheckStrategy().Obj(),
 			wantErr: field.ErrorList{
 				field.Invalid(specPath, "spec", "Either AdmissionChecks or AdmissionCheckStrategy can be set, but not both"),
 			},

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -550,7 +550,7 @@ func RemoveFinalizer(ctx context.Context, c client.Client, wl *kueue.Workload) e
 
 // AdmissionChecksForWorkload returns AdmissionChecks that should be assigned to a specific Workload based on
 // ClusterQueue configuration and ResourceFlavors
-func AdmissionChecksForWorkload(log logr.Logger, wl *kueue.Workload, admissionChecks map[string]sets.Set[string]) sets.Set[string] {
+func AdmissionChecksForWorkload(log logr.Logger, wl *kueue.Workload, admissionChecks map[string]sets.Set[kueue.ResourceFlavorReference]) sets.Set[string] {
 	// If all admissionChecks should be run for all flavors we don't need to wait for Workload's Admission to be set.
 	// This is also the case if admissionChecks are specified with ClusterQueue.Spec.AdmissionChecks instead of
 	// ClusterQueue.Spec.AdmissionCheckStrategy
@@ -586,7 +586,7 @@ func AdmissionChecksForWorkload(log logr.Logger, wl *kueue.Workload, admissionCh
 			continue
 		}
 		for _, fName := range assignedFlavors {
-			if flavors.Has(string(fName)) {
+			if flavors.Has(fName) {
 				acNames.Insert(acName)
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Addresses comments of an already merged PR #1960 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #1432 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE

```