### PR TITLE
Add documentation for the excludeResourcePrefixes

### DIFF
--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -116,6 +116,8 @@ managerConfig:
     #fairSharing:
     #  enable: true
     #  preemptionStrategies: [LessThanOrEqualToFinalShare, LessThanInitialShare]
+    #resources:
+    #  excludeResourcePrefixes: []
 # ports definition for metricsService and webhookService.
 metricsService:
   ports:

--- a/config/components/manager/controller_manager_config.yaml
+++ b/config/components/manager/controller_manager_config.yaml
@@ -60,3 +60,5 @@ integrations:
 #fairSharing:
 #  enable: true
 #  preemptionStrategies: [LessThanOrEqualToFinalShare, LessThanInitialShare]
+#resources:
+#  excludeResourcePrefixes: []

--- a/site/content/en/docs/tasks/manage/administer_cluster_quotas.md
+++ b/site/content/en/docs/tasks/manage/administer_cluster_quotas.md
@@ -384,3 +384,21 @@ following command:
 ```shell
 kubectl apply -f team-a-cq.yaml -f team-b-cq.yaml -f shared-cq.yaml
 ```
+
+## Exclude arbitrary resources in the quota management 
+By default, administrators must specify all resources used by any Pods in the ClusterQueues `.spec.resourceGroups[*]`.
+If you want to exclude some resources for the specific devices in the ClusterQueues management, 
+you can specify the resource prefixes in the Kueue configuration as a cluster-level setting.
+
+Follow the instructions described
+[here](/docs/installation#install-a-custom-configured-released-version) to
+install a release version by extending the configuration with the following
+fields:
+
+```yaml
+...
+resources:
+  excludeResourcePrefixes:
+  - "example.com"
+...
+```

--- a/site/content/en/docs/tasks/manage/administer_cluster_quotas.md
+++ b/site/content/en/docs/tasks/manage/administer_cluster_quotas.md
@@ -386,19 +386,17 @@ kubectl apply -f team-a-cq.yaml -f team-b-cq.yaml -f shared-cq.yaml
 ```
 
 ## Exclude arbitrary resources in the quota management 
-By default, administrators must specify all resources used by any Pods in the ClusterQueues `.spec.resourceGroups[*]`.
-If you want to exclude some resources for the specific devices in the ClusterQueues management, 
-you can specify the resource prefixes in the Kueue configuration as a cluster-level setting.
+By default, administrators must specify all resources required by Pods in the ClusterQueues `.spec.resourceGroups[*]`.
+If you want to exclude some resources in the ClusterQueues quota management and admission process, 
+you can specify the resource prefixes in the Kueue Configuration as a cluster-level setting.
 
-Follow the instructions described
-[here](/docs/installation#install-a-custom-configured-released-version) to
-install a release version by extending the configuration with the following
-fields:
+Follow the [installation instructions for using a custom configuration](/docs/installation#install-a-custom-configured-released-version) 
+and extend the configuration with fields similar to the following:
 
 ```yaml
-...
+apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
 resources:
   excludeResourcePrefixes:
   - "example.com"
-...
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
There is a lack of documentation for the `resources.excludeResourcePrefixes`: #2267.
Also, I added the default parameter to manifests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part-of #2266

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```