### PR TITLE
Simplify the user-facing documentation for JobSet in MultiKueue

### DIFF
--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -6,8 +6,8 @@ description: >
   Kueue multi cluster job dispatching.
 ---
 
-{{% alert title="Warning" color="warning" %}}
-_Available in Kueue v0.7.0 and later_
+{{% alert title="Note" color="primary" %}}
+Available in Kueue v0.6.0 and newer
 {{% /alert %}}
 
 {{% alert title="Warning" color="warning" %}}

--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -7,7 +7,7 @@ description: >
 ---
 
 {{% alert title="Warning" color="warning" %}}
-_Available in Kueue v0.6.0 and later_
+_Available in Kueue v0.7.0 and later_
 {{% /alert %}}
 
 {{% alert title="Warning" color="warning" %}}
@@ -59,8 +59,7 @@ There is an ongoing effort to overcome these limitations by adding the possibili
 
 ### JobSet
 
-When you want to submit JobSets to a ClusterQueue with a MultiKueue admission check, you should set the `spec.managedBy` field to `kueue.x-k8s.io/multikueue`, otherwise the admission check controller will `Reject` the workload causing it to be marked as `Finished` with an error indicating the cause.
-The `managedBy` field is available in JobSet v0.5.0 and newer.
+We recommend using JobSet v0.5.1 or newer.
 
 ## Submitting Jobs
 In a [configured MultiKueue environment](/docs/tasks/manage/setup_multikueue), you can submit any MultiKueue supported job to the Manager cluster, targeting a ClusterQueue configured for Multikueue.

--- a/site/content/en/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/en/docs/tasks/manage/setup_multikueue.md
@@ -60,6 +60,20 @@ kubectl config use-context manager-cluster
 ```
 {{% /alert %}}
 
+### JobSet installation
+
+If you are using Kueue in version 0.7.0 or newer install the JobSet on the
+management cluster (see [JobSet Installation](https://jobset.sigs.k8s.io/docs/installation/)
+for more details). We recommend using JobSet 0.5.1+ for MultiKueue.
+
+{{% alert title="Warning" color="warning" %}}
+If you are using an older version of Kueue than 0.7.0, only install the JobSet
+CRD in the management cluster. You can do this by running:
+```bash
+kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/jobset/v0.5.1/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
+```
+{{% /alert %}}
+
 ### Enable the MultiKueue feature
 
 Enable the `MultiKueue` feature.

--- a/site/content/en/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/en/docs/tasks/manage/setup_multikueue.md
@@ -64,7 +64,7 @@ kubectl config use-context manager-cluster
 
 If you are using Kueue in version 0.7.0 or newer install the JobSet on the
 management cluster (see [JobSet Installation](https://jobset.sigs.k8s.io/docs/installation/)
-for more details). We recommend using JobSet 0.5.1+ for MultiKueue.
+for more details). Please install JobSet 0.5.1 or newer for MultiKueue.
 
 {{% alert title="Warning" color="warning" %}}
 If you are using an older version of Kueue than 0.7.0, only install the JobSet

--- a/site/content/en/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/en/docs/tasks/manage/setup_multikueue.md
@@ -60,13 +60,6 @@ kubectl config use-context manager-cluster
 ```
 {{% /alert %}}
 
-### Jobset CRD only install
-
-As mentioned in the [MultiKueue Overview](/docs/concepts/multikueue/#jobset) section, in the manager cluster only the JobSet CRDs should be installed, you can do this by running:
-```bash
-kubectl apply --server-side -f  https://raw.githubusercontent.com/kubernetes-sigs/jobset/v0.4.0/config/components/crd/bases/jobset.x-k8s.io_jobsets.yaml
-```
-
 ### Enable the MultiKueue feature
 
 Enable the `MultiKueue` feature.

--- a/site/content/en/docs/tasks/run/jobsets.md
+++ b/site/content/en/docs/tasks/run/jobsets.md
@@ -32,13 +32,9 @@ metadata:
     kueue.x-k8s.io/queue-name: user-queue
 ```
 
-### b. MultiKueue
+### b. Configure the resource needs
 
-If the JobSet is submitted to a queue using [MultiKueue](/docs/concepts/multikueue) its `spec.managedBy` field needs to be set to `kueue.x-k8s.io/multikueue`. Otherwise the its workload will be marked as `Finished` with an error indicating this cause.
-
-### c. Configure the resource needs
-
-The resource needs of the workload can be configured in the `spec.replicatedJobs`. Should also be taken into account that number of replicas, [parallelism](https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs) and completions affect the resource calculations. 
+The resource needs of the workload can be configured in the `spec.replicatedJobs`. Should also be taken into account that number of replicas, [parallelism](https://kubernetes.io/docs/concepts/workloads/controllers/job/#parallel-jobs) and completions affect the resource calculations.
 
 ```yaml
     - replicas: 1
@@ -54,8 +50,8 @@ The resource needs of the workload can be configured in the `spec.replicatedJobs
                       cpu: 1
 ```
 
-### d. Jobs prioritisation
-  
+### c. Jobs prioritisation
+
 The first [PriorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass) of `spec.replicatedJobs` that is not empty will be used as the priority.
 
 ```yaml
@@ -126,7 +122,8 @@ spec:
 
 {{% alert title="Note" color="note" %}}
 The same `jobset-sample.yaml` file from [single cluster environment](#single-cluster-environment) can be used in a [MultiKueue environment](#multikueue-environment).
-The `spec.managedBy` field will be set to `kueue.x-k8s.io/multikueue` automatically, if not specified, as long as  the `kueue.x-k8s.io/queue-name` annotation
+In that setup, the `spec.managedBy` field will be set to `kueue.x-k8s.io/multikueue`
+automatically, if not specified, as long as  the `kueue.x-k8s.io/queue-name` annotation
 is specified and the corresponding Cluster Queue uses the Multi Kueue admission check.
 {{% /alert %}}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Simplify the user-facing documentation. The support in 0.6.0 had limitations which are not worth documenting.
Let's recommend Kueue 0.7.0+ with JobSet 0.5.1+

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

The main issue is that in 0.6.x we didn't support the managedBy mechanism, and for that reason users couldn't install the Jobset controller on management, so the documentation will differ significantly for 0.6 and 0.7.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```