### PR TITLE
Add troubleshooting note for pending admission checks

### DIFF
--- a/site/content/en/docs/tasks/troubleshooting/troubleshooting_jobs.md
+++ b/site/content/en/docs/tasks/troubleshooting/troubleshooting_jobs.md
@@ -171,6 +171,31 @@ spec:
 
 See [resources groups](https://kueue.sigs.k8s.io/docs/concepts/cluster_queue/#resource-groups) for more information.
 
+### Pending Admission Checks
+
+When the ClusterQueue has [admission checks](/docs/concepts/admission_check) configured, such as
+[ProvisioningRequest](/docs/admission-check-controllers/provisioning) or [MultiKueue](/docs/concepts/multikueue),
+a Workload might stay with a status similar to the following, until the admission checks pass:
+
+```yaml
+status:
+  admission:
+    clusterQueue: dws-cluster-queue
+    podSetAssignments:
+      ...
+  admissionChecks:
+  - lastTransitionTime: "2024-05-03T20:01:59Z"
+    message: ""
+    name: dws-prov
+    state: Pending
+  conditions:
+  - lastTransitionTime: "2024-05-03T20:01:59Z"
+    message: Quota reserved in ClusterQueue dws-cluster-queue
+    reason: QuotaReserved
+    status: "True"
+    type: QuotaReserved
+```
+
 ### Unattempted Workload
 
 When using a [ClusterQueue](/docs/concepts/cluster_queue) with the `StrictFIFO`


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Just a quick note about what to look for when using admission checks. We should probably have a dedicated page for ProvisioningRequest and MultiKueue specifically, but I'll leave those for a follow up.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

@pajakd recently improved the messaging for ProvisioningRequest in #2007, but we can update that in a separate PR, after we cherry-pick this one.

I also opened #2121 to improve the Admitted condition during this time.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```