### PR TITLE
[workload] Allow specifying PodSetUpdates for a subset of PodSets

### DIFF
--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -154,7 +154,8 @@ func validateContainer(c *corev1.Container, path *field.Path) field.ErrorList {
 func validateAdmissionChecks(obj *kueue.Workload, basePath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	for i := range obj.Status.AdmissionChecks {
-		// the number of podSetUpdates cannot exceed the one of the podSets without having an unknown podSet name
+		// no need to check the number of podSetUpdates,
+		// because it cannot exceed the one of the podSets without having an unknown podSet name
 		allErrs = append(allErrs, validatePodSetUpdates(&obj.Status.AdmissionChecks[i], obj, basePath.Index(i).Child("podSetUpdates"))...)
 	}
 	return allErrs

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -154,12 +154,8 @@ func validateContainer(c *corev1.Container, path *field.Path) field.ErrorList {
 func validateAdmissionChecks(obj *kueue.Workload, basePath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	for i := range obj.Status.AdmissionChecks {
-		admissionChecksPath := basePath.Index(i)
-		ac := &obj.Status.AdmissionChecks[i]
-		if len(ac.PodSetUpdates) > 0 && len(ac.PodSetUpdates) != len(obj.Spec.PodSets) {
-			allErrs = append(allErrs, field.Invalid(admissionChecksPath.Child("podSetUpdates"), field.OmitValueType{}, "must have the same number of podSetUpdates as the podSets"))
-		}
-		allErrs = append(allErrs, validatePodSetUpdates(ac, obj, admissionChecksPath.Child("podSetUpdates"))...)
+		// the number of podSetUpdates cannot exceed the one of the podSets without having an unknown podSet name
+		allErrs = append(allErrs, validatePodSetUpdates(&obj.Status.AdmissionChecks[i], obj, basePath.Index(i).Child("podSetUpdates"))...)
 	}
 	return allErrs
 }

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -120,6 +120,15 @@ func TestValidateWorkload(t *testing.T) {
 			workload: testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).AdmissionChecks(kueue.AdmissionCheckState{}).Obj(),
 			wantErr:  nil,
 		},
+		"should accept podSetUpdates for only a subset of podSets": {
+			workload: testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).PodSets(
+				*testingutil.MakePodSet("first", 1).Obj(),
+				*testingutil.MakePodSet("second", 1).Obj(),
+			).AdmissionChecks(
+				kueue.AdmissionCheckState{PodSetUpdates: []kueue.PodSetUpdate{{Name: "first"}}},
+			).Obj(),
+			wantErr: nil,
+		},
 		"mismatched names in podSetUpdates with names in podSets": {
 			workload: testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).PodSets(
 				*testingutil.MakePodSet("first", 1).Obj(),

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -120,17 +120,6 @@ func TestValidateWorkload(t *testing.T) {
 			workload: testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).AdmissionChecks(kueue.AdmissionCheckState{}).Obj(),
 			wantErr:  nil,
 		},
-		"should podSetUpdates have the same number of podSets": {
-			workload: testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).PodSets(
-				*testingutil.MakePodSet("first", 1).Obj(),
-				*testingutil.MakePodSet("second", 1).Obj(),
-			).AdmissionChecks(
-				kueue.AdmissionCheckState{PodSetUpdates: []kueue.PodSetUpdate{{Name: "first"}}},
-			).Obj(),
-			wantErr: field.ErrorList{
-				field.Invalid(podSetUpdatePath, nil, "must have the same number of podSetUpdates as the podSets"),
-			},
-		},
 		"mismatched names in podSetUpdates with names in podSets": {
 			workload: testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).PodSets(
 				*testingutil.MakePodSet("first", 1).Obj(),

--- a/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
@@ -341,7 +341,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("add labels & annotations to the admission check", func() {
+			ginkgo.By("add labels & annotations for the workers to the admission check", func() {
 				gomega.Eventually(func() error {
 					var newWL kueue.Workload
 					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdWorkload), &newWL)).To(gomega.Succeed())
@@ -349,18 +349,6 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						Name:  "check",
 						State: kueue.CheckStateReady,
 						PodSetUpdates: []kueue.PodSetUpdate{
-							{
-								Name: "launcher",
-								Annotations: map[string]string{
-									"ann1": "ann-value-for-launcher",
-								},
-								Labels: map[string]string{
-									"label1": "label-value-for-launcher",
-								},
-								NodeSelector: map[string]string{
-									"selector1": "selector-value-for-launcher",
-								},
-							},
 							{
 								Name: "worker",
 								Annotations: map[string]string{
@@ -438,12 +426,9 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				))
 			})
 
-			ginkgo.By("verify the PodSetUpdates are propagated to the running job, for launcher", func() {
+			ginkgo.By("verify the node selectors are propagated to the running job, for launcher", func() {
 				launcher := createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template
-				gomega.Expect(launcher.Annotations).Should(gomega.HaveKeyWithValue("ann1", "ann-value-for-launcher"))
-				gomega.Expect(launcher.Labels).Should(gomega.HaveKeyWithValue("label1", "label-value-for-launcher"))
 				gomega.Expect(launcher.Spec.NodeSelector).Should(gomega.HaveKeyWithValue(instanceKey, "test-flavor"))
-				gomega.Expect(launcher.Spec.NodeSelector).Should(gomega.HaveKeyWithValue("selector1", "selector-value-for-launcher"))
 			})
 
 			ginkgo.By("delete the localQueue to prevent readmission", func() {

--- a/test/integration/webhook/workload_test.go
+++ b/test/integration/webhook/workload_test.go
@@ -366,20 +366,6 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				return k8sClient.Status().Update(ctx, wl)
 			}, util.Timeout, util.Interval).Should(testing.BeAPIError(testing.ForbiddenError))
 		},
-			ginkgo.Entry("podSetUpdates have the same number of podSets",
-				func() *kueue.Workload {
-					return testing.MakeWorkload(workloadName, ns.Name).
-						PodSets(
-							*testing.MakePodSet("first", 1).Obj(),
-							*testing.MakePodSet("second", 1).Obj(),
-						).
-						Obj()
-				},
-				kueue.AdmissionCheckState{
-					Name:          "check",
-					State:         kueue.CheckStateReady,
-					PodSetUpdates: []kueue.PodSetUpdate{{Name: "first"}}},
-			),
 			ginkgo.Entry("mismatched names in podSetUpdates with names in podSets",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Allow an admission check controller to provide podSetUpdates for a podSet subset when needed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2260

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix support for MPIJobs when using a ProvisioningRequest engine that applies updates only to worker templates.
```