### PR TITLE
[release-0.6] Improve deduce acuracy for the deactivated reason

### DIFF
--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -1412,7 +1412,7 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 		cfg = fwk.Init()
 		waitForPodsReady := &configapi.WaitForPodsReady{
 			Enable:  true,
-			Timeout: &metav1.Duration{Duration: 10 * time.Millisecond},
+			Timeout: &metav1.Duration{Duration: 1 * time.Second},
 			RequeuingStrategy: &configapi.RequeuingStrategy{
 				Timestamp:         ptr.To(configapi.EvictionTimestamp),
 				BackoffLimitCount: ptr.To[int32](1),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
In the current implementation, the workload can be marked deactivated due to exceeding the backoffLimitCount even though the workload is manually deactivated. We can imagine the situation in which users manually deactivate (`.spec.active`=false) the workload during the backoff duration.

I missed this edge case in https://github.com/kubernetes-sigs/kueue/pull/2220.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```