### PR TITLE
Pod controller: "when Using pod group Should keep the running pod group with the queue name if workload is evicted" flakes

### DIFF
--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -655,6 +655,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				ginkgo.By("set the pods as running", func() {
 					util.SetPodsPhase(ctx, k8sClient, corev1.PodRunning, pod1, pod2)
+					util.SetNodeName(ctx, k8sClient, "node1", pod1, pod2)
 				})
 
 				createdPod := &corev1.Pod{}
@@ -697,6 +698,12 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				ginkgo.By("creating the replacement pod and readmitting the workload will unsuspended the replacement", func() {
 					gomega.Expect(k8sClient.Create(ctx, replacementPod)).Should(gomega.Succeed())
+
+					// Eventually pod2 fully removed
+					gomega.Eventually(func() bool {
+						err := k8sClient.Get(ctx, pod2LookupKey, createdPod)
+						return apierrors.IsNotFound(err) || (err == nil && len(createdPod.Finalizers) == 0)
+					}, util.Timeout, util.Interval).Should(gomega.BeTrue())
 
 					gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 					gomega.Expect(createdWorkload.UID).To(gomega.Equal(originalWorkloadUID))

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -654,8 +654,8 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				})
 
 				ginkgo.By("set the pods as running", func() {
+					util.BindPodWithNode(ctx, k8sClient, "node1", pod1, pod2)
 					util.SetPodsPhase(ctx, k8sClient, corev1.PodRunning, pod1, pod2)
-					util.SetNodeName(ctx, k8sClient, "node1", pod1, pod2)
 				})
 
 				createdPod := &corev1.Pod{}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -678,6 +678,20 @@ func SetPodsPhase(ctx context.Context, k8sClient client.Client, phase corev1.Pod
 	}
 }
 
+func SetNodeName(ctx context.Context, k8sClient client.Client, nodeName string, pods ...*corev1.Pod) {
+	for _, p := range pods {
+		updatedPod := corev1.Pod{}
+		gomega.ExpectWithOffset(1, k8sClient.Get(ctx, client.ObjectKeyFromObject(p), &updatedPod)).To(gomega.Succeed())
+		binding := corev1.Binding{
+			Target: corev1.ObjectReference{
+				Kind: "Node",
+				Name: nodeName,
+			},
+		}
+		gomega.ExpectWithOffset(1, k8sClient.SubResource("binding").Create(ctx, &updatedPod, &binding)).To(gomega.Succeed())
+	}
+}
+
 func ExpectPodUnsuspendedWithNodeSelectors(ctx context.Context, k8sClient client.Client, key types.NamespacedName, ns map[string]string) {
 	createdPod := &corev1.Pod{}
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -678,7 +678,7 @@ func SetPodsPhase(ctx context.Context, k8sClient client.Client, phase corev1.Pod
 	}
 }
 
-func SetNodeName(ctx context.Context, k8sClient client.Client, nodeName string, pods ...*corev1.Pod) {
+func BindPodWithNode(ctx context.Context, k8sClient client.Client, nodeName string, pods ...*corev1.Pod) {
 	for _, p := range pods {
 		updatedPod := corev1.Pod{}
 		gomega.ExpectWithOffset(1, k8sClient.Get(ctx, client.ObjectKeyFromObject(p), &updatedPod)).To(gomega.Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes failing test caused by changes in isPodRunnableOrSucceeded of #2212
```
-	if p.DeletionTimestamp != nil && len(p.Spec.SchedulingGates) > 0 {
+	if p.DeletionTimestamp != nil && len(p.Spec.NodeName) == 0 {
```
It's solely tests issue, since node name was not set, the workload reconciliation was stuck in a reclaimable pods reset attempt

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2243

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```