### PR TITLE
Refactor variable names according to Go style guide

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,7 @@ linters-settings:
     enable-all-rules: false
     rules:
       - name: empty-lines
+      - name: var-naming
 
 # Settings for enabling and disabling linters
 linters:

--- a/apis/config/v1beta1/defaults.go
+++ b/apis/config/v1beta1/defaults.go
@@ -60,6 +60,8 @@ func getOperatorNamespace() string {
 }
 
 // SetDefaults_Configuration sets default values for ComponentConfig.
+//
+//nolint:revive // format required by generated code for defaulting
 func SetDefaults_Configuration(cfg *Configuration) {
 	if cfg.Namespace == nil {
 		cfg.Namespace = ptr.To(getOperatorNamespace())

--- a/apis/visibility/v1alpha1/defaults.go
+++ b/apis/visibility/v1alpha1/defaults.go
@@ -30,6 +30,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
+//nolint:revive // format required by generated code for defaulting
 func SetDefaults_PendingWorkloadOptions(obj *PendingWorkloadOptions) {
 	if obj.Limit == 0 {
 		obj.Limit = constants.DefaultPendingWorkloadsLimit

--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -135,9 +135,9 @@ func Import(ctx context.Context, c client.Client, cache *util.ImportCache, jobs 
 }
 
 func checkError(err error) (retry, reload bool, timeout time.Duration) {
-	retry_seconds, retry := apierrors.SuggestsClientDelay(err)
+	retrySeconds, retry := apierrors.SuggestsClientDelay(err)
 	if retry {
-		return true, false, time.Duration(retry_seconds) * time.Second
+		return true, false, time.Duration(retrySeconds) * time.Second
 	}
 
 	if apierrors.IsConflict(err) {

--- a/pkg/controller/admissionchecks/multikueue/fswatch.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch.go
@@ -150,16 +150,16 @@ func (w *KubeConfigFSWatcher) remove(cluster string) {
 	kcPath := w.clusterToFile[cluster]
 	dir := path.Dir(kcPath)
 
-	file_removed := false
+	fileRemoved := false
 	if s, found := w.fileToClusters[kcPath]; found {
 		s.Delete(cluster)
 		if s.Len() == 0 {
 			delete(w.fileToClusters, kcPath)
-			file_removed = true
+			fileRemoved = true
 		}
 	}
 
-	if file_removed {
+	if fileRemoved {
 		if s, found := w.parentDirToFiles[dir]; found {
 			s.Delete(kcPath)
 			if s.Len() == 0 {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -888,14 +888,14 @@ func (r *JobReconciler) constructWorkload(ctx context.Context, job GenericJob, o
 	if wl.Labels == nil {
 		wl.Labels = make(map[string]string)
 	}
-	jobUid := string(job.Object().GetUID())
-	if errs := validation.IsValidLabelValue(jobUid); len(errs) == 0 {
-		wl.Labels[controllerconsts.JobUIDLabel] = jobUid
+	jobUID := string(job.Object().GetUID())
+	if errs := validation.IsValidLabelValue(jobUID); len(errs) == 0 {
+		wl.Labels[controllerconsts.JobUIDLabel] = jobUID
 	} else {
 		log.V(2).Info(
 			"Validation of the owner job UID label has failed. Creating workload without the label.",
 			"ValidationErrors", errs,
-			"LabelValue", jobUid,
+			"LabelValue", jobUID,
 		)
 	}
 

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -214,8 +214,8 @@ func (j *Job) ReclaimablePods() ([]kueue.ReclaimablePod, error) {
 var (
 	// the legacy names are no longer defined in the api, only in k/2/apis/batch
 	legacyJobNameLabel       = "job-name"
-	legacyControllerUidLabel = "controller-uid"
-	ManagedLabels            = []string{legacyJobNameLabel, legacyControllerUidLabel, batchv1.JobNameLabel, batchv1.ControllerUidLabel}
+	legacyControllerUIDLabel = "controller-uid"
+	ManagedLabels            = []string{legacyJobNameLabel, legacyControllerUIDLabel, batchv1.JobNameLabel, batchv1.ControllerUidLabel}
 )
 
 func cleanManagedLabels(pt *corev1.PodTemplateSpec) *corev1.PodTemplateSpec {

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -588,13 +588,13 @@ func getRoleHash(p corev1.Pod) (string, error) {
 		},
 	}
 
-	shapeJson, err := json.Marshal(shape)
+	shapeJSON, err := json.Marshal(shape)
 	if err != nil {
 		return "", err
 	}
 
 	// Trim hash to 8 characters and return
-	return fmt.Sprintf("%x", sha256.Sum256(shapeJson))[:8], nil
+	return fmt.Sprintf("%x", sha256.Sum256(shapeJSON))[:8], nil
 }
 
 // Load loads all pods in the group
@@ -951,14 +951,14 @@ func (p *Pod) ConstructComposableWorkload(ctx context.Context, c client.Client, 
 		wl.Spec.PodSets = p.PodSets()
 
 		wl.Name = jobframework.GetWorkloadNameForOwnerWithGVK(p.pod.GetName(), p.pod.GetUID(), p.GVK())
-		jobUid := string(object.GetUID())
-		if errs := validation.IsValidLabelValue(jobUid); len(errs) == 0 {
-			wl.Labels[controllerconsts.JobUIDLabel] = jobUid
+		jobUID := string(object.GetUID())
+		if errs := validation.IsValidLabelValue(jobUID); len(errs) == 0 {
+			wl.Labels[controllerconsts.JobUIDLabel] = jobUID
 		} else {
 			log.V(2).Info(
 				"Validation of the owner job UID label has failed. Creating workload without the label.",
 				"ValidationErrors", errs,
-				"LabelValue", jobUid,
+				"LabelValue", jobUID,
 			)
 		}
 

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -380,7 +380,7 @@ func (a *Assignment) append(requests workload.Requests, psAssignment *PodSetAssi
 // reasons or failure.
 func (a *FlavorAssigner) findFlavorForPodSetResource(
 	log logr.Logger,
-	psId int,
+	psID int,
 	requests workload.Requests,
 	resName corev1.ResourceName,
 	assignmentUsage cache.FlavorResourceQuantities,
@@ -394,7 +394,7 @@ func (a *FlavorAssigner) findFlavorForPodSetResource(
 
 	status := &Status{}
 	requests = filterRequestedResources(requests, resourceGroup.CoveredResources)
-	podSpec := &a.wl.Obj.Spec.PodSets[psId].Template.Spec
+	podSpec := &a.wl.Obj.Spec.PodSets[psID].Template.Spec
 
 	var bestAssignment ResourceAssignment
 	bestAssignmentMode := NoFit
@@ -402,7 +402,7 @@ func (a *FlavorAssigner) findFlavorForPodSetResource(
 	// We will only check against the flavors' labels for the resource.
 	selector := flavorSelector(podSpec, resourceGroup.LabelKeys)
 	assignedFlavorIdx := -1
-	idx := a.wl.LastAssignment.NextFlavorToTryForPodSetResource(psId, resName)
+	idx := a.wl.LastAssignment.NextFlavorToTryForPodSetResource(psID, resName)
 	for ; idx < len(resourceGroup.Flavors); idx++ {
 		flvQuotas := resourceGroup.Flavors[idx]
 		flavor, exist := a.resourceFlavors[flvQuotas.Name]

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1967,7 +1967,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Resource(corev1.ResourceCPU, "100", "0").Obj(),
 			).Obj(),
 	}
-	clusterQueue_cohort := []kueue.ClusterQueue{
+	clusterQueueCohort := []kueue.ClusterQueue{
 		*utiltesting.MakeClusterQueue("eng-cohort-alpha").
 			Cohort("cohort").
 			QueueingStrategy(kueue.StrictFIFO).
@@ -2118,7 +2118,7 @@ func TestLastSchedulingContext(t *testing.T) {
 		},
 		{
 			name: "borrow before next flavor",
-			cqs:  clusterQueue_cohort,
+			cqs:  clusterQueueCohort,
 			admittedWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder", "default").
 					Request(corev1.ResourceCPU, "50").
@@ -2150,7 +2150,7 @@ func TestLastSchedulingContext(t *testing.T) {
 		},
 		{
 			name: "borrow after all flavors",
-			cqs:  clusterQueue_cohort,
+			cqs:  clusterQueueCohort,
 			admittedWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder", "default").
 					Request(corev1.ResourceCPU, "50").
@@ -2182,7 +2182,7 @@ func TestLastSchedulingContext(t *testing.T) {
 		},
 		{
 			name: "when the next flavor is full, but can borrow on first",
-			cqs:  clusterQueue_cohort,
+			cqs:  clusterQueueCohort,
 			admittedWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder", "default").
 					Request(corev1.ResourceCPU, "40").
@@ -2220,7 +2220,7 @@ func TestLastSchedulingContext(t *testing.T) {
 		},
 		{
 			name: "when the next flavor is full, but can preempt on first",
-			cqs:  clusterQueue_cohort,
+			cqs:  clusterQueueCohort,
 			admittedWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder-alpha", "default").
 					Priority(-1).

--- a/pkg/util/resource/resource_test.go
+++ b/pkg/util/resource/resource_test.go
@@ -25,31 +25,31 @@ import (
 )
 
 func TestMerge(t *testing.T) {
-	rl_500mcpu_2GiMem := corev1.ResourceList{
+	resList500mCPU2GiMem := corev1.ResourceList{
 		corev1.ResourceCPU:    resource.MustParse("500m"),
 		corev1.ResourceMemory: resource.MustParse("2Gi"),
 	}
-	rl_1cpu := corev1.ResourceList{
+	resList1CPU := corev1.ResourceList{
 		corev1.ResourceCPU: resource.MustParse("1"),
 	}
-	rl_1cpu_1GiMem := corev1.ResourceList{
+	resList1CPU1GiMem := corev1.ResourceList{
 		corev1.ResourceCPU:    resource.MustParse("1"),
 		corev1.ResourceMemory: resource.MustParse("1Gi"),
 	}
 
-	type oper_result struct {
+	type operResult struct {
 		oper   func(a, b corev1.ResourceList) corev1.ResourceList
 		result corev1.ResourceList
 	}
 	cases := map[string]struct {
 		a    corev1.ResourceList
 		b    corev1.ResourceList
-		want map[string]oper_result
+		want map[string]operResult
 	}{
 		"asymmetric": {
-			a: rl_1cpu,
-			b: rl_500mcpu_2GiMem,
-			want: map[string]oper_result{
+			a: resList1CPU,
+			b: resList500mCPU2GiMem,
+			want: map[string]operResult{
 				"merge": {
 					oper: MergeResourceListKeepFirst,
 					result: corev1.ResourceList{
@@ -81,9 +81,9 @@ func TestMerge(t *testing.T) {
 			},
 		},
 		"symmetric": {
-			a: rl_1cpu_1GiMem,
-			b: rl_500mcpu_2GiMem,
-			want: map[string]oper_result{
+			a: resList1CPU1GiMem,
+			b: resList500mCPU2GiMem,
+			want: map[string]operResult{
 				"merge": {
 					oper: MergeResourceListKeepFirst,
 					result: corev1.ResourceList{
@@ -115,53 +115,53 @@ func TestMerge(t *testing.T) {
 			},
 		},
 		"nil source": {
-			a: rl_1cpu_1GiMem,
+			a: resList1CPU1GiMem,
 			b: nil,
-			want: map[string]oper_result{
+			want: map[string]operResult{
 				"merge": {
 					oper:   MergeResourceListKeepFirst,
-					result: rl_1cpu_1GiMem,
+					result: resList1CPU1GiMem,
 				},
 				"min": {
 					oper:   MergeResourceListKeepMin,
-					result: rl_1cpu_1GiMem,
+					result: resList1CPU1GiMem,
 				},
 				"max": {
 					oper:   MergeResourceListKeepMax,
-					result: rl_1cpu_1GiMem,
+					result: resList1CPU1GiMem,
 				},
 				"sum": {
 					oper:   MergeResourceListKeepSum,
-					result: rl_1cpu_1GiMem,
+					result: resList1CPU1GiMem,
 				},
 			},
 		},
 		"nil destination": {
 			a: nil,
-			b: rl_1cpu_1GiMem,
-			want: map[string]oper_result{
+			b: resList1CPU1GiMem,
+			want: map[string]operResult{
 				"merge": {
 					oper:   MergeResourceListKeepFirst,
-					result: rl_1cpu_1GiMem,
+					result: resList1CPU1GiMem,
 				},
 				"min": {
 					oper:   MergeResourceListKeepMin,
-					result: rl_1cpu_1GiMem,
+					result: resList1CPU1GiMem,
 				},
 				"max": {
 					oper:   MergeResourceListKeepMax,
-					result: rl_1cpu_1GiMem,
+					result: resList1CPU1GiMem,
 				},
 				"sum": {
 					oper:   MergeResourceListKeepSum,
-					result: rl_1cpu_1GiMem,
+					result: resList1CPU1GiMem,
 				},
 			},
 		},
 		"nil": {
 			a: nil,
 			b: nil,
-			want: map[string]oper_result{
+			want: map[string]operResult{
 				"merge": {
 					oper:   MergeResourceListKeepFirst,
 					result: nil,

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -764,7 +764,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, podLookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
 
 				// cache the uid of the workload it should be the same until the execution ends otherwise the workload was recreated
-				wlUid := createdWorkload.UID
+				wlUID := createdWorkload.UID
 
 				ginkgo.By("Failing the running pod")
 
@@ -809,7 +809,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				gomega.Eventually(func(g gomega.Gomega) []metav1.Condition {
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-					g.Expect(createdWorkload.UID).To(gomega.Equal(wlUid))
+					g.Expect(createdWorkload.UID).To(gomega.Equal(wlUID))
 					return createdWorkload.Status.Conditions
 				}, util.Timeout, util.Interval).Should(gomega.ContainElement(
 					gomega.BeComparableTo(

--- a/test/performance/scheduler/runner/main.go
+++ b/test/performance/scheduler/runner/main.go
@@ -69,7 +69,7 @@ var (
 
 	// related to minimalkueue
 	minimalKueuePath = flag.String("minimalKueue", "", "path to minimalkueue, run in the hosts default cluster if empty")
-	withCpuProfile   = flag.Bool("withCPUProfile", false, "generate a CPU profile for minimalkueue")
+	withCPUProfile   = flag.Bool("withCPUProfile", false, "generate a CPU profile for minimalkueue")
 	withLogs         = flag.Bool("withLogs", false, "capture minimalkueue logs")
 	logLevel         = flag.Int("withLogsLevel", 2, "set minimalkueue logs level")
 	logToFile        = flag.Bool("logToFile", false, "capture minimalkueue logs to files")
@@ -148,7 +148,7 @@ func main() {
 		}
 
 		// start the minimal kueue manager process
-		err = runCommand(ctx, *outputDir, *minimalKueuePath, "kubeconfig", *withCpuProfile, *withLogs, *logToFile, *logLevel, errCh, wg, metricsPort)
+		err = runCommand(ctx, *outputDir, *minimalKueuePath, "kubeconfig", *withCPUProfile, *withLogs, *logToFile, *logLevel, errCh, wg, metricsPort)
 		if err != nil {
 			log.Error(err, "MinimalKueue start")
 			os.Exit(1)

--- a/test/performance/scheduler/runner/recorder/recorder.go
+++ b/test/performance/scheduler/runner/recorder/recorder.go
@@ -92,7 +92,7 @@ type WLEvent struct {
 }
 
 type WLState struct {
-	Id int
+	ID int
 	types.NamespacedName
 	ClassName        string
 	FirstEventTime   time.Time
@@ -114,7 +114,7 @@ var WLStateCsvHeader = []string{
 
 func (wls *WLState) CsvRecord() []string {
 	return []string{
-		strconv.Itoa(wls.Id),
+		strconv.Itoa(wls.ID),
 		wls.ClassName,
 		wls.Namespace,
 		wls.Name,
@@ -178,7 +178,7 @@ func (r *Recorder) recordWLEvent(ev *WLEvent) {
 	state, found := r.Store.WL[ev.UID]
 	if !found {
 		state = &WLState{
-			Id:             len(r.Store.WL),
+			ID:             len(r.Store.WL),
 			NamespacedName: ev.NamespacedName,
 			ClassName:      ev.ClassName,
 			FirstEventTime: ev.Time,

--- a/test/performance/scheduler/runner/scraper/scraper.go
+++ b/test/performance/scheduler/runner/scraper/scraper.go
@@ -37,7 +37,7 @@ func GetFreePort() (int, error) {
 	}
 	defer l.Close()
 	l.Close()
-	if taddr, isTcp := l.Addr().(*net.TCPAddr); isTcp {
+	if taddr, isTCP := l.Addr().(*net.TCPAddr); isTCP {
 		return taddr.Port, nil
 	}
 	return 0, errors.New("cannot get a free tcp address")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Refactor unexported variable names: remove underscores and change case for initialisms. Enable `revive.var-naming` rule to enforce proper variable names.

#### Special notes for your reviewer:

From the [Google style guide](https://google.github.io/styleguide/go/guide#mixed-caps):

> Go source code usually uses `MixedCaps` or `mixedCaps` (camel case) rather than `underscores` (snake case) when writing multi-word names.

From [Effective Go](https://go.dev/doc/effective_go#mixed-caps):

> Finally, the convention in Go is to use MixedCaps or mixedCaps rather than underscores to write multiword names.

From [Go wiki](https://go.dev/wiki/CodeReviewComments#initialisms):

> Words in names that are initialisms or acronyms (e.g. “URL” or “NATO”) have a consistent case. For example, “URL” should appear as “URL” or “url” (as in “urlPony”, or “URLPony”), never as “Url”.
> This rule also applies to “ID” when it is short for “identifier” (which is pretty much all cases when it’s not the “id” as in “ego”, “superego”), so write “appID” instead of “appId”.


#### Does this PR introduce a user-facing change?

```release-note
NONE
```