### PR TITLE
Improve AdmissionCheck documentation

### DIFF
--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -61,7 +61,7 @@ type AdmissionCheckSpec struct {
 	RetryDelayMinutes *int64 `json:"retryDelayMinutes,omitempty"`
 
 	// Parameters identifies a configuration with additional parameters for the
-	// check, e.g. [`ProvisioningRequestConfig`](https://kueue.sigs.k8s.io/docs/admission-check-controllers/provisioning/#provisioningrequest-configuration)
+	// check.
 	// +optional
 	Parameters *AdmissionCheckParametersReference `json:"parameters,omitempty"`
 }

--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -31,8 +31,7 @@ const (
 
 	// CheckStateRejected means that the check will not pass in the near future. It is not worth
 	// to retry.
-	// A workload having at least one check in this state will be evicted if admitted and
-	// will be marked as Finished.
+	// A workload having at least one check in this state will be evicted if admitted and deactivated
 	CheckStateRejected CheckState = "Rejected"
 
 	// CheckStatePending means that the check still hasn't been performed and the state can be

--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -31,7 +31,7 @@ const (
 
 	// CheckStateRejected means that the check will not pass in the near future. It is not worth
 	// to retry.
-	// A workload having at least one check in this state will be evicted if admitted and deactivated
+	// A workload having at least one check in this state will be evicted if admitted and deactivated.
 	CheckStateRejected CheckState = "Rejected"
 
 	// CheckStatePending means that the check still hasn't been performed and the state can be

--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -53,8 +53,8 @@ type AdmissionCheckSpec struct {
 	ControllerName string `json:"controllerName"`
 
 	// RetryDelayMinutes specifies how long to keep the workload suspended after
-	// a failed check (after it transitioned to False). After that the check
-	// state goes to “Unknown”. The default is 15 min.
+	// a failed check (after it transitioned to False). When the delay period has passed, the check
+	// state goes to "Unknown". The default is 15 min.
 	// The default is 15 min.
 	// +optional
 	// +kubebuilder:default=15

--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -52,7 +52,7 @@ type AdmissionCheckSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="field is immutable"
 	ControllerName string `json:"controllerName"`
 
-	// RetryDelayMinutes specifies how long to keep the workload suspended after
+	// RetryDelayMinutes **deprecated** specifies how long to keep the workload suspended after
 	// a failed check (after it transitioned to False). When the delay period has passed, the check
 	// state goes to "Unknown". The default is 15 min.
 	// The default is 15 min.

--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -46,22 +46,22 @@ const (
 
 // AdmissionCheckSpec defines the desired state of AdmissionCheck
 type AdmissionCheckSpec struct {
-	// controllerName is name of the controller which will actually perform
-	// the checks. This is the name with which controller identifies with,
-	// not necessarily a K8S Pod or Deployment name. Cannot be empty.
+	// controllerName identifies the controller that processes the AdmissionCheck,
+	// not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="field is immutable"
 	ControllerName string `json:"controllerName"`
 
-	// RetryDelayMinutes specifies how long to keep the workload suspended
-	// after a failed check (after it transitioned to False).
-	// After that the check state goes to "Unknown".
+	// RetryDelayMinutes specifies how long to keep the workload suspended after
+	// a failed check (after it transitioned to False). After that the check
+	// state goes to “Unknown”. The default is 15 min.
 	// The default is 15 min.
 	// +optional
 	// +kubebuilder:default=15
 	RetryDelayMinutes *int64 `json:"retryDelayMinutes,omitempty"`
 
-	// Parameters identifies the resource providing additional check parameters.
+	// Parameters identifies a configuration with additional parameters for the
+	// check, e.g. [`ProvisioningRequestConfig`](https://kueue.sigs.k8s.io/docs/admission-check-controllers/provisioning/#provisioningrequest-configuration)
 	// +optional
 	Parameters *AdmissionCheckParametersReference `json:"parameters,omitempty"`
 }

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -91,8 +91,8 @@ spec:
                 default: 15
                 description: |-
                   RetryDelayMinutes specifies how long to keep the workload suspended after
-                  a failed check (after it transitioned to False). After that the check
-                  state goes to “Unknown”. The default is 15 min.
+                  a failed check (after it transitioned to False). When the delay period has passed, the check
+                  state goes to "Unknown". The default is 15 min.
                   The default is 15 min.
                 format: int64
                 type: integer

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -90,7 +90,7 @@ spec:
               retryDelayMinutes:
                 default: 15
                 description: |-
-                  RetryDelayMinutes specifies how long to keep the workload suspended after
+                  RetryDelayMinutes **deprecated** specifies how long to keep the workload suspended after
                   a failed check (after it transitioned to False). When the delay period has passed, the check
                   state goes to "Unknown". The default is 15 min.
                   The default is 15 min.

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -56,16 +56,16 @@ spec:
             properties:
               controllerName:
                 description: |-
-                  controllerName is name of the controller which will actually perform
-                  the checks. This is the name with which controller identifies with,
-                  not necessarily a K8S Pod or Deployment name. Cannot be empty.
+                  controllerName identifies the controller that processes the AdmissionCheck,
+                  not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
                 type: string
                 x-kubernetes-validations:
                 - message: field is immutable
                   rule: self == oldSelf
               parameters:
-                description: Parameters identifies the resource providing additional
-                  check parameters.
+                description: |-
+                  Parameters identifies a configuration with additional parameters for the
+                  check, e.g. [`ProvisioningRequestConfig`](https://kueue.sigs.k8s.io/docs/admission-check-controllers/provisioning/#provisioningrequest-configuration)
                 properties:
                   apiGroup:
                     description: ApiGroup is the group for the resource being referenced.
@@ -90,9 +90,9 @@ spec:
               retryDelayMinutes:
                 default: 15
                 description: |-
-                  RetryDelayMinutes specifies how long to keep the workload suspended
-                  after a failed check (after it transitioned to False).
-                  After that the check state goes to "Unknown".
+                  RetryDelayMinutes specifies how long to keep the workload suspended after
+                  a failed check (after it transitioned to False). After that the check
+                  state goes to “Unknown”. The default is 15 min.
                   The default is 15 min.
                 format: int64
                 type: integer

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -65,7 +65,7 @@ spec:
               parameters:
                 description: |-
                   Parameters identifies a configuration with additional parameters for the
-                  check, e.g. [`ProvisioningRequestConfig`](https://kueue.sigs.k8s.io/docs/admission-check-controllers/provisioning/#provisioningrequest-configuration)
+                  check.
                 properties:
                   apiGroup:
                     description: ApiGroup is the group for the resource being referenced.

--- a/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
@@ -76,8 +76,8 @@ spec:
                 default: 15
                 description: |-
                   RetryDelayMinutes specifies how long to keep the workload suspended after
-                  a failed check (after it transitioned to False). After that the check
-                  state goes to “Unknown”. The default is 15 min.
+                  a failed check (after it transitioned to False). When the delay period has passed, the check
+                  state goes to "Unknown". The default is 15 min.
                   The default is 15 min.
                 format: int64
                 type: integer

--- a/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
@@ -75,7 +75,7 @@ spec:
               retryDelayMinutes:
                 default: 15
                 description: |-
-                  RetryDelayMinutes specifies how long to keep the workload suspended after
+                  RetryDelayMinutes **deprecated** specifies how long to keep the workload suspended after
                   a failed check (after it transitioned to False). When the delay period has passed, the check
                   state goes to "Unknown". The default is 15 min.
                   The default is 15 min.

--- a/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
@@ -41,16 +41,16 @@ spec:
             properties:
               controllerName:
                 description: |-
-                  controllerName is name of the controller which will actually perform
-                  the checks. This is the name with which controller identifies with,
-                  not necessarily a K8S Pod or Deployment name. Cannot be empty.
+                  controllerName identifies the controller that processes the AdmissionCheck,
+                  not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
                 type: string
                 x-kubernetes-validations:
                 - message: field is immutable
                   rule: self == oldSelf
               parameters:
-                description: Parameters identifies the resource providing additional
-                  check parameters.
+                description: |-
+                  Parameters identifies a configuration with additional parameters for the
+                  check, e.g. [`ProvisioningRequestConfig`](https://kueue.sigs.k8s.io/docs/admission-check-controllers/provisioning/#provisioningrequest-configuration)
                 properties:
                   apiGroup:
                     description: ApiGroup is the group for the resource being referenced.
@@ -75,9 +75,9 @@ spec:
               retryDelayMinutes:
                 default: 15
                 description: |-
-                  RetryDelayMinutes specifies how long to keep the workload suspended
-                  after a failed check (after it transitioned to False).
-                  After that the check state goes to "Unknown".
+                  RetryDelayMinutes specifies how long to keep the workload suspended after
+                  a failed check (after it transitioned to False). After that the check
+                  state goes to “Unknown”. The default is 15 min.
                   The default is 15 min.
                 format: int64
                 type: integer

--- a/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
@@ -50,7 +50,7 @@ spec:
               parameters:
                 description: |-
                   Parameters identifies a configuration with additional parameters for the
-                  check, e.g. [`ProvisioningRequestConfig`](https://kueue.sigs.k8s.io/docs/admission-check-controllers/provisioning/#provisioningrequest-configuration)
+                  check.
                 properties:
                   apiGroup:
                     description: ApiGroup is the group for the resource being referenced.

--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -16,8 +16,8 @@ Kueue can only admit a Workload when all of the AdmissionChecks have provided a 
 AdmissionCheck is a non-namespaced API object used to define details about an admission check:
 
 - `controllerName` - identifies the controller that processes the AdmissionCheck, not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
-- **retryDelayMinutes (deprecated)** - specifies how long to keep the workload suspended after a failed check (after it transitioned to False). After that the check state goes to "Unknown". The default is 15 min.
-- **parameters** - identifies a configuration with additional parameters for the check.
+- `retryDelayMinutes` (deprecated) - specifies how long to keep the workload suspended after a failed check (after it transitioned to False). After that the check state goes to "Unknown". The default is 15 min.
+- `parameters` - identifies a configuration with additional parameters for the check.
 
 An AdmissionCheck object looks like the following:
 ```yaml

--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -9,14 +9,14 @@ description: >
 AdmissionChecks are a mechanism that allows Kueue to consider additional criteria before admitting a Workload.
 After Kueue has reserved quota for a Workload, Kueue runs all the admission checks configured
 in the ClusterQueue concurrently.
-All of the AdmissionChecks have to provide a positive signal to the Workload before it can be [Admitted](/docs/concepts#admission).
+Kueue can only admit a Workload when all of the AdmissionChecks have provided a positive signal for the Workload.
 
 ### API
 
 AdmissionCheck is a non-namespaced API object used to define details about an admission check:
 
 - **controllerName** - identifies the controller that processes the AdmissionCheck, not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
-- **retryDelayMinutes (deprecated)** - specifies how long to keep the workload suspended after a failed check (after it transitioned to False). After that the check state goes to “Unknown”. The default is 15 min.
+- **retryDelayMinutes (deprecated)** - specifies how long to keep the workload suspended after a failed check (after it transitioned to False). After that the check state goes to "Unknown". The default is 15 min.
 - **parameters** - identifies a configuration with additional parameters for the check.
 
 An AdmissionCheck object looks like the following:
@@ -120,7 +120,7 @@ If any of the Workload's AdmissionCheck is in the `Retry` state:
   - Event `EvictedDueToAdmissionCheck` is emitted
 
 If any of the Workload's AdmissionCheck is in the `Rejected` state:
-  - Workload is deactivated - `workload.Spec.Active` is set to `False`
+  - Workload is deactivated - [`workload.Spec.Active`](docs/concepts/workload/#active) is set to `False`
   - If `Admitted` the Workload is evicted - Workload has an `Evicted` condition in `workload.Status.Condition` with `InactiveWorkload` as a `Reason`
   - If the Workload has `QuotaReservation` it will be released.
   - Event `AdmissionCheckRejected` is emitted

--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -7,7 +7,8 @@ description: >
 ---
 
 AdmissionChecks are a mechanism that allows Kueue to consider additional criteria before admitting a Workload.
-Kueue runs all AdmissionChecks at the same time, after a Workload has reserved the quota.
+After Kueue has reserved quota for a Workload, Kueue runs all the admission checks configured
+in the ClusterQueue concurrently.
 All of the AdmissionChecks have to provide a positive signal to the Workload before it can be [Admitted](/docs/concepts#admission).
 
 ### API
@@ -79,7 +80,7 @@ spec:
 
 ### AdmissionCheckStates
 
-AdmissionCheckStates is representation of the AdmissionCheck's state for a specific Workload.
+An AdmissionCheckState is the representation of the AdmissionCheck's state for a specific Workload.
 AdmissionCheckStates are listed in the Workload's `.status.admissionCheckStates` field.
 
 AdmissionCheck can be in one of the following states:
@@ -115,7 +116,7 @@ Once a Workload has `QuotaReservation` condition set to `True`, and all of its A
 
 If any of the Workload's AdmissionCheck is in the `Retry` state:
   - If `Admitted` the Workload is evicted - Workload will have an `Evicted` condition in `workload.Status.Condition` with `AdmissionCheck` as a `Reason`
-  - If the Workload has `QuotaReservation` it will be release released.
+  - If the Workload has `QuotaReservation` it will be released.
   - Event `EvictedDueToAdmissionCheck` is emitted
 
 If any of the Workload's AdmissionCheck is in the `Rejected` state:

--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -15,8 +15,8 @@ All of the AdmissionChecks have to provide a positive signal to the Workload bef
 AdmissionCheck is a non-namespaced API object used to define details about an admission check:
 
 - **controllerName** - identifies the controller that processes the AdmissionCheck, not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
-- **retryDelayMinutes (deprecated)g** - Specifies how long to keep the workload suspended after a failed check (after it transitioned to False). After that the check state goes to “Unknown”. The default is 15 min.
-- **parameters** - identifies additional resources providing additional parameters for the check, e.g. [`ProvisioningRequestConfig`](/docs/admission-check-controllers/provisioning/#provisioningrequest-configuration)
+- **retryDelayMinutes (deprecated)** - Specifies how long to keep the workload suspended after a failed check (after it transitioned to False). After that the check state goes to “Unknown”. The default is 15 min.
+- **parameters** - identifies a configuration with additional parameters for the check, e.g. [`ProvisioningRequestConfig`](/docs/admission-check-controllers/provisioning/#provisioningrequest-configuration)
 
 An AdmissionCheck object looks like the following:
 ```yaml
@@ -114,8 +114,8 @@ If a Workload is admitted, adding a new AdmissionCheck does not evict the Worklo
 Once a Workload has `QuotaReservation` condition set to `True`, and all of its AdmissionChecks are in `Ready` state the Workload will become `Admitted`.
 
 If any of the Workload's AdmissionCheck is in the `Retry` state:
-  - If `Admitted` th Workload is evicted - Workload will have an `Evicted` condition in `workload.Status.Condition` with `AdmissionCheck` as a `Reason`
-  - If the Workload has `QuotaReservation` it will be release released.
+  - If `Admitted` the Workload is evicted - Workload will have an `Evicted` condition in `workload.Status.Condition` with `AdmissionCheck` as a `Reason`
+  - If the Workload has `QuotaReservation` it will be released.
   - Event is emitted
 
 If any of the Workload's AdmissionCheck is in the `Rejected` state:

--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -15,7 +15,7 @@ Kueue can only admit a Workload when all of the AdmissionChecks have provided a 
 
 AdmissionCheck is a non-namespaced API object used to define details about an admission check:
 
-- **controllerName** - identifies the controller that processes the AdmissionCheck, not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
+- `controllerName` - identifies the controller that processes the AdmissionCheck, not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
 - **retryDelayMinutes (deprecated)** - specifies how long to keep the workload suspended after a failed check (after it transitioned to False). After that the check state goes to "Unknown". The default is 15 min.
 - **parameters** - identifies a configuration with additional parameters for the check.
 

--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -15,7 +15,7 @@ All of the AdmissionChecks have to provide a positive signal to the Workload bef
 AdmissionCheck is a non-namespaced API object used to define details about an admission check:
 
 - **controllerName** - identifies the controller that processes the AdmissionCheck, not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
-- **retryDelayMinutes (deprecated)** - Specifies how long to keep the workload suspended after a failed check (after it transitioned to False). After that the check state goes to “Unknown”. The default is 15 min.
+- **retryDelayMinutes (deprecated)** - specifies how long to keep the workload suspended after a failed check (after it transitioned to False). After that the check state goes to “Unknown”. The default is 15 min.
 - **parameters** - identifies a configuration with additional parameters for the check, e.g. [`ProvisioningRequestConfig`](/docs/admission-check-controllers/provisioning/#provisioningrequest-configuration)
 
 An AdmissionCheck object looks like the following:
@@ -115,14 +115,14 @@ Once a Workload has `QuotaReservation` condition set to `True`, and all of its A
 
 If any of the Workload's AdmissionCheck is in the `Retry` state:
   - If `Admitted` the Workload is evicted - Workload will have an `Evicted` condition in `workload.Status.Condition` with `AdmissionCheck` as a `Reason`
-  - If the Workload has `QuotaReservation` it will be released.
-  - Event is emitted
+  - If the Workload has `QuotaReservation` it will be release released.
+  - Event `EvictedDueToAdmissionCheck` is emitted
 
 If any of the Workload's AdmissionCheck is in the `Rejected` state:
   - Workload is deactivated - `workload.Spec.Active` is set to `False`
   - If `Admitted` the Workload is evicted - Workload has an `Evicted` condition in `workload.Status.Condition` with `InactiveWorkload` as a `Reason`
   - If the Workload has `QuotaReservation` it will be released.
-  - Event is emitted
+  - Event `AdmissionCheckRejected` is emitted
 
 ## What's next?
 

--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -16,7 +16,7 @@ AdmissionCheck is a non-namespaced API object used to define details about an ad
 
 - **controllerName** - identifies the controller that processes the AdmissionCheck, not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
 - **retryDelayMinutes (deprecated)** - specifies how long to keep the workload suspended after a failed check (after it transitioned to False). After that the check state goes to “Unknown”. The default is 15 min.
-- **parameters** - identifies a configuration with additional parameters for the check, e.g. [`ProvisioningRequestConfig`](/docs/admission-check-controllers/provisioning/#provisioningrequest-configuration)
+- **parameters** - identifies a configuration with additional parameters for the check.
 
 An AdmissionCheck object looks like the following:
 ```yaml

--- a/site/content/en/docs/concepts/admission_check.md
+++ b/site/content/en/docs/concepts/admission_check.md
@@ -1,23 +1,22 @@
 ---
 title: "Admission Check"
-date: 2023-10-05
+date: 2024-13-06
 weight: 6
 description: >
-  A mechanism allowing internal or external components to influence the timing of
-  workloads admission.
+  Mechanism allowing internal or external components to influence the workload's admission.
 ---
 
 AdmissionChecks are a mechanism that allows Kueue to consider additional criteria before admitting a Workload.
-When a ClusterQueue has AdmissionChecks configured, each of the checks has to provide a
-positive signal to the Workload before it can be [Admitted](https://kueue.sigs.k8s.io/docs/concepts#admission).
+Kueue runs all AdmissionChecks at the same time, after a Workload has reserved the quota.
+All of the AdmissionChecks have to provide a positive signal to the Workload before it can be [Admitted](/docs/concepts#admission).
 
-### AdmissionCheck
+### API
 
-AdmissionCheck is a non-namespaced API object used to define details about an admission check like:
+AdmissionCheck is a non-namespaced API object used to define details about an admission check:
 
-- **controllerName** - It's an identifier for the controller that processes this AdmissionCheck, not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
-- **retryDelayMinutes** - Specifies how long to keep the workload suspended after a failed check (after it transitioned to False). After that the check state goes to "Unknown". The default is 15 min.
-- **parameters** - Identifies an additional resource providing additional parameters for the check.
+- **controllerName** - identifies the controller that processes the AdmissionCheck, not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
+- **retryDelayMinutes (deprecated)g** - Specifies how long to keep the workload suspended after a failed check (after it transitioned to False). After that the check state goes to “Unknown”. The default is 15 min.
+- **parameters** - identifies additional resources providing additional parameters for the check, e.g. [`ProvisioningRequestConfig`](/docs/admission-check-controllers/provisioning/#provisioningrequest-configuration)
 
 An AdmissionCheck object looks like the following:
 ```yaml
@@ -27,7 +26,6 @@ metadata:
   name: prov-test
 spec:
   controllerName: kueue.x-k8s.io/provisioning-request
-  retryDelayMinutes: 15
   parameters:
     apiGroup: kueue.x-k8s.io
     kind: ProvisioningRequestConfig
@@ -47,9 +45,9 @@ with a specific ResourceFlavor. To specify ResourceFlavors that an AdmissionChec
 
 Only one of the above-mentioned fields can be specified at the time.
 
-See examples below:
+#### Examples
 
-Using `.spec.admissionChecks`
+##### Using `.spec.admissionChecks`
 
 ```yaml
 apiVersion: kueue.x-k8s.io/v1beta1
@@ -62,7 +60,7 @@ spec:
   - sample-prov
 ```
 
-Using `.spec.admissionCheckStrategy`
+##### Using `.spec.admissionCheckStrategy`
 
 ```yaml
 apiVersion: kueue.x-k8s.io/v1beta1
@@ -79,13 +77,18 @@ spec:
 ```
 
 
-### AdmissionCheckState
+### AdmissionCheckStates
 
-AdmissionCheckState is the way the state of an AdmissionCheck for a specific Workload is tracked.
-
+AdmissionCheckStates is representation of the AdmissionCheck's state for a specific Workload.
 AdmissionCheckStates are listed in the Workload's `.status.admissionCheckStates` field.
 
-The status of a Workload that has pending AdmissionChecks looks like the following:
+AdmissionCheck can be in one of the following states:
+- `Pending` - the check still hasn't been performed/hasn't finished
+- `Ready` - the check has passed
+- `Retry` - the check cannot pass at the moment, it will back off (possibly allowing other to try, unblock quota) and retry.
+- `Rejected` - the check will not pass in the near future. It is not worth to retry.
+
+The status of a Workload that has `Pending` AdmissionChecks is similar to the following:
 ```yaml
 status:
   admission:
@@ -98,27 +101,28 @@ status:
     - annotations:
         cluster-autoscaler.kubernetes.io/consume-provisioning-request: job-prov-job-9815b-sample-prov
       name: main
-    state: Ready
+    state: Pending
   <...>
 ```
 
-A list of states being maintained in the Status of all the monitored Workloads.
+Kueue ensures that the list of the Workload's AdmissionCheckStates is in sync with the list of the Workload's ClusterQueue.
+When a user adds a new AdmissionCheck, Kueue adds it to the Workload's AdmissionCheckStates with the `Pending` state.
+If a Workload is admitted, adding a new AdmissionCheck does not evict the Workload.
 
-Kueue ensures that the list of the Workloads AdmissionCheckStates is in sync with the list of its associated ClusterQueue, Kueue adds new checks with the `Pending` state.
+### Admitting Workload with AdmissionChecks
 
-- Once a workload has QuotaReservation and all its AdmissionChecks are in "Ready" state it will become Admitted.
-- If at least one of the Workloads AdmissionCheck is in the `Retry` state.
-  - If `Admitted` the workload is evicted.
-  - If the workload has `QuotaReservation` it will be release released.
-- If at least one of the Workloads AdmissionCheck is in the `Rejected`:
-  - If `Admitted` the workload is evicted.
-  - If the workload has `QuotaReservation` it will be release released.
-  - The workload is marked as 'Finished' with a relevant failure message.
+Once a Workload has `QuotaReservation` condition set to `True`, and all of its AdmissionChecks are in `Ready` state the Workload will become `Admitted`.
 
-### Admission Check Controller
+If any of the Workload's AdmissionCheck is in the `Retry` state:
+  - If `Admitted` th Workload is evicted - Workload will have an `Evicted` condition in `workload.Status.Condition` with `AdmissionCheck` as a `Reason`
+  - If the Workload has `QuotaReservation` it will be release released.
+  - Event is emitted
 
-Is a component that monitors Workloads maintaining the content of its specific `admissionCheckStates` and the `Active` condition of the AdmissionChecks it's  controlling.
-The logic for how an AdmissionCheck changes states is not part of Kueue.
+If any of the Workload's AdmissionCheck is in the `Rejected` state:
+  - Workload is deactivated - `workload.Spec.Active` is set to `False`
+  - If `Admitted` the Workload is evicted - Workload has an `Evicted` condition in `workload.Status.Condition` with `InactiveWorkload` as a `Reason`
+  - If the Workload has `QuotaReservation` it will be released.
+  - Event is emitted
 
 ## What's next?
 

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -341,8 +341,8 @@ not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.</p>
 </td>
 <td>
    <p>RetryDelayMinutes specifies how long to keep the workload suspended after
-a failed check (after it transitioned to False). After that the check
-state goes to “Unknown”. The default is 15 min.
+a failed check (after it transitioned to False). When the delay period has passed, the check
+state goes to &quot;Unknown&quot;. The default is 15 min.
 The default is 15 min.</p>
 </td>
 </tr>

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -351,7 +351,7 @@ The default is 15 min.</p>
 </td>
 <td>
    <p>Parameters identifies a configuration with additional parameters for the
-check, e.g. <a href="https://kueue.sigs.k8s.io/docs/admission-check-controllers/provisioning/#provisioningrequest-configuration"><code>ProvisioningRequestConfig</code></a></p>
+check.</p>
 </td>
 </tr>
 </tbody>

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -332,18 +332,17 @@ when this workloadPriorityClass should be used.</p>
 <code>string</code>
 </td>
 <td>
-   <p>controllerName is name of the controller which will actually perform
-the checks. This is the name with which controller identifies with,
-not necessarily a K8S Pod or Deployment name. Cannot be empty.</p>
+   <p>controllerName identifies the controller that processes the AdmissionCheck,
+not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.</p>
 </td>
 </tr>
 <tr><td><code>retryDelayMinutes</code><br/>
 <code>int64</code>
 </td>
 <td>
-   <p>RetryDelayMinutes specifies how long to keep the workload suspended
-after a failed check (after it transitioned to False).
-After that the check state goes to &quot;Unknown&quot;.
+   <p>RetryDelayMinutes specifies how long to keep the workload suspended after
+a failed check (after it transitioned to False). After that the check
+state goes to “Unknown”. The default is 15 min.
 The default is 15 min.</p>
 </td>
 </tr>
@@ -351,7 +350,8 @@ The default is 15 min.</p>
 <a href="#kueue-x-k8s-io-v1beta1-AdmissionCheckParametersReference"><code>AdmissionCheckParametersReference</code></a>
 </td>
 <td>
-   <p>Parameters identifies the resource providing additional check parameters.</p>
+   <p>Parameters identifies a configuration with additional parameters for the
+check, e.g. <a href="https://kueue.sigs.k8s.io/docs/admission-check-controllers/provisioning/#provisioningrequest-configuration"><code>ProvisioningRequestConfig</code></a></p>
 </td>
 </tr>
 </tbody>

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -340,7 +340,7 @@ not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.</p>
 <code>int64</code>
 </td>
 <td>
-   <p>RetryDelayMinutes specifies how long to keep the workload suspended after
+   <p>RetryDelayMinutes <strong>deprecated</strong> specifies how long to keep the workload suspended after
 a failed check (after it transitioned to False). When the delay period has passed, the check
 state goes to &quot;Unknown&quot;. The default is 15 min.
 The default is 15 min.</p>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
AdmissionCheck documentation needed an update as it was outdated. Main changes are:
- `retryDelayMinutes` field is deprecated
- AdmissionChecks can be configured per ResourceFlavor
- If AdmissionChecks gets `Rejected` a Workload is deactivated

Additionally it was lacking documentation on AdmissionCheck states (`Pending`,`Ready`, `Retry`, `Rejected`).
I've also fixed some typos.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```