### PR TITLE
Adapt scalability range spec to the CI results

### DIFF
--- a/test/scalability/default_rangespec.yaml
+++ b/test/scalability/default_rangespec.yaml
@@ -1,15 +1,32 @@
-# Until we have a clear picture on how the setup
-# performs in CI keep the values "very relaxed"
+# The values are computed based on the result of 5 trial runs:
+# - #1782760671465705472
+# - #1782764439129296896
+# - #1782768037514973184
+# - #1782772615836864512
+# - #1782775995984515072
 cmd:
-  maxWallMs: 3600_000 #1h 
-  maxUserMs: 3600_000
-  maxSysMs: 3600_000
-  maxrss: 1024_000 #1000MiB
+  # Average value 351116.4 (+/- 0.9%), setting at +5%
+  maxWallMs: 368672
+
+  # Average value 111500 (+/- 14%), setting at +20%
+  maxUserMs: 133800
+
+  # Average value 27875 (+/- 16%), setting at +20%
+  maxSysMs: 33450
+  
+  # Average value 445012 (+/- 0.3%), setting at +5%
+  maxrss: 467263
 
 clusterQueueClassesMinUsage:
-  cq: 10  #10%
+  # Average value 58.7 (+/- 1.2%), setting at -5%
+  cq: 56 #%
 
 wlClassesMaxAvgTimeToAdmissionMs:
-  large: 3600_000 #1h
-  medium: 3600_000
-  small: 3600_000
+  # Average value 6666 (+/- 14%), setting at +20%
+  large: 8_000
+
+  # Average value 76768 (+/- 2%), setting at +5%
+  medium: 80_606
+
+  # Average value 215468 (+/- 2%), setting at +5%
+  small: 226_241

--- a/test/scalability/default_rangespec.yaml
+++ b/test/scalability/default_rangespec.yaml
@@ -6,16 +6,16 @@
 # - #1782775995984515072
 cmd:
   # Average value 351116.4 (+/- 0.9%), setting at +5%
-  maxWallMs: 368672
+  maxWallMs: 368_000
 
   # Average value 111500 (+/- 14%), setting at +20%
-  maxUserMs: 133800
+  maxUserMs: 134_000
 
   # Average value 27875 (+/- 16%), setting at +20%
-  maxSysMs: 33450
+  maxSysMs: 34_000
   
   # Average value 445012 (+/- 0.3%), setting at +5%
-  maxrss: 467263
+  maxrss: 468_000
 
 clusterQueueClassesMinUsage:
   # Average value 58.7 (+/- 1.2%), setting at -5%
@@ -26,7 +26,7 @@ wlClassesMaxAvgTimeToAdmissionMs:
   large: 8_000
 
   # Average value 76768 (+/- 2%), setting at +5%
-  medium: 80_606
+  medium: 81_000
 
   # Average value 215468 (+/- 2%), setting at +5%
-  small: 226_241
+  small: 227_000


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adapt scalability  test range spec to the observed CI results.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #1912

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
None
```