### PR TITLE
fix(helm): ensure Manager Deployment is restarted when config changes

### DIFF
--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
       {{- include "kueue.selectorLabels" . | nindent 8 }}
       annotations:
+        charts.kueue.x-k8s.io/config-checksum: {{ include (print .Template.BasePath "/manager/manager-config.yaml") . | sha256sum }}
         kubectl.kubernetes.io/default-container: manager
         {{- if .Values.controllerManager.manager.podAnnotations }}
         {{- toYaml .Values.controllerManager.manager.podAnnotations | nindent 8 }}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Changes to Kueue config requires Pod to be restarted in order of being picked up

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
