### PR TITLE
Add AdmissionCheckStrategy documentation

### DIFF
--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -46,12 +46,12 @@ Similarly to `ResourceFlavors`, if an `AdmissionCheck` is not found or its contr
 There are two ways of referencing AdmissionChecks in the ClusterQueue's spec:
 
 - `.spec.admissionChecks` - is the list of AdmissionChecks that will be run for all Workloads submitted to the ClusterQueue
-- `.spec.admissionCheckStrategy` - wraps the list of `AdmissionCheckStrategyRules` that give you more flexibility. It allows you to both run an AdmissionCheck for all Workloads or to associate an AdmissionCheck
+- `.spec.admissionCheckStrategy` - wraps the list of `admissionCheckStrategyRules` that give you more flexibility. It allows you to both run an AdmissionCheck for all Workloads or to associate an AdmissionCheck
 with a specific ResourceFlavor. To specify ResourceFlavors that an AdmissionCheck should run for use the `admissionCheckStrategyRule.onFlavors` field, and if you want to run AdmissionCheck for all Workloads, simply leave the field empty.
 
 See examples below:
 
-Using `.spec.AdmissionChecks`
+Using `.spec.admissionChecks`
 
 ```yaml
 apiVersion: kueue.x-k8s.io/v1beta1
@@ -75,7 +75,8 @@ spec:
   - sample-prov
 ```
 
-Using `.spec.AdmissionCheckStrategy`
+Using `.spec.admissionCheckStrategy`
+
 ```yaml
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue

--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -40,7 +40,7 @@ spec:
 
 ### Usage
 
-Once defined, an AdmissionCheck can be referenced in the ClusterQueue's spec. All Workloads associated with the queue need to be evaluated by the AdmissionCheck's controller before being admitted.
+Once defined, an AdmissionCheck can be referenced in the [ClusterQueue's spec](/docs/concepts/cluster_queue). All Workloads associated with the queue need to be evaluated by the AdmissionCheck's controller before being admitted.
 Similarly to `ResourceFlavors`, if an `AdmissionCheck` is not found or its controller has not marked it as `Active`, the ClusterQueue will be marked as Inactive.
 
 There are two ways of referencing AdmissionChecks in the ClusterQueue's spec:
@@ -48,6 +48,8 @@ There are two ways of referencing AdmissionChecks in the ClusterQueue's spec:
 - `.spec.admissionChecks` - is the list of AdmissionChecks that will be run for all Workloads submitted to the ClusterQueue
 - `.spec.admissionCheckStrategy` - wraps the list of `admissionCheckStrategyRules` that give you more flexibility. It allows you to both run an AdmissionCheck for all Workloads or to associate an AdmissionCheck
 with a specific ResourceFlavor. To specify ResourceFlavors that an AdmissionCheck should run for use the `admissionCheckStrategyRule.onFlavors` field, and if you want to run AdmissionCheck for all Workloads, simply leave the field empty.
+
+Only one of the above-mentioned fields can be specified at the time.
 
 See examples below:
 
@@ -72,12 +74,12 @@ kind: ClusterQueue
 metadata:
   name: "cluster-queue"
 spec:
-  admissionCheckStrategy:
+<...>
+  admissionChecksStrategy:
     admissionChecks:
     - name: "sample-prov"           # Name of the AdmissionCheck to be run
       onFlavors: ["default-flavor"] # This AdmissionCheck will only run for Workloads that use default-flavor
-    - name: "sample-prov-2" # This AdmissionCheck will run for all Workloads regardless of a used ResourceFlavor
-<...>
+    - name: "sample-prov-2"         # This AdmissionCheck will run for all Workloads regardless of a used ResourceFlavor
 ```
 
 

--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -38,10 +38,70 @@ spec:
     name: prov-test-config
 ```
 
-### ClusterQueue admissionChecks
+### Usage
 
-Once defined, an AdmissionCheck can be referenced in the ClusterQueues' spec. All Workloads associated with the queue need to be evaluated by the AdmissionCheck's controller before being admitted.
+Once defined, an AdmissionCheck can be referenced in the ClusterQueue's spec. All Workloads associated with the queue need to be evaluated by the AdmissionCheck's controller before being admitted.
 Similarly to `ResourceFlavors`, if an `AdmissionCheck` is not found or its controller has not marked it as `Active`, the ClusterQueue will be marked as Inactive.
+
+There are two ways of referencing AdmissionChecks in the ClusterQueue's spec:
+
+- `.spec.admissionChecks` - is the list of AdmissionChecks that will be run for all Workloads submitted to the ClusterQueue
+- `.spec.admissionCheckStrategy` - wraps the list of `AdmissionCheckStrategyRules` that give you more flexibility. It allows you to both run an AdmissionCheck for all Workloads or to associate an AdmissionCheck
+with a specific ResourceFlavor. To specify ResourceFlavors that an AdmissionCheck should run for use the `admissionCheckStrategyRule.onFlavors` field, and if you want to run AdmissionCheck for all Workloads, simply leave the field empty.
+
+See examples below:
+
+Using `.spec.AdmissionChecks`
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: "cluster-queue"
+spec:
+  namespaceSelector: {} # match all.
+  resourceGroups:
+  - coveredResources: ["cpu", "memory", "nvidia.com/gpu"]
+    flavors:
+    - name: "default-flavor"
+      resources:
+      - name: "cpu"
+        nominalQuota: 9
+      - name: "memory"
+        nominalQuota: 36Gi
+      - name: "nvidia.com/gpu"
+        nominalQuota: 9
+  admissionChecks:
+  - sample-prov
+```
+
+Using `.spec.AdmissionCheckStrategy`
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: "cluster-queue"
+spec:
+  admissionCheckStrategy:
+    admissionChecks:
+    - name: "sample-prov"           # Name of the AdmissionCheck to be run
+      onFlavors: ["default-flavor"] # This AdmissionCheck will only run for Workloads that use default-flavor
+    - name: "sample-prov-2"
+      onFlavors: []                 # This AdmissionCheck will run for all Workloads regardless of a used ResourceFlavor
+  namespaceSelector: {} # match all.
+  resourceGroups:
+  - coveredResources: ["cpu", "memory", "nvidia.com/gpu"]
+    flavors:
+    - name: "default-flavor"
+      resources:
+      - name: "cpu"
+        nominalQuota: 9
+      - name: "memory"
+        nominalQuota: 36Gi
+      - name: "nvidia.com/gpu"
+        nominalQuota: 9
+```
+
 
 ### AdmissionCheckState
 

--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -59,18 +59,7 @@ kind: ClusterQueue
 metadata:
   name: "cluster-queue"
 spec:
-  namespaceSelector: {} # match all.
-  resourceGroups:
-  - coveredResources: ["cpu", "memory", "nvidia.com/gpu"]
-    flavors:
-    - name: "default-flavor"
-      resources:
-      - name: "cpu"
-        nominalQuota: 9
-      - name: "memory"
-        nominalQuota: 36Gi
-      - name: "nvidia.com/gpu"
-        nominalQuota: 9
+<...>
   admissionChecks:
   - sample-prov
 ```
@@ -88,18 +77,7 @@ spec:
     - name: "sample-prov"           # Name of the AdmissionCheck to be run
       onFlavors: ["default-flavor"] # This AdmissionCheck will only run for Workloads that use default-flavor
     - name: "sample-prov-2" # This AdmissionCheck will run for all Workloads regardless of a used ResourceFlavor
-  namespaceSelector: {} # match all.
-  resourceGroups:
-  - coveredResources: ["cpu", "memory", "nvidia.com/gpu"]
-    flavors:
-    - name: "default-flavor"
-      resources:
-      - name: "cpu"
-        nominalQuota: 9
-      - name: "memory"
-        nominalQuota: 36Gi
-      - name: "nvidia.com/gpu"
-        nominalQuota: 9
+<...>
 ```
 
 

--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -86,8 +86,7 @@ spec:
     admissionChecks:
     - name: "sample-prov"           # Name of the AdmissionCheck to be run
       onFlavors: ["default-flavor"] # This AdmissionCheck will only run for Workloads that use default-flavor
-    - name: "sample-prov-2"
-      onFlavors: []                 # This AdmissionCheck will run for all Workloads regardless of a used ResourceFlavor
+    - name: "sample-prov-2" # This AdmissionCheck will run for all Workloads regardless of a used ResourceFlavor
   namespaceSelector: {} # match all.
   resourceGroups:
   - coveredResources: ["cpu", "memory", "nvidia.com/gpu"]

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -527,6 +527,10 @@ The `HoldAndDrain` will have a similar effect but, in addition, it will trigger 
 
 If set to `None` or `spec.stopPolicy` is removed the ClusterQueue will to normal admission behavior.
 
+## AdmissionChecks
+
+AdmissionChecks are a mechanism that allows Kueue to consider additional criteria before admitting a Workload. See [Admission Checks](/docs/concepts/admission_check#usage) for ClusterQueue's example configuration.
+
 ## What's next?
 
 - Create [local queues](/docs/concepts/local_queue)

--- a/site/static/examples/admin/minimal-cq.yaml
+++ b/site/static/examples/admin/minimal-cq.yaml
@@ -1,0 +1,11 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: "cluster-queue-2"
+spec:
+  namespaceSelector: {} # match all.
+  admissionChecksStrategy:
+    admissionChecks:
+    - name: "sample-prov"           # Name of the AdmissionCheck to be run
+      onFlavors: ["default-flavor"] # This AdmissionCheck will only run for Workloads that use default-flavor
+    - name: "sample-prov-2" # This AdmissionCheck will run for all Workloads regardless of a used ResourceFlavor


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #1432 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE

```