### PR TITLE
Add sidecar containers to resource requests computation

### DIFF
--- a/pkg/util/limitrange/limitrange.go
+++ b/pkg/util/limitrange/limitrange.go
@@ -103,7 +103,7 @@ func TotalRequests(ps *corev1.PodSpec) corev1.ResourceList {
 func calculateRegularInitContainersResources(initContainers []corev1.Container) corev1.ResourceList {
 	total := corev1.ResourceList{}
 	for i := range initContainers {
-		if initContainers[i].RestartPolicy == nil || *initContainers[i].RestartPolicy != corev1.ContainerRestartPolicyAlways {
+		if !isSidecarContainer(initContainers[i]) {
 			total = resource.MergeResourceListKeepMax(total, initContainers[i].Resources.Requests)
 		}
 	}
@@ -113,11 +113,15 @@ func calculateRegularInitContainersResources(initContainers []corev1.Container) 
 func calculateSidecarContainersResources(initContainers []corev1.Container) corev1.ResourceList {
 	total := corev1.ResourceList{}
 	for i := range initContainers {
-		if initContainers[i].RestartPolicy != nil && *initContainers[i].RestartPolicy == corev1.ContainerRestartPolicyAlways {
+		if isSidecarContainer(initContainers[i]) {
 			total = resource.MergeResourceListKeepSum(total, initContainers[i].Resources.Requests)
 		}
 	}
 	return total
+}
+
+func isSidecarContainer(container corev1.Container) bool {
+	return container.RestartPolicy != nil && *container.RestartPolicy == corev1.ContainerRestartPolicyAlways
 }
 
 // ValidatePodSpec verifies if the provided podSpec (ps) first into the boundaries of the summary (s).

--- a/pkg/util/limitrange/limitrange_test.go
+++ b/pkg/util/limitrange/limitrange_test.go
@@ -164,7 +164,7 @@ func TestTotalRequest(t *testing.T) {
 		podSpec *corev1.PodSpec
 		want    corev1.ResourceList
 	}{
-		"pod without init containers": {
+		"pod without init containers. request sum(containers)": {
 			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					*testingutil.MakeContainer().
@@ -172,18 +172,18 @@ func TestTotalRequest(t *testing.T) {
 						WithResourceReq(corev1.ResourceMemory, "2Gi").
 						Obj(),
 					*testingutil.MakeContainer().
-						WithResourceReq(corev1.ResourceCPU, "1500m").
+						WithResourceReq(corev1.ResourceCPU, "1.5").
 						WithResourceReq("example.com/gpu", "2").
 						Obj(),
 				},
 			},
 			want: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2500m"),
+				corev1.ResourceCPU:    resource.MustParse("2.5"),
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 				"example.com/gpu":     resource.MustParse("2"),
 			},
 		},
-		"pod only with regular init containers": {
+		"pod only with regular init containers. request max(regularContainers)": {
 			podSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					*testingutil.MakeContainer().
@@ -191,7 +191,7 @@ func TestTotalRequest(t *testing.T) {
 						WithResourceReq(corev1.ResourceMemory, "2Gi").
 						Obj(),
 					*testingutil.MakeContainer().
-						WithResourceReq(corev1.ResourceCPU, "1500m").
+						WithResourceReq(corev1.ResourceCPU, "1.5").
 						WithResourceReq("example.com/gpu", "2").
 						Obj(),
 				},
@@ -201,18 +201,18 @@ func TestTotalRequest(t *testing.T) {
 						WithResourceReq(corev1.ResourceMemory, "2Gi").
 						Obj(),
 					*testingutil.MakeContainer().
-						WithResourceReq(corev1.ResourceCPU, "1500m").
+						WithResourceReq(corev1.ResourceCPU, "1.5").
 						WithResourceReq("example.com/gpu", "2").
 						Obj(),
 				},
 			},
 			want: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("4000m"),
+				corev1.ResourceCPU:    resource.MustParse("4"),
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 				"example.com/gpu":     resource.MustParse("2"),
 			},
 		},
-		"pod only with sidecar containers": {
+		"pod only with sidecar containers. request sum(sidecar) + sum(containers)": {
 			podSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					*testingutil.MakeContainer().
@@ -221,7 +221,7 @@ func TestTotalRequest(t *testing.T) {
 						AsSidecar().
 						Obj(),
 					*testingutil.MakeContainer().
-						WithResourceReq(corev1.ResourceCPU, "1500m").
+						WithResourceReq(corev1.ResourceCPU, "1.5").
 						WithResourceReq("example.com/gpu", "2").
 						AsSidecar().
 						Obj(),
@@ -232,18 +232,18 @@ func TestTotalRequest(t *testing.T) {
 						WithResourceReq(corev1.ResourceMemory, "2Gi").
 						Obj(),
 					*testingutil.MakeContainer().
-						WithResourceReq(corev1.ResourceCPU, "1500m").
+						WithResourceReq(corev1.ResourceCPU, "1.5").
 						WithResourceReq("example.com/gpu", "2").
 						Obj(),
 				},
 			},
 			want: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("8000m"),
+				corev1.ResourceCPU:    resource.MustParse("8"),
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 				"example.com/gpu":     resource.MustParse("4"),
 			},
 		},
-		"pod only with init containers": {
+		"pod only with regular init and sidecar containers. request max(regularContainers) + sum(sidecar)": {
 			podSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					*testingutil.MakeContainer().
@@ -271,7 +271,7 @@ func TestTotalRequest(t *testing.T) {
 				corev1.ResourceMemory: resource.MustParse("9Gi"),
 			},
 		},
-		"pod with regular init and sidecar containers": {
+		"pod with regular init and sidecar containers. request max(max(regularCointainers) + sum(sidecar), sum(sidecar) + sum(containers))": {
 			podSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					*testingutil.MakeContainer().
@@ -310,7 +310,7 @@ func TestTotalRequest(t *testing.T) {
 				"example.com/gpu":     resource.MustParse("4"),
 			},
 		},
-		"adds overhead": {
+		"adds overhead. request  max(max(regularCointainers) + sum(sidecar), sum(sidecar) + sum(containers)) + overhead": {
 			podSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					*testingutil.MakeContainer().
@@ -318,7 +318,7 @@ func TestTotalRequest(t *testing.T) {
 						WithResourceReq(corev1.ResourceMemory, "2Gi").
 						Obj(),
 					*testingutil.MakeContainer().
-						WithResourceReq(corev1.ResourceCPU, "1500m").
+						WithResourceReq(corev1.ResourceCPU, "1.5").
 						WithResourceReq("example.com/gpu", "2").
 						Obj(),
 					*testingutil.MakeContainer().
@@ -334,7 +334,7 @@ func TestTotalRequest(t *testing.T) {
 						WithResourceReq(corev1.ResourceMemory, "2Gi").
 						Obj(),
 					*testingutil.MakeContainer().
-						WithResourceReq(corev1.ResourceCPU, "1500m").
+						WithResourceReq(corev1.ResourceCPU, "1.5").
 						WithResourceReq("example.com/gpu", "2").
 						Obj(),
 				},
@@ -345,7 +345,7 @@ func TestTotalRequest(t *testing.T) {
 				},
 			},
 			want: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("6000m"),
+				corev1.ResourceCPU:    resource.MustParse("6"),
 				corev1.ResourceMemory: resource.MustParse("5Gi"),
 				"example.com/gpu":     resource.MustParse("5"),
 			},
@@ -370,7 +370,7 @@ func TestValidatePodSpec(t *testing.T) {
 				WithResourceReq("example.com/mainContainerGpu", "2").
 				Obj(),
 			*testingutil.MakeContainer().
-				WithResourceReq(corev1.ResourceCPU, "1500m").
+				WithResourceReq(corev1.ResourceCPU, "1.5").
 				WithResourceReq("example.com/gpu", "2").
 				Obj(),
 		},
@@ -380,7 +380,7 @@ func TestValidatePodSpec(t *testing.T) {
 				WithResourceReq(corev1.ResourceMemory, "2Gi").
 				Obj(),
 			*testingutil.MakeContainer().
-				WithResourceReq(corev1.ResourceCPU, "1500m").
+				WithResourceReq(corev1.ResourceCPU, "1.5").
 				WithResourceReq("example.com/gpu", "2").
 				WithResourceReq("example.com/initContainerGpu", "2").
 				Obj(),

--- a/pkg/util/limitrange/limitrange_test.go
+++ b/pkg/util/limitrange/limitrange_test.go
@@ -183,7 +183,7 @@ func TestTotalRequest(t *testing.T) {
 				"example.com/gpu":     resource.MustParse("2"),
 			},
 		},
-		"pod only with regular init containers. request max(regularContainers)": {
+		"pod only with regular init containers. request max( max(each initContainerUse), sum(containers) )": {
 			podSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					*testingutil.MakeContainer().
@@ -212,7 +212,7 @@ func TestTotalRequest(t *testing.T) {
 				"example.com/gpu":     resource.MustParse("2"),
 			},
 		},
-		"pod only with sidecar containers. request sum(sidecar) + sum(containers)": {
+		"pod only with sidecar containers. request max( max(each initContainerUse), sum(sidecarContainers) + sum(containers) )": {
 			podSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					*testingutil.MakeContainer().
@@ -243,7 +243,7 @@ func TestTotalRequest(t *testing.T) {
 				"example.com/gpu":     resource.MustParse("4"),
 			},
 		},
-		"pod only with regular init and sidecar containers. request max(regularContainers) + sum(sidecar)": {
+		"pod only with regular init and sidecar containers. request max( max(each InitContainerUse), sum(sidecarContainers) )": {
 			podSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					*testingutil.MakeContainer().
@@ -267,11 +267,11 @@ func TestTotalRequest(t *testing.T) {
 				},
 			},
 			want: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("9"),
-				corev1.ResourceMemory: resource.MustParse("9Gi"),
+				corev1.ResourceCPU:    resource.MustParse("7"),
+				corev1.ResourceMemory: resource.MustParse("7Gi"),
 			},
 		},
-		"pod with regular init and sidecar containers. request max(max(regularCointainers) + sum(sidecar), sum(sidecar) + sum(containers))": {
+		"pod with regular init and sidecar containers. request max( max(each InitContainer), sum(sidecarContainers) + sum(containers) )": {
 			podSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					*testingutil.MakeContainer().
@@ -310,7 +310,7 @@ func TestTotalRequest(t *testing.T) {
 				"example.com/gpu":     resource.MustParse("4"),
 			},
 		},
-		"adds overhead. request  max(max(regularCointainers) + sum(sidecar), sum(sidecar) + sum(containers)) + overhead": {
+		"adds overhead. request max( max(each InitContainer), sum(sidecarContainers) + sum(containers) ) + overhead": {
 			podSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					*testingutil.MakeContainer().
@@ -345,7 +345,7 @@ func TestTotalRequest(t *testing.T) {
 				},
 			},
 			want: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("6"),
+				corev1.ResourceCPU:    resource.MustParse("5"),
 				corev1.ResourceMemory: resource.MustParse("5Gi"),
 				"example.com/gpu":     resource.MustParse("5"),
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

Includes `SidecarContainers` in the computation of total resource requests of a pod.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2068 

#### Special notes for your reviewer:

The new formula to calculate the total was extracted from [KEP-753](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/753-sidecar-containers#resources-calculation-for-scheduling-and-pod-admission).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix the resource requests computation taking into account sidecar containers.
```