### PR TITLE
[multikueue] Remove remote objects synchronously when reachable.

### DIFF
--- a/pkg/util/maps/maps.go
+++ b/pkg/util/maps/maps.go
@@ -21,6 +21,7 @@ package maps
 import (
 	"fmt"
 	"maps"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -118,4 +119,35 @@ func DeepCopySets[T comparable](src map[string]sets.Set[T]) map[string]sets.Set[
 		copy[key] = set.Clone()
 	}
 	return copy
+}
+
+// SyncMap - generic RWMutex protected map.
+type SyncMap[K comparable, V any] struct {
+	lock sync.RWMutex
+	m    map[K]V
+}
+
+func NewSyncMap[K comparable, V any](size int) *SyncMap[K, V] {
+	return &SyncMap[K, V]{
+		m: make(map[K]V, size),
+	}
+}
+
+func (dwc *SyncMap[K, V]) Add(k K, v V) {
+	dwc.lock.Lock()
+	defer dwc.lock.Unlock()
+	dwc.m[k] = v
+}
+
+func (dwc *SyncMap[K, V]) Get(k K) (V, bool) {
+	dwc.lock.RLock()
+	defer dwc.lock.RUnlock()
+	v, found := dwc.m[k]
+	return v, found
+}
+
+func (dwc *SyncMap[K, V]) Delete(k K) {
+	dwc.lock.Lock()
+	defer dwc.lock.Unlock()
+	delete(dwc.m, k)
 }

--- a/pkg/util/maps/maps.go
+++ b/pkg/util/maps/maps.go
@@ -146,6 +146,12 @@ func (dwc *SyncMap[K, V]) Get(k K) (V, bool) {
 	return v, found
 }
 
+func (dwc *SyncMap[K, V]) Len() int {
+	dwc.lock.RLock()
+	defer dwc.lock.RUnlock()
+	return len(dwc.m)
+}
+
 func (dwc *SyncMap[K, V]) Delete(k K) {
 	dwc.lock.Lock()
 	defer dwc.lock.Unlock()

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -697,13 +697,13 @@ var _ = ginkgo.Describe("Multikueue", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 				g.Expect(managerTestCluster.client.Delete(managerTestCluster.ctx, createdWorkload)).To(gomega.Succeed())
-			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Eventually(func(g gomega.Gomega) {
 				createdJob := batchv1.Job{}
 				g.Expect(worker1TestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(utiltesting.BeNotFoundError())
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
-			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

 Remove the multikueue remote objects synchronously when reachable based on the filters cache workload content.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2320

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[multikueue] Remove remote objects synchronously when reachable.
```