### PR TITLE
Automated cherry pick of #2239: Plain Pod gets deleted once admitted via ProvisioningRequest

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -662,17 +662,17 @@ func equivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, 
 	jobPodSets := clearMinCountsIfFeatureDisabled(job.PodSets())
 
 	if runningPodSets := expectedRunningPodSets(ctx, c, wl); runningPodSets != nil {
-		if equality.ComparePodSetSlices(jobPodSets, runningPodSets) {
+		if equality.ComparePodSetSlices(jobPodSets, runningPodSets, workload.IsAdmitted(wl)) {
 			return true
 		}
 		// If the workload is admitted but the job is suspended, do the check
 		// against the non-running info.
 		// This might allow some violating jobs to pass equivalency checks, but their
 		// workloads would be invalidated in the next sync after unsuspending.
-		return job.IsSuspended() && equality.ComparePodSetSlices(jobPodSets, wl.Spec.PodSets)
+		return job.IsSuspended() && equality.ComparePodSetSlices(jobPodSets, wl.Spec.PodSets, workload.IsAdmitted(wl))
 	}
 
-	return equality.ComparePodSetSlices(jobPodSets, wl.Spec.PodSets)
+	return equality.ComparePodSetSlices(jobPodSets, wl.Spec.PodSets, workload.IsAdmitted(wl))
 }
 
 func (r *JobReconciler) updateWorkloadToMatchJob(ctx context.Context, job GenericJob, object client.Object, wl *kueue.Workload) (*kueue.Workload, error) {

--- a/pkg/util/equality/podset.go
+++ b/pkg/util/equality/podset.go
@@ -26,8 +26,8 @@ import (
 
 // TODO: Revisit this, maybe we should extend the check to everything that could potentially impact
 // the workload scheduling (priority, nodeSelectors(when suspended), tolerations and maybe more)
-func comparePodTemplate(a, b *corev1.PodSpec) bool {
-	if !equality.Semantic.DeepEqual(a.Tolerations, b.Tolerations) {
+func comparePodTemplate(a, b *corev1.PodSpec, ignoreTolerations bool) bool {
+	if !ignoreTolerations && !equality.Semantic.DeepEqual(a.Tolerations, b.Tolerations) {
 		return false
 	}
 	if !equality.Semantic.DeepEqual(a.InitContainers, b.InitContainers) {
@@ -36,7 +36,7 @@ func comparePodTemplate(a, b *corev1.PodSpec) bool {
 	return equality.Semantic.DeepEqual(a.Containers, b.Containers)
 }
 
-func ComparePodSets(a, b *kueue.PodSet) bool {
+func ComparePodSets(a, b *kueue.PodSet, ignoreTolerations bool) bool {
 	if a.Count != b.Count {
 		return false
 	}
@@ -44,15 +44,15 @@ func ComparePodSets(a, b *kueue.PodSet) bool {
 		return false
 	}
 
-	return comparePodTemplate(&a.Template.Spec, &b.Template.Spec)
+	return comparePodTemplate(&a.Template.Spec, &b.Template.Spec, ignoreTolerations)
 }
 
-func ComparePodSetSlices(a, b []kueue.PodSet) bool {
+func ComparePodSetSlices(a, b []kueue.PodSet, ignoreTolerations bool) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i := range a {
-		if !ComparePodSets(&a[i], &b[i]) {
+		if !ComparePodSets(&a[i], &b[i], ignoreTolerations) {
 			return false
 		}
 	}

--- a/pkg/util/equality/podset_test.go
+++ b/pkg/util/equality/podset_test.go
@@ -97,10 +97,9 @@ func TestComparePodSetSlices(t *testing.T) {
 			wantEqual: false,
 		},
 	}
-
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := ComparePodSetSlices(tc.a, tc.b)
+			got := ComparePodSetSlices(tc.a, tc.b, false)
 			if got != tc.wantEqual {
 				t.Errorf("Unexpected result, want %v", tc.wantEqual)
 			}


### PR DESCRIPTION
Cherry pick of #2239 on release-0.6.
#2239: Plain Pod gets deleted once admitted via ProvisioningRequest
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
Ignore tolerations for admitted workloads
```