### PR TITLE
fix(helm): wrong secret name in certificate

### DIFF
--- a/charts/kueue/templates/certmanager/certificate.yaml
+++ b/charts/kueue/templates/certmanager/certificate.yaml
@@ -19,9 +19,9 @@ metadata:
 spec:
   dnsNames:
   - '{{ include "kueue.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc'
-  - '{{ include "kueue.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesClusterDomain}}'
+  - '{{ include "kueue.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesClusterDomain }}'
   issuerRef:
     kind: Issuer
-    name: '{{ include "kueue.fullname" . }}-selfsigned-issuer'
-  secretName: webhook-server-cert  
+    name: {{ include "kueue.fullname" . }}-selfsigned-issuer
+  secretName: {{ include "kueue.fullname" . }}-webhook-server-cert
 {{- end }}

--- a/charts/kueue/templates/internalcert/secret.yaml
+++ b/charts/kueue/templates/internalcert/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.enableCertManager }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Without these changes the integration with cert-manager is not working

#### Does this PR introduce a user-facing change?

```release-note
Helm Chart: Fix a bug that the kueue does not work with the cert-manager.
```