### PR TITLE
[test/int/kueuectl] Delete the used CQ at the end of stop/resume tests.

### DIFF
--- a/test/integration/kueuectl/resume_test.go
+++ b/test/integration/kueuectl/resume_test.go
@@ -87,6 +87,10 @@ var _ = ginkgo.Describe("Kueuectl Resume", ginkgo.Ordered, ginkgo.ContinueOnFail
 					gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
 				})
 
+				ginkgo.DeferCleanup(func() {
+					util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, cq, true)
+				})
+
 				createdClusterQueue := &v1beta1.ClusterQueue{}
 				ginkgo.By("Get created ClusterQueue", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
@@ -109,13 +113,6 @@ var _ = ginkgo.Describe("Kueuectl Resume", ginkgo.Ordered, ginkgo.ContinueOnFail
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdClusterQueue), createdClusterQueue)).To(gomega.Succeed())
 						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(v1beta1.None))
-					}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				})
-
-				ginkgo.By("Delete the ClusterQueue", func() {
-					gomega.Expect(k8sClient.Delete(ctx, cq)).To(gomega.Succeed())
-					gomega.Eventually(func(g gomega.Gomega) {
-						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdClusterQueue)).To(testing.BeNotFoundError())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 			},

--- a/test/integration/kueuectl/resume_test.go
+++ b/test/integration/kueuectl/resume_test.go
@@ -111,6 +111,13 @@ var _ = ginkgo.Describe("Kueuectl Resume", ginkgo.Ordered, ginkgo.ContinueOnFail
 						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(v1beta1.None))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
+
+				ginkgo.By("Delete the ClusterQueue", func() {
+					gomega.Expect(k8sClient.Delete(ctx, cq)).To(gomega.Succeed())
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdClusterQueue)).To(testing.BeNotFoundError())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
 			},
 			ginkgo.Entry("HoldAndDrain",
 				testing.MakeClusterQueue("cq-1").StopPolicy(v1beta1.HoldAndDrain).Obj(),

--- a/test/integration/kueuectl/stop_test.go
+++ b/test/integration/kueuectl/stop_test.go
@@ -111,6 +111,13 @@ var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailur
 						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(wantStopPolicy))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
+
+				ginkgo.By("Delete the ClusterQueue", func() {
+					gomega.Expect(k8sClient.Delete(ctx, cq)).To(gomega.Succeed())
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdClusterQueue)).To(testing.BeNotFoundError())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
 			},
 			ginkgo.Entry("Stop a ClusterQueue and drain workloads",
 				testing.MakeClusterQueue("cq-1").Obj(),

--- a/test/integration/kueuectl/stop_test.go
+++ b/test/integration/kueuectl/stop_test.go
@@ -87,6 +87,10 @@ var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailur
 					gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
 				})
 
+				ginkgo.DeferCleanup(func() {
+					util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, cq, true)
+				})
+
 				createdClusterQueue := &v1beta1.ClusterQueue{}
 				ginkgo.By("Get created ClusterQueue", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
@@ -109,13 +113,6 @@ var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailur
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdClusterQueue), createdClusterQueue)).To(gomega.Succeed())
 						g.Expect(ptr.Deref(createdClusterQueue.Spec.StopPolicy, v1beta1.None)).Should(gomega.Equal(wantStopPolicy))
-					}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				})
-
-				ginkgo.By("Delete the ClusterQueue", func() {
-					gomega.Expect(k8sClient.Delete(ctx, cq)).To(gomega.Succeed())
-					gomega.Eventually(func(g gomega.Gomega) {
-						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdClusterQueue)).To(testing.BeNotFoundError())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Delete the used CQ at the end of stop/resume integration tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2245

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```