### PR TITLE
[kueuectl] Clearing cluster queues after each creation on "Creating a ClusterQueue" tests.

### DIFF
--- a/test/integration/kueuectl/create_test.go
+++ b/test/integration/kueuectl/create_test.go
@@ -22,11 +22,13 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app"
@@ -134,9 +136,18 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 	})
 
 	ginkgo.When("Creating a ClusterQueue", func() {
-		ginkgo.It("Should create a cluster queue with default values", func() {
-			cqName := "cluster-queue-1"
+		const cqName = "cluster-queue"
 
+		ginkgo.AfterEach(func() {
+			var createdQueue v1beta1.ClusterQueue
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: cqName, Namespace: ns.Name}, &createdQueue)
+			gomega.Expect(client.IgnoreNotFound(err)).To(gomega.Succeed())
+			if !apierrors.IsNotFound(err) {
+				util.ExpectClusterQueueToBeDeleted(ctx, k8sClient, &createdQueue, true)
+			}
+		})
+
+		ginkgo.It("Should create a cluster queue with default values", func() {
 			ginkgo.By("Create a cluster queue with default values", func() {
 				streams, _, output, _ := genericiooptions.NewTestIOStreams()
 				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
@@ -166,8 +177,6 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 		})
 
 		ginkgo.It("Should create a cluster queue with nominal quota and a single resource flavor", func() {
-			cqName := "cluster-queue-2"
-
 			ginkgo.By("Create a cluster queue with default values", func() {
 				streams, _, output, _ := genericiooptions.NewTestIOStreams()
 				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
@@ -217,8 +226,6 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 		})
 
 		ginkgo.It("Should create a cluster queue with nominal quota, a single resource group and multiple flavors", func() {
-			cqName := "cluster-queue-3"
-
 			ginkgo.By("Create a cluster queue with default values", func() {
 				streams, _, output, _ := genericiooptions.NewTestIOStreams()
 				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
@@ -260,8 +267,6 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 		})
 
 		ginkgo.It("Should create a cluster queue with nominal quota, multiple resource groups and multiple flavors", func() {
-			cqName := "cluster-queue-4"
-
 			ginkgo.By("Create a cluster queue with default values", func() {
 				streams, _, output, _ := genericiooptions.NewTestIOStreams()
 				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
@@ -311,8 +316,6 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 		})
 
 		ginkgo.It("Should create a cluster queue with all options, a single resource group and a single flavor", func() {
-			cqName := "cluster-queue-5"
-
 			ginkgo.By("Create a cluster queue with default values", func() {
 				streams, _, output, _ := genericiooptions.NewTestIOStreams()
 				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)
@@ -357,8 +360,6 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 		})
 
 		ginkgo.It("Should create a cluster queue with all options, multiple resource groups and multiple flavors", func() {
-			cqName := "cluster-queue-6"
-
 			ginkgo.By("Create a cluster queue with default values", func() {
 				streams, _, output, _ := genericiooptions.NewTestIOStreams()
 				configFlags := CreateConfigFlagsWithRestConfig(cfg, streams)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We need to clear cluster queues after each test cases on "Creating a ClusterQueue" tests to fix "Should print cluster queues list with paging" integration test and don't show this cluster queues on the list.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2454 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```