### PR TITLE
Distinguish between Preemption due to reclamation and fair sharing

### DIFF
--- a/pkg/scheduler/logging.go
+++ b/pkg/scheduler/logging.go
@@ -37,7 +37,7 @@ func logAdmissionAttemptIfVerbose(log logr.Logger, e *entry) {
 	}
 	if log.V(4).Enabled() {
 		args = append(args, "nominatedAssignment", e.assignment)
-		args = append(args, "preempted", preemption.GetWorkloadReferences(e.preemptionTargets))
+		args = append(args, "preempted", getWorkloadReferences(e.preemptionTargets))
 	}
 	logV.Info("Workload evaluated for admission", args...)
 }
@@ -46,4 +46,15 @@ func logSnapshotIfVerbose(log logr.Logger, s *cache.Snapshot) {
 	if logV := log.V(6); logV.Enabled() {
 		s.Log(logV)
 	}
+}
+
+func getWorkloadReferences(targets []*preemption.Target) []klog.ObjectRef {
+	if len(targets) == 0 {
+		return nil
+	}
+	keys := make([]klog.ObjectRef, len(targets))
+	for i, t := range targets {
+		keys[i] = klog.KObj(t.WorkloadInfo.Obj)
+	}
+	return keys
 }

--- a/pkg/scheduler/logging.go
+++ b/pkg/scheduler/logging.go
@@ -22,8 +22,6 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
-	"sigs.k8s.io/kueue/pkg/util/slices"
-	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 func logAdmissionAttemptIfVerbose(log logr.Logger, e *entry) {
@@ -39,9 +37,7 @@ func logAdmissionAttemptIfVerbose(log logr.Logger, e *entry) {
 	}
 	if log.V(4).Enabled() {
 		args = append(args, "nominatedAssignment", e.assignment)
-		args = append(args, "preempted", workload.References(
-			slices.Map(e.preemptionTargets, func(p **preemption.Target) *workload.Info { return (*p).Wl }),
-		))
+		args = append(args, "preempted", preemption.GetWorkloadReferences(e.preemptionTargets))
 	}
 	logV.Info("Workload evaluated for admission", args...)
 }

--- a/pkg/scheduler/logging.go
+++ b/pkg/scheduler/logging.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
+	"sigs.k8s.io/kueue/pkg/util/slices"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -37,7 +39,9 @@ func logAdmissionAttemptIfVerbose(log logr.Logger, e *entry) {
 	}
 	if log.V(4).Enabled() {
 		args = append(args, "nominatedAssignment", e.assignment)
-		args = append(args, "preempted", workload.References(e.preemptionTargets))
+		args = append(args, "preempted", workload.References(
+			slices.Map(e.preemptionTargets, func(p **preemption.Target) *workload.Info { return (*p).Wl }),
+		))
 	}
 	logV.Info("Workload evaluated for admission", args...)
 }

--- a/pkg/scheduler/logging.go
+++ b/pkg/scheduler/logging.go
@@ -22,6 +22,7 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
+	"sigs.k8s.io/kueue/pkg/util/slices"
 )
 
 func logAdmissionAttemptIfVerbose(log logr.Logger, e *entry) {
@@ -49,12 +50,5 @@ func logSnapshotIfVerbose(log logr.Logger, s *cache.Snapshot) {
 }
 
 func getWorkloadReferences(targets []*preemption.Target) []klog.ObjectRef {
-	if len(targets) == 0 {
-		return nil
-	}
-	keys := make([]klog.ObjectRef, len(targets))
-	for i, t := range targets {
-		keys[i] = klog.KObj(t.WorkloadInfo.Obj)
-	}
-	return keys
+	return slices.Map(targets, func(t **preemption.Target) klog.ObjectRef { return klog.KObj((*t).WorkloadInfo.Obj) })
 }

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -18,6 +18,7 @@ package preemption
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync"
 	"testing"
@@ -1440,6 +1441,9 @@ func TestPreemption(t *testing.T) {
 			gotPreempted := sets.New[string]()
 			broadcaster := record.NewBroadcaster()
 			scheme := runtime.NewScheme()
+			if err := kueue.AddToScheme(scheme); err != nil {
+				t.Fatalf("Failed adding kueue scheme: %v", err)
+			}
 			recorder := broadcaster.NewRecorder(scheme, corev1.EventSource{Component: constants.AdmissionName})
 			preemptor := New(cl, workload.Ordering{}, recorder, config.FairSharing{})
 			preemptor.applyPreemption = func(ctx context.Context, w *kueue.Workload, _, _ string) error {
@@ -1456,7 +1460,7 @@ func TestPreemption(t *testing.T) {
 			wlInfo.ClusterQueue = tc.targetCQ
 			targetClusterQueue := snapshot.ClusterQueues[wlInfo.ClusterQueue]
 			targets := preemptor.GetTargets(log, *wlInfo, tc.assignment, &snapshot)
-			preempted, err := preemptor.IssuePreemptions(ctx, wlInfo, targets, targetClusterQueue, true)
+			preempted, err := preemptor.IssuePreemptions(ctx, wlInfo, targets, targetClusterQueue)
 			if err != nil {
 				t.Fatalf("Failed doing preemption")
 			}
@@ -1548,7 +1552,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      unitWl.Clone().Name("c_incoming").Obj(),
 			targetCQ:      "c",
-			wantPreempted: sets.New("/b1"),
+			wantPreempted: sets.New(targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin)),
 		},
 		"can reclaim from queue using less, if taking the latest workload from user using the most isn't enough": {
 			clusterQueues: baseCQs,
@@ -1560,7 +1564,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      utiltesting.MakeWorkload("c_incoming", "").Request(corev1.ResourceCPU, "3").SimpleReserveQuota("a", "default", now).Obj(),
 			targetCQ:      "c",
-			wantPreempted: sets.New("/a1"), // attempts to preempt b1, but it's not enough.
+			wantPreempted: sets.New(targetKeyReasonScope("/a1", InCohortFairSharingReason, CohortOrigin)), // attempts to preempt b1, but it's not enough.
 		},
 		"reclaim borrowable quota from user using the most": {
 			clusterQueues: baseCQs,
@@ -1577,7 +1581,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      unitWl.Clone().Name("a_incoming").Obj(),
 			targetCQ:      "a",
-			wantPreempted: sets.New("/b1"),
+			wantPreempted: sets.New(targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin)),
 		},
 		"preempt one from each CQ borrowing": {
 			clusterQueues: baseCQs,
@@ -1589,9 +1593,12 @@ func TestFairPreemptions(t *testing.T) {
 				*utiltesting.MakeWorkload("b2", "").Request(corev1.ResourceCPU, "0.5").SimpleReserveQuota("b", "default", now).Obj(),
 				*utiltesting.MakeWorkload("b3", "").Request(corev1.ResourceCPU, "3").SimpleReserveQuota("b", "default", now).Obj(),
 			},
-			incoming:      utiltesting.MakeWorkload("c_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
-			targetCQ:      "c",
-			wantPreempted: sets.New("/a1", "/b1"),
+			incoming: utiltesting.MakeWorkload("c_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
+			targetCQ: "c",
+			wantPreempted: sets.New(
+				targetKeyReasonScope("/a1", InCohortFairSharingReason, CohortOrigin),
+				targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin),
+			),
 		},
 		"can't preempt when everyone under nominal": {
 			clusterQueues: baseCQs,
@@ -1637,9 +1644,12 @@ func TestFairPreemptions(t *testing.T) {
 				*unitWl.Clone().Name("b4").SimpleReserveQuota("b", "default", now).Obj(),
 				*unitWl.Clone().Name("b5").SimpleReserveQuota("b", "default", now).Obj(),
 			},
-			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
-			targetCQ:      "a",
-			wantPreempted: sets.New("/a1_low", "/a2_low"),
+			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
+			targetCQ: "a",
+			wantPreempted: sets.New(
+				targetKeyReasonScope("/a1_low", InClusterQueueReason, ClusterQueueOrigin),
+				targetKeyReasonScope("/a2_low", InClusterQueueReason, ClusterQueueOrigin),
+			),
 		},
 		"can preempt a combination of same CQ and highest user": {
 			clusterQueues: baseCQs,
@@ -1654,9 +1664,12 @@ func TestFairPreemptions(t *testing.T) {
 				*unitWl.Clone().Name("b5").SimpleReserveQuota("b", "default", now).Obj(),
 				*unitWl.Clone().Name("b6").SimpleReserveQuota("b", "default", now).Obj(),
 			},
-			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
-			targetCQ:      "a",
-			wantPreempted: sets.New("/a_low", "/b1"),
+			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
+			targetCQ: "a",
+			wantPreempted: sets.New(
+				targetKeyReasonScope("/a_low", InClusterQueueReason, ClusterQueueOrigin),
+				targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin),
+			),
 		},
 		"preempt huge workload if there is no other option, as long as the target CQ gets a lower share": {
 			clusterQueues: baseCQs,
@@ -1665,7 +1678,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ:      "a",
-			wantPreempted: sets.New("/b1"),
+			wantPreempted: sets.New(targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin)),
 		},
 		"can't preempt huge workload if the incoming is also huge": {
 			clusterQueues: baseCQs,
@@ -1694,9 +1707,12 @@ func TestFairPreemptions(t *testing.T) {
 				*utiltesting.MakeWorkload("b1", "").Request(corev1.ResourceCPU, "3").SimpleReserveQuota("b", "default", now).Obj(),
 				*utiltesting.MakeWorkload("b2", "").Request(corev1.ResourceCPU, "3").SimpleReserveQuota("b", "default", now).Obj(),
 			},
-			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "4").Obj(),
-			targetCQ:      "a",
-			wantPreempted: sets.New("/a1_low", "/b1"),
+			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "4").Obj(),
+			targetCQ: "a",
+			wantPreempted: sets.New(
+				targetKeyReasonScope("/a1_low", InClusterQueueReason, ClusterQueueOrigin),
+				targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin),
+			),
 		},
 		"prefer to preempt workloads that don't make the target CQ have the biggest share": {
 			clusterQueues: baseCQs,
@@ -1709,7 +1725,7 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "3.5").Obj(),
 			targetCQ: "a",
 			// It would have been possible to preempt "/b1" under rule S2-b, but S2-a was possible first.
-			wantPreempted: sets.New("/b2"),
+			wantPreempted: sets.New(targetKeyReasonScope("/b2", InCohortFairSharingReason, CohortOrigin)),
 		},
 		"preempt from different cluster queues if the end result has a smaller max share": {
 			clusterQueues: baseCQs,
@@ -1719,9 +1735,12 @@ func TestFairPreemptions(t *testing.T) {
 				*utiltesting.MakeWorkload("c1", "").Request(corev1.ResourceCPU, "2").SimpleReserveQuota("c", "default", now).Obj(),
 				*utiltesting.MakeWorkload("c2", "").Request(corev1.ResourceCPU, "2.5").SimpleReserveQuota("c", "default", now).Obj(),
 			},
-			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "3.5").Obj(),
-			targetCQ:      "a",
-			wantPreempted: sets.New("/b1", "/c1"),
+			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "3.5").Obj(),
+			targetCQ: "a",
+			wantPreempted: sets.New(
+				targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin),
+				targetKeyReasonScope("/c1", InCohortFairSharingReason, CohortOrigin),
+			),
 		},
 		"scenario above does not flap": {
 			clusterQueues: baseCQs,
@@ -1756,9 +1775,12 @@ func TestFairPreemptions(t *testing.T) {
 				*unitWl.Clone().Name("preemptible2").Priority(-3).SimpleReserveQuota("preemptible", "default", now).Obj(),
 				*unitWl.Clone().Name("preemptible3").Priority(-3).SimpleReserveQuota("preemptible", "default", now).Obj(),
 			},
-			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
-			targetCQ:      "a",
-			wantPreempted: sets.New("/preemptible1", "/preemptible2"),
+			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
+			targetCQ: "a",
+			wantPreempted: sets.New(
+				targetKeyReasonScope("/preemptible1", InCohortFairSharingReason, CohortOrigin),
+				targetKeyReasonScope("/preemptible2", InCohortFairSharingReason, CohortOrigin),
+			),
 		},
 		"preempt lower priority first, even if big": {
 			clusterQueues: baseCQs,
@@ -1770,7 +1792,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "1").Obj(),
 			targetCQ:      "a",
-			wantPreempted: sets.New("/b_low"),
+			wantPreempted: sets.New(targetKeyReasonScope("/b_low", InCohortFairSharingReason, CohortOrigin)),
 		},
 		"preempt workload that doesn't transfer the imbalance, even if high priority": {
 			clusterQueues: baseCQs,
@@ -1782,7 +1804,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "1").Obj(),
 			targetCQ:      "a",
-			wantPreempted: sets.New("/b_high"),
+			wantPreempted: sets.New(targetKeyReasonScope("/b_high", InCohortFairSharingReason, CohortOrigin)),
 		},
 		"CQ with higher weight can preempt more": {
 			clusterQueues: []*kueue.ClusterQueue{
@@ -1826,9 +1848,12 @@ func TestFairPreemptions(t *testing.T) {
 				*unitWl.Clone().Name("b5").SimpleReserveQuota("b", "default", now).Obj(),
 				*unitWl.Clone().Name("b6").SimpleReserveQuota("b", "default", now).Obj(),
 			},
-			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
-			targetCQ:      "a",
-			wantPreempted: sets.New("/b1", "/b2"),
+			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
+			targetCQ: "a",
+			wantPreempted: sets.New(
+				targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin),
+				targetKeyReasonScope("/b2", InCohortFairSharingReason, CohortOrigin),
+			),
 		},
 		"can preempt anything borrowing from CQ with 0 weight": {
 			clusterQueues: []*kueue.ClusterQueue{
@@ -1872,9 +1897,13 @@ func TestFairPreemptions(t *testing.T) {
 				*unitWl.Clone().Name("b5").SimpleReserveQuota("b", "default", now).Obj(),
 				*unitWl.Clone().Name("b6").SimpleReserveQuota("b", "default", now).Obj(),
 			},
-			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "3").Obj(),
-			targetCQ:      "a",
-			wantPreempted: sets.New("/b1", "/b2", "/b3"),
+			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "3").Obj(),
+			targetCQ: "a",
+			wantPreempted: sets.New(
+				targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin),
+				targetKeyReasonScope("/b2", InCohortFairSharingReason, CohortOrigin),
+				targetKeyReasonScope("/b3", InCohortFairSharingReason, CohortOrigin),
+			),
 		},
 		"can't preempt nominal from CQ with 0 weight": {
 			clusterQueues: []*kueue.ClusterQueue{
@@ -1948,14 +1977,18 @@ func TestFairPreemptions(t *testing.T) {
 					},
 				},
 			), &snapshot)
-			gotTargets := sets.New(slices.Map(targets, func(w **workload.Info) string {
-				return workload.Key((*w).Obj)
+			gotTargets := sets.New(slices.Map(targets, func(t **Target) string {
+				return targetKeyReasonScope(workload.Key((*t).Wl.Obj), (*t).Reason, (*t).Scope)
 			})...)
 			if diff := cmp.Diff(tc.wantPreempted, gotTargets, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Issued preemptions (-want,+got):\n%s", diff)
 			}
 		})
 	}
+}
+
+func targetKeyReasonScope(key, reason, scope string) string {
+	return fmt.Sprintf("%s:%s:%s", key, reason, scope)
 }
 
 func TestCandidatesOrdering(t *testing.T) {

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -1456,7 +1456,7 @@ func TestPreemption(t *testing.T) {
 			wlInfo.ClusterQueue = tc.targetCQ
 			targetClusterQueue := snapshot.ClusterQueues[wlInfo.ClusterQueue]
 			targets := preemptor.GetTargets(log, *wlInfo, tc.assignment, &snapshot)
-			preempted, err := preemptor.IssuePreemptions(ctx, wlInfo, targets, targetClusterQueue)
+			preempted, err := preemptor.IssuePreemptions(ctx, wlInfo, targets, targetClusterQueue, true)
 			if err != nil {
 				t.Fatalf("Failed doing preemption")
 			}

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -1552,7 +1552,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      unitWl.Clone().Name("c_incoming").Obj(),
 			targetCQ:      "c",
-			wantPreempted: sets.New(targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin)),
+			wantPreempted: sets.New(targetKeyReasonScope("/b1", InCohortFairSharingReason)),
 		},
 		"can reclaim from queue using less, if taking the latest workload from user using the most isn't enough": {
 			clusterQueues: baseCQs,
@@ -1564,7 +1564,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      utiltesting.MakeWorkload("c_incoming", "").Request(corev1.ResourceCPU, "3").SimpleReserveQuota("a", "default", now).Obj(),
 			targetCQ:      "c",
-			wantPreempted: sets.New(targetKeyReasonScope("/a1", InCohortFairSharingReason, CohortOrigin)), // attempts to preempt b1, but it's not enough.
+			wantPreempted: sets.New(targetKeyReasonScope("/a1", InCohortFairSharingReason)), // attempts to preempt b1, but it's not enough.
 		},
 		"reclaim borrowable quota from user using the most": {
 			clusterQueues: baseCQs,
@@ -1581,7 +1581,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      unitWl.Clone().Name("a_incoming").Obj(),
 			targetCQ:      "a",
-			wantPreempted: sets.New(targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin)),
+			wantPreempted: sets.New(targetKeyReasonScope("/b1", InCohortFairSharingReason)),
 		},
 		"preempt one from each CQ borrowing": {
 			clusterQueues: baseCQs,
@@ -1596,8 +1596,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("c_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ: "c",
 			wantPreempted: sets.New(
-				targetKeyReasonScope("/a1", InCohortFairSharingReason, CohortOrigin),
-				targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin),
+				targetKeyReasonScope("/a1", InCohortFairSharingReason),
+				targetKeyReasonScope("/b1", InCohortFairSharingReason),
 			),
 		},
 		"can't preempt when everyone under nominal": {
@@ -1647,8 +1647,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReasonScope("/a1_low", InClusterQueueReason, ClusterQueueOrigin),
-				targetKeyReasonScope("/a2_low", InClusterQueueReason, ClusterQueueOrigin),
+				targetKeyReasonScope("/a1_low", InClusterQueueReason),
+				targetKeyReasonScope("/a2_low", InClusterQueueReason),
 			),
 		},
 		"can preempt a combination of same CQ and highest user": {
@@ -1667,8 +1667,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReasonScope("/a_low", InClusterQueueReason, ClusterQueueOrigin),
-				targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin),
+				targetKeyReasonScope("/a_low", InClusterQueueReason),
+				targetKeyReasonScope("/b1", InCohortFairSharingReason),
 			),
 		},
 		"preempt huge workload if there is no other option, as long as the target CQ gets a lower share": {
@@ -1678,7 +1678,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ:      "a",
-			wantPreempted: sets.New(targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin)),
+			wantPreempted: sets.New(targetKeyReasonScope("/b1", InCohortFairSharingReason)),
 		},
 		"can't preempt huge workload if the incoming is also huge": {
 			clusterQueues: baseCQs,
@@ -1710,8 +1710,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "4").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReasonScope("/a1_low", InClusterQueueReason, ClusterQueueOrigin),
-				targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin),
+				targetKeyReasonScope("/a1_low", InClusterQueueReason),
+				targetKeyReasonScope("/b1", InCohortFairSharingReason),
 			),
 		},
 		"prefer to preempt workloads that don't make the target CQ have the biggest share": {
@@ -1725,7 +1725,7 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "3.5").Obj(),
 			targetCQ: "a",
 			// It would have been possible to preempt "/b1" under rule S2-b, but S2-a was possible first.
-			wantPreempted: sets.New(targetKeyReasonScope("/b2", InCohortFairSharingReason, CohortOrigin)),
+			wantPreempted: sets.New(targetKeyReasonScope("/b2", InCohortFairSharingReason)),
 		},
 		"preempt from different cluster queues if the end result has a smaller max share": {
 			clusterQueues: baseCQs,
@@ -1738,8 +1738,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "3.5").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin),
-				targetKeyReasonScope("/c1", InCohortFairSharingReason, CohortOrigin),
+				targetKeyReasonScope("/b1", InCohortFairSharingReason),
+				targetKeyReasonScope("/c1", InCohortFairSharingReason),
 			),
 		},
 		"scenario above does not flap": {
@@ -1778,8 +1778,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReasonScope("/preemptible1", InCohortFairSharingReason, CohortOrigin),
-				targetKeyReasonScope("/preemptible2", InCohortFairSharingReason, CohortOrigin),
+				targetKeyReasonScope("/preemptible1", InCohortFairSharingReason),
+				targetKeyReasonScope("/preemptible2", InCohortReclaimWhileBorrowingReason),
 			),
 		},
 		"preempt lower priority first, even if big": {
@@ -1792,7 +1792,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "1").Obj(),
 			targetCQ:      "a",
-			wantPreempted: sets.New(targetKeyReasonScope("/b_low", InCohortFairSharingReason, CohortOrigin)),
+			wantPreempted: sets.New(targetKeyReasonScope("/b_low", InCohortFairSharingReason)),
 		},
 		"preempt workload that doesn't transfer the imbalance, even if high priority": {
 			clusterQueues: baseCQs,
@@ -1804,7 +1804,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "1").Obj(),
 			targetCQ:      "a",
-			wantPreempted: sets.New(targetKeyReasonScope("/b_high", InCohortFairSharingReason, CohortOrigin)),
+			wantPreempted: sets.New(targetKeyReasonScope("/b_high", InCohortFairSharingReason)),
 		},
 		"CQ with higher weight can preempt more": {
 			clusterQueues: []*kueue.ClusterQueue{
@@ -1851,8 +1851,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin),
-				targetKeyReasonScope("/b2", InCohortFairSharingReason, CohortOrigin),
+				targetKeyReasonScope("/b1", InCohortFairSharingReason),
+				targetKeyReasonScope("/b2", InCohortFairSharingReason),
 			),
 		},
 		"can preempt anything borrowing from CQ with 0 weight": {
@@ -1900,9 +1900,9 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "3").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReasonScope("/b1", InCohortFairSharingReason, CohortOrigin),
-				targetKeyReasonScope("/b2", InCohortFairSharingReason, CohortOrigin),
-				targetKeyReasonScope("/b3", InCohortFairSharingReason, CohortOrigin),
+				targetKeyReasonScope("/b1", InCohortFairSharingReason),
+				targetKeyReasonScope("/b2", InCohortFairSharingReason),
+				targetKeyReasonScope("/b3", InCohortFairSharingReason),
 			),
 		},
 		"can't preempt nominal from CQ with 0 weight": {
@@ -1978,7 +1978,7 @@ func TestFairPreemptions(t *testing.T) {
 				},
 			), &snapshot)
 			gotTargets := sets.New(slices.Map(targets, func(t **Target) string {
-				return targetKeyReasonScope(workload.Key((*t).Wl.Obj), (*t).Reason, (*t).Scope)
+				return targetKeyReasonScope(workload.Key((*t).Wl.Obj), (*t).Reason)
 			})...)
 			if diff := cmp.Diff(tc.wantPreempted, gotTargets, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Issued preemptions (-want,+got):\n%s", diff)
@@ -1987,8 +1987,8 @@ func TestFairPreemptions(t *testing.T) {
 	}
 }
 
-func targetKeyReasonScope(key, reason, scope string) string {
-	return fmt.Sprintf("%s:%s:%s", key, reason, scope)
+func targetKeyReasonScope(key, reason string) string {
+	return fmt.Sprintf("%s:%s", key, reason)
 }
 
 func TestCandidatesOrdering(t *testing.T) {

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -1978,7 +1978,7 @@ func TestFairPreemptions(t *testing.T) {
 				},
 			), &snapshot)
 			gotTargets := sets.New(slices.Map(targets, func(t **Target) string {
-				return targetKeyReasonScope(workload.Key((*t).Wl.Obj), (*t).Reason)
+				return targetKeyReasonScope(workload.Key((*t).WorkloadInfo.Obj), (*t).Reason)
 			})...)
 			if diff := cmp.Diff(tc.wantPreempted, gotTargets, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Issued preemptions (-want,+got):\n%s", diff)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -254,7 +254,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 			if len(e.preemptionTargets) != 0 {
 				// If preemptions are issued, the next attempt should try all the flavors.
 				e.LastAssignment = nil
-				preempted, err := s.preemptor.IssuePreemptions(ctx, &e.Info, e.preemptionTargets, cq)
+				preempted, err := s.preemptor.IssuePreemptions(ctx, &e.Info, e.preemptionTargets, cq, !e.assignment.Borrowing)
 				if err != nil {
 					log.Error(err, "Failed to preempt workloads")
 				}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -254,7 +254,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 			if len(e.preemptionTargets) != 0 {
 				// If preemptions are issued, the next attempt should try all the flavors.
 				e.LastAssignment = nil
-				preempted, err := s.preemptor.IssuePreemptions(ctx, &e.Info, e.preemptionTargets, cq, e.assignment.Borrowing)
+				preempted, err := s.preemptor.IssuePreemptions(ctx, &e.Info, e.preemptionTargets, cq)
 				if err != nil {
 					log.Error(err, "Failed to preempt workloads")
 				}
@@ -332,7 +332,7 @@ type entry struct {
 	status                entryStatus
 	inadmissibleMsg       string
 	requeueReason         queue.RequeueReason
-	preemptionTargets     []*workload.Info
+	preemptionTargets     []*preemption.Target
 }
 
 // nominate returns the workloads with their requirements (resource flavors, borrowing) if
@@ -409,14 +409,14 @@ func resourcesToReserve(e *entry, cq *cache.ClusterQueueSnapshot) resources.Flav
 
 type partialAssignment struct {
 	assignment        flavorassigner.Assignment
-	preemptionTargets []*workload.Info
+	preemptionTargets []*preemption.Target
 }
 
-func (s *Scheduler) getAssignments(log logr.Logger, wl *workload.Info, snap *cache.Snapshot) (flavorassigner.Assignment, []*workload.Info) {
+func (s *Scheduler) getAssignments(log logr.Logger, wl *workload.Info, snap *cache.Snapshot) (flavorassigner.Assignment, []*preemption.Target) {
 	cq := snap.ClusterQueues[wl.ClusterQueue]
 	flvAssigner := flavorassigner.New(wl, cq, snap.ResourceFlavors, s.fairSharing.Enable)
 	fullAssignment := flvAssigner.Assign(log, nil)
-	var faPreemtionTargets []*workload.Info
+	var faPreemtionTargets []*preemption.Target
 
 	arm := fullAssignment.RepresentativeMode()
 	if arm == flavorassigner.Fit {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -254,7 +254,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 			if len(e.preemptionTargets) != 0 {
 				// If preemptions are issued, the next attempt should try all the flavors.
 				e.LastAssignment = nil
-				preempted, err := s.preemptor.IssuePreemptions(ctx, &e.Info, e.preemptionTargets, cq, !e.assignment.Borrowing)
+				preempted, err := s.preemptor.IssuePreemptions(ctx, &e.Info, e.preemptionTargets, cq, e.assignment.Borrowing)
 				if err != nil {
 					log.Error(err, "Failed to preempt workloads")
 				}

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -31,6 +31,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -285,7 +286,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 					g.Expect(apimeta.FindStatusCondition(alphaLowWl.Status.Conditions, kueue.WorkloadPreempted)).To(gomega.BeComparableTo(&metav1.Condition{
 						Type:    kueue.WorkloadPreempted,
 						Status:  metav1.ConditionTrue,
-						Reason:  "InClusterQueue",
+						Reason:  preemption.InClusterQueueReason,
 						Message: fmt.Sprintf("Preempted to accommodate a workload (UID: %s) in the ClusterQueue", alphaMidWl.UID),
 					}, conditionCmpOpts))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -295,7 +296,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 					g.Expect(apimeta.FindStatusCondition(betaMidWl.Status.Conditions, kueue.WorkloadPreempted)).To(gomega.BeComparableTo(&metav1.Condition{
 						Type:    kueue.WorkloadPreempted,
 						Status:  metav1.ConditionTrue,
-						Reason:  "InCohort",
+						Reason:  preemption.InCohortReclamationReason,
 						Message: fmt.Sprintf("Preempted to accommodate a workload (UID: %s) in the cohort", alphaMidWl.UID),
 					}, conditionCmpOpts))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -297,7 +297,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 						Type:    kueue.WorkloadPreempted,
 						Status:  metav1.ConditionTrue,
 						Reason:  preemption.InCohortReclamationReason,
-						Message: fmt.Sprintf("Preempted to accommodate a workload (UID: %s) in the cohort", alphaMidWl.UID),
+						Message: fmt.Sprintf("Preempted to accommodate a workload (UID: %s) in the Cohort", alphaMidWl.UID),
 					}, conditionCmpOpts))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -323,7 +323,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 						Type:    kueue.WorkloadPreempted,
 						Status:  metav1.ConditionFalse,
 						Reason:  "QuotaReserved",
-						Message: fmt.Sprintf("Previously: Preempted to accommodate a workload (UID: %s) in the cohort", alphaMidWl.UID),
+						Message: fmt.Sprintf("Previously: Preempted to accommodate a workload (UID: %s) in the Cohort", alphaMidWl.UID),
 					}, conditionCmpOpts))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Introduces an additional reason in the Preemption condition to indicate that the preemption was due to fair sharing and not regular reclamation.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2404

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
More granular Preemption condition reasons: PriorityReclamation, InCohortReclamation, InCohortFairSharing, InCohortReclaimWhileBorrowing
```