### PR TITLE
Automated cherry pick of #2025: Make the defaults for PodsReady backoff more practical

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -231,12 +231,12 @@ type RequeuingStrategy struct {
 	// Once the number is reached, the workload is deactivated (`.spec.activate`=`false`).
 	// When it is null, the workloads will repeatedly and endless re-queueing.
 	//
-	// Every backoff duration is about "1.41284738^(n-1)+Rand" where the "n" represents the "workloadStatus.requeueState.count",
-	// and the "Rand" represents the random jitter. During this time, the workload is taken as an inadmissible and
+	// Every backoff duration is about "10s*2^(n-1)+Rand" where:
+	// - "n" represents the "workloadStatus.requeueState.count",
+	// - "Rand" represents the random jitter.
+	// During this time, the workload is taken as an inadmissible and
 	// other workloads will have a chance to be admitted.
-	// For example, when the "waitForPodsReady.timeout" is the default, the workload deactivation time is as follows:
-	//   {backoffLimitCount, workloadDeactivationSeconds}
-	//     ~= {1, 601}, {2, 902}, ...,{5, 1811}, ...,{10, 3374}, ...,{20, 8730}, ...,{30, 86400(=24 hours)}, ...
+	// By default, the consecutive requeue delays are around: (10s, 20s, 40s, ...).
 	//
 	// Defaults to null.
 	// +optional

--- a/keps/1282-pods-ready-requeue-strategy/README.md
+++ b/keps/1282-pods-ready-requeue-strategy/README.md
@@ -143,12 +143,12 @@ type RequeuingStrategy struct {
 	// Once the number is reached, the workload is deactivated (`.spec.activate`=`false`).
 	// When it is null, the workloads will repeatedly and endless re-queueing.
 	//
-	// Every backoff duration is about "1.41284738^(n-1)+Rand" where the "n" represents the "workloadStatus.requeueState.count",
-	// and the "Rand" represents the random jitter. During this time, the workload is taken as an inadmissible and
+	// Every backoff duration is about "10s*2^(n-1)+Rand" where:
+	// - "n" represents the "workloadStatus.requeueState.count",
+	// - "Rand" represents the random jitter.
+	// During this time, the workload is taken as an inadmissible and
 	// other workloads will have a chance to be admitted.
-	// For example, when the "waitForPodsReady.timeout" is the default, the workload deactivation time is as follows:
-	//   {backoffLimitCount, workloadDeactivationSeconds}
-	//     ~= {1, 601}, {2, 902}, ...,{5, 1811}, ...,{10, 3374}, ...,{20, 8730}, ...,{30, 86400(=24 hours)}, ...
+	// By default, the consecutive requeue delays are around: (10s, 20s, 40s, ...).
 	//
 	// Defaults to null.
 	// +optional
@@ -222,16 +222,16 @@ the queueManager holds the evicted workloads as inadmissible workloads while exp
 Duration this time, other workloads will have a chance to be admitted.
 
 The queueManager calculates an exponential backoff duration by [the Step function](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait@v0.29.1#Backoff.Step)
-according to the $1.41284738^{(n-1)}+Rand$ where the $n$ represents the `workloadStatus.requeueState.count`, and the $Rand$ represents the random jitter.
+according to the $10s*2^{(n-1)}+Rand$ where the $n$ represents the `workloadStatus.requeueState.count`, and the $Rand$ represents the random jitter.
 
-Considering the `.waitForPodsReady.timeout` (default: 300 seconds),
-this duration indicates that an evicted workload with `PodsReadyTimeout` reason is continued re-queuing 
-for the following period where the $t$ represents `.waitForPodsReady.timeout`:
+It will spend awaiting to be requeued after eviction:
+$$\sum_{k=1}^{n}(10s*2^{(k-1)} + Rand)$$
 
-$$t(n+1) + \sum_{k=1}^{n}(1.41284738^{(k-1)} + Rand)$$
-
-Given that the `backoffLimitCount` equals `30` and the `waitForPodsReady.timeout` equals `300` (default),
-the result equals 24 hours (+ $Rand$ seconds).
+Assuming `backoffLimitCount` equals 10, and the workload is requeued 10 times
+after failing to have all pods ready, then the total time awaiting for requeue
+will take (neglecting the jitter): `10s+20s+40s +...+7680s=2h 8min`.
+Also, considering `.waitForPodsReady.timeout=300s` (default),
+the workload will spend `50min` total waiting for pods ready.
 
 #### Evaluation
 

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -455,6 +455,7 @@ func TestReconcile(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithPodsReadyTimeout(ptr.To(3 * time.Second)),
 				WithRequeuingBackoffLimitCount(ptr.To[int32](100)),
+				WithRequeuingBaseDelaySeconds(10),
 			},
 			workload: utiltesting.MakeWorkload("wl", "ns").
 				ReserveQuota(utiltesting.MakeAdmission("q1").Obj()).
@@ -470,7 +471,7 @@ func TestReconcile(t *testing.T) {
 					Message:            "Admitted by ClusterQueue q1",
 				}).
 				Admitted(true).
-				RequeueState(ptr.To[int32](29), nil).
+				RequeueState(ptr.To[int32](3), nil).
 				Obj(),
 			wantWorkload: utiltesting.MakeWorkload("wl", "ns").
 				ReserveQuota(utiltesting.MakeAdmission("q1").Obj()).
@@ -485,8 +486,8 @@ func TestReconcile(t *testing.T) {
 					Reason:  kueue.WorkloadEvictedByPodsReadyTimeout,
 					Message: "Exceeded the PodsReady timeout ns/wl",
 				}).
-				// 1.41284738^(30-1) = 22530.0558
-				RequeueState(ptr.To[int32](30), ptr.To(metav1.NewTime(testStartTime.Add(22530*time.Second).Truncate(time.Second)))).
+				// 10s * 2^(4-1) = 80s
+				RequeueState(ptr.To[int32](4), ptr.To(metav1.NewTime(testStartTime.Add(80*time.Second).Truncate(time.Second)))).
 				Obj(),
 		},
 		"deactivated workload": {

--- a/test/integration/scheduler/podsready/suite_test.go
+++ b/test/integration/scheduler/podsready/suite_test.go
@@ -87,7 +87,8 @@ func managerAndSchedulerSetupWithTimeoutAdmission(
 		queue.WithPodsReadyRequeuingTimestamp(requeuingTimestamp),
 	)
 
-	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, cfg)
+	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, cfg,
+		core.WithControllerRequeuingBaseDelaySeconds(1))
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 	failedWebhook, err := webhooks.Setup(mgr)


### PR DESCRIPTION
Cherry pick of #2025 on release-0.6.
#2025: Make the defaults for PodsReady backoff more practical
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```