### PR TITLE
Cleanup CQ and cohort resource stats

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -127,11 +127,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  10_000,
-							Lendable: 10_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -159,11 +156,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  15_000,
-							Lendable: 15_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 15_000,
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -210,11 +204,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"nonexistent-flavor": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  15_000,
-							Lendable: 15_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 15_000,
 					},
 					Status:     pending,
 					Preemption: defaultPreemption,
@@ -303,11 +294,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  10_000,
-							Lendable: 10_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -335,11 +323,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  15_000,
-							Lendable: 15_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 15_000,
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -388,11 +373,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"nonexistent-flavor": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  15_000,
-							Lendable: 15_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 15_000,
 					},
 					Status:     pending,
 					Preemption: defaultPreemption,
@@ -478,11 +460,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  5_000,
-							Lendable: 5_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 5_000,
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -547,11 +526,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  5_000,
-							Lendable: 4_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 4_000,
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -614,11 +590,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  15_000,
-							Lendable: 15_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 15_000,
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -657,11 +630,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"nonexistent-flavor": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  15_000,
-							Lendable: 15_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 15_000,
 					},
 					Status:     pending,
 					Preemption: defaultPreemption,
@@ -722,11 +692,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  10_000,
-							Lendable: 10_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -754,11 +721,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  15_000,
-							Lendable: 15_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 15_000,
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -805,11 +769,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AdmittedUsage: FlavorResourceQuantities{
 						"nonexistent-flavor": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  15_000,
-							Lendable: 15_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 15_000,
 					},
 					Status:     active,
 					Preemption: defaultPreemption,
@@ -934,10 +895,10 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							"example.com/gpu": 0,
 						},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU:    {},
-						corev1.ResourceMemory: {},
-						"example.com/gpu":     {},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU:    0,
+						corev1.ResourceMemory: 0,
+						"example.com/gpu":     0,
 					},
 					Status:     pending,
 					Preemption: defaultPreemption,
@@ -1108,12 +1069,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					FlavorFungibility:             defaultFlavorFungibility,
 					Usage:                         FlavorResourceQuantities{"f1": {corev1.ResourceCPU: 2000}},
 					AdmittedUsage:                 FlavorResourceQuantities{"f1": {corev1.ResourceCPU: 1000}},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: &QuotaStats{
-							Nominal:  10_000,
-							Lendable: 10_000,
-							Usage:    2_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
 					},
 					Workloads: map[string]*workload.Info{
 						"ns/reserving": {
@@ -1146,6 +1103,113 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 			},
 			wantCohorts: map[string]sets.Set[string]{},
+		},
+		{
+			name:               "add CQ with multiple resource groups and flavors",
+			enableLendingLimit: true,
+			operation: func(cache *Cache) error {
+				cq := utiltesting.MakeClusterQueue("foo").
+					ResourceGroup(
+						kueue.FlavorQuotas{
+							Name: "on-demand",
+							Resources: []kueue.ResourceQuota{
+								{
+									Name:         corev1.ResourceCPU,
+									NominalQuota: resource.MustParse("10"),
+									LendingLimit: ptr.To(resource.MustParse("8")),
+								},
+								{
+									Name:         corev1.ResourceMemory,
+									NominalQuota: resource.MustParse("10Gi"),
+									LendingLimit: ptr.To(resource.MustParse("8Gi")),
+								},
+							},
+						},
+						kueue.FlavorQuotas{
+							Name: "spot",
+							Resources: []kueue.ResourceQuota{
+								{
+									Name:         corev1.ResourceCPU,
+									NominalQuota: resource.MustParse("20"),
+									LendingLimit: ptr.To(resource.MustParse("20")),
+								},
+								{
+									Name:         corev1.ResourceMemory,
+									NominalQuota: resource.MustParse("20Gi"),
+									LendingLimit: ptr.To(resource.MustParse("20Gi")),
+								},
+							},
+						},
+					).
+					ResourceGroup(
+						kueue.FlavorQuotas{
+							Name: "license",
+							Resources: []kueue.ResourceQuota{
+								{
+									Name:         "license",
+									NominalQuota: resource.MustParse("8"),
+									LendingLimit: ptr.To(resource.MustParse("4")),
+								},
+							},
+						},
+					).
+					Obj()
+				return cache.AddClusterQueue(context.Background(), cq)
+			},
+			wantClusterQueues: map[string]*ClusterQueue{
+				"foo": {
+					Name:                          "foo",
+					NamespaceSelector:             labels.Everything(),
+					Status:                        pending,
+					Preemption:                    defaultPreemption,
+					AllocatableResourceGeneration: 1,
+					FlavorFungibility:             defaultFlavorFungibility,
+					GuaranteedQuota: FlavorResourceQuantities{
+						"on-demand": {
+							corev1.ResourceCPU:    2_000,
+							corev1.ResourceMemory: 2 * utiltesting.Gi,
+						},
+						"spot": {
+							corev1.ResourceCPU:    0,
+							corev1.ResourceMemory: 0,
+						},
+						"license": {
+							"license": 4,
+						},
+					},
+					Usage: FlavorResourceQuantities{
+						"on-demand": {
+							corev1.ResourceCPU:    0,
+							corev1.ResourceMemory: 0,
+						},
+						"spot": {
+							corev1.ResourceCPU:    0,
+							corev1.ResourceMemory: 0,
+						},
+						"license": {
+							"license": 0,
+						},
+					},
+					AdmittedUsage: FlavorResourceQuantities{
+						"on-demand": {
+							corev1.ResourceCPU:    0,
+							corev1.ResourceMemory: 0,
+						},
+						"spot": {
+							corev1.ResourceCPU:    0,
+							corev1.ResourceMemory: 0,
+						},
+						"license": {
+							"license": 0,
+						},
+					},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU:    28_000,
+						corev1.ResourceMemory: 28 * utiltesting.Gi,
+						"license":             4,
+					},
+				},
+			},
 		},
 	}
 
@@ -1250,7 +1314,6 @@ func TestCacheWorkloadOperations(t *testing.T) {
 	type result struct {
 		Workloads     sets.Set[string]
 		UsedResources FlavorResourceQuantities
-		ResourceStats ResourceStats
 	}
 
 	steps := []struct {
@@ -1285,22 +1348,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c", "/d"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
 					},
 				},
 			},
@@ -1324,22 +1377,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
 					},
 				},
 			},
@@ -1362,22 +1405,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
 					},
 				},
 			},
@@ -1401,22 +1434,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/a", "/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
 					},
 				},
 			},
@@ -1440,22 +1463,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
 					},
 				},
 			},
@@ -1479,22 +1492,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
 					},
 				},
 			},
@@ -1517,22 +1520,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c", "/d"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
 					},
 				},
 			},
@@ -1552,22 +1545,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
 					},
 				},
 			},
@@ -1585,22 +1568,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
 					},
 				},
 			},
@@ -1619,22 +1592,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
 					},
 				},
 			},
@@ -1655,22 +1618,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
 					},
 				},
 			},
@@ -1690,22 +1643,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
 					},
 				},
 			},
@@ -1737,22 +1680,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 20},
 						"spot":      {corev1.ResourceCPU: 30},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 50,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c", "/e"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
 					},
 				},
 			},
@@ -1780,22 +1713,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
 					},
 				},
 			},
@@ -1830,22 +1753,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c", "/e"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
 					},
 				},
 			},
@@ -1872,22 +1785,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 0},
 						"spot":      {corev1.ResourceCPU: 0},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 0,
-						},
 					},
 				},
 			},
@@ -1924,22 +1827,12 @@ func TestCacheWorkloadOperations(t *testing.T) {
 						"on-demand": {corev1.ResourceCPU: 20},
 						"spot":      {corev1.ResourceCPU: 30},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 50,
-						},
-					},
 				},
 				"two": {
 					Workloads: sets.New("/c", "/e"),
 					UsedResources: FlavorResourceQuantities{
 						"on-demand": {corev1.ResourceCPU: 10},
 						"spot":      {corev1.ResourceCPU: 15},
-					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Usage: 25,
-						},
 					},
 				},
 			},
@@ -1967,7 +1860,6 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				gotResult[name] = result{
 					Workloads:     sets.KeySet(cq.Workloads),
 					UsedResources: cq.Usage,
-					ResourceStats: cq.ResourceStats,
 				}
 			}
 			if diff := cmp.Diff(step.wantResults, gotResult); diff != "" {

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -40,16 +40,6 @@ var (
 	errQueueAlreadyExists = errors.New("queue already exists")
 )
 
-// QuotaStats holds the nominal quota and usage for a resource.
-type QuotaStats struct {
-	Nominal  int64
-	Lendable int64
-	Usage    int64
-}
-
-// ResourceStats holds QuotaStats for resources.
-type ResourceStats map[corev1.ResourceName]*QuotaStats
-
 // ClusterQueue is the internal implementation of kueue.ClusterQueue that
 // holds admitted workloads.
 type ClusterQueue struct {

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -75,8 +75,8 @@ type ClusterQueue struct {
 	// deleted, or the resource groups are changed.
 	AllocatableResourceGeneration int64
 
-	// ResourceStats holds nominal quota and usage for the resources of the ClusterQueue, independent of the flavor.
-	ResourceStats ResourceStats
+	// Lendable holds the total lendable quota for the resources of the ClusterQueue, independent of the flavor.
+	Lendable map[corev1.ResourceName]int64
 
 	// The following fields are not populated in a snapshot.
 
@@ -101,7 +101,7 @@ type Cohort struct {
 	// RequestableResources equals to the sum of LendingLimit when feature LendingLimit enabled.
 	RequestableResources FlavorResourceQuantities
 	Usage                FlavorResourceQuantities
-	ResourceStats        ResourceStats
+	Lendable             map[corev1.ResourceName]int64
 	// AllocatableResourceGeneration equals to
 	// the sum of allocatable generation among its members.
 	AllocatableResourceGeneration int64
@@ -265,29 +265,10 @@ func filterFlavorQuantities(orig FlavorResourceQuantities, resourceGroups []kueu
 	return ret
 }
 
-// resetResourceStatsFromResourceGroups maintains the Usage stats for the given resource groups
-// and resets Nominal and Lendable values. They are calculated again in updateResourceGroups.
-func (c *ClusterQueue) resetResourceStatsFromResourceGroups(resourceGroups []kueue.ResourceGroup) {
-	updatedResourceStats := make(ResourceStats, len(resourceGroups))
-	for _, rg := range resourceGroups {
-		for _, res := range rg.CoveredResources {
-			if oStats := c.ResourceStats[res]; oStats != nil {
-				updatedResourceStats[res] = &QuotaStats{
-					Usage: c.ResourceStats[res].Usage,
-					// Reset Nominal and Lendable.
-				}
-			} else {
-				updatedResourceStats[res] = &QuotaStats{}
-			}
-		}
-	}
-	c.ResourceStats = updatedResourceStats
-}
-
 func (c *ClusterQueue) updateResourceGroups(in []kueue.ResourceGroup) {
 	oldRG := c.ResourceGroups
 	c.ResourceGroups = make([]ResourceGroup, len(in))
-	c.resetResourceStatsFromResourceGroups(in)
+	c.Lendable = make(map[corev1.ResourceName]int64)
 	for i, rgIn := range in {
 		rg := &c.ResourceGroups[i]
 		*rg = ResourceGroup{
@@ -305,15 +286,14 @@ func (c *ClusterQueue) updateResourceGroups(in []kueue.ResourceGroup) {
 				rQuota := ResourceQuota{
 					Nominal: nominal,
 				}
-				c.ResourceStats[rIn.Name].Nominal += nominal
 				if rIn.BorrowingLimit != nil {
 					rQuota.BorrowingLimit = ptr.To(workload.ResourceValue(rIn.Name, *rIn.BorrowingLimit))
 				}
 				if features.Enabled(features.LendingLimit) && rIn.LendingLimit != nil {
 					rQuota.LendingLimit = ptr.To(workload.ResourceValue(rIn.Name, *rIn.LendingLimit))
-					c.ResourceStats[rIn.Name].Lendable += *rQuota.LendingLimit
+					c.Lendable[rIn.Name] += *rQuota.LendingLimit
 				} else {
-					c.ResourceStats[rIn.Name].Lendable += nominal
+					c.Lendable[rIn.Name] += nominal
 				}
 				fQuotas.Resources[rIn.Name] = &rQuota
 			}
@@ -499,7 +479,6 @@ func (c *ClusterQueue) reportActiveWorkloads() {
 func (c *ClusterQueue) updateWorkloadUsage(wi *workload.Info, m int64) {
 	admitted := workload.IsAdmitted(wi.Obj)
 	updateFlavorUsage(wi, c.Usage, m)
-	updateResourceStats(wi, c.ResourceStats, m)
 	if admitted {
 		updateFlavorUsage(wi, c.AdmittedUsage, m)
 		c.admittedWorkloadsCount += int(m)
@@ -511,16 +490,6 @@ func (c *ClusterQueue) updateWorkloadUsage(wi *workload.Info, m int64) {
 		if admitted {
 			updateFlavorUsage(wi, lq.admittedUsage, m)
 			lq.admittedWorkloads += int(m)
-		}
-	}
-}
-
-func updateResourceStats(wi *workload.Info, rStats ResourceStats, m int64) {
-	for _, ps := range wi.TotalRequests {
-		for res, v := range ps.Requests {
-			if _, exists := rStats[res]; exists {
-				rStats[res].Usage += v * m
-			}
 		}
 	}
 }
@@ -723,7 +692,7 @@ func (c *ClusterQueue) dominantResourceShare(wlReq FlavorResourceQuantities, m i
 	var drs int64 = -1
 	var dRes corev1.ResourceName
 	for rName, b := range borrowing {
-		if lendable := c.Cohort.ResourceStats[rName].Lendable; lendable > 0 {
+		if lendable := c.Cohort.Lendable[rName]; lendable > 0 {
 			ratio := b * 1000 / lendable
 			// Use alphabetical order to get a deterministic resource name.
 			if ratio > drs || (ratio == drs && rName < dRes) {

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -816,17 +816,9 @@ func TestDominantResourceShare(t *testing.T) {
 					},
 				},
 				Cohort: &Cohort{
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  10_000,
-							Lendable: 10_000,
-							Usage:    2_000,
-						},
-						"example.com/gpu": {
-							Nominal:  10,
-							Lendable: 10,
-							Usage:    6,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
+						"example.com/gpu":  10,
 					},
 				},
 			},
@@ -857,17 +849,9 @@ func TestDominantResourceShare(t *testing.T) {
 					},
 				},
 				Cohort: &Cohort{
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  10_000,
-							Lendable: 10_000,
-							Usage:    10_000,
-						},
-						"example.com/gpu": {
-							Nominal:  10,
-							Lendable: 10,
-							Usage:    10,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
+						"example.com/gpu":  10,
 					},
 				},
 			},
@@ -900,17 +884,9 @@ func TestDominantResourceShare(t *testing.T) {
 					},
 				},
 				Cohort: &Cohort{
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  10_000,
-							Lendable: 10_000,
-							Usage:    10_000,
-						},
-						"example.com/gpu": {
-							Nominal:  10,
-							Lendable: 10,
-							Usage:    10,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
+						"example.com/gpu":  10,
 					},
 				},
 			},
@@ -943,17 +919,9 @@ func TestDominantResourceShare(t *testing.T) {
 					},
 				},
 				Cohort: &Cohort{
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  10_000,
-							Lendable: 10_000,
-							Usage:    2_000,
-						},
-						"example.com/gpu": {
-							Nominal:  10,
-							Lendable: 10,
-							Usage:    6,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
+						"example.com/gpu":  10,
 					},
 				},
 			},
@@ -993,16 +961,9 @@ func TestDominantResourceShare(t *testing.T) {
 					},
 				},
 				Cohort: &Cohort{
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  10_000,
-							Lendable: 10_000,
-							Usage:    2_000,
-						},
-						"example.com/gpu": {
-							Nominal: 10_000,
-							Usage:   5_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
+						"example.com/gpu":  0,
 					},
 				},
 			},
@@ -1048,12 +1009,8 @@ func TestDominantResourceShare(t *testing.T) {
 					},
 				},
 				Cohort: &Cohort{
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  200_000,
-							Lendable: 200_000,
-							Usage:    20_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 200_000,
 					},
 				},
 			},

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -55,14 +54,12 @@ func (s *Snapshot) AddWorkload(wl *workload.Info) {
 
 func (c *ClusterQueue) addOrRemoveWorkload(wl *workload.Info, m int64) {
 	updateFlavorUsage(wl, c.Usage, m)
-	updateResourceStats(wl, c.ResourceStats, m)
 	if c.Cohort != nil {
 		if features.Enabled(features.LendingLimit) {
 			updateCohortUsage(wl, c, m)
 		} else {
 			updateFlavorUsage(wl, c.Cohort.Usage, m)
 		}
-		updateResourceStats(wl, c.Cohort.ResourceStats, m)
 	}
 }
 
@@ -138,7 +135,7 @@ func (c *ClusterQueue) snapshot() *ClusterQueue {
 		FlavorFungibility:             c.FlavorFungibility,
 		AllocatableResourceGeneration: c.AllocatableResourceGeneration,
 		Usage:                         make(FlavorResourceQuantities, len(c.Usage)),
-		ResourceStats:                 make(ResourceStats, len(c.ResourceStats)),
+		Lendable:                      maps.Clone(c.Lendable),
 		Workloads:                     maps.Clone(c.Workloads),
 		Preemption:                    c.Preemption,
 		NamespaceSelector:             c.NamespaceSelector,
@@ -151,9 +148,6 @@ func (c *ClusterQueue) snapshot() *ClusterQueue {
 	}
 	if features.Enabled(features.LendingLimit) {
 		cc.GuaranteedQuota = c.GuaranteedQuota
-	}
-	for rName, rStats := range c.ResourceStats {
-		cc.ResourceStats[rName] = ptr.To(*rStats)
 	}
 
 	return cc
@@ -203,17 +197,11 @@ func (c *ClusterQueue) accumulateResources(cohort *Cohort) {
 			used[res] += val
 		}
 	}
-	if cohort.ResourceStats == nil {
-		cohort.ResourceStats = make(ResourceStats, len(c.ResourceStats))
-	}
-	for rName, rStats := range c.ResourceStats {
-		cohortRStats := cohort.ResourceStats[rName]
-		if cohortRStats == nil {
-			cohort.ResourceStats[rName] = ptr.To(*rStats)
-			continue
+	if cohort.Lendable == nil {
+		cohort.Lendable = maps.Clone(c.Lendable)
+	} else {
+		for res, v := range c.Lendable {
+			cohort.Lendable[res] += v
 		}
-		cohortRStats.Nominal += rStats.Nominal
-		cohortRStats.Lendable += rStats.Lendable
-		cohortRStats.Usage += rStats.Usage
 	}
 }

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -223,17 +223,9 @@ func TestSnapshot(t *testing.T) {
 							"example.com/gpu": 15,
 						},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  400_000,
-							Lendable: 400_000,
-							Usage:    20_000,
-						},
-						"example.com/gpu": {
-							Nominal:  50,
-							Lendable: 50,
-							Usage:    15,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 400_000,
+						"example.com/gpu":  50,
 					},
 				}
 				return Snapshot{
@@ -267,12 +259,8 @@ func TestSnapshot(t *testing.T) {
 								"demand": {corev1.ResourceCPU: 10_000},
 								"spot":   {corev1.ResourceCPU: 0},
 							},
-							ResourceStats: ResourceStats{
-								corev1.ResourceCPU: {
-									Nominal:  300_000,
-									Lendable: 300_000,
-									Usage:    10_000,
-								},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 300_000,
 							},
 							Workloads: map[string]*workload.Info{
 								"/alpha": workload.NewInfo(utiltesting.MakeWorkload("alpha", "").
@@ -322,17 +310,9 @@ func TestSnapshot(t *testing.T) {
 									"example.com/gpu": 15,
 								},
 							},
-							ResourceStats: ResourceStats{
-								corev1.ResourceCPU: {
-									Nominal:  100_000,
-									Lendable: 100_000,
-									Usage:    10_000,
-								},
-								"example.com/gpu": {
-									Nominal:  50,
-									Lendable: 50,
-									Usage:    15,
-								},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 100_000,
+								"example.com/gpu":  50,
 							},
 							Workloads: map[string]*workload.Info{
 								"/beta": workload.NewInfo(utiltesting.MakeWorkload("beta", "").
@@ -383,11 +363,8 @@ func TestSnapshot(t *testing.T) {
 									corev1.ResourceCPU: 0,
 								},
 							},
-							ResourceStats: ResourceStats{
-								corev1.ResourceCPU: {
-									Nominal:  100_000,
-									Lendable: 100_000,
-								},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 100_000,
 							},
 							Preemption:        defaultPreemption,
 							NamespaceSelector: labels.Everything(),
@@ -492,12 +469,8 @@ func TestSnapshot(t *testing.T) {
 							corev1.ResourceCPU: 0,
 						},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  60_000,
-							Lendable: 30_000,
-							Usage:    25_000,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 30_000,
 					},
 				}
 				return Snapshot{
@@ -539,12 +512,8 @@ func TestSnapshot(t *testing.T) {
 								"arm": {corev1.ResourceCPU: 15_000},
 								"x86": {corev1.ResourceCPU: 10_000},
 							},
-							ResourceStats: ResourceStats{
-								corev1.ResourceCPU: {
-									Nominal:  30_000,
-									Lendable: 15_000,
-									Usage:    25_000,
-								},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 15_000,
 							},
 							Workloads: map[string]*workload.Info{
 								"/alpha": workload.NewInfo(utiltesting.MakeWorkload("alpha", "").
@@ -618,11 +587,8 @@ func TestSnapshot(t *testing.T) {
 								"arm": {corev1.ResourceCPU: 0},
 								"x86": {corev1.ResourceCPU: 0},
 							},
-							ResourceStats: ResourceStats{
-								corev1.ResourceCPU: {
-									Nominal:  30_000,
-									Lendable: 15_000,
-								},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 15_000,
 							},
 							Preemption:        defaultPreemption,
 							NamespaceSelector: labels.Everything(),
@@ -771,15 +737,9 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 						"alpha":   {corev1.ResourceMemory: 0},
 						"beta":    {corev1.ResourceMemory: 0},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  12_000,
-							Lendable: 12_000,
-						},
-						corev1.ResourceMemory: {
-							Nominal:  12 * utiltesting.Gi,
-							Lendable: 12 * utiltesting.Gi,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU:    12_000,
+						corev1.ResourceMemory: 12 * utiltesting.Gi,
 					},
 				}
 				return Snapshot{
@@ -796,15 +756,9 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								"alpha":   {corev1.ResourceMemory: 0},
 								"beta":    {corev1.ResourceMemory: 0},
 							},
-							ResourceStats: ResourceStats{
-								corev1.ResourceCPU: {
-									Nominal:  6_000,
-									Lendable: 6_000,
-								},
-								corev1.ResourceMemory: {
-									Nominal:  12 * utiltesting.Gi,
-									Lendable: 12 * utiltesting.Gi,
-								},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU:    6_000,
+								corev1.ResourceMemory: 12 * utiltesting.Gi,
 							},
 						},
 						"c2": {
@@ -817,11 +771,8 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							Usage: FlavorResourceQuantities{
 								"default": {corev1.ResourceCPU: 0},
 							},
-							ResourceStats: ResourceStats{
-								corev1.ResourceCPU: {
-									Nominal:  6_000,
-									Lendable: 6_000,
-								},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 6_000,
 							},
 						},
 					},
@@ -840,17 +791,9 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 						"alpha":   {corev1.ResourceMemory: utiltesting.Gi},
 						"beta":    {corev1.ResourceMemory: utiltesting.Gi},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  12_000,
-							Lendable: 12_000,
-							Usage:    2_000,
-						},
-						corev1.ResourceMemory: {
-							Nominal:  12 * utiltesting.Gi,
-							Lendable: 12 * utiltesting.Gi,
-							Usage:    2 * utiltesting.Gi,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU:    12_000,
+						corev1.ResourceMemory: 12 * utiltesting.Gi,
 					},
 				}
 				return Snapshot{
@@ -870,16 +813,9 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								"alpha":   {corev1.ResourceMemory: utiltesting.Gi},
 								"beta":    {corev1.ResourceMemory: utiltesting.Gi},
 							},
-							ResourceStats: ResourceStats{
-								corev1.ResourceCPU: {
-									Nominal:  6_000,
-									Lendable: 6_000,
-								},
-								corev1.ResourceMemory: {
-									Nominal:  12 * utiltesting.Gi,
-									Lendable: 12 * utiltesting.Gi,
-									Usage:    2 * utiltesting.Gi,
-								},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU:    6_000,
+								corev1.ResourceMemory: 12 * utiltesting.Gi,
 							},
 						},
 						"c2": {
@@ -895,12 +831,8 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							Usage: FlavorResourceQuantities{
 								"default": {corev1.ResourceCPU: 2_000},
 							},
-							ResourceStats: ResourceStats{
-								corev1.ResourceCPU: {
-									Nominal:  6_000,
-									Lendable: 6_000,
-									Usage:    2_000,
-								},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 6_000,
 							},
 						},
 					},
@@ -919,17 +851,9 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 						"alpha":   {corev1.ResourceMemory: 0},
 						"beta":    {corev1.ResourceMemory: utiltesting.Gi},
 					},
-					ResourceStats: ResourceStats{
-						corev1.ResourceCPU: {
-							Nominal:  12_000,
-							Lendable: 12_000,
-							Usage:    3_000,
-						},
-						corev1.ResourceMemory: {
-							Nominal:  12 * utiltesting.Gi,
-							Lendable: 12 * utiltesting.Gi,
-							Usage:    utiltesting.Gi,
-						},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU:    12_000,
+						corev1.ResourceMemory: 12 * utiltesting.Gi,
 					},
 				}
 				return Snapshot{
@@ -949,17 +873,9 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								"alpha":   {corev1.ResourceMemory: 0},
 								"beta":    {corev1.ResourceMemory: utiltesting.Gi},
 							},
-							ResourceStats: ResourceStats{
-								corev1.ResourceCPU: {
-									Nominal:  6_000,
-									Lendable: 6_000,
-									Usage:    1_000,
-								},
-								corev1.ResourceMemory: {
-									Nominal:  12 * utiltesting.Gi,
-									Lendable: 12 * utiltesting.Gi,
-									Usage:    utiltesting.Gi,
-								},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU:    6_000,
+								corev1.ResourceMemory: 12 * utiltesting.Gi,
 							},
 						},
 						"c2": {
@@ -975,12 +891,8 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							Usage: FlavorResourceQuantities{
 								"default": {corev1.ResourceCPU: 2_000},
 							},
-							ResourceStats: ResourceStats{
-								corev1.ResourceCPU: {
-									Nominal:  6_000,
-									Lendable: 6_000,
-									Usage:    2_000,
-								},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 6_000,
 							},
 						},
 					},
@@ -1095,8 +1007,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						"cpu": {Nominal: 20_000, Lendable: 10_000},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
 					},
 				}
 				return Snapshot{
@@ -1116,8 +1028,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 4_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 4_000,
 							},
 						},
 						"lend-b": {
@@ -1135,8 +1047,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 4_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 6_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 6_000,
 							},
 						},
 					},
@@ -1153,8 +1065,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 1_000},
 					},
-					ResourceStats: ResourceStats{
-						"cpu": {Nominal: 20_000, Lendable: 10_000, Usage: 11_000},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
 					},
 				}
 				return Snapshot{
@@ -1174,8 +1086,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 4_000, Usage: 7_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 4_000,
 							},
 						},
 						"lend-b": {
@@ -1193,8 +1105,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 4_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 6_000, Usage: 4_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 6_000,
 							},
 						},
 					},
@@ -1211,8 +1123,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						"cpu": {Nominal: 20_000, Lendable: 10_000, Usage: 10_000},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
 					},
 				}
 				return Snapshot{
@@ -1232,8 +1144,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 4_000, Usage: 6_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 4_000,
 							},
 						},
 						"lend-b": {
@@ -1251,8 +1163,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 4_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 6_000, Usage: 4_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 6_000,
 							},
 						},
 					},
@@ -1269,8 +1181,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						"cpu": {Nominal: 20_000, Lendable: 10_000, Usage: 5_000},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
 					},
 				}
 				return Snapshot{
@@ -1290,8 +1202,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 4_000, Usage: 1_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 4_000,
 							},
 						},
 						"lend-b": {
@@ -1309,8 +1221,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 4_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 6_000, Usage: 4_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 6_000,
 							},
 						},
 					},
@@ -1328,8 +1240,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						"cpu": {Nominal: 20_000, Lendable: 10_000, Usage: 1_000},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
 					},
 				}
 				return Snapshot{
@@ -1349,8 +1261,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 4_000, Usage: 1_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 4_000,
 							},
 						},
 						"lend-b": {
@@ -1368,8 +1280,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 4_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 6_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 6_000,
 							},
 						},
 					},
@@ -1387,8 +1299,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 0},
 					},
-					ResourceStats: ResourceStats{
-						"cpu": {Nominal: 20_000, Lendable: 10_000, Usage: 6_000},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
 					},
 				}
 				return Snapshot{
@@ -1408,8 +1320,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 4_000, Usage: 6_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 4_000,
 							},
 						},
 						"lend-b": {
@@ -1427,8 +1339,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 4_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 6_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 6_000,
 							},
 						},
 					},
@@ -1446,8 +1358,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					Usage: FlavorResourceQuantities{
 						"default": {corev1.ResourceCPU: 3_000},
 					},
-					ResourceStats: ResourceStats{
-						"cpu": {Nominal: 20_000, Lendable: 10_000, Usage: 9_000},
+					Lendable: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 10_000,
 					},
 				}
 				return Snapshot{
@@ -1467,8 +1379,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 6_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 4_000, Usage: 9_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 4_000,
 							},
 						},
 						"lend-b": {
@@ -1486,8 +1398,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 									corev1.ResourceCPU: 4_000,
 								},
 							},
-							ResourceStats: ResourceStats{
-								"cpu": {Nominal: 10_000, Lendable: 6_000},
+							Lendable: map[corev1.ResourceName]int64{
+								corev1.ResourceCPU: 6_000,
 							},
 						},
 					},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Follow up to #2037.
The only information we need from the cohort to calculate a dominant resource share is how much lendable resources there are.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```