### PR TITLE
Enforce the pre null pointer check for the Integrations when performing WithEnabledFrameworks()

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -215,7 +215,7 @@ func setupIndexes(ctx context.Context, mgr ctrl.Manager, cfg *configapi.Configur
 	}
 
 	opts := []jobframework.Option{
-		jobframework.WithEnabledFrameworks(cfg.Integrations),
+		jobframework.WithEnabledFrameworks(cfg.Integrations.Frameworks),
 	}
 	return jobframework.SetupIndexes(ctx, mgr.GetFieldIndexer(), opts...)
 }
@@ -266,7 +266,7 @@ func setupControllers(mgr ctrl.Manager, cCache *cache.Cache, queues *queue.Manag
 		jobframework.WithWaitForPodsReady(cfg.WaitForPodsReady),
 		jobframework.WithKubeServerVersion(serverVersionFetcher),
 		jobframework.WithIntegrationOptions(corev1.SchemeGroupVersion.WithKind("Pod").String(), cfg.Integrations.PodOptions),
-		jobframework.WithEnabledFrameworks(cfg.Integrations),
+		jobframework.WithEnabledFrameworks(cfg.Integrations.Frameworks),
 		jobframework.WithEnabledExternalFrameworks(cfg.Integrations.ExternalFrameworks),
 		jobframework.WithManagerName(constants.KueueName),
 		jobframework.WithLabelKeysToCopy(cfg.Integrations.LabelKeysToCopy),

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -126,12 +126,12 @@ func WithIntegrationOptions(integrationName string, opts any) Option {
 }
 
 // WithEnabledFrameworks adds framework names enabled in the ConfigAPI.
-func WithEnabledFrameworks(i *configapi.Integrations) Option {
+func WithEnabledFrameworks(frameworks []string) Option {
 	return func(o *Options) {
-		if i == nil || len(i.Frameworks) == 0 {
+		if len(frameworks) == 0 {
 			return
 		}
-		o.EnabledFrameworks = sets.New(i.Frameworks...)
+		o.EnabledFrameworks = sets.New(frameworks...)
 	}
 }
 

--- a/pkg/controller/jobframework/setup_test.go
+++ b/pkg/controller/jobframework/setup_test.go
@@ -37,7 +37,6 @@ import (
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
-	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -51,9 +50,7 @@ func TestSetupControllers(t *testing.T) {
 	}{
 		"setup controllers succeed": {
 			opts: []Option{
-				WithEnabledFrameworks(&configapi.Integrations{
-					Frameworks: []string{"batch/job", "kubeflow.org/mpijob"},
-				}),
+				WithEnabledFrameworks([]string{"batch/job", "kubeflow.org/mpijob"}),
 				WithEnabledExternalFrameworks([]string{
 					"Foo.v1.example.com",
 					"Bar.v2.example.com",
@@ -66,9 +63,7 @@ func TestSetupControllers(t *testing.T) {
 		},
 		"mapper doesn't have kubeflow.org/mpijob, but no error occur": {
 			opts: []Option{
-				WithEnabledFrameworks(&configapi.Integrations{
-					Frameworks: []string{"batch/job", "kubeflow.org/mpijob"},
-				}),
+				WithEnabledFrameworks([]string{"batch/job", "kubeflow.org/mpijob"}),
 			},
 			mapperGVKs: []schema.GroupVersionKind{
 				batchv1.SchemeGroupVersion.WithKind("Job"),
@@ -131,9 +126,7 @@ func TestSetupIndexes(t *testing.T) {
 					Obj(),
 			},
 			opts: []Option{
-				WithEnabledFrameworks(&configapi.Integrations{
-					Frameworks: []string{"batch/job"},
-				}),
+				WithEnabledFrameworks([]string{"batch/job"}),
 			},
 			filter:        client.MatchingFields{GetOwnerKey(batchv1.SchemeGroupVersion.WithKind("Job")): "alpha"},
 			wantWorkloads: []string{"alpha-wl"},
@@ -148,9 +141,7 @@ func TestSetupIndexes(t *testing.T) {
 					Obj(),
 			},
 			opts: []Option{
-				WithEnabledFrameworks(&configapi.Integrations{
-					Frameworks: []string{"batch/job"},
-				}),
+				WithEnabledFrameworks([]string{"batch/job"}),
 			},
 			filter:                client.MatchingFields{GetOwnerKey(kubeflow.SchemeGroupVersionKind): "alpha"},
 			wantFieldMatcherError: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Based on this discussion (https://github.com/kubernetes-sigs/kueue/pull/2130#discussion_r1593749594), I replaced the arguments `.integrations` with `.integrations.frameworks` to enforce the pre-check null pointer when performing the `WithEnabledFrameworks()`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
JobFramework: Repaced the argument ".integrations" with the ".integrations.frameworks" in the "WithEnabledFrameworks()".
```
