### PR TITLE
Do not omit weightedShare when zero

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -349,7 +349,7 @@ type FairSharingStatus struct {
 	// If zero, it means that the usage of the ClusterQueue is below the nominal quota.
 	// If the ClusterQueue has a weight of zero, this will return 9223372036854775807,
 	// the maximum possible share value.
-	WeightedShare int64 `json:"weightedShare,omitempty"`
+	WeightedShare int64 `json:"weightedShare"`
 }
 
 const (

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -613,6 +613,8 @@ spec:
                       the maximum possible share value.
                     format: int64
                     type: integer
+                required:
+                - weightedShare
                 type: object
               flavorsReservation:
                 description: |-

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -598,6 +598,8 @@ spec:
                       the maximum possible share value.
                     format: int64
                     type: integer
+                required:
+                - weightedShare
                 type: object
               flavorsReservation:
                 description: |-


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A zero value for weightedShare should be visible in the API, as it has the meaning that the CQ is not borrowing.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Show weightedShared in ClusterQueue status even if the value is zero
```