### PR TITLE
[kueuectl] Stop/resume cluster queue

### DIFF
--- a/cmd/kueuectl/app/list/list_localqueue.go
+++ b/cmd/kueuectl/app/list/list_localqueue.go
@@ -36,7 +36,7 @@ const (
 	lqLong = `Lists LocalQueues that match the given criteria: point to a specific CQ, 
 being active/inactive, belonging to the specified namespace, matching 
 the label selector or the field selector.`
-	lqExample = `  # List LocalQueue 
+	lqExample = `  # List LocalQueue
   kueuectl list localqueue`
 )
 

--- a/cmd/kueuectl/app/options/update_workload_activation_options.go
+++ b/cmd/kueuectl/app/options/update_workload_activation_options.go
@@ -101,8 +101,6 @@ func (o *UpdateWorkloadActivationOptions) Run(ctx context.Context) error {
 		return err
 	}
 
-	// TODO ask if there should be a check if wl != nil
-
 	wlOriginal := wl.DeepCopy()
 	wl.Spec.Active = ptr.To(o.Active)
 

--- a/cmd/kueuectl/app/options/update_workload_activation_options.go
+++ b/cmd/kueuectl/app/options/update_workload_activation_options.go
@@ -101,6 +101,8 @@ func (o *UpdateWorkloadActivationOptions) Run(ctx context.Context) error {
 		return err
 	}
 
+	// TODO ask if there should be a check if wl != nil
+
 	wlOriginal := wl.DeepCopy()
 	wl.Spec.Active = ptr.To(o.Active)
 

--- a/cmd/kueuectl/app/resume/resume.go
+++ b/cmd/kueuectl/app/resume/resume.go
@@ -38,6 +38,7 @@ func NewResumeCmd(clientGetter util.ClientGetter, streams genericiooptions.IOStr
 	util.AddDryRunFlag(cmd)
 
 	cmd.AddCommand(NewWorkloadCmd(clientGetter, streams))
+	cmd.AddCommand(NewClusterQueueCmd(clientGetter, streams))
 
 	return cmd
 }

--- a/cmd/kueuectl/app/resume/resume_clusterqueue.go
+++ b/cmd/kueuectl/app/resume/resume_clusterqueue.go
@@ -41,14 +41,10 @@ const (
 )
 
 type ClusterQueueOptions struct {
-	PrintFlags *genericclioptions.PrintFlags
-
 	ClusterQueueName string
-
-	Client kueuev1beta1.KueueV1beta1Interface
-
-	PrintObj printers.ResourcePrinterFunc
-
+	Client           kueuev1beta1.KueueV1beta1Interface
+	PrintFlags       *genericclioptions.PrintFlags
+	PrintObj         printers.ResourcePrinterFunc
 	genericiooptions.IOStreams
 }
 
@@ -109,12 +105,8 @@ func (o *ClusterQueueOptions) Run(ctx context.Context) error {
 		return err
 	}
 
-	if cq == nil {
-		return nil
-	}
-
 	cqOriginal := cq.DeepCopy()
-	o.resumeClusterQueue(cq)
+	cq.Spec.StopPolicy = ptr.To(v1beta1.None)
 
 	opts := metav1.PatchOptions{}
 	patch := client.MergeFrom(cqOriginal)
@@ -129,8 +121,4 @@ func (o *ClusterQueueOptions) Run(ctx context.Context) error {
 	}
 
 	return o.PrintObj(cq, o.Out)
-}
-
-func (o *ClusterQueueOptions) resumeClusterQueue(cq *v1beta1.ClusterQueue) {
-	cq.Spec.StopPolicy = ptr.To(v1beta1.None)
 }

--- a/cmd/kueuectl/app/stop/helpers.go
+++ b/cmd/kueuectl/app/stop/helpers.go
@@ -18,27 +18,9 @@ package stop
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericiooptions"
-
-	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
 )
 
-const (
-	stopExample = `  # Stop the workload 
-  kueuectl stop workload my-workload`
-)
-
-func NewStopCmd(clientGetter util.ClientGetter, streams genericiooptions.IOStreams) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:     "stop",
-		Short:   "Stop the resource",
-		Example: stopExample,
-	}
-
-	util.AddDryRunFlag(cmd)
-
-	cmd.AddCommand(NewWorkloadCmd(clientGetter, streams))
-	cmd.AddCommand(NewClusterQueueCmd(clientGetter, streams))
-
-	return cmd
+func addKeepAlreadyRunningFlagVar(cmd *cobra.Command, p *bool) {
+	cmd.Flags().BoolVar(p, "keep-already-running", false,
+		"Indicates whether to keep already running local queues.")
 }

--- a/cmd/kueuectl/app/stop/helpers.go
+++ b/cmd/kueuectl/app/stop/helpers.go
@@ -22,5 +22,5 @@ import (
 
 func addKeepAlreadyRunningFlagVar(cmd *cobra.Command, p *bool) {
 	cmd.Flags().BoolVar(p, "keep-already-running", false,
-		"Indicates whether to keep already running local queues.")
+		"Indicates whether to keep already running workloads.")
 }

--- a/cmd/kueuectl/app/stop/stop_clusterqueue.go
+++ b/cmd/kueuectl/app/stop/stop_clusterqueue.go
@@ -41,15 +41,11 @@ const (
 )
 
 type ClusterQueueOptions struct {
-	PrintFlags *genericclioptions.PrintFlags
-
 	ClusterQueueName   string
 	KeepAlreadyRunning bool
-
-	Client kueuev1beta1.KueueV1beta1Interface
-
-	PrintObj printers.ResourcePrinterFunc
-
+	Client             kueuev1beta1.KueueV1beta1Interface
+	PrintFlags         *genericclioptions.PrintFlags
+	PrintObj           printers.ResourcePrinterFunc
 	genericiooptions.IOStreams
 }
 

--- a/cmd/kueuectl/app/stop/stop_clusterqueue.go
+++ b/cmd/kueuectl/app/stop/stop_clusterqueue.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stop
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
+	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
+)
+
+const (
+	cqLong    = `Puts the given ClusterQueue on hold.`
+	cqExample = `  # Stop the clusterqueue
+  kueuectl stop clusterqueue my-clusterqueue`
+)
+
+type ClusterQueueOptions struct {
+	PrintFlags *genericclioptions.PrintFlags
+
+	DryRunStrategy     util.DryRunStrategy
+	ClusterQueueName   string
+	KeepAlreadyRunning bool
+
+	Client kueuev1beta1.KueueV1beta1Interface
+
+	PrintObj printers.ResourcePrinterFunc
+
+	genericiooptions.IOStreams
+}
+
+func NewClusterQueueOptions(streams genericiooptions.IOStreams) *ClusterQueueOptions {
+	return &ClusterQueueOptions{
+		PrintFlags: genericclioptions.NewPrintFlags("stop").WithTypeSetter(scheme.Scheme), // TODO check what print flags are needed
+		IOStreams:  streams,
+	}
+}
+
+func NewClusterQueueCmd(clientGetter util.ClientGetter, streams genericiooptions.IOStreams) *cobra.Command {
+	o := NewClusterQueueOptions(streams)
+
+	cmd := &cobra.Command{
+		Use:                   "clusterqueue NAME [--dry-run STRATEGY] [--keep-already-running] [--resource-flavor=rfnam]",
+		DisableFlagsInUseLine: true,
+		Aliases:               []string{"cq"},
+		Short:                 "Stop the ClusterQueue",
+		Long:                  cqLong,
+		Example:               cqExample,
+		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Run: func(cmd *cobra.Command, args []string) {
+			cobra.CheckErr(o.Complete(clientGetter, cmd, args))
+			cobra.CheckErr(o.Run(cmd.Context()))
+		},
+	}
+
+	o.PrintFlags.AddFlags(cmd)
+
+	addKeepAlreadyRunningFlagVar(cmd, &o.KeepAlreadyRunning)
+
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *ClusterQueueOptions) Complete(clientGetter util.ClientGetter, cmd *cobra.Command, args []string) error {
+	o.ClusterQueueName = args[0]
+
+	clientset, err := clientGetter.KueueClientSet()
+	if err != nil {
+		return err
+	}
+
+	o.Client = clientset.KueueV1beta1()
+
+	o.DryRunStrategy, err = util.GetDryRunStrategy(cmd)
+	if err != nil {
+		return err
+	}
+
+	err = util.PrintFlagsWithDryRunStrategy(o.PrintFlags, o.DryRunStrategy)
+	if err != nil {
+		return err
+	}
+
+	printer, err := o.PrintFlags.ToPrinter()
+	if err != nil {
+		return err
+	}
+
+	o.PrintObj = printer.PrintObj
+
+	return nil
+}
+
+// Run executes the command
+func (o *ClusterQueueOptions) Run(ctx context.Context) error {
+	cq, err := o.Client.ClusterQueues().Get(ctx, o.ClusterQueueName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if cq == nil {
+		return nil
+	}
+
+	cqOriginal := cq.DeepCopy()
+	o.stopClusterQueue(cq)
+
+	opts := metav1.PatchOptions{}
+	patch := client.MergeFrom(cqOriginal)
+	data, err := patch.Data(cq)
+	if err != nil {
+		return err
+	}
+	cq, err = o.Client.ClusterQueues().
+		Patch(ctx, o.ClusterQueueName, types.MergePatchType, data, opts)
+	if err != nil {
+		return err
+	}
+
+	return o.PrintObj(cq, o.Out)
+}
+
+func (o *ClusterQueueOptions) stopClusterQueue(cq *v1beta1.ClusterQueue) {
+	if o.KeepAlreadyRunning {
+		cq.Spec.StopPolicy = ptr.To(v1beta1.Hold)
+	} else {
+		cq.Spec.StopPolicy = ptr.To(v1beta1.HoldAndDrain)
+	}
+}

--- a/cmd/kueuectl/app/util/dry_run.go
+++ b/cmd/kueuectl/app/util/dry_run.go
@@ -29,11 +29,11 @@ const (
 	// DryRunNone indicates the client will make all mutating calls
 	DryRunNone DryRunStrategy = iota
 
-	// DryRunClient, or client-side dry-run, indicates the client will prevent
+	// DryRunClient or client-side dry-run, indicates the client will prevent
 	// making mutating calls such as CREATE, PATCH, and DELETE
 	DryRunClient
 
-	// DryRunServer, or server-side dry-run, indicates the client will send
+	// DryRunServer or server-side dry-run, indicates the client will send
 	// mutating calls to the APIServer with the dry-run parameter to prevent
 	// persisting changes.
 	//

--- a/site/content/en/docs/reference/kubectl-kueue/commands/resume.md
+++ b/site/content/en/docs/reference/kubectl-kueue/commands/resume.md
@@ -18,6 +18,8 @@ kubectl kueue resume [TYPE]
 ```bash
 # Resume the workload 
 kubectl kueue resume workload my-workload
+# Resume the ClusterQueue 
+kubectl kueue resume clusterqueue my-clusterqueue
 ```
 
 ## Resource types
@@ -27,3 +29,4 @@ The following table includes a list of all the supported resource types and thei
 | Name     | Short | API version            | Namespaced | Kind     |
 |----------|-------|------------------------|------------|----------|
 | workload | wl    | kueue.x-k8s.io/v1beta1 | true       | Workload |
+| clusterqueue | cq    | kueue.x-k8s.io/v1beta1 | false       | ClusterQueue |

--- a/site/content/en/docs/reference/kubectl-kueue/commands/stop.md
+++ b/site/content/en/docs/reference/kubectl-kueue/commands/stop.md
@@ -17,6 +17,8 @@ kubectl kueue stop [TYPE]
 ```bash
 # Stop the workload
 kubectl kueue stop workload my-workload
+# Stop the ClusterQueue
+kubectl kueue stop clusterqueue my-clusterqueue
 ```
 
 ## Resource types
@@ -26,3 +28,4 @@ The following table includes a list of all the supported resource types and thei
 | Name     | Short | API version            | Namespaced | Kind     |
 |----------|-------|------------------------|------------|----------|
 | workload | wl    | kueue.x-k8s.io/v1beta1 | true       | Workload |
+| clusterqueue | cq    | kueue.x-k8s.io/v1beta1 | false       | ClusterQueue |

--- a/test/integration/kueuectl/resume_test.go
+++ b/test/integration/kueuectl/resume_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app"
@@ -74,6 +75,74 @@ var _ = ginkgo.Describe("Kueuectl Resume", ginkgo.Ordered, ginkgo.ContinueOnFail
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: wl.Name, Namespace: ns.Name}, wl)).To(gomega.Succeed())
 					g.Expect(ptr.Deref(wl.Spec.Active, true)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+
+	ginkgo.When("Resuming a ClusterQueue from HoldAndDrain StopPolicy", func() {
+		ginkgo.It("Should resume a ClusterQueue and drain workloads", func() {
+			cq := testing.MakeClusterQueue("cq-1").StopPolicy(v1beta1.HoldAndDrain).Obj()
+			ginkgo.By("Create a ClusterQueue", func() {
+				gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
+			})
+
+			createdClusterQueue := &v1beta1.ClusterQueue{}
+			ginkgo.By("Get created ClusterQueue", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdClusterQueue)).To(gomega.Succeed())
+					g.Expect(cq.Spec.StopPolicy).Should(gomega.Equal(ptr.To(v1beta1.HoldAndDrain)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Resume created ClusterQueue", func() {
+				streams, _, output, _ := genericiooptions.NewTestIOStreams()
+				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+
+				kueuectl.SetArgs([]string{"resume", "clusterqueue", cq.Name})
+				err := kueuectl.Execute()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			})
+
+			ginkgo.By("Check that the ClusterQueue is successfully resumed", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), cq)).To(gomega.Succeed())
+					g.Expect(cq.Spec.StopPolicy).Should(gomega.Equal(ptr.To(v1beta1.None)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+
+	ginkgo.When("Resuming a ClusterQueue from Hold StopPolicy", func() {
+		ginkgo.It("Should resume a ClusterQueue and drain workloads", func() {
+			cq := testing.MakeClusterQueue("cq-2").StopPolicy(v1beta1.Hold).Obj()
+			ginkgo.By("Create a ClusterQueue", func() {
+				gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
+			})
+
+			createdClusterQueue := &v1beta1.ClusterQueue{}
+			ginkgo.By("Get created ClusterQueue", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdClusterQueue)).To(gomega.Succeed())
+					g.Expect(cq.Spec.StopPolicy).Should(gomega.Equal(ptr.To(v1beta1.Hold)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Resume created ClusterQueue", func() {
+				streams, _, output, _ := genericiooptions.NewTestIOStreams()
+				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+
+				kueuectl.SetArgs([]string{"resume", "clusterqueue", cq.Name})
+				err := kueuectl.Execute()
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+			})
+
+			ginkgo.By("Check that the ClusterQueue is successfully resumed", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), cq)).To(gomega.Succeed())
+					g.Expect(cq.Spec.StopPolicy).Should(gomega.Equal(ptr.To(v1beta1.None)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})

--- a/test/integration/kueuectl/stop_test.go
+++ b/test/integration/kueuectl/stop_test.go
@@ -81,68 +81,47 @@ var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailur
 	})
 
 	ginkgo.When("Stopping a ClusterQueue", func() {
-		ginkgo.It("Should stop a ClusterQueue and drain workloads", func() {
-			cq := testing.MakeClusterQueue("cq-1").Obj()
-			ginkgo.By("Create a ClusterQueue", func() {
-				gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
-			})
+		ginkgo.DescribeTable("Should stop a ClusterQueue",
+			func(cq *v1beta1.ClusterQueue, stopCmdArgs []string, wantStopPolicy v1beta1.StopPolicy) {
+				ginkgo.By("Create a ClusterQueue", func() {
+					gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
+				})
 
-			createdClusterQueue := &v1beta1.ClusterQueue{}
-			ginkgo.By("Get created ClusterQueue", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdClusterQueue)).To(gomega.Succeed())
-					g.Expect(ptr.Deref(cq.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(v1beta1.None))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
+				createdClusterQueue := &v1beta1.ClusterQueue{}
+				ginkgo.By("Get created ClusterQueue", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdClusterQueue)).To(gomega.Succeed())
+						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(v1beta1.None))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
 
-			ginkgo.By("Stop created ClusterQueue", func() {
-				streams, _, output, _ := genericiooptions.NewTestIOStreams()
-				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
-				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+				ginkgo.By("Stop created ClusterQueue", func() {
+					streams, _, output, _ := genericiooptions.NewTestIOStreams()
+					configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
+					kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
 
-				kueuectl.SetArgs([]string{"stop", "clusterqueue", cq.Name})
-				err := kueuectl.Execute()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
-			})
+					kueuectl.SetArgs(append([]string{"stop", "clusterqueue", createdClusterQueue.Name}, stopCmdArgs...))
+					err := kueuectl.Execute()
+					gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
+				})
 
-			ginkgo.By("Check that the ClusterQueue is successfully stopped", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), cq)).To(gomega.Succeed())
-					g.Expect(cq.Spec.StopPolicy).Should(gomega.Equal(ptr.To(v1beta1.HoldAndDrain)))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-		})
-
-		ginkgo.It("Should stop a ClusterQueue and finish workloads", func() {
-			cq := testing.MakeClusterQueue("cq-2").Obj()
-			ginkgo.By("Create a ClusterQueue", func() {
-				gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
-			})
-
-			createdClusterQueue := &v1beta1.ClusterQueue{}
-			ginkgo.By("Get created ClusterQueue", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdClusterQueue)).To(gomega.Succeed())
-					g.Expect(ptr.Deref(cq.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(v1beta1.None))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Stop created ClusterQueue", func() {
-				streams, _, output, _ := genericiooptions.NewTestIOStreams()
-				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
-				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
-
-				kueuectl.SetArgs([]string{"stop", "clusterqueue", cq.Name, "--keep-already-running"})
-				err := kueuectl.Execute()
-				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
-			})
-
-			ginkgo.By("Check that the ClusterQueue is successfully stopped", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), cq)).To(gomega.Succeed())
-					g.Expect(cq.Spec.StopPolicy).Should(gomega.Equal(ptr.To(v1beta1.Hold)))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-		})
+				ginkgo.By("Check that the ClusterQueue is successfully stopped", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdClusterQueue), createdClusterQueue)).To(gomega.Succeed())
+						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(wantStopPolicy))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			},
+			ginkgo.Entry("Stop a ClusterQueue and drain workloads",
+				testing.MakeClusterQueue("cq-1").Obj(),
+				[]string{},
+				v1beta1.HoldAndDrain,
+			),
+			ginkgo.Entry("Stop a ClusterQueue and let the admitted workloads finish",
+				testing.MakeClusterQueue("cq-2").Obj(),
+				[]string{"--keep-already-running"},
+				v1beta1.Hold,
+			),
+		)
 	})
 })

--- a/test/integration/kueuectl/stop_test.go
+++ b/test/integration/kueuectl/stop_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package kueuectl
 
 import (
-	"fmt"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -105,7 +103,6 @@ var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailur
 				kueuectl.SetArgs([]string{"stop", "clusterqueue", cq.Name})
 				err := kueuectl.Execute()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
-				fmt.Println(output.String())
 			})
 
 			ginkgo.By("Check that the ClusterQueue is successfully stopped", func() {
@@ -138,7 +135,6 @@ var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailur
 				kueuectl.SetArgs([]string{"stop", "clusterqueue", cq.Name, "--keep-already-running"})
 				err := kueuectl.Execute()
 				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
-				fmt.Println(output.String())
 			})
 
 			ginkgo.By("Check that the ClusterQueue is successfully stopped", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds `kueuectl stop clusterqueue`, `kueuectl resume clusterqueue` commands
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2136 and #2137

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Stop/Resume ClusterQueue (`kueuectl stop clusterqueue`, `kueuectl resume clusterqueue`) commands are available
```