### PR TITLE
Fix race condition on run garbage collection in multikueuecluster reconciler.

### DIFF
--- a/pkg/util/maps/maps.go
+++ b/pkg/util/maps/maps.go
@@ -98,7 +98,17 @@ func Keys[K comparable, V any, M ~map[K]V](m M) []K {
 	return ret
 }
 
-// Filter returns a sub-map containing only keys from the given list
+// Values returns the values of the map m.
+// The values will be in an indeterminate order.
+func Values[M ~map[K]V, K comparable, V any](m M) []V {
+	r := make([]V, 0, len(m))
+	for _, v := range m {
+		r = append(r, v)
+	}
+	return r
+}
+
+// FilterKeys returns a sub-map containing only keys from the given list
 func FilterKeys[K comparable, V any, M ~map[K]V](m M, k []K) M {
 	if m == nil || len(k) == 0 {
 		return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix race condition on run garbage collection in multikueuecluster reconciler.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Related with #2468.

This error happens  when running test-integration with --race flag.

```
WARNING: DATA RACE
  Write at 0x00c000b6e570 by goroutine 526:
    runtime.mapassign_faststr()
        /usr/local/go/src/runtime/map_faststr.go:203 +0x0
    sigs.k8s.io/kueue/pkg/controller/admissionchecks/multikueue.(*clustersReconciler).setRemoteClientConfig()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/controller/admissionchecks/multikueue/multikueuecluster.go:368 +0x32d
    sigs.k8s.io/kueue/pkg/controller/admissionchecks/multikueue.(*clustersReconciler).Reconcile()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/controller/admissionchecks/multikueue/multikueuecluster.go:416 +0x454
    sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:119 +0x1a1
    sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:316 +0x59a
    sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266 +0x338
    sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227 +0xb2
```

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kueue/2468/pull-kueue-test-integration-main/1806545541862002688

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix race condition on run garbage collection in multikueuecluster reconciler.
```