### PR TITLE
Remove gci linter because it breaks import comments

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,23 +19,6 @@ linters-settings:
   govet:
     enable:
       - nilness
-  gci:
-    # Section configuration to compare against.
-    # Section names are case-insensitive and may contain parameters in ().
-    # The default order of sections is `standard > default > custom > blank > dot > alias`,
-    # If `custom-order` is `true`, it follows the order of `sections` option.
-    # Default: ["standard", "default"]
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - prefix(sigs.k8s.io/kueue) # Custom section: groups all imports with the specified Prefix.
-    # Skip generated files.
-    # Default: true
-    skip-generated: true
-    # Enable custom order of sections.
-    # If `true`, make the section order the same as the order of `sections`.
-    # Default: false
-    custom-order: true
   revive:
     enable-all-rules: false
     rules:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes `gci` from the `linter-settings` golangci-lint's config because it's does nothing. This reverts #2069.

#### Special notes for your reviewer:

Adding `gci` to `linters-settings` has no effect. This can be checked by running golangci-lint in verbose mode (see "Active 14 linters"):

```
❯ golangci-lint run -v
INFO [config_reader] Config search paths: [./ /Users/Oleksandr_Redko/src/github.com/kubernetes-sigs/kueue /Users/Oleksandr_Redko/src/github.com/kubernetes-sigs /Users/Oleksandr_Redko/src/github.com /Users/Oleksandr_Redko/src /Users/Oleksandr_Redko /Users /] 
INFO [config_reader] Used config file .golangci.yaml 
INFO [lintersdb] Active 14 linters: [copyloopvar dupword errcheck ginkgolinter gocritic goimports gosimple govet ineffassign loggercheck misspell staticcheck unconvert unused] 
INFO [loader] Go packages loading at mode 575 (compiled_files|exports_file|files|imports|name|deps|types_sizes) took 893.271667ms 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 28.035667ms 
```

To enable `gci`, it's needed to extend `linters.enable` list:

```
linters:
  enable:
    - ...
    - dupword
    - gci
    - ginkgolinter
    - ...
```

However, enabling `gci` can lead to some problems. `gci` removes the comments `// +kubebuilder:scaffold:imports`. This can be confirmed by running `golangci-lint run --enable=gci --fix` and observing the diff. Additionally, we already use `goimports`, which is also designed to sort imports.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```