### PR TITLE
[release-0.6] WaitForPodsReady: Reset .status.requeueState once the workload is deactivated

### DIFF
--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -1545,8 +1545,7 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				g.Expect(ptr.Deref(wl.Spec.Active, true)).Should(gomega.BeFalse())
-				g.Expect(wl.Status.RequeueState).ShouldNot(gomega.BeNil())
-				g.Expect(wl.Status.RequeueState.Count).Should(gomega.Equal(ptr.To[int32](1)))
+				g.Expect(wl.Status.RequeueState).Should(gomega.BeNil())
 				g.Expect(wl.Status.Conditions).To(gomega.ContainElements(
 					gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.WorkloadPodsReady,
@@ -1558,13 +1557,13 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
 						Reason:  "Pending",
-						Message: "The workload is deactivated",
+						Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
 					}, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "ObservedGeneration")),
 					gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.WorkloadEvicted,
 						Status:  metav1.ConditionTrue,
 						Reason:  "InactiveWorkload",
-						Message: "The workload is deactivated",
+						Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
 					}, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "ObservedGeneration")),
 					gomega.BeComparableTo(metav1.Condition{
 						Type:    kueue.WorkloadAdmitted,

--- a/test/integration/scheduler/podsready/scheduler_test.go
+++ b/test/integration/scheduler/podsready/scheduler_test.go
@@ -197,7 +197,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 	var _ = ginkgo.Context("Short PodsReady timeout", func() {
 
 		ginkgo.BeforeEach(func() {
-			podsReadyTimeout = 3 * time.Second
+			podsReadyTimeout = 1 * time.Second
 			requeuingBackoffLimitCount = ptr.To[int32](2)
 		})
 
@@ -252,41 +252,54 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			ginkgo.By("create the 'prod' workload")
 			prodWl := testing.MakeWorkload("prod", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
 			gomega.Expect(k8sClient.Create(ctx, prodWl)).Should(gomega.Succeed())
+
 			ginkgo.By("checking the 'prod' workload is admitted")
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, prodWl)
 			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 1)
-			ginkgo.By("exceed the timeout for the 'prod' workload")
-			time.Sleep(podsReadyTimeout)
+			util.AwaitWorkloadEvictionByPodsReadyTimeout(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), podsReadyTimeout)
+
 			ginkgo.By("finish the eviction, and the workload is pending by backoff")
 			util.FinishEvictionForWorkloads(ctx, k8sClient, prodWl)
+			util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), &kueue.RequeueState{
+				Count: ptr.To[int32](1),
+			}, true)
 			// To avoid flakiness, we don't verify if the workload has a QuotaReserved=false with pending reason here.
 
 			ginkgo.By("verify the 'prod' workload gets re-admitted twice")
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, prodWl)
 			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 2)
-			time.Sleep(podsReadyTimeout)
+			util.AwaitWorkloadEvictionByPodsReadyTimeout(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), podsReadyTimeout)
 			util.FinishEvictionForWorkloads(ctx, k8sClient, prodWl)
+			util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), &kueue.RequeueState{
+				Count: ptr.To[int32](2),
+			}, true)
+
+			ginkgo.By("the workload exceeded re-queue backoff limit should be deactivated")
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, prodWl)
 			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 3)
 			time.Sleep(podsReadyTimeout)
-			ginkgo.By("evicted re-admitted workload should have 2 in the re-queue count")
-			util.ExpectWorkloadToHaveRequeueCount(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), ptr.To[int32](2))
-			ginkgo.By("the workload exceeded re-queue backoff limit should be deactivated")
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodWl), prodWl))
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodWl), prodWl)).Should(gomega.Succeed())
 				g.Expect(ptr.Deref(prodWl.Spec.Active, true)).Should(gomega.BeFalse())
+				g.Expect(prodWl.Status.RequeueState).Should(gomega.BeNil())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.FinishEvictionForWorkloads(ctx, k8sClient, prodWl)
 
-			ginkgo.By("verify the re-activated inactive 'prod' workload re-queue state is reset")
+			ginkgo.By("the reactivated workload should not be deactivated by the scheduler unless exceeding the backoffLimitCount")
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodWl), prodWl)).Should(gomega.Succeed())
 				prodWl.Spec.Active = ptr.To(true)
 				g.Expect(k8sClient.Update(ctx, prodWl)).Should(gomega.Succeed())
-			}, util.Timeout, util.Interval).Should(gomega.Succeed(), "Reactivate inactive Workload")
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodWl), prodWl)).Should(gomega.Succeed())
-				g.Expect(prodWl.Status.RequeueState).Should(gomega.BeNil())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			// We await for re-admission. Then, the workload keeps the QuotaReserved condition
+			// even after timeout until FinishEvictionForWorkloads is called below.
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, prodWl)
+			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 4)
+			util.AwaitWorkloadEvictionByPodsReadyTimeout(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), podsReadyTimeout)
+			util.FinishEvictionForWorkloads(ctx, k8sClient, prodWl)
+			util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), &kueue.RequeueState{
+				Count: ptr.To[int32](1),
+			}, true)
 		})
 
 		ginkgo.It("Should unblock admission of new workloads in other ClusterQueues once the admitted workload exceeds timeout", func() {
@@ -424,9 +437,17 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			})
 
 			ginkgo.By("verifying if all workloads have a proper re-queue count", func() {
-				util.ExpectWorkloadToHaveRequeueCount(ctx, k8sClient, client.ObjectKeyFromObject(wl1), ptr.To[int32](2))
-				util.ExpectWorkloadToHaveRequeueCount(ctx, k8sClient, client.ObjectKeyFromObject(wl2), ptr.To[int32](1))
-				util.ExpectWorkloadToHaveRequeueCount(ctx, k8sClient, client.ObjectKeyFromObject(wl3), ptr.To[int32](1))
+				// Here, we focus on verifying if the requeuingTimestamp works well.
+				// So, we don't check if the .status.requeueState.requeueAt is reset.
+				util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(wl1), &kueue.RequeueState{
+					Count: ptr.To[int32](2),
+				}, true)
+				util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(wl2), &kueue.RequeueState{
+					Count: ptr.To[int32](1),
+				}, true)
+				util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(wl3), &kueue.RequeueState{
+					Count: ptr.To[int32](1),
+				}, true)
 			})
 		})
 	})
@@ -605,7 +626,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 
 	var _ = ginkgo.Context("Short PodsReady timeout", func() {
 		ginkgo.BeforeEach(func() {
-			podsReadyTimeout = 3 * time.Second
+			podsReadyTimeout = 1 * time.Second
 		})
 
 		ginkgo.It("Should re-admit a timed out workload", func() {
@@ -623,9 +644,10 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 			ginkgo.By("verify the 'prod' workload gets re-admitted once")
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, prodWl)
 			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 2)
-			time.Sleep(podsReadyTimeout)
-			util.ExpectWorkloadToHaveRequeueCount(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), ptr.To[int32](2))
-			gomega.Expect(prodWl)
+			util.AwaitWorkloadEvictionByPodsReadyTimeout(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), podsReadyTimeout)
+			util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), &kueue.RequeueState{
+				Count: ptr.To[int32](2),
+			}, true)
 			gomega.Expect(ptr.Deref(prodWl.Spec.Active, true)).Should(gomega.BeTrue())
 		})
 	})
@@ -696,13 +718,18 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 				// To avoid flakiness, we don't verify if the workload has a QuotaReserved=false with pending reason here.
 			})
 			ginkgo.By("verifying if all workloads have a proper re-queue count", func() {
-				util.ExpectWorkloadToHaveRequeueCount(ctx, k8sClient, client.ObjectKeyFromObject(wl1), ptr.To[int32](2))
-				util.ExpectWorkloadToHaveRequeueCount(ctx, k8sClient, client.ObjectKeyFromObject(wl2), ptr.To[int32](1))
+				// Here, we focus on verifying if the requeuingTimestamp works well.
+				// So, we don't check if the .status.requeueState.requeueAt is reset.
+				util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(wl1), &kueue.RequeueState{
+					Count: ptr.To[int32](2),
+				}, true)
+				util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(wl2), &kueue.RequeueState{
+					Count: ptr.To[int32](1),
+				}, true)
 				ginkgo.By("wl3 had never been admitted", func() {
-					util.ExpectWorkloadToHaveRequeueCount(ctx, k8sClient, client.ObjectKeyFromObject(wl3), nil)
+					util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(wl3), nil, false)
 				})
 			})
 		})
 	})
-
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
If the Workload is deactivated, the workload resets the requeueState to avoid a race condition between the kueue-scheduler and the workload controller in the case of the deactivated workload.

When the workload is deactivated by exceeding the backoffLimitCount, the workload is added `The workload is deactivated due to exceeding the maximum number of re-queuing retries`. I will introduce a dedicated reason in another PR to focus on fixing the bug.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2174

#### Special notes for your reviewer:
This PR is cherry-pick of #2219

The primary difference from #2219 is the criteria to deduce that the Workload is deactivated due to exceeding the backoffLimitCount.

In the v0.7 implementation, the deactivated workload doesn't have the `.status.requeuesState.requeueAt` since the `requeueAt` should be reset when the workload was requeued (`Requeued=true` condition).

```go
// The deactivation reason could be deduced as the maximum number of re-queuing retries if the workload met all criteria below:
//  1. The waitForPodsReady feature is enabled, which means that it has "PodsReady" condition.
//  2. The workload has already exceeded the PodsReadyTimeout.
//  3. The workload already has been re-queued previously, which means it doesn't have the requeueAt field.
//  4. The number of re-queued has already reached the waitForPodsReady.requeuingBackoffLimitCount.
```

But, in the v0.6 implementation, an empty `requeueAt` is dropped from the criteria since we never reset the `requeueAt` and `Requeued` condition, a new feature for the v0.7.

```go
// The deactivation reason could be deduced as the maximum number of re-queuing retries if the workload met all criteria below:
//  1. The waitForPodsReady feature is enabled, which means that it has "PodsReady" condition.
//  2. The workload has already exceeded the PodsReadyTimeout.
//  3. The number of re-queued has already reached the waitForPodsReady.requeuingBackoffLimitCount.
```


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug that causes the reactivated Workload to be immediately deactivated even though it doesn't exceed the backoffLimit.
```