### PR TITLE
Fix panic when not enough quota on FairSharing enabled.

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -361,7 +361,7 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 			e.assignment, e.preemptionTargets = s.getAssignments(log, &e.Info, &snap)
 			e.inadmissibleMsg = e.assignment.Message()
 			e.Info.LastAssignment = &e.assignment.LastState
-			if s.fairSharing.Enable {
+			if s.fairSharing.Enable && e.assignment.RepresentativeMode() != flavorassigner.NoFit {
 				e.dominantResourceShare, e.dominantResourceName = cq.DominantResourceShareWith(e.assignment.TotalRequestsFor(&w))
 			}
 		}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1649,6 +1649,33 @@ func TestSchedule(t *testing.T) {
 				"eng-gamma/gamma4":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
 			},
 		},
+		"not enough resources": {
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("new", "sales").
+					Queue("main").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "100").
+						Obj()).
+					Obj(),
+			},
+			wantLeft: map[string][]string{
+				"sales": {"sales/new"},
+			},
+		},
+		"not enough resources with fair sharing enabled": {
+			enableFairSharing: true,
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("new", "sales").
+					Queue("main").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "100").
+						Obj()).
+					Obj(),
+			},
+			wantLeft: map[string][]string{
+				"sales": {"sales/new"},
+			},
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix panic when there is not enough quota to assign flavors to a Workload in the cohort, when FairSharing is enabled.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kueue/2439/pull-kueue-test-integration-main/1803339372448190464

```
goroutine 369 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x23ff460, 0x420acc0})
	/go/pkg/mod/k8s.io/apimachinery@v0.30.2/pkg/util/runtime/runtime.go:75 +0x85
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc0007ba8c0?})
	/go/pkg/mod/k8s.io/apimachinery@v0.30.2/pkg/util/runtime/runtime.go:49 +0x6b
panic({0x23ff460?, 0x420acc0?})
	/usr/local/go/src/runtime/panic.go:770 +0x132
sigs.k8s.io/kueue/pkg/scheduler/flavorassigner.(*Assignment).TotalRequestsFor(...)
	/workspace/pkg/scheduler/flavorassigner/flavorassigner.go:112
sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).nominate(0xc00021c280, {0x2c2b350, 0xc000bfcc00}, {0xc0008f8680, 0x1, 0xc0009d06e8?}, {0xc0013a2630, 0xc0013a2660, 0xc0013a2720})
	/workspace/pkg/scheduler/scheduler.go:367 +0xfc8
sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).schedule(0xc00021c280, {0x2c2b350, 0xc000bfcc00})
	/workspace/pkg/scheduler/scheduler.go:203 +0x1e5
sigs.k8s.io/kueue/pkg/util/wait.untilWithBackoff.func1()
	/workspace/pkg/util/wait/backoff.go:43 +0x2b
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000f02b28?)
	/go/pkg/mod/k8s.io/apimachinery@v0.30.2/pkg/util/wait/backoff.go:226 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc00101df30, {0x2c03f80, 0xc000f02b28}, 0x0, 0xc000993860)
	/go/pkg/mod/k8s.io/apimachinery@v0.30.2/pkg/util/wait/backoff.go:227 +0xaf
sigs.k8s.io/kueue/pkg/util/wait.untilWithBackoff({0x2c2b350, 0xc000bfcc00}, 0xc0008513f0, {0x2c248e0, 0xc000308490})
	/workspace/pkg/util/wait/backoff.go:42 +0xe5
sigs.k8s.io/kueue/pkg/util/wait.UntilWithBackoff({0x2c2b350, 0xc000bfcc00}, 0xc0008513f0)
	/workspace/pkg/util/wait/backoff.go:34 +0x8f
created by sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).Start in goroutine 319
	/workspace/pkg/scheduler/scheduler.go:129 +0x131
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x19e6f08]
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix panic when there is not enough quota to assign flavors to a Workload in the cohort, when FairSharing is enabled.
```