### PR TITLE
Split "should requeued after job status ready" test.

### DIFF
--- a/test/integration/controller/jobs/job/job_controller_test.go
+++ b/test/integration/controller/jobs/job/job_controller_test.go
@@ -1898,13 +1898,14 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 
 var _ = ginkgo.Describe("Job controller interacting with Workload controller when waitForPodsReady with requeuing strategy is enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
-		ns *corev1.Namespace
-		fl *kueue.ResourceFlavor
-		cq *kueue.ClusterQueue
-		lq *kueue.LocalQueue
+		backoffBaseSeconds int32
+		ns                 *corev1.Namespace
+		fl                 *kueue.ResourceFlavor
+		cq                 *kueue.ClusterQueue
+		lq                 *kueue.LocalQueue
 	)
 
-	ginkgo.BeforeAll(func() {
+	ginkgo.JustBeforeEach(func() {
 		fwk = &framework.Framework{
 			CRDPath: crdPath,
 		}
@@ -1915,7 +1916,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			Timeout:        &metav1.Duration{Duration: 10 * time.Millisecond},
 			RequeuingStrategy: &configapi.RequeuingStrategy{
 				Timestamp:          ptr.To(configapi.EvictionTimestamp),
-				BackoffBaseSeconds: ptr.To[int32](2),
+				BackoffBaseSeconds: ptr.To[int32](backoffBaseSeconds),
 			},
 		}
 		ctx, k8sClient = fwk.RunManager(cfg, managerAndControllersSetup(
@@ -1923,12 +1924,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			&configapi.Configuration{WaitForPodsReady: waitForPodsReady},
 			jobframework.WithWaitForPodsReady(waitForPodsReady),
 		))
-	})
-	ginkgo.AfterAll(func() {
-		fwk.Teardown()
-	})
 
-	ginkgo.BeforeEach(func() {
 		ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "core-"}}
 		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
@@ -1943,14 +1939,19 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 		gomega.Expect(k8sClient.Create(ctx, lq)).Should(gomega.Succeed())
 	})
 
-	ginkgo.AfterEach(func() {
+	ginkgo.JustAfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, cq, true)
 		util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, fl, true)
+		fwk.Teardown()
 	})
 
-	ginkgo.When("workload evicted due pods ready timeout", func() {
-		ginkgo.It("should re-queue a workload evicted due to PodsReady timeout after the backoff elapses", func() {
+	ginkgo.When("long backoffBaseSeconds", func() {
+		ginkgo.BeforeEach(func() {
+			backoffBaseSeconds = 10
+		})
+
+		ginkgo.It("should evict workload due pods ready timeout", func() {
 			ginkgo.By("creating job")
 			job := testingjob.MakeJob("job", ns.Name).Queue(lq.Name).Request(corev1.ResourceCPU, "2").Obj()
 			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
@@ -1968,6 +1969,12 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				g.Expect(wl.Status.Conditions).To(gomega.ContainElements(
+					gomega.BeComparableTo(metav1.Condition{
+						Type:    kueue.WorkloadPodsReady,
+						Status:  metav1.ConditionFalse,
+						Reason:  kueue.WorkloadPodsReady,
+						Message: "Not all pods are ready or succeeded",
+					}, util.IgnoreConditionTimestampsAndObservedGeneration),
 					gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
@@ -1993,6 +2000,32 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 						Message: fmt.Sprintf("Exceeded the PodsReady timeout %s", wlKey.String()),
 					}, util.IgnoreConditionTimestampsAndObservedGeneration),
 				))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.When("short backoffBaseSeconds", func() {
+		ginkgo.BeforeEach(func() {
+			backoffBaseSeconds = 1
+		})
+
+		ginkgo.It("should re-queue a workload evicted due to PodsReady timeout after the backoff elapses", func() {
+			ginkgo.By("creating job")
+			job := testingjob.MakeJob("job", ns.Name).Queue(lq.Name).Request(corev1.ResourceCPU, "2").Obj()
+			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+
+			wl := &kueue.Workload{}
+			wlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: job.Namespace}
+
+			ginkgo.By("admit the workload, it gets evicted due to PodsReadyTimeout and re-queued")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+				admission := testing.MakeAdmission(cq.Name).
+					Assignment(corev1.ResourceCPU, "on-demand", "1m").
+					AssignmentPodCount(wl.Spec.PodSets[0].Count).
+					Obj()
+				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, admission)).Should(gomega.Succeed())
+				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("checking the workload is requeued")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Split "should requeued after job status ready" test into two, with two different values for BackoffBaseSeconds. One large, which will be used to assert that Requeued=False, and one short to assert that Requeued=True.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2155 

#### Special notes for your reviewer:
Related for this comment https://github.com/kubernetes-sigs/kueue/pull/2161#discussion_r1595141135.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```