### PR TITLE
Remove redundant lines at the start/end of a block

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -36,7 +36,10 @@ linters-settings:
     # If `true`, make the section order the same as the order of `sections`.
     # Default: false
     custom-order: true
-
+  revive:
+    enable-all-rules: false
+    rules:
+      - name: empty-lines
 
 # Settings for enabling and disabling linters
 linters:
@@ -49,6 +52,7 @@ linters:
     - govet
     - loggercheck
     - misspell
+    - revive
     - unconvert
 
 # Settings related to issues

--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -83,7 +83,6 @@ func Import(ctx context.Context, c client.Client, cache *util.ImportCache, jobs 
 
 		if err := createWorkload(ctx, c, wl); err != nil {
 			return false, fmt.Errorf("creating workload: %w", err)
-
 		}
 
 		//make its admission and update its status

--- a/cmd/importer/pod/import_test.go
+++ b/cmd/importer/pod/import_test.go
@@ -204,7 +204,6 @@ func TestImportNamespace(t *testing.T) {
 			if diff := cmp.Diff(tc.wantWorkloads, wlList.Items, wlCmpOpts...); diff != "" {
 				t.Errorf("Unexpected workloads (-want/+got)\n%s", diff)
 			}
-
 		})
 	}
 }

--- a/cmd/importer/util/util_test.go
+++ b/cmd/importer/util/util_test.go
@@ -152,8 +152,6 @@ func TestMappingMatch(t *testing.T) {
 			if tc.wantQueue != gotQueue {
 				t.Errorf("unexpected queue want %q got %q", tc.wantQueue, gotQueue)
 			}
-
 		})
 	}
-
 }

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -374,10 +374,8 @@ func TestFitInCohort(t *testing.T) {
 			if got != tc.wantFit {
 				t.Errorf("Unexpected result, %v", got)
 			}
-
 		})
 	}
-
 }
 
 func TestClusterQueueUpdate(t *testing.T) {

--- a/pkg/controller/admissionchecks/multikueue/admissioncheck.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck.go
@@ -83,7 +83,6 @@ func (a *ACReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		newCondition.Status = metav1.ConditionFalse
 		newCondition.Reason = "BadConfig"
 		newCondition.Message = fmt.Sprintf("Cannot load the AdmissionChecks parameters: %s", err.Error())
-
 	} else {
 		var missingClusters []string
 		var inactiveClusters []string

--- a/pkg/controller/admissionchecks/multikueue/admissioncheck_test.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck_test.go
@@ -286,7 +286,6 @@ func TestReconcile(t *testing.T) {
 				cmpopts.SortSlices(func(a, b metav1.Condition) bool { return a.Type < b.Type })); diff != "" {
 				t.Errorf("unexpected controllers (-want/+got):\n%s", diff)
 			}
-
 		})
 	}
 }

--- a/pkg/controller/admissionchecks/multikueue/batchjob_adapter.go
+++ b/pkg/controller/admissionchecks/multikueue/batchjob_adapter.go
@@ -63,7 +63,6 @@ func (b *batchJobAdapter) SyncJob(ctx context.Context, localClient client.Client
 		} else {
 			return nil
 		}
-
 	}
 
 	remoteJob = batchv1.Job{

--- a/pkg/controller/admissionchecks/multikueue/fswatch.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch.go
@@ -85,7 +85,6 @@ func (w *KubeConfigFSWatcher) Start(ctx context.Context) error {
 					w.notifyPathWrite(ev.Name)
 				default:
 					log.V(2).Info("Ignore event", "name", ev.Name, "op", ev.Op)
-
 				}
 			case err := <-w.watcher.Errors:
 				log.Error(err, "Kubeconfigs FS Watch")
@@ -94,7 +93,6 @@ func (w *KubeConfigFSWatcher) Start(ctx context.Context) error {
 				return
 			}
 		}
-
 	}()
 	return nil
 }

--- a/pkg/controller/admissionchecks/multikueue/fswatch_test.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch_test.go
@@ -178,7 +178,6 @@ func TestFSWatch(t *testing.T) {
 			if diff := cmp.Diff(tc.wantEventsForClusters, gotEventsForClusters); diff != "" {
 				t.Errorf("unexpected events for clusters(-want/+got):\n%s", diff)
 			}
-
 		})
 	}
 }
@@ -455,5 +454,4 @@ func TestFSWatchAddRm(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -704,7 +704,6 @@ func TestWlReconcile(t *testing.T) {
 					w2remoteClient.pendingReconnect.Store(true)
 				}
 				cRec.remoteClients["worker2"] = w2remoteClient
-
 			}
 
 			helper, _ := newMultiKueueStoreHelper(managerClient)

--- a/pkg/controller/admissionchecks/provisioning/admissioncheck_reconciler_test.go
+++ b/pkg/controller/admissionchecks/provisioning/admissioncheck_reconciler_test.go
@@ -152,7 +152,6 @@ func TestReconcileAdmissionCheck(t *testing.T) {
 			gotAc := &kueue.AdmissionCheck{}
 			if err := k8sclient.Get(ctx, types.NamespacedName{Name: tc.check.Name}, gotAc); err != nil {
 				t.Errorf("unexpected error getting check %q", tc.check.Name)
-
 			}
 
 			gotCondition := apimeta.FindStatusCondition(gotAc.Status.Conditions, kueue.AdmissionCheckActive)

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -749,7 +749,6 @@ func TestReconcile(t *testing.T) {
 				gotWl := &kueue.Workload{}
 				if err := k8sclient.Get(ctx, types.NamespacedName{Namespace: TestNamespace, Name: name}, gotWl); err != nil {
 					t.Errorf("unexpected error getting workload %q", name)
-
 				}
 
 				if diff := cmp.Diff(wantWl, gotWl, wlCmpOptions...); diff != "" {
@@ -761,7 +760,6 @@ func TestReconcile(t *testing.T) {
 				gotRequest := &autoscaling.ProvisioningRequest{}
 				if err := k8sclient.Get(ctx, types.NamespacedName{Namespace: TestNamespace, Name: name}, gotRequest); err != nil {
 					t.Errorf("unexpected error getting request %q", name)
-
 				}
 
 				if diff := cmp.Diff(wantRequest, gotRequest, reqCmpOptions...); diff != "" {
@@ -773,7 +771,6 @@ func TestReconcile(t *testing.T) {
 				gotTemplate := &corev1.PodTemplate{}
 				if err := k8sclient.Get(ctx, types.NamespacedName{Namespace: TestNamespace, Name: name}, gotTemplate); err != nil {
 					t.Errorf("unexpected error getting template %q", name)
-
 				}
 
 				if diff := cmp.Diff(wantTemplate, gotTemplate, tmplCmpOptions...); diff != "" {
@@ -793,7 +790,6 @@ func TestReconcile(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestActiveOrLastPRForChecks(t *testing.T) {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -538,7 +538,6 @@ func (r *JobReconciler) getParentWorkload(ctx context.Context, job GenericJob, o
 
 	// In theory the parent can own multiple Workloads, we cannot do too much about it, maybe log it.
 	return &wlList.Items[0], nil
-
 }
 
 // ensureOneWorkload will query for the single matched workload corresponding to job and return it.
@@ -1043,7 +1042,6 @@ func GetPodSetsInfoFromWorkload(wl *kueue.Workload) []podset.PodSetInfo {
 	}
 
 	return slices.Map(wl.Spec.PodSets, podset.FromPodSet)
-
 }
 
 type ReconcilerSetup func(*builder.Builder, client.Client) *builder.Builder

--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -415,5 +415,4 @@ func TestReconciler(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
@@ -65,7 +65,6 @@ func (j *KubeflowJob) RunWithPodSetsInfo(podSetsInfo []podset.PodSetInfo) error 
 		if err := podset.Merge(&replica.ObjectMeta, &replica.Spec, info); err != nil {
 			return err
 		}
-
 	}
 	return nil
 }

--- a/pkg/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller_test.go
@@ -319,5 +319,4 @@ func TestReconciler(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -294,7 +294,6 @@ func (p *Pod) Run(ctx context.Context, c client.Client, podSetsInfo []podset.Pod
 		}
 		return nil
 	})
-
 }
 
 // RunWithPodSetsInfo will inject the node affinity and podSet counts extracting from workload to job and unsuspend it.

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -3755,7 +3755,6 @@ func TestReconciler(t *testing.T) {
 					// Make life easier when changing the hashing function.
 					hash, _ := getRoleHash(p)
 					t.Logf("note, the hash for pod[%v] = %s", i, hash)
-
 				}
 				t.Errorf("Workloads after reconcile (-want,+got):\n%s", diff)
 			}

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -347,7 +347,6 @@ func TestGetRoleHash(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-
 			var previousHash string
 			for i := range tc.pods {
 				hash, err := getRoleHash(tc.pods[i].pod)

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -343,7 +343,6 @@ func TestReconciler(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-
 			ctx, _ := utiltesting.ContextWithLog(t)
 			clientBuilder := utiltesting.NewClientBuilder(rayv1.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -185,7 +185,6 @@ func TestFromAssignment(t *testing.T) {
 }
 
 func TestMergeRestore(t *testing.T) {
-
 	basePodSet := utiltesting.MakePodSet("", 1).
 		NodeSelector(map[string]string{"ns0": "ns0v"}).
 		Labels(map[string]string{"l0": "l0v"}).
@@ -301,7 +300,6 @@ func TestMergeRestore(t *testing.T) {
 				if diff := cmp.Diff(orig.Template, tc.podSet.Template, cmpopts.EquateEmpty()); diff != "" {
 					t.Errorf("Unexpected template (-want/+got):\n%s", diff)
 				}
-
 			}
 		})
 	}

--- a/pkg/scheduler/flavorassigner/podset_reducer_test.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer_test.go
@@ -112,19 +112,15 @@ func TestSearch(t *testing.T) {
 					total += v
 				}
 				return total, total <= tc.countLimit
-
 			})
 			count, found := red.Search()
 			if count != tc.wantCount {
-
 				t.Errorf("Unexpected count:%d, want: %d", count, tc.wantCount)
 			}
 
 			if found != tc.wantFound {
 				t.Errorf("Unexpected found:%v, want: %v", found, tc.wantFound)
-
 			}
 		})
 	}
-
 }

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -172,7 +172,6 @@ func (p *Preemptor) IssuePreemptions(ctx context.Context, preemptor *workload.In
 	workqueue.ParallelizeUntil(ctx, parallelPreemptions, len(targets), func(i int) {
 		target := targets[i]
 		if !meta.IsStatusConditionTrue(target.Obj.Status.Conditions, kueue.WorkloadEvicted) {
-
 			origin := "ClusterQueue"
 			reason := "InClusterQueue"
 			if cq.Name != target.ClusterQueue {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -392,7 +392,6 @@ func resourcesToReserve(e *entry, cq *cache.ClusterQueue) cache.FlavorResourceQu
 					reservedUsage[flavor][resource] = min(usage, cqQuota.Nominal+*cqQuota.BorrowingLimit-cq.Usage[flavor][resource])
 				}
 			}
-
 		}
 	}
 	return reservedUsage
@@ -431,11 +430,9 @@ func (s *Scheduler) getAssignments(log logr.Logger, wl *workload.Info, snap *cac
 			}
 			preemptionTargets := s.preemptor.GetTargets(*wl, assignment, snap)
 			if len(preemptionTargets) > 0 {
-
 				return &partialAssignment{assignment: assignment, preemptionTargets: preemptionTargets}, true
 			}
 			return nil, false
-
 		})
 		if pa, found := reducer.Search(); found {
 			return pa.assignment, pa.preemptionTargets

--- a/pkg/util/maps/maps_test.go
+++ b/pkg/util/maps/maps_test.go
@@ -61,7 +61,6 @@ func TestToRefMap(t *testing.T) {
 				}
 			}
 		})
-
 	}
 }
 

--- a/pkg/util/resource/resource_test.go
+++ b/pkg/util/resource/resource_test.go
@@ -194,7 +194,6 @@ func TestMerge(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestGetGraterKeys(t *testing.T) {

--- a/pkg/util/testing/metrics/metrics.go
+++ b/pkg/util/testing/metrics/metrics.go
@@ -32,7 +32,6 @@ type MetricDataPoint struct {
 }
 
 func (a *MetricDataPoint) Less(b *MetricDataPoint) bool {
-
 	keys := maps.Keys(a.Labels)
 	sort.Strings(keys)
 	for _, k := range keys {
@@ -58,7 +57,6 @@ func (a *MetricDataPoint) Less(b *MetricDataPoint) bool {
 		return false
 	}
 	return a.Value < b.Value
-
 }
 
 func CollectFilteredGaugeVec(v prometheus.Collector, labels map[string]string) []MetricDataPoint {

--- a/pkg/util/testing/metrics/metrics_test.go
+++ b/pkg/util/testing/metrics/metrics_test.go
@@ -129,6 +129,5 @@ func TestCollect(t *testing.T) {
 				t.Errorf("Unexpected data points (-want,+got):\n%s", diff)
 			}
 		})
-
 	}
 }

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -208,7 +208,6 @@ func reclaimableCounts(wl *kueue.Workload) map[string]int32 {
 }
 
 func podSetsCounts(wl *kueue.Workload) map[string]int32 {
-
 	ret := make(map[string]int32, len(wl.Spec.PodSets))
 	for i := range wl.Spec.PodSets {
 		ps := &wl.Spec.PodSets[i]

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -756,6 +756,5 @@ func TestAdmissionCheckStrategy(t *testing.T) {
 				t.Errorf("Unexpected AdmissionChecks, (want-/got+):\n%s", diff)
 			}
 		})
-
 	}
 }

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -113,7 +113,6 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				g.Expect(k8sManagerClient.Get(ctx, acKey, &updatedAc)).To(gomega.Succeed())
 				g.Expect(apimeta.IsStatusConditionTrue(updatedAc.Status.Conditions, kueue.AdmissionCheckActive)).To(gomega.BeTrue())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
 		})
 		managerFlavor = utiltesting.MakeResourceFlavor("default").Obj()
 		gomega.Expect(k8sManagerClient.Create(ctx, managerFlavor)).Should(gomega.Succeed())

--- a/test/e2e/singlecluster/e2e_test.go
+++ b/test/e2e/singlecluster/e2e_test.go
@@ -81,7 +81,6 @@ var _ = ginkgo.Describe("Kueue", func() {
 					return false
 				}
 				return workload.HasQuotaReservation(createdWorkload)
-
 			}, util.Timeout, util.Interval).Should(gomega.BeFalse())
 			gomega.Expect(k8sClient.Delete(ctx, sampleJob)).Should(gomega.Succeed())
 		})
@@ -146,7 +145,6 @@ var _ = ginkgo.Describe("Kueue", func() {
 				}
 				return workload.HasQuotaReservation(createdWorkload) &&
 					apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadFinished)
-
 			}, util.LongTimeout, util.Interval).Should(gomega.BeTrue())
 		})
 
@@ -310,7 +308,6 @@ var _ = ginkgo.Describe("Kueue", func() {
 					g.Expect(ptr.Deref(updatedJob.Spec.Parallelism, 0)).To(gomega.Equal(int32(2)))
 					g.Expect(ptr.Deref(updatedJob.Spec.Completions, 0)).To(gomega.Equal(int32(4)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
 			})
 
 			ginkgo.By("Wait for the job to finish", func() {
@@ -322,7 +319,6 @@ var _ = ginkgo.Describe("Kueue", func() {
 					}
 					return workload.HasQuotaReservation(createdWorkload) &&
 						apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadFinished)
-
 				}, util.LongTimeout, util.Interval).Should(gomega.BeTrue())
 			})
 		})
@@ -377,7 +373,6 @@ var _ = ginkgo.Describe("Kueue", func() {
 						return nil
 					}
 					return slices.ToMap(createdWorkload.Status.AdmissionChecks, func(i int) (string, string) { return createdWorkload.Status.AdmissionChecks[i].Name, "" })
-
 				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(map[string]string{"check1": ""}))
 			})
 
@@ -387,7 +382,6 @@ var _ = ginkgo.Describe("Kueue", func() {
 						return false
 					}
 					return apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadQuotaReserved)
-
 				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
 			})
 
@@ -399,7 +393,6 @@ var _ = ginkgo.Describe("Kueue", func() {
 						return false
 					}
 					return ptr.Deref(createdJob.Spec.Suspend, false)
-
 				}, util.ConsistentDuration, util.Interval).Should(gomega.BeTrue())
 			})
 
@@ -427,7 +420,6 @@ var _ = ginkgo.Describe("Kueue", func() {
 				}
 				return workload.HasQuotaReservation(createdWorkload) &&
 					apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadFinished)
-
 			}, util.LongTimeout, util.Interval).Should(gomega.BeTrue())
 		})
 
@@ -443,7 +435,6 @@ var _ = ginkgo.Describe("Kueue", func() {
 						return nil
 					}
 					return slices.ToMap(createdWorkload.Status.AdmissionChecks, func(i int) (string, string) { return createdWorkload.Status.AdmissionChecks[i].Name, "" })
-
 				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(map[string]string{"check1": ""}))
 			})
 
@@ -487,7 +478,6 @@ var _ = ginkgo.Describe("Kueue", func() {
 						return false
 					}
 					return ptr.Deref(createdJob.Spec.Suspend, false)
-
 				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
 			})
 		})

--- a/test/e2e/singlecluster/visibility_test.go
+++ b/test/e2e/singlecluster/visibility_test.go
@@ -386,7 +386,6 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			})
 		})
 		ginkgo.It("Should allow fetching information about position of pending workloads from different LocalQueues from different Namespaces", func() {
-
 			ginkgo.By("Create a LocalQueue in a different Namespace", func() {
 				localQueueB = testing.MakeLocalQueue("b", nsB.Name).ClusterQueue(clusterQueue.Name).Obj()
 				gomega.Expect(k8sClient.Create(ctx, localQueueB)).Should(gomega.Succeed())

--- a/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
@@ -43,7 +43,6 @@ const (
 )
 
 var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-
 	var (
 		defaultMaxRetries        = provisioning.MaxRetries
 		defaultMinBackoffSeconds = provisioning.MinBackoffSeconds
@@ -150,7 +149,6 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 					},
 				).
 				Obj()
-
 		})
 
 		ginkgo.AfterEach(func() {
@@ -530,7 +528,6 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 						"p3":                "v3",
 						"ValidUntilSeconds": "0",
 					}))
-
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -557,7 +554,6 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 						"p2":                "v2.2",
 						"ValidUntilSeconds": "0",
 					}))
-
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -791,7 +787,6 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 					},
 				).
 				Obj()
-
 		})
 
 		ginkgo.AfterEach(func() {
@@ -892,7 +887,6 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 		})
 
 		ginkgo.It("Should retry when ProvisioningRequestConfig has MaxRetries>o, and every Provisioning request retry fails", func() {
-
 			ginkgo.By("Setting the admission check to the workload", func() {
 				updatedWl := &kueue.Workload{}
 				gomega.Eventually(func() error {

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -419,7 +419,6 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 		})
 
 		ginkgo.It("Should update status when workloads have reclaimable pods", func() {
-
 			ginkgo.By("Creating ResourceFlavors", func() {
 				onDemandFlavor = testing.MakeResourceFlavor(flavorOnDemand).Obj()
 				gomega.Expect(k8sClient.Create(ctx, onDemandFlavor)).To(gomega.Succeed())
@@ -592,7 +591,6 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 				util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 				util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 0)
 			})
-
 		})
 	})
 
@@ -692,7 +690,6 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 		})
 
 		ginkgo.It("Should update status conditions when admission checks are created", func() {
-
 			cpuArchAFlavor = testing.MakeResourceFlavor(flavorCPUArchA).Obj()
 			gomega.Expect(k8sClient.Create(ctx, cpuArchAFlavor)).To(gomega.Succeed())
 

--- a/test/integration/controller/core/workload_controller_test.go
+++ b/test/integration/controller/core/workload_controller_test.go
@@ -417,7 +417,6 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Ordered, ginkgo.ContinueOn
 		ginkgo.BeforeEach(func() {
 			workloadPriorityClass = testing.MakeWorkloadPriorityClass("workload-priority-class").PriorityValue(200).Obj()
 			gomega.Expect(k8sClient.Create(ctx, workloadPriorityClass)).To(gomega.Succeed())
-
 		})
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())

--- a/test/integration/controller/jobs/job/job_controller_test.go
+++ b/test/integration/controller/jobs/job/job_controller_test.go
@@ -60,7 +60,6 @@ const (
 // +kubebuilder:docs-gen:collapse=Imports
 
 var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-
 	ginkgo.BeforeAll(func() {
 		fwk = &framework.Framework{
 			CRDPath: crdPath,
@@ -310,7 +309,6 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 	})
 
 	ginkgo.When("The parent job is managed by kueue", func() {
-
 		ginkgo.It("Should suspend a job if the parent workload does not exist", func() {
 			ginkgo.By("creating the parent job")
 			parentJob := testingjob.MakeJob(parentJobName, ns.Name).Label(constants.PrebuiltWorkloadLabel, "missing").Obj()
@@ -470,7 +468,6 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 					// The workload is not marked as finished.
 					g.Expect(apimeta.IsStatusConditionTrue(createdWl.Status.Conditions, kueue.WorkloadFinished)).To(gomega.BeFalse())
-
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -527,7 +524,6 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				})
 			})
 		})
-
 	})
 
 	ginkgo.It("Should finish the preemption when the job becomes inactive", func() {
@@ -1327,7 +1323,6 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 				gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, nil)).Should(gomega.Succeed())
 				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
-
 			})
 
 			ginkgo.By("the node selector should be restored", func() {
@@ -1506,7 +1501,6 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 			gomega.Eventually(func() []kueue.ReclaimablePod {
 				gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				return wl.Status.ReclaimablePods
-
 			}, util.Timeout, util.Interval).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{{
 				Name:  "main",
 				Count: 1,
@@ -1891,7 +1885,6 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 					Should(gomega.Succeed())
 				g.Expect(sampleJob.Spec.Suspend).To(gomega.Equal(ptr.To(false)))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
 		})
 	})
 })

--- a/test/integration/controller/jobs/job/job_webhook_test.go
+++ b/test/integration/controller/jobs/job/job_webhook_test.go
@@ -40,7 +40,6 @@ var _ = ginkgo.Describe("Job Webhook", func() {
 	var ns *corev1.Namespace
 
 	ginkgo.When("With manageJobsWithoutQueueName enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-
 		ginkgo.BeforeAll(func() {
 			fwk = &framework.Framework{
 				CRDPath:     crdPath,

--- a/test/integration/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/controller/jobs/jobset/jobset_controller_test.go
@@ -74,7 +74,6 @@ var _ = ginkgo.Describe("JobSet controller", ginkgo.Ordered, ginkgo.ContinueOnFa
 			},
 		}
 		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
-
 	})
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
@@ -873,7 +872,6 @@ var _ = ginkgo.Describe("JobSet controller interacting with scheduler", ginkgo.O
 		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
-
 	})
 
 	ginkgo.It("Should allow reclaim of resources that are no longer needed", func() {
@@ -961,7 +959,6 @@ var _ = ginkgo.Describe("JobSet controller interacting with scheduler", ginkgo.O
 			gomega.Eventually(func() []kueue.ReclaimablePod {
 				gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				return wl.Status.ReclaimablePods
-
 			}, util.Timeout, util.Interval).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{
 				{
 					Name:  "replicated-job-1",

--- a/test/integration/controller/jobs/jobset/jobset_webhook_test.go
+++ b/test/integration/controller/jobs/jobset/jobset_webhook_test.go
@@ -63,5 +63,4 @@ var _ = ginkgo.Describe("JobSet Webhook", func() {
 			gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.BeTrue(), "error: %v", err)
 		})
 	})
-
 })

--- a/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
@@ -55,7 +55,6 @@ const (
 // +kubebuilder:docs-gen:collapse=Imports
 
 var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-
 	ginkgo.BeforeAll(func() {
 		fwk = &framework.Framework{
 			CRDPath:     crdPath,
@@ -869,12 +868,10 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 		gomega.Expect(createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeWorker].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
-
 	})
 
 	ginkgo.When("The workload's admission is removed", func() {
 		ginkgo.It("Should restore the original node selectors", func() {
-
 			localQueue := testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
 			job := testingmpijob.MakeMPIJob(jobName, ns.Name).Queue(localQueue.Name).
 				Request(kubeflow.MPIReplicaTypeLauncher, corev1.ResourceCPU, "3").

--- a/test/integration/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/test/integration/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -32,7 +32,6 @@ var _ = ginkgo.Describe("MPIJob Webhook", func() {
 	var ns *corev1.Namespace
 
 	ginkgo.When("With manageJobsWithoutQueueName disabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-
 		ginkgo.BeforeAll(func() {
 			fwk = &framework.Framework{
 				CRDPath:     crdPath,

--- a/test/integration/controller/jobs/mxjob/mxjob_controller_test.go
+++ b/test/integration/controller/jobs/mxjob/mxjob_controller_test.go
@@ -45,7 +45,6 @@ const (
 // +kubebuilder:docs-gen:collapse=Imports
 
 var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-
 	ginkgo.BeforeAll(func() {
 		fwk = &framework.Framework{
 			CRDPath:     crdPath,

--- a/test/integration/controller/jobs/paddlejob/paddlejob_controller_test.go
+++ b/test/integration/controller/jobs/paddlejob/paddlejob_controller_test.go
@@ -47,7 +47,6 @@ const (
 // +kubebuilder:docs-gen:collapse=Imports
 
 var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-
 	ginkgo.BeforeAll(func() {
 		fwk = &framework.Framework{
 			CRDPath:     crdPath,

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -1096,7 +1096,6 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						}
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
-
 			})
 
 			ginkgo.It("Should finalize workload if pods are absent", func() {
@@ -1208,7 +1207,6 @@ var _ = ginkgo.Describe("Pod controller interacting with scheduler", ginkgo.Orde
 			},
 		}
 		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
-
 	})
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())

--- a/test/integration/controller/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/test/integration/controller/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -52,7 +52,6 @@ const (
 // +kubebuilder:docs-gen:collapse=Imports
 
 var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-
 	ginkgo.BeforeAll(func() {
 		fwk = &framework.Framework{
 			CRDPath:     crdPath,
@@ -534,7 +533,6 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 
 	ginkgo.When("The workload's admission is removed", func() {
 		ginkgo.It("Should restore the original node selectors", func() {
-
 			localQueue := testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
 			job := testingpytorchjob.MakePyTorchJob(jobName, ns.Name).Queue(localQueue.Name).
 				Request(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "3").

--- a/test/integration/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/controller/jobs/raycluster/raycluster_controller_test.go
@@ -324,7 +324,6 @@ var _ = ginkgo.Describe("Job controller RayCluster for workloads when only jobs 
 			return childCluster.Spec.Suspend
 		}, util.Timeout, util.Interval).Should(gomega.Equal(ptr.To(true)))
 	})
-
 })
 
 var _ = ginkgo.Describe("Job controller when waitForPodsReady enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {

--- a/test/integration/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/test/integration/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -39,7 +39,6 @@ var _ = ginkgo.Describe("RayCluster Webhook", func() {
 	var ns *corev1.Namespace
 
 	ginkgo.When("With manageJobsWithoutQueueName disabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-
 		ginkgo.BeforeAll(func() {
 			fwk = &framework.Framework{
 				CRDPath:     crdPath,
@@ -74,7 +73,6 @@ var _ = ginkgo.Describe("RayCluster Webhook", func() {
 	})
 
 	ginkgo.When("With manageJobsWithoutQueueName enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-
 		ginkgo.BeforeAll(func() {
 			fwk = &framework.Framework{
 				CRDPath:     crdPath,

--- a/test/integration/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/controller/jobs/rayjob/rayjob_controller_test.go
@@ -321,7 +321,6 @@ var _ = ginkgo.Describe("Job controller for workloads when only jobs with queue 
 			return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
-
 })
 
 var _ = ginkgo.Describe("Job controller when waitForPodsReady enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
@@ -594,7 +593,6 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
 		util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
-
 	})
 })
 

--- a/test/integration/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/test/integration/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -32,7 +32,6 @@ var _ = ginkgo.Describe("RayJob Webhook", func() {
 	var ns *corev1.Namespace
 
 	ginkgo.When("With manageJobsWithoutQueueName disabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-
 		ginkgo.BeforeAll(func() {
 			fwk = &framework.Framework{
 				CRDPath:     crdPath,

--- a/test/integration/controller/jobs/tfjob/tfjob_controller_test.go
+++ b/test/integration/controller/jobs/tfjob/tfjob_controller_test.go
@@ -46,7 +46,6 @@ const (
 // +kubebuilder:docs-gen:collapse=Imports
 
 var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-
 	ginkgo.BeforeAll(func() {
 		fwk = &framework.Framework{
 			CRDPath:     crdPath,

--- a/test/integration/controller/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/test/integration/controller/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -46,7 +46,6 @@ const (
 // +kubebuilder:docs-gen:collapse=Imports
 
 var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-
 	ginkgo.BeforeAll(func() {
 		fwk = &framework.Framework{
 			CRDPath:     crdPath,

--- a/test/integration/importer/importer_test.go
+++ b/test/integration/importer/importer_test.go
@@ -62,7 +62,6 @@ var _ = ginkgo.Describe("Importer", func() {
 
 		lq = utiltesting.MakeLocalQueue("lq1", ns.Name).ClusterQueue("cq1").Obj()
 		gomega.Expect(k8sClient.Create(ctx, lq)).To(gomega.Succeed())
-
 	})
 
 	ginkgo.AfterEach(func() {
@@ -73,7 +72,6 @@ var _ = ginkgo.Describe("Importer", func() {
 
 	ginkgo.When("Kueue is started after import", func() {
 		ginkgo.It("Should keep the imported pods admitted", func() {
-
 			pod1 := utiltestingpod.MakePod("pod1", ns.Name).
 				Label("src.lbl", "src-val").
 				Request(corev1.ResourceCPU, "2").
@@ -161,5 +159,4 @@ var _ = ginkgo.Describe("Importer", func() {
 			})
 		})
 	})
-
 })

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -527,7 +527,6 @@ var _ = ginkgo.Describe("Multikueue", func() {
 				createdWorkload := &kueue.Workload{}
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, createdWorkload)).To(utiltesting.BeNotFoundError())
 			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-
 		})
 	})
 
@@ -599,7 +598,6 @@ var _ = ginkgo.Describe("Multikueue", func() {
 					Reason:  "Admitted",
 					Message: "The workload is admitted",
 				}, util.IgnoreConditionTimestampsAndObservedGeneration))
-
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -649,7 +647,6 @@ var _ = ginkgo.Describe("Multikueue", func() {
 				createdWorkload := &kueue.Workload{}
 				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlLookupKey, createdWorkload)).To(utiltesting.BeNotFoundError())
 			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-
 		})
 	})
 
@@ -700,7 +697,6 @@ var _ = ginkgo.Describe("Multikueue", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 				g.Expect(managerTestCluster.client.Delete(managerTestCluster.ctx, createdWorkload)).To(gomega.Succeed())
-
 			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -779,7 +775,6 @@ var _ = ginkgo.Describe("Multikueue", func() {
 					Reason:  "Admitted",
 					Message: "The workload is admitted",
 				}, util.IgnoreConditionTimestampsAndObservedGeneration))
-
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/scheduler/fairsharing/fair_sharing_test.go
@@ -35,7 +35,6 @@ import (
 )
 
 var _ = ginkgo.Describe("Scheduler", func() {
-
 	var (
 		defaultFlavor *kueue.ResourceFlavor
 		ns            *corev1.Namespace
@@ -51,7 +50,6 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			},
 		}
 		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
-
 	})
 
 	ginkgo.AfterEach(func() {
@@ -59,7 +57,6 @@ var _ = ginkgo.Describe("Scheduler", func() {
 	})
 
 	ginkgo.When("Preemption is disabled", func() {
-
 		var (
 			cqA      *kueue.ClusterQueue
 			lqA      *kueue.LocalQueue
@@ -146,7 +143,6 @@ var _ = ginkgo.Describe("Scheduler", func() {
 	})
 
 	ginkgo.When("Preemption is enabled", func() {
-
 		var (
 			cqA *kueue.ClusterQueue
 			lqA *kueue.LocalQueue
@@ -236,7 +232,6 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectReservingActiveWorkloadsMetric(cqC, 1)
 		})
 	})
-
 })
 
 func finishRunningWorkloadsInCQ(cq *kueue.ClusterQueue, n int) {

--- a/test/integration/scheduler/podsready/scheduler_test.go
+++ b/test/integration/scheduler/podsready/scheduler_test.go
@@ -54,7 +54,6 @@ const (
 // +kubebuilder:docs-gen:collapse=Imports
 
 var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
-
 	var (
 		// Values changed by tests (and reset after each):
 		podsReadyTimeout           = defaultPodsReadyTimeout
@@ -124,7 +123,6 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 	})
 
 	ginkgo.Context("Long PodsReady timeout", func() {
-
 		ginkgo.BeforeEach(func() {
 			podsReadyTimeout = time.Minute
 		})
@@ -191,11 +189,9 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, prodWl)
 			util.ExpectWorkloadsToBeWaiting(ctx, k8sClient, devWl)
 		})
-
 	})
 
 	var _ = ginkgo.Context("Short PodsReady timeout", func() {
-
 		ginkgo.BeforeEach(func() {
 			podsReadyTimeout = 3 * time.Second
 			requeuingBackoffLimitCount = ptr.To[int32](2)
@@ -451,7 +447,6 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 	})
 
 	var _ = ginkgo.Context("Requeuing timestamp set to Creation", func() {
-
 		var (
 			standaloneClusterQ *kueue.ClusterQueue
 			standaloneQueue    *kueue.LocalQueue
@@ -517,7 +512,6 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			})
 		})
 	})
-
 })
 
 var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
@@ -590,7 +584,6 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 	})
 
 	ginkgo.Context("Long PodsReady timeout", func() {
-
 		ginkgo.BeforeEach(func() {
 			podsReadyTimeout = time.Minute
 		})
@@ -619,7 +612,6 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, prodWl)
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, devClusterQ.Name, devWl)
 		})
-
 	})
 
 	var _ = ginkgo.Context("Short PodsReady timeout", func() {
@@ -651,7 +643,6 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 	})
 
 	var _ = ginkgo.Context("Requeuing timestamp set to Creation", func() {
-
 		var (
 			standaloneClusterQ *kueue.ClusterQueue
 			standaloneQueue    *kueue.LocalQueue
@@ -724,5 +715,4 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 			})
 		})
 	})
-
 })

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -536,7 +536,6 @@ var _ = ginkgo.Describe("Preemption", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, preemptorBetaWl)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, useAllAlphaWl, pendingAlphaWl)
 		})
-
 	})
 
 	ginkgo.Context("When most quota is in a shared ClusterQueue in a cohort", func() {
@@ -727,7 +726,6 @@ var _ = ginkgo.Describe("Preemption", func() {
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, bBestEffortLowWl,
 				testing.MakeAdmission(bBestEffortCQ.Name).Assignment(corev1.ResourceCPU, "one", "1").Obj(),
 			)
-
 		})
 	})
 
@@ -792,5 +790,4 @@ var _ = ginkgo.Describe("Preemption", func() {
 				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "alpha", "4").Obj())
 		})
 	})
-
 })

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -530,7 +530,6 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				createWl := &kueue.Workload{}
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), createWl)).To(gomega.Succeed())
 				gomega.Expect(*createWl.Status.Admission.PodSetAssignments[0].Count).To(gomega.Equal(int32(1)))
-
 			})
 		})
 	})

--- a/test/integration/webhook/admissioncheck_test.go
+++ b/test/integration/webhook/admissioncheck_test.go
@@ -15,7 +15,6 @@ import (
 
 var _ = ginkgo.Describe("AdmissionCheck Webhook", func() {
 	ginkgo.When("Creating a AdmissionCheck", func() {
-
 		ginkgo.DescribeTable("Defaulting on creating", func(ac, wantAC kueue.AdmissionCheck) {
 			gomega.Expect(k8sClient.Create(ctx, &ac)).Should(gomega.Succeed())
 			defer func() {

--- a/test/integration/webhook/clusterqueue_test.go
+++ b/test/integration/webhook/clusterqueue_test.go
@@ -63,7 +63,6 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 	})
 
 	ginkgo.When("Creating a ClusterQueue", func() {
-
 		ginkgo.DescribeTable("Defaulting on creation", func(cq, wantCQ kueue.ClusterQueue) {
 			gomega.Expect(k8sClient.Create(ctx, &cq)).Should(gomega.Succeed())
 			defer func() {

--- a/test/integration/webhook/workload_test.go
+++ b/test/integration/webhook/workload_test.go
@@ -113,13 +113,11 @@ var _ = ginkgo.Describe("Workload defaulting webhook", func() {
 			}
 			gomega.Expect(k8sClient.Create(ctx, &workload)).Should(testing.BeAPIError(testing.InvalidError))
 		})
-
 	})
 })
 
 var _ = ginkgo.Describe("Workload validating webhook", func() {
 	ginkgo.Context("When creating a Workload", func() {
-
 		ginkgo.DescribeTable("Should have valid PodSet when creating", func(podSetsCapacity int, podSetCount int, isInvalid bool) {
 			podSets := make([]kueue.PodSet, podSetsCapacity)
 			for i := range podSets {
@@ -367,7 +365,6 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				workload.SetAdmissionCheckState(&wl.Status.AdmissionChecks, acs)
 				return k8sClient.Status().Update(ctx, wl)
 			}, util.Timeout, util.Interval).Should(testing.BeAPIError(testing.ForbiddenError))
-
 		},
 			ginkgo.Entry("podSetUpdates have the same number of podSets",
 				func() *kueue.Workload {
@@ -444,7 +441,6 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 			})
 			gomega.Expect(err).Should(testing.BeAPIError(testing.ForbiddenError), "error: %v", err)
 		})
-
 	})
 
 	ginkgo.Context("When updating a Workload", func() {
@@ -459,7 +455,6 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 			priorityClass = testing.MakePriorityClass("priority-class").PriorityValue(100).Obj()
 			gomega.Expect(k8sClient.Create(ctx, workloadPriorityClass)).To(gomega.Succeed())
 			gomega.Expect(k8sClient.Create(ctx, priorityClass)).To(gomega.Succeed())
-
 		})
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
@@ -793,7 +788,6 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				newWL.Status.Admission.ClusterQueue = "foo-cluster-queue"
 				return k8sClient.Status().Update(ctx, &newWL)
 			}, util.Timeout, util.Interval).Should(testing.BeAPIError(testing.ForbiddenError))
-
 		})
 
 		ginkgo.It("Should have priority once priorityClassName is set", func() {
@@ -954,6 +948,5 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				return k8sClient.Status().Update(ctx, wl)
 			}, util.Timeout, util.Interval).Should(testing.BeAPIError(testing.ForbiddenError))
 		})
-
 	})
 })

--- a/test/performance/scheduler/runner/main.go
+++ b/test/performance/scheduler/runner/main.go
@@ -190,7 +190,6 @@ func main() {
 			log.Error(err, "Scraper start")
 			os.Exit(1)
 		}
-
 	}
 
 	err = runManager(ctx, cfg, errCh, wg, recorder)

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -92,6 +92,5 @@ func WaitForKueueAvailability(ctx context.Context, k8sClient client.Client) {
 			},
 			cmpopts.IgnoreFields(appsv1.DeploymentCondition{}, "Reason", "Message", "LastUpdateTime", "LastTransitionTime"))))
 		return nil
-
 	}, StartUpTimeout, Interval).Should(gomega.Succeed())
 }

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -703,7 +703,6 @@ func ExpectEventsForObjects(eventWatcher watch.Interface, objs sets.Set[types.Na
 readCh:
 	for !gotObjs.Equal(objs) {
 		select {
-
 		case evt, ok := <-eventWatcher.ResultChan():
 			gomega.Expect(ok).To(gomega.BeTrue())
 			event, ok := evt.Object.(*corev1.Event)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR removes excessive empty lines at the start and end of a block.

#### Special notes for your reviewer:

It's a straightforward way to decrease the number of code lines without harming readability.

`revive` linter detects such empty lines.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```