### PR TITLE
ConfigAPI: Implement the non negative validation for the queueVisibility.clusterQueues.maxCount

### DIFF
--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -56,6 +56,7 @@ var (
 	multiKueuePath                    = field.NewPath("multiKueue")
 	fsPreemptionStrategiesPath        = field.NewPath("fairSharing", "preemptionStrategies")
 	internalCertManagementPath        = field.NewPath("internalCertManagement")
+	queueVisibilityPath               = field.NewPath("queueVisibility")
 )
 
 func validate(c *configapi.Configuration, scheme *runtime.Scheme) field.ErrorList {
@@ -141,11 +142,13 @@ func validateWaitForPodsReady(c *configapi.Configuration) field.ErrorList {
 func validateQueueVisibility(cfg *configapi.Configuration) field.ErrorList {
 	var allErrs field.ErrorList
 	if cfg.QueueVisibility != nil {
-		queueVisibilityPath := field.NewPath("queueVisibility")
 		if cfg.QueueVisibility.ClusterQueues != nil {
-			clusterQueues := queueVisibilityPath.Child("clusterQueues")
+			maxCountPath := queueVisibilityPath.Child("clusterQueues").Child("maxCount")
+			if cfg.QueueVisibility.ClusterQueues.MaxCount < 0 {
+				allErrs = append(allErrs, field.Invalid(maxCountPath, cfg.QueueVisibility.ClusterQueues.MaxCount, constants.IsNegativeErrorMsg))
+			}
 			if cfg.QueueVisibility.ClusterQueues.MaxCount > queueVisibilityClusterQueuesMaxValue {
-				allErrs = append(allErrs, field.Invalid(clusterQueues.Child("maxCount"), cfg.QueueVisibility.ClusterQueues.MaxCount, fmt.Sprintf("must be less than %d", queueVisibilityClusterQueuesMaxValue)))
+				allErrs = append(allErrs, field.Invalid(maxCountPath, cfg.QueueVisibility.ClusterQueues.MaxCount, fmt.Sprintf("must be less than %d", queueVisibilityClusterQueuesMaxValue)))
 			}
 		}
 		if cfg.QueueVisibility.UpdateIntervalSeconds < queueVisibilityClusterQueuesUpdateIntervalSeconds {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -88,7 +88,7 @@ func TestValidate(t *testing.T) {
 				field.Invalid(field.NewPath("queueVisibility").Child("updateIntervalSeconds"), 0, fmt.Sprintf("greater than or equal to %d", queueVisibilityClusterQueuesUpdateIntervalSeconds)),
 			},
 		},
-		"invalid queue visibility cluster queue max count": {
+		"invalid queue visibility cluster queue max count due to exceeding maximal value": {
 			cfg: &configapi.Configuration{
 				QueueVisibility: &configapi.QueueVisibility{
 					ClusterQueues: &configapi.ClusterQueueVisibility{
@@ -100,6 +100,23 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: field.ErrorList{
 				field.Invalid(field.NewPath("queueVisibility").Child("clusterQueues").Child("maxCount"), 4001, fmt.Sprintf("must be less than %d", queueVisibilityClusterQueuesMaxValue)),
+			},
+		},
+		"negative queue visibility cluster queue max cont": {
+			cfg: &configapi.Configuration{
+				QueueVisibility: &configapi.QueueVisibility{
+					ClusterQueues: &configapi.ClusterQueueVisibility{
+						MaxCount: -1,
+					},
+					UpdateIntervalSeconds: 1,
+				},
+				Integrations: defaultIntegrations,
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "queueVisibility.clusterQueues.maxCount",
+				},
 			},
 		},
 		"empty integrations.frameworks": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Currently, the configAPI validation doesn't have non negative check for the `queueVisibility.clusterQueues.maxCount`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes: #2084

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added non-negative validations for the ".queueVisibility.clusterQueues.maxCount" in the Configuration.
```