### PR TITLE
[multikueue] Batch remote workload reconcile events.

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/controllers.go
+++ b/pkg/controller/admissionchecks/multikueue/controllers.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/kueue/pkg/constants"
 )
 
 const (
@@ -32,6 +34,7 @@ type SetupOptions struct {
 	gcInterval        time.Duration
 	origin            string
 	workerLostTimeout time.Duration
+	eventsBatchPeriod time.Duration
 }
 
 type SetupOption func(o *SetupOptions)
@@ -60,11 +63,20 @@ func WithWorkerLostTimeout(d time.Duration) SetupOption {
 	}
 }
 
+// WithEventBatchPeriod - sets the delay used when adding remote triggered
+// events to the workload's reconcile queue.
+func WithEventBatchPeriod(d time.Duration) SetupOption {
+	return func(o *SetupOptions) {
+		o.eventsBatchPeriod = d
+	}
+}
+
 func SetupControllers(mgr ctrl.Manager, namespace string, opts ...SetupOption) error {
 	options := &SetupOptions{
 		gcInterval:        defaultGCInterval,
 		origin:            defaultOrigin,
 		workerLostTimeout: defaultWorkerLostTimeout,
+		eventsBatchPeriod: constants.UpdatesBatchPeriod,
 	}
 
 	for _, o := range opts {
@@ -94,6 +106,6 @@ func SetupControllers(mgr ctrl.Manager, namespace string, opts ...SetupOption) e
 		return err
 	}
 
-	wlRec := newWlReconciler(mgr.GetClient(), helper, cRec, options.origin, options.workerLostTimeout)
+	wlRec := newWlReconciler(mgr.GetClient(), helper, cRec, options.origin, options.workerLostTimeout, options.eventsBatchPeriod)
 	return wlRec.setupWithManager(mgr)
 }

--- a/pkg/controller/admissionchecks/multikueue/controllers.go
+++ b/pkg/controller/admissionchecks/multikueue/controllers.go
@@ -63,9 +63,9 @@ func WithWorkerLostTimeout(d time.Duration) SetupOption {
 	}
 }
 
-// WithEventBatchPeriod - sets the delay used when adding remote triggered
+// WithEventsBatchPeriod - sets the delay used when adding remote triggered
 // events to the workload's reconcile queue.
-func WithEventBatchPeriod(d time.Duration) SetupOption {
+func WithEventsBatchPeriod(d time.Duration) SetupOption {
 	return func(o *SetupOptions) {
 		o.eventsBatchPeriod = d
 	}

--- a/pkg/controller/admissionchecks/multikueue/jobset_adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/jobset_adapter_test.go
@@ -19,6 +19,7 @@ package multikueue
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -347,7 +348,7 @@ func TestWlReconcileJobset(t *testing.T) {
 			cRec.remoteClients["worker1"] = w1remoteClient
 
 			helper, _ := newMultiKueueStoreHelper(managerClient)
-			reconciler := newWlReconciler(managerClient, helper, cRec, defaultOrigin, defaultWorkerLostTimeout)
+			reconciler := newWlReconciler(managerClient, helper, cRec, defaultOrigin, defaultWorkerLostTimeout, time.Second)
 
 			for _, val := range tc.managersDeletedWorkloads {
 				reconciler.Delete(event.DeleteEvent{

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -1050,7 +1050,7 @@ func TestWlReconcile(t *testing.T) {
 			}
 
 			helper, _ := newMultiKueueStoreHelper(managerClient)
-			reconciler := newWlReconciler(managerClient, helper, cRec, defaultOrigin, defaultWorkerLostTimeout)
+			reconciler := newWlReconciler(managerClient, helper, cRec, defaultOrigin, defaultWorkerLostTimeout, time.Second)
 
 			for _, val := range tc.managersDeletedWorkloads {
 				reconciler.Delete(event.DeleteEvent{

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -176,6 +176,7 @@ func managerAndMultiKueueSetup(mgr manager.Manager, ctx context.Context) {
 	err = multikueue.SetupControllers(mgr, managersConfigNamespace.Name,
 		multikueue.WithGCInterval(2*time.Second),
 		multikueue.WithWorkerLostTimeout(testingWorkerLostTimeout),
+		multikueue.WithEventBatchPeriod(100*time.Millisecond),
 	)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -176,7 +176,7 @@ func managerAndMultiKueueSetup(mgr manager.Manager, ctx context.Context) {
 	err = multikueue.SetupControllers(mgr, managersConfigNamespace.Name,
 		multikueue.WithGCInterval(2*time.Second),
 		multikueue.WithWorkerLostTimeout(testingWorkerLostTimeout),
-		multikueue.WithEventBatchPeriod(100*time.Millisecond),
+		multikueue.WithEventsBatchPeriod(100*time.Millisecond),
 	)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[multikueue] Batch remote workload reconcile events.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #693 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
[multikueue] Batch remote workload reconcile events.
```