### PR TITLE
[multikueue] add support for custom multikueue controller

### DIFF
--- a/apis/kueue/v1alpha1/multikueue_types.go
+++ b/apis/kueue/v1alpha1/multikueue_types.go
@@ -59,6 +59,14 @@ type KubeConfig struct {
 }
 
 type MultiKueueClusterSpec struct {
+	// controllerName is name of the controller which will actually perform
+	// the checks. This is the name with which controller identifies with,
+	// not necessarily a K8S Pod or Deployment name. Cannot be empty.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:default="kueue.x-k8s.io/multikueue"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="field is immutable"
+	ControllerName string `json:"controllerName"`
+
 	// Information how to connect to the cluster.
 	KubeConfig KubeConfig `json:"kubeConfig"`
 }

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
@@ -53,6 +53,16 @@ spec:
             type: object
           spec:
             properties:
+              controllerName:
+                default: kueue.x-k8s.io/multikueue
+                description: |-
+                  controllerName is name of the controller which will actually perform
+                  the checks. This is the name with which controller identifies with,
+                  not necessarily a K8S Pod or Deployment name. Cannot be empty.
+                type: string
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
               kubeConfig:
                 description: Information how to connect to the cluster.
                 properties:
@@ -76,6 +86,7 @@ spec:
                 - locationType
                 type: object
             required:
+            - controllerName
             - kubeConfig
             type: object
           status:

--- a/client-go/applyconfiguration/kueue/v1alpha1/multikueueclusterspec.go
+++ b/client-go/applyconfiguration/kueue/v1alpha1/multikueueclusterspec.go
@@ -20,13 +20,22 @@ package v1alpha1
 // MultiKueueClusterSpecApplyConfiguration represents an declarative configuration of the MultiKueueClusterSpec type for use
 // with apply.
 type MultiKueueClusterSpecApplyConfiguration struct {
-	KubeConfig *KubeConfigApplyConfiguration `json:"kubeConfig,omitempty"`
+	ControllerName *string                       `json:"controllerName,omitempty"`
+	KubeConfig     *KubeConfigApplyConfiguration `json:"kubeConfig,omitempty"`
 }
 
 // MultiKueueClusterSpecApplyConfiguration constructs an declarative configuration of the MultiKueueClusterSpec type for use with
 // apply.
 func MultiKueueClusterSpec() *MultiKueueClusterSpecApplyConfiguration {
 	return &MultiKueueClusterSpecApplyConfiguration{}
+}
+
+// WithControllerName sets the ControllerName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ControllerName field is set to the value of the last call.
+func (b *MultiKueueClusterSpecApplyConfiguration) WithControllerName(value string) *MultiKueueClusterSpecApplyConfiguration {
+	b.ControllerName = &value
+	return b
 }
 
 // WithKubeConfig sets the KubeConfig field in the declarative configuration to the given value

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -256,10 +256,18 @@ func setupControllers(mgr ctrl.Manager, cCache *cache.Cache, queues *queue.Manag
 	}
 
 	if features.Enabled(features.MultiKueue) {
+		adapters, err := jobframework.GetMultiKueueAdapters()
+		if err != nil {
+			setupLog.Error(err, "Could not get the multikueue adapters")
+			os.Exit(1)
+		}
+
 		if err := multikueue.SetupControllers(mgr, *cfg.Namespace,
 			multikueue.WithGCInterval(cfg.MultiKueue.GCInterval.Duration),
 			multikueue.WithOrigin(ptr.Deref(cfg.MultiKueue.Origin, configapi.DefaultMultiKueueOrigin)),
 			multikueue.WithWorkerLostTimeout(cfg.MultiKueue.WorkerLostTimeout.Duration),
+			multikueue.WithControllerName(kueuealpha.MultiKueueControllerName),
+			multikueue.WithAdapters(adapters),
 		); err != nil {
 			setupLog.Error(err, "Could not setup MultiKueue controller")
 			os.Exit(1)

--- a/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_multikueueclusters.yaml
@@ -38,6 +38,16 @@ spec:
             type: object
           spec:
             properties:
+              controllerName:
+                default: kueue.x-k8s.io/multikueue
+                description: |-
+                  controllerName is name of the controller which will actually perform
+                  the checks. This is the name with which controller identifies with,
+                  not necessarily a K8S Pod or Deployment name. Cannot be empty.
+                type: string
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
               kubeConfig:
                 description: Information how to connect to the cluster.
                 properties:
@@ -61,6 +71,7 @@ spec:
                 - locationType
                 type: object
             required:
+            - controllerName
             - kubeConfig
             type: object
           status:

--- a/pkg/controller/admissionchecks/multikueue/controllers.go
+++ b/pkg/controller/admissionchecks/multikueue/controllers.go
@@ -83,14 +83,14 @@ func WithControllerName(controllerName string) SetupOption {
 	}
 }
 
-// WithAdapters - sets all the MultiKueue adaptors.
+// WithAdapters - sets all the MultiKueue adapters.
 func WithAdapters(adapters map[string]jobframework.MultiKueueAdapter) SetupOption {
 	return func(o *SetupOptions) {
 		o.adapters = adapters
 	}
 }
 
-// WithAdapters - sets or updates the adadpter of the MultiKueue adaptors.
+// WithAdapter - sets or updates the adapter of the MultiKueue adapters.
 func WithAdapter(adapter jobframework.MultiKueueAdapter) SetupOption {
 	return func(o *SetupOptions) {
 		o.adapters[adapter.GVK().String()] = adapter

--- a/pkg/controller/admissionchecks/multikueue/controllers.go
+++ b/pkg/controller/admissionchecks/multikueue/controllers.go
@@ -22,6 +22,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 )
 
@@ -82,11 +83,17 @@ func WithControllerName(controllerName string) SetupOption {
 	}
 }
 
-// WithAdapters - sets the controller name for which the multikueue
-// admission check match.
+// WithAdapters - sets all the MultiKueue adaptors.
 func WithAdapters(adapters map[string]jobframework.MultiKueueAdapter) SetupOption {
 	return func(o *SetupOptions) {
 		o.adapters = adapters
+	}
+}
+
+// WithAdapters - sets or updates the adadpter of the MultiKueue adaptors.
+func WithAdapter(adapter jobframework.MultiKueueAdapter) SetupOption {
+	return func(o *SetupOptions) {
+		o.adapters[adapter.GVK().String()] = adapter
 	}
 }
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -510,7 +510,7 @@ func (c *clustersReconciler) runGC(ctx context.Context) {
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=multikueueclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=multikueueclusters/status,verbs=get;update;patch
 
-func newClustersReconciler(c client.Client, namespace string, so SetupOptions, fsWatcher *KubeConfigFSWatcher, adapters map[string]jobframework.MultiKueueAdapter) *clustersReconciler {
+func newClustersReconciler(c client.Client, namespace string, so SetupOptions, fsWatcher *KubeConfigFSWatcher) *clustersReconciler {
 	return &clustersReconciler{
 		localClient:     c,
 		configNamespace: namespace,
@@ -521,7 +521,7 @@ func newClustersReconciler(c client.Client, namespace string, so SetupOptions, f
 		origin:          so.origin,
 		watchEndedCh:    make(chan event.GenericEvent, eventChBufferSize),
 		fsWatcher:       fsWatcher,
-		adapters:        adapters,
+		adapters:        so.adapters,
 	}
 }
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -399,7 +399,8 @@ func TestUpdateConfig(t *testing.T) {
 			adapters, _ := jobframework.GetMultiKueueAdapters()
 			setupOptions := NewSetupOptions()
 			setupOptions.gcInterval = 0
-			reconciler := newClustersReconciler(c, TestNamespace, *setupOptions, nil, adapters)
+			setupOptions.adapters = adapters
+			reconciler := newClustersReconciler(c, TestNamespace, *setupOptions, nil)
 			reconciler.rootContext = ctx
 
 			if len(tc.remoteClients) > 0 {

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -113,6 +113,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Generation(1).
 					Obj(),
@@ -122,6 +123,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Active(metav1.ConditionTrue, "Active", "Connected", 1).
 					Generation(1).
@@ -137,6 +139,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Generation(1).
 					Obj(),
@@ -149,6 +152,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Active(metav1.ConditionTrue, "Active", "Connected", 1).
 					Generation(1).
@@ -165,6 +169,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.PathLocationType, "testdata/worker1KubeConfig").
 					Generation(1).
 					Obj(),
@@ -174,6 +179,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.PathLocationType, "testdata/worker1KubeConfig").
 					Active(metav1.ConditionTrue, "Active", "Connected", 1).
 					Generation(1).
@@ -190,6 +196,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Generation(1).
 					Obj(),
@@ -205,6 +212,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Active(metav1.ConditionFalse, "ClientConnectionFailed", "invalid kubeconfig", 1).
 					Generation(1).
@@ -216,6 +224,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.PathLocationType, "").
 					Generation(1).
 					Obj(),
@@ -225,6 +234,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.PathLocationType, "").
 					Active(metav1.ConditionFalse, "BadConfig", "open : no such file or directory", 1).
 					Generation(1).
@@ -236,6 +246,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker2",
 			clusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Generation(1).
 					Obj(),
@@ -246,6 +257,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Generation(1).
 					Obj(),
@@ -261,6 +273,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Generation(1).
 					Obj(),
@@ -276,6 +289,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Active(metav1.ConditionFalse, "ClientConnectionFailed", "client cannot watch", 1).
 					Generation(1).
@@ -288,6 +302,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Active(metav1.ConditionFalse, "ClientConnectionFailed", "client cannot watch", 1).
 					Generation(1).
@@ -304,6 +319,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Active(metav1.ConditionFalse, "ClientConnectionFailed", "client cannot watch", 1).
 					Generation(1).
@@ -316,6 +332,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Active(metav1.ConditionFalse, "ClientConnectionFailed", "client cannot watch", 1).
 					Generation(1).
@@ -332,6 +349,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Active(metav1.ConditionTrue, "Active", "Connected", 1).
 					Generation(1).
@@ -343,6 +361,7 @@ func TestUpdateConfig(t *testing.T) {
 			reconcileFor: "worker1",
 			clusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Active(metav1.ConditionFalse, "ClientConnectionFailed", "client cannot watch", 1).
 					Generation(1).
@@ -359,6 +378,7 @@ func TestUpdateConfig(t *testing.T) {
 			},
 			wantClusters: []kueuealpha.MultiKueueCluster{
 				*utiltesting.MakeMultiKueueCluster("worker1").
+					ControllerName(kueuealpha.MultiKueueControllerName).
 					KubeConfig(kueuealpha.SecretLocationType, "worker1").
 					Active(metav1.ConditionFalse, "ClientConnectionFailed", "invalid kubeconfig", 1).
 					Generation(1).
@@ -377,7 +397,9 @@ func TestUpdateConfig(t *testing.T) {
 			c := builder.Build()
 
 			adapters, _ := jobframework.GetMultiKueueAdapters()
-			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters)
+			setupOptions := NewSetupOptions()
+			setupOptions.gcInterval = 0
+			reconciler := newClustersReconciler(c, TestNamespace, *setupOptions, nil, adapters)
 			reconciler.rootContext = ctx
 
 			if len(tc.remoteClients) > 0 {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -181,7 +181,7 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 	// If the workload is deleted there is a chance that it's owner is also deleted. In that case
 	// we skip calling `IsJobManagedByKueue` as its output would not be reliable.
 	if !isDeleted {
-		managed, unmanagedReason, err := adapter.IsJobManagedByKueue(ctx, w.client, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace})
+		managed, unmanagedReason, err := adapter.IsJobManagedByKueue(ctx, w.client, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, w.controllerName)
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -439,7 +439,7 @@ func (w *wlReconciler) Generic(_ event.GenericEvent) bool {
 	return true
 }
 
-func newWlReconciler(c client.Client, helper *multiKueueStoreHelper, cRec *clustersReconciler, so SetupOptions, adapters map[string]jobframework.MultiKueueAdapter) *wlReconciler {
+func newWlReconciler(c client.Client, helper *multiKueueStoreHelper, cRec *clustersReconciler, so SetupOptions) *wlReconciler {
 	return &wlReconciler{
 		controllerName:    so.controllerName,
 		client:            c,
@@ -449,7 +449,7 @@ func newWlReconciler(c client.Client, helper *multiKueueStoreHelper, cRec *clust
 		workerLostTimeout: so.workerLostTimeout,
 		deletedWlCache:    utilmaps.NewSyncMap[string, *kueue.Workload](0),
 		eventsBatchPeriod: so.eventsBatchPeriod,
-		adapters:          adapters,
+		adapters:          so.adapters,
 	}
 }
 

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -1009,7 +1009,9 @@ func TestWlReconcile(t *testing.T) {
 			managerClient := managerBuilder.Build()
 
 			adapters, _ := jobframework.GetMultiKueueAdapters()
-			cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters)
+			setupOptions := NewSetupOptions()
+			setupOptions.gcInterval = 0
+			cRec := newClustersReconciler(managerClient, TestNamespace, *setupOptions, nil, adapters)
 
 			worker1Builder, _ := getClientBuilder()
 			worker1Builder = worker1Builder.WithLists(&kueue.WorkloadList{Items: tc.worker1Workloads}, &batchv1.JobList{Items: tc.worker1Jobs})
@@ -1055,7 +1057,9 @@ func TestWlReconcile(t *testing.T) {
 			}
 
 			helper, _ := newMultiKueueStoreHelper(managerClient)
-			reconciler := newWlReconciler(managerClient, helper, cRec, defaultOrigin, defaultWorkerLostTimeout, time.Second, adapters)
+			setupOptions.workerLostTimeout = defaultWorkerLostTimeout
+			setupOptions.eventsBatchPeriod = time.Second
+			reconciler := newWlReconciler(managerClient, helper, cRec, *setupOptions, adapters)
 
 			for _, val := range tc.managersDeletedWorkloads {
 				reconciler.Delete(event.DeleteEvent{

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -1011,7 +1011,8 @@ func TestWlReconcile(t *testing.T) {
 			adapters, _ := jobframework.GetMultiKueueAdapters()
 			setupOptions := NewSetupOptions()
 			setupOptions.gcInterval = 0
-			cRec := newClustersReconciler(managerClient, TestNamespace, *setupOptions, nil, adapters)
+			setupOptions.adapters = adapters
+			cRec := newClustersReconciler(managerClient, TestNamespace, *setupOptions, nil)
 
 			worker1Builder, _ := getClientBuilder()
 			worker1Builder = worker1Builder.WithLists(&kueue.WorkloadList{Items: tc.worker1Workloads}, &batchv1.JobList{Items: tc.worker1Jobs})
@@ -1059,7 +1060,8 @@ func TestWlReconcile(t *testing.T) {
 			helper, _ := newMultiKueueStoreHelper(managerClient)
 			setupOptions.workerLostTimeout = defaultWorkerLostTimeout
 			setupOptions.eventsBatchPeriod = time.Second
-			reconciler := newWlReconciler(managerClient, helper, cRec, *setupOptions, adapters)
+			setupOptions.adapters = adapters
+			reconciler := newWlReconciler(managerClient, helper, cRec, *setupOptions)
 
 			for _, val := range tc.managersDeletedWorkloads {
 				reconciler.Delete(event.DeleteEvent{

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -160,7 +160,7 @@ type MultiKueueAdapter interface {
 	// - a bool indicating if the job object identified by key is managed by kueue and can be delegated.
 	// - a reason indicating why the job is not managed by Kueue
 	// - any API error encountered during the check
-	IsJobManagedByKueue(ctx context.Context, localClient client.Client, key types.NamespacedName) (bool, string, error)
+	IsJobManagedByKueue(ctx context.Context, localClient client.Client, key types.NamespacedName, controllerName string) (bool, string, error)
 	// KeepAdmissionCheckPending returns true if the state of the multikueue admission check should be
 	// kept Pending while the job runs in a worker. This might be needed to keep the managers job
 	// suspended and not start the execution locally.

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -115,7 +115,7 @@ func (b *multikueueAdapter) KeepAdmissionCheckPending() bool {
 	return !features.Enabled(features.MultiKueueBatchJobWithManagedBy)
 }
 
-func (b *multikueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
+func (b *multikueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName, controllerName string) (bool, string, error) {
 	if !features.Enabled(features.MultiKueueBatchJobWithManagedBy) {
 		return true, "", nil
 	}
@@ -126,7 +126,7 @@ func (b *multikueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Cl
 		return false, "", err
 	}
 	jobControllerName := ptr.Deref(job.Spec.ManagedBy, "")
-	if jobControllerName != kueuealpha.MultiKueueControllerName {
+	if jobControllerName != controllerName {
 		return false, fmt.Sprintf("Expecting spec.managedBy to be %q not %q", kueuealpha.MultiKueueControllerName, jobControllerName), nil
 	}
 	return true, "", nil

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -205,7 +205,7 @@ func TestMultikueueAdapter(t *testing.T) {
 		},
 		"missing job is not considered managed": {
 			operation: func(ctx context.Context, adapter *multikueueAdapter, managerClient, workerClient client.Client) error {
-				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}); isManged {
+				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, kueuealpha.MultiKueueControllerName); isManged {
 					return errors.New("expecting false")
 				}
 				return nil
@@ -216,7 +216,7 @@ func TestMultikueueAdapter(t *testing.T) {
 				*baseJobBuilder.Clone().Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multikueueAdapter, managerClient, workerClient client.Client) error {
-				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}); isManged {
+				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, kueuealpha.MultiKueueControllerName); isManged {
 					return errors.New("expecting false")
 				}
 				return nil
@@ -231,7 +231,7 @@ func TestMultikueueAdapter(t *testing.T) {
 				*baseJobManagedByKueueBuilder.Clone().Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multikueueAdapter, managerClient, workerClient client.Client) error {
-				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}); !isManged {
+				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, kueuealpha.MultiKueueControllerName); !isManged {
 					return errors.New("expecting true")
 				}
 				return nil
@@ -246,7 +246,7 @@ func TestMultikueueAdapter(t *testing.T) {
 			},
 			withoutJobManagedBy: true,
 			operation: func(ctx context.Context, adapter *multikueueAdapter, managerClient, workerClient client.Client) error {
-				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}); !isManged {
+				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "job1", Namespace: TestNamespace}, kueuealpha.MultiKueueControllerName); !isManged {
 					return errors.New("expecting true")
 				}
 				return nil

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
@@ -88,14 +88,14 @@ func (b *multikueueAdapter) KeepAdmissionCheckPending() bool {
 	return false
 }
 
-func (b *multikueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
+func (b *multikueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName, controllerName string) (bool, string, error) {
 	js := jobset.JobSet{}
 	err := c.Get(ctx, key, &js)
 	if err != nil {
 		return false, "", err
 	}
 	jobsetControllerName := ptr.Deref(js.Spec.ManagedBy, "")
-	if jobsetControllerName != kueuealpha.MultiKueueControllerName {
+	if jobsetControllerName != controllerName {
 		return false, fmt.Sprintf("Expecting spec.managedBy to be %q not %q", kueuealpha.MultiKueueControllerName, jobsetControllerName), nil
 	}
 	return true, "", nil

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter_test.go
@@ -164,7 +164,7 @@ func TestMultikueueAdapter(t *testing.T) {
 		},
 		"missing jobset is not considered managed": {
 			operation: func(ctx context.Context, adapter *multikueueAdapter, managerClient, workerClient client.Client) error {
-				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}); isManged {
+				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, kueuealpha.MultiKueueControllerName); isManged {
 					return errors.New("expecting false")
 				}
 				return nil
@@ -175,7 +175,7 @@ func TestMultikueueAdapter(t *testing.T) {
 				*baseJobSetBuilder.DeepCopy().Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multikueueAdapter, managerClient, workerClient client.Client) error {
-				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}); isManged {
+				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, kueuealpha.MultiKueueControllerName); isManged {
 					return errors.New("expecting false")
 				}
 				return nil
@@ -190,7 +190,7 @@ func TestMultikueueAdapter(t *testing.T) {
 				*baseJobSetManagedByKueueBuilder.DeepCopy().Obj(),
 			},
 			operation: func(ctx context.Context, adapter *multikueueAdapter, managerClient, workerClient client.Client) error {
-				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}); !isManged {
+				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "jobset1", Namespace: TestNamespace}, kueuealpha.MultiKueueControllerName); !isManged {
 					return errors.New("expecting true")
 				}
 				return nil

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -1069,6 +1069,11 @@ func (mkc *MultiKueueClusterWrapper) Obj() *kueuealpha.MultiKueueCluster {
 	return &mkc.MultiKueueCluster
 }
 
+func (mkc *MultiKueueClusterWrapper) ControllerName(controllerName string) *MultiKueueClusterWrapper {
+	mkc.Spec.ControllerName = controllerName
+	return mkc
+}
+
 func (mkc *MultiKueueClusterWrapper) KubeConfig(locationType kueuealpha.LocationType, location string) *MultiKueueClusterWrapper {
 	mkc.Spec.KubeConfig = kueuealpha.KubeConfig{
 		Location:     location,

--- a/site/content/en/docs/reference/kueue-alpha.v1alpha1.md
+++ b/site/content/en/docs/reference/kueue-alpha.v1alpha1.md
@@ -133,6 +133,15 @@ which the kueue controller manager is running. The config should be stored in th
 <tbody>
     
   
+<tr><td><code>controllerName</code> <B>[Required]</B><br/>
+<code>string</code>
+</td>
+<td>
+   <p>controllerName is name of the controller which will actually perform
+the checks. This is the name with which controller identifies with,
+not necessarily a K8S Pod or Deployment name. Cannot be empty.</p>
+</td>
+</tr>
 <tr><td><code>kubeConfig</code> <B>[Required]</B><br/>
 <a href="#kueue-x-k8s-io-v1alpha1-KubeConfig"><code>KubeConfig</code></a>
 </td>

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -91,10 +91,14 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		}
 		gomega.Expect(k8sWorker2Client.Create(ctx, worker2Ns)).To(gomega.Succeed())
 
-		workerCluster1 = utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, "multikueue1").Obj()
+		workerCluster1 = utiltesting.MakeMultiKueueCluster("worker1").
+			ControllerName(kueuealpha.MultiKueueControllerName).
+			KubeConfig(kueuealpha.SecretLocationType, "multikueue1").Obj()
 		gomega.Expect(k8sManagerClient.Create(ctx, workerCluster1)).To(gomega.Succeed())
 
-		workerCluster2 = utiltesting.MakeMultiKueueCluster("worker2").KubeConfig(kueuealpha.SecretLocationType, "multikueue2").Obj()
+		workerCluster2 = utiltesting.MakeMultiKueueCluster("worker2").
+			ControllerName(kueuealpha.MultiKueueControllerName).
+			KubeConfig(kueuealpha.SecretLocationType, "multikueue2").Obj()
 		gomega.Expect(k8sManagerClient.Create(ctx, workerCluster2)).To(gomega.Succeed())
 
 		multiKueueConfig = utiltesting.MakeMultiKueueConfig("multikueueconfig").Clusters("worker1", "worker2").Obj()

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -128,10 +128,14 @@ var _ = ginkgo.Describe("Multikueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 		}
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerMultikueueSecret2)).To(gomega.Succeed())
 
-		workerCluster1 = utiltesting.MakeMultiKueueCluster("worker1").KubeConfig(kueuealpha.SecretLocationType, managerMultikueueSecret1.Name).Obj()
+		workerCluster1 = utiltesting.MakeMultiKueueCluster("worker1").
+			ControllerName(kueuealpha.MultiKueueControllerName).
+			KubeConfig(kueuealpha.SecretLocationType, managerMultikueueSecret1.Name).Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, workerCluster1)).To(gomega.Succeed())
 
-		workerCluster2 = utiltesting.MakeMultiKueueCluster("worker2").KubeConfig(kueuealpha.SecretLocationType, managerMultikueueSecret2.Name).Obj()
+		workerCluster2 = utiltesting.MakeMultiKueueCluster("worker2").
+			ControllerName(kueuealpha.MultiKueueControllerName).
+			KubeConfig(kueuealpha.SecretLocationType, managerMultikueueSecret2.Name).Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, workerCluster2)).To(gomega.Succeed())
 
 		managerMultiKueueConfig = utiltesting.MakeMultiKueueConfig("multikueueconfig").Clusters(workerCluster1.Name, workerCluster2.Name).Obj()
@@ -251,7 +255,9 @@ var _ = ginkgo.Describe("Multikueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 			})
 		})
 
-		cluster := utiltesting.MakeMultiKueueCluster("testing-cluster").KubeConfig(kueuealpha.SecretLocationType, "testing-secret").Obj()
+		cluster := utiltesting.MakeMultiKueueCluster("testing-cluster").
+			ControllerName(kueuealpha.MultiKueueControllerName).
+			KubeConfig(kueuealpha.SecretLocationType, "testing-secret").Obj()
 		ginkgo.By("creating the cluster, its Active state is updated, the admission check's state is updated", func() {
 			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, cluster)).Should(gomega.Succeed())
 			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, cluster) })
@@ -392,7 +398,9 @@ var _ = ginkgo.Describe("Multikueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 			})
 		})
 
-		cluster := utiltesting.MakeMultiKueueCluster("testing-cluster").KubeConfig(kueuealpha.PathLocationType, fsKubeConfig).Obj()
+		cluster := utiltesting.MakeMultiKueueCluster("testing-cluster").
+			ControllerName(kueuealpha.MultiKueueControllerName).
+			KubeConfig(kueuealpha.PathLocationType, fsKubeConfig).Obj()
 		ginkgo.By("creating the cluster, its Active state is updated, the admission check's state is updated", func() {
 			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, cluster)).Should(gomega.Succeed())
 			ginkgo.DeferCleanup(func() error { return managerTestCluster.client.Delete(managerTestCluster.ctx, cluster) })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Provide a way to pass custom controller to multikueue admission check controller.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2349 

#### Special notes for your reviewer:
Consider base branch:  #2373
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```