### PR TITLE
[release-0.6] WaitForPodsReady: Load the backoffLimitCount regardless of the requeueingStrategy.timestamp

### DIFF
--- a/apis/config/v1beta1/defaults.go
+++ b/apis/config/v1beta1/defaults.go
@@ -120,10 +120,11 @@ func SetDefaults_Configuration(cfg *Configuration) {
 			}
 			cfg.WaitForPodsReady.BlockAdmission = &defaultBlockAdmission
 		}
-		if cfg.WaitForPodsReady.RequeuingStrategy == nil || cfg.WaitForPodsReady.RequeuingStrategy.Timestamp == nil {
-			cfg.WaitForPodsReady.RequeuingStrategy = &RequeuingStrategy{
-				Timestamp: ptr.To(EvictionTimestamp),
-			}
+		if cfg.WaitForPodsReady.RequeuingStrategy == nil {
+			cfg.WaitForPodsReady.RequeuingStrategy = &RequeuingStrategy{}
+		}
+		if cfg.WaitForPodsReady.RequeuingStrategy.Timestamp == nil {
+			cfg.WaitForPodsReady.RequeuingStrategy.Timestamp = ptr.To(EvictionTimestamp)
 		}
 	}
 	if cfg.Integrations == nil {

--- a/apis/config/v1beta1/defaults_test.go
+++ b/apis/config/v1beta1/defaults_test.go
@@ -412,7 +412,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Enable:  true,
 					Timeout: &podsReadyTimeoutOverwrite,
 					RequeuingStrategy: &RequeuingStrategy{
-						Timestamp: ptr.To(CreationTimestamp),
+						Timestamp:         ptr.To(CreationTimestamp),
+						BackoffLimitCount: ptr.To[int32](10),
 					},
 				},
 				InternalCertManagement: &InternalCertManagement{
@@ -425,7 +426,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					BlockAdmission: ptr.To(true),
 					Timeout:        &podsReadyTimeoutOverwrite,
 					RequeuingStrategy: &RequeuingStrategy{
-						Timestamp: ptr.To(CreationTimestamp),
+						Timestamp:         ptr.To(CreationTimestamp),
+						BackoffLimitCount: ptr.To[int32](10),
 					},
 				},
 				Namespace:         ptr.To(DefaultNamespace),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
If we don't set the `requeuingStrategy.timestamp` , the `backoffLimitCount` is ignored.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This has already been fixed in #2040 as a feature enhancement.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug that the ".waitForPodsReady.requeuingStrategy.backoffLimitCount" is ignored when the ".waitForPodsReady.requeuingStrategy.timestamp" is not set.
```