### PR TITLE
Fix lint issue reported by fatcontext

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,6 +31,7 @@ linters:
     - copyloopvar
     - dupword
     - durationcheck
+    - fatcontext
     - ginkgolinter
     - gocritic
     - goimports

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -944,7 +944,7 @@ func (w *workloadQueueHandler) queueReconcileForWorkloadsOfClusterQueue(ctx cont
 	}
 	for _, lq := range lst.Items {
 		log := log.WithValues("localQueue", klog.KObj(&lq))
-		ctx = ctrl.LoggerInto(ctx, log)
+		ctx := ctrl.LoggerInto(ctx, log)
 		w.queueReconcileForWorkloadsOfLocalQueue(ctx, &lq, wq)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR refactors `queueReconcileForWorkloadsOfClusterQueue` to avoid using nested contexts, as it has become unwieldy. This issue was identified by the `fatcontext` linter.

#### Special notes for your reviewer:

We don't need nested context in our case `ctx = ctrl.LoggerInto(ctx, log)`.

Also, nested contexts may cause performance issues. See more about fat contexts here https://gabnotes.org/fat-contexts/

#### Does this PR introduce a user-facing change?

```release-note
Fix performance issue in logging when processing LocalQueues.
```