### PR TITLE
Filter resource prefixes

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -73,6 +73,9 @@ type Configuration struct {
 
 	// FairSharing controls the fair sharing semantics across the cluster.
 	FairSharing *FairSharing `json:"fairSharing,omitempty"`
+
+	//Resources provides additional configuration options for handling the resources.
+	Resources *Resources `json:"resources,omitempty"`
 }
 
 type ControllerManager struct {
@@ -354,6 +357,11 @@ type ClusterQueueVisibility struct {
 	// The maximal value is 4000.
 	// Defaults to 10.
 	MaxCount int32 `json:"maxCount,omitempty"`
+}
+
+type Resources struct {
+	// ExcludedResourcePrefixes defines which resources should be ignored by Kueue
+	ExcludedResourcePrefixes []string `json:"excludedResourcePrefixes,omitempty"`
 }
 
 type PreemptionStrategy string

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -84,6 +84,7 @@ type ClusterQueue struct {
 	hasFlavorIndependentAdmissionCheckAppliedPerFlavor bool
 	admittedWorkloadsCount                             int
 	isStopped                                          bool
+	workloadInfoOptions                                []workload.InfoOption
 }
 
 // Cohort is a set of ClusterQueues that can borrow resources from each other.
@@ -454,7 +455,7 @@ func (c *ClusterQueue) addWorkload(w *kueue.Workload) error {
 	if _, exist := c.Workloads[k]; exist {
 		return fmt.Errorf("workload already exists in ClusterQueue")
 	}
-	wi := workload.NewInfo(w)
+	wi := workload.NewInfo(w, c.workloadInfoOptions...)
 	c.Workloads[k] = wi
 	c.updateWorkloadUsage(wi, 1)
 	if c.podsReadyTracking && !apimeta.IsStatusConditionTrue(w.Status.Conditions, kueue.WorkloadPodsReady) {

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -43,6 +43,7 @@ var (
 
 type options struct {
 	podsReadyRequeuingTimestamp config.RequeuingTimestamp
+	workloadInfoOptions         []workload.InfoOption
 }
 
 // Option configures the manager.
@@ -50,6 +51,7 @@ type Option func(*options)
 
 var defaultOptions = options{
 	podsReadyRequeuingTimestamp: config.EvictionTimestamp,
+	workloadInfoOptions:         []workload.InfoOption{},
 }
 
 // WithPodsReadyRequeuingTimestamp sets the timestamp that is used for ordering
@@ -57,6 +59,13 @@ var defaultOptions = options{
 func WithPodsReadyRequeuingTimestamp(ts config.RequeuingTimestamp) Option {
 	return func(o *options) {
 		o.podsReadyRequeuingTimestamp = ts
+	}
+}
+
+// WithExcludedResourcePrefixes ....
+func WithExcludedResourcePrefixes(excludedPrefixes []string) Option {
+	return func(o *options) {
+		o.workloadInfoOptions = append(o.workloadInfoOptions, workload.WithExcludedResourcePrefixes(excludedPrefixes))
 	}
 }
 
@@ -76,6 +85,8 @@ type Manager struct {
 	cohorts map[string]sets.Set[string]
 
 	workloadOrdering workload.Ordering
+
+	workloadInfoOptions []workload.InfoOption
 }
 
 func NewManager(client client.Client, checker StatusChecker, opts ...Option) *Manager {
@@ -94,6 +105,7 @@ func NewManager(client client.Client, checker StatusChecker, opts ...Option) *Ma
 		workloadOrdering: workload.Ordering{
 			PodsReadyRequeuingTimestamp: options.podsReadyRequeuingTimestamp,
 		},
+		workloadInfoOptions: options.workloadInfoOptions,
 	}
 	m.cond.L = &m.RWMutex
 	return m
@@ -204,7 +216,7 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 			continue
 		}
 		workload.AdjustResources(ctx, m.client, &w)
-		qImpl.AddOrUpdate(workload.NewInfo(&w))
+		qImpl.AddOrUpdate(workload.NewInfo(&w, m.workloadInfoOptions...))
 	}
 	cq := m.clusterQueues[qImpl.ClusterQueue]
 	if cq != nil && cq.AddFromLocalQueue(qImpl) {
@@ -302,7 +314,7 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(w *kueue.Workload) bool {
 	if q == nil {
 		return false
 	}
-	wInfo := workload.NewInfo(w)
+	wInfo := workload.NewInfo(w, m.workloadInfoOptions...)
 	q.AddOrUpdate(wInfo)
 	cq := m.clusterQueues[q.ClusterQueue]
 	if cq == nil {

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -50,7 +50,7 @@ func MakePod(name, ns string) *PodWrapper {
 				{
 					Name:      "c",
 					Image:     "pause",
-					Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
+					Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}, Limits: corev1.ResourceList{}},
 				},
 			},
 			SchedulingGates: make([]corev1.PodSchedulingGate, 0),
@@ -173,6 +173,12 @@ func (p *PodWrapper) Request(r corev1.ResourceName, v string) *PodWrapper {
 func (p *PodWrapper) Image(image string, args []string) *PodWrapper {
 	p.Spec.Containers[0].Image = image
 	p.Spec.Containers[0].Args = args
+	return p
+}
+
+// Request adds a resource limit to the default container.
+func (p *PodWrapper) Limit(r corev1.ResourceName, v string) *PodWrapper {
+	p.Spec.Containers[0].Resources.Limits[r] = resource.MustParse(v)
 	return p
 }
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -59,6 +59,23 @@ type AssignmentClusterQueueState struct {
 	ClusterQueueGeneration int64
 }
 
+type InfoOptions struct {
+	excludedResourcePrefixes []string
+}
+
+type InfoOption func(*InfoOptions)
+
+var defaultOptions = InfoOptions{
+	excludedResourcePrefixes: []string{},
+}
+
+// WithExcludedResourcePrefixes adds the prefixes
+func WithExcludedResourcePrefixes(n []string) InfoOption {
+	return func(o *InfoOptions) {
+		o.excludedResourcePrefixes = n
+	}
+}
+
 func (s *AssignmentClusterQueueState) Clone() *AssignmentClusterQueueState {
 	c := AssignmentClusterQueueState{
 		LastTriedFlavorIdx:     make([]map[corev1.ResourceName]int, len(s.LastTriedFlavorIdx)),
@@ -137,7 +154,11 @@ func (psr *PodSetResources) ScaledTo(newCount int32) *PodSetResources {
 	return ret
 }
 
-func NewInfo(w *kueue.Workload) *Info {
+func NewInfo(w *kueue.Workload, opts ...InfoOption) *Info {
+	options := defaultOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
 	info := &Info{
 		Obj: w,
 	}
@@ -146,6 +167,9 @@ func NewInfo(w *kueue.Workload) *Info {
 		info.TotalRequests = totalRequestsFromAdmission(w)
 	} else {
 		info.TotalRequests = totalRequestsFromPodSets(w)
+	}
+	if len(options.excludedResourcePrefixes) > 0 {
+		FilterResources(info.TotalRequests, options.excludedResourcePrefixes)
 	}
 	return info
 }
@@ -178,6 +202,23 @@ func (i *Info) FlavorResourceUsage() map[kueue.ResourceFlavorReference]Requests 
 		}
 	}
 	return total
+}
+
+func FilterResources(resources []PodSetResources, excludedPrefixes []string) {
+	for _, resource := range resources {
+		for requestKey := range resource.Requests {
+			exclude := false
+			for _, excludedPrefix := range excludedPrefixes {
+				if strings.HasPrefix(string(requestKey), excludedPrefix) {
+					exclude = true
+					break
+				}
+			}
+			if exclude {
+				delete(resource.Requests, requestKey)
+			}
+		}
+	}
 }
 
 func CanBePartiallyAdmitted(wl *kueue.Workload) bool {
@@ -626,5 +667,6 @@ func AdmissionChecksForWorkload(log logr.Logger, wl *kueue.Workload, admissionCh
 			}
 		}
 	}
+
 	return acNames
 }

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -38,8 +38,9 @@ import (
 
 func TestNewInfo(t *testing.T) {
 	cases := map[string]struct {
-		workload kueue.Workload
-		wantInfo Info
+		workload    kueue.Workload
+		infoOptions []InfoOption
+		wantInfo    Info
 	}{
 		"pending": {
 			workload: *utiltesting.MakeWorkload("", "").
@@ -190,10 +191,30 @@ func TestNewInfo(t *testing.T) {
 				},
 			},
 		},
+		"filterResources": {
+			workload: *utiltesting.MakeWorkload("", "").
+				Request(corev1.ResourceCPU, "10m").
+				Request(corev1.ResourceMemory, "512Ki").
+				Request("networking.gke.io.networks/vpc1", "1").
+				Obj(),
+			infoOptions: []InfoOption{WithExcludedResourcePrefixes([]string{"dummyPrefix", "networking.gke.io.networks/"})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{
+					{
+						Name: "main",
+						Requests: Requests{
+							corev1.ResourceCPU:    10,
+							corev1.ResourceMemory: 512 * 1024,
+						},
+						Count: 1,
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			info := NewInfo(&tc.workload)
+			info := NewInfo(&tc.workload, tc.infoOptions...)
 			if diff := cmp.Diff(info, &tc.wantInfo, cmpopts.IgnoreFields(Info{}, "Obj")); diff != "" {
 				t.Errorf("NewInfo(_) = (-want,+got):\n%s", diff)
 			}

--- a/test/e2e/config/controller_manager_config.yaml
+++ b/test/e2e/config/controller_manager_config.yaml
@@ -25,3 +25,5 @@ integrations:
   - "kubeflow.org/tfjob"
   - "kubeflow.org/xgboostjob"
   - "pod"
+resources:
+  excludedResourcePrefixes: ["networking"]

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -96,6 +96,10 @@ var _ = ginkgo.Describe("Pod groups", func() {
 				Image("gcr.io/k8s-staging-perf-tests/sleep:v0.1.0", []string{"1ms"}).
 				Queue(lq.Name).
 				Request(corev1.ResourceCPU, "1").
+				// Adding a resource that is *not* in Cluster Queue but is marked
+				// as excluded in the configuration. Testing that it passes without error.
+				Request("networking.networks/vpc1", "1").
+				Limit("networking.networks/vpc1", "1").
 				MakeGroup(2)
 			gKey := client.ObjectKey{Namespace: ns.Name, Name: "group"}
 			for _, p := range group {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
 Adds a functionality to Kueue to ignore resources with certain (configurable) prefixes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2266 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Kueue can ignore resources with certain prefixes.
```