### PR TITLE
Fix ms function implementation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -41,6 +41,7 @@ linters:
   enable:
     - copyloopvar
     - dupword
+    - durationcheck
     - ginkgolinter
     - gocritic
     - goimports

--- a/pkg/util/wait/backoff_test.go
+++ b/pkg/util/wait/backoff_test.go
@@ -42,8 +42,8 @@ func makeSpyTimer() SpyTimer {
 	return SpyTimer{history: ptr.To([]time.Duration{}), Timer: timer}
 }
 
-func ms(m time.Duration) time.Duration {
-	return time.Millisecond * m
+func ms(m int) time.Duration {
+	return time.Duration(m) * time.Millisecond
 }
 
 func TestUntilWithBackoff(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Fixes `ms` function implementation in `wait` package tests to prevent future bugs.

#### Special notes for your reviewer:

Actually, there are no current bugs because `ms` is always called with an integer number. However, if someone calls `ms` with `time.Duration`, the result will be a much larger value than expected. For example, `ms(time.Minute)` will yield `60000000000` milliseconds, but the expected result is `60000`.

This was discovered using the [durationcheck](https://github.com/charithe/durationcheck) linter.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```