### PR TITLE
[kueuectl] Added validation for ClusterQueue on creating LocalQueue.

### DIFF
--- a/site/content/en/docs/reference/kubectl-kueue.md
+++ b/site/content/en/docs/reference/kubectl-kueue.md
@@ -85,4 +85,7 @@ The following table includes short descriptions and the general syntax for all o
 ```shell
 # Create a local queue 
 kubectl kueue create localqueue my-local-queue -c my-cluster-queue
+
+# Create a local queue with unknown cluster queue
+kubectl kueue create localqueue my-local-queue -c my-cluster-queue -i`
 ```

--- a/test/e2e/singlecluster/kueuectl_test.go
+++ b/test/e2e/singlecluster/kueuectl_test.go
@@ -68,5 +68,21 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
+
+		ginkgo.It("Shouldn't create local queue with unknown cluster queue", func() {
+			lqName := "e2e-lq"
+			cqName := "e2e-cq-unknown"
+
+			ginkgo.By("Create local queue by kueuectl", func() {
+				cmd := exec.Command(kueuectlPath, "create", "localqueue", lqName, "--clusterqueue", cqName, "--namespace", ns.Name)
+				_, err := cmd.CombinedOutput()
+				gomega.Expect(err).To(gomega.HaveOccurred())
+			})
+
+			ginkgo.By("Check that the local queue did not create", func() {
+				var createdQueue v1beta1.LocalQueue
+				gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: lqName, Namespace: ns.Name}, &createdQueue)).ToNot(gomega.Succeed())
+			})
+		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
To prevent the creation of a localqueue if a clusterqueue not exist.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2112 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add validation for ClusterQueue on creating LocalQueue
```