### PR TITLE
Automated cherry pick of #2265: [workload] Allow specifying PodSetUpdates for a subset of PodSets

### DIFF
--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -189,12 +189,8 @@ func validateContainer(c *corev1.Container, path *field.Path) field.ErrorList {
 func validateAdmissionChecks(obj *kueue.Workload, basePath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	for i := range obj.Status.AdmissionChecks {
-		admissionChecksPath := basePath.Index(i)
-		ac := &obj.Status.AdmissionChecks[i]
-		if len(ac.PodSetUpdates) > 0 && len(ac.PodSetUpdates) != len(obj.Spec.PodSets) {
-			allErrs = append(allErrs, field.Invalid(admissionChecksPath.Child("podSetUpdates"), field.OmitValueType{}, "must have the same number of podSetUpdates as the podSets"))
-		}
-		allErrs = append(allErrs, validatePodSetUpdates(ac, obj, admissionChecksPath.Child("podSetUpdates"))...)
+		// the number of podSetUpdates cannot exceed the one of the podSets without having an unknown podSet name
+		allErrs = append(allErrs, validatePodSetUpdates(&obj.Status.AdmissionChecks[i], obj, basePath.Index(i).Child("podSetUpdates"))...)
 	}
 	return allErrs
 }

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -189,7 +189,8 @@ func validateContainer(c *corev1.Container, path *field.Path) field.ErrorList {
 func validateAdmissionChecks(obj *kueue.Workload, basePath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	for i := range obj.Status.AdmissionChecks {
-		// the number of podSetUpdates cannot exceed the one of the podSets without having an unknown podSet name
+		// no need to check the number of podSetUpdates,
+		// because it cannot exceed the one of the podSets without having an unknown podSet name
 		allErrs = append(allErrs, validatePodSetUpdates(&obj.Status.AdmissionChecks[i], obj, basePath.Index(i).Child("podSetUpdates"))...)
 	}
 	return allErrs

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -242,6 +242,15 @@ func TestValidateWorkload(t *testing.T) {
 			workload: testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).AdmissionChecks(kueue.AdmissionCheckState{}).Obj(),
 			wantErr:  nil,
 		},
+		"should accept podSetUpdates for only a subset of podSets": {
+			workload: testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).PodSets(
+				*testingutil.MakePodSet("first", 1).Obj(),
+				*testingutil.MakePodSet("second", 1).Obj(),
+			).AdmissionChecks(
+				kueue.AdmissionCheckState{PodSetUpdates: []kueue.PodSetUpdate{{Name: "first"}}},
+			).Obj(),
+			wantErr: nil,
+		},
 		"mismatched names in podSetUpdates with names in podSets": {
 			workload: testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).PodSets(
 				*testingutil.MakePodSet("first", 1).Obj(),

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -242,17 +242,6 @@ func TestValidateWorkload(t *testing.T) {
 			workload: testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).AdmissionChecks(kueue.AdmissionCheckState{}).Obj(),
 			wantErr:  nil,
 		},
-		"should podSetUpdates have the same number of podSets": {
-			workload: testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).PodSets(
-				*testingutil.MakePodSet("first", 1).Obj(),
-				*testingutil.MakePodSet("second", 1).Obj(),
-			).AdmissionChecks(
-				kueue.AdmissionCheckState{PodSetUpdates: []kueue.PodSetUpdate{{Name: "first"}}},
-			).Obj(),
-			wantErr: field.ErrorList{
-				field.Invalid(podSetUpdatePath, nil, "must have the same number of podSetUpdates as the podSets"),
-			},
-		},
 		"mismatched names in podSetUpdates with names in podSets": {
 			workload: testingutil.MakeWorkload(testWorkloadName, testWorkloadNamespace).PodSets(
 				*testingutil.MakePodSet("first", 1).Obj(),

--- a/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
@@ -349,7 +349,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("add labels & annotations to the admission check", func() {
+			ginkgo.By("add labels & annotations for the workers to the admission check", func() {
 				gomega.Eventually(func() error {
 					var newWL kueue.Workload
 					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdWorkload), &newWL)).To(gomega.Succeed())
@@ -357,18 +357,6 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						Name:  "check",
 						State: kueue.CheckStateReady,
 						PodSetUpdates: []kueue.PodSetUpdate{
-							{
-								Name: "launcher",
-								Annotations: map[string]string{
-									"ann1": "ann-value-for-launcher",
-								},
-								Labels: map[string]string{
-									"label1": "label-value-for-launcher",
-								},
-								NodeSelector: map[string]string{
-									"selector1": "selector-value-for-launcher",
-								},
-							},
 							{
 								Name: "worker",
 								Annotations: map[string]string{
@@ -446,12 +434,9 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				))
 			})
 
-			ginkgo.By("verify the PodSetUpdates are propagated to the running job, for launcher", func() {
+			ginkgo.By("verify the node selectors are propagated to the running job, for launcher", func() {
 				launcher := createdJob.Spec.MPIReplicaSpecs[kubeflow.MPIReplicaTypeLauncher].Template
-				gomega.Expect(launcher.Annotations).Should(gomega.HaveKeyWithValue("ann1", "ann-value-for-launcher"))
-				gomega.Expect(launcher.Labels).Should(gomega.HaveKeyWithValue("label1", "label-value-for-launcher"))
 				gomega.Expect(launcher.Spec.NodeSelector).Should(gomega.HaveKeyWithValue(instanceKey, "test-flavor"))
-				gomega.Expect(launcher.Spec.NodeSelector).Should(gomega.HaveKeyWithValue("selector1", "selector-value-for-launcher"))
 			})
 
 			ginkgo.By("delete the localQueue to prevent readmission", func() {


### PR DESCRIPTION
Cherry pick of #2265 on release-0.6.
#2265: Allow specifying PodSetUpdates for subset of
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
Fix support for MPIJobs when using a ProvisioningRequest engine that applies updates only to worker templates.
```