### PR TITLE
Automated cherry pick of #2189: Cleanup the TODO in the integration test

### DIFF
--- a/test/integration/scheduler/podsready/scheduler_test.go
+++ b/test/integration/scheduler/podsready/scheduler_test.go
@@ -278,18 +278,6 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("verify the re-activated inactive 'prod' workload re-queue state is reset")
-			// TODO: Once we move a logic to issue the Eviction with InactiveWorkload reason, we need to remove the below updates.
-			// REF: https://github.com/kubernetes-sigs/kueue/issues/1841
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodWl), prodWl)).Should(gomega.Succeed())
-				apimeta.SetStatusCondition(&prodWl.Status.Conditions, metav1.Condition{
-					Type:    kueue.WorkloadEvicted,
-					Status:  metav1.ConditionTrue,
-					Reason:  kueue.WorkloadEvictedByDeactivation,
-					Message: "evicted by Test",
-				})
-				g.Expect(k8sClient.Status().Update(ctx, prodWl)).Should(gomega.Succeed())
-			}, util.Timeout, util.Interval).Should(gomega.Succeed(), "Job reconciler should add an Evicted condition with InactiveWorkload to the Workload")
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodWl), prodWl)).Should(gomega.Succeed())
 				prodWl.Spec.Active = ptr.To(true)


### PR DESCRIPTION
Cherry pick of #2189 on release-0.6.
#2189: Cleanup the TODO in the integration test
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
NONE
```