### PR TITLE
[kueuectl] Fix "should print workloads list with paging" test

### DIFF
--- a/test/integration/kueuectl/list_test.go
+++ b/test/integration/kueuectl/list_test.go
@@ -229,9 +229,9 @@ very-long-workload-name                         lq1                             
 wl1                                             lq1                                         PENDING                       %s
 wl2                                             very-long-local-queue-name                  PENDING                       %s
 `,
+					duration.HumanDuration(executeTime.Sub(wl3.CreationTimestamp.Time)),
 					duration.HumanDuration(executeTime.Sub(wl1.CreationTimestamp.Time)),
 					duration.HumanDuration(executeTime.Sub(wl2.CreationTimestamp.Time)),
-					duration.HumanDuration(executeTime.Sub(wl3.CreationTimestamp.Time)),
 				)))
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
To fix "Should print workloads list with paging" test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2353

#### Special notes for your reviewer:
The order of workloads in the table is wl3, wl1, wl2, which is different that the order of workloads in the expectations. Since the creation timestamps are generated by API server they may differ, so we need to use the same order.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```