### PR TITLE
Disabled scheduler on "should requeued after job status ready" test.

### DIFF
--- a/test/integration/controller/jobs/job/job_controller_test.go
+++ b/test/integration/controller/jobs/job/job_controller_test.go
@@ -1103,7 +1103,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 			CRDPath: crdPath,
 		}
 		cfg = fwk.Init()
-		ctx, k8sClient = fwk.RunManager(cfg, managerAndSchedulerSetup(nil))
+		ctx, k8sClient = fwk.RunManager(cfg, managerAndControllersSetup(true, nil))
 	})
 	ginkgo.AfterAll(func() {
 		fwk.Teardown()
@@ -1896,7 +1896,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 	})
 })
 
-var _ = ginkgo.Describe("Job controller interacting with scheduler when waitForPodsReady enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+var _ = ginkgo.Describe("Job controller interacting with Workload controller when waitForPodsReady with requeuing strategy is enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns *corev1.Namespace
 		fl *kueue.ResourceFlavor
@@ -1915,10 +1915,11 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler when waitForP
 			Timeout:        &metav1.Duration{Duration: 10 * time.Millisecond},
 			RequeuingStrategy: &configapi.RequeuingStrategy{
 				Timestamp:          ptr.To(configapi.EvictionTimestamp),
-				BackoffBaseSeconds: ptr.To[int32](1),
+				BackoffBaseSeconds: ptr.To[int32](2),
 			},
 		}
-		ctx, k8sClient = fwk.RunManager(cfg, managerAndSchedulerSetup(
+		ctx, k8sClient = fwk.RunManager(cfg, managerAndControllersSetup(
+			false,
 			&configapi.Configuration{WaitForPodsReady: waitForPodsReady},
 			jobframework.WithWaitForPodsReady(waitForPodsReady),
 		))
@@ -1949,7 +1950,7 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler when waitForP
 	})
 
 	ginkgo.When("workload evicted due pods ready timeout", func() {
-		ginkgo.It("should requeued after job status ready", func() {
+		ginkgo.It("should re-queue a workload evicted due to PodsReady timeout after the backoff elapses", func() {
 			ginkgo.By("creating job")
 			job := testingjob.MakeJob("job", ns.Name).Queue(lq.Name).Request(corev1.ResourceCPU, "2").Obj()
 			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
@@ -1957,13 +1958,14 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler when waitForP
 			wl := &kueue.Workload{}
 			wlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: job.Namespace}
 
-			jobKey := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
-			createdJob := &batchv1.Job{}
+			ginkgo.By("setting quota reservation")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+				g.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, testing.MakeAdmission(cq.Name).Obj())).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("checking the workload is evicted")
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, jobKey, createdJob)).Should(gomega.Succeed())
-				g.Expect(createdJob.Status.Ready, 0).Should(gomega.BeNil())
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				g.Expect(wl.Status.Conditions).To(gomega.ContainElements(
 					gomega.BeComparableTo(metav1.Condition{
@@ -1993,45 +1995,36 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler when waitForP
 				))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			ginkgo.By("setting job status ready")
-			createdJob.Status.Ready = ptr.To(int32(1))
-			gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
-
 			ginkgo.By("checking the workload is requeued")
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, jobKey, createdJob)).Should(gomega.Succeed())
-				g.Expect(createdJob.Status.Ready).ShouldNot(gomega.BeNil())
-				g.Expect(*createdJob.Status.Ready).Should(gomega.Equal(int32(1)))
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				g.Expect(wl.Status.RequeueState).ShouldNot(gomega.BeNil())
-				// Assert count>0 since the workload may get requeued and evicted
-				// more than once before we mark the Job status as ready.
-				g.Expect(ptr.Deref(wl.Status.RequeueState.Count, 0)).Should(gomega.BeNumerically(">", 0))
+				g.Expect(wl.Status.RequeueState.Count).Should(gomega.Equal(ptr.To[int32](1)))
 				g.Expect(wl.Status.RequeueState.RequeueAt).Should(gomega.BeNil())
 				g.Expect(wl.Status.Conditions).To(gomega.ContainElements(
 					gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.WorkloadPodsReady,
-						Status:  metav1.ConditionTrue,
+						Status:  metav1.ConditionFalse,
 						Reason:  kueue.WorkloadPodsReady,
-						Message: "All pods were ready or succeeded since the workload admission",
+						Message: "Not all pods are ready or succeeded",
 					}, util.IgnoreConditionTimestampsAndObservedGeneration),
 					gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
-						Status:  metav1.ConditionTrue,
-						Reason:  kueue.WorkloadQuotaReserved,
-						Message: fmt.Sprintf("Quota reserved in ClusterQueue %s", cq.Name),
+						Status:  metav1.ConditionFalse,
+						Reason:  "Pending",
+						Message: fmt.Sprintf("Exceeded the PodsReady timeout %s", wlKey.String()),
 					}, util.IgnoreConditionTimestampsAndObservedGeneration),
 					gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.WorkloadEvicted,
-						Status:  metav1.ConditionFalse,
-						Reason:  kueue.WorkloadQuotaReserved,
-						Message: fmt.Sprintf("Previously: Exceeded the PodsReady timeout %s", wlKey.String()),
+						Status:  metav1.ConditionTrue,
+						Reason:  kueue.WorkloadEvictedByPodsReadyTimeout,
+						Message: fmt.Sprintf("Exceeded the PodsReady timeout %s", wlKey.String()),
 					}, util.IgnoreConditionTimestampsAndObservedGeneration),
 					gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.WorkloadAdmitted,
-						Status:  metav1.ConditionTrue,
-						Reason:  kueue.WorkloadAdmitted,
-						Message: "The workload is admitted",
+						Status:  metav1.ConditionFalse,
+						Reason:  "NoReservation",
+						Message: "The workload has no reservation",
 					}, util.IgnoreConditionTimestampsAndObservedGeneration),
 					gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.WorkloadRequeued,

--- a/test/integration/controller/jobs/job/suite_test.go
+++ b/test/integration/controller/jobs/job/suite_test.go
@@ -76,7 +76,7 @@ func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 	}
 }
 
-func managerAndSchedulerSetup(configuration *config.Configuration, opts ...jobframework.Option) framework.ManagerSetup {
+func managerAndControllersSetup(enableScheduler bool, configuration *config.Configuration, opts ...jobframework.Option) framework.ManagerSetup {
 	return func(mgr manager.Manager, ctx context.Context) {
 		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -100,8 +100,10 @@ func managerAndSchedulerSetup(configuration *config.Configuration, opts ...jobfr
 		err = job.SetupWebhook(mgr, opts...)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName))
-		err = sched.Start(ctx)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		if enableScheduler {
+			sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName))
+			err = sched.Start(ctx)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Disable scheduler on "should requeued after job status ready" test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2155 and #2158

#### Special notes for your reviewer:
Related for this comment https://github.com/kubernetes-sigs/kueue/pull/2158#discussion_r1593690691.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```