### PR TITLE
Automated cherry pick of #2456: Wait for jobset operator on starting e2e tests.

### DIFF
--- a/test/e2e/multikueue/suite_test.go
+++ b/test/e2e/multikueue/suite_test.go
@@ -69,8 +69,14 @@ var _ = ginkgo.BeforeSuite(func() {
 	ctx = context.Background()
 
 	waitForAvailableStart := time.Now()
+
 	util.WaitForKueueAvailability(ctx, k8sManagerClient)
 	util.WaitForKueueAvailability(ctx, k8sWorker1Client)
 	util.WaitForKueueAvailability(ctx, k8sWorker2Client)
-	ginkgo.GinkgoLogr.Info("Kueue is Available in all the clusters", "waitingTime", time.Since(waitForAvailableStart))
+
+	util.WaitForJobSetAvailability(ctx, k8sManagerClient)
+	util.WaitForJobSetAvailability(ctx, k8sWorker1Client)
+	util.WaitForJobSetAvailability(ctx, k8sWorker2Client)
+
+	ginkgo.GinkgoLogr.Info("Kueue and JobSet operators are available in all the clusters", "waitingTime", time.Since(waitForAvailableStart))
 })

--- a/test/e2e/singlecluster/suite_test.go
+++ b/test/e2e/singlecluster/suite_test.go
@@ -60,5 +60,6 @@ var _ = ginkgo.BeforeSuite(func() {
 
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)
-	ginkgo.GinkgoLogr.Info("Kueue is Available in the cluster", "waitingTime", time.Since(waitForAvailableStart))
+	util.WaitForJobSetAvailability(ctx, k8sClient)
+	ginkgo.GinkgoLogr.Info("Kueue and JobSet oprators are available in the cluster", "waitingTime", time.Since(waitForAvailableStart))
 })


### PR DESCRIPTION
Cherry pick of #2456 on release-0.7.
#2456: Wait for jobset operator on starting e2e tests.
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
NONE
```