### PR TITLE
Fix race condition on requeueAndUpdate.

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -626,9 +626,9 @@ func (s *Scheduler) requeueAndUpdate(ctx context.Context, e entry) {
 	log.V(2).Info("Workload re-queued", "workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", e.ClusterQueue), "queue", klog.KRef(e.Obj.Namespace, e.Obj.Spec.QueueName), "requeueReason", e.requeueReason, "added", added, "status", e.status)
 
 	if e.status == notNominated || e.status == skipped {
-		if workload.UnsetQuotaReservationWithCondition(e.Obj, "Pending", e.inadmissibleMsg) {
-			err := workload.ApplyAdmissionStatus(ctx, s.client, e.Obj, true)
-			if err != nil {
+		patch := workload.AdmissionStatusPatch(e.Obj, true)
+		if workload.UnsetQuotaReservationWithCondition(patch, "Pending", e.inadmissibleMsg) {
+			if err := workload.ApplyAdmissionStatusPatch(ctx, s.client, patch); err != nil {
 				log.Error(err, "Could not update Workload status")
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix race condition on requeueAndUpdate.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Related with #2468.

This error happens  when running test-integration with --race flag.

```
==================
  WARNING: DATA RACE
  Read at 0x00c0012d79f0 by goroutine 288:
    sigs.k8s.io/kueue/pkg/queue.(*ClusterQueue).PushOrUpdate()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/queue/cluster_queue.go:156 +0x428
    sigs.k8s.io/kueue/pkg/queue.(*Manager).AddOrUpdateWorkloadWithoutLock()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/queue/manager.go:329 +0x26b
    sigs.k8s.io/kueue/pkg/queue.(*Manager).UpdateWorkload()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/queue/manager.go:474 +0x24e
    sigs.k8s.io/kueue/pkg/controller/core.(*WorkloadReconciler).Update()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/controller/core/workload_controller.go:678 +0x136b
    sigs.k8s.io/controller-runtime/pkg/internal/source.(*EventHandler).OnUpdate()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/sigs.k8s.io/controller-runtime/pkg/internal/source/event_handler.go:113 +0x5bd
    sigs.k8s.io/controller-runtime/pkg/internal/source.(*EventHandler).OnUpdate-fm()
        <autogenerated>:1 +0x64
    k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/client-go/tools/cache/controller.go:246 +0x81
    k8s.io/client-go/tools/cache.(*ResourceEventHandlerFuncs).OnUpdate()
        <autogenerated>:1 +0x1f
    k8s.io/client-go/tools/cache.(*processorListener).run.func1()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/client-go/tools/cache/shared_informer.go:970 +0x1f4
    k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x41
    k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xc4
    k8s.io/apimachinery/pkg/util/wait.JitterUntil()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:204 +0x10a
    k8s.io/apimachinery/pkg/util/wait.Until()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:161 +0x9b
    k8s.io/client-go/tools/cache.(*processorListener).run()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/client-go/tools/cache/shared_informer.go:966 +0x38
    k8s.io/client-go/tools/cache.(*processorListener).run-fm()
        <autogenerated>:1 +0x33
    k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:72 +0x86
  Previous write at 0x00c0012d79f0 by goroutine 172:
    k8s.io/apimachinery/pkg/api/meta.SetStatusCondition()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/api/meta/conditions.go:40 +0x784
    sigs.k8s.io/kueue/pkg/workload.UnsetQuotaReservationWithCondition()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/workload/workload.go:429 +0x144
    sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).requeueAndUpdate()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/scheduler/scheduler.go:624 +0xa73
    sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).schedule()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/scheduler/scheduler.go:294 +0x17ef
    sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).schedule-fm()
        <autogenerated>:1 +0x47
    sigs.k8s.io/kueue/pkg/util/wait.untilWithBackoff.func1()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/util/wait/backoff.go:43 +0x58
    k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:226 +0x41
    k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/backoff.go:227 +0xc4
    sigs.k8s.io/kueue/pkg/util/wait.untilWithBackoff()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/util/wait/backoff.go:42 +0x144
    sigs.k8s.io/kueue/pkg/util/wait.UntilWithBackoff()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/util/wait/backoff.go:34 +0xc9
    sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).Start.gowrap1()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/scheduler/scheduler.go:130 +0x4f
  Goroutine 288 (running) created at:
    k8s.io/apimachinery/pkg/util/wait.(*Group).Start()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:70 +0xe4
    k8s.io/client-go/tools/cache.(*sharedProcessor).addListener()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/client-go/tools/cache/shared_informer.go:742 +0x227
    k8s.io/client-go/tools/cache.(*sharedIndexInformer).AddEventHandlerWithResyncPeriod()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/client-go/tools/cache/shared_informer.go:617 +0x770
    k8s.io/client-go/tools/cache.(*sharedIndexInformer).AddEventHandler()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/k8s.io/client-go/tools/cache/shared_informer.go:555 +0x51
    sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/sigs.k8s.io/controller-runtime/pkg/internal/source/kind.go:82 +0x58d
  Goroutine 172 (running) created at:
    sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).Start()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/scheduler/scheduler.go:130 +0x245
    sigs.k8s.io/kueue/test/integration/controller/jobs/jobset.init.func4.1.managerAndSchedulerSetup.1()
        /home/prow/go/src/sigs.k8s.io/kueue/test/integration/controller/jobs/jobset/suite_test.go:99 +0x6ae
    sigs.k8s.io/kueue/test/integration/framework.(*Framework).StartManager()
        /home/prow/go/src/sigs.k8s.io/kueue/test/integration/framework/framework.go:136 +0x43d
    sigs.k8s.io/kueue/test/integration/framework.(*Framework).RunManager()
        /home/prow/go/src/sigs.k8s.io/kueue/test/integration/framework/framework.go:161 +0x6d
    sigs.k8s.io/kueue/test/integration/controller/jobs/jobset.init.func4.1()
        /home/prow/go/src/sigs.k8s.io/kueue/test/integration/controller/jobs/jobset/jobset_controller_test.go:869 +0x2b2
    github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/github.com/onsi/ginkgo/v2/internal/node.go:472 +0x2e
    github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
        /home/prow/go/src/sigs.k8s.io/kueue/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:894 +0x12b
```

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kueue/2468/pull-kueue-test-integration-main/1807635494377361408

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix race condition on requeue workload.
```