### PR TITLE
[KEP] Support new ProvisioningRequest's conditions

### DIFF
--- a/keps/1136-provisioning-request-support/README.md
+++ b/keps/1136-provisioning-request-support/README.md
@@ -116,9 +116,10 @@ will also need to watch `ProvisioningRequestConfigs`.
   - `Provisioned=true` controller should mark the AdmissionCheck as `Ready` and propagate the information about `ProvisioningRequest` name to
 workload pods - [KEP #1145](https://github.com/kubernetes-sigs/kueue/blob/main/keps/1145-additional-labels/kep.yaml) under `"cluster-autoscaler.kubernetes.io/consume-provisioning-request"`.
   - `Failed=true` controller should retry AdmissionCheck with respect to the `RetryConfig` configuration, or mark the AdmissionCheck as `Rejected`
-  - `BookingExpired=true` if a Workload is not `Admitted` controller should act the same as for `Failed=true`.
-  - `CapacityRevoked=true` if a Workload is not `Finished` controller should mark it as `Inactive`, which will evict it.
-    Additionally, an event should be emitted to signalize this happening. This can happen only if a user uses `batch.v1/Job` and
+  - `BookingExpired=true` if a Workload is not `Admitted`, the controller should act the same as for `Failed=true`.
+  - `CapacityRevoked=true` if a Workload is not `Finished`, the controller should mark it as `Inactive`, which will evict it.
+    Additionally, an event should be emitted to signalize this happening. This can happen only if the job
+    allows for retries, for example, in the case of `batch.v1/Job`, when the user
     sets `.spec.backOffLimit > 0`.
 
 * Watch the admission of the workload - if it is again suspended or finished,

--- a/keps/1136-provisioning-request-support/README.md
+++ b/keps/1136-provisioning-request-support/README.md
@@ -10,6 +10,7 @@
     - [Story 1](#story-1)
     - [Story 2](#story-2)
   - [Risks and Mitigations](#risks-and-mitigations)
+    - [BookingExpired condition](#bookingexpired-condition)
 - [Design Details](#design-details)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
@@ -77,6 +78,21 @@ There doesn't seem to be much risks or mitigations.
 [Two phase admission process](https://github.com/kubernetes-sigs/kueue/tree/main/keps/993-two-phase-admission)
 was added specifically for use cases like this.
 
+#### BookingExpired condition
+
+Kueue's support for the BookingExpired condition in ProvisioningRequest poses a risk. The Cluster Autoscaler may set `BookingExpired=true`,
+potentially ceasing to guarantee the capacity before all pods are scheduled. This can occur in two scenarios:
+
+- **Other AdmissionChecks**: If other AdmissionChecks are used, they might delay pod creation, causing the Cluster Autoscaler to expire the booking.
+- **Massive jobs**: When a very large job is created, the controller responsible for pod creation might not be able to
+  keep pace, again leading to the booking expiring before all pods are scheduled.
+
+This could result in the scheduling of only a subset of pods. To mitigate the first scenario, users can utilize the
+[`WaitForPodsReady`](https://github.com/kubernetes-sigs/kueue/tree/main/keps/349-all-or-nothing) field. This ensures
+a Workload is evicted if not all of its pods are scheduled after a specified timeout. For the second scenario, cluster
+administrators should ensure their control plane is adequately provisioned with sufficient resources - larger VMs and/or
+higher qps for the pod-creating controller) to handle large jobs efficiently.
+
 ## Design Details
 
 The new ProvisioningRequest controller will:
@@ -95,11 +111,14 @@ The `ProvisioningRequest` should have the owner reference set to the workload.
 To understand what details should it put into `ProvisioningRequest` the controller
 will also need to watch `ProvisioningRequestConfigs`.
 
-* Watch all changes CA makes to `ProvisioningRequests`. If the `Provisioned`
-or `CapacityAvailable` condition is set to `True` then finish the `AdmissionCheck`
-with success (and propagate the information about `ProvisioningRequest` name to
+* Watch all changes CA makes to `ProvisioningRequests`. If the `ProvisioningRequest's` conditions are set to:
+  - `Provisioned=false` controller should surface information about ProvisioningRequest's ETA. It should emit an event regarding that and for every ETA change.
+  - `Provisioned=true` controller should mark the AdmissionCheck as `Ready` and propagate the information about `ProvisioningRequest` name to
 workload pods - [KEP #1145](https://github.com/kubernetes-sigs/kueue/blob/main/keps/1145-additional-labels/kep.yaml) under `"cluster-autoscaler.kubernetes.io/consume-provisioning-request"`.
-If the `ProvisioningRequest` fails, fail the `AdmissionCheck`.
+  - `Failed=true` controller should retry AdmissionCheck with respect to the `RetryConfig` configuration, or mark the AdmissionCheck as `Rejected`
+  - `BookingExpired=true` if a Workload is not `Admitted` controller should act the same as for `Failed=true`.
+  - `CapacityRevoked=true` if a Workload is not `Finished` controller should mark it as `Inactive`, which will evict it.
+    Additionally, an event should be emitted to signalize this happening.
 
 * Watch the admission of the workload - if it is again suspended or finished,
 the provisioning request should also be deleted (the last one can be achieved via

--- a/keps/1136-provisioning-request-support/README.md
+++ b/keps/1136-provisioning-request-support/README.md
@@ -74,10 +74,6 @@ succeeds.
 
 ### Risks and Mitigations
 
-There doesn't seem to be much risks or mitigations.
-[Two phase admission process](https://github.com/kubernetes-sigs/kueue/tree/main/keps/993-two-phase-admission)
-was added specifically for use cases like this.
-
 #### BookingExpired condition
 
 Kueue's support for the BookingExpired condition in ProvisioningRequest poses a risk. The Cluster Autoscaler may set `BookingExpired=true`,

--- a/keps/1136-provisioning-request-support/README.md
+++ b/keps/1136-provisioning-request-support/README.md
@@ -118,7 +118,8 @@ workload pods - [KEP #1145](https://github.com/kubernetes-sigs/kueue/blob/main/k
   - `Failed=true` controller should retry AdmissionCheck with respect to the `RetryConfig` configuration, or mark the AdmissionCheck as `Rejected`
   - `BookingExpired=true` if a Workload is not `Admitted` controller should act the same as for `Failed=true`.
   - `CapacityRevoked=true` if a Workload is not `Finished` controller should mark it as `Inactive`, which will evict it.
-    Additionally, an event should be emitted to signalize this happening.
+    Additionally, an event should be emitted to signalize this happening. This can happen only if a user uses `batch.v1/Job` and
+    sets `.spec.backOffLimit > 0`.
 
 * Watch the admission of the workload - if it is again suspended or finished,
 the provisioning request should also be deleted (the last one can be achieved via


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Describes behavior of ProvisioningRequest controller regarding recently introduced new [conditions](https://github.com/kubernetes/autoscaler/blob/349559c32f496900ccd643172c7e4f87a8fecc02/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1/types.go#L177)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #2041 


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE

```