### PR TITLE
[scalability] Adjust the threshold for small workloads

### DIFF
--- a/test/performance/scheduler/default_rangespec.yaml
+++ b/test/performance/scheduler/default_rangespec.yaml
@@ -25,5 +25,5 @@ wlClassesMaxAvgTimeToAdmissionMs:
   # Average value 76768 (+/- 2%), setting at +20%
   medium: 90_000
 
-  # Average value 215468 (+/- 2%), setting at +5%
-  small: 227_000
+  # Average value 215468 (+/- 2%), setting at +5% + 6s accounting for observed failures
+  small: 233_000


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Because the test flaked on the main branch: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-kueue-test-scheduling-perf-main/1794363845955817472

Dashboard:
![image](https://github.com/kubernetes-sigs/kueue/assets/10359181/d972db31-f92e-4fa8-8d8a-c8f087022c29)

Message:
```
=== Failed
=== FAIL: test/performance/scheduler/checker TestScalability/WorkloadClasses/small (0.00s)
    checker_test.go:117: Average wait for admission 227486ms is more then expected 227000ms
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

From the comment https://github.com/kubernetes-sigs/kueue/pull/2290#discussion_r1616738204, we also observed 231068ms.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```