### PR TITLE
[release-0.7] [MultiKueue] Do not reject JobSet when ClusterQueue does not exist

### DIFF
--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -73,9 +73,10 @@ func (w *JobSetWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		if !found {
 			return nil
 		}
-		clusterQueueName, err := w.queues.ClusterQueueFromLocalQueue(queue.QueueKey(jobSet.ObjectMeta.Namespace, localQueueName))
-		if err != nil {
-			return err
+		clusterQueueName, ok := w.queues.ClusterQueueFromLocalQueue(queue.QueueKey(jobSet.ObjectMeta.Namespace, localQueueName))
+		if !ok {
+			log.V(5).Info("Cluster queue for local queue not found", "jobset", klog.KObj(jobSet), "localQueue", localQueueName)
+			return nil
 		}
 		for _, admissionCheck := range w.cache.AdmissionChecksForClusterQueue(clusterQueueName) {
 			if admissionCheck.Controller == multikueue.ControllerName {

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -168,7 +168,6 @@ func TestDefault(t *testing.T) {
 				},
 			},
 			multiKueueEnabled: true,
-			wantErr:           queue.ErrQueueDoesNotExist,
 		},
 		{
 			name: "TestDefault_QueueNotFound",
@@ -181,7 +180,6 @@ func TestDefault(t *testing.T) {
 				},
 			},
 			multiKueueEnabled: true,
-			wantErr:           queue.ErrQueueDoesNotExist,
 		},
 		{
 			name: "TestDefault_AdmissionCheckNotFound",

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -580,14 +580,15 @@ func (m *Manager) PendingWorkloadsInfo(cqName string) []*workload.Info {
 	return cq.Snapshot()
 }
 
-// ClusterQueueFromLocalQueue returns ClusterQueue name, with a QueueKey(namespace/localQueueName) as the parameter
-func (m *Manager) ClusterQueueFromLocalQueue(localQueueKey string) (string, error) {
+// ClusterQueueFromLocalQueue returns ClusterQueue name and whether it's found,
+// given a QueueKey(namespace/localQueueName) as the parameter
+func (m *Manager) ClusterQueueFromLocalQueue(localQueueKey string) (string, bool) {
 	m.RLock()
 	defer m.RUnlock()
 	if lq, ok := m.localQueues[localQueueKey]; ok {
-		return lq.ClusterQueue, nil
+		return lq.ClusterQueue, true
 	}
-	return "", ErrQueueDoesNotExist
+	return "", false
 }
 
 func QueueKey(namespace, name string) string {

--- a/pkg/visibility/api/rest/pending_workloads_lq.go
+++ b/pkg/visibility/api/rest/pending_workloads_lq.go
@@ -67,8 +67,8 @@ func (m *pendingWorkloadsInLqREST) Get(ctx context.Context, name string, opts ru
 	offset := pendingWorkloadOpts.Offset
 
 	namespace := genericapirequest.NamespaceValue(ctx)
-	cqName, err := m.queueMgr.ClusterQueueFromLocalQueue(queue.QueueKey(namespace, name))
-	if err != nil {
+	cqName, ok := m.queueMgr.ClusterQueueFromLocalQueue(queue.QueueKey(namespace, name))
+	if !ok {
 		return nil, errors.NewNotFound(v1alpha1.Resource("localqueue"), name)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This is a cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/2425

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Do not reject a JobSet if the corresponding cluster queue doesn't exist (when MultiKueue is enabled).
```