### PR TITLE
Allow podSet count to be 0

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -139,7 +139,8 @@ type PodSet struct {
 	Template corev1.PodTemplateSpec `json:"template"`
 
 	// count is the number of pods for the spec.
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:default=1
+	// +kubebuilder:validation:Minimum=0
 	Count int32 `json:"count"`
 
 	// minCount is the minimum number of pods for the spec acceptable

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -96,9 +96,10 @@ spec:
                 items:
                   properties:
                     count:
+                      default: 1
                       description: count is the number of pods for the spec.
                       format: int32
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     minCount:
                       description: |-

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -81,9 +81,10 @@ spec:
                 items:
                   properties:
                     count:
+                      default: 1
                       description: count is the number of pods for the spec.
                       format: int32
-                      minimum: 1
+                      minimum: 0
                       type: integer
                     minCount:
                       description: |-

--- a/pkg/scheduler/flavorassigner/podset_reducer_test.go
+++ b/pkg/scheduler/flavorassigner/podset_reducer_test.go
@@ -103,6 +103,14 @@ func TestSearch(t *testing.T) {
 			wantFound:  true,
 			wantCount:  150_000,
 		},
+		"podset with replica count 0": {
+			podSets: []kueue.PodSet{
+				*utiltesting.MakePodSet("ps1", 0).SetMinimumCount(0).Obj(),
+			},
+			countLimit: 0,
+			wantFound:  false,
+			wantCount:  0,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/test/integration/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/controller/jobs/jobset/jobset_controller_test.go
@@ -19,6 +19,7 @@ package jobset
 import (
 	"fmt"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -79,204 +80,300 @@ var _ = ginkgo.Describe("JobSet controller", ginkgo.Ordered, ginkgo.ContinueOnFa
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 	})
 
-	ginkgo.It("Should reconcile JobSets", func() {
-		ginkgo.By("checking the JobSet gets suspended when created unsuspended")
-		priorityClass := testing.MakePriorityClass(priorityClassName).
-			PriorityValue(priorityValue).Obj()
-		gomega.Expect(k8sClient.Create(ctx, priorityClass)).Should(gomega.Succeed())
+	ginkgo.When("basic setup", func() {
+		var (
+			clusterQueue   *kueue.ClusterQueue
+			localQueue     *kueue.LocalQueue
+			onDemandFlavor *kueue.ResourceFlavor
+			spotFlavor     *kueue.ResourceFlavor
+		)
 
-		jobSet := testingjobset.MakeJobSet(jobSetName, ns.Name).ReplicatedJobs(
-			testingjobset.ReplicatedJobRequirements{
-				Name:        "replicated-job-1",
-				Replicas:    1,
-				Parallelism: 1,
-				Completions: 1,
-			}, testingjobset.ReplicatedJobRequirements{
-				Name:        "replicated-job-2",
-				Replicas:    3,
-				Parallelism: 1,
-				Completions: 1,
-			},
-		).Suspend(false).
-			PriorityClass(priorityClassName).
-			Obj()
-		err := k8sClient.Create(ctx, jobSet)
-		gomega.Expect(err).To(gomega.Succeed())
-		createdJobSet := &jobsetapi.JobSet{}
+		ginkgo.BeforeEach(func() {
+			clusterQueue = testing.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
+					*testing.MakeFlavorQuotas("spot").Resource(corev1.ResourceCPU, "5").Obj(),
+				).Obj()
 
-		gomega.Eventually(func() bool {
-			if err := k8sClient.Get(ctx, types.NamespacedName{Name: jobSetName, Namespace: ns.Name}, createdJobSet); err != nil {
-				return false
+			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).Should(gomega.Succeed())
+			localQueue = testing.MakeLocalQueue("queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
+			onDemandFlavor = testing.MakeResourceFlavor("on-demand").Label(instanceKey, "on-demand").Obj()
+			gomega.Expect(k8sClient.Create(ctx, onDemandFlavor)).Should(gomega.Succeed())
+			spotFlavor = testing.MakeResourceFlavor("spot").Label(instanceKey, "spot").Obj()
+			gomega.Expect(k8sClient.Create(ctx, spotFlavor)).Should(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func() {
+			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
+			util.ExpectResourceFlavorToBeDeleted(ctx, k8sClient, spotFlavor, true)
+			util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		})
+
+		ginkgo.It("Should reconcile JobSets", func() {
+			ginkgo.By("checking the JobSet gets suspended when created unsuspended")
+			priorityClass := testing.MakePriorityClass(priorityClassName).
+				PriorityValue(priorityValue).Obj()
+			gomega.Expect(k8sClient.Create(ctx, priorityClass)).Should(gomega.Succeed())
+
+			jobSet := testingjobset.MakeJobSet(jobSetName, ns.Name).ReplicatedJobs(
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-1",
+					Replicas:    1,
+					Parallelism: 1,
+					Completions: 1,
+				}, testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-2",
+					Replicas:    3,
+					Parallelism: 1,
+					Completions: 1,
+				},
+			).Suspend(false).
+				PriorityClass(priorityClassName).
+				Obj()
+			err := k8sClient.Create(ctx, jobSet)
+			gomega.Expect(err).To(gomega.Succeed())
+			createdJobSet := &jobsetapi.JobSet{}
+
+			gomega.Eventually(func() bool {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: jobSetName, Namespace: ns.Name}, createdJobSet); err != nil {
+					return false
+				}
+				return ptr.Deref(createdJobSet.Spec.Suspend, false)
+			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+
+			ginkgo.By("checking the workload is created without queue assigned")
+			createdWorkload := &kueue.Workload{}
+			wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: ns.Name}
+			gomega.Eventually(func() error {
+				return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(""), "The Workload shouldn't have .spec.queueName set")
+			gomega.Expect(metav1.IsControlledBy(createdWorkload, createdJobSet)).To(gomega.BeTrue(), "The Workload should be owned by the JobSet")
+
+			ginkgo.By("checking the workload is created with priority and priorityName")
+			gomega.Expect(createdWorkload.Spec.PriorityClassName).Should(gomega.Equal(priorityClassName))
+			gomega.Expect(*createdWorkload.Spec.Priority).Should(gomega.Equal(priorityValue))
+
+			ginkgo.By("checking the workload is updated with queue name when the JobSet does")
+			jobSetQueueName := "test-queue"
+			createdJobSet.Annotations = map[string]string{constants.QueueLabel: jobSetQueueName}
+			gomega.Expect(k8sClient.Update(ctx, createdJobSet)).Should(gomega.Succeed())
+			gomega.Eventually(func() bool {
+				if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
+					return false
+				}
+				return createdWorkload.Spec.QueueName == jobSetQueueName
+			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+
+			ginkgo.By("checking a second non-matching workload is deleted")
+			secondWl := &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      workloadjobset.GetWorkloadNameForJobSet("second-workload", "test-uid"),
+					Namespace: createdWorkload.Namespace,
+				},
+				Spec: *createdWorkload.Spec.DeepCopy(),
 			}
-			return ptr.Deref(createdJobSet.Spec.Suspend, false)
-		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+			gomega.Expect(ctrl.SetControllerReference(createdJobSet, secondWl, scheme.Scheme)).Should(gomega.Succeed())
+			secondWl.Spec.PodSets[0].Count += 1
+			gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())
+			gomega.Eventually(func() error {
+				wl := &kueue.Workload{}
+				key := types.NamespacedName{Name: secondWl.Name, Namespace: secondWl.Namespace}
+				return k8sClient.Get(ctx, key, wl)
+			}, util.Timeout, util.Interval).Should(testing.BeNotFoundError())
+			// check the original wl is still there
+			gomega.Eventually(func() error {
+				return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-		ginkgo.By("checking the workload is created without queue assigned")
-		createdWorkload := &kueue.Workload{}
-		wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: ns.Name}
-		gomega.Eventually(func() error {
-			return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(""), "The Workload shouldn't have .spec.queueName set")
-		gomega.Expect(metav1.IsControlledBy(createdWorkload, createdJobSet)).To(gomega.BeTrue(), "The Workload should be owned by the JobSet")
+			ginkgo.By("checking the JobSet is unsuspended when workload is assigned")
 
-		ginkgo.By("checking the workload is created with priority and priorityName")
-		gomega.Expect(createdWorkload.Spec.PriorityClassName).Should(gomega.Equal(priorityClassName))
-		gomega.Expect(*createdWorkload.Spec.Priority).Should(gomega.Equal(priorityValue))
-
-		ginkgo.By("checking the workload is updated with queue name when the JobSet does")
-		jobSetQueueName := "test-queue"
-		createdJobSet.Annotations = map[string]string{constants.QueueLabel: jobSetQueueName}
-		gomega.Expect(k8sClient.Update(ctx, createdJobSet)).Should(gomega.Succeed())
-		gomega.Eventually(func() bool {
-			if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
-				return false
-			}
-			return createdWorkload.Spec.QueueName == jobSetQueueName
-		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-
-		ginkgo.By("checking a second non-matching workload is deleted")
-		secondWl := &kueue.Workload{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      workloadjobset.GetWorkloadNameForJobSet("second-workload", "test-uid"),
-				Namespace: createdWorkload.Namespace,
-			},
-			Spec: *createdWorkload.Spec.DeepCopy(),
-		}
-		gomega.Expect(ctrl.SetControllerReference(createdJobSet, secondWl, scheme.Scheme)).Should(gomega.Succeed())
-		secondWl.Spec.PodSets[0].Count += 1
-		gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())
-		gomega.Eventually(func() error {
-			wl := &kueue.Workload{}
-			key := types.NamespacedName{Name: secondWl.Name, Namespace: secondWl.Namespace}
-			return k8sClient.Get(ctx, key, wl)
-		}, util.Timeout, util.Interval).Should(testing.BeNotFoundError())
-		// check the original wl is still there
-		gomega.Eventually(func() error {
-			return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		ginkgo.By("checking the JobSet is unsuspended when workload is assigned")
-		onDemandFlavor := testing.MakeResourceFlavor("on-demand").Label(instanceKey, "on-demand").Obj()
-		gomega.Expect(k8sClient.Create(ctx, onDemandFlavor)).Should(gomega.Succeed())
-		spotFlavor := testing.MakeResourceFlavor("spot").Label(instanceKey, "spot").Obj()
-		gomega.Expect(k8sClient.Create(ctx, spotFlavor)).Should(gomega.Succeed())
-		clusterQueue := testing.MakeClusterQueue("cluster-queue").
-			ResourceGroup(
-				*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
-				*testing.MakeFlavorQuotas("spot").Resource(corev1.ResourceCPU, "5").Obj(),
+			admission := testing.MakeAdmission(clusterQueue.Name).PodSets(
+				kueue.PodSetAssignment{
+					Name: createdWorkload.Spec.PodSets[0].Name,
+					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+						corev1.ResourceCPU: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+					},
+				}, kueue.PodSetAssignment{
+					Name: createdWorkload.Spec.PodSets[1].Name,
+					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+						corev1.ResourceCPU: kueue.ResourceFlavorReference(spotFlavor.Name),
+					},
+				},
 			).Obj()
-		admission := testing.MakeAdmission(clusterQueue.Name).PodSets(
-			kueue.PodSetAssignment{
-				Name: createdWorkload.Spec.PodSets[0].Name,
-				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-					corev1.ResourceCPU: "on-demand",
-				},
-			}, kueue.PodSetAssignment{
-				Name: createdWorkload.Spec.PodSets[1].Name,
-				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-					corev1.ResourceCPU: "spot",
-				},
-			},
-		).Obj()
-		gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
-		util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
-		lookupKey := types.NamespacedName{Name: jobSetName, Namespace: ns.Name}
-		gomega.Eventually(func() bool {
-			if err := k8sClient.Get(ctx, lookupKey, createdJobSet); err != nil {
-				return false
-			}
-			return !ptr.Deref(createdJobSet.Spec.Suspend, false)
-		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		gomega.Eventually(func() bool {
-			ok, _ := testing.CheckLatestEvent(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name))
-			return ok
-		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector).Should(gomega.Equal(map[string]string{instanceKey: onDemandFlavor.Name}))
-		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector).Should(gomega.Equal(map[string]string{instanceKey: spotFlavor.Name}))
-		gomega.Eventually(func() bool {
-			if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
-				return false
-			}
-			return apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadQuotaReserved)
-		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+			gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
+			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+			lookupKey := types.NamespacedName{Name: jobSetName, Namespace: ns.Name}
+			gomega.Eventually(func() bool {
+				if err := k8sClient.Get(ctx, lookupKey, createdJobSet); err != nil {
+					return false
+				}
+				return !ptr.Deref(createdJobSet.Spec.Suspend, false)
+			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool {
+				ok, _ := testing.CheckLatestEvent(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name))
+				return ok
+			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+			gomega.Expect(createdJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector).Should(gomega.Equal(map[string]string{instanceKey: onDemandFlavor.Name}))
+			gomega.Expect(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector).Should(gomega.Equal(map[string]string{instanceKey: spotFlavor.Name}))
+			gomega.Eventually(func() bool {
+				if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
+					return false
+				}
+				return apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadQuotaReserved)
+			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
 
-		ginkgo.By("checking the JobSet gets suspended when parallelism changes and the added node selectors are removed")
-		parallelism := jobSet.Spec.ReplicatedJobs[0].Replicas
-		newParallelism := parallelism + 1
-		createdJobSet.Spec.ReplicatedJobs[0].Replicas = newParallelism
-		gomega.Expect(k8sClient.Update(ctx, createdJobSet)).Should(gomega.Succeed())
-		gomega.Eventually(func() bool {
-			if err := k8sClient.Get(ctx, lookupKey, createdJobSet); err != nil {
-				return false
-			}
-			return createdJobSet.Spec.Suspend != nil && *createdJobSet.Spec.Suspend &&
-				len(jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector) == 0
-		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		gomega.Eventually(func() bool {
-			ok, _ := testing.CheckLatestEvent(ctx, k8sClient, "DeletedWorkload", corev1.EventTypeNormal, fmt.Sprintf("Deleted not matching Workload: %v", wlLookupKey.String()))
-			return ok
-		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+			ginkgo.By("checking the JobSet gets suspended when parallelism changes and the added node selectors are removed")
+			parallelism := jobSet.Spec.ReplicatedJobs[0].Replicas
+			newParallelism := parallelism + 1
+			createdJobSet.Spec.ReplicatedJobs[0].Replicas = newParallelism
+			gomega.Expect(k8sClient.Update(ctx, createdJobSet)).Should(gomega.Succeed())
+			gomega.Eventually(func() bool {
+				if err := k8sClient.Get(ctx, lookupKey, createdJobSet); err != nil {
+					return false
+				}
+				return createdJobSet.Spec.Suspend != nil && *createdJobSet.Spec.Suspend &&
+					len(jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector) == 0
+			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+			gomega.Eventually(func() bool {
+				ok, _ := testing.CheckLatestEvent(ctx, k8sClient, "DeletedWorkload", corev1.EventTypeNormal, fmt.Sprintf("Deleted not matching Workload: %v", wlLookupKey.String()))
+				return ok
+			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
 
-		ginkgo.By("checking the workload is updated with new count")
-		gomega.Eventually(func() bool {
-			if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
-				return false
-			}
-			return createdWorkload.Spec.PodSets[0].Count == newParallelism
-		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
-		gomega.Expect(createdWorkload.Status.Admission).Should(gomega.BeNil())
+			ginkgo.By("checking the workload is updated with new count")
+			gomega.Eventually(func() bool {
+				if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
+					return false
+				}
+				return createdWorkload.Spec.PodSets[0].Count == newParallelism
+			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+			gomega.Expect(createdWorkload.Status.Admission).Should(gomega.BeNil())
 
-		ginkgo.By("checking the JobSet is unsuspended and selectors added when workload is assigned again")
-		admission = testing.MakeAdmission(clusterQueue.Name).
-			PodSets(
-				kueue.PodSetAssignment{
-					Name: "replicated-job-1",
-					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-						corev1.ResourceCPU: "on-demand",
+			ginkgo.By("checking the JobSet is unsuspended and selectors added when workload is assigned again")
+			admission = testing.MakeAdmission(clusterQueue.Name).
+				PodSets(
+					kueue.PodSetAssignment{
+						Name: "replicated-job-1",
+						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+							corev1.ResourceCPU: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+						},
+						Count: ptr.To(createdWorkload.Spec.PodSets[0].Count),
 					},
-					Count: ptr.To(createdWorkload.Spec.PodSets[0].Count),
-				},
-				kueue.PodSetAssignment{
-					Name: "replicated-job-2",
-					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-						corev1.ResourceCPU: "spot",
+					kueue.PodSetAssignment{
+						Name: "replicated-job-2",
+						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+							corev1.ResourceCPU: kueue.ResourceFlavorReference(spotFlavor.Name),
+						},
+						Count: ptr.To(createdWorkload.Spec.PodSets[1].Count),
 					},
-					Count: ptr.To(createdWorkload.Spec.PodSets[1].Count),
+				).
+				Obj()
+			gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
+			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+			gomega.Eventually(func() bool {
+				if err := k8sClient.Get(ctx, lookupKey, createdJobSet); err != nil {
+					return false
+				}
+				return !*createdJobSet.Spec.Suspend
+			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+
+			gomega.Expect(createdJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
+			gomega.Expect(createdJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
+			gomega.Expect(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
+			gomega.Expect(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
+
+			ginkgo.By("checking the workload is finished when JobSet is completed")
+			createdJobSet.Status.Conditions = append(createdJobSet.Status.Conditions,
+				metav1.Condition{
+					Type:               string(jobsetapi.JobSetCompleted),
+					Status:             metav1.ConditionStatus(corev1.ConditionTrue),
+					Reason:             "AllJobsCompleted",
+					Message:            "jobset completed successfully",
+					LastTransitionTime: metav1.Now(),
+				})
+			gomega.Expect(k8sClient.Status().Update(ctx, createdJobSet)).Should(gomega.Succeed())
+			gomega.Eventually(func() bool {
+				err := k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+				if err != nil {
+					return false
+				}
+				return apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadFinished)
+			}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+		})
+
+		ginkgo.It("Should allow to create jobset with one replicated job replica count 0", func() {
+			mixJobSet := testingjobset.MakeJobSet("mix-jobset", ns.Name).ReplicatedJobs(
+				testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-1",
+					Replicas:    2,
+					Parallelism: 2,
+					Completions: 2,
+				}, testingjobset.ReplicatedJobRequirements{
+					Name:        "replicated-job-2-empty",
+					Replicas:    0,
+					Parallelism: 0,
+					Completions: 0,
 				},
-			).
-			Obj()
-		gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
-		util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
-		gomega.Eventually(func() bool {
-			if err := k8sClient.Get(ctx, lookupKey, createdJobSet); err != nil {
-				return false
-			}
-			return !*createdJobSet.Spec.Suspend
-		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+			).Queue(localQueue.Name).
+				Request("replicated-job-1", corev1.ResourceCPU, "250m").
+				Request("replicated-job-2-empty", corev1.ResourceCPU, "250m").
+				Obj()
 
-		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
-		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
-		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
-		gomega.Expect(createdJobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
-
-		ginkgo.By("checking the workload is finished when JobSet is completed")
-		createdJobSet.Status.Conditions = append(createdJobSet.Status.Conditions,
-			metav1.Condition{
-				Type:               string(jobsetapi.JobSetCompleted),
-				Status:             metav1.ConditionStatus(corev1.ConditionTrue),
-				Reason:             "AllJobsCompleted",
-				Message:            "jobset completed successfully",
-				LastTransitionTime: metav1.Now(),
+			jobSetLookupKey := types.NamespacedName{Name: mixJobSet.Name, Namespace: ns.Name}
+			ginkgo.By("create the jobset", func() {
+				gomega.Expect(k8sClient.Create(ctx, mixJobSet)).Should(gomega.Succeed())
+				gomega.Eventually(func() *bool {
+					createdJobSet1 := &jobsetapi.JobSet{}
+					gomega.Expect(k8sClient.Get(ctx, jobSetLookupKey, createdJobSet1)).Should(gomega.Succeed())
+					return createdJobSet1.Spec.Suspend
+				}, util.Timeout, util.Interval).Should(gomega.Equal(ptr.To(true)))
 			})
-		gomega.Expect(k8sClient.Status().Update(ctx, createdJobSet)).Should(gomega.Succeed())
-		gomega.Eventually(func() bool {
-			err := k8sClient.Get(ctx, wlLookupKey, createdWorkload)
-			if err != nil {
-				return false
-			}
-			return apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadFinished)
-		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+
+			wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(mixJobSet.Name, mixJobSet.UID), Namespace: ns.Name}
+			ginkgo.By("waiting for workload to be created", func() {
+				createdWorkload := &kueue.Workload{}
+				checkPSOpts := cmpopts.IgnoreFields(kueue.PodSet{}, "Template", "MinCount")
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					g.Expect(createdWorkload.Spec.PodSets).To(gomega.ContainElements(
+						gomega.BeComparableTo(kueue.PodSet{Name: "replicated-job-1", Count: 4}, checkPSOpts),
+						gomega.BeComparableTo(kueue.PodSet{Name: "replicated-job-2-empty", Count: 0}, checkPSOpts),
+					))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("admit the workload", func() {
+				createdWorkload := &kueue.Workload{}
+				gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				admission := testing.MakeAdmission(clusterQueue.Name).
+					PodSets(
+						kueue.PodSetAssignment{
+							Name: createdWorkload.Spec.PodSets[0].Name,
+							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+								corev1.ResourceCPU: kueue.ResourceFlavorReference(spotFlavor.Name),
+							},
+						}, kueue.PodSetAssignment{
+							Name: createdWorkload.Spec.PodSets[1].Name,
+							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+								corev1.ResourceCPU: kueue.ResourceFlavorReference(spotFlavor.Name),
+							},
+						},
+					).
+					Obj()
+				gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
+				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+			})
+
+			ginkgo.By("checking the jobset gets unsuspended", func() {
+				createdJobSet1 := &jobsetapi.JobSet{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, jobSetLookupKey, createdJobSet1)).Should(gomega.Succeed())
+					g.Expect(ptr.Deref(createdJobSet1.Spec.Suspend, false)).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
 	})
 
 	ginkgo.When("the queue has admission checks", func() {

--- a/test/integration/webhook/workload_test.go
+++ b/test/integration/webhook/workload_test.go
@@ -133,7 +133,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 		},
 			ginkgo.Entry("podSets count less than 1", 0, 1, true),
 			ginkgo.Entry("podSets count more than 8", podSetsMaxItems+1, 1, true),
-			ginkgo.Entry("invalid podSet.Count", 3, 0, true),
+			ginkgo.Entry("valid podSet, count can be 0", 3, 0, false),
 			ginkgo.Entry("valid podSet", 3, 3, false),
 		)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Allow for `workload.spec.podSet.[*].count` to be 0

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2227 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow for `workload.spec.podSet.[*].count` to be 0
```