### PR TITLE
Rule s2-b for flat fair preemption

### DIFF
--- a/pkg/queue/cluster_queue.go
+++ b/pkg/queue/cluster_queue.go
@@ -95,7 +95,7 @@ func newClusterQueue(cq *kueue.ClusterQueue, wo workload.Ordering) (*ClusterQueu
 func newClusterQueueImpl(wo workload.Ordering, clock clock.Clock) *ClusterQueue {
 	lessFunc := queueOrderingFunc(wo)
 	return &ClusterQueue{
-		heap:                   heap.New(workloadKey, lessFunc),
+		heap:                   *heap.New(workloadKey, lessFunc),
 		inadmissibleWorkloads:  make(map[string]*workload.Info),
 		queueInadmissibleCycle: -1,
 		lessFunc:               lessFunc,

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -361,7 +361,7 @@ func cqHeapFromCandidates(candidates []*workload.Info, firstOnly bool, snapshot 
 				share:     share,
 				workloads: []*workload.Info{cand},
 			}
-			_ = cqHeap.PushIfNotPresent(candCQ)
+			cqHeap.PushOrUpdate(candCQ)
 		} else if !firstOnly {
 			candCQ.workloads = append(candCQ.workloads, cand)
 		}

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -1533,9 +1533,9 @@ func TestFairPreemptions(t *testing.T) {
 		"can't preempt huge workload if the incoming is also huge": {
 			admitted: []kueue.Workload{
 				*utiltesting.MakeWorkload("a1", "").Request(corev1.ResourceCPU, "2").SimpleReserveQuota("a", "default", now).Obj(),
-				*utiltesting.MakeWorkload("b1", "").Request(corev1.ResourceCPU, "9").SimpleReserveQuota("b", "default", now).Obj(),
+				*utiltesting.MakeWorkload("b1", "").Request(corev1.ResourceCPU, "7").SimpleReserveQuota("b", "default", now).Obj(),
 			},
-			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "7").Obj(),
+			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "5").Obj(),
 			targetCQ: "a",
 		},
 		"can't preempt 2 smaller workloads if the incoming is huge": {
@@ -1567,7 +1567,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "3.5").Obj(),
 			targetCQ: "a",
-			// It would have been possible to preempt "/b1" under rule S2-b, but S2-1 was possible first.
+			// It would have been possible to preempt "/b1" under rule S2-b, but S2-a was possible first.
 			wantPreempted: sets.New("/b2"),
 		},
 		"preempt from different cluster queues if the end result has a smaller max share": {

--- a/pkg/util/heap/heap.go
+++ b/pkg/util/heap/heap.go
@@ -171,8 +171,8 @@ func (h *Heap[T]) List() []*T {
 }
 
 // New returns a Heap which can be used to queue up items to process.
-func New[T any](keyFn keyFunc[T], lessFn lessFunc[T]) Heap[T] {
-	return Heap[T]{
+func New[T any](keyFn keyFunc[T], lessFn lessFunc[T]) *Heap[T] {
+	return &Heap[T]{
 		data: data[T]{
 			items:    make(map[string]*heapItem[T]),
 			keyFunc:  keyFn,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Continues #1948, adding rule S2-b from https://github.com/kubernetes-sigs/kueue/tree/main/keps/1714-fair-sharing#choosing-workloads-from-clusterqueues-for-preemption

```
value of AlmostLCA(y,x) (with z) is strictly higher than AlmostLCA(x,y) with admitted workload w. Here the case is that Y’s sub-org is greedy, and doesn’t allow smaller requests on the x’s size. If no other preemption option is possible inside any other CQ, z should be considered for preemption. Maybe y has a smaller workload that could be admitted, and then both x and y will be ”happy”. In practice this rule prevents huge workloads from taking the whole unused capacity, blocking everyone else and claiming that this is fair-sharing.
```

In other words, allow preemption if the highest share value among the CQs will monotonically decrease.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #1714

#### Special notes for your reviewer:

WIP because I want to play a little more with the algorithm and more test cases.

#### Does this PR introduce a user-facing change?

Not yet. The boolean that determines the use of fair sharing is not accessible through any API.

```release-note
NONE
```