### PR TITLE
Propagate provisioning status of a ProvReq into the Workload status

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -536,6 +536,9 @@ func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, ch
 				updated = updateCheckState(&checkState, kueue.CheckStatePending) || updated
 			}
 			if prAccepted && !prFailed {
+				// we propagate the message from the provisioning request status into the workload
+				// this happens for provisioned = false (ETA updates) and also for provisioned = true
+				// to change to the "successfully provisioned" message after provisioning
 				updated = updateCheckMessage(&checkState, apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Provisioned).Message) || updated
 			}
 		}

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -462,6 +462,22 @@ func passProvReqParams(wl *kueue.Workload, req *autoscaling.ProvisioningRequest)
 	}
 }
 
+func updateCheckMessage(checkState *kueue.AdmissionCheckState, message string) bool {
+	if message == "" || checkState.Message == message {
+		return false
+	}
+	checkState.Message = message
+	return true
+}
+
+func updateCheckState(checkState *kueue.AdmissionCheckState, state kueue.CheckState) bool {
+	if checkState.State == state {
+		return false
+	}
+	checkState.State = state
+	return true
+}
+
 func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, checks []string, activeOrLastPRForChecks map[string]*autoscaling.ProvisioningRequest) error {
 	log := ctrl.LoggerFrom(ctx)
 	checksMap := slices.ToRefMap(wl.Status.AdmissionChecks, func(c *kueue.AdmissionCheckState) string { return c.Name })
@@ -472,15 +488,10 @@ func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, ch
 		checkState := *checksMap[check]
 		if prc, err := c.helper.ConfigForAdmissionCheck(ctx, check); err != nil {
 			// the check is not active
-			if checkState.State != kueue.CheckStatePending || checkState.Message != CheckInactiveMessage {
-				updated = true
-				checkState.State = kueue.CheckStatePending
-				checkState.Message = CheckInactiveMessage
-			}
+			updated = updated || updateCheckState(&checkState, kueue.CheckStatePending) || updateCheckMessage(&checkState, CheckInactiveMessage)
 		} else if !c.reqIsNeeded(ctx, wl, prc) {
-			if checkState.State != kueue.CheckStateReady {
+			if updateCheckState(&checkState, kueue.CheckStateReady) {
 				updated = true
-				checkState.State = kueue.CheckStateReady
 				checkState.Message = NoRequestNeeded
 				checkState.PodSetUpdates = nil
 			}
@@ -493,7 +504,12 @@ func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, ch
 			prFailed := apimeta.IsStatusConditionTrue(pr.Status.Conditions, autoscaling.Failed)
 			prProvisioned := apimeta.IsStatusConditionTrue(pr.Status.Conditions, autoscaling.Provisioned)
 			prAccepted := apimeta.IsStatusConditionTrue(pr.Status.Conditions, autoscaling.Accepted)
-			log.V(3).Info("Synchronizing admission check state based on provisioning request", "wl", klog.KObj(wl), "check", check, "prName", pr.Name, "failed", prFailed, "accepted", prProvisioned)
+			log.V(3).Info("Synchronizing admission check state based on provisioning request", "wl", klog.KObj(wl),
+				"check", check,
+				"prName", pr.Name,
+				"failed", prFailed,
+				"provisioned", prProvisioned,
+				"accepted", prAccepted)
 
 			switch {
 			case prFailed:
@@ -501,9 +517,7 @@ func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, ch
 					if attempt := getAttempt(ctx, pr, wl.Name, check); attempt <= MaxRetries {
 						// it is going to be retried
 						message := fmt.Sprintf("Retrying after failure: %s", apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Failed).Message)
-						updated = updated || checkState.State != kueue.CheckStatePending || checkState.Message != message
-						checkState.State = kueue.CheckStatePending
-						checkState.Message = message
+						updated = updated || updateCheckState(&checkState, kueue.CheckStatePending) || updateCheckMessage(&checkState, message)
 					} else {
 						updated = true
 						checkState.State = kueue.CheckStateRejected
@@ -511,23 +525,16 @@ func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, ch
 					}
 				}
 			case prProvisioned:
-				if checkState.State != kueue.CheckStateReady {
+				if updateCheckState(&checkState, kueue.CheckStateReady) {
 					updated = true
-					checkState.State = kueue.CheckStateReady
 					// add the pod podSetUpdates
 					checkState.PodSetUpdates = podSetUpdates(wl, pr)
 				}
-			case prAccepted:
-				provisionedStatus := apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Provisioned)
-				updated = true
-				checkState.State = kueue.CheckStatePending
-				checkState.Message = provisionedStatus.Message
-				
 			default:
-				if checkState.State != kueue.CheckStatePending {
-					updated = true
-					checkState.State = kueue.CheckStatePending
-				}
+				updated = updated || updateCheckState(&checkState, kueue.CheckStatePending)
+			}
+			if prAccepted && !prFailed && !prProvisioned {
+				updated = updated || updateCheckMessage(&checkState, apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Provisioned).Message)
 			}
 		}
 

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -488,7 +488,8 @@ func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, ch
 		checkState := *checksMap[check]
 		if prc, err := c.helper.ConfigForAdmissionCheck(ctx, check); err != nil {
 			// the check is not active
-			updated = updated || updateCheckState(&checkState, kueue.CheckStatePending) || updateCheckMessage(&checkState, CheckInactiveMessage)
+			updated = updateCheckState(&checkState, kueue.CheckStatePending) || updated
+			updated = updateCheckMessage(&checkState, CheckInactiveMessage) || updated
 		} else if !c.reqIsNeeded(ctx, wl, prc) {
 			if updateCheckState(&checkState, kueue.CheckStateReady) {
 				updated = true
@@ -517,7 +518,8 @@ func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, ch
 					if attempt := getAttempt(ctx, pr, wl.Name, check); attempt <= MaxRetries {
 						// it is going to be retried
 						message := fmt.Sprintf("Retrying after failure: %s", apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Failed).Message)
-						updated = updated || updateCheckState(&checkState, kueue.CheckStatePending) || updateCheckMessage(&checkState, message)
+						updated = updateCheckState(&checkState, kueue.CheckStatePending) || updated
+						updated = updateCheckMessage(&checkState, message) || updated
 					} else {
 						updated = true
 						checkState.State = kueue.CheckStateRejected
@@ -531,10 +533,10 @@ func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, ch
 					checkState.PodSetUpdates = podSetUpdates(wl, pr)
 				}
 			default:
-				updated = updated || updateCheckState(&checkState, kueue.CheckStatePending)
+				updated = updateCheckState(&checkState, kueue.CheckStatePending) || updated
 			}
 			if prAccepted && !prFailed {
-				updated = updated || updateCheckMessage(&checkState, apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Provisioned).Message)
+				updated = updateCheckMessage(&checkState, apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Provisioned).Message) || updated
 			}
 		}
 

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -531,15 +531,16 @@ func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, ch
 					updated = true
 					// add the pod podSetUpdates
 					checkState.PodSetUpdates = podSetUpdates(wl, pr)
+					updateCheckMessage(&checkState, apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Provisioned).Message)
 				}
-			default:
-				updated = updateCheckState(&checkState, kueue.CheckStatePending) || updated
-			}
-			if prAccepted && !prFailed {
+			case prAccepted:
 				// we propagate the message from the provisioning request status into the workload
 				// this happens for provisioned = false (ETA updates) and also for provisioned = true
 				// to change to the "successfully provisioned" message after provisioning
 				updated = updateCheckMessage(&checkState, apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Provisioned).Message) || updated
+				updated = updateCheckState(&checkState, kueue.CheckStatePending) || updated
+			default:
+				updated = updateCheckState(&checkState, kueue.CheckStatePending) || updated
 			}
 		}
 

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -533,7 +533,7 @@ func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, ch
 			default:
 				updated = updated || updateCheckState(&checkState, kueue.CheckStatePending)
 			}
-			if prAccepted && !prFailed && !prProvisioned {
+			if prAccepted && !prFailed {
 				updated = updated || updateCheckMessage(&checkState, apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Provisioned).Message)
 			}
 		}

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -64,6 +64,14 @@ var (
 	}
 )
 
+func requestWithConditions(r *autoscaling.ProvisioningRequest, conditions []metav1.Condition) *autoscaling.ProvisioningRequest {
+	r = r.DeepCopy()
+	for _, condition := range conditions {
+		apimeta.SetStatusCondition(&r.Status.Conditions, condition)
+	}
+	return r
+}
+
 func requestWithCondition(r *autoscaling.ProvisioningRequest, conditionType string, status metav1.ConditionStatus) *autoscaling.ProvisioningRequest {
 	r = r.DeepCopy()
 	apimeta.SetStatusCondition(&r.Status.Conditions, metav1.Condition{
@@ -645,6 +653,55 @@ func TestReconcile(t *testing.T) {
 			wantRequestsNotFound: []string{
 				GetProvisioningRequestName("wl", "check1", 1),
 				GetProvisioningRequestName("wl", "check2", 1),
+			},
+		},
+		"workloads status gets updated based on the provisioning request": {
+			workload: baseWorkload.DeepCopy(),
+			checks:   []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
+			flavors:  []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
+			configs: []kueue.ProvisioningRequestConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "config1",
+					},
+					Spec: kueue.ProvisioningRequestConfigSpec{
+						ProvisioningClassName: "class1",
+						Parameters: map[string]kueue.Parameter{
+							"p1": "v1",
+						},
+					},
+				},
+			},
+			templates: []corev1.PodTemplate{*baseTemplate1.DeepCopy(), *baseTemplate2.DeepCopy()},
+			requests: []autoscaling.ProvisioningRequest{
+				*requestWithConditions(baseRequest,
+					[]metav1.Condition{
+						{
+							Type:   autoscaling.Failed,
+							Status: metav1.ConditionFalse,
+						},
+						{
+							Type:    autoscaling.Provisioned,
+							Status:  metav1.ConditionFalse,
+							Message: "Provisioning Request wasn't provisioned. ETA: 2024-02-22T10:36:40Z",
+						},
+						{
+							Type:   autoscaling.Accepted,
+							Status: metav1.ConditionTrue,
+						},
+					}),
+			},
+			wantWorkloads: map[string]*kueue.Workload{
+				baseWorkload.Name: (&utiltesting.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).
+					AdmissionChecks(kueue.AdmissionCheckState{
+						Name:    "check1",
+						State:   kueue.CheckStatePending,
+						Message: "Provisioning Request wasn't provisioned. ETA: 2024-02-22T10:36:40Z",
+					}, kueue.AdmissionCheckState{
+						Name:  "not-provisioning",
+						State: kueue.CheckStatePending,
+					}).
+					Obj(),
 			},
 		},
 	}

--- a/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
@@ -317,6 +317,38 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 				Namespace: wlKey.Namespace,
 				Name:      provisioning.GetProvisioningRequestName(wlKey.Name, ac.Name, 1),
 			}
+			ginkgo.By("Setting the provision request as Not Provisioned and providing ETA", func() {
+				createdRequest := &autoscaling.ProvisioningRequest{}
+				gomega.Eventually(func() error {
+					err := k8sClient.Get(ctx, provReqKey, createdRequest)
+					if err != nil {
+						return err
+					}
+					apimeta.SetStatusCondition(&createdRequest.Status.Conditions, metav1.Condition{
+						Type:   autoscaling.Accepted,
+						Status: metav1.ConditionTrue,
+						Reason: "Reason",
+					})
+					apimeta.SetStatusCondition(&createdRequest.Status.Conditions, metav1.Condition{
+						Type:    autoscaling.Provisioned,
+						Status:  metav1.ConditionFalse,
+						Reason:  "Reason",
+						Message: "Not provisioned, ETA: 2024-02-22T10:36:40Z.",
+					})
+					return k8sClient.Status().Update(ctx, createdRequest)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+			ginkgo.By("Checking that the ETA is propagated to workload", func() {
+				updatedWl := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, updatedWl)).To(gomega.Succeed())
+					state := workload.FindAdmissionCheck(updatedWl.Status.AdmissionChecks, ac.Name)
+					g.Expect(state).NotTo(gomega.BeNil())
+					g.Expect(state.State).To(gomega.Equal(kueue.CheckStatePending))
+					g.Expect(state.Message).To(gomega.Equal("Not provisioned, ETA: 2024-02-22T10:36:40Z."))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
 			ginkgo.By("Setting the provision request as Provisioned", func() {
 				createdRequest := &autoscaling.ProvisioningRequest{}
 				gomega.Eventually(func() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
It propagates the message from the Provisioning Request (condition Provisioned = false) into the Workload. The message will contain the expected time for the resources to be provisioned. Exposing this information to the users will allow them to understand why the job is still pending and how long until the resources will be available.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1749

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The message for a ProvisioningRequest being provisioned (which might include an ETA, depending on the implementation) is now propagated to workloads.
```