### PR TITLE
MultiKueue skip garbage collection for disconnected clients.

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/jobset_adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/jobset_adapter_test.go
@@ -342,6 +342,7 @@ func TestWlReconcileJobset(t *testing.T) {
 
 			w1remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "")
 			w1remoteClient.client = worker1Client
+			w1remoteClient.connecting.Store(false)
 
 			cRec.remoteClients["worker1"] = w1remoteClient
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -76,7 +76,7 @@ func newTestClient(config string, watchCancel func()) *remoteClient {
 
 func setReconnectState(rc *remoteClient, a uint) *remoteClient {
 	rc.failedConnAttempts = a
-	rc.pendingReconnect.Store(true)
+	rc.connecting.Store(true)
 	return rc
 }
 
@@ -535,6 +535,7 @@ func TestRemoteClientGC(t *testing.T) {
 
 			w1remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "")
 			w1remoteClient.client = worker1Client
+			w1remoteClient.connecting.Store(false)
 
 			w1remoteClient.runGC(ctx)
 

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -247,7 +247,7 @@ func (w *wlReconciler) remoteClientsForAC(ctx context.Context, acName string) (m
 	for _, clusterName := range cfg.Spec.Clusters {
 		if client, found := w.clusters.controllerFor(clusterName); found {
 			// Skip the client if its reconnect is ongoing.
-			if !client.pendingReconnect.Load() {
+			if !client.connecting.Load() {
 				clients[clusterName] = client
 			}
 		}

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -1012,6 +1012,7 @@ func TestWlReconcile(t *testing.T) {
 
 			w1remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "")
 			w1remoteClient.client = worker1Client
+			w1remoteClient.connecting.Store(false)
 			cRec.remoteClients["worker1"] = w1remoteClient
 
 			var worker2Client client.WithWatch
@@ -1042,8 +1043,8 @@ func TestWlReconcile(t *testing.T) {
 
 				w2remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "")
 				w2remoteClient.client = worker2Client
-				if tc.worker2Reconnecting {
-					w2remoteClient.pendingReconnect.Store(true)
+				if !tc.worker2Reconnecting {
+					w2remoteClient.connecting.Store(false)
 				}
 				cRec.remoteClients["worker2"] = w2remoteClient
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
MultiKueue skip garbage collection for disconnected clients, which otherwise can cause a panic if the GC runes between the time a `remoteClient` is connected and it's initial connection to the worker cluster.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2365 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[MultiKueue] Skip garbage collection for disconnected clients which could occasionally result in panic.
```