### PR TITLE
Fix nested context in loop

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -853,7 +853,7 @@ func (w *workloadCqHandler) queueReconcileForWorkloads(ctx context.Context, cqNa
 	}
 	for _, lq := range lst.Items {
 		log := log.WithValues("localQueue", klog.KObj(&lq))
-		ctx = ctrl.LoggerInto(ctx, log)
+		ctx := ctrl.LoggerInto(ctx, log)
 		w.queueReconcileForWorkloadsOfLocalQueue(ctx, lq.Namespace, lq.Name, wq)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Cherry-picking from #2485

#### Special notes for your reviewer:

Cherry-picking is done manually due to conflicts https://github.com/kubernetes-sigs/kueue/pull/2485#issuecomment-2195064130

I can't enable `fatcontext` because the linter requires golangci-lint v1.58.0 but `release-0.7` has v1.57.2.

#### Does this PR introduce a user-facing change?

```release-note
Fix performance issue in logging when processing LocalQueues.
```