### PR TITLE
Chore: Remove HasRequeueState helper function

### DIFF
--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -606,11 +606,6 @@ func ReclaimablePodsAreEqual(a, b []kueue.ReclaimablePod) bool {
 	return true
 }
 
-// HasRequeueState returns true if the workload has re-queue state.
-func HasRequeueState(w *kueue.Workload) bool {
-	return w.Status.RequeueState != nil
-}
-
 // IsAdmitted returns true if the workload is admitted.
 func IsAdmitted(w *kueue.Workload) bool {
 	return apimeta.IsStatusConditionTrue(w.Status.Conditions, kueue.WorkloadAdmitted)

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -484,29 +484,6 @@ func TestAssignmentClusterQueueState(t *testing.T) {
 	}
 }
 
-func TestHasRequeueState(t *testing.T) {
-	cases := map[string]struct {
-		workload *kueue.Workload
-		want     bool
-	}{
-		"workload has requeue state": {
-			workload: utiltesting.MakeWorkload("test", "test").RequeueState(ptr.To[int32](5), ptr.To(metav1.Now())).Obj(),
-			want:     true,
-		},
-		"workload doesn't have requeue state": {
-			workload: utiltesting.MakeWorkload("test", "test").RequeueState(nil, nil).Obj(),
-		},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			got := HasRequeueState(tc.workload)
-			if tc.want != got {
-				t.Errorf("Unexpected result from HasRequeueState\nwant:%v\ngot:%v\n", tc.want, got)
-			}
-		})
-	}
-}
-
 func TestIsEvictedByDeactivation(t *testing.T) {
 	cases := map[string]struct {
 		workload *kueue.Workload


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Based on [this discussion](https://github.com/kubernetes-sigs/kueue/pull/2289#discussion_r1616661188), I removed the `HasRequeueState` helper function. That just verifies nil.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```