### PR TITLE
Do not default managedBy when running on the worker

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/jobset_adapter.go
+++ b/pkg/controller/admissionchecks/multikueue/jobset_adapter.go
@@ -66,8 +66,8 @@ func (b *jobsetAdapter) SyncJob(ctx context.Context, localClient client.Client, 
 	remoteJob.Labels[constants.PrebuiltWorkloadLabel] = workloadName
 	remoteJob.Labels[kueuealpha.MultiKueueOriginLabel] = origin
 
-	// set the manager
-	remoteJob.Spec.ManagedBy = ptr.To(jobset.JobSetControllerName)
+	// clear the managedBy enables the JobSet controller to take over
+	remoteJob.Spec.ManagedBy = nil
 
 	return remoteClient.Create(ctx, &remoteJob)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

To be consistent with the general philosophy of not defaulting to the field. See related PR in the JobSet itself: https://github.com/kubernetes-sigs/jobset/pull/528. The JobSet controller also handles JobSets without managedBy.

In particular, it allows some other systems to take over the execution of the jobset without overriding the field (just set).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Do not default the managedBy field for the mirror copy of the Job on the worker cluster.
```