### PR TITLE
Use the fake time instead of real in tests

### DIFF
--- a/cmd/kueuectl/app/cmd.go
+++ b/cmd/kueuectl/app/cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/utils/clock"
 
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/completion"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/create"
@@ -34,6 +35,7 @@ import (
 )
 
 type KueuectlOptions struct {
+	Clock       clock.Clock
 	ConfigFlags *genericclioptions.ConfigFlags
 
 	genericiooptions.IOStreams
@@ -48,6 +50,7 @@ func NewDefaultKueuectlCmd() *cobra.Command {
 	return NewKueuectlCmd(KueuectlOptions{
 		ConfigFlags: defaultConfigFlags().WithWarningPrinter(ioStreams),
 		IOStreams:   ioStreams,
+		Clock:       clock.RealClock{},
 	})
 }
 
@@ -75,7 +78,8 @@ func NewKueuectlCmd(o KueuectlOptions) *cobra.Command {
 	cmd.AddCommand(create.NewCreateCmd(clientGetter, o.IOStreams))
 	cmd.AddCommand(resume.NewResumeCmd(clientGetter, o.IOStreams))
 	cmd.AddCommand(stop.NewStopCmd(clientGetter, o.IOStreams))
-	cmd.AddCommand(list.NewListCmd(clientGetter, o.IOStreams))
+	cmd.AddCommand(list.NewListCmd(clientGetter, o.IOStreams, o.Clock))
+
 	pCommands, err := passthrough.NewCommands()
 	if err != nil {
 		// we can still use the other commands, jut push an warning

--- a/cmd/kueuectl/app/list/list.go
+++ b/cmd/kueuectl/app/list/list.go
@@ -19,6 +19,7 @@ package list
 import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/utils/clock"
 
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/util"
 )
@@ -28,7 +29,7 @@ const (
   kueuectl list localqueue`
 )
 
-func NewListCmd(clientGetter util.ClientGetter, streams genericiooptions.IOStreams) *cobra.Command {
+func NewListCmd(clientGetter util.ClientGetter, streams genericiooptions.IOStreams, clock clock.Clock) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:        "list",
 		Short:      "Display resources",
@@ -36,9 +37,9 @@ func NewListCmd(clientGetter util.ClientGetter, streams genericiooptions.IOStrea
 		SuggestFor: []string{"ps"},
 	}
 
-	cmd.AddCommand(NewLocalQueueCmd(clientGetter, streams))
-	cmd.AddCommand(NewClusterQueueCmd(clientGetter, streams))
-	cmd.AddCommand(NewWorkloadCmd(clientGetter, streams))
+	cmd.AddCommand(NewLocalQueueCmd(clientGetter, streams, clock))
+	cmd.AddCommand(NewClusterQueueCmd(clientGetter, streams, clock))
+	cmd.AddCommand(NewWorkloadCmd(clientGetter, streams, clock))
 
 	return cmd
 }

--- a/cmd/kueuectl/app/list/list_clusterqueue_test.go
+++ b/cmd/kueuectl/app/list/list_clusterqueue_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	testingclock "k8s.io/utils/clock/testing"
 
 	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
@@ -146,7 +147,7 @@ cq1    cohort1   1                   2                    true     60m
 			tf := cmdtesting.NewTestClientGetter()
 			tf.KueueClientset = fake.NewSimpleClientset(tc.objs...)
 
-			cmd := NewClusterQueueCmd(tf, streams)
+			cmd := NewClusterQueueCmd(tf, streams, testingclock.NewFakeClock(testStartTime))
 			cmd.SetArgs(tc.args)
 
 			gotErr := cmd.Execute()

--- a/cmd/kueuectl/app/list/list_localqueue_printer_test.go
+++ b/cmd/kueuectl/app/list/list_localqueue_printer_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	testingclock "k8s.io/utils/clock/testing"
 
 	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
@@ -76,7 +77,8 @@ func TestLocalQueuePrint(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			out := printLocalQueueList(tc.in)
+			p := newLocalQueueTablePrinter().WithClock(testingclock.NewFakeClock(testStartTime))
+			out := p.printLocalQueueList(tc.in)
 			if diff := cmp.Diff(tc.out, out); diff != "" {
 				t.Errorf("Unexpected result (-want,+got):\n%s", diff)
 			}

--- a/cmd/kueuectl/app/list/list_localqueue_test.go
+++ b/cmd/kueuectl/app/list/list_localqueue_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	testingclock "k8s.io/utils/clock/testing"
 
 	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
@@ -208,7 +209,7 @@ lq1    cq1            1                   1                    60m
 
 			tf.KueueClientset = fake.NewSimpleClientset(tc.objs...)
 
-			cmd := NewLocalQueueCmd(tf, streams)
+			cmd := NewLocalQueueCmd(tf, streams, testingclock.NewFakeClock(testStartTime))
 			cmd.SetArgs(tc.args)
 
 			gotErr := cmd.Execute()

--- a/cmd/kueuectl/app/list/list_test.go
+++ b/cmd/kueuectl/app/list/list_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	testingclock "k8s.io/utils/clock/testing"
 
 	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/client-go/clientset/versioned/fake"
@@ -147,8 +148,9 @@ ns2         wl2               j2         lq2          cq2            PENDING    
 			}
 
 			tf.KueueClientset = fake.NewSimpleClientset(tc.objs...)
+			fc := testingclock.NewFakeClock(testStartTime)
 
-			cmd := NewListCmd(tf, streams)
+			cmd := NewListCmd(tf, streams, fc)
 			cmd.SetArgs(tc.args)
 
 			gotErr := cmd.Execute()

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	kubetesting "k8s.io/client-go/testing"
+	testingclock "k8s.io/utils/clock/testing"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/apis/visibility/v1alpha1"
@@ -567,7 +568,8 @@ wl2               j2         lq2          cq2            PENDING   22           
 			tf.KueueClientset = clientset
 			tf.KueueClientset.Discovery().(*fakediscovery.FakeDiscovery).Resources = tc.apiResourceLists
 
-			cmd := NewWorkloadCmd(tf, streams)
+			fc := testingclock.NewFakeClock(testStartTime)
+			cmd := NewWorkloadCmd(tf, streams, fc)
 			cmd.SetArgs(tc.args)
 
 			gotErr := cmd.Execute()

--- a/test/integration/kueuectl/create_test.go
+++ b/test/integration/kueuectl/create_test.go
@@ -17,12 +17,15 @@ limitations under the License.
 package kueuectl
 
 import (
+	"time"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -57,7 +60,7 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 			ginkgo.By("Create a local queue with full flags", func() {
 				streams, _, output, _ := genericiooptions.NewTestIOStreams()
 				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
-				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(time.Now())})
 				kueuectl.SetOut(output)
 				kueuectl.SetErr(output)
 

--- a/test/integration/kueuectl/list_test.go
+++ b/test/integration/kueuectl/list_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	testingclock "k8s.io/utils/clock/testing"
 
 	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app"
@@ -70,13 +71,13 @@ var _ = ginkgo.Describe("Kueuectl List", ginkgo.Ordered, ginkgo.ContinueOnFailur
 		ginkgo.It("Should print local queues list filtered by field selector", func() {
 			streams, _, output, errOutput := genericiooptions.NewTestIOStreams()
 			configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
-			kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+			executeTime := time.Now()
+			kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(executeTime)})
 
 			kueuectl.SetArgs([]string{"list", "localqueue", "--field-selector",
 				fmt.Sprintf("metadata.name=%s", lq1.Name), "--namespace", ns.Name})
-			executeTime := time.Now()
-			err := kueuectl.Execute()
 
+			err := kueuectl.Execute()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
 			gomega.Expect(errOutput.String()).Should(gomega.BeEmpty())
 
@@ -91,13 +92,13 @@ lq1    cq1            0                   0                    %s
 		ginkgo.It("Should print local queues list with paging", func() {
 			streams, _, output, errOutput := genericiooptions.NewTestIOStreams()
 			configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
-			kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+			executeTime := time.Now()
+			kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(executeTime)})
 
 			os.Setenv(list.KueuectlListRequestLimitEnvName, "1")
 			kueuectl.SetArgs([]string{"list", "localqueue", "--namespace", ns.Name})
-			executeTime := time.Now()
-			err := kueuectl.Execute()
 
+			err := kueuectl.Execute()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
 			gomega.Expect(errOutput.String()).Should(gomega.BeEmpty())
 
@@ -136,12 +137,12 @@ very-long-local-queue-name   cq1                            0                   
 		ginkgo.It("Should print local queues list filtered by field selector", func() {
 			streams, _, output, errOutput := genericiooptions.NewTestIOStreams()
 			configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
-			kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+			executeTime := time.Now()
+			kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(executeTime)})
 
 			kueuectl.SetArgs([]string{"list", "clusterqueue", "--field-selector",
 				fmt.Sprintf("metadata.name=%s", cq1.Name)})
 			err := kueuectl.Execute()
-			executeTime := time.Now()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
 			gomega.Expect(errOutput.String()).Should(gomega.BeEmpty())
 			gomega.Expect(output.String()).Should(gomega.Equal(fmt.Sprintf(`NAME   COHORT   PENDING WORKLOADS   ADMITTED WORKLOADS   ACTIVE   AGE
@@ -155,11 +156,11 @@ cq1             0                   0                    true     %s
 		ginkgo.It("Should print local queues list with paging", func() {
 			streams, _, output, errOutput := genericiooptions.NewTestIOStreams()
 			configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
-			kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+			executeTime := time.Now()
+			kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(executeTime)})
 
 			os.Setenv(list.KueuectlListRequestLimitEnvName, "1")
 			kueuectl.SetArgs([]string{"list", "clusterqueue"})
-			executeTime := time.Now()
 			err := kueuectl.Execute()
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
@@ -195,11 +196,11 @@ very-long-cluster-queue-name            0                   0                   
 			ginkgo.It("Should print workloads list filtered by field selector", func() {
 				streams, _, output, errOutput := genericiooptions.NewTestIOStreams()
 				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
-				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+				executeTime := time.Now()
+				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(executeTime)})
 
 				kueuectl.SetArgs([]string{"list", "workload", "--field-selector",
 					fmt.Sprintf("metadata.name=%s", wl1.Name), "--namespace", ns.Name})
-				executeTime := time.Now()
 				err := kueuectl.Execute()
 
 				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
@@ -214,11 +215,11 @@ wl1                          lq1                         PENDING                
 			ginkgo.It("Should print workloads list with paging", func() {
 				streams, _, output, errOutput := genericiooptions.NewTestIOStreams()
 				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
-				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+				executeTime := time.Now()
+				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(executeTime)})
 
 				os.Setenv(list.KueuectlListRequestLimitEnvName, "1")
 				kueuectl.SetArgs([]string{"list", "workload", "--namespace", ns.Name})
-				executeTime := time.Now()
 				err := kueuectl.Execute()
 
 				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)

--- a/test/integration/kueuectl/resume_test.go
+++ b/test/integration/kueuectl/resume_test.go
@@ -17,12 +17,15 @@ limitations under the License.
 package kueuectl
 
 import (
+	"time"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -64,7 +67,7 @@ var _ = ginkgo.Describe("Kueuectl Resume", ginkgo.Ordered, ginkgo.ContinueOnFail
 			ginkgo.By("Resume the created Workload", func() {
 				streams, _, output, _ := genericiooptions.NewTestIOStreams()
 				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
-				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(time.Now())})
 
 				kueuectl.SetArgs([]string{"resume", "workload", wl.Name, "--namespace", ns.Name})
 				err := kueuectl.Execute()
@@ -102,7 +105,7 @@ var _ = ginkgo.Describe("Kueuectl Resume", ginkgo.Ordered, ginkgo.ContinueOnFail
 				ginkgo.By("Resume created ClusterQueue", func() {
 					streams, _, output, _ := genericiooptions.NewTestIOStreams()
 					configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
-					kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+					kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(time.Now())})
 
 					kueuectl.SetArgs([]string{"resume", "clusterqueue", createdClusterQueue.Name})
 					err := kueuectl.Execute()

--- a/test/integration/kueuectl/stop_test.go
+++ b/test/integration/kueuectl/stop_test.go
@@ -17,12 +17,15 @@ limitations under the License.
 package kueuectl
 
 import (
+	"time"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -64,7 +67,7 @@ var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailur
 			ginkgo.By("Stop the created Workload", func() {
 				streams, _, output, _ := genericiooptions.NewTestIOStreams()
 				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
-				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+				kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(time.Now())})
 
 				kueuectl.SetArgs([]string{"stop", "workload", wl.Name, "--namespace", ns.Name})
 				err := kueuectl.Execute()
@@ -102,7 +105,7 @@ var _ = ginkgo.Describe("Kueuectl Stop", ginkgo.Ordered, ginkgo.ContinueOnFailur
 				ginkgo.By("Stop created ClusterQueue", func() {
 					streams, _, output, _ := genericiooptions.NewTestIOStreams()
 					configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
-					kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams})
+					kueuectl := app.NewKueuectlCmd(app.KueuectlOptions{ConfigFlags: configFlags, IOStreams: streams, Clock: testingclock.NewFakeClock(time.Now())})
 
 					kueuectl.SetArgs(append([]string{"stop", "clusterqueue", createdClusterQueue.Name}, stopCmdArgs...))
 					err := kueuectl.Execute()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We want to use fake clocks in tests as they allow for necessary time manipulation when required.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2287
Fixes #2353

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```