### PR TITLE
Refresh documentation for waitForPodsReady

### DIFF
--- a/CHANGELOG/CHANGELOG-0.3.md
+++ b/CHANGELOG/CHANGELOG-0.3.md
@@ -60,7 +60,7 @@ Changes since `v0.2.1`:
 - Multiplatform support for `linux/amd64` and `linux/arm64`.
 - Validating webhook for `batch/v1.Job` validates kueue-specific labels and
   annotations.
-- Sequential admission of jobs https://kueue.sigs.k8s.io/docs/tasks/setup_sequential_admission/
+- Sequential admission of jobs https://kueue.sigs.k8s.io/docs/tasks/setup_wait_for_pods_ready/
 - Preemption within ClusterQueue and cohort https://kueue.sigs.k8s.io/docs/concepts/cluster_queue/#preemption
 - Support for LimitRanges when calculating jobs usage.
 - Library for integrating job-like CRDs (controller and webhooks) https://sigs.k8s.io/kueue/pkg/controller/jobframework

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) to learn more.
 - **System insight:** Build-in [prometheus metrics](https://kueue.sigs.k8s.io/docs/reference/metrics/) to help monitor the state of the system, as well as Conditions.
 - **AdmissionChecks:** A mechanism for internal or external components to influence whether a workload can be [admitted](https://kueue.sigs.k8s.io/docs/concepts/admission_check/).
 - **Advanced autoscaling support:** Integration with cluster-autoscaler's [provisioningRequest](https://kueue.sigs.k8s.io/docs/admission-check-controllers/provisioning/#job-using-a-provisioningrequest) via admissionChecks.
-- **Sequential admission:** A simple implementation of [all-or-nothing scheduling](https://kueue.sigs.k8s.io/docs/tasks/manage/setup_sequential_admission/).
+- **All-or-nothing with ready Pods:** A timeout-based implementation of [all-or-nothing scheduling](https://kueue.sigs.k8s.io/docs/tasks/manage/setup_wait_for_pods_ready/).
 - **Partial admission:** Allows jobs to run with a [smaller parallelism](https://kueue.sigs.k8s.io/docs/tasks/run/jobs/#partial-admission), based on available quota, if the application supports it.
 
 ## Production Readiness status

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -50,10 +50,10 @@ type Configuration struct {
 	// InternalCertManagement is configuration for internalCertManagement
 	InternalCertManagement *InternalCertManagement `json:"internalCertManagement,omitempty"`
 
-	// WaitForPodsReady is configuration to provide simple all-or-nothing
-	// scheduling semantics for jobs to ensure they get resources assigned.
-	// This is achieved by blocking the start of new jobs until the previously
-	// started job has all pods running (ready).
+	// WaitForPodsReady is configuration to provide a time-based all-or-nothing
+	// scheduling semantics for Jobs, by ensuring all pods are ready (running
+	// and passing the readiness probe) within the specified time. If the timeout
+	// is exceeded, then the workload is evicted.
 	WaitForPodsReady *WaitForPodsReady `json:"waitForPodsReady,omitempty"`
 
 	// ClientConnection provides additional configuration options for Kubernetes
@@ -184,23 +184,23 @@ type ControllerConfigurationSpec struct {
 	CacheSyncTimeout *time.Duration `json:"cacheSyncTimeout,omitempty"`
 }
 
+// WaitForPodsReady defines configuration for the Wait For Pods Ready feature,
+// which is used to ensure that all Pods are ready within the specified time.
 type WaitForPodsReady struct {
-	// Enable when true, indicates that each admitted workload
-	// blocks the admission of all other workloads from all queues until it is in the
-	// `PodsReady` condition. If false, all workloads start as soon as they are
-	// admitted and do not block admission of other workloads. The PodsReady
-	// condition is only added if this setting is enabled. It defaults to false.
+	// Enable indicates whether to enable wait for pods ready feature.
+	// Defaults to false.
 	Enable bool `json:"enable,omitempty"`
 
 	// Timeout defines the time for an admitted workload to reach the
-	// PodsReady=true condition. When the timeout is reached, the workload admission
-	// is cancelled and requeued in the same cluster queue. Defaults to 5min.
+	// PodsReady=true condition. When the timeout is exceeded, the workload
+	// evicted and requeued in the same cluster queue.
+	// Defaults to 5min.
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
-	// BlockAdmission when true, cluster queue will block admissions for all subsequent jobs
-	// until the jobs reach the PodsReady=true condition. It defaults to false if Enable is false
-	// and defaults to true otherwise.
+	// BlockAdmission when true, cluster queue will block admissions for all
+	// subsequent jobs until the jobs reach the PodsReady=true condition.
+	// It defaults to false if Enable is false and defaults to true otherwise.
 	BlockAdmission *bool `json:"blockAdmission,omitempty"`
 
 	// RequeuingStrategy defines the strategy for requeuing a Workload.

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -24,6 +24,7 @@ controllerManager:
       repository: gcr.io/k8s-staging-kueue/kueue
       # This should be set to 'IfNotPresent' for released version      
       pullPolicy: Always
+      tag: main
     podAnnotations: {}
     resources:
       limits:

--- a/site/content/en/docs/concepts/workload.md
+++ b/site/content/en/docs/concepts/workload.md
@@ -89,7 +89,7 @@ Kueue will mark the workload as `Inadmissible` if the range validation fails.
 
 #### Reserved resource names
 
-In addition to the usual resource naming restrictions, you cannot use the `pods` resource name in a Pod spec, as it is reserved for internal Kueue use. You can use the `pods` resource name in a [ClusterQueue](/docs/concepts/cluster_queue#resources) to set quotas on the maximum number of pods. 
+In addition to the usual resource naming restrictions, you cannot use the `pods` resource name in a Pod spec, as it is reserved for internal Kueue use. You can use the `pods` resource name in a [ClusterQueue](/docs/concepts/cluster_queue#resources) to set quotas on the maximum number of pods.
 
 ## Priority
 
@@ -124,18 +124,18 @@ status:
     count: 2
   - name: podset2
     count: 2
-    
+
 ```
 The `count` can only increase while the workload holds a Quota Reservation.
 
-## All or Nothing semantics for Job Resource Assignment
+## All-or-Nothing semantics for Job Resource Assignment
 
-This mechanism allows a Job to be evicted and re-queued if the job doesn't become ready. 
-Please refer to the [Sequential Admission with Ready Pods](/docs/tasks/setup_sequential_admission) for more details.
+This mechanism allows a Job to be evicted and re-queued if the job doesn't become ready.
+Please refer to the [All-or-nothing with ready Pods](/docs/tasks/setup_wait_for_pods_ready) for more details.
 
 ### Exponential Backoff Requeueing
 
-Once evictions with `PodsReadyTimeout` reasons occur, a Workload will be re-queued with backoff. 
+Once evictions with `PodsReadyTimeout` reasons occur, a Workload will be re-queued with backoff.
 The Workload status allows you to know the following:
 
 - `.status.requeueState.count` indicates the numbers of times a Workload has already been backoff re-queued by Eviction with PodsReadyTimeout reason
@@ -148,7 +148,7 @@ status:
     requeueAt: 2024-02-11T04:51:03Z
 ```
 
-When a Workload deactivated by Sequential Admission with Ready Pods is re-activated, 
+When a Workload deactivated by All-or-nothing with ready Pods is re-activated,
 the requeueState (`.status.requeueState`) will be reset to null.
 
 ## What's next

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -147,7 +147,7 @@ data:
 __The `integrations.externalFrameworks` field is available in Kueue v0.7.0 and later.__
 
 {{% alert title="Note" color="primary" %}}
-See [Sequential Admission with Ready Pods](/docs/tasks/manage/setup_sequential_admission) to learn
+See [All-or-nothing with ready Pods](/docs/tasks/manage/setup_wait_for_pods_ready) to learn
 more about using `waitForPodsReady` for Kueue.
 {{% /alert %}}
 
@@ -219,7 +219,7 @@ To install and configure Kueue with [Helm](https://helm.sh/), follow the [instru
 
 Kueue uses a similar mechanism to configure features as described in [Kubernetes Feature Gates](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates).
 
-In order to change the default of a feature, you need to edit the `kueue-controller-manager` deployment within the kueue installation namespace and change the `manager` container arguments to include 
+In order to change the default of a feature, you need to edit the `kueue-controller-manager` deployment within the kueue installation namespace and change the `manager` container arguments to include
 
 ```
 --feature-gates=...,<FeatureName>=<true|false>

--- a/site/content/en/docs/overview/_index.md
+++ b/site/content/en/docs/overview/_index.md
@@ -32,7 +32,7 @@ A core design principle for Kueue is to avoid duplicating mature functionality i
 - **System insight:** Built-in [prometheus metrics](/docs/reference/metrics/) to help monitor the state of the system, as well as Conditions.
 - **AdmissionChecks:** A mechanism for internal or external components to influence whether a workload can be [admitted](/docs/concepts/admission_check/).
 - **Advanced autoscaling support:** Integration with cluster-autoscaler's [provisioningRequest](/docs/admission-check-controllers/provisioning/#job-using-a-provisioningrequest) via admissionChecks.
-- **Sequential admission:** A simple implementation of [all-or-nothing scheduling](/docs/tasks/setup_sequential_admission/).
+- **All-or-nothing with ready Pods:** A timeout-based implementation of [all-or-nothing scheduling](/docs/tasks/setup_wait_for_pods_ready/).
 - **Partial admission:** Allows jobs to run with a [smaller parallelism](/docs/tasks/run/jobs/#partial-admission), based on available quota, if the application supports it.
 
 ## High-level Kueue operation

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -126,10 +126,10 @@ unsuspended, they will start immediately.</p>
 <a href="#WaitForPodsReady"><code>WaitForPodsReady</code></a>
 </td>
 <td>
-   <p>WaitForPodsReady is configuration to provide simple all-or-nothing
-scheduling semantics for jobs to ensure they get resources assigned.
-This is achieved by blocking the start of new jobs until the previously
-started job has all pods running (ready).</p>
+   <p>WaitForPodsReady is configuration to provide a time-based all-or-nothing
+scheduling semantics for Jobs, by ensuring all pods are ready (running
+and passing the readiness probe) within the specified time. If the timeout
+is exceeded, then the workload is evicted.</p>
 </td>
 </tr>
 <tr><td><code>clientConnection</code> <B>[Required]</B><br/>
@@ -793,6 +793,9 @@ re-queuing an evicted workload.</p>
 
 
 
+<p>WaitForPodsReady defines configuration for the Wait For Pods Ready feature,
+which is used to ensure that all Pods are ready within the specified time.</p>
+
 
 <table class="table">
 <thead><tr><th width="30%">Field</th><th>Description</th></tr></thead>
@@ -803,11 +806,8 @@ re-queuing an evicted workload.</p>
 <code>bool</code>
 </td>
 <td>
-   <p>Enable when true, indicates that each admitted workload
-blocks the admission of all other workloads from all queues until it is in the
-<code>PodsReady</code> condition. If false, all workloads start as soon as they are
-admitted and do not block admission of other workloads. The PodsReady
-condition is only added if this setting is enabled. It defaults to false.</p>
+   <p>Enable indicates whether to enable wait for pods ready feature.
+Defaults to false.</p>
 </td>
 </tr>
 <tr><td><code>timeout</code><br/>
@@ -815,17 +815,18 @@ condition is only added if this setting is enabled. It defaults to false.</p>
 </td>
 <td>
    <p>Timeout defines the time for an admitted workload to reach the
-PodsReady=true condition. When the timeout is reached, the workload admission
-is cancelled and requeued in the same cluster queue. Defaults to 5min.</p>
+PodsReady=true condition. When the timeout is exceeded, the workload
+evicted and requeued in the same cluster queue.
+Defaults to 5min.</p>
 </td>
 </tr>
 <tr><td><code>blockAdmission</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
 <td>
-   <p>BlockAdmission when true, cluster queue will block admissions for all subsequent jobs
-until the jobs reach the PodsReady=true condition. It defaults to false if Enable is false
-and defaults to true otherwise.</p>
+   <p>BlockAdmission when true, cluster queue will block admissions for all
+subsequent jobs until the jobs reach the PodsReady=true condition.
+It defaults to false if Enable is false and defaults to true otherwise.</p>
 </td>
 </tr>
 <tr><td><code>requeuingStrategy</code><br/>

--- a/site/content/en/docs/tasks/_index.md
+++ b/site/content/en/docs/tasks/_index.md
@@ -22,7 +22,7 @@ As a batch administrator, you can learn how to:
 - [Setup role-based access control](manage/rbac)
   to Kueue objects.
 - [Administer cluster quotas](manage/administer_cluster_quotas) with ClusterQueues and LocalQueues.
-- Setup [Sequential Admission with Ready Pods](manage/setup_sequential_admission).
+- Setup [All-or-nothing with ready Pods](manage/setup_wait_for_pods_ready).
 - As a batch administrator, you can learn how to
   [monitor pending workloads](manage/monitor_pending_workloads).
 - As a batch administrator, you can learn how to [run a Kueue managed Jobs with a custom WorkloadPriority](manage/run_job_with_workload_priority).

--- a/site/static/_redirects
+++ b/site/static/_redirects
@@ -9,7 +9,7 @@
 /docs/tasks/rbac                           /docs/tasks/manage/rbac                           301
 /docs/tasks/run_job_with_workload_priority /docs/tasks/manage/run_job_with_workload_priority 301
 /docs/tasks/setup_multikueue               /docs/tasks/manage/setup_multikueue               301
-/docs/tasks/setup_sequential_admission     /docs/tasks/manage/setup_sequential_admission     301
+/docs/tasks/setup_wait_for_pods_ready      /docs/tasks/manage/setup_wait_for_pods_ready      301
 
 /docs/tasks/enabling_pprof_endpoints /docs/tasks/dev/enabling_pprof_endpoints 301
 /docs/tasks/integrate_a_custom_job   /docs/tasks/dev/integrate_a_custom_job   301


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

* To fix the documentation of some of the fields. In particular [this](https://github.com/kubernetes-sigs/kueue/blob/46ceaa5cdaff5c0e7f3eead8c7f9c94ceb85b8b5/apis/config/v1beta1/configuration_types.go#L53-L56) is no longer true, since blockAdmission can be false
* To rename the user-facing name of the feature to make the feature more discoverable. Most users want to achieve "all-or-nothing scheduling", rather than enable "Sequential admission", so the current names makes it hard to find


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Other names of the feature / admin task considered:
1. Setup `Timeout-based all-or-nothing`
2. Setup `Workload startup time`

Any of these works for me.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Improve the documentation for the waitForPodsReady
```