### PR TITLE
Add the ProvisioningRequest's classname annotation

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/constants.go
+++ b/pkg/controller/admissionchecks/provisioning/constants.go
@@ -17,9 +17,10 @@ limitations under the License.
 package provisioning
 
 const (
-	ConfigKind            = "ProvisioningRequestConfig"
-	ControllerName        = "kueue.x-k8s.io/provisioning-request"
-	ConsumesAnnotationKey = "cluster-autoscaler.kubernetes.io/consume-provisioning-request"
+	ConfigKind             = "ProvisioningRequestConfig"
+	ControllerName         = "kueue.x-k8s.io/provisioning-request"
+	ConsumesAnnotationKey  = "cluster-autoscaler.kubernetes.io/consume-provisioning-request"
+	ClassNameAnnotationKey = "cluster-autoscaler.kubernetes.io/provisioning-class-name"
 
 	CheckInactiveMessage = "the check is not active"
 	NoRequestNeeded      = "the provisioning request is not needed"

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -573,8 +573,10 @@ func podSetUpdates(wl *kueue.Workload, pr *autoscaling.ProvisioningRequest) []ku
 	})
 	return slices.Map(pr.Spec.PodSets, func(ps *autoscaling.PodSet) kueue.PodSetUpdate {
 		return kueue.PodSetUpdate{
-			Name:        refMap[ps.PodTemplateRef.Name],
-			Annotations: map[string]string{ConsumesAnnotationKey: pr.Name},
+			Name: refMap[ps.PodTemplateRef.Name],
+			Annotations: map[string]string{
+				ConsumesAnnotationKey:  pr.Name,
+				ClassNameAnnotationKey: pr.Spec.ProvisioningClassName},
 		}
 	})
 }

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -547,12 +547,15 @@ func TestReconcile(t *testing.T) {
 						State: kueue.CheckStateReady,
 						PodSetUpdates: []kueue.PodSetUpdate{
 							{
-								Name:        "ps1",
-								Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1-1"},
+								Name: "ps1",
+								Annotations: map[string]string{
+									"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1-1",
+									"cluster-autoscaler.kubernetes.io/provisioning-class-name":      "class1"},
 							},
 							{
-								Name:        "ps2",
-								Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1-1"},
+								Name: "ps2",
+								Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1-1",
+									"cluster-autoscaler.kubernetes.io/provisioning-class-name": "class1"},
 							},
 						},
 					}, kueue.AdmissionCheckState{

--- a/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
@@ -376,13 +376,15 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 						{
 							Name: "ps1",
 							Annotations: map[string]string{
-								provisioning.ConsumesAnnotationKey: provReqKey.Name,
+								provisioning.ConsumesAnnotationKey:  provReqKey.Name,
+								provisioning.ClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
 							},
 						},
 						{
 							Name: "ps2",
 							Annotations: map[string]string{
-								provisioning.ConsumesAnnotationKey: provReqKey.Name,
+								provisioning.ConsumesAnnotationKey:  provReqKey.Name,
+								provisioning.ClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
 							},
 						},
 					}))
@@ -641,13 +643,15 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 						{
 							Name: "ps1",
 							Annotations: map[string]string{
-								provisioning.ConsumesAnnotationKey: provReqKey.Name,
+								provisioning.ConsumesAnnotationKey:  provReqKey.Name,
+								provisioning.ClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
 							},
 						},
 						{
 							Name: "ps2",
 							Annotations: map[string]string{
-								provisioning.ConsumesAnnotationKey: provReqKey.Name,
+								provisioning.ConsumesAnnotationKey:  provReqKey.Name,
+								provisioning.ClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
 							},
 						},
 					}))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2051 

#### Special notes for your reviewer:
I've tested it e2e manually

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Pods created by Kueue have now the ProvisioningRequest's classname annotation
```