### PR TITLE
Make dominant resource share flavor aware

### DIFF
--- a/keps/1714-fair-sharing/README.md
+++ b/keps/1714-fair-sharing/README.md
@@ -206,10 +206,12 @@ The value function is a variation of DRF (see
 [1](https://amplab.cs.berkeley.edu/wp-content/uploads/2011/06/Dominant-Resource-Fairness-Fair-Allocation-of-Multiple-Resource-Types.pdf),
 [2](https://dash.harvard.edu/bitstream/handle/1/11956916/Parkes_BeyondDominant.pdf;jsessionid=AC0D06C2CC07C693BD42008D7AE25D99?sequence=1)):
 
-For a given resource r provided by a ClusterQueue or cohort c, we calculate T_r as the total
-requests consumed by the Workloads for that resource in that CQ or cohort, independent of the
-flavor, that are above the nominal quota. The value for a resource is the ratio of T_r and the
-total nominal quotas (or lendingLimits, if defined) in the hierarchy of the parent of C.
+For a given resource _r_ provided by a ClusterQueue or cohort _c_, we calculate $T_r$ as the
+total requests consumed by the Workloads for resource _r_ in that CQ or cohort,
+that are above the nominal quota, added up for all flavors.
+The value for a resource is the ratio of $T_r$ and the total nominal quotas
+(or lendingLimits, if defined) for the resource _r_, added up for all flavors,
+in the hierarchy of the parent of _c_.
 
 Note that the share value for a suborganization (a node in the tree) is independent of the 
 share value for its children. In other words, the calculation of the share value only 

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -22,12 +22,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
-	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 func TestClusterQueueUpdateWithFlavors(t *testing.T) {
@@ -759,38 +759,60 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 func TestDominantResourceShare(t *testing.T) {
 	cases := map[string]struct {
 		cq          ClusterQueue
-		workload    *workload.Info
+		flvResQ     FlavorResourceQuantities
 		wantDRValue int
 		wantDRName  corev1.ResourceName
 	}{
 		"no cohort": {
 			cq: ClusterQueue{
-				ResourceStats: ResourceStats{
-					corev1.ResourceCPU: {
-						Nominal:  2_000,
-						Lendable: 2_000,
-						Usage:    1_000,
+				Usage: FlavorResourceQuantities{
+					"default": {
+						corev1.ResourceCPU: 1_000,
+						"example.com/gpu":  2,
 					},
-					"example.com/gpu": {
-						Nominal:  5,
-						Lendable: 5,
-						Usage:    2_000,
+				},
+				ResourceGroups: []ResourceGroup{
+					{
+						Flavors: []FlavorQuotas{
+							{
+								Name: "default",
+								Resources: map[corev1.ResourceName]*ResourceQuota{
+									corev1.ResourceCPU: {
+										Nominal: 2_000,
+									},
+									"example.com/gpu": {
+										Nominal: 5,
+									},
+								},
+							},
+						},
 					},
 				},
 			},
 		},
 		"usage below nominal": {
 			cq: ClusterQueue{
-				ResourceStats: ResourceStats{
-					corev1.ResourceCPU: {
-						Nominal:  2_000,
-						Lendable: 2_000,
-						Usage:    1_000,
+				Usage: FlavorResourceQuantities{
+					"default": {
+						corev1.ResourceCPU: 1_000,
+						"example.com/gpu":  2,
 					},
-					"example.com/gpu": {
-						Nominal:  5,
-						Lendable: 5,
-						Usage:    2,
+				},
+				ResourceGroups: []ResourceGroup{
+					{
+						Flavors: []FlavorQuotas{
+							{
+								Name: "default",
+								Resources: map[corev1.ResourceName]*ResourceQuota{
+									corev1.ResourceCPU: {
+										Nominal: 2_000,
+									},
+									"example.com/gpu": {
+										Nominal: 5,
+									},
+								},
+							},
+						},
 					},
 				},
 				Cohort: &Cohort{
@@ -808,20 +830,30 @@ func TestDominantResourceShare(t *testing.T) {
 					},
 				},
 			},
-			wantDRName: corev1.ResourceCPU, // due to alphabetical order.
 		},
 		"usage above nominal": {
 			cq: ClusterQueue{
-				ResourceStats: ResourceStats{
-					corev1.ResourceCPU: {
-						Nominal:  2_000,
-						Lendable: 2_000,
-						Usage:    3_000,
+				Usage: FlavorResourceQuantities{
+					"default": {
+						corev1.ResourceCPU: 3_000,
+						"example.com/gpu":  7,
 					},
-					"example.com/gpu": {
-						Nominal:  5,
-						Lendable: 5,
-						Usage:    7,
+				},
+				ResourceGroups: []ResourceGroup{
+					{
+						Flavors: []FlavorQuotas{
+							{
+								Name: "default",
+								Resources: map[corev1.ResourceName]*ResourceQuota{
+									corev1.ResourceCPU: {
+										Nominal: 2_000,
+									},
+									"example.com/gpu": {
+										Nominal: 5,
+									},
+								},
+							},
+						},
 					},
 				},
 				Cohort: &Cohort{
@@ -840,20 +872,31 @@ func TestDominantResourceShare(t *testing.T) {
 				},
 			},
 			wantDRName:  "example.com/gpu",
-			wantDRValue: 20, // (7-5)/10
+			wantDRValue: 200, // (7-5)*1000/10
 		},
 		"one resource above nominal": {
 			cq: ClusterQueue{
-				ResourceStats: ResourceStats{
-					corev1.ResourceCPU: {
-						Nominal:  2_000,
-						Lendable: 2_000,
-						Usage:    3_000,
+				Usage: FlavorResourceQuantities{
+					"default": {
+						corev1.ResourceCPU: 3_000,
+						"example.com/gpu":  3,
 					},
-					"example.com/gpu": {
-						Nominal:  5,
-						Lendable: 5,
-						Usage:    3,
+				},
+				ResourceGroups: []ResourceGroup{
+					{
+						Flavors: []FlavorQuotas{
+							{
+								Name: "default",
+								Resources: map[corev1.ResourceName]*ResourceQuota{
+									corev1.ResourceCPU: {
+										Nominal: 2_000,
+									},
+									"example.com/gpu": {
+										Nominal: 5,
+									},
+								},
+							},
+						},
 					},
 				},
 				Cohort: &Cohort{
@@ -872,20 +915,31 @@ func TestDominantResourceShare(t *testing.T) {
 				},
 			},
 			wantDRName:  corev1.ResourceCPU,
-			wantDRValue: 10, // (3-2)/10
+			wantDRValue: 100, // (3-2)*1000/10
 		},
 		"usage with workload above nominal": {
 			cq: ClusterQueue{
-				ResourceStats: ResourceStats{
-					corev1.ResourceCPU: {
-						Nominal:  2_000,
-						Lendable: 2_000,
-						Usage:    1_000,
+				Usage: FlavorResourceQuantities{
+					"default": {
+						corev1.ResourceCPU: 1_000,
+						"example.com/gpu":  2,
 					},
-					"example.com/gpu": {
-						Nominal:  5,
-						Lendable: 5,
-						Usage:    2,
+				},
+				ResourceGroups: []ResourceGroup{
+					{
+						Flavors: []FlavorQuotas{
+							{
+								Name: "default",
+								Resources: map[corev1.ResourceName]*ResourceQuota{
+									corev1.ResourceCPU: {
+										Nominal: 2_000,
+									},
+									"example.com/gpu": {
+										Nominal: 5,
+									},
+								},
+							},
+						},
 					},
 				},
 				Cohort: &Cohort{
@@ -903,28 +957,39 @@ func TestDominantResourceShare(t *testing.T) {
 					},
 				},
 			},
-			workload: &workload.Info{
-				TotalRequests: []workload.PodSetResources{{
-					Requests: workload.Requests{
-						corev1.ResourceCPU: 4_000,
-						"example.com/gpu":  4,
-					},
-				}},
+			flvResQ: FlavorResourceQuantities{
+				"default": {
+					corev1.ResourceCPU: 4_000,
+					"example.com/gpu":  4,
+				},
 			},
 			wantDRName:  corev1.ResourceCPU,
-			wantDRValue: 30, // (1+4-2)/10
+			wantDRValue: 300, // (1+4-2)*1000/10
 		},
 		"A resource with zero lendable": {
 			cq: ClusterQueue{
-				ResourceStats: ResourceStats{
-					corev1.ResourceCPU: {
-						Nominal:  2_000,
-						Lendable: 2_000,
-						Usage:    1_000,
+				Usage: FlavorResourceQuantities{
+					"default": {
+						corev1.ResourceCPU: 1_000,
+						"example.com/gpu":  1,
 					},
-					"example.com/gpu": {
-						Nominal: 2_000,
-						Usage:   1_000,
+				},
+				ResourceGroups: []ResourceGroup{
+					{
+						Flavors: []FlavorQuotas{
+							{
+								Name: "default",
+								Resources: map[corev1.ResourceName]*ResourceQuota{
+									corev1.ResourceCPU: {
+										Nominal: 2_000,
+									},
+									"example.com/gpu": {
+										Nominal:      2,
+										LendingLimit: ptr.To[int64](0),
+									},
+								},
+							},
+						},
 					},
 				},
 				Cohort: &Cohort{
@@ -941,21 +1006,69 @@ func TestDominantResourceShare(t *testing.T) {
 					},
 				},
 			},
-			workload: &workload.Info{
-				TotalRequests: []workload.PodSetResources{{
-					Requests: workload.Requests{
-						corev1.ResourceCPU: 4_000,
-						"example.com/gpu":  4,
-					},
-				}},
+			flvResQ: FlavorResourceQuantities{
+				"default": {
+					corev1.ResourceCPU: 4_000,
+					"example.com/gpu":  4,
+				},
 			},
 			wantDRName:  corev1.ResourceCPU,
-			wantDRValue: 30, // (1+4-2)/10
+			wantDRValue: 300, // (1+4-2)*1000/10
+		},
+		"multiple flavors": {
+			cq: ClusterQueue{
+				Usage: FlavorResourceQuantities{
+					"on-demand": {
+						corev1.ResourceCPU: 15_000,
+					},
+					"spot": {
+						corev1.ResourceCPU: 5_000,
+					},
+				},
+				ResourceGroups: []ResourceGroup{
+					{
+						Flavors: []FlavorQuotas{
+							{
+								Name: "on-demand",
+								Resources: map[corev1.ResourceName]*ResourceQuota{
+									corev1.ResourceCPU: {
+										Nominal: 20_000,
+									},
+								},
+							},
+							{
+								Name: "spot",
+								Resources: map[corev1.ResourceName]*ResourceQuota{
+									corev1.ResourceCPU: {
+										Nominal: 80_000,
+									},
+								},
+							},
+						},
+					},
+				},
+				Cohort: &Cohort{
+					ResourceStats: ResourceStats{
+						corev1.ResourceCPU: {
+							Nominal:  200_000,
+							Lendable: 200_000,
+							Usage:    20_000,
+						},
+					},
+				},
+			},
+			flvResQ: FlavorResourceQuantities{
+				"on-demand": {
+					corev1.ResourceCPU: 10_000,
+				},
+			},
+			wantDRName:  corev1.ResourceCPU,
+			wantDRValue: 25, // ((15+10-20)+0)*1000/200 (spot under nominal)
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			drValue, drName := tc.cq.DominantResourceShareWith(tc.workload)
+			drValue, drName := tc.cq.DominantResourceShareWith(tc.flvResQ)
 			if drValue != tc.wantDRValue {
 				t.Errorf("DominantResourceShare(_) returned value %d, want %d", drValue, tc.wantDRValue)
 			}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -105,6 +105,22 @@ func (a *Assignment) ToAPI() []kueue.PodSetAssignment {
 	return psFlavors
 }
 
+func (a *Assignment) TotalRequestsFor(wl *workload.Info) cache.FlavorResourceQuantities {
+	usage := make(cache.FlavorResourceQuantities)
+	for i, ps := range wl.TotalRequests {
+		for res, q := range ps.Requests {
+			flv := a.PodSets[i].Flavors[res].Name
+			resUsage := usage[flv]
+			if resUsage == nil {
+				resUsage = make(map[corev1.ResourceName]int64)
+				usage[flv] = resUsage
+			}
+			resUsage[res] += q
+		}
+	}
+	return usage
+}
+
 type Status struct {
 	reasons []string
 	err     error

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -159,7 +159,7 @@ func (cu *cohortsUsage) add(cohort string, assignment cache.FlavorResourceQuanti
 }
 
 func (cu *cohortsUsage) totalUsageForCommonFlavorResources(cohort string, assignment cache.FlavorResourceQuantities) cache.FlavorResourceQuantities {
-	return utilmaps.Intersect((*cu)[cohort], assignment, func(a, b cache.ResourceQuantities) cache.ResourceQuantities {
+	return utilmaps.Intersect((*cu)[cohort], assignment, func(a, b workload.Requests) workload.Requests {
 		return utilmaps.Intersect(a, b, func(a, b int64) int64 { return a + b })
 	})
 }
@@ -358,7 +358,7 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 			e.inadmissibleMsg = e.assignment.Message()
 			e.Info.LastAssignment = &e.assignment.LastState
 			if s.enableFairSharing {
-				e.dominantResourceShare, e.dominantResourceName = cq.DominantResourceShareWith(&w)
+				e.dominantResourceShare, e.dominantResourceName = cq.DominantResourceShareWith(e.assignment.TotalRequestsFor(&w))
 			}
 		}
 		entries = append(entries, e)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -152,18 +152,25 @@ func (i *Info) CanBePartiallyAdmitted() bool {
 }
 
 // ResourceUsage returns the total resource usage for the workload,
-// per resource.
-func (i *Info) ResourceUsage() Requests {
+// per flavor (if assigned, otherwise flavor shows as empty string), per resource.
+func (i *Info) FlavorResourceUsage() map[kueue.ResourceFlavorReference]Requests {
 	if i == nil || len(i.TotalRequests) == 0 {
 		return nil
 	}
-	req := maps.Clone(i.TotalRequests[0].Requests)
-	for j := 1; j < len(i.TotalRequests); j++ {
-		for rName, rVal := range i.TotalRequests[j].Requests {
-			req[rName] += rVal
+	total := make(map[kueue.ResourceFlavorReference]Requests)
+	for _, psReqs := range i.TotalRequests {
+		for res, q := range psReqs.Requests {
+			flv := psReqs.Flavors[res]
+			if requests, found := total[flv]; found {
+				requests[res] += q
+			} else {
+				total[flv] = Requests{
+					res: q,
+				}
+			}
 		}
 	}
-	return req
+	return total
 }
 
 func CanBePartiallyAdmitted(wl *kueue.Workload) bool {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -591,13 +591,13 @@ func TestIsEvictedByPodsReadyTimeout(t *testing.T) {
 	}
 }
 
-func TestResourceUsage(t *testing.T) {
+func TestFlavorResourceUsage(t *testing.T) {
 	cases := map[string]struct {
 		info *Info
-		want Requests
+		want map[kueue.ResourceFlavorReference]Requests
 	}{
 		"nil": {},
-		"one podset": {
+		"one podset, no flavors": {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Requests: Requests{
@@ -606,12 +606,36 @@ func TestResourceUsage(t *testing.T) {
 					},
 				}},
 			},
-			want: Requests{
-				corev1.ResourceCPU: 1_000,
-				"example.com/gpu":  3,
+			want: map[kueue.ResourceFlavorReference]Requests{
+				"": {
+					corev1.ResourceCPU: 1_000,
+					"example.com/gpu":  3,
+				},
 			},
 		},
-		"multiple podsets": {
+		"one podset, multiple flavors": {
+			info: &Info{
+				TotalRequests: []PodSetResources{{
+					Requests: Requests{
+						corev1.ResourceCPU: 1_000,
+						"example.com/gpu":  3,
+					},
+					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+						corev1.ResourceCPU: "default",
+						"example.com/gpu":  "gpu",
+					},
+				}},
+			},
+			want: map[kueue.ResourceFlavorReference]Requests{
+				"default": {
+					corev1.ResourceCPU: 1_000,
+				},
+				"gpu": {
+					"example.com/gpu": 3,
+				},
+			},
+		},
+		"multiple podsets, multiple flavors": {
 			info: &Info{
 				TotalRequests: []PodSetResources{
 					{
@@ -619,30 +643,48 @@ func TestResourceUsage(t *testing.T) {
 							corev1.ResourceCPU: 1_000,
 							"example.com/gpu":  3,
 						},
+						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+							corev1.ResourceCPU: "default",
+							"example.com/gpu":  "model_a",
+						},
 					},
 					{
 						Requests: Requests{
 							corev1.ResourceCPU:    2_000,
 							corev1.ResourceMemory: 2 * utiltesting.Gi,
 						},
+						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+							corev1.ResourceCPU:    "default",
+							corev1.ResourceMemory: "default",
+						},
 					},
 					{
 						Requests: Requests{
 							"example.com/gpu": 1,
 						},
+						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+							"example.com/gpu": "model_b",
+						},
 					},
 				},
 			},
-			want: Requests{
-				corev1.ResourceCPU:    3_000,
-				corev1.ResourceMemory: 2 * utiltesting.Gi,
-				"example.com/gpu":     4,
+			want: map[kueue.ResourceFlavorReference]Requests{
+				"default": {
+					corev1.ResourceCPU:    3_000,
+					corev1.ResourceMemory: 2 * utiltesting.Gi,
+				},
+				"model_a": {
+					"example.com/gpu": 3,
+				},
+				"model_b": {
+					"example.com/gpu": 1,
+				},
 			},
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := tc.info.ResourceUsage()
+			got := tc.info.FlavorResourceUsage()
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("info.ResourceUsage() returned (-want,+got):\n%s", diff)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Consider a case where there are two flavors of CPU, with the following quotas and usage:

- `on-demand`: nominal=20, usage=25
- `spot`: nominal=80, usage=5

This CQ is borrowing 5 units of `on-demand`. However, the old logic would give the CQ a score of `0`, because (25+5<=20+80).
This would have prevented legitimate preemptions in the on-demand flavor.

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes-sigs/kueue/issues/1714

#### Special notes for your reviewer:

This interpretation would actually simplify a lot of the changes that I did in #1777 
We basically only need to keep the total "lendable" quota for a cohort.
Sorry for not realizing this problem earlier :(

But I'll leave the clean up for the next PR.

#### Does this PR introduce a user-facing change?

Feature not released yet

```release-note
NONE
```