### PR TITLE
[jobs] refactor GenericJob.Finished implementation

### DIFF
--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -278,22 +278,13 @@ func (j *Job) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 }
 
 func (j *Job) Finished() (message string, success, finished bool) {
-	var conditionType batchv1.JobConditionType
 	for _, c := range j.Status.Conditions {
 		if (c.Type == batchv1.JobComplete || c.Type == batchv1.JobFailed) && c.Status == corev1.ConditionTrue {
-			conditionType = c.Type
-			finished = true
-			message = c.Message
-			break
+			return c.Message, c.Type != batchv1.JobFailed, true
 		}
 	}
 
-	success = true
-	if conditionType == batchv1.JobFailed {
-		success = false
-	}
-
-	return message, success, finished
+	return "", true, false
 }
 
 func (j *Job) PodsReady() bool {

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
@@ -83,24 +83,16 @@ func (j *KubeflowJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 
 func (j *KubeflowJob) Finished() (message string, success, finished bool) {
 	if j.KFJobControl.JobStatus() == nil {
-		return message, finished, false
+		return "", false, false
 	}
-	var conditionType kftraining.JobConditionType
+
 	for _, c := range j.KFJobControl.JobStatus().Conditions {
 		if (c.Type == kftraining.JobSucceeded || c.Type == kftraining.JobFailed) && c.Status == corev1.ConditionTrue {
-			conditionType = c.Type
-			finished = true
-			message = c.Message
-			break
+			return c.Message, c.Type != kftraining.JobFailed, true
 		}
 	}
 
-	success = true
-	if conditionType == kftraining.JobFailed {
-		success = false
-	}
-
-	return message, success, finished
+	return "", true, false
 }
 
 func (j *KubeflowJob) PodSets() []kueue.PodSet {

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -149,22 +149,13 @@ func (j *MPIJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 }
 
 func (j *MPIJob) Finished() (message string, success, finished bool) {
-	var conditionType kubeflow.JobConditionType
 	for _, c := range j.Status.Conditions {
 		if (c.Type == kubeflow.JobSucceeded || c.Type == kubeflow.JobFailed) && c.Status == corev1.ConditionTrue {
-			conditionType = c.Type
-			finished = true
-			message = c.Message
-			break
+			return c.Message, c.Type != kubeflow.JobFailed, true
 		}
 	}
 
-	success = true
-	if conditionType == kubeflow.JobFailed {
-		success = false
-	}
-
-	return message, success, finished
+	return "", true, false
 }
 
 // PriorityClass calculates the priorityClass name needed for workload according to the following priorities:

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -161,12 +161,8 @@ func (j *RayCluster) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 }
 
 func (j *RayCluster) Finished() (message string, success, finished bool) {
-	success = true
-	if j.Status.State == rayv1.Failed {
-		success = false
-	}
 	// Technically a RayCluster is never "finished"
-	return j.Status.Reason, success, false
+	return j.Status.Reason, j.Status.State != rayv1.Failed, false
 }
 
 func (j *RayCluster) PodsReady() bool {

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -161,11 +161,8 @@ func (j *RayJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 }
 
 func (j *RayJob) Finished() (message string, success, finished bool) {
-	success = true
-	if j.Status.JobStatus == rayv1.JobStatusFailed {
-		success = false
-	}
 	message = j.Status.Message
+	success = j.Status.JobStatus != rayv1.JobStatusFailed
 	finished = j.Status.JobStatus == rayv1.JobStatusFailed || j.Status.JobStatus == rayv1.JobStatusSucceeded
 	return message, success, finished
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The PR simplifies implementation of `Finished()` method for all types of jobs.

#### Special notes for your reviewer:

I think this `for` loop is more readable

```go
	for _, c := range conditions {
		if (c.Type == JobComplete || c.Type == JobFailed) && c.Status == ConditionTrue {
			return c.Message, c.Type != JobFailed, true
		}
	}

	return "", true, false
```

than

```go
	var conditionType JobConditionType
	for _, c := range conditions {
		if (c.Type == JobComplete || c.Type == JobFailed) && c.Status == ConditionTrue {
			conditionType = c.Type
			finished = true
			message = c.Message
			break
		}
	}

	success = true
	if conditionType == JobFailed {
		success = false
	}

	return message, success, finished
```

Also, using one liner `success = conditionType != JobFailed` is readable enough.

Of course, it's subjective and reviewers can decline this PR.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```