### PR TITLE
Refactor to use filepath.Join instead of path.Join for consistency

### DIFF
--- a/cmd/importer/util/util_test.go
+++ b/cmd/importer/util/util_test.go
@@ -18,7 +18,7 @@ package util
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -76,7 +76,7 @@ var testMappingRules = MappingRules{
 
 func TestMappingFromFile(t *testing.T) {
 	tdir := t.TempDir()
-	fPath := path.Join(tdir, "mapping.yaml")
+	fPath := filepath.Join(tdir, "mapping.yaml")
 	err := os.WriteFile(fPath, []byte(testContent), os.FileMode(0600))
 	if err != nil {
 		t.Fatalf("unable to create the test file: %s", err)

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -19,7 +19,7 @@ package multikueue
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -358,7 +358,7 @@ var _ = ginkgo.Describe("Multikueue", func() {
 		})
 
 		tempDir := ginkgo.GinkgoT().TempDir()
-		fsKubeConfig := path.Join(tempDir, "testing.kubeconfig")
+		fsKubeConfig := filepath.Join(tempDir, "testing.kubeconfig")
 
 		config := utiltesting.MakeMultiKueueConfig("testing-config").Clusters("testing-cluster").Obj()
 		ginkgo.By("creating the config, the admission check's state is updated", func() {

--- a/test/performance/scheduler/runner/generator/generator_test.go
+++ b/test/performance/scheduler/runner/generator/generator_test.go
@@ -18,7 +18,7 @@ package generator
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -120,7 +120,7 @@ func TestLoadConfig(t *testing.T) {
         request: 20
 `
 	tempDir := t.TempDir()
-	fPath := path.Join(tempDir, "config.yaml")
+	fPath := filepath.Join(tempDir, "config.yaml")
 	err := os.WriteFile(fPath, []byte(testContent), os.FileMode(0600))
 	if err != nil {
 		t.Fatalf("unable to create the test file: %s", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor to use only `filepath.Join` when dealing with OS paths for consistency.

#### Special notes for your reviewer:

`filepath.Join` is preferred when dealing with paths even if the project doesn't run on Windows. From the [path doc](https://pkg.go.dev/path):

> to manipulate operating system paths, use the [path/filepath](https://pkg.go.dev/path/filepath) package

Also, I chose `filepath.Join` because the number of existing occurrences:

```
❯ grep -r -w --include=\*.go "filepath.Join" . | wc -l
      59

❯ grep -r -w --include=\*.go "path.Join" . | wc -l
      32
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```