### PR TITLE
configAPI: Implement waitForPodsReady validations

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -152,9 +152,12 @@ apiVersion: config.kueue.x-k8s.io/v1beta1
 kind: Configuration
 waitForPodsReady:
   enable: true
+  timeout: 50s
+  blockAdmission: false
   requeuingStrategy:
     timestamp: Creation
     backoffLimitCount: 10
+    backoffBaseSeconds: 30
 `), os.FileMode(0600)); err != nil {
 		t.Fatal(err)
 	}
@@ -547,12 +550,12 @@ multiKueue:
 				InternalCertManagement:     enableDefaultInternalCertManagement,
 				WaitForPodsReady: &configapi.WaitForPodsReady{
 					Enable:         true,
-					BlockAdmission: ptr.To(true),
-					Timeout:        &metav1.Duration{Duration: 5 * time.Minute},
+					BlockAdmission: ptr.To(false),
+					Timeout:        &metav1.Duration{Duration: 50 * time.Second},
 					RequeuingStrategy: &configapi.RequeuingStrategy{
 						Timestamp:          ptr.To(configapi.CreationTimestamp),
 						BackoffLimitCount:  ptr.To[int32](10),
-						BackoffBaseSeconds: ptr.To[int32](10),
+						BackoffBaseSeconds: ptr.To[int32](30),
 					},
 				},
 				ClientConnection: defaultClientConnection,

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -112,6 +112,10 @@ func validateWaitForPodsReady(c *configapi.Configuration) field.ErrorList {
 	if !WaitForPodsReadyIsEnabled(c) {
 		return allErrs
 	}
+	if c.WaitForPodsReady.Timeout != nil && c.WaitForPodsReady.Timeout.Duration < 0 {
+		allErrs = append(allErrs, field.Invalid(waitForPodsReadyPath.Child("timeout"),
+			c.WaitForPodsReady.Timeout, constants.IsNegativeErrorMsg))
+	}
 	if strategy := c.WaitForPodsReady.RequeuingStrategy; strategy != nil {
 		if strategy.Timestamp != nil &&
 			*strategy.Timestamp != configapi.CreationTimestamp && *strategy.Timestamp != configapi.EvictionTimestamp {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -324,29 +324,39 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
-		"supported waitForPodsReady.requeuingStrategy.timestamp": {
+		"negative waitForPodsReady.timeout": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				WaitForPodsReady: &configapi.WaitForPodsReady{
 					Enable: true,
-					RequeuingStrategy: &configapi.RequeuingStrategy{
-						Timestamp: ptr.To(configapi.CreationTimestamp),
+					Timeout: &metav1.Duration{
+						Duration: -1,
 					},
 				},
 			},
-			wantErr: nil,
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "waitForPodsReady.timeout",
+				},
+			},
 		},
-		"non-negative waitForPodsReady.requeuingStrategy.backoffLimitCount": {
+		"valid waitForPodsReady": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				WaitForPodsReady: &configapi.WaitForPodsReady{
 					Enable: true,
+					Timeout: &metav1.Duration{
+						Duration: 50,
+					},
+					BlockAdmission: ptr.To(false),
 					RequeuingStrategy: &configapi.RequeuingStrategy{
-						BackoffLimitCount: ptr.To[int32](10),
+						Timestamp:          ptr.To(configapi.CreationTimestamp),
+						BackoffLimitCount:  ptr.To[int32](10),
+						BackoffBaseSeconds: ptr.To[int32](30),
 					},
 				},
 			},
-			wantErr: nil,
 		},
 		"negative waitForPodsReady.requeuingStrategy.backoffLimitCount": {
 			cfg: &configapi.Configuration{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
I implemented the `.waitForPodsReady` validations.
Also, I consolidated the valid test cases for the `waitForPodsReady` into one case, and added fields to the defaulting tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part-of https://github.com/kubernetes-sigs/kueue/issues/2084

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added validations for the "waitForPodsReady.timeout" in the Configuration.
```