### PR TITLE
Add a note on PodsReady timeout requeuing

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_sequential_admission.md
+++ b/site/content/en/docs/tasks/manage/setup_sequential_admission.md
@@ -47,6 +47,7 @@ fields:
       requeuingStrategy:
         timestamp: Eviction | Creation
         backoffLimitCount: 5
+        backoffBaseSeconds: 10
 ```
 
 {{% alert title="Note" color="primary" %}}
@@ -92,6 +93,14 @@ Kueue will re-queue a Workload evicted by the `PodsReadyTimeout` reason until th
 If you don't specify any value for `backoffLimitCount`,
 a Workload is repeatedly and endlessly re-queued to the queue based on the `timestamp`.
 Once the number of re-queues reaches the limit, Kueue [deactivates the Workload](/docs/concepts/workload/#active).
+
+{{% alert title="Note" color="primary" %}}
+_The `backoffBaseSeconds` is available in Kueue v0.7.0 and later_
+{{% /alert %}}
+The time to re-queue a workload after each consecutive timeout is increased
+exponentially, with the exponent of 2. The first delay is determined by the
+`backoffBaseSeconds` parameter (defaulting to 10). So, after the consecutive timeouts
+the evicted workload is re-queued after approximately `10, 20, 40, ...` seconds.
 
 ## Example
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2009

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```