### PR TITLE
Follow-up of #2239

### DIFF
--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -2336,13 +2336,14 @@ func TestReconciler(t *testing.T) {
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
-			}).
+			}).NodeSelector("node-label1", "value").
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
-			}).Obj(),
+			}).NodeSelector("node-label1", "value").
+				Obj(),
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload(GetWorkloadNameForJob(baseJobWrapper.Name, baseJobWrapper.GetUID()), "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
@@ -2354,6 +2355,7 @@ func TestReconciler(t *testing.T) {
 								Operator: corev1.TolerationOpExists,
 								Effect:   corev1.TaintEffectNoSchedule,
 							}).
+							NodeSelector(map[string]string{"node-label": "value"}).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2374,6 +2376,7 @@ func TestReconciler(t *testing.T) {
 								Operator: corev1.TolerationOpExists,
 								Effect:   corev1.TaintEffectNoSchedule,
 							}).
+							NodeSelector(map[string]string{"node-label1": "value"}).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2397,12 +2400,16 @@ func TestReconciler(t *testing.T) {
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
-			}).Suspend(false).Obj(),
+			}).NodeSelector("node-label1", "value").
+				Suspend(false).
+				Obj(),
 			wantJob: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
-			}).Suspend(false).Obj(),
+			}).NodeSelector("node-label1", "value").
+				Suspend(false).
+				Obj(),
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload(GetWorkloadNameForJob(baseJobWrapper.Name, baseJobWrapper.GetUID()), "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
@@ -2414,6 +2421,7 @@ func TestReconciler(t *testing.T) {
 								Operator: corev1.TolerationOpExists,
 								Effect:   corev1.TaintEffectNoSchedule,
 							}).
+							NodeSelector(map[string]string{"different node-label": "different value"}).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2441,7 +2449,10 @@ func TestReconciler(t *testing.T) {
 								Key:      "tolerationkey1",
 								Operator: corev1.TolerationOpExists,
 								Effect:   corev1.TaintEffectNoSchedule,
-							}).Request(corev1.ResourceCPU, "1").Obj(),
+							}).
+							NodeSelector(map[string]string{"different node-label": "different value"}).
+							Request(corev1.ResourceCPU, "1").
+							Obj(),
 					).
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "",

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -2331,18 +2331,18 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
-		"the workload is not admitted and tolerations change": {
+		"the workload is not admitted, tolerations and node selector change": {
 			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
-			}).NodeSelector("node-label1", "value").
+			}).NodeSelector("node-label", "value").
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
-			}).NodeSelector("node-label1", "value").
+			}).NodeSelector("node-label", "value").
 				Obj(),
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload(GetWorkloadNameForJob(baseJobWrapper.Name, baseJobWrapper.GetUID()), "ns").
@@ -2355,7 +2355,7 @@ func TestReconciler(t *testing.T) {
 								Operator: corev1.TolerationOpExists,
 								Effect:   corev1.TaintEffectNoSchedule,
 							}).
-							NodeSelector(map[string]string{"node-label": "value"}).
+							NodeSelector(map[string]string{"different node-label": "different value"}).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2376,7 +2376,7 @@ func TestReconciler(t *testing.T) {
 								Operator: corev1.TolerationOpExists,
 								Effect:   corev1.TaintEffectNoSchedule,
 							}).
-							NodeSelector(map[string]string{"node-label1": "value"}).
+							NodeSelector(map[string]string{"node-label": "value"}).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2395,19 +2395,19 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
-		"the workload is admitted and tolerations change": {
+		"the workload is admitted, tolerations and node selector change": {
 			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
-			}).NodeSelector("node-label1", "value").
+			}).NodeSelector("node-label", "value").
 				Suspend(false).
 				Obj(),
 			wantJob: *baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
 				Operator: corev1.TolerationOpExists,
 				Effect:   corev1.TaintEffectNoSchedule,
-			}).NodeSelector("node-label1", "value").
+			}).NodeSelector("node-label", "value").
 				Suspend(false).
 				Obj(),
 			workloads: []kueue.Workload{

--- a/pkg/util/equality/podset_test.go
+++ b/pkg/util/equality/podset_test.go
@@ -31,27 +31,27 @@ func TestComparePodSetSlices(t *testing.T) {
 		a                 []kueue.PodSet
 		b                 []kueue.PodSet
 		ignoreTolerations bool
-		wantEqual         bool
+		wantEquivalent    bool
 	}{
 		"different name": {
-			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
-			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps2", 10).SetMinimumCount(5).Obj()},
-			wantEqual: true,
+			a:              []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
+			b:              []kueue.PodSet{*utiltestting.MakePodSet("ps2", 10).SetMinimumCount(5).Obj()},
+			wantEquivalent: true,
 		},
 		"different min count": {
-			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
-			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(2).Obj()},
-			wantEqual: false,
+			a:              []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
+			b:              []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(2).Obj()},
+			wantEquivalent: false,
 		},
 		"different node selector": {
-			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
-			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).NodeSelector(map[string]string{"key": "val"}).Obj()},
-			wantEqual: true,
+			a:              []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
+			b:              []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).NodeSelector(map[string]string{"key": "val"}).Obj()},
+			wantEquivalent: true,
 		},
 		"different requests": {
-			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Request("res", "1").Obj()},
-			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Request("res", "2").Obj()},
-			wantEqual: false,
+			a:              []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Request("res", "1").Obj()},
+			b:              []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Request("res", "2").Obj()},
+			wantEquivalent: false,
 		},
 		"different requests in init containers": {
 			a: []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).InitContainers(corev1.Container{
@@ -70,7 +70,7 @@ func TestComparePodSetSlices(t *testing.T) {
 					},
 				},
 			}).Obj()},
-			wantEqual: false,
+			wantEquivalent: false,
 		},
 		"different requests in toleration": {
 			a: []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Toleration(corev1.Toleration{
@@ -85,17 +85,17 @@ func TestComparePodSetSlices(t *testing.T) {
 				Value:    "demand",
 				Effect:   corev1.TaintEffectNoSchedule,
 			}).Obj()},
-			wantEqual: false,
+			wantEquivalent: false,
 		},
 		"different count": {
-			a:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
-			b:         []kueue.PodSet{*utiltestting.MakePodSet("ps", 20).SetMinimumCount(5).Obj()},
-			wantEqual: false,
+			a:              []kueue.PodSet{*utiltestting.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
+			b:              []kueue.PodSet{*utiltestting.MakePodSet("ps", 20).SetMinimumCount(5).Obj()},
+			wantEquivalent: false,
 		},
 		"different slice len": {
-			a:         []kueue.PodSet{{}, {}},
-			b:         []kueue.PodSet{{}, {}, {}},
-			wantEqual: false,
+			a:              []kueue.PodSet{{}, {}},
+			b:              []kueue.PodSet{{}, {}, {}},
+			wantEquivalent: false,
 		},
 		"different requests in toleration, ignore tolerations": {
 			a: []kueue.PodSet{
@@ -119,7 +119,7 @@ func TestComparePodSetSlices(t *testing.T) {
 					}).Obj(),
 			},
 			ignoreTolerations: true,
-			wantEqual:         true,
+			wantEquivalent:    true,
 		},
 		"different requests in node selector": {
 			a: []kueue.PodSet{
@@ -134,14 +134,14 @@ func TestComparePodSetSlices(t *testing.T) {
 					NodeSelector(map[string]string{"key": "val2"}).
 					Obj(),
 			},
-			wantEqual: true,
+			wantEquivalent: true,
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := ComparePodSetSlices(tc.a, tc.b, tc.ignoreTolerations)
-			if got != tc.wantEqual {
-				t.Errorf("Unexpected result, want %v", tc.wantEqual)
+			if got != tc.wantEquivalent {
+				t.Errorf("Unexpected result, want %v", tc.wantEquivalent)
 			}
 		})
 	}

--- a/pkg/util/equality/podset_test.go
+++ b/pkg/util/equality/podset_test.go
@@ -121,6 +121,21 @@ func TestComparePodSetSlices(t *testing.T) {
 			ignoreTolerations: true,
 			wantEqual:         true,
 		},
+		"different requests in node selector": {
+			a: []kueue.PodSet{
+				*utiltestting.MakePodSet("ps", 10).
+					SetMinimumCount(5).
+					NodeSelector(map[string]string{"key": "val"}).
+					Obj(),
+			},
+			b: []kueue.PodSet{
+				*utiltestting.MakePodSet("ps", 10).
+					SetMinimumCount(5).
+					NodeSelector(map[string]string{"key": "val2"}).
+					Obj(),
+			},
+			wantEqual: true,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Follow-up of #2239
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2213

#### Special notes for your reviewer:
* Test for ignoreTolerations
* Add node selector to test to make sure it's not a part of equality check

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```