### PR TITLE
Set DefaultRequeuingBackoffBaseSeconds to 60s.

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -247,7 +247,7 @@ type RequeuingStrategy struct {
 	// - "Rand" represents the random jitter.
 	// During this time, the workload is taken as an inadmissible and
 	// other workloads will have a chance to be admitted.
-	// By default, the consecutive requeue delays are around: (10s, 20s, 40s, ...).
+	// By default, the consecutive requeue delays are around: (60s, 120s, 240s, ...).
 	//
 	// Defaults to null.
 	// +optional
@@ -256,7 +256,7 @@ type RequeuingStrategy struct {
 	// BackoffBaseSeconds defines the base for the exponential backoff for
 	// re-queuing an evicted workload.
 	//
-	// Defaults to 10.
+	// Defaults to 60.
 	// +optional
 	BackoffBaseSeconds *int32 `json:"backoffBaseSeconds,omitempty"`
 }

--- a/apis/config/v1beta1/defaults.go
+++ b/apis/config/v1beta1/defaults.go
@@ -47,7 +47,7 @@ const (
 	DefaultMultiKueueGCInterval                         = time.Minute
 	DefaultMultiKueueOrigin                             = "multikueue"
 	DefaultMultiKueueWorkerLostTimeout                  = 15 * time.Minute
-	DefaultRequeuingBackoffBaseSeconds                  = 10
+	DefaultRequeuingBackoffBaseSeconds                  = 60
 )
 
 func getOperatorNamespace() string {

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -85,7 +85,7 @@ managerConfig:
     #  requeuingStrategy:
     #    timestamp: Eviction
     #    backoffLimitCount: null # null indicates infinite requeuing
-    #    backoffBaseSeconds: 10
+    #    backoffBaseSeconds: 60
     #manageJobsWithoutQueueName: true
     #internalCertManagement:
     #  enable: false

--- a/config/components/manager/controller_manager_config.yaml
+++ b/config/components/manager/controller_manager_config.yaml
@@ -29,7 +29,7 @@ clientConnection:
 #  requeuingStrategy:
 #    timestamp: Eviction
 #    backoffLimitCount: null # null indicates infinite requeuing
-#    backoffBaseSeconds: 10
+#    backoffBaseSeconds: 60
 #manageJobsWithoutQueueName: true
 #internalCertManagement:
 #  enable: false

--- a/keps/1282-pods-ready-requeue-strategy/README.md
+++ b/keps/1282-pods-ready-requeue-strategy/README.md
@@ -143,12 +143,12 @@ type RequeuingStrategy struct {
 	// Once the number is reached, the workload is deactivated (`.spec.activate`=`false`).
 	// When it is null, the workloads will repeatedly and endless re-queueing.
 	//
-	// Every backoff duration is about "10s*2^(n-1)+Rand" where:
+	// Every backoff duration is about "60s*2^(n-1)+Rand" where:
 	// - "n" represents the "workloadStatus.requeueState.count",
 	// - "Rand" represents the random jitter.
 	// During this time, the workload is taken as an inadmissible and
 	// other workloads will have a chance to be admitted.
-	// By default, the consecutive requeue delays are around: (10s, 20s, 40s, ...).
+	// By default, the consecutive requeue delays are around: (60s, 120s, 240s, ...).
 	//
 	// Defaults to null.
 	// +optional
@@ -157,7 +157,7 @@ type RequeuingStrategy struct {
 	// BackoffBaseSeconds defines the base for the exponential backoff for
 	// re-queuing an evicted workload.
 	//
-	// Defaults to 10.
+	// Defaults to 60.
 	// +optional
 	BackoffBaseSeconds *int32 `json:"backoffBaseSeconds,omitempty"`
 }
@@ -230,16 +230,16 @@ Duration this time, other workloads will have a chance to be admitted.
 
 The queueManager calculates an exponential backoff duration by [the Step function](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait@v0.29.1#Backoff.Step)
 according to the $b*2^{(n-1)}+Rand$ where:
-- $b$ represents the base delay, configured by `baseDelaySeconds`
+- $b$ represents the base delay, configured by `backoffBaseSeconds`
 - $n$ represents the `workloadStatus.requeueState.count`,
 - $Rand$ represents the random jitter.
 
 It will spend awaiting to be requeued after eviction:
 $$\sum_{k=1}^{n}(b*2^{(k-1)} + Rand)$$
 
-Assuming `backoffLimitCount` equals 10, and `baseDelaySeconds` equals 10 (default) the workload is requeued 10 times
+Assuming `backoffLimitCount` equals 10, and `backoffBaseSeconds` equals 60 (default) the workload is requeued 10 times
 after failing to have all pods ready, then the total time awaiting for requeue
-will take (neglecting the jitter): `10s+20s+40s +...+7680s=2h 8min`.
+will take (neglecting the jitter): `60s+120s+240s +...+30720s=8h 32min`.
 Also, considering `.waitForPodsReady.timeout=300s` (default),
 the workload will spend `50min` total waiting for pods ready.
 

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -455,7 +455,7 @@ func (r *WorkloadReconciler) triggerDeactivationOrBackoffRequeue(ctx context.Con
 			"Deactivated Workload %q by reached re-queue backoffLimitCount", klog.KObj(wl))
 		return true, nil
 	}
-	// Every backoff duration is about "10s*2^(n-1)+Rand" where:
+	// Every backoff duration is about "60s*2^(n-1)+Rand" where:
 	// - "n" represents the "requeuingCount",
 	// - "Rand" represents the random jitter.
 	// During this time, the workload is taken as an inadmissible and other

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -719,7 +719,7 @@ When it is null, the workloads will repeatedly and endless re-queueing.</p>
 <li>&quot;Rand&quot; represents the random jitter.
 During this time, the workload is taken as an inadmissible and
 other workloads will have a chance to be admitted.
-By default, the consecutive requeue delays are around: (10s, 20s, 40s, ...).</li>
+By default, the consecutive requeue delays are around: (60s, 120s, 240s, ...).</li>
 </ul>
 <p>Defaults to null.</p>
 </td>
@@ -730,7 +730,7 @@ By default, the consecutive requeue delays are around: (10s, 20s, 40s, ...).</li
 <td>
    <p>BackoffBaseSeconds defines the base for the exponential backoff for
 re-queuing an evicted workload.</p>
-<p>Defaults to 10.</p>
+<p>Defaults to 60.</p>
 </td>
 </tr>
 </tbody>

--- a/site/content/en/docs/tasks/manage/setup_sequential_admission.md
+++ b/site/content/en/docs/tasks/manage/setup_sequential_admission.md
@@ -47,7 +47,7 @@ fields:
       requeuingStrategy:
         timestamp: Eviction | Creation
         backoffLimitCount: 5
-        backoffBaseSeconds: 10
+        backoffBaseSeconds: 60
 ```
 
 {{% alert title="Note" color="primary" %}}
@@ -99,8 +99,8 @@ _The `backoffBaseSeconds` is available in Kueue v0.7.0 and later_
 {{% /alert %}}
 The time to re-queue a workload after each consecutive timeout is increased
 exponentially, with the exponent of 2. The first delay is determined by the
-`backoffBaseSeconds` parameter (defaulting to 10). So, after the consecutive timeouts
-the evicted workload is re-queued after approximately `10, 20, 40, ...` seconds.
+`backoffBaseSeconds` parameter (defaulting to 60). So, after the consecutive timeouts
+the evicted workload is re-queued after approximately `60, 120, 240, ...` seconds.
 
 ## Example
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Set DefaultRequeuingBackoffBaseSeconds to 60s.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2215

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Increased the default value in the `.waitForPodsReady.requeuingStrategy.backoffBaseSeconds` to 60

ACTION REQUIRED: You can configure `.waitForPodsReady.requeuingStrategy.backoffBaseSeconds` as needed.
```