### PR TITLE
[hack] Remove workaround for code-generator

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -26,13 +26,6 @@ cd $(dirname ${BASH_SOURCE[0]})/..
 
 source "${CODEGEN_PKG}/kube_codegen.sh"
 
-# TODO: remove the workaround when the issue is solved in the code-generator
-# (https://github.com/kubernetes/code-generator/issues/165).
-# Here, we create the soft link named "sigs.k8s.io" to the parent directory of
-# Kueue to ensure the layout required by the kube_codegen.sh script.
-ln -s .. sigs.k8s.io
-trap "rm sigs.k8s.io" EXIT
-
 # Generating conversion and defaults functions
 kube::codegen::gen_helpers \
   --input-pkg-root sigs.k8s.io/kueue/apis \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the unneeded workaround from the `hack/update-codegen.sh` script as the issue https://github.com/kubernetes/code-generator/issues/165 has been resolved.

#### Special notes for your reviewer:

See https://github.com/kubernetes/code-generator/issues/165#issuecomment-1992559196

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```