### PR TITLE
Automated cherry pick of #2087: fix(helm): wrong secret name in certificate

### DIFF
--- a/charts/kueue/templates/certmanager/certificate.yaml
+++ b/charts/kueue/templates/certmanager/certificate.yaml
@@ -15,9 +15,9 @@ metadata:
 spec:
   dnsNames:
   - '{{ include "kueue.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc'
-  - '{{ include "kueue.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesClusterDomain}}'
+  - '{{ include "kueue.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesClusterDomain }}'
   issuerRef:
     kind: Issuer
-    name: '{{ include "kueue.fullname" . }}-selfsigned-issuer'
-  secretName: webhook-server-cert  
+    name: {{ include "kueue.fullname" . }}-selfsigned-issuer
+  secretName: {{ include "kueue.fullname" . }}-webhook-server-cert
 {{- end }}

--- a/charts/kueue/templates/internalcert/secret.yaml
+++ b/charts/kueue/templates/internalcert/secret.yaml
@@ -1,5 +1,7 @@
+{{- if not .Values.enableCertManager }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "kueue.fullname" . }}-webhook-server-cert
   namespace: '{{ .Release.Namespace }}'
+{{- end }}


### PR DESCRIPTION
Cherry pick of #2087 on release-0.6.
#2087: fix(helm): wrong secret name in certificate
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
Helm Chart: Fix a bug that the kueue does not work with the cert-manager.
```