### PR TITLE
Fix indentation of commented out configurations

### DIFF
--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -104,16 +104,18 @@ managerConfig:
       - "kubeflow.org/pytorchjob"
       - "kubeflow.org/tfjob"
       - "kubeflow.org/xgboostjob"
-    # - "pod"
-    # podOptions:
-    #   namespaceSelector:
-    #     matchExpressions:
-    #       - key: kubernetes.io/metadata.name
-    #         operator: NotIn
-    #         values: [ kube-system, kueue-system ]
-    # fairSharing:
-    #   enable: true
-    #   preemptionStrategies: [LessThanOrEqualToFinalShare, LessThanInitialShare]
+    #  - "pod"
+    #  externalFrameworks:
+    #  - "Foo.v1.example.com"
+    #  podOptions:
+    #    namespaceSelector:
+    #      matchExpressions:
+    #        - key: kubernetes.io/metadata.name
+    #          operator: NotIn
+    #          values: [ kube-system, kueue-system ]
+    #fairSharing:
+    #  enable: true
+    #  preemptionStrategies: [LessThanOrEqualToFinalShare, LessThanInitialShare]
 # ports definition for metricsService and webhookService.
 metricsService:
   ports:

--- a/config/components/manager/controller_manager_config.yaml
+++ b/config/components/manager/controller_manager_config.yaml
@@ -48,15 +48,15 @@ integrations:
   - "kubeflow.org/pytorchjob"
   - "kubeflow.org/tfjob"
   - "kubeflow.org/xgboostjob"
-# - "pod"
-# externalFrameworks:
-# - "Foo.v1.example.com"
-# podOptions:
-#   namespaceSelector:
-#     matchExpressions:
-#       - key: kubernetes.io/metadata.name
-#         operator: NotIn
-#         values: [ kube-system, kueue-system ]
-# fairSharing:
-#   enable: true
-#   preemptionStrategies: [LessThanOrEqualToFinalShare, LessThanInitialShare]
+#  - "pod"
+#  externalFrameworks:
+#  - "Foo.v1.example.com"
+#  podOptions:
+#    namespaceSelector:
+#      matchExpressions:
+#        - key: kubernetes.io/metadata.name
+#          operator: NotIn
+#          values: [ kube-system, kueue-system ]
+#fairSharing:
+#  enable: true
+#  preemptionStrategies: [LessThanOrEqualToFinalShare, LessThanInitialShare]

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -138,14 +138,9 @@ data:
     waitForPodsReady:
       enable: true
       timeout: 10m
-    # pprofBindAddress: :8083
     integrations:
       frameworks:
       - "batch/job"
-    # - "kubeflow.org/mpijob"
-    # - "ray.io/rayjob"
-    # externalFrameworks:
-    # - "Foo.v1.example.com"
 ```
 
 __The `integrations.externalFrameworks` field is available in Kueue v0.7.0 and later.__


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

There was inconsistency on the amount of spaces of the commented out settings.
Now it's always just one `#` that needs to be removed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```