### PR TITLE
Make the defaults for PodsReadyTimeout backoff more practical

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -238,12 +238,12 @@ type RequeuingStrategy struct {
 	// Once the number is reached, the workload is deactivated (`.spec.activate`=`false`).
 	// When it is null, the workloads will repeatedly and endless re-queueing.
 	//
-	// Every backoff duration is about "1.41284738^(n-1)+Rand" where the "n" represents the "workloadStatus.requeueState.count",
-	// and the "Rand" represents the random jitter. During this time, the workload is taken as an inadmissible and
+	// Every backoff duration is about "10s*2^(n-1)+Rand" where:
+	// - "n" represents the "workloadStatus.requeueState.count",
+	// - "Rand" represents the random jitter.
+	// During this time, the workload is taken as an inadmissible and
 	// other workloads will have a chance to be admitted.
-	// For example, when the "waitForPodsReady.timeout" is the default, the workload deactivation time is as follows:
-	//   {backoffLimitCount, workloadDeactivationSeconds}
-	//     ~= {1, 601}, {2, 902}, ...,{5, 1811}, ...,{10, 3374}, ...,{20, 8730}, ...,{30, 86400(=24 hours)}, ...
+	// By default, the consecutive requeue delays are around: (10s, 20s, 40s, ...).
 	//
 	// Defaults to null.
 	// +optional

--- a/keps/1282-pods-ready-requeue-strategy/README.md
+++ b/keps/1282-pods-ready-requeue-strategy/README.md
@@ -143,12 +143,12 @@ type RequeuingStrategy struct {
 	// Once the number is reached, the workload is deactivated (`.spec.activate`=`false`).
 	// When it is null, the workloads will repeatedly and endless re-queueing.
 	//
-	// Every backoff duration is about "1.41284738^(n-1)+Rand" where the "n" represents the "workloadStatus.requeueState.count",
-	// and the "Rand" represents the random jitter. During this time, the workload is taken as an inadmissible and
+	// Every backoff duration is about "10s*2^(n-1)+Rand" where:
+	// - "n" represents the "workloadStatus.requeueState.count",
+	// - "Rand" represents the random jitter.
+	// During this time, the workload is taken as an inadmissible and
 	// other workloads will have a chance to be admitted.
-	// For example, when the "waitForPodsReady.timeout" is the default, the workload deactivation time is as follows:
-	//   {backoffLimitCount, workloadDeactivationSeconds}
-	//     ~= {1, 601}, {2, 902}, ...,{5, 1811}, ...,{10, 3374}, ...,{20, 8730}, ...,{30, 86400(=24 hours)}, ...
+	// By default, the consecutive requeue delays are around: (10s, 20s, 40s, ...).
 	//
 	// Defaults to null.
 	// +optional
@@ -222,16 +222,16 @@ the queueManager holds the evicted workloads as inadmissible workloads while exp
 Duration this time, other workloads will have a chance to be admitted.
 
 The queueManager calculates an exponential backoff duration by [the Step function](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait@v0.29.1#Backoff.Step)
-according to the $1.41284738^{(n-1)}+Rand$ where the $n$ represents the `workloadStatus.requeueState.count`, and the $Rand$ represents the random jitter.
+according to the $10s*2^{(n-1)}+Rand$ where the $n$ represents the `workloadStatus.requeueState.count`, and the $Rand$ represents the random jitter.
 
-Considering the `.waitForPodsReady.timeout` (default: 300 seconds),
-this duration indicates that an evicted workload with `PodsReadyTimeout` reason is continued re-queuing 
-for the following period where the $t$ represents `.waitForPodsReady.timeout`:
+It will spend awaiting to be requeued after eviction:
+$$\sum_{k=1}^{n}(10s*2^{(k-1)} + Rand)$$
 
-$$t(n+1) + \sum_{k=1}^{n}(1.41284738^{(k-1)} + Rand)$$
-
-Given that the `backoffLimitCount` equals `30` and the `waitForPodsReady.timeout` equals `300` (default),
-the result equals 24 hours (+ $Rand$ seconds).
+Assuming `backoffLimitCount` equals 10, and the workload is requeued 10 times
+after failing to have all pods ready, then the total time awaiting for requeue
+will take (neglecting the jitter): `10s+20s+40s +...+7680s=2h 8min`.
+Also, considering `.waitForPodsReady.timeout=300s` (default),
+the workload will spend `50min` total waiting for pods ready.
 
 #### Evaluation
 

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -72,6 +72,7 @@ type options struct {
 	watchers                   []WorkloadUpdateWatcher
 	podsReadyTimeout           *time.Duration
 	requeuingBackoffLimitCount *int32
+	requeuingBaseDelaySeconds  int32
 }
 
 // Option configures the reconciler.
@@ -90,6 +91,14 @@ func WithPodsReadyTimeout(value *time.Duration) Option {
 func WithRequeuingBackoffLimitCount(value *int32) Option {
 	return func(o *options) {
 		o.requeuingBackoffLimitCount = value
+	}
+}
+
+// WithRequeuingBaseDelaySeconds indicates the base delay for the computation
+// of the requeue delay.
+func WithRequeuingBaseDelaySeconds(value int32) Option {
+	return func(o *options) {
+		o.requeuingBaseDelaySeconds = value
 	}
 }
 
@@ -115,6 +124,7 @@ type WorkloadReconciler struct {
 	watchers                   []WorkloadUpdateWatcher
 	podsReadyTimeout           *time.Duration
 	requeuingBackoffLimitCount *int32
+	requeuingBaseDelaySeconds  int32
 	recorder                   record.EventRecorder
 }
 
@@ -132,6 +142,7 @@ func NewWorkloadReconciler(client client.Client, queues *queue.Manager, cache *c
 		watchers:                   options.watchers,
 		podsReadyTimeout:           options.podsReadyTimeout,
 		requeuingBackoffLimitCount: options.requeuingBackoffLimitCount,
+		requeuingBaseDelaySeconds:  options.requeuingBaseDelaySeconds,
 		recorder:                   recorder,
 	}
 }
@@ -389,17 +400,14 @@ func (r *WorkloadReconciler) triggerDeactivationOrBackoffRequeue(ctx context.Con
 			"Deactivated Workload %q by reached re-queue backoffLimitCount", klog.KObj(wl))
 		return true, nil
 	}
-	// Every backoff duration is about "1.41284738^(n-1)+Rand" where the "n" represents the "requeuingCount",
-	// and the "Rand" represents the random jitter. During this time, the workload is taken as an inadmissible and
-	// other workloads will have a chance to be admitted.
-	// Considering the ".waitForPodsReady.timeout",
-	// this indicates that an evicted workload with PodsReadyTimeout reason is continued re-queuing for
-	// the "t(n+1) + SUM[k=1,n](1.41284738^(k-1) + Rand)" seconds where the "t" represents "waitForPodsReady.timeout".
-	// Given that the "backoffLimitCount" equals "30" and the "waitForPodsReady.timeout" equals "300" (default),
-	// the result equals 24 hours (+Rand seconds).
+	// Every backoff duration is about "10s*2^(n-1)+Rand" where:
+	// - "n" represents the "requeuingCount",
+	// - "Rand" represents the random jitter.
+	// During this time, the workload is taken as an inadmissible and other
+	// workloads will have a chance to be admitted.
 	backoff := &wait.Backoff{
-		Duration: 1 * time.Second,
-		Factor:   1.41284738,
+		Duration: time.Duration(r.requeuingBaseDelaySeconds) * time.Second,
+		Factor:   2,
 		Jitter:   0.0001,
 		Steps:    int(requeuingCount),
 	}

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -508,6 +508,7 @@ func TestReconcile(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithPodsReadyTimeout(ptr.To(3 * time.Second)),
 				WithRequeuingBackoffLimitCount(ptr.To[int32](100)),
+				WithRequeuingBaseDelaySeconds(10),
 			},
 			workload: utiltesting.MakeWorkload("wl", "ns").
 				ReserveQuota(utiltesting.MakeAdmission("q1").Obj()).
@@ -523,7 +524,7 @@ func TestReconcile(t *testing.T) {
 					Message:            "Admitted by ClusterQueue q1",
 				}).
 				Admitted(true).
-				RequeueState(ptr.To[int32](29), nil).
+				RequeueState(ptr.To[int32](3), nil).
 				Generation(1).
 				Obj(),
 			wantWorkload: utiltesting.MakeWorkload("wl", "ns").
@@ -541,8 +542,8 @@ func TestReconcile(t *testing.T) {
 					Message:            "Exceeded the PodsReady timeout ns/wl",
 					ObservedGeneration: 1,
 				}).
-				// 1.41284738^(30-1) = 22530.0558
-				RequeueState(ptr.To[int32](30), ptr.To(metav1.NewTime(testStartTime.Add(22530*time.Second).Truncate(time.Second)))).
+				// 10s * 2^(4-1) = 80s
+				RequeueState(ptr.To[int32](4), ptr.To(metav1.NewTime(testStartTime.Add(80*time.Second).Truncate(time.Second)))).
 				Obj(),
 		},
 		"deactivated workload": {

--- a/test/integration/scheduler/podsready/suite_test.go
+++ b/test/integration/scheduler/podsready/suite_test.go
@@ -87,7 +87,8 @@ func managerAndSchedulerSetupWithTimeoutAdmission(
 		queue.WithPodsReadyRequeuingTimestamp(requeuingTimestamp),
 	)
 
-	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, cfg)
+	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, cfg,
+		core.WithControllerRequeuingBaseDelaySeconds(1))
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 	failedWebhook, err := webhooks.Setup(mgr)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #2009

#### Special notes for your reviewer:

WIP because still testing, and I need to update the estimations from KEP and API comments.
Early feedback is welcome.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Make the defaults for PodsReadyTimeout backoff more practical, as for the original values
the couple of first requeues made the impression as immediate on users (below 10s, which 
is negligible to the wait time spent waiting for PodsReady). 

The defaults values for the formula to determine the exponential back are changed as follows:
- base `1s -> 10s`
- exponent: `1.41284738 -> 2`
So, now the consecutive times to requeue a workload are: 10s, 20s, 40s, ...
```