### PR TITLE
Add event for eviction on the workload.

### DIFF
--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,6 +39,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	"sigs.k8s.io/kueue/pkg/util/limitrange"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
@@ -686,4 +688,9 @@ func AdmissionChecksForWorkload(log logr.Logger, wl *kueue.Workload, admissionCh
 		}
 	}
 	return acNames
+}
+
+func ReportEvictedWorkload(recorder record.EventRecorder, wl *kueue.Workload, cqName, reason, message string) {
+	metrics.ReportEvictedWorkloads(cqName, reason)
+	recorder.Event(wl, corev1.EventTypeNormal, fmt.Sprintf("%sDueTo%s", kueue.WorkloadEvicted, reason), message)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add event for eviction on the workload.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2012

#### Special notes for your reviewer:
```
Events:
  Type    Reason                        Age                  From                       Message
  ----    ------                        ----                 ----                       -------
  Normal  Pending                       3m5s (x5 over 3m5s)  kueue-admission            couldn't assign flavors to pod set main: flavor spot doesn't match node affinity, insufficient unused quota for cpu in flavor on-demand, 1 more needed. Pending the preemption of 1 workload(s)
  Normal  QuotaReserved                 3m5s                 kueue-admission            Quota reserved in ClusterQueue cluster-queue, wait time since queued was 1s
  Normal  EvictedDueToPodsReadyTimeout  2m5s                 kueue-workload-controller  Exceeded the PodsReady timeout e2e-gsj4m/job-high-67543
  Normal  Admitted                      65s (x2 over 3m5s)   kueue-admission            Admitted by ClusterQueue cluster-queue, wait time since reservation was 0s
  Normal  QuotaReserved                 65s                  kueue-admission            Quota reserved in ClusterQueue cluster-queue, wait time since queued was 0s
  Normal  EvictedDueToInactiveWorkload  5s                   kueue-workload-controller  The workload is deactivated due to exceeding the maximum number of re-queuing retries
```

Preempted event is not renamed to keep backwards compatibility.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add the following events for eviction on the workload indicating the reason for eviction:
- "EvictedDueToPodsReadyTimeout"
- "EvictedDueToAdmissionCheck"
- "EvictedDueToClusterQueueStopped"
- "EvictedDueToInactiveWorkload" (renamed from InactiveWorkload)

ACTION REQUIRED: If you were watching for the typed Normal event with `InactiveWorkload` reason, use `EvictedDueToInactiveWorkload` reason one instead.
```