### PR TITLE
[importer] fix typo in log field name

### DIFF
--- a/cmd/importer/pod/check.go
+++ b/cmd/importer/pod/check.go
@@ -74,7 +74,7 @@ func Check(ctx context.Context, c client.Client, cache *util.ImportCache, jobs u
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Check done", "checked", summary.TotalPods, "skipped", summary.SkippedPods, "failed", summary.FailedPods)
 	for e, pods := range summary.ErrorsForPods {
-		log.Info("Validation failed for Pods", "err", e, "occurrences", len(pods), "obsevedFirstIn", pods[0])
+		log.Info("Validation failed for Pods", "err", e, "occurrences", len(pods), "observedFirstIn", pods[0])
 	}
 	return errors.Join(summary.Errors...)
 }

--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -129,7 +129,7 @@ func Import(ctx context.Context, c client.Client, cache *util.ImportCache, jobs 
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Import done", "checked", summary.TotalPods, "skipped", summary.SkippedPods, "failed", summary.FailedPods)
 	for e, pods := range summary.ErrorsForPods {
-		log.Info("Import failed for Pods", "err", e, "occurrences", len(pods), "obsevedFirstIn", pods[0])
+		log.Info("Import failed for Pods", "err", e, "occurrences", len(pods), "observedFirstIn", pods[0])
 	}
 	return errors.Join(summary.Errors...)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Corrects spelling mistake in the log field `observedFirstIn`.

#### Does this PR introduce a user-facing change?

```release-note
Importer: corrects the field name `observedFirstIn` in logs.
```