### PR TITLE
Validate admission check applies to all flavors

### DIFF
--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -105,8 +105,8 @@ const (
 	// set to true will cause the ClusterQueue to be marked as Inactive.
 	AdmissionChecksSingleInstanceInClusterQueue string = "SingleInstanceInClusterQueue"
 
-	// AdmissionCheckApplyToAllFlavors indicates if the AdmissionCheck should apply to all ResourceFlavor.
-	AdmissionCheckApplyToAllFlavors string = "ApplyToAllFlavors"
+	// AdmissionCheckApplyOnlyToAllFlavors indicates if the AdmissionCheck cannot be applied at ResourceFlavor level.
+	AdmissionCheckApplyOnlyToAllFlavors string = "ApplyOnlyToAllFlavors"
 )
 
 // +genclient

--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -104,6 +104,9 @@ const (
 	// Having multiple AdmissionChecks managed by the same controller where at least one has this condition
 	// set to true will cause the ClusterQueue to be marked as Inactive.
 	AdmissionChecksSingleInstanceInClusterQueue string = "SingleInstanceInClusterQueue"
+
+	// AdmissionCheckApplyToAllFlavors indicates if the AdmissionCheck should apply to all ResourceFlavor.
+	AdmissionCheckApplyToAllFlavors string = "ApplyToAllFlavors"
 )
 
 // +genclient

--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -105,8 +105,8 @@ const (
 	// set to true will cause the ClusterQueue to be marked as Inactive.
 	AdmissionChecksSingleInstanceInClusterQueue string = "SingleInstanceInClusterQueue"
 
-	// AdmissionCheckApplyOnlyToAllFlavors indicates if the AdmissionCheck cannot be applied at ResourceFlavor level.
-	AdmissionCheckApplyOnlyToAllFlavors string = "ApplyOnlyToAllFlavors"
+	// FlavorIndependentAdmissionCheck indicates if the AdmissionCheck cannot be applied at ResourceFlavor level.
+	FlavorIndependentAdmissionCheck string = "FlavorIndependent"
 )
 
 // +genclient

--- a/pkg/cache/admissioncheck.go
+++ b/pkg/cache/admissioncheck.go
@@ -20,5 +20,5 @@ type AdmissionCheck struct {
 	Active                       bool
 	Controller                   string
 	SingleInstanceInClusterQueue bool
-	ApplyToAllFlavors            bool
+	ApplyOnlyToAllFlavors        bool
 }

--- a/pkg/cache/admissioncheck.go
+++ b/pkg/cache/admissioncheck.go
@@ -20,4 +20,5 @@ type AdmissionCheck struct {
 	Active                       bool
 	Controller                   string
 	SingleInstanceInClusterQueue bool
+	ApplyToAllFlavors            bool
 }

--- a/pkg/cache/admissioncheck.go
+++ b/pkg/cache/admissioncheck.go
@@ -20,5 +20,5 @@ type AdmissionCheck struct {
 	Active                       bool
 	Controller                   string
 	SingleInstanceInClusterQueue bool
-	ApplyOnlyToAllFlavors        bool
+	FlavorIndependent            bool
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -211,7 +211,7 @@ func (c *Cache) AddOrUpdateAdmissionCheck(ac *kueue.AdmissionCheck) sets.Set[str
 		Active:                       apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionCheckActive),
 		Controller:                   ac.Spec.ControllerName,
 		SingleInstanceInClusterQueue: apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionChecksSingleInstanceInClusterQueue),
-		ApplyOnlyToAllFlavors:        apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionCheckApplyOnlyToAllFlavors),
+		FlavorIndependent:            apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.FlavorIndependentAdmissionCheck),
 	}
 
 	return c.updateClusterQueues()

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -211,7 +211,7 @@ func (c *Cache) AddOrUpdateAdmissionCheck(ac *kueue.AdmissionCheck) sets.Set[str
 		Active:                       apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionCheckActive),
 		Controller:                   ac.Spec.ControllerName,
 		SingleInstanceInClusterQueue: apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionChecksSingleInstanceInClusterQueue),
-		ApplyToAllFlavors:            apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionCheckApplyToAllFlavors),
+		ApplyOnlyToAllFlavors:        apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionCheckApplyOnlyToAllFlavors),
 	}
 
 	return c.updateClusterQueues()

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -211,6 +211,7 @@ func (c *Cache) AddOrUpdateAdmissionCheck(ac *kueue.AdmissionCheck) sets.Set[str
 		Active:                       apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionCheckActive),
 		Controller:                   ac.Spec.ControllerName,
 		SingleInstanceInClusterQueue: apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionChecksSingleInstanceInClusterQueue),
+		ApplyToAllFlavors:            apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionCheckApplyToAllFlavors),
 	}
 
 	return c.updateClusterQueues()

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -87,7 +87,7 @@ type ClusterQueue struct {
 	hasMissingFlavors                                      bool
 	hasMissingOrInactiveAdmissionChecks                    bool
 	hasMultipleSingleInstanceControllersChecks             bool
-	hasClusterQueueLevelAdmissionCheckAppliedAtFlavorLevel bool
+	hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel bool
 	admittedWorkloadsCount                                 int
 	isStopped                                              bool
 }
@@ -341,7 +341,7 @@ func (c *ClusterQueue) UpdateRGByResource() {
 
 func (c *ClusterQueue) updateQueueStatus() {
 	status := active
-	if c.hasMissingFlavors || c.hasMissingOrInactiveAdmissionChecks || c.isStopped || c.hasMultipleSingleInstanceControllersChecks || c.hasClusterQueueLevelAdmissionCheckAppliedAtFlavorLevel {
+	if c.hasMissingFlavors || c.hasMissingOrInactiveAdmissionChecks || c.isStopped || c.hasMultipleSingleInstanceControllersChecks || c.hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel {
 		status = pending
 	}
 	if c.Status == terminating {
@@ -373,8 +373,8 @@ func (c *ClusterQueue) inactiveReason() (string, string) {
 			reasons = append(reasons, "MultipleSingleInstanceControllerChecks")
 		}
 
-		if c.hasClusterQueueLevelAdmissionCheckAppliedAtFlavorLevel {
-			reasons = append(reasons, "MultiKueueAdmissionCheckAppliedPerFlavor")
+		if c.hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel {
+			reasons = append(reasons, "FlavorIndependentAdmissionCheckAppliedPerFlavor")
 		}
 
 		if len(reasons) == 0 {
@@ -461,8 +461,8 @@ func (c *ClusterQueue) updateWithAdmissionChecks(checks map[string]AdmissionChec
 		update = true
 	}
 
-	if c.hasClusterQueueLevelAdmissionCheckAppliedAtFlavorLevel != hasSpecificChecks {
-		c.hasClusterQueueLevelAdmissionCheckAppliedAtFlavorLevel = hasSpecificChecks
+	if c.hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel != hasSpecificChecks {
+		c.hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel = hasSpecificChecks
 		update = true
 	}
 

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -82,14 +82,14 @@ type ClusterQueue struct {
 
 	AdmittedUsage FlavorResourceQuantities
 	// localQueues by (namespace/name).
-	localQueues                                            map[string]*queue
-	podsReadyTracking                                      bool
-	hasMissingFlavors                                      bool
-	hasMissingOrInactiveAdmissionChecks                    bool
-	hasMultipleSingleInstanceControllersChecks             bool
-	hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel bool
-	admittedWorkloadsCount                                 int
-	isStopped                                              bool
+	localQueues                                        map[string]*queue
+	podsReadyTracking                                  bool
+	hasMissingFlavors                                  bool
+	hasMissingOrInactiveAdmissionChecks                bool
+	hasMultipleSingleInstanceControllersChecks         bool
+	hasFlavorIndependentAdmissionCheckAppliedPerFlavor bool
+	admittedWorkloadsCount                             int
+	isStopped                                          bool
 }
 
 // Cohort is a set of ClusterQueues that can borrow resources from each other.
@@ -341,7 +341,7 @@ func (c *ClusterQueue) UpdateRGByResource() {
 
 func (c *ClusterQueue) updateQueueStatus() {
 	status := active
-	if c.hasMissingFlavors || c.hasMissingOrInactiveAdmissionChecks || c.isStopped || c.hasMultipleSingleInstanceControllersChecks || c.hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel {
+	if c.hasMissingFlavors || c.hasMissingOrInactiveAdmissionChecks || c.isStopped || c.hasMultipleSingleInstanceControllersChecks || c.hasFlavorIndependentAdmissionCheckAppliedPerFlavor {
 		status = pending
 	}
 	if c.Status == terminating {
@@ -373,7 +373,7 @@ func (c *ClusterQueue) inactiveReason() (string, string) {
 			reasons = append(reasons, "MultipleSingleInstanceControllerChecks")
 		}
 
-		if c.hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel {
+		if c.hasFlavorIndependentAdmissionCheckAppliedPerFlavor {
 			reasons = append(reasons, "FlavorIndependentAdmissionCheckAppliedPerFlavor")
 		}
 
@@ -461,8 +461,8 @@ func (c *ClusterQueue) updateWithAdmissionChecks(checks map[string]AdmissionChec
 		update = true
 	}
 
-	if c.hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel != hasSpecificChecks {
-		c.hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel = hasSpecificChecks
+	if c.hasFlavorIndependentAdmissionCheckAppliedPerFlavor != hasSpecificChecks {
+		c.hasFlavorIndependentAdmissionCheckAppliedPerFlavor = hasSpecificChecks
 		update = true
 	}
 

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -87,7 +87,7 @@ type ClusterQueue struct {
 	hasMissingFlavors                          bool
 	hasMissingOrInactiveAdmissionChecks        bool
 	hasMultipleSingleInstanceControllersChecks bool
-	hasSpecificFlavorChecks                    bool
+	hasAllFlavorsChecksAppliedToSpecificFlavor bool
 	admittedWorkloadsCount                     int
 	isStopped                                  bool
 }
@@ -341,7 +341,7 @@ func (c *ClusterQueue) UpdateRGByResource() {
 
 func (c *ClusterQueue) updateQueueStatus() {
 	status := active
-	if c.hasMissingFlavors || c.hasMissingOrInactiveAdmissionChecks || c.isStopped || c.hasMultipleSingleInstanceControllersChecks || c.hasSpecificFlavorChecks {
+	if c.hasMissingFlavors || c.hasMissingOrInactiveAdmissionChecks || c.isStopped || c.hasMultipleSingleInstanceControllersChecks || c.hasAllFlavorsChecksAppliedToSpecificFlavor {
 		status = pending
 	}
 	if c.Status == terminating {
@@ -373,8 +373,8 @@ func (c *ClusterQueue) inactiveReason() (string, string) {
 			reasons = append(reasons, "MultipleSingleInstanceControllerChecks")
 		}
 
-		if c.hasSpecificFlavorChecks {
-			reasons = append(reasons, "ChecksNotApplyToAllFlavors")
+		if c.hasAllFlavorsChecksAppliedToSpecificFlavor {
+			reasons = append(reasons, "AllFlavorsChecksAppliedToSpecificFlavor")
 		}
 
 		if len(reasons) == 0 {
@@ -437,7 +437,7 @@ func (c *ClusterQueue) updateWithAdmissionChecks(checks map[string]AdmissionChec
 			if ac.SingleInstanceInClusterQueue {
 				singleInstanceControllers.Insert(ac.Controller)
 			}
-			if flavors.Len() != 0 && ac.ApplyToAllFlavors {
+			if ac.ApplyOnlyToAllFlavors && flavors.Len() != 0 {
 				hasSpecificChecks = true
 			}
 		}
@@ -461,8 +461,8 @@ func (c *ClusterQueue) updateWithAdmissionChecks(checks map[string]AdmissionChec
 		update = true
 	}
 
-	if c.hasSpecificFlavorChecks != hasSpecificChecks {
-		c.hasSpecificFlavorChecks = hasSpecificChecks
+	if c.hasAllFlavorsChecksAppliedToSpecificFlavor != hasSpecificChecks {
+		c.hasAllFlavorsChecksAppliedToSpecificFlavor = hasSpecificChecks
 		update = true
 	}
 

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -758,11 +758,11 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			if tc.cqStatus == active {
 				cq.hasMultipleSingleInstanceControllersChecks = false
 				cq.hasMissingOrInactiveAdmissionChecks = false
-				cq.hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel = false
+				cq.hasFlavorIndependentAdmissionCheckAppliedPerFlavor = false
 			} else {
 				cq.hasMultipleSingleInstanceControllersChecks = true
 				cq.hasMissingOrInactiveAdmissionChecks = true
-				cq.hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel = true
+				cq.hasFlavorIndependentAdmissionCheckAppliedPerFlavor = true
 			}
 			cq.updateWithAdmissionChecks(tc.admissionChecks)
 

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -659,22 +659,22 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			cqStatus: pending,
 			admissionChecks: map[string]AdmissionCheck{
 				"check1": {
-					Active:            true,
-					Controller:        "controller1",
-					ApplyToAllFlavors: true,
+					Active:                true,
+					Controller:            "controller1",
+					ApplyOnlyToAllFlavors: true,
 				},
 				"check2": {
 					Active:     true,
 					Controller: "controller2",
 				},
 				"check3": {
-					Active:            true,
-					Controller:        "controller3",
-					ApplyToAllFlavors: true,
+					Active:                true,
+					Controller:            "controller3",
+					ApplyOnlyToAllFlavors: true,
 				},
 			},
 			wantStatus: pending,
-			wantReason: "ChecksNotApplyToAllFlavors",
+			wantReason: "AllFlavorsChecksAppliedToSpecificFlavor",
 		},
 		{
 			name:     "Terminating clusterQueue updated with valid AC list",
@@ -768,11 +768,11 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			if tc.cqStatus == active {
 				cq.hasMultipleSingleInstanceControllersChecks = false
 				cq.hasMissingOrInactiveAdmissionChecks = false
-				cq.hasSpecificFlavorChecks = false
+				cq.hasAllFlavorsChecksAppliedToSpecificFlavor = false
 			} else {
 				cq.hasMultipleSingleInstanceControllersChecks = true
 				cq.hasMissingOrInactiveAdmissionChecks = true
-				cq.hasSpecificFlavorChecks = true
+				cq.hasAllFlavorsChecksAppliedToSpecificFlavor = true
 			}
 			cq.updateWithAdmissionChecks(tc.admissionChecks)
 

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -653,7 +653,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			wantReason: "MultipleSingleInstanceControllerChecks",
 		},
 		{
-			name:     "Active clusterQueue with an AC per ResourceFlavor",
+			name:     "Active clusterQueue with a FlavorIndependent AC applied per ResourceFlavor",
 			cq:       cqWithACPerFlavor,
 			cqStatus: pending,
 			admissionChecks: map[string]AdmissionCheck{
@@ -664,7 +664,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 				},
 			},
 			wantStatus: pending,
-			wantReason: "MultiKueueAdmissionCheckAppliedPerFlavor",
+			wantReason: "FlavorIndependentAdmissionCheckAppliedPerFlavor",
 		},
 		{
 			name:     "Terminating clusterQueue updated with valid AC list",
@@ -758,11 +758,11 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			if tc.cqStatus == active {
 				cq.hasMultipleSingleInstanceControllersChecks = false
 				cq.hasMissingOrInactiveAdmissionChecks = false
-				cq.hasClusterQueueLevelAdmissionCheckAppliedAtFlavorLevel = false
+				cq.hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel = false
 			} else {
 				cq.hasMultipleSingleInstanceControllersChecks = true
 				cq.hasMissingOrInactiveAdmissionChecks = true
-				cq.hasClusterQueueLevelAdmissionCheckAppliedAtFlavorLevel = true
+				cq.hasFlavorIndependentAdmissionCheckAppliedAtFlavorLevel = true
 			}
 			cq.updateWithAdmissionChecks(tc.admissionChecks)
 

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -659,22 +659,22 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			cqStatus: pending,
 			admissionChecks: map[string]AdmissionCheck{
 				"check1": {
-					Active:                true,
-					Controller:            "controller1",
-					ApplyOnlyToAllFlavors: true,
+					Active:            true,
+					Controller:        "controller1",
+					FlavorIndependent: true,
 				},
 				"check2": {
 					Active:     true,
 					Controller: "controller2",
 				},
 				"check3": {
-					Active:                true,
-					Controller:            "controller3",
-					ApplyOnlyToAllFlavors: true,
+					Active:            true,
+					Controller:        "controller3",
+					FlavorIndependent: true,
 				},
 			},
 			wantStatus: pending,
-			wantReason: "AllFlavorsChecksAppliedToSpecificFlavor",
+			wantReason: "MultiKueueAdmissionCheckAppliedPerFlavor",
 		},
 		{
 			name:     "Terminating clusterQueue updated with valid AC list",
@@ -768,11 +768,11 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			if tc.cqStatus == active {
 				cq.hasMultipleSingleInstanceControllersChecks = false
 				cq.hasMissingOrInactiveAdmissionChecks = false
-				cq.hasAllFlavorsChecksAppliedToSpecificFlavor = false
+				cq.hasClusterQueueLevelAdmissionCheckAppliedAtFlavorLevel = false
 			} else {
 				cq.hasMultipleSingleInstanceControllersChecks = true
 				cq.hasMissingOrInactiveAdmissionChecks = true
-				cq.hasAllFlavorsChecksAppliedToSpecificFlavor = true
+				cq.hasClusterQueueLevelAdmissionCheckAppliedAtFlavorLevel = true
 			}
 			cq.updateWithAdmissionChecks(tc.admissionChecks)
 

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -476,9 +476,8 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 
 	cqWithACPerFlavor := utiltesting.MakeClusterQueue("cq3").
 		AdmissionCheckStrategy(
-			*utiltesting.MakeAdmissionCheckStrategyRule("check1", "flavor1").Obj(),
-			*utiltesting.MakeAdmissionCheckStrategyRule("check2", "flavor2").Obj(),
-			*utiltesting.MakeAdmissionCheckStrategyRule("check3", "flavor3").Obj()).
+			*utiltesting.MakeAdmissionCheckStrategyRule("check1", "flavor1", "flavor2", "flavor3").Obj(),
+		).
 		Obj()
 
 	testcases := []struct {
@@ -661,15 +660,6 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 				"check1": {
 					Active:            true,
 					Controller:        "controller1",
-					FlavorIndependent: true,
-				},
-				"check2": {
-					Active:     true,
-					Controller: "controller2",
-				},
-				"check3": {
-					Active:            true,
-					Controller:        "controller3",
 					FlavorIndependent: true,
 				},
 			},

--- a/pkg/controller/admissionchecks/multikueue/admissioncheck.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck.go
@@ -142,9 +142,9 @@ func (a *ACReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		needsUpdate = true
 	}
 
-	if !apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionCheckApplyToAllFlavors) {
+	if !apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionCheckApplyOnlyToAllFlavors) {
 		apimeta.SetStatusCondition(&ac.Status.Conditions, metav1.Condition{
-			Type:               kueue.AdmissionCheckApplyToAllFlavors,
+			Type:               kueue.AdmissionCheckApplyOnlyToAllFlavors,
 			Status:             metav1.ConditionTrue,
 			Reason:             AllFlavorsCheckReason,
 			Message:            AllFlavorsCheckMessage,

--- a/pkg/controller/admissionchecks/multikueue/admissioncheck.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck.go
@@ -39,11 +39,11 @@ import (
 )
 
 const (
-	ControllerName         = "kueue.x-k8s.io/multikueue"
-	SingleInstanceReason   = "MultiKueue"
-	SingleInstanceMessage  = "only one multikueue managed admission check can be used in one ClusterQueue"
-	AllFlavorsCheckReason  = "MultiKueue"
-	AllFlavorsCheckMessage = "admission check should be applied to all flavors"
+	ControllerName                = "kueue.x-k8s.io/multikueue"
+	SingleInstanceReason          = "MultiKueue"
+	SingleInstanceMessage         = "only one multikueue managed admission check can be used in one ClusterQueue"
+	FlavorIndependentCheckReason  = "MultiKueue"
+	FlavorIndependentCheckMessage = "admission check cannot be applied at ResourceFlavor level"
 )
 
 type multiKueueStoreHelper = admissioncheck.ConfigHelper[*kueuealpha.MultiKueueConfig, kueuealpha.MultiKueueConfig]
@@ -142,12 +142,12 @@ func (a *ACReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		needsUpdate = true
 	}
 
-	if !apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionCheckApplyOnlyToAllFlavors) {
+	if !apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.FlavorIndependentAdmissionCheck) {
 		apimeta.SetStatusCondition(&ac.Status.Conditions, metav1.Condition{
-			Type:               kueue.AdmissionCheckApplyOnlyToAllFlavors,
+			Type:               kueue.FlavorIndependentAdmissionCheck,
 			Status:             metav1.ConditionTrue,
-			Reason:             AllFlavorsCheckReason,
-			Message:            AllFlavorsCheckMessage,
+			Reason:             FlavorIndependentCheckReason,
+			Message:            FlavorIndependentCheckMessage,
 			ObservedGeneration: ac.Generation,
 		})
 		needsUpdate = true

--- a/pkg/controller/admissionchecks/multikueue/admissioncheck.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck.go
@@ -39,9 +39,11 @@ import (
 )
 
 const (
-	ControllerName        = "kueue.x-k8s.io/multikueue"
-	SingleInstanceReason  = "MultiKueue"
-	SingleInstanceMessage = "only one multikueue managed admission check can be used in one ClusterQueue"
+	ControllerName         = "kueue.x-k8s.io/multikueue"
+	SingleInstanceReason   = "MultiKueue"
+	SingleInstanceMessage  = "only one multikueue managed admission check can be used in one ClusterQueue"
+	AllFlavorsCheckReason  = "MultiKueue"
+	AllFlavorsCheckMessage = "admission check should be applied to all flavors"
 )
 
 type multiKueueStoreHelper = admissioncheck.ConfigHelper[*kueuealpha.MultiKueueConfig, kueuealpha.MultiKueueConfig]
@@ -135,6 +137,17 @@ func (a *ACReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 			Status:             metav1.ConditionTrue,
 			Reason:             SingleInstanceReason,
 			Message:            SingleInstanceMessage,
+			ObservedGeneration: ac.Generation,
+		})
+		needsUpdate = true
+	}
+
+	if !apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionCheckApplyToAllFlavors) {
+		apimeta.SetStatusCondition(&ac.Status.Conditions, metav1.Condition{
+			Type:               kueue.AdmissionCheckApplyToAllFlavors,
+			Status:             metav1.ConditionTrue,
+			Reason:             AllFlavorsCheckReason,
+			Message:            AllFlavorsCheckMessage,
 			ObservedGeneration: ac.Generation,
 		})
 		needsUpdate = true

--- a/pkg/controller/admissionchecks/multikueue/admissioncheck_test.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck_test.go
@@ -57,7 +57,7 @@ func TestReconcile(t *testing.T) {
 					ControllerName(ControllerName).
 					Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "config1").
 					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
-					ApplyToAllFlavors(true, AllFlavorsCheckReason, AllFlavorsCheckMessage, 1).
+					ApplyToAllFlavors(true, FlavorIndependentCheckReason, FlavorIndependentCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionFalse,
@@ -98,7 +98,7 @@ func TestReconcile(t *testing.T) {
 					ControllerName(ControllerName).
 					Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "config1").
 					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
-					ApplyToAllFlavors(true, AllFlavorsCheckReason, AllFlavorsCheckMessage, 1).
+					ApplyToAllFlavors(true, FlavorIndependentCheckReason, FlavorIndependentCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionFalse,
@@ -131,7 +131,7 @@ func TestReconcile(t *testing.T) {
 					ControllerName(ControllerName).
 					Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "config1").
 					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
-					ApplyToAllFlavors(true, AllFlavorsCheckReason, AllFlavorsCheckMessage, 1).
+					ApplyToAllFlavors(true, FlavorIndependentCheckReason, FlavorIndependentCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionFalse,
@@ -167,7 +167,7 @@ func TestReconcile(t *testing.T) {
 					ControllerName(ControllerName).
 					Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "config1").
 					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
-					ApplyToAllFlavors(true, AllFlavorsCheckReason, AllFlavorsCheckMessage, 1).
+					ApplyToAllFlavors(true, FlavorIndependentCheckReason, FlavorIndependentCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionFalse,
@@ -203,7 +203,7 @@ func TestReconcile(t *testing.T) {
 					ControllerName(ControllerName).
 					Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "config1").
 					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
-					ApplyToAllFlavors(true, AllFlavorsCheckReason, AllFlavorsCheckMessage, 1).
+					ApplyToAllFlavors(true, FlavorIndependentCheckReason, FlavorIndependentCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionTrue,
@@ -236,7 +236,7 @@ func TestReconcile(t *testing.T) {
 					ControllerName(ControllerName).
 					Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "config1").
 					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
-					ApplyToAllFlavors(true, AllFlavorsCheckReason, AllFlavorsCheckMessage, 1).
+					ApplyToAllFlavors(true, FlavorIndependentCheckReason, FlavorIndependentCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionTrue,

--- a/pkg/controller/admissionchecks/multikueue/admissioncheck_test.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck_test.go
@@ -57,6 +57,7 @@ func TestReconcile(t *testing.T) {
 					ControllerName(ControllerName).
 					Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "config1").
 					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
+					ApplyToAllFlavors(true, AllFlavorsCheckReason, AllFlavorsCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionFalse,
@@ -97,6 +98,7 @@ func TestReconcile(t *testing.T) {
 					ControllerName(ControllerName).
 					Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "config1").
 					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
+					ApplyToAllFlavors(true, AllFlavorsCheckReason, AllFlavorsCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionFalse,
@@ -129,6 +131,7 @@ func TestReconcile(t *testing.T) {
 					ControllerName(ControllerName).
 					Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "config1").
 					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
+					ApplyToAllFlavors(true, AllFlavorsCheckReason, AllFlavorsCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionFalse,
@@ -164,6 +167,7 @@ func TestReconcile(t *testing.T) {
 					ControllerName(ControllerName).
 					Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "config1").
 					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
+					ApplyToAllFlavors(true, AllFlavorsCheckReason, AllFlavorsCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionFalse,
@@ -199,6 +203,7 @@ func TestReconcile(t *testing.T) {
 					ControllerName(ControllerName).
 					Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "config1").
 					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
+					ApplyToAllFlavors(true, AllFlavorsCheckReason, AllFlavorsCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionTrue,
@@ -231,6 +236,7 @@ func TestReconcile(t *testing.T) {
 					ControllerName(ControllerName).
 					Parameters(kueuealpha.GroupVersion.Group, "MultiKueueConfig", "config1").
 					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
+					ApplyToAllFlavors(true, AllFlavorsCheckReason, AllFlavorsCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionTrue,

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -918,6 +918,22 @@ func (ac *AdmissionCheckWrapper) SingleInstanceInClusterQueue(singleInstance boo
 	return ac
 }
 
+func (ac *AdmissionCheckWrapper) ApplyToAllFlavors(applyToAllFlavors bool, reason, message string, observedGeneration int64) *AdmissionCheckWrapper {
+	cond := metav1.Condition{
+		Type:               kueue.AdmissionCheckApplyToAllFlavors,
+		Status:             metav1.ConditionTrue,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: observedGeneration,
+	}
+	if !applyToAllFlavors {
+		cond.Status = metav1.ConditionFalse
+	}
+
+	apimeta.SetStatusCondition(&ac.Status.Conditions, cond)
+	return ac
+}
+
 func (ac *AdmissionCheckWrapper) Obj() *kueue.AdmissionCheck {
 	return &ac.AdmissionCheck
 }

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -920,7 +920,7 @@ func (ac *AdmissionCheckWrapper) SingleInstanceInClusterQueue(singleInstance boo
 
 func (ac *AdmissionCheckWrapper) ApplyToAllFlavors(applyToAllFlavors bool, reason, message string, observedGeneration int64) *AdmissionCheckWrapper {
 	cond := metav1.Condition{
-		Type:               kueue.AdmissionCheckApplyToAllFlavors,
+		Type:               kueue.AdmissionCheckApplyOnlyToAllFlavors,
 		Status:             metav1.ConditionTrue,
 		Reason:             reason,
 		Message:            message,

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -920,7 +920,7 @@ func (ac *AdmissionCheckWrapper) SingleInstanceInClusterQueue(singleInstance boo
 
 func (ac *AdmissionCheckWrapper) ApplyToAllFlavors(applyToAllFlavors bool, reason, message string, observedGeneration int64) *AdmissionCheckWrapper {
 	cond := metav1.Condition{
-		Type:               kueue.AdmissionCheckApplyOnlyToAllFlavors,
+		Type:               kueue.FlavorIndependentAdmissionCheck,
 		Status:             metav1.ConditionTrue,
 		Reason:             reason,
 		Message:            message,

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -200,10 +200,10 @@ var _ = ginkgo.Describe("Multikueue", func() {
 							Message: multikueue.SingleInstanceMessage,
 						}, util.IgnoreConditionTimestampsAndObservedGeneration),
 						gomega.BeComparableTo(metav1.Condition{
-							Type:    kueue.AdmissionCheckApplyOnlyToAllFlavors,
+							Type:    kueue.FlavorIndependentAdmissionCheck,
 							Status:  metav1.ConditionTrue,
-							Reason:  multikueue.AllFlavorsCheckReason,
-							Message: multikueue.AllFlavorsCheckMessage,
+							Reason:  multikueue.FlavorIndependentCheckReason,
+							Message: multikueue.FlavorIndependentCheckMessage,
 						}, util.IgnoreConditionTimestampsAndObservedGeneration),
 					))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -199,6 +199,12 @@ var _ = ginkgo.Describe("Multikueue", func() {
 							Reason:  multikueue.SingleInstanceReason,
 							Message: multikueue.SingleInstanceMessage,
 						}, util.IgnoreConditionTimestampsAndObservedGeneration),
+						gomega.BeComparableTo(metav1.Condition{
+							Type:    kueue.AdmissionCheckApplyToAllFlavors,
+							Status:  metav1.ConditionTrue,
+							Reason:  multikueue.AllFlavorsCheckReason,
+							Message: multikueue.AllFlavorsCheckMessage,
+						}, util.IgnoreConditionTimestampsAndObservedGeneration),
 					))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -200,7 +200,7 @@ var _ = ginkgo.Describe("Multikueue", func() {
 							Message: multikueue.SingleInstanceMessage,
 						}, util.IgnoreConditionTimestampsAndObservedGeneration),
 						gomega.BeComparableTo(metav1.Condition{
-							Type:    kueue.AdmissionCheckApplyToAllFlavors,
+							Type:    kueue.AdmissionCheckApplyOnlyToAllFlavors,
 							Status:  metav1.ConditionTrue,
 							Reason:  multikueue.AllFlavorsCheckReason,
 							Message: multikueue.AllFlavorsCheckMessage,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

- Allow to validate if a MultiKueue admission check is configured only for a subset of flavors.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2021

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```