### PR TITLE
Fix race condition on delete workload from queue manager.

### DIFF
--- a/pkg/queue/cluster_queue.go
+++ b/pkg/queue/cluster_queue.go
@@ -190,6 +190,13 @@ func (c *ClusterQueue) backoffWaitingTimeExpired(wInfo *workload.Info) bool {
 
 // Delete removes the workload from ClusterQueue.
 func (c *ClusterQueue) Delete(w *kueue.Workload) {
+	c.rwm.Lock()
+	defer c.rwm.Unlock()
+	c.delete(w)
+}
+
+// delete removes the workload from ClusterQueue without lock.
+func (c *ClusterQueue) delete(w *kueue.Workload) {
 	key := workload.Key(w)
 	delete(c.inadmissibleWorkloads, key)
 	c.heap.Delete(key)
@@ -208,7 +215,7 @@ func (c *ClusterQueue) DeleteFromLocalQueue(q *LocalQueue) {
 		}
 	}
 	for _, w := range q.items {
-		c.Delete(w.Obj)
+		c.delete(w.Obj)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix race condition on delete workload from queue manager.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I found it locally when test using `golang.org/x/tools/cmd/stress`.

```
WARNING: DATA RACE
Write at 0x00c0012ad0b0 by goroutine 1313:
  runtime.mapassign_faststr()
      /Users/mykhailo_bobrovskyi/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.4.darwin-arm64/src/runtime/map_faststr.go:203 +0x41c
  sigs.k8s.io/kueue/pkg/queue.(*ClusterQueue).Delete()
      /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/queue/cluster_queue.go:194 +0x10c
  sigs.k8s.io/kueue/pkg/queue.(*Manager).deleteWorkloadFromQueueAndClusterQueue()
      /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/queue/manager.go:377 +0x1c4
  sigs.k8s.io/kueue/pkg/queue.(*Manager).DeleteWorkload()
      /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/queue/manager.go:365 +0xec
  sigs.k8s.io/kueue/pkg/controller/core.(*WorkloadReconciler).Update()
      /Users/mykhailo_bobrovskyi/Projects/epam/kueue/pkg/controller/core/workload_controller.go:661 +0x1840
  sigs.k8s.io/controller-runtime/pkg/internal/source.(*EventHandler).OnUpdate()
      /Users/mykhailo_bobrovskyi/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/source/event_handler.go:113 +0x49c
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix race condition on delete workload from queue manager.
```