### PR TITLE
[PodSetInfo] Skip duplicate Tolerations during merge.

### DIFF
--- a/pkg/podset/podset.go
+++ b/pkg/podset/podset.go
@@ -108,7 +108,13 @@ func (podSetInfo *PodSetInfo) Merge(o PodSetInfo) error {
 	podSetInfo.Annotations = utilmaps.MergeKeepFirst(podSetInfo.Annotations, o.Annotations)
 	podSetInfo.Labels = utilmaps.MergeKeepFirst(podSetInfo.Labels, o.Labels)
 	podSetInfo.NodeSelector = utilmaps.MergeKeepFirst(podSetInfo.NodeSelector, o.NodeSelector)
-	podSetInfo.Tolerations = append(podSetInfo.Tolerations, o.Tolerations...)
+
+	// make sure we don't duplicate tolerations
+	for _, t := range o.Tolerations {
+		if slices.Index(podSetInfo.Tolerations, t) == -1 {
+			podSetInfo.Tolerations = append(podSetInfo.Tolerations, t)
+		}
+	}
 	return nil
 }
 

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -248,6 +248,40 @@ func TestMergeRestore(t *testing.T) {
 				Obj(),
 			wantRestoreChanges: true,
 		},
+		"don't duplicate tolerations": {
+			podSet: basePodSet.DeepCopy(),
+			info: PodSetInfo{
+				Annotations: map[string]string{
+					"a1": "a1v",
+				},
+				Labels: map[string]string{
+					"l1": "l1v",
+				},
+				NodeSelector: map[string]string{
+					"ns1": "ns1v",
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "t0",
+						Operator: corev1.TolerationOpEqual,
+						Value:    "t0v",
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+				},
+			},
+			wantPodSet: utiltesting.MakePodSet("", 1).
+				NodeSelector(map[string]string{"ns0": "ns0v", "ns1": "ns1v"}).
+				Labels(map[string]string{"l0": "l0v", "l1": "l1v"}).
+				Annotations(map[string]string{"a0": "a0v", "a1": "a1v"}).
+				Toleration(corev1.Toleration{
+					Key:      "t0",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "t0v",
+					Effect:   corev1.TaintEffectNoSchedule,
+				}).
+				Obj(),
+			wantRestoreChanges: true,
+		},
 		"conflicting label": {
 			podSet: basePodSet.DeepCopy(),
 			info: PodSetInfo{

--- a/test/integration/controller/jobs/job/job_controller_test.go
+++ b/test/integration/controller/jobs/job/job_controller_test.go
@@ -627,6 +627,12 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				Queue(localQueue.Name).
 				Request(corev1.ResourceCPU, "5").
 				PodAnnotation("old-ann-key", "old-ann-value").
+				Toleration(corev1.Toleration{
+					Key:      "selector0",
+					Value:    "selector-value1",
+					Operator: corev1.TolerationOpEqual,
+					Effect:   corev1.TaintEffectNoSchedule,
+				}).
 				PodLabel("old-label-key", "old-label-value").
 				Obj()
 
@@ -669,6 +675,12 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 								},
 								Tolerations: []corev1.Toleration{
 									{
+										Key:      "selector0",
+										Value:    "selector-value1",
+										Operator: corev1.TolerationOpEqual,
+										Effect:   corev1.TaintEffectNoSchedule,
+									},
+									{
 										Key:      "selector1",
 										Value:    "selector-value1",
 										Operator: corev1.TolerationOpEqual,
@@ -708,6 +720,12 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdJob.Spec.Template.Spec.NodeSelector).Should(gomega.HaveKeyWithValue("selector1", "selector-value1"))
 				gomega.Expect(createdJob.Spec.Template.Spec.Tolerations).Should(gomega.BeComparableTo(
 					[]corev1.Toleration{
+						{
+							Key:      "selector0",
+							Value:    "selector-value1",
+							Operator: corev1.TolerationOpEqual,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
 						{
 							Key:      "selector1",
 							Value:    "selector-value1",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Skip duplicate Tolerations during PodSetInfo merge.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2427

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Skip duplicate Tolerations when an admission check introduces a toleration that the job also set.
```