### PR TITLE
[provisionong-AC] Check the limits for used resources.

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -422,6 +422,11 @@ func containerUses(cont *corev1.Container, resourceSet sets.Set[corev1.ResourceN
 			return true
 		}
 	}
+	for r := range cont.Resources.Limits {
+		if resourceSet.Has(r) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -373,6 +373,9 @@ func (c *Controller) syncProvisionRequestsPodTemplates(ctx context.Context, wl *
 				return err
 			}
 
+			// copy limits to requests if needed
+			workload.UseLimitsAsMissingRequestsInPod(&newPt.Template.Spec)
+
 			if err := ctrl.SetControllerReference(request, newPt, c.client.Scheme()); err != nil {
 				return err
 			}

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -595,7 +595,7 @@ func TestReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
-		"when request is needed for one PodSet": {
+		"when request is needed for one PodSet (resource request)": {
 			workload: baseWorkload.DeepCopy(),
 			checks:   []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
 			flavors:  []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
@@ -635,6 +635,92 @@ func TestReconcile(t *testing.T) {
 			},
 			wantTemplates: map[string]*corev1.PodTemplate{
 				baseTemplate2.Name: baseTemplate2.DeepCopy(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkload),
+					EventType: corev1.EventTypeNormal,
+					Reason:    "ProvisioningRequestCreated",
+					Message:   `Created ProvisioningRequest: "wl-check1-1"`,
+				},
+			},
+		},
+		"when request is needed for one PodSet (resource limit)": {
+			workload: (&utiltesting.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).Limit("example.com/gpu", "1").Obj(),
+			checks:   []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
+			flavors:  []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
+			configs: []kueue.ProvisioningRequestConfig{
+				{ObjectMeta: metav1.ObjectMeta{
+					Name: "config1",
+				},
+					Spec: kueue.ProvisioningRequestConfigSpec{
+						ProvisioningClassName: "class1",
+						Parameters: map[string]kueue.Parameter{
+							"p1": "v1",
+						},
+						ManagedResources: []corev1.ResourceName{"example.com/gpu"},
+					},
+				},
+			},
+			wantWorkloads: map[string]*kueue.Workload{
+				baseWorkload.Name: (&utiltesting.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).Limit("example.com/gpu", "1").Obj(),
+			},
+			wantRequests: map[string]*autoscaling.ProvisioningRequest{
+				"wl-check1-1": {
+					Spec: autoscaling.ProvisioningRequestSpec{
+						PodSets: []autoscaling.PodSet{
+							{
+								PodTemplateRef: autoscaling.Reference{
+									Name: "ppt-wl-check1-1-ps1",
+								},
+								Count: 4,
+							},
+						},
+						ProvisioningClassName: "class1",
+						Parameters: map[string]autoscaling.Parameter{
+							"p1": "v1",
+						},
+					},
+				},
+			},
+			wantTemplates: map[string]*corev1.PodTemplate{
+				baseTemplate1.Name: &corev1.PodTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: TestNamespace,
+						Name:      "ppt-wl-check1-1-ps1",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Name: "wl-check1-1",
+							},
+						},
+					},
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "c",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU: resource.MustParse("1"),
+										},
+										Limits: corev1.ResourceList{
+											"example.com/gpu": resource.MustParse("1"),
+										},
+									},
+								},
+							},
+							NodeSelector: map[string]string{"f1l1": "v1"},
+							Tolerations: []corev1.Toleration{
+								{
+									Key:      "f1t1k",
+									Value:    "f1t1v",
+									Operator: corev1.TolerationOpEqual,
+									Effect:   corev1.TaintEffectNoSchedule,
+								},
+							},
+						},
+					},
+				},
 			},
 			wantEvents: []utiltesting.EventRecord{
 				{

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -702,6 +702,7 @@ func TestReconcile(t *testing.T) {
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU: resource.MustParse("1"),
+											"example.com/gpu":  resource.MustParse("1"),
 										},
 										Limits: corev1.ResourceList{
 											"example.com/gpu": resource.MustParse("1"),

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -88,15 +88,20 @@ func handlePodLimitRange(ctx context.Context, cl client.Client, wl *kueue.Worklo
 
 func handleLimitsToRequests(wl *kueue.Workload) {
 	for pi := range wl.Spec.PodSets {
-		pod := &wl.Spec.PodSets[pi].Template.Spec
-		for ci := range pod.InitContainers {
-			res := &pod.InitContainers[ci].Resources
-			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, res.Limits)
-		}
-		for ci := range pod.Containers {
-			res := &pod.Containers[ci].Resources
-			res.Requests = resource.MergeResourceListKeepFirst(res.Requests, res.Limits)
-		}
+		UseLimitsAsMissingRequestsInPod(&wl.Spec.PodSets[pi].Template.Spec)
+	}
+}
+
+// UseLimitsAsMissingRequestsInPod adjust the resource requests to the limits value
+// for resources that only set limits.
+func UseLimitsAsMissingRequestsInPod(pod *corev1.PodSpec) {
+	for ci := range pod.InitContainers {
+		res := &pod.InitContainers[ci].Resources
+		res.Requests = resource.MergeResourceListKeepFirst(res.Requests, res.Limits)
+	}
+	for ci := range pod.Containers {
+		res := &pod.Containers[ci].Resources
+		res.Requests = resource.MergeResourceListKeepFirst(res.Requests, res.Limits)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2278

#### Special notes for your reviewer:
Check the containers limits for used resources in provisioning admission check controller.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Check the containers limits for used resources in provisioning admission check controller and include them in the ProvisioningRequest as requests
```