### PR TITLE
[MultiKueue] Default managedBy for ClusterQueues configured to use MultiKueue AC

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -270,6 +270,8 @@ func setupControllers(mgr ctrl.Manager, cCache *cache.Cache, queues *queue.Manag
 		jobframework.WithEnabledExternalFrameworks(cfg.Integrations.ExternalFrameworks),
 		jobframework.WithManagerName(constants.KueueName),
 		jobframework.WithLabelKeysToCopy(cfg.Integrations.LabelKeysToCopy),
+		jobframework.WithCache(cCache),
+		jobframework.WithQueues(queues),
 	}
 	if err := jobframework.SetupControllers(mgr, setupLog, opts...); err != nil {
 		setupLog.Error(err, "Unable to create controller or webhook", "kubernetesVersion", serverVersionFetcher.GetServerVersion())

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -388,13 +388,6 @@ func (c *Cache) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 	metrics.ClearCacheMetrics(cq.Name)
 }
 
-func (c *Cache) ClusterQueue(name string) (*ClusterQueue, bool) {
-	c.RLock()
-	defer c.RUnlock()
-	cq, ok := c.clusterQueues[name]
-	return cq, ok
-}
-
 func (c *Cache) AddLocalQueue(q *kueue.LocalQueue) error {
 	c.Lock()
 	defer c.Unlock()

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -224,6 +224,13 @@ func (c *Cache) DeleteAdmissionCheck(ac *kueue.AdmissionCheck) sets.Set[string] 
 	return c.updateClusterQueues()
 }
 
+func (c *Cache) GetAdmissionCheck(name string) (AdmissionCheck, bool) {
+	c.RLock()
+	defer c.RUnlock()
+	ac, ok := c.admissionChecks[name]
+	return ac, ok
+}
+
 func (c *Cache) ClusterQueueActive(name string) bool {
 	return c.clusterQueueInStatus(name, active)
 }
@@ -370,6 +377,13 @@ func (c *Cache) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 	c.deleteClusterQueueFromCohort(cqImpl)
 	delete(c.clusterQueues, cq.Name)
 	metrics.ClearCacheMetrics(cq.Name)
+}
+
+func (c *Cache) GetClusterQueue(name string) (*ClusterQueue, bool) {
+	c.RLock()
+	defer c.RUnlock()
+	cq, ok := c.clusterQueues[name]
+	return cq, ok
 }
 
 func (c *Cache) AddLocalQueue(q *kueue.LocalQueue) error {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -224,11 +224,20 @@ func (c *Cache) DeleteAdmissionCheck(ac *kueue.AdmissionCheck) sets.Set[string] 
 	return c.updateClusterQueues()
 }
 
-func (c *Cache) GetAdmissionCheck(name string) (AdmissionCheck, bool) {
+func (c *Cache) AdmissionChecksForClusterQueue(cqName string) []AdmissionCheck {
 	c.RLock()
 	defer c.RUnlock()
-	ac, ok := c.admissionChecks[name]
-	return ac, ok
+	cq, ok := c.clusterQueues[cqName]
+	if !ok || len(cq.AdmissionChecks) == 0 {
+		return nil
+	}
+	acs := make([]AdmissionCheck, 0, len(cq.AdmissionChecks))
+	for acName := range cq.AdmissionChecks {
+		if ac, ok := c.admissionChecks[acName]; ok {
+			acs = append(acs, ac)
+		}
+	}
+	return acs
 }
 
 func (c *Cache) ClusterQueueActive(name string) bool {
@@ -379,7 +388,7 @@ func (c *Cache) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 	metrics.ClearCacheMetrics(cq.Name)
 }
 
-func (c *Cache) GetClusterQueue(name string) (*ClusterQueue, bool) {
+func (c *Cache) ClusterQueue(name string) (*ClusterQueue, bool) {
 	c.RLock()
 	defer c.RUnlock()
 	cq, ok := c.clusterQueues[name]

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -34,11 +34,13 @@ import (
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/podset"
+	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	"sigs.k8s.io/kueue/pkg/util/equality"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
@@ -78,6 +80,8 @@ type Options struct {
 	EnabledExternalFrameworks sets.Set[string]
 	ManagerName               string
 	LabelKeysToCopy           []string
+	Queues                    *queue.Manager
+	Cache                     *cache.Cache
 }
 
 // Option configures the reconciler.
@@ -156,6 +160,20 @@ func WithManagerName(n string) Option {
 func WithLabelKeysToCopy(n []string) Option {
 	return func(o *Options) {
 		o.LabelKeysToCopy = n
+	}
+}
+
+// WithQueues adds the queue manager.
+func WithQueues(q *queue.Manager) Option {
+	return func(o *Options) {
+		o.Queues = q
+	}
+}
+
+// WithCache adds the cache manager.
+func WithCache(c *cache.Cache) Option {
+	return func(o *Options) {
+		o.Cache = c
 	}
 }
 

--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -77,15 +77,7 @@ func (w *JobSetWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		if err != nil {
 			return err
 		}
-		clusterQueue, found := w.cache.GetClusterQueue(clusterQueueName)
-		if !found {
-			return nil
-		}
-		for admissionCheckName := range clusterQueue.AdmissionChecks {
-			admissionCheck, ok := w.cache.GetAdmissionCheck(admissionCheckName)
-			if !ok {
-				continue
-			}
+		for _, admissionCheck := range w.cache.AdmissionChecksForClusterQueue(clusterQueueName) {
 			if admissionCheck.Controller == multikueue.ControllerName {
 				log.V(5).Info("Defaulting ManagedBy", "jobset", klog.KObj(jobSet), "oldManagedBy", jobSet.Spec.ManagedBy, "managedBy", multikueue.ControllerName)
 				jobSet.Spec.ManagedBy = ptr.To(multikueue.ControllerName)

--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -81,7 +81,7 @@ func (w *JobSetWebhook) Default(ctx context.Context, obj runtime.Object) error {
 			if admissionCheck.Controller == multikueue.ControllerName {
 				log.V(5).Info("Defaulting ManagedBy", "jobset", klog.KObj(jobSet), "oldManagedBy", jobSet.Spec.ManagedBy, "managedBy", multikueue.ControllerName)
 				jobSet.Spec.ManagedBy = ptr.To(multikueue.ControllerName)
-				break
+				return nil
 			}
 		}
 	}

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -263,6 +263,28 @@ func TestDefault(t *testing.T) {
 			multiKueueEnabled: true,
 			wantManagedBy:     ptr.To("example.com/foo"),
 		},
+		{
+			name: "TestDefault_ClusterQueueWithoutAdmissionCheck",
+			jobSet: &jobset.JobSet{
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels: map[string]string{
+						constants.QueueLabel: "local-queue",
+					},
+					Namespace: "default",
+				},
+			},
+			queues: []kueue.LocalQueue{
+				*utiltesting.MakeLocalQueue("local-queue", "default").
+					ClusterQueue("cluster-queue").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("cluster-queue").
+					Obj(),
+			},
+			multiKueueEnabled: true,
+			wantManagedBy:     nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -122,7 +122,7 @@ func TestDefault(t *testing.T) {
 				Active(metav1.ConditionTrue).
 				Obj(),
 			multiKueueEnabled: true,
-			wantManagedBy:     ptr.To(jobset.JobSetControllerName),
+			wantManagedBy:     ptr.To(multikueue.ControllerName),
 		},
 		{
 			name: "TestDefault_WithQueueLabel",
@@ -232,6 +232,36 @@ func TestDefault(t *testing.T) {
 				Obj(),
 			multiKueueEnabled: false,
 			wantManagedBy:     nil,
+		},
+		{
+			name: "TestDefault_UserSpecifiedManagedBy",
+			jobSet: &jobset.JobSet{
+				Spec: jobset.JobSetSpec{
+					ManagedBy: ptr.To("example.com/foo"),
+				},
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels: map[string]string{
+						constants.QueueLabel: "local-queue",
+					},
+					Namespace: "default",
+				},
+			},
+			queues: []kueue.LocalQueue{
+				*utiltesting.MakeLocalQueue("local-queue", "default").
+					ClusterQueue("cluster-queue").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("cluster-queue").
+					AdmissionChecks("admission-check").
+					Obj(),
+			},
+			admissionCheck: utiltesting.MakeAdmissionCheck("admission-check").
+				ControllerName(multikueue.ControllerName).
+				Active(metav1.ConditionTrue).
+				Obj(),
+			multiKueueEnabled: true,
+			wantManagedBy:     ptr.To("example.com/foo"),
 		},
 	}
 

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -18,13 +18,23 @@ package jobset
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/controller/admissionchecks/multikueue"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/queue"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingutil "sigs.k8s.io/kueue/pkg/util/testingjobs/jobset"
 )
 
@@ -67,6 +77,182 @@ func TestValidateCreate(t *testing.T) {
 
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("validateCreate() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDefault(t *testing.T) {
+	testCases := []struct {
+		name              string
+		jobSet            *jobset.JobSet
+		queues            []kueue.LocalQueue
+		clusterQueues     []kueue.ClusterQueue
+		admissionCheck    *kueue.AdmissionCheck
+		multiKueueEnabled bool
+		expectedManagedBy string
+		expectedError     error
+	}{
+		{
+			name: "TestDefault_WithQueueLabel",
+			jobSet: &jobset.JobSet{
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels: map[string]string{
+						constants.QueueLabel: "local-queue",
+					},
+					Namespace: "default",
+				},
+			},
+			queues: []kueue.LocalQueue{
+				*utiltesting.MakeLocalQueue("local-queue", "default").
+					ClusterQueue("cluster-queue").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("cluster-queue").
+					AdmissionChecks("admission-check").
+					Obj(),
+			},
+			admissionCheck: utiltesting.MakeAdmissionCheck("admission-check").
+				ControllerName(multikueue.ControllerName).
+				Active(metav1.ConditionTrue).
+				Obj(),
+			multiKueueEnabled: true,
+			expectedManagedBy: multikueue.ControllerName,
+		},
+		{
+			name: "TestDefault_WithoutQueueLabel",
+			jobSet: &jobset.JobSet{
+				ObjectMeta: ctrl.ObjectMeta{Namespace: "default"},
+			},
+			multiKueueEnabled: true,
+			expectedManagedBy: "",
+		},
+		{
+			name: "TestDefault_InvalidQueueName",
+			jobSet: &jobset.JobSet{
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels:    map[string]string{constants.QueueLabel: "invalid-queue"},
+					Namespace: "default",
+				},
+			},
+			multiKueueEnabled: true,
+			expectedError:     errors.New("queue doesn't exist"),
+		},
+		{
+			name: "TestDefault_QueueNotFound",
+			jobSet: &jobset.JobSet{
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels: map[string]string{
+						constants.QueueLabel: "non-existent-queue",
+					},
+					Namespace: "default",
+				},
+			},
+			multiKueueEnabled: true,
+			expectedError:     errors.New("queue doesn't exist"),
+		},
+		{
+			name: "TestDefault_AdmissionCheckNotFound",
+			jobSet: &jobset.JobSet{
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels: map[string]string{
+						constants.QueueLabel: "local-queue",
+					},
+					Namespace: "default",
+				},
+			},
+			queues: []kueue.LocalQueue{
+				*utiltesting.MakeLocalQueue("local-queue", "default").
+					ClusterQueue("cluster-queue").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("cluster-queue").
+					AdmissionChecks("non-existent-admission-check").
+					Obj(),
+			},
+			multiKueueEnabled: true,
+			expectedManagedBy: "",
+		},
+		{
+			name: "TestDefault_MultiKueueFeatureDisabled",
+			jobSet: &jobset.JobSet{
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels: map[string]string{
+						constants.QueueLabel: "local-queue",
+					},
+					Namespace: "default",
+				},
+			},
+			queues: []kueue.LocalQueue{
+				*utiltesting.MakeLocalQueue("local-queue", "default").
+					ClusterQueue("cluster-queue").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("cluster-queue").
+					AdmissionChecks("admission-check").
+					Obj(),
+			},
+			admissionCheck: utiltesting.MakeAdmissionCheck("admission-check").
+				ControllerName(multikueue.ControllerName).
+				Active(metav1.ConditionTrue).
+				Obj(),
+			multiKueueEnabled: false,
+			expectedManagedBy: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)()
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+
+			clientBuilder := utiltesting.NewClientBuilder().
+				WithObjects(
+					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+				)
+			cl := clientBuilder.Build()
+			cqCache := cache.New(cl)
+			queueManager := queue.NewManager(cl, cqCache)
+
+			for _, q := range tc.queues {
+				if err := queueManager.AddLocalQueue(ctx, &q); err != nil {
+					t.Fatalf("Inserting queue %s/%s in manager: %v", q.Namespace, q.Name, err)
+				}
+			}
+			for _, cq := range tc.clusterQueues {
+				if err := cqCache.AddClusterQueue(ctx, &cq); err != nil {
+					t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
+				}
+				if tc.admissionCheck != nil {
+					cqCache.AddOrUpdateAdmissionCheck(tc.admissionCheck)
+					if err := queueManager.AddClusterQueue(ctx, &cq); err != nil {
+						t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
+					}
+				}
+			}
+			webhook := &JobSetWebhook{
+				manageJobsWithoutQueueName: false,
+				queues:                     queueManager,
+				cache:                      cqCache,
+			}
+
+			err := webhook.Default(ctx, tc.jobSet)
+			if err != nil && tc.expectedError == nil {
+				t.Errorf("Unexpected error: %v", err)
+			} else if err == nil && tc.expectedError != nil {
+				t.Errorf("Expected error %v, but got nil", tc.expectedError)
+			} else if err != nil && err.Error() != tc.expectedError.Error() {
+				t.Errorf("Expected error %v, but got %v", tc.expectedError, err)
+			}
+
+			if tc.jobSet.Spec.ManagedBy == nil && tc.expectedManagedBy != "" {
+				t.Errorf("Expected jobSet.Spec.ManagedBy to be %s, but got nil", tc.expectedManagedBy)
+			} else if tc.jobSet.Spec.ManagedBy != nil && *tc.jobSet.Spec.ManagedBy != tc.expectedManagedBy {
+				t.Errorf("Expected jobSet.Spec.ManagedBy to be %s, but got %v", tc.expectedManagedBy, *tc.jobSet.Spec.ManagedBy)
 			}
 		})
 	}

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -36,7 +36,7 @@ import (
 )
 
 var (
-	errQueueDoesNotExist         = errors.New("queue doesn't exist")
+	ErrQueueDoesNotExist         = errors.New("queue doesn't exist")
 	errClusterQueueDoesNotExist  = errors.New("clusterQueue doesn't exist")
 	errClusterQueueAlreadyExists = errors.New("clusterQueue already exists")
 )
@@ -218,7 +218,7 @@ func (m *Manager) UpdateLocalQueue(q *kueue.LocalQueue) error {
 	defer m.Unlock()
 	qImpl, ok := m.localQueues[Key(q)]
 	if !ok {
-		return errQueueDoesNotExist
+		return ErrQueueDoesNotExist
 	}
 	if qImpl.ClusterQueue != string(q.Spec.ClusterQueue) {
 		oldCQ := m.clusterQueues[qImpl.ClusterQueue]
@@ -255,7 +255,7 @@ func (m *Manager) PendingWorkloads(q *kueue.LocalQueue) (int32, error) {
 
 	qImpl, ok := m.localQueues[Key(q)]
 	if !ok {
-		return 0, errQueueDoesNotExist
+		return 0, ErrQueueDoesNotExist
 	}
 
 	return int32(len(qImpl.items)), nil
@@ -569,13 +569,17 @@ func (m *Manager) PendingWorkloadsInfo(cqName string) []*workload.Info {
 }
 
 // ClusterQueueFromLocalQueue returns ClusterQueue name, with a QueueKey(namespace/localQueueName) as the parameter
-func (m *Manager) ClusterQueueFromLocalQueue(lqName string) (string, error) {
+func (m *Manager) ClusterQueueFromLocalQueue(localQueueKey string) (string, error) {
 	m.RLock()
 	defer m.RUnlock()
-	if lq, ok := m.localQueues[lqName]; ok {
+	if lq, ok := m.localQueues[localQueueKey]; ok {
 		return lq.ClusterQueue, nil
 	}
-	return "", errQueueDoesNotExist
+	return "", ErrQueueDoesNotExist
+}
+
+func QueueKey(namespace, name string) string {
+	return fmt.Sprintf("%s/%s", namespace, name)
 }
 
 // UpdateSnapshot computes the new snapshot and replaces if it differs from the

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -481,7 +481,7 @@ func TestStatus(t *testing.T) {
 		"fake": {
 			queue:      &kueue.LocalQueue{ObjectMeta: metav1.ObjectMeta{Name: "fake"}},
 			wantStatus: 0,
-			wantErr:    errQueueDoesNotExist,
+			wantErr:    ErrQueueDoesNotExist,
 		},
 	}
 	for name, tc := range cases {

--- a/pkg/visibility/api/rest/pending_workloads_lq.go
+++ b/pkg/visibility/api/rest/pending_workloads_lq.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	v1alpha1 "sigs.k8s.io/kueue/apis/visibility/v1alpha1"
+	"sigs.k8s.io/kueue/apis/visibility/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/queue"
 
@@ -67,7 +67,7 @@ func (m *pendingWorkloadsInLqREST) Get(ctx context.Context, name string, opts ru
 	offset := pendingWorkloadOpts.Offset
 
 	namespace := genericapirequest.NamespaceValue(ctx)
-	cqName, err := m.queueMgr.ClusterQueueFromLocalQueue(fmt.Sprintf("%s/%s", namespace, name))
+	cqName, err := m.queueMgr.ClusterQueueFromLocalQueue(queue.QueueKey(namespace, name))
 	if err != nil {
 		return nil, errors.NewNotFound(v1alpha1.Resource("localqueue"), name)
 	}

--- a/site/content/en/docs/tasks/run/jobsets.md
+++ b/site/content/en/docs/tasks/run/jobsets.md
@@ -126,7 +126,8 @@ spec:
 
 {{% alert title="Note" color="note" %}}
 The same `jobset-sample.yaml` file from [single cluster environment](#single-cluster-environment) can be used in a [MultiKueue environment](#multikueue-environment).
-The `spec.managedBy` field will be set to `kueue.x-k8s.io/multikueue` automatically, if not specified.
+The `spec.managedBy` field will be set to `kueue.x-k8s.io/multikueue` automatically, if not specified, as long as  the `kueue.x-k8s.io/queue-name` annotation
+is specified and the corresponding Cluster Queue uses the Multi Kueue admission check.
 {{% /alert %}}
 
 You can run this JobSet with the following commands:

--- a/site/content/en/docs/tasks/run/jobsets.md
+++ b/site/content/en/docs/tasks/run/jobsets.md
@@ -70,8 +70,6 @@ The first [PriorityClassName](https://kubernetes.io/docs/concepts/scheduling-evi
 
 The JobSet looks like the following:
 
-### Single Cluster Environment
-
 ```yaml
 # jobset-sample.yaml
 apiVersion: jobset.x-k8s.io/v1alpha2
@@ -126,10 +124,10 @@ spec:
                     - 100s
 ```
 
-### MultiKueue Environment
-
+{{% alert title="Note" color="note" %}}
 The same `jobset-sample.yaml` file from [single cluster environment](#single-cluster-environment) can be used in a [MultiKueue environment](#multikueue-environment).
 The `spec.managedBy` field will be set to `kueue.x-k8s.io/multikueue` automatically, if not specified.
+{{% /alert %}}
 
 You can run this JobSet with the following commands:
 

--- a/site/content/en/docs/tasks/run/jobsets.md
+++ b/site/content/en/docs/tasks/run/jobsets.md
@@ -128,60 +128,8 @@ spec:
 
 ### MultiKueue Environment
 
-```yaml
-# jobset-sample.yaml
-apiVersion: jobset.x-k8s.io/v1alpha2
-kind: JobSet
-metadata:
-  generateName: sleep-job-
-  labels:
-    kueue.x-k8s.io/queue-name: user-queue
-spec:
-  network:
-    enableDNSHostnames: false
-    subdomain: some-subdomain
-  replicatedJobs:
-    - name: workers
-      replicas: 2
-      template:
-        spec:
-          parallelism: 4
-          completions: 4
-          backoffLimit: 0
-          template:
-            spec:
-              containers:
-                - name: sleep
-                  image: busybox
-                  resources:
-                    requests:
-                      cpu: 1
-                      memory: "200Mi"
-                  command:
-                    - sleep
-                  args:
-                    - 100s
-    - name: driver
-      template:
-        spec:
-          parallelism: 1
-          completions: 1
-          backoffLimit: 0
-          template:
-            spec:
-              containers:
-                - name: sleep
-                  image: busybox
-                  resources:
-                    requests:
-                      cpu: 2
-                      memory: "200Mi"
-                  command:
-                    - sleep
-                  args:
-                    - 100s
-  managedBy: kueue.x-k8s.io/multikueue
-```
+The same `jobset-sample.yaml` file from [single cluster environment](#single-cluster-environment) can be used in a [MultiKueue environment](#multikueue-environment).
+The `spec.managedBy` field will be set to `kueue.x-k8s.io/multikueue` automatically, if not specified.
 
 You can run this JobSet with the following commands:
 

--- a/test/e2e/singlecluster/jobset_test.go
+++ b/test/e2e/singlecluster/jobset_test.go
@@ -34,7 +34,7 @@ import (
 
 // +kubebuilder:docs-gen:collapse=Imports
 
-var _ = ginkgo.Describe("Jobset", func() {
+var _ = ginkgo.Describe("JobSet", func() {
 	var ns *corev1.Namespace
 
 	ginkgo.BeforeEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Sets jobSet's ManagedBy field by default if it's managed by MultiKueue
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2022

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The ManagedBy field in jobSet will now be set by default if managed by MultiKueue.
```