### PR TITLE
Fix panic on update cluster queue status if cluster queue not found on queue manager.

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -39,7 +39,7 @@ import (
 )
 
 var (
-	errCqNotFound          = errors.New("cluster queue not found")
+	ErrCqNotFound          = errors.New("cluster queue not found")
 	errQNotFound           = errors.New("queue not found")
 	errWorkloadNotAdmitted = errors.New("workload not admitted by a ClusterQueue")
 )
@@ -369,7 +369,7 @@ func (c *Cache) UpdateClusterQueue(cq *kueue.ClusterQueue) error {
 	defer c.Unlock()
 	cqImpl, ok := c.clusterQueues[cq.Name]
 	if !ok {
-		return errCqNotFound
+		return ErrCqNotFound
 	}
 	if err := cqImpl.update(cq, c.resourceFlavors, c.admissionChecks); err != nil {
 		return err
@@ -503,7 +503,7 @@ func (c *Cache) DeleteWorkload(w *kueue.Workload) error {
 
 	cq := c.clusterQueueForWorkload(w)
 	if cq == nil {
-		return errCqNotFound
+		return ErrCqNotFound
 	}
 
 	c.cleanupAssumedState(w)
@@ -547,7 +547,7 @@ func (c *Cache) AssumeWorkload(w *kueue.Workload) error {
 
 	cq, ok := c.clusterQueues[string(w.Status.Admission.ClusterQueue)]
 	if !ok {
-		return errCqNotFound
+		return ErrCqNotFound
 	}
 
 	if err := cq.addWorkload(w); err != nil {
@@ -572,7 +572,7 @@ func (c *Cache) ForgetWorkload(w *kueue.Workload) error {
 
 	cq, ok := c.clusterQueues[string(w.Status.Admission.ClusterQueue)]
 	if !ok {
-		return errCqNotFound
+		return ErrCqNotFound
 	}
 	cq.deleteWorkload(w)
 	if c.podsReadyTracking {
@@ -596,7 +596,7 @@ func (c *Cache) Usage(cqObj *kueue.ClusterQueue) (*ClusterQueueUsageStats, error
 
 	cq := c.clusterQueues[cqObj.Name]
 	if cq == nil {
-		return nil, errCqNotFound
+		return nil, ErrCqNotFound
 	}
 
 	stats := &ClusterQueueUsageStats{

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -644,7 +644,11 @@ func (r *ClusterQueueReconciler) updateCqStatusIfChanged(
 	reason, msg string,
 ) error {
 	oldStatus := cq.Status.DeepCopy()
-	pendingWorkloads := r.qManager.Pending(cq)
+	pendingWorkloads, err := r.qManager.Pending(cq)
+	if err != nil {
+		r.log.Error(err, "Failed getting pending workloads from queue manager")
+		return err
+	}
 	stats, err := r.cache.Usage(cq)
 	if err != nil {
 		r.log.Error(err, "Failed getting usage from cache")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix panic on update cluster queue status if cluster queue not found on queue manager.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2459

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix panic that could occur when a ClusterQueue is deleted while Kueue was updating the ClusterQueue status.
```