### PR TITLE
Fix handling of eviction in StrictFIFO to ensure the evicted workload is in the head

### DIFF
--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -293,10 +293,10 @@ func (m *Manager) ClusterQueueForWorkload(wl *kueue.Workload) (string, bool) {
 func (m *Manager) AddOrUpdateWorkload(w *kueue.Workload) bool {
 	m.Lock()
 	defer m.Unlock()
-	return m.addOrUpdateWorkload(w)
+	return m.AddOrUpdateWorkloadWithoutLock(w)
 }
 
-func (m *Manager) addOrUpdateWorkload(w *kueue.Workload) bool {
+func (m *Manager) AddOrUpdateWorkloadWithoutLock(w *kueue.Workload) bool {
 	qKey := workload.QueueKey(w)
 	q := m.localQueues[qKey]
 	if q == nil {
@@ -453,7 +453,7 @@ func (m *Manager) UpdateWorkload(oldW, w *kueue.Workload) bool {
 	if oldW.Spec.QueueName != w.Spec.QueueName {
 		m.deleteWorkloadFromQueueAndClusterQueue(w, workload.QueueKey(oldW))
 	}
-	return m.addOrUpdateWorkload(w)
+	return m.AddOrUpdateWorkloadWithoutLock(w)
 }
 
 // CleanUpOnContext tracks the context. When closed, it wakes routines waiting


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2020

#### Special notes for your reviewer:

In this scenario occasionally the workload `pendingAlphaWl` gets admitted before `useAllAlphaWl`
is requeued.

The scenario can be reproduced reliably by inserting a time delay (say 500ms) around [here](https://github.com/kubernetes-sigs/kueue/blob/9ea94ac20f4a4b5546ab899c60f3627b23bd0a74/pkg/controller/core/workload_controller.go#L560), between `r.cache.DeleteWorkload(wl)` and `!r.queues.AddOrUpdateWorkload(wlCopy)`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix handling of eviction in StrictFIFO to ensure the evicted workload is in the head.
Previously, in case of priority-based preemption, it was possible that the lower-priority
workload might get admitted while the higher priority workload is being evicted.
```