### PR TITLE
[kjobctl] Added autocompletion.

### DIFF
--- a/cmd/experimental/kjobctl/README.md
+++ b/cmd/experimental/kjobctl/README.md
@@ -34,6 +34,24 @@ echo 'alias kjobctl="kubectl kjob"' >> ~/.bashrc
 echo 'alias kjobctl="kubectl kjob"' >> ~/.zshrc
 ```
 
+**Autocompletion:**
+
+```bash
+echo '[[ $commands[kubectl-kjob] ]] && source <(kubectl-kjob completion bash)' >> ~/.bashrc
+# Or if you are using ZSH
+echo '[[ $commands[kubectl-kjob] ]] && source <(kubectl-kjob completion zsh)' >> ~/.zshrc
+
+cat <<EOF >kubectl_complete-kjob
+#!/usr/bin/env sh
+
+# Call the __complete command passing it all arguments
+kubectl kjob __complete "\$@"
+EOF
+
+chmod u+x kubectl_complete-kjob
+sudo mv kubectl_complete-kjob /usr/local/bin/kubectl_complete-kjob
+```
+
 ### To Uninstall
 
 **Delete the APIs(CRDs) from the cluster:**

--- a/cmd/experimental/kjobctl/pkg/cmd/cmd.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/cmd.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 
+	"sigs.k8s.io/kueue/cmd/experimental/kjobctl/pkg/cmd/completion"
 	"sigs.k8s.io/kueue/cmd/experimental/kjobctl/pkg/cmd/util"
 )
 
@@ -58,7 +59,12 @@ func NewKjobctlCmd(o KjobctlOptions) *cobra.Command {
 	}
 	configFlags.AddFlags(flags)
 
-	_ = util.NewClientGetter(configFlags)
+	clientGetter := util.NewClientGetter(configFlags)
+
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("namespace", completion.NamespaceNameFunc(clientGetter)))
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("context", completion.ContextsFunc(clientGetter)))
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("cluster", completion.ClustersFunc(clientGetter)))
+	cobra.CheckErr(cmd.RegisterFlagCompletionFunc("user", completion.UsersFunc(clientGetter)))
 
 	return cmd
 }

--- a/cmd/experimental/kjobctl/pkg/cmd/completion/completion.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/completion/completion.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package completion
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/kueue/cmd/experimental/kjobctl/pkg/cmd/util"
+)
+
+const completionLimit = 100
+
+func NamespaceNameFunc(clientGetter util.ClientGetter) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		clientSet, err := clientGetter.K8sClientSet()
+		if err != nil {
+			return []string{}, cobra.ShellCompDirectiveError
+		}
+
+		list, err := clientSet.CoreV1().Namespaces().List(cmd.Context(), metav1.ListOptions{Limit: completionLimit})
+		if err != nil {
+			return []string{}, cobra.ShellCompDirectiveError
+		}
+
+		validArgs := make([]string, len(list.Items))
+		for i, wl := range list.Items {
+			validArgs[i] = wl.Name
+		}
+
+		return validArgs, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func ContextsFunc(clientGetter util.ClientGetter) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		config, err := clientGetter.ToRawKubeConfigLoader().RawConfig()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var validArgs []string
+		for name := range config.Contexts {
+			if strings.HasPrefix(name, toComplete) {
+				validArgs = append(validArgs, name)
+			}
+		}
+		return validArgs, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func ClustersFunc(clientGetter util.ClientGetter) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		config, err := clientGetter.ToRawKubeConfigLoader().RawConfig()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var validArgs []string
+		for name := range config.Clusters {
+			if strings.HasPrefix(name, toComplete) {
+				validArgs = append(validArgs, name)
+			}
+		}
+		return validArgs, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func UsersFunc(clientGetter util.ClientGetter) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		config, err := clientGetter.ToRawKubeConfigLoader().RawConfig()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var validArgs []string
+		for name := range config.AuthInfos {
+			if strings.HasPrefix(name, toComplete) {
+				validArgs = append(validArgs, name)
+			}
+		}
+		return validArgs, cobra.ShellCompDirectiveNoFileComp
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
To use autocompletion on kjobctl.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```