### PR TITLE
Fix SBOM filename to latest openssf convention

### DIFF
--- a/.github/workflows/sbom.yaml
+++ b/.github/workflows/sbom.yaml
@@ -31,12 +31,11 @@ jobs:
       - name: Generate SBOM
         shell: bash
         run: |
-          bom generate -o /tmp/kueue.spdx .
-          cd /tmp
-          tar zcf sbom.tar.gz *.spdx
+          bom generate --format=json -o /tmp/kueue-$TAG.spdx.json .
+         
       - name: Upload SBOM
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          gh release upload $TAG /tmp/sbom.tar.gz
+          gh release upload $TAG /tmp/kueue-$TAG.spdx.json


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR renames the SBOM output to match the latest @ossf naming conventions:

https://github.com/ossf/sbom-everywhere/blob/main/reference/sbom_naming.md

See sample release:  https://github.com/puerco/kueue/releases/tag/v0.6.3-rc.1


#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

/cc @alculquicondor 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```