### PR TITLE
Automated cherry pick of #1991: * Rename "Admitted by" to "Reserving in" printed column *

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -316,7 +316,7 @@ const (
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Queue",JSONPath=".spec.queueName",type="string",description="Name of the queue this workload was submitted to"
-// +kubebuilder:printcolumn:name="Reserving in",JSONPath=".status.admission.clusterQueue",type="string",description="Name of the ClusterQueue where the workload is reserving quota"
+// +kubebuilder:printcolumn:name="Reserved in",JSONPath=".status.admission.clusterQueue",type="string",description="Name of the ClusterQueue where the workload is reserving quota"
 // +kubebuilder:printcolumn:name="Admitted",JSONPath=".status.conditions[?(@.type=='Admitted')].status",type="string",description="Admission status"
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",description="Time this workload was created"
 // +kubebuilder:resource:shortName={wl}

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -315,9 +315,10 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Queue",JSONPath=".spec.queueName",type=string,description="Name of the queue this workload was submitted to"
-// +kubebuilder:printcolumn:name="Admitted by",JSONPath=".status.admission.clusterQueue",type=string,description="Name of the ClusterQueue that admitted this workload"
-// +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type=date,description="Time this workload was created"
+// +kubebuilder:printcolumn:name="Queue",JSONPath=".spec.queueName",type="string",priority=0,description="Name of the queue this workload was submitted to"
+// +kubebuilder:printcolumn:name="Reserving in",JSONPath=".status.admission.clusterQueue",type="string",priority=0,description="Name of the ClusterQueue where the workload is reserving quota"
+// +kubebuilder:printcolumn:name="Admitted",JSONPath=".status.conditions[?(@.type=='Admitted')].status",type="string",priority=10,description="Admission status"
+// +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",priority=0,description="Time this workload was created"
 // +kubebuilder:resource:shortName={wl}
 
 // Workload is the Schema for the workloads API

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -315,10 +315,10 @@ const (
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Queue",JSONPath=".spec.queueName",type="string",priority=0,description="Name of the queue this workload was submitted to"
-// +kubebuilder:printcolumn:name="Reserving in",JSONPath=".status.admission.clusterQueue",type="string",priority=0,description="Name of the ClusterQueue where the workload is reserving quota"
+// +kubebuilder:printcolumn:name="Queue",JSONPath=".spec.queueName",type="string",description="Name of the queue this workload was submitted to"
+// +kubebuilder:printcolumn:name="Reserving in",JSONPath=".status.admission.clusterQueue",type="string",description="Name of the ClusterQueue where the workload is reserving quota"
 // +kubebuilder:printcolumn:name="Admitted",JSONPath=".status.conditions[?(@.type=='Admitted')].status",type="string",description="Admission status"
-// +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",priority=0,description="Time this workload was created"
+// +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",description="Time this workload was created"
 // +kubebuilder:resource:shortName={wl}
 
 // Workload is the Schema for the workloads API

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -317,7 +317,7 @@ const (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Queue",JSONPath=".spec.queueName",type="string",priority=0,description="Name of the queue this workload was submitted to"
 // +kubebuilder:printcolumn:name="Reserving in",JSONPath=".status.admission.clusterQueue",type="string",priority=0,description="Name of the ClusterQueue where the workload is reserving quota"
-// +kubebuilder:printcolumn:name="Admitted",JSONPath=".status.conditions[?(@.type=='Admitted')].status",type="string",priority=10,description="Admission status"
+// +kubebuilder:printcolumn:name="Admitted",JSONPath=".status.conditions[?(@.type=='Admitted')].status",type="string",description="Admission status"
 // +kubebuilder:printcolumn:name="Age",JSONPath=".metadata.creationTimestamp",type="date",priority=0,description="Time this workload was created"
 // +kubebuilder:resource:shortName={wl}
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -34,9 +34,14 @@ spec:
       jsonPath: .spec.queueName
       name: Queue
       type: string
-    - description: Name of the ClusterQueue that admitted this workload
+    - description: Name of the ClusterQueue where the workload is reserving quota
       jsonPath: .status.admission.clusterQueue
-      name: Admitted by
+      name: Reserving in
+      type: string
+    - description: Admission status
+      jsonPath: .status.conditions[?(@.type=='Admitted')].status
+      name: Admitted
+      priority: 10
       type: string
     - description: Time this workload was created
       jsonPath: .metadata.creationTimestamp

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -36,7 +36,7 @@ spec:
       type: string
     - description: Name of the ClusterQueue where the workload is reserving quota
       jsonPath: .status.admission.clusterQueue
-      name: Reserving in
+      name: Reserved in
       type: string
     - description: Admission status
       jsonPath: .status.conditions[?(@.type=='Admitted')].status

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -41,7 +41,6 @@ spec:
     - description: Admission status
       jsonPath: .status.conditions[?(@.type=='Admitted')].status
       name: Admitted
-      priority: 10
       type: string
     - description: Time this workload was created
       jsonPath: .metadata.creationTimestamp

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -28,7 +28,6 @@ spec:
     - description: Admission status
       jsonPath: .status.conditions[?(@.type=='Admitted')].status
       name: Admitted
-      priority: 10
       type: string
     - description: Time this workload was created
       jsonPath: .metadata.creationTimestamp

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -21,9 +21,14 @@ spec:
       jsonPath: .spec.queueName
       name: Queue
       type: string
-    - description: Name of the ClusterQueue that admitted this workload
+    - description: Name of the ClusterQueue where the workload is reserving quota
       jsonPath: .status.admission.clusterQueue
-      name: Admitted by
+      name: Reserving in
+      type: string
+    - description: Admission status
+      jsonPath: .status.conditions[?(@.type=='Admitted')].status
+      name: Admitted
+      priority: 10
       type: string
     - description: Time this workload was created
       jsonPath: .metadata.creationTimestamp

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -23,7 +23,7 @@ spec:
       type: string
     - description: Name of the ClusterQueue where the workload is reserving quota
       jsonPath: .status.admission.clusterQueue
-      name: Reserving in
+      name: Reserved in
       type: string
     - description: Admission status
       jsonPath: .status.conditions[?(@.type=='Admitted')].status

--- a/site/content/en/docs/tasks/run_jobs.md
+++ b/site/content/en/docs/tasks/run_jobs.md
@@ -76,8 +76,8 @@ kubectl -n default get workloads
 The output will be similar to the following:
 
 ```shell
-NAME               QUEUE         ADMITTED BY     AGE
-sample-job-sl4bm   user-queue                    1s
+NAME               QUEUE         RESERVED IN   ADMITTED   AGE
+sample-job-sl4bm   user-queue                             1s
 ```
 
 ## 3. (Optional) Monitor the status of the workload
@@ -123,8 +123,8 @@ kubectl -n default get workloads
 The output is similar to the following:
 
 ```shell
-NAME               QUEUE         ADMITTED BY     AGE
-sample-job-sl4bm   user-queue    cluster-queue   45s
+NAME               QUEUE         RESERVED IN   ADMITTED   AGE
+sample-job-sl4bm   user-queue    cluster-queue True       1s
 ```
 
 To view the event for the Workload admission, run the following command:


### PR DESCRIPTION
Cherry pick of #1991 on release-0.6.
#1991: * Rename "Admitted by" to "Reserving in" printed column *
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
Improve the kubectl output for workloads using admission checks.
```