### PR TITLE
Initialise FairSharing option when building options for cache.

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -160,6 +160,9 @@ func main() {
 		cacheOptions = append(cacheOptions, cache.WithExcludedResourcePrefixes(cfg.Resources.ExcludeResourcePrefixes))
 		queueOptions = append(queueOptions, queue.WithExcludedResourcePrefixes(cfg.Resources.ExcludeResourcePrefixes))
 	}
+	if cfg.FairSharing != nil {
+		cacheOptions = append(cacheOptions, cache.WithFairSharing(cfg.FairSharing.Enable))
+	}
 	cCache := cache.New(mgr.GetClient(), cacheOptions...)
 	queues := queue.NewManager(mgr.GetClient(), cCache, queueOptions...)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Initialise FairSharing option when building options for cache.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2422 

#### Special notes for your reviewer:
```
apiVersion: kueue.x-k8s.io/v1beta1
kind: ClusterQueue
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"kueue.x-k8s.io/v1beta1","kind":"ClusterQueue","metadata":{"annotations":{},"name":"cq-a"},"spec":{"cohort":"cohort","namespaceSelector":{},"resourceGroups":[{"coveredResources":["cpu","memory"],"flavors":[{"name":"default-flavor","resources":[{"name":"cpu","nominalQuota":9},{"name":"memory","nominalQuota":"36Gi"}]}]}]}}
  creationTimestamp: "2024-06-17T11:54:20Z"
  finalizers:
  - kueue.x-k8s.io/resource-in-use
  generation: 1
  name: cq-a
  resourceVersion: "1177"
  uid: cd4c73e6-1ec4-4f20-9ba5-ee089272b138
spec:
  cohort: cohort
  flavorFungibility:
    whenCanBorrow: Borrow
    whenCanPreempt: TryNextFlavor
  namespaceSelector: {}
  preemption:
    borrowWithinCohort:
      policy: Never
    reclaimWithinCohort: Never
    withinClusterQueue: Never
  queueingStrategy: BestEffortFIFO
  resourceGroups:
  - coveredResources:
    - cpu
    - memory
    flavors:
    - name: default-flavor
      resources:
      - name: cpu
        nominalQuota: "9"
      - name: memory
        nominalQuota: 36Gi
  stopPolicy: None
status:
  admittedWorkloads: 4
  conditions:
  - lastTransitionTime: "2024-06-17T11:54:20Z"
    message: Can admit new workloads
    observedGeneration: 1
    reason: Ready
    status: "True"
    type: Active
  fairSharing:
    weightedShare: 111
  flavorsReservation:
  - name: default-flavor
    resources:
    - borrowed: "3"
      name: cpu
      total: "12"
    - borrowed: "0"
      name: memory
      total: 2400Mi
  flavorsUsage:
  - name: default-flavor
    resources:
    - borrowed: "3"
      name: cpu
      total: "12"
    - borrowed: "0"
      name: memory
      total: 2400Mi
  pendingWorkloads: 0
  reservingWorkloads: 4
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Initialise FairSharing option when building options for cache.
```