### PR TITLE
WaitForPodsReady: Add documentation for the backoffMaxSeconds

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_sequential_admission.md
+++ b/site/content/en/docs/tasks/manage/setup_sequential_admission.md
@@ -48,6 +48,7 @@ fields:
         timestamp: Eviction | Creation
         backoffLimitCount: 5
         backoffBaseSeconds: 60
+        backoffMaxSeconds: 3600
 ```
 
 {{% alert title="Note" color="primary" %}}
@@ -75,11 +76,17 @@ When the `blockAdmission` is set to `true`, admitted Workload with not ready pod
 
 ### Requeuing Strategy
 {{% alert title="Warning" color="warning" %}}
-_Available in Kueue v0.6.0 and later_
+Available in Kueue v0.6.0 and later
+{{% /alert %}}
+{{% alert title="Note" color="primary" %}}
+The `backoffBaseSeconds` and `backodMaxSeconds` are available in Kueue v0.7.0 and later
 {{% /alert %}}
 
 The `requeuingStrategy` (`waitForPodsReady.requeuingStrategy`) contains optional parameters: 
-`timestamp` (`waitForPodsReady.requeuingStrategy.timestamp`) and `backoffLimitCount` (`waitForPodsReady.requeuingStrategy.backoffLimitCount`).
+- `timestamp`
+- `backoffLimitCount`
+- `backoffBaseSeconds`
+- `backoffMaxSeconds`
 
 The `timestamp` field defines which timestamp Kueue uses to order the Workloads in the queue:
 
@@ -94,13 +101,13 @@ If you don't specify any value for `backoffLimitCount`,
 a Workload is repeatedly and endlessly re-queued to the queue based on the `timestamp`.
 Once the number of re-queues reaches the limit, Kueue [deactivates the Workload](/docs/concepts/workload/#active).
 
-{{% alert title="Note" color="primary" %}}
-_The `backoffBaseSeconds` is available in Kueue v0.7.0 and later_
-{{% /alert %}}
 The time to re-queue a workload after each consecutive timeout is increased
 exponentially, with the exponent of 2. The first delay is determined by the
-`backoffBaseSeconds` parameter (defaulting to 60). So, after the consecutive timeouts
-the evicted workload is re-queued after approximately `60, 120, 240, ...` seconds.
+`backoffBaseSeconds` parameter (defaulting to 60). You can configure the maximum
+backoff time by setting the `backoffMaxSeconds` (defaulting to 3600). Using the defaults, the
+evicted workload is re-queued after approximately `60, 120, 240, ..., 3600, ..., 3600` seconds.
+Even if the backoff time reaches the `backoffMaxSeconds`, Kueue will continue to re-queue an evicted Workload with the `backoffMaxSeconds`
+until the number of re-queue reaches the `backoffLimitCount`.
 
 ## Example
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
We don't have any documentation about https://github.com/kubernetes-sigs/kueue/pull/2264.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part-of #2216

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```