### PR TITLE
[kjobctl][builder] Detect surplus flags

### DIFF
--- a/cmd/experimental/kjobctl/go.mod
+++ b/cmd/experimental/kjobctl/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/spf13/cobra v1.8.1
+	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.30.3
 	k8s.io/apimachinery v0.30.3
 	k8s.io/cli-runtime v0.30.3
@@ -62,7 +63,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	golang.org/x/net v0.25.0 // indirect

--- a/cmd/experimental/kjobctl/pkg/cmd/create/create_test.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/create/create_test.go
@@ -159,7 +159,11 @@ func TestCreateCmd(t *testing.T) {
 			kjobctlObjs: []runtime.Object{
 				wrappers.MakeJobTemplate("job-template", metav1.NamespaceDefault).Obj(),
 				wrappers.MakeApplicationProfile("profile", metav1.NamespaceDefault).
-					WithSupportedMode(*wrappers.MakeSupportedMode(v1alpha1.JobMode, "job-template").Obj()).
+					WithSupportedMode(
+						*wrappers.MakeSupportedMode(v1alpha1.JobMode, "job-template").
+							RequiredFlags(v1alpha1.LocalQueueFlag).
+							Obj(),
+					).
 					Obj(),
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
@@ -184,7 +188,11 @@ func TestCreateCmd(t *testing.T) {
 					Completions(1).
 					Obj(),
 				wrappers.MakeApplicationProfile("profile", metav1.NamespaceDefault).
-					WithSupportedMode(*wrappers.MakeSupportedMode(v1alpha1.JobMode, "job-template").Obj()).
+					WithSupportedMode(
+						*wrappers.MakeSupportedMode(v1alpha1.JobMode, "job-template").
+							RequiredFlags(v1alpha1.ParallelismFlag).
+							Obj(),
+					).
 					Obj(),
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
@@ -210,7 +218,11 @@ func TestCreateCmd(t *testing.T) {
 					Completions(1).
 					Obj(),
 				wrappers.MakeApplicationProfile("profile", metav1.NamespaceDefault).
-					WithSupportedMode(*wrappers.MakeSupportedMode(v1alpha1.JobMode, "job-template").Obj()).
+					WithSupportedMode(
+						*wrappers.MakeSupportedMode(v1alpha1.JobMode, "job-template").
+							RequiredFlags(v1alpha1.CompletionsFlag).
+							Obj(),
+					).
 					Obj(),
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
@@ -238,7 +250,11 @@ func TestCreateCmd(t *testing.T) {
 					WithContainer(*wrappers.MakeContainer("c2", "sleep").Obj()).
 					Obj(),
 				wrappers.MakeApplicationProfile("profile", metav1.NamespaceDefault).
-					WithSupportedMode(*wrappers.MakeSupportedMode(v1alpha1.JobMode, "job-template").Obj()).
+					WithSupportedMode(
+						*wrappers.MakeSupportedMode(v1alpha1.JobMode, "job-template").
+							RequiredFlags(v1alpha1.CmdFlag).
+							Obj(),
+					).
 					Obj(),
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
@@ -276,7 +292,11 @@ func TestCreateCmd(t *testing.T) {
 					WithContainer(*wrappers.MakeContainer("c2", "sleep").Obj()).
 					Obj(),
 				wrappers.MakeApplicationProfile("profile", metav1.NamespaceDefault).
-					WithSupportedMode(*wrappers.MakeSupportedMode(v1alpha1.JobMode, "job-template").Obj()).
+					WithSupportedMode(
+						*wrappers.MakeSupportedMode(v1alpha1.JobMode, "job-template").
+							RequiredFlags(v1alpha1.RequestFlag).
+							Obj(),
+					).
 					Obj(),
 			},
 			gvk: schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},

--- a/cmd/experimental/kjobctl/pkg/cmd/util/dry_run.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/util/dry_run.go
@@ -46,10 +46,14 @@ const (
 	DryRunServer
 )
 
+const (
+	DryRunFlagName = "dry-run"
+)
+
 // AddDryRunFlag adds dry-run flag to a command.
 func AddDryRunFlag(cmd *cobra.Command) {
 	cmd.PersistentFlags().String(
-		"dry-run",
+		DryRunFlagName,
 		"none",
 		`Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource.`,
 	)

--- a/cmd/experimental/kjobctl/pkg/testing/wrappers/supported_mode_wrappers.go
+++ b/cmd/experimental/kjobctl/pkg/testing/wrappers/supported_mode_wrappers.go
@@ -37,3 +37,8 @@ func MakeSupportedMode(name v1alpha1.ApplicationProfileMode, template v1alpha1.T
 func (m *SupportedModeWrapper) Obj() *v1alpha1.SupportedMode {
 	return &m.SupportedMode
 }
+
+func (m *SupportedModeWrapper) RequiredFlags(flags ...v1alpha1.Flag) *SupportedModeWrapper {
+	m.SupportedMode.RequiredFlags = flags
+	return m
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Detect unnecessary profile flags provided.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```