### PR TITLE
Log Kueue's feature gates at the start-up

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -121,6 +121,8 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	setupLog.Info("Initializing", "gitVersion", version.GitVersion, "gitCommit", version.GitCommit)
 
+	features.LogFeatureGates(setupLog)
+
 	options, cfg, err := apply(configFile)
 	if err != nil {
 		setupLog.Error(err, "Unable to load the configuration")

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -130,5 +130,5 @@ func LogFeatureGates(log logr.Logger) {
 			features[f] = Enabled(f)
 		}
 	}
-	log.V(2).Info("Feature gates:", "Feature gates:", features)
+	log.V(2).Info("Loaded feature gates", "featureGates", features)
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/featuregate"
@@ -120,4 +121,14 @@ func Enabled(f featuregate.Feature) bool {
 // https://github.com/kubernetes/kubernetes/pull/118346
 func SetEnable(f featuregate.Feature, v bool) error {
 	return utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=%v", f, v))
+}
+
+func LogFeatureGates(log logr.Logger) {
+	features := make(map[featuregate.Feature]bool, len(defaultFeatureGates))
+	for f := range utilfeature.DefaultMutableFeatureGate.GetAll() {
+		if _, ok := defaultFeatureGates[f]; ok {
+			features[f] = Enabled(f)
+		}
+	}
+	log.V(2).Info("Feature gates:", "Feature gates:", features)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
To make debugging easier for users

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
Tested e2e manually

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users can now see configuration of Kueue's feature gates in `kueue-controller-manager` logs
```