### PR TITLE
[kueuectl] Support autocompletion on kueue CLI commands

### DIFF
--- a/cmd/kueuectl/app/cmd.go
+++ b/cmd/kueuectl/app/cmd.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/create"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/list"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/passthrough"
@@ -52,7 +53,7 @@ func NewDefaultKueuectlCmd() *cobra.Command {
 
 func NewKueuectlCmd(o KueuectlOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "kueue",
+		Use:   "kueuectl",
 		Short: "Controls Kueue queueing manager",
 	}
 
@@ -65,6 +66,11 @@ func NewKueuectlCmd(o KueuectlOptions) *cobra.Command {
 	configFlags.AddFlags(flags)
 
 	clientGetter := util.NewClientGetter(configFlags)
+
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("namespace", completion.NamespaceNameFunc(clientGetter)))
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("context", completion.ContextsFunc(clientGetter)))
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("cluster", completion.ClustersFunc(clientGetter)))
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("user", completion.UsersFunc(clientGetter)))
 
 	cmd.AddCommand(create.NewCreateCmd(clientGetter, o.IOStreams))
 	cmd.AddCommand(resume.NewResumeCmd(clientGetter, o.IOStreams))

--- a/cmd/kueuectl/app/completion/completion.go
+++ b/cmd/kueuectl/app/completion/completion.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package completion
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
+)
+
+const completionLimit = 100
+
+func NamespaceNameFunc(clientGetter util.ClientGetter) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		clientSet, err := clientGetter.K8sClientSet()
+		if err != nil {
+			return []string{}, cobra.ShellCompDirectiveError
+		}
+
+		list, err := clientSet.CoreV1().Namespaces().List(cmd.Context(), metav1.ListOptions{Limit: completionLimit})
+		if err != nil {
+			return []string{}, cobra.ShellCompDirectiveError
+		}
+
+		validArgs := make([]string, len(list.Items))
+		for i, wl := range list.Items {
+			validArgs[i] = wl.Name
+		}
+
+		return validArgs, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func ContextsFunc(clientGetter util.ClientGetter) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		config, err := clientGetter.ToRawKubeConfigLoader().RawConfig()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var validArgs []string
+		for name := range config.Contexts {
+			if strings.HasPrefix(name, toComplete) {
+				validArgs = append(validArgs, name)
+			}
+		}
+		return validArgs, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func ClustersFunc(clientGetter util.ClientGetter) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		config, err := clientGetter.ToRawKubeConfigLoader().RawConfig()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var validArgs []string
+		for name := range config.Clusters {
+			if strings.HasPrefix(name, toComplete) {
+				validArgs = append(validArgs, name)
+			}
+		}
+		return validArgs, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func UsersFunc(clientGetter util.ClientGetter) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		config, err := clientGetter.ToRawKubeConfigLoader().RawConfig()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var validArgs []string
+		for name := range config.AuthInfos {
+			if strings.HasPrefix(name, toComplete) {
+				validArgs = append(validArgs, name)
+			}
+		}
+		return validArgs, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func WorkloadNameFunc(clientGetter util.ClientGetter, activeStatus *bool) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		clientSet, err := clientGetter.KueueClientSet()
+		if err != nil {
+			return []string{}, cobra.ShellCompDirectiveError
+		}
+
+		namespace, _, err := clientGetter.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return []string{}, cobra.ShellCompDirectiveError
+		}
+
+		list, err := clientSet.KueueV1beta1().Workloads(namespace).List(cmd.Context(), metav1.ListOptions{Limit: completionLimit})
+		if err != nil {
+			return []string{}, cobra.ShellCompDirectiveError
+		}
+
+		if activeStatus != nil {
+			filteredItems := make([]v1beta1.Workload, 0, len(list.Items))
+			for _, wl := range list.Items {
+				if ptr.Deref(wl.Spec.Active, true) == *activeStatus {
+					filteredItems = append(filteredItems, wl)
+				}
+			}
+			list.Items = filteredItems
+		}
+
+		validArgs := make([]string, len(list.Items))
+		for i, wl := range list.Items {
+			validArgs[i] = wl.Name
+		}
+
+		return validArgs, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func ClusterQueueNameFunc(clientGetter util.ClientGetter, activeStatus *bool) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		clientSet, err := clientGetter.KueueClientSet()
+		if err != nil {
+			return []string{}, cobra.ShellCompDirectiveError
+		}
+
+		list, err := clientSet.KueueV1beta1().ClusterQueues().List(cmd.Context(), metav1.ListOptions{Limit: completionLimit})
+		if err != nil {
+			return []string{}, cobra.ShellCompDirectiveError
+		}
+
+		if activeStatus != nil {
+			filteredItems := make([]v1beta1.ClusterQueue, 0, len(list.Items))
+			for _, cq := range list.Items {
+				stopPolicy := ptr.Deref(cq.Spec.StopPolicy, v1beta1.None)
+				if *activeStatus && stopPolicy == v1beta1.None {
+					filteredItems = append(filteredItems, cq)
+				} else if !*activeStatus && stopPolicy != v1beta1.None {
+					filteredItems = append(filteredItems, cq)
+				}
+			}
+			list.Items = filteredItems
+		}
+
+		validArgs := make([]string, len(list.Items))
+		for i, wl := range list.Items {
+			validArgs[i] = wl.Name
+		}
+
+		return validArgs, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func LocalQueueNameFunc(clientGetter util.ClientGetter) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		clientSet, err := clientGetter.KueueClientSet()
+		if err != nil {
+			return []string{}, cobra.ShellCompDirectiveError
+		}
+
+		namespace, _, err := clientGetter.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return []string{}, cobra.ShellCompDirectiveError
+		}
+
+		list, err := clientSet.KueueV1beta1().LocalQueues(namespace).List(cmd.Context(), metav1.ListOptions{Limit: completionLimit})
+		if err != nil {
+			return []string{}, cobra.ShellCompDirectiveError
+		}
+
+		validArgs := make([]string, len(list.Items))
+		for i, wl := range list.Items {
+			validArgs[i] = wl.Name
+		}
+
+		return validArgs, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/cmd/kueuectl/app/completion/completion_test.go
+++ b/cmd/kueuectl/app/completion/completion_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package completion
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
+	cmdtesting "sigs.k8s.io/kueue/cmd/kueuectl/app/testing"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+func TestWorkloadNameCompletionFunc(t *testing.T) {
+	testCases := map[string]struct {
+		ns            string
+		status        *bool
+		toComplete    string
+		objs          []runtime.Object
+		args          []string
+		wantNames     []string
+		wantDirective cobra.ShellCompDirective
+	}{
+		"should return workload names": {
+			objs: []runtime.Object{
+				utiltesting.MakeWorkload("wl1", metav1.NamespaceDefault).Active(true).Obj(),
+				utiltesting.MakeWorkload("wl2", metav1.NamespaceDefault).Active(false).Obj(),
+			},
+			wantNames:     []string{"wl1", "wl2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		"should return active workload names": {
+			status: ptr.To(true),
+			objs: []runtime.Object{
+				utiltesting.MakeWorkload("wl1", metav1.NamespaceDefault).Active(true).Obj(),
+				utiltesting.MakeWorkload("wl2", metav1.NamespaceDefault).Active(false).Obj(),
+			},
+			wantNames:     []string{"wl1"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		"should return inactive workload names": {
+			status: ptr.To(false),
+			objs: []runtime.Object{
+				utiltesting.MakeWorkload("wl1", metav1.NamespaceDefault).Active(true).Obj(),
+				utiltesting.MakeWorkload("wl2", metav1.NamespaceDefault).Active(false).Obj(),
+			},
+			wantNames:     []string{"wl2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		"shouldn't return workload names because only one argument can be passed": {
+			objs: []runtime.Object{
+				utiltesting.MakeWorkload("wl1", metav1.NamespaceDefault).Active(true).Obj(),
+				utiltesting.MakeWorkload("wl2", metav1.NamespaceDefault).Active(false).Obj(),
+			},
+			args:          []string{"wl2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tf := cmdtesting.NewTestClientGetter()
+			if len(tc.ns) > 0 {
+				tf.WithNamespace(tc.ns)
+			}
+
+			clientset := fake.NewSimpleClientset(tc.objs...)
+			tf.KueueClientset = clientset
+
+			complFn := WorkloadNameFunc(tf, tc.status)
+			names, directive := complFn(&cobra.Command{}, tc.args, tc.toComplete)
+			if diff := cmp.Diff(tc.wantNames, names); diff != "" {
+				t.Errorf("Unexpected names (-want/+got)\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantDirective, directive); diff != "" {
+				t.Errorf("Unexpected directive (-want/+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestClusterQueueNameCompletionFunc(t *testing.T) {
+	testCases := map[string]struct {
+		ns            string
+		status        *bool
+		toComplete    string
+		objs          []runtime.Object
+		args          []string
+		wantNames     []string
+		wantDirective cobra.ShellCompDirective
+	}{
+		"should return active cluster queue names": {
+			objs: []runtime.Object{
+				utiltesting.MakeClusterQueue("cq1").StopPolicy(v1beta1.None).Obj(),
+				utiltesting.MakeClusterQueue("cq2").StopPolicy(v1beta1.Hold).Obj(),
+				utiltesting.MakeClusterQueue("cq3").StopPolicy(v1beta1.HoldAndDrain).Obj(),
+			},
+			wantNames:     []string{"cq1", "cq2", "cq3"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		"should return cluster queue names": {
+			status: ptr.To(true),
+			objs: []runtime.Object{
+				utiltesting.MakeClusterQueue("cq1").StopPolicy(v1beta1.None).Obj(),
+				utiltesting.MakeClusterQueue("cq2").StopPolicy(v1beta1.Hold).Obj(),
+				utiltesting.MakeClusterQueue("cq3").StopPolicy(v1beta1.HoldAndDrain).Obj(),
+			},
+			wantNames:     []string{"cq1"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		"should return inactive cluster queue names": {
+			status: ptr.To(false),
+			objs: []runtime.Object{
+				utiltesting.MakeClusterQueue("cq1").StopPolicy(v1beta1.None).Obj(),
+				utiltesting.MakeClusterQueue("cq2").StopPolicy(v1beta1.Hold).Obj(),
+				utiltesting.MakeClusterQueue("cq3").StopPolicy(v1beta1.HoldAndDrain).Obj(),
+			},
+			wantNames:     []string{"cq2", "cq3"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		"shouldn't return cluster queue names because only one argument can be passed": {
+			objs: []runtime.Object{
+				utiltesting.MakeClusterQueue("cq1").StopPolicy(v1beta1.None).Obj(),
+				utiltesting.MakeClusterQueue("cq2").StopPolicy(v1beta1.Hold).Obj(),
+				utiltesting.MakeClusterQueue("cq3").StopPolicy(v1beta1.HoldAndDrain).Obj(),
+			},
+			args:          []string{"cq2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tf := cmdtesting.NewTestClientGetter()
+			if len(tc.ns) > 0 {
+				tf.WithNamespace(tc.ns)
+			}
+
+			clientset := fake.NewSimpleClientset(tc.objs...)
+			tf.KueueClientset = clientset
+
+			complFn := ClusterQueueNameFunc(tf, tc.status)
+			names, directive := complFn(&cobra.Command{}, tc.args, tc.toComplete)
+			if diff := cmp.Diff(tc.wantNames, names); diff != "" {
+				t.Errorf("Unexpected names (-want/+got)\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantDirective, directive); diff != "" {
+				t.Errorf("Unexpected directive (-want/+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLocalQueueNameCompletionFunc(t *testing.T) {
+	testCases := map[string]struct {
+		ns            string
+		toComplete    string
+		objs          []runtime.Object
+		args          []string
+		wantNames     []string
+		wantDirective cobra.ShellCompDirective
+	}{
+		"should return active local queue names": {
+			objs: []runtime.Object{
+				utiltesting.MakeLocalQueue("lq1", metav1.NamespaceDefault).Obj(),
+				utiltesting.MakeLocalQueue("lq2", metav1.NamespaceDefault).Obj(),
+			},
+			wantNames:     []string{"lq1", "lq2"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+		"shouldn't return local queue names because only one argument can be passed": {
+			objs: []runtime.Object{
+				utiltesting.MakeLocalQueue("lq1", metav1.NamespaceDefault).Obj(),
+				utiltesting.MakeLocalQueue("lq2", metav1.NamespaceDefault).Obj(),
+			},
+			args:          []string{"lq1"},
+			wantDirective: cobra.ShellCompDirectiveNoFileComp,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tf := cmdtesting.NewTestClientGetter()
+			if len(tc.ns) > 0 {
+				tf.WithNamespace(tc.ns)
+			}
+
+			clientset := fake.NewSimpleClientset(tc.objs...)
+			tf.KueueClientset = clientset
+
+			complFn := LocalQueueNameFunc(tf)
+			names, directive := complFn(&cobra.Command{}, tc.args, tc.toComplete)
+			if diff := cmp.Diff(tc.wantNames, names); diff != "" {
+				t.Errorf("Unexpected names (-want/+got)\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantDirective, directive); diff != "" {
+				t.Errorf("Unexpected directive (-want/+got)\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/kueuectl/app/create/create_localqueue.go
+++ b/cmd/kueuectl/app/create/create_localqueue.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
 )
 
@@ -93,6 +94,8 @@ func NewLocalQueueCmd(clientGetter util.ClientGetter, streams genericiooptions.I
 		"The cluster queue name which will be associated with the local queue (required).")
 	cmd.Flags().BoolVarP(&o.IgnoreUnknownCq, "ignore-unknown-cq", "i", false,
 		"Ignore unknown cluster queue.")
+
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("clusterqueue", completion.ClusterQueueNameFunc(clientGetter, nil)))
 
 	_ = cmd.MarkFlagRequired("clusterqueue")
 

--- a/cmd/kueuectl/app/list/list_clusterqueue_test.go
+++ b/cmd/kueuectl/app/list/list_clusterqueue_test.go
@@ -144,7 +144,7 @@ cq1    cohort1   1                   2                    true     60m
 			streams, _, out, outErr := genericiooptions.NewTestIOStreams()
 
 			tf := cmdtesting.NewTestClientGetter()
-			tf.ClientSet = fake.NewSimpleClientset(tc.objs...)
+			tf.KueueClientset = fake.NewSimpleClientset(tc.objs...)
 
 			cmd := NewClusterQueueCmd(tf, streams)
 			cmd.SetArgs(tc.args)

--- a/cmd/kueuectl/app/list/list_localqueue.go
+++ b/cmd/kueuectl/app/list/list_localqueue.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
 )
 
@@ -85,6 +86,8 @@ func NewLocalQueueCmd(clientGetter util.ClientGetter, streams genericiooptions.I
 	addFieldSelectorFlagVar(cmd, &o.FieldSelector)
 	addLabelSelectorFlagVar(cmd, &o.LabelSelector)
 	addClusterQueueFilterFlagVar(cmd, &o.ClusterQueueFilter)
+
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("clusterqueue", completion.ClusterQueueNameFunc(clientGetter, nil)))
 
 	return cmd
 }

--- a/cmd/kueuectl/app/list/list_localqueue_test.go
+++ b/cmd/kueuectl/app/list/list_localqueue_test.go
@@ -206,7 +206,7 @@ lq1    cq1            1                   1                    60m
 				tf.WithNamespace(tc.ns)
 			}
 
-			tf.ClientSet = fake.NewSimpleClientset(tc.objs...)
+			tf.KueueClientset = fake.NewSimpleClientset(tc.objs...)
 
 			cmd := NewLocalQueueCmd(tf, streams)
 			cmd.SetArgs(tc.args)

--- a/cmd/kueuectl/app/list/list_test.go
+++ b/cmd/kueuectl/app/list/list_test.go
@@ -146,7 +146,7 @@ ns2         wl2               j2         lq2          cq2            PENDING    
 				tf.WithNamespace(tc.ns)
 			}
 
-			tf.ClientSet = fake.NewSimpleClientset(tc.objs...)
+			tf.KueueClientset = fake.NewSimpleClientset(tc.objs...)
 
 			cmd := NewListCmd(tf, streams)
 			cmd.SetArgs(tc.args)

--- a/cmd/kueuectl/app/list/list_workload.go
+++ b/cmd/kueuectl/app/list/list_workload.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/kueue/apis/visibility/v1alpha1"
 	clientset "sigs.k8s.io/kueue/client-go/clientset/versioned"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -98,6 +99,9 @@ func NewWorkloadCmd(clientGetter util.ClientGetter, streams genericiooptions.IOS
 	addLabelSelectorFlagVar(cmd, &o.LabelSelector)
 	addClusterQueueFilterFlagVar(cmd, &o.ClusterQueueFilter)
 	addLocalQueueFilterFlagVar(cmd, &o.LocalQueueFilter)
+
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("clusterqueue", completion.ClusterQueueNameFunc(clientGetter, nil)))
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("localqueue", completion.LocalQueueNameFunc(clientGetter)))
 
 	cmd.Flags().StringArray("status", nil, `Filter workloads by status. Must be "all", "pending", "admitted" or "finished"`)
 

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -564,8 +564,8 @@ wl2               j2         lq2          cq2            PENDING   22           
 				},
 			}, clientset.Fake.ReactionChain...)
 
-			tf.ClientSet = clientset
-			tf.ClientSet.Discovery().(*fakediscovery.FakeDiscovery).Resources = tc.apiResourceLists
+			tf.KueueClientset = clientset
+			tf.KueueClientset.Discovery().(*fakediscovery.FakeDiscovery).Resources = tc.apiResourceLists
 
 			cmd := NewWorkloadCmd(tf, streams)
 			cmd.SetArgs(tc.args)

--- a/cmd/kueuectl/app/resume/resume_clusterqueue.go
+++ b/cmd/kueuectl/app/resume/resume_clusterqueue.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
 )
 
@@ -66,6 +67,7 @@ func NewClusterQueueCmd(clientGetter util.ClientGetter, streams genericiooptions
 		Long:                  cqLong,
 		Example:               cqExample,
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		ValidArgsFunction:     completion.ClusterQueueNameFunc(clientGetter, ptr.To(false)),
 		Run: func(cmd *cobra.Command, args []string) {
 			cobra.CheckErr(o.Complete(clientGetter, cmd, args))
 			cobra.CheckErr(o.Run(cmd.Context()))

--- a/cmd/kueuectl/app/resume/resume_workload.go
+++ b/cmd/kueuectl/app/resume/resume_workload.go
@@ -19,7 +19,9 @@ package resume
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/utils/ptr"
 
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/options"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
 )
@@ -42,6 +44,7 @@ func NewWorkloadCmd(clientGetter util.ClientGetter, streams genericiooptions.IOS
 		Long:                  wlLong,
 		Example:               wlExample,
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		ValidArgsFunction:     completion.WorkloadNameFunc(clientGetter, ptr.To(false)),
 		Run: func(cmd *cobra.Command, args []string) {
 			cobra.CheckErr(o.Complete(clientGetter, cmd, args))
 			cobra.CheckErr(o.Run(cmd.Context()))

--- a/cmd/kueuectl/app/stop/stop_clusterqueue.go
+++ b/cmd/kueuectl/app/stop/stop_clusterqueue.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/scheme"
 	kueuev1beta1 "sigs.k8s.io/kueue/client-go/clientset/versioned/typed/kueue/v1beta1"
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
 )
 
@@ -67,6 +68,7 @@ func NewClusterQueueCmd(clientGetter util.ClientGetter, streams genericiooptions
 		Long:                  cqLong,
 		Example:               cqExample,
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		ValidArgsFunction:     completion.ClusterQueueNameFunc(clientGetter, ptr.To(true)),
 		Run: func(cmd *cobra.Command, args []string) {
 			cobra.CheckErr(o.Complete(clientGetter, cmd, args))
 			cobra.CheckErr(o.Run(cmd.Context()))

--- a/cmd/kueuectl/app/stop/stop_workload.go
+++ b/cmd/kueuectl/app/stop/stop_workload.go
@@ -19,7 +19,9 @@ package stop
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/utils/ptr"
 
+	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/options"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
 )
@@ -44,6 +46,7 @@ func NewWorkloadCmd(clientGetter util.ClientGetter, streams genericiooptions.IOS
 		Long:                  wlLong,
 		Example:               wlExample,
 		Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		ValidArgsFunction:     completion.WorkloadNameFunc(clientGetter, ptr.To(true)),
 		Run: func(cmd *cobra.Command, args []string) {
 			cobra.CheckErr(o.Complete(clientGetter, cmd, args))
 			cobra.CheckErr(o.Run(cmd.Context()))

--- a/cmd/kueuectl/app/testing/fake.go
+++ b/cmd/kueuectl/app/testing/fake.go
@@ -3,6 +3,7 @@ package testing
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"sigs.k8s.io/kueue/client-go/clientset/versioned"
@@ -13,7 +14,8 @@ import (
 type TestClientGetter struct {
 	util.ClientGetter
 
-	ClientSet versioned.Interface
+	KueueClientset versioned.Interface
+	K8sClientset   k8s.Interface
 
 	configFlags *genericclioptions.TestConfigFlags
 }
@@ -26,9 +28,9 @@ func NewTestClientGetter() *TestClientGetter {
 		WithClientConfig(clientConfig).
 		WithNamespace(metav1.NamespaceDefault)
 	return &TestClientGetter{
-		ClientGetter: util.NewClientGetter(configFlags),
-		ClientSet:    fake.NewSimpleClientset(),
-		configFlags:  configFlags,
+		ClientGetter:   util.NewClientGetter(configFlags),
+		KueueClientset: fake.NewSimpleClientset(),
+		configFlags:    configFlags,
 	}
 }
 
@@ -38,5 +40,9 @@ func (f *TestClientGetter) WithNamespace(ns string) *TestClientGetter {
 }
 
 func (f *TestClientGetter) KueueClientSet() (versioned.Interface, error) {
-	return f.ClientSet, nil
+	return f.KueueClientset, nil
+}
+
+func (f *TestClientGetter) K8sClientSet() (k8s.Interface, error) {
+	return f.K8sClientset, nil
 }

--- a/cmd/kueuectl/app/util/client_getter.go
+++ b/cmd/kueuectl/app/util/client_getter.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	k8s "k8s.io/client-go/kubernetes"
 
 	"sigs.k8s.io/kueue/client-go/clientset/versioned"
 )
@@ -26,6 +27,7 @@ type ClientGetter interface {
 	genericclioptions.RESTClientGetter
 
 	KueueClientSet() (versioned.Interface, error)
+	K8sClientSet() (k8s.Interface, error)
 }
 
 type clientGetterImpl struct {
@@ -47,6 +49,20 @@ func (f *clientGetterImpl) KueueClientSet() (versioned.Interface, error) {
 	}
 
 	clientset, err := versioned.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset, nil
+}
+
+func (f *clientGetterImpl) K8sClientSet() (k8s.Interface, error) {
+	config, err := f.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := k8s.NewForConfig(config)
 	if err != nil {
 		return nil, err
 	}

--- a/site/content/en/docs/reference/kubectl-kueue/installation.md
+++ b/site/content/en/docs/reference/kubectl-kueue/installation.md
@@ -55,3 +55,21 @@ echo 'alias kueuectl="kubectl kueue"' >> ~/.bashrc
 # Or if you are using ZSH
 echo 'alias kueuectl="kubectl kueue"' >> ~/.zshrc
 ```
+
+## Autocompletion
+
+```bash
+echo '[[ $commands[kubectl-kueue] ]] && source <(kubectl-kueue completion bash)' >> ~/.bashrc
+# Or if you are using ZSH
+echo '[[ $commands[kubectl-kueue] ]] && source <(kubectl-kueue completion zsh)' >> ~/.zshrc
+
+cat <<EOF >kubectl_complete-kueue
+#!/usr/bin/env sh
+
+# Call the __complete command passing it all arguments
+kubectl kueue __complete "\$@"
+EOF
+
+chmod u+x kubectl_complete-kueue
+sudo mv kubectl_complete-kueue /usr/local/bin/kubectl_complete-kueue
+```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Support autocompletion on kueue CLI commands.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2295 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support autocompletion on kueue CLI commands
```