### PR TITLE
[jobframework] Only check if the owner is managed for enabled integrations.

### DIFF
--- a/pkg/controller/jobframework/integrationmanager.go
+++ b/pkg/controller/jobframework/integrationmanager.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -204,7 +205,8 @@ func EnableIntegration(name string) {
 
 // EnableIntegrationsForTest - should be used only in tests
 // Mark the frameworks identified by names and return a revert function.
-func EnableIntegrationsForTest(names ...string) func() {
+func EnableIntegrationsForTest(tb testing.TB, names ...string) func() {
+	tb.Helper()
 	old := manager.enabledIntegrations.Clone()
 	for _, name := range names {
 		manager.enableIntegration(name)

--- a/pkg/controller/jobframework/integrationmanager_test.go
+++ b/pkg/controller/jobframework/integrationmanager_test.go
@@ -377,7 +377,7 @@ func TestGetJobTypeForOwner(t *testing.T) {
 	externalK3 := func() runtime.Object {
 		return &metav1.PartialObjectMetadata{TypeMeta: metav1.TypeMeta{Kind: "K3"}}
 	}()
-	manageK4 := func() IntegrationCallbacks {
+	disabledK4 := func() IntegrationCallbacks {
 		ret := dontManage
 		ret.IsManagingObjectsOwner = func(owner *metav1.OwnerReference) bool { return owner.Kind == "K4" }
 		ret.JobType = &metav1.PartialObjectMetadata{TypeMeta: metav1.TypeMeta{Kind: "K4"}}
@@ -385,12 +385,12 @@ func TestGetJobTypeForOwner(t *testing.T) {
 	}()
 
 	mgr := integrationManager{
-		names: []string{"manageK1", "dontManage", "manageK2", "manageK4"},
+		names: []string{"manageK1", "dontManage", "manageK2", "disabledK4"},
 		integrations: map[string]IntegrationCallbacks{
 			"dontManage": dontManage,
 			"manageK1":   manageK1,
 			"manageK2":   manageK2,
-			"manageK4":   manageK4,
+			"disabledK4": disabledK4,
 		},
 		externalIntegrations: map[string]runtime.Object{
 			"externalK3": externalK3,

--- a/pkg/controller/jobframework/integrationmanager_test.go
+++ b/pkg/controller/jobframework/integrationmanager_test.go
@@ -363,18 +363,28 @@ func TestGetJobTypeForOwner(t *testing.T) {
 	externalK3 := func() runtime.Object {
 		return &metav1.PartialObjectMetadata{TypeMeta: metav1.TypeMeta{Kind: "K3"}}
 	}()
+	manageK4 := func() IntegrationCallbacks {
+		ret := dontManage
+		ret.IsManagingObjectsOwner = func(owner *metav1.OwnerReference) bool { return owner.Kind == "K4" }
+		ret.JobType = &metav1.PartialObjectMetadata{TypeMeta: metav1.TypeMeta{Kind: "K4"}}
+		return ret
+	}()
 
 	mgr := integrationManager{
-		names: []string{"manageK1", "dontManage", "manageK2"},
+		names: []string{"manageK1", "dontManage", "manageK2", "manageK4"},
 		integrations: map[string]IntegrationCallbacks{
 			"dontManage": dontManage,
 			"manageK1":   manageK1,
 			"manageK2":   manageK2,
+			"manageK4":   manageK4,
 		},
 		externalIntegrations: map[string]runtime.Object{
 			"externalK3": externalK3,
 		},
 	}
+	mgr.enableIntegration("dontManage")
+	mgr.enableIntegration("manageK1")
+	mgr.enableIntegration("manageK2")
 
 	cases := map[string]struct {
 		owner       *metav1.OwnerReference
@@ -394,6 +404,10 @@ func TestGetJobTypeForOwner(t *testing.T) {
 		},
 		"K4": {
 			owner:       &metav1.OwnerReference{Kind: "K4"},
+			wantJobType: nil,
+		},
+		"K5": {
+			owner:       &metav1.OwnerReference{Kind: "K5"},
 			wantJobType: nil,
 		},
 	}

--- a/pkg/controller/jobframework/integrationmanager_test.go
+++ b/pkg/controller/jobframework/integrationmanager_test.go
@@ -32,10 +32,24 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func testNewReconciler(client.Client, record.EventRecorder, ...Option) JobReconcilerInterface {
+type testReconciler struct{}
+
+func (t *testReconciler) Reconcile(context.Context, reconcile.Request) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}
+
+func (t *testReconciler) SetupWithManager(mgr ctrlmgr.Manager) error {
 	return nil
+}
+
+var _ JobReconcilerInterface = (*testReconciler)(nil)
+
+func testNewReconciler(client.Client, record.EventRecorder, ...Option) JobReconcilerInterface {
+	return &testReconciler{}
 }
 
 func testSetupWebhook(ctrl.Manager, ...Option) error {

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -84,6 +84,7 @@ func TestIsParentJobManaged(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			defer EnableIntegrationsForTest("kubeflow.org/mpijob")()
 			builder := utiltesting.NewClientBuilder(kubeflow.AddToScheme)
 			if tc.parentJob != nil {
 				builder = builder.WithObjects(tc.parentJob)

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -84,7 +84,7 @@ func TestIsParentJobManaged(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			defer EnableIntegrationsForTest("kubeflow.org/mpijob")()
+			defer EnableIntegrationsForTest(t, "kubeflow.org/mpijob")()
 			builder := utiltesting.NewClientBuilder(kubeflow.AddToScheme)
 			if tc.parentJob != nil {
 				builder = builder.WithObjects(tc.parentJob)

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -84,7 +84,7 @@ func TestIsParentJobManaged(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			defer EnableIntegrationsForTest(t, "kubeflow.org/mpijob")()
+			t.Cleanup(EnableIntegrationsForTest(t, "kubeflow.org/mpijob"))
 			builder := utiltesting.NewClientBuilder(kubeflow.AddToScheme)
 			if tc.parentJob != nil {
 				builder = builder.WithObjects(tc.parentJob)

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -45,6 +45,10 @@ var (
 // until the webhooks are operating, and the webhook won't work until the
 // certs are all in place.
 func SetupControllers(mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
+	return manager.setupControllers(mgr, log, opts...)
+}
+
+func (m *integrationManager) setupControllers(mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
 	options := ProcessOptions(opts...)
 
 	for fwkName := range options.EnabledExternalFrameworks {
@@ -52,7 +56,7 @@ func SetupControllers(mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
 			return err
 		}
 	}
-	return ForEachIntegration(func(name string, cb IntegrationCallbacks) error {
+	return m.forEach(func(name string, cb IntegrationCallbacks) error {
 		logger := log.WithValues("jobFrameworkName", name)
 		fwkNamePrefix := fmt.Sprintf("jobFrameworkName %q", name)
 
@@ -83,7 +87,7 @@ func SetupControllers(mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
 				if err = cb.SetupWebhook(mgr, opts...); err != nil {
 					return fmt.Errorf("%s: unable to create webhook: %w", fwkNamePrefix, err)
 				}
-				EnableIntegration(name)
+				m.enableIntegration(name)
 				logger.Info("Set up controller and webhook for job framework")
 				return nil
 			}

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -83,6 +83,7 @@ func SetupControllers(mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
 				if err = cb.SetupWebhook(mgr, opts...); err != nil {
 					return fmt.Errorf("%s: unable to create webhook: %w", fwkNamePrefix, err)
 				}
+				EnableIntegration(name)
 				logger.Info("Set up controller and webhook for job framework")
 				return nil
 			}

--- a/pkg/controller/jobframework/setup_test.go
+++ b/pkg/controller/jobframework/setup_test.go
@@ -43,8 +43,8 @@ import (
 )
 
 func TestSetupControllers(t *testing.T) {
-	aviableIntegrations := map[string]IntegrationCallbacks{
-		"batch/job": IntegrationCallbacks{
+	availableIntegrations := map[string]IntegrationCallbacks{
+		"batch/job": {
 			NewReconciler:         testNewReconciler,
 			SetupWebhook:          testSetupWebhook,
 			JobType:               &batchv1.Job{},
@@ -52,7 +52,7 @@ func TestSetupControllers(t *testing.T) {
 			AddToScheme:           testAddToScheme,
 			CanSupportIntegration: testCanSupportIntegration,
 		},
-		"kubeflow.org/mpijob": IntegrationCallbacks{
+		"kubeflow.org/mpijob": {
 			NewReconciler:         testNewReconciler,
 			SetupWebhook:          testSetupWebhook,
 			JobType:               &kubeflow.MPIJob{},
@@ -60,7 +60,7 @@ func TestSetupControllers(t *testing.T) {
 			AddToScheme:           testAddToScheme,
 			CanSupportIntegration: testCanSupportIntegration,
 		},
-		"pod": IntegrationCallbacks{
+		"pod": {
 			NewReconciler:         testNewReconciler,
 			SetupWebhook:          testSetupWebhook,
 			JobType:               &corev1.Pod{},
@@ -103,7 +103,7 @@ func TestSetupControllers(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			manager := integrationManager{}
-			for name, cbs := range aviableIntegrations {
+			for name, cbs := range availableIntegrations {
 				err := manager.register(name, cbs)
 				if err != nil {
 					t.Fatalf("Unexpected error while registering %q: %s", name, err)

--- a/pkg/controller/jobframework/setup_test.go
+++ b/pkg/controller/jobframework/setup_test.go
@@ -43,10 +43,38 @@ import (
 )
 
 func TestSetupControllers(t *testing.T) {
+	aviableIntegrations := map[string]IntegrationCallbacks{
+		"batch/job": IntegrationCallbacks{
+			NewReconciler:         testNewReconciler,
+			SetupWebhook:          testSetupWebhook,
+			JobType:               &batchv1.Job{},
+			SetupIndexes:          testSetupIndexes,
+			AddToScheme:           testAddToScheme,
+			CanSupportIntegration: testCanSupportIntegration,
+		},
+		"kubeflow.org/mpijob": IntegrationCallbacks{
+			NewReconciler:         testNewReconciler,
+			SetupWebhook:          testSetupWebhook,
+			JobType:               &kubeflow.MPIJob{},
+			SetupIndexes:          testSetupIndexes,
+			AddToScheme:           testAddToScheme,
+			CanSupportIntegration: testCanSupportIntegration,
+		},
+		"pod": IntegrationCallbacks{
+			NewReconciler:         testNewReconciler,
+			SetupWebhook:          testSetupWebhook,
+			JobType:               &corev1.Pod{},
+			SetupIndexes:          testSetupIndexes,
+			AddToScheme:           testAddToScheme,
+			CanSupportIntegration: testCanSupportIntegration,
+		},
+	}
+
 	cases := map[string]struct {
-		opts       []Option
-		mapperGVKs []schema.GroupVersionKind
-		wantError  error
+		opts                    []Option
+		mapperGVKs              []schema.GroupVersionKind
+		wantError               error
+		wantEnabledIntegrations []string
 	}{
 		"setup controllers succeed": {
 			opts: []Option{
@@ -60,6 +88,7 @@ func TestSetupControllers(t *testing.T) {
 				batchv1.SchemeGroupVersion.WithKind("Job"),
 				kubeflow.SchemeGroupVersionKind,
 			},
+			wantEnabledIntegrations: []string{"batch/job", "kubeflow.org/mpijob"},
 		},
 		"mapper doesn't have kubeflow.org/mpijob, but no error occur": {
 			opts: []Option{
@@ -68,10 +97,19 @@ func TestSetupControllers(t *testing.T) {
 			mapperGVKs: []schema.GroupVersionKind{
 				batchv1.SchemeGroupVersion.WithKind("Job"),
 			},
+			wantEnabledIntegrations: []string{"batch/job"},
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			manager := integrationManager{}
+			for name, cbs := range aviableIntegrations {
+				err := manager.register(name, cbs)
+				if err != nil {
+					t.Fatalf("Unexpected error while registering %q: %s", name, err)
+				}
+			}
+
 			_, logger := utiltesting.ContextWithLog(t)
 			k8sClient := utiltesting.NewClientBuilder(jobset.AddToScheme, kubeflow.AddToScheme, kftraining.AddToScheme, rayv1.AddToScheme).Build()
 
@@ -97,9 +135,13 @@ func TestSetupControllers(t *testing.T) {
 				t.Fatalf("Failed to setup manager: %v", err)
 			}
 
-			gotError := SetupControllers(mgr, logger, tc.opts...)
+			gotError := manager.setupControllers(mgr, logger, tc.opts...)
 			if diff := cmp.Diff(tc.wantError, gotError, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected error from SetupControllers (-want,+got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantEnabledIntegrations, manager.enabledIntegrations.SortedList()); len(diff) != 0 {
+				t.Errorf("Unexpected enabled integrations (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -396,6 +396,7 @@ var (
 )
 
 func TestReconciler(t *testing.T) {
+	defer jobframework.EnableIntegrationsForTest(FrameworkName)()
 	baseJobWrapper := utiltestingjob.MakeJob("job", "ns").
 		Suspend(true).
 		Queue("foo").

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -396,7 +396,7 @@ var (
 )
 
 func TestReconciler(t *testing.T) {
-	defer jobframework.EnableIntegrationsForTest(FrameworkName)()
+	defer jobframework.EnableIntegrationsForTest(t, FrameworkName)()
 	baseJobWrapper := utiltestingjob.MakeJob("job", "ns").
 		Suspend(true).
 		Queue("foo").

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -396,7 +396,7 @@ var (
 )
 
 func TestReconciler(t *testing.T) {
-	defer jobframework.EnableIntegrationsForTest(t, FrameworkName)()
+	t.Cleanup(jobframework.EnableIntegrationsForTest(t, FrameworkName))
 	baseJobWrapper := utiltestingjob.MakeJob("job", "ns").
 		Suspend(true).
 		Queue("foo").

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -4879,6 +4879,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 }
 
 func TestIsPodOwnerManagedByQueue(t *testing.T) {
+	defer jobframework.EnableIntegrationsForTest("batch/job", "ray.io/raycluster")()
 	testCases := map[string]struct {
 		ownerReference metav1.OwnerReference
 		wantRes        bool

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -4879,7 +4879,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 }
 
 func TestIsPodOwnerManagedByQueue(t *testing.T) {
-	defer jobframework.EnableIntegrationsForTest("batch/job", "ray.io/raycluster")()
+	defer jobframework.EnableIntegrationsForTest(t, "batch/job", "ray.io/raycluster")()
 	testCases := map[string]struct {
 		ownerReference metav1.OwnerReference
 		wantRes        bool

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -4879,7 +4879,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 }
 
 func TestIsPodOwnerManagedByQueue(t *testing.T) {
-	defer jobframework.EnableIntegrationsForTest(t, "batch/job", "ray.io/raycluster")()
+	t.Cleanup(jobframework.EnableIntegrationsForTest(t, "batch/job", "ray.io/raycluster"))
 	testCases := map[string]struct {
 		ownerReference metav1.OwnerReference
 		wantRes        bool

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -286,7 +286,7 @@ func TestDefault(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			defer jobframework.EnableIntegrationsForTest(tc.enableIntegrations...)()
+			defer jobframework.EnableIntegrationsForTest(t, tc.enableIntegrations...)()
 			builder := utiltesting.NewClientBuilder()
 			builder = builder.WithObjects(tc.initObjects...)
 			cli := builder.Build()
@@ -400,7 +400,7 @@ func TestGetRoleHash(t *testing.T) {
 }
 
 func TestValidateCreate(t *testing.T) {
-	defer jobframework.EnableIntegrationsForTest("batch/job")()
+	defer jobframework.EnableIntegrationsForTest(t, "batch/job")()
 	testCases := map[string]struct {
 		pod       *corev1.Pod
 		wantErr   error
@@ -503,7 +503,7 @@ func TestValidateCreate(t *testing.T) {
 }
 
 func TestValidateUpdate(t *testing.T) {
-	defer jobframework.EnableIntegrationsForTest("batch/job")()
+	defer jobframework.EnableIntegrationsForTest(t, "batch/job")()
 	testCases := map[string]struct {
 		oldPod    *corev1.Pod
 		newPod    *corev1.Pod

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -286,7 +286,7 @@ func TestDefault(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			defer jobframework.EnableIntegrationsForTest(t, tc.enableIntegrations...)()
+			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.enableIntegrations...))
 			builder := utiltesting.NewClientBuilder()
 			builder = builder.WithObjects(tc.initObjects...)
 			cli := builder.Build()
@@ -400,7 +400,7 @@ func TestGetRoleHash(t *testing.T) {
 }
 
 func TestValidateCreate(t *testing.T) {
-	defer jobframework.EnableIntegrationsForTest(t, "batch/job")()
+	t.Cleanup(jobframework.EnableIntegrationsForTest(t, "batch/job"))
 	testCases := map[string]struct {
 		pod       *corev1.Pod
 		wantErr   error
@@ -503,7 +503,7 @@ func TestValidateCreate(t *testing.T) {
 }
 
 func TestValidateUpdate(t *testing.T) {
-	defer jobframework.EnableIntegrationsForTest(t, "batch/job")()
+	t.Cleanup(jobframework.EnableIntegrationsForTest(t, "batch/job"))
 	testCases := map[string]struct {
 		oldPod    *corev1.Pod
 		newPod    *corev1.Pod

--- a/test/integration/controller/jobs/job/suite_test.go
+++ b/test/integration/controller/jobs/job/suite_test.go
@@ -73,6 +73,7 @@ func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = job.SetupWebhook(mgr, opts...)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		jobframework.EnableIntegration(job.FrameworkName)
 	}
 }
 
@@ -99,6 +100,7 @@ func managerAndControllersSetup(enableScheduler bool, configuration *config.Conf
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = job.SetupWebhook(mgr, opts...)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		jobframework.EnableIntegration(job.FrameworkName)
 
 		if enableScheduler {
 			sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName))

--- a/test/integration/controller/jobs/mpijob/suite_test.go
+++ b/test/integration/controller/jobs/mpijob/suite_test.go
@@ -73,6 +73,7 @@ func managerSetup(setupJobManager bool, opts ...jobframework.Option) framework.M
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = mpijob.SetupMPIJobWebhook(mgr, opts...)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		jobframework.EnableIntegration(mpijob.FrameworkName)
 
 		if setupJobManager {
 			jobReconciler := job.NewReconciler(

--- a/test/integration/controller/jobs/pod/suite_test.go
+++ b/test/integration/controller/jobs/pod/suite_test.go
@@ -92,6 +92,7 @@ func managerSetup(configuration *config.Configuration, opts ...jobframework.Opti
 			opts...)
 		err = jobReconciler.SetupWithManager(mgr)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		jobframework.EnableIntegration(job.FrameworkName)
 
 		cCache := cache.New(mgr.GetClient())
 		queues := queue.NewManager(mgr.GetClient(), cCache)

--- a/test/integration/controller/jobs/raycluster/suite_test.go
+++ b/test/integration/controller/jobs/raycluster/suite_test.go
@@ -70,6 +70,7 @@ func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = raycluster.SetupRayClusterWebhook(mgr, opts...)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		jobframework.EnableIntegration(rayjob.FrameworkName)
 	}
 }
 
@@ -123,6 +124,7 @@ func managerWithRayClusterAndRayJobControllersSetup(opts ...jobframework.Option)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		err = rayjob.SetupRayJobWebhook(mgr, opts...)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		jobframework.EnableIntegration(rayjob.FrameworkName)
 
 		failedWebhook, err := webhooks.Setup(mgr)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Only check if the owner of a job is managed against the list of  jobs integrations currently enabled .
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2481

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow usage of the pod integration for pods belonging to jobs that Kueue supports, if the support for the job type is explicitly disabled
```