### PR TITLE
[scalability] Collect extra information by default (metrics and logs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,24 +222,8 @@ performance-scheduler-runner:
 
 MINIMALKUEUE_RUNNER := $(PROJECT_DIR)/bin/minimalkueue
 .PHONY: minimalkueue
-minimalkueue: 
+minimalkueue:
 	$(GO_BUILD_ENV) $(GO_CMD) build -ldflags="$(LD_FLAGS)" -o $(MINIMALKUEUE_RUNNER) test/performance/scheduler/minimalkueue/main.go
-
-ifdef SCALABILITY_CPU_PROFILE
-SCALABILITY_EXTRA_ARGS += --withCPUProfile=true
-endif
-
-ifdef SCALABILITY_KUEUE_LOGS
-SCALABILITY_EXTRA_ARGS +=  --withLogs=true --logToFile=true
-endif
-
-ifdef SCALABILITY_SCRAPE_INTERVAL
-SCALABILITY_SCRAPE_ARGS +=  --metricsScrapeInterval=$(SCALABILITY_SCRAPE_INTERVAL)
-endif
-
-ifdef SCALABILITY_SCRAPE_URL
-SCALABILITY_SCRAPE_ARGS +=  --metricsScrapeURL=$(SCALABILITY_SCRAPE_URL)
-endif
 
 SCALABILITY_GENERATOR_CONFIG ?= $(PROJECT_DIR)/test/performance/scheduler/default_generator_config.yaml
 
@@ -252,7 +236,7 @@ run-performance-scheduler: envtest performance-scheduler-runner minimalkueue
 		--o $(SCALABILITY_RUN_DIR) \
 		--crds=$(PROJECT_DIR)/config/components/crd/bases \
 		--generatorConfig=$(SCALABILITY_GENERATOR_CONFIG) \
-		--minimalKueue=$(MINIMALKUEUE_RUNNER) $(SCALABILITY_EXTRA_ARGS) $(SCALABILITY_SCRAPE_ARGS)
+		--minimalKueue=$(MINIMALKUEUE_RUNNER) $(SCALABILITY_EXTRA_ARGS)
 
 .PHONY: test-performance-scheduler
 test-performance-scheduler: gotestsum run-performance-scheduler
@@ -268,7 +252,7 @@ run-performance-scheduler-in-cluster: envtest performance-scheduler-runner
 	$(SCALABILITY_RUNNER) \
 		--o $(ARTIFACTS)/run-performance-scheduler-in-cluster \
 		--generatorConfig=$(SCALABILITY_GENERATOR_CONFIG) \
-		--qps=1000 --burst=2000 --timeout=15m $(SCALABILITY_SCRAPE_ARGS)
+		--qps=1000 --burst=2000 --timeout=15m $(SCALABILITY_EXTRA_ARGS)
 
 .PHONY: ci-lint
 ci-lint: golangci-lint

--- a/test/performance/scheduler/runner/main.go
+++ b/test/performance/scheduler/runner/main.go
@@ -64,15 +64,15 @@ var (
 	burst           = flag.Int("burst", 0, "qps used by the runner clients, use default if 0")
 
 	// metrics scarping
-	metricsScrapeInterval = flag.Duration("metricsScrapeInterval", 0, "the duration between two metrics scraping, if 0 the metrics scraping is disabled")
+	metricsScrapeInterval = flag.Duration("metricsScrapeInterval", 5*time.Second, "the duration between two metrics scraping, if 0 the metrics scraping is disabled")
 	metricsScrapeURL      = flag.String("metricsScrapeURL", "", "the URL to scrape metrics from, ignored when minimal kueue is used")
 
 	// related to minimalkueue
 	minimalKueuePath = flag.String("minimalKueue", "", "path to minimalkueue, run in the hosts default cluster if empty")
 	withCpuProfile   = flag.Bool("withCPUProfile", false, "generate a CPU profile for minimalkueue")
-	withLogs         = flag.Bool("withLogs", false, "capture minimalkueue logs")
+	withLogs         = flag.Bool("withLogs", true, "capture minimalkueue logs")
 	logLevel         = flag.Int("withLogsLevel", 2, "set minimalkueue logs level")
-	logToFile        = flag.Bool("logToFile", false, "capture minimalkueue logs to files")
+	logToFile        = flag.Bool("logToFile", true, "capture minimalkueue logs to files")
 )
 
 var (

--- a/test/performance/scheduler/runner/main.go
+++ b/test/performance/scheduler/runner/main.go
@@ -64,15 +64,15 @@ var (
 	burst           = flag.Int("burst", 0, "qps used by the runner clients, use default if 0")
 
 	// metrics scarping
-	metricsScrapeInterval = flag.Duration("metricsScrapeInterval", 5*time.Second, "the duration between two metrics scraping, if 0 the metrics scraping is disabled")
+	metricsScrapeInterval = flag.Duration("metricsScrapeInterval", 0, "the duration between two metrics scraping, if 0 the metrics scraping is disabled")
 	metricsScrapeURL      = flag.String("metricsScrapeURL", "", "the URL to scrape metrics from, ignored when minimal kueue is used")
 
 	// related to minimalkueue
 	minimalKueuePath = flag.String("minimalKueue", "", "path to minimalkueue, run in the hosts default cluster if empty")
 	withCpuProfile   = flag.Bool("withCPUProfile", false, "generate a CPU profile for minimalkueue")
-	withLogs         = flag.Bool("withLogs", true, "capture minimalkueue logs")
+	withLogs         = flag.Bool("withLogs", false, "capture minimalkueue logs")
 	logLevel         = flag.Int("withLogsLevel", 2, "set minimalkueue logs level")
-	logToFile        = flag.Bool("logToFile", true, "capture minimalkueue logs to files")
+	logToFile        = flag.Bool("logToFile", false, "capture minimalkueue logs to files")
 )
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

To collect more data which will help us diagnose regressions, or failures. 

The logs can be helpful to understand why some certain workloads took long. 

The metrics can be helpful to understand how the dynamics changes over time during the test (e. g. first we accumulate pending workloads, then gradually process).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

To eval the performance I checked 5 builds for `scrape 5s + logs`:
1787881265534341120
1788122597204955136
1788130374614781952
1788133679826997248
1788136923525550080
And 12 builds for `scrape 1s + logs + cpu profile`:
1787379334198071296
1783914210393067520
1787401375009738752
1787442170244894720
1787454666427076608
1787461693572386816
1787463978864087040
1787486099027791872
1787488286453796864
1787493923178942464
1787500095751589888
1787519348999458816
The `base` is taken from the `default_rangespec.yaml`

|  | base | scrape 5s + logs  | scrape 1s + logs + cpu profile  |
|---|---|---|---|
| wallTimeMs |  351116| 352075 (+0.27%) | 356409 (+1.5%)|
| maxrss | 445012 | 451190  (+1.4%)| 459065 (+3.1%)|
| avg. time to admit small | 6666 | 6609 (-) | 7402 (+11%) |
| avg. time to admit medium | 76768 | 77711 (+1.2%) | 78878 (+2.7%) |
| avg. time to admit large | 215468 | 217186 (+0.8%) | 218507 (+1.4%) |


Also, I feel that having good defaults allows us to cleanup the configuration for the root Makefile. If one needs custom options they can still be passed via `SCALABILITY_EXTRA_ARGS`, analogously to `GINKGO_ARGS`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```