### PR TITLE
[doc] fix website broken links to "Run Python Jobs" page

### DIFF
--- a/site/content/en/docs/tasks/run/flux_miniclusters.md
+++ b/site/content/en/docs/tasks/run/flux_miniclusters.md
@@ -65,4 +65,4 @@ spec:
     kueue.x-k8s.io/queue-name: user-queue
 ```
 
-For equivalent instructions for doing this in Python, see [Run Python Jobs](/docs/tasks/run_python_jobs/#flux-operator-job).
+For equivalent instructions for doing this in Python, see [Run Python Jobs](/docs/tasks/run/python_jobs/#flux-operator-job).

--- a/site/content/en/docs/tasks/run/kubeflow/mpijobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/mpijobs.md
@@ -46,4 +46,4 @@ This example is based on https://github.com/kubeflow/mpi-operator/blob/ccf2756f7
 
 {{< include "examples/jobs/sample-mpijob.yaml" "yaml" >}}
 
-For equivalent instructions for doing this in Python, see [Run Python Jobs](/docs/tasks/run_python_jobs/#mpi-operator-job).
+For equivalent instructions for doing this in Python, see [Run Python Jobs](/docs/tasks/run/python_jobs/#mpi-operator-job).


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Fixes broken URL to the "Run Jobs Using Python" page.

#### Special notes for your reviewer:

1. Actual: https://kueue.sigs.k8s.io/docs/tasks/run_python_jobs/#mpi-operator-job
Expected: https://kueue.sigs.k8s.io/docs/tasks/run/python_jobs/#mpi-operator-job
2. Actual: https://kueue.sigs.k8s.io/docs/tasks/run_python_jobs/#flux-operator-job
Expected: https://kueue.sigs.k8s.io/docs/tasks/run/python_jobs/#flux-operator-job

#### Does this PR introduce a user-facing change?

```release-note
NONE
```