### PR TITLE
fix: wrong use of apivalication.ValidateImmutableField

### DIFF
--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -87,16 +87,16 @@ func ValidateLabelAsCRDName(job GenericJob, crdNameLabel string) field.ErrorList
 func validateUpdateForQueueName(oldJob, newJob GenericJob) field.ErrorList {
 	var allErrs field.ErrorList
 	if !newJob.IsSuspended() {
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(QueueName(oldJob), QueueName(newJob), queueNameLabelPath)...)
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(QueueName(newJob), QueueName(oldJob), queueNameLabelPath)...)
 	}
 
 	oldWlName, _ := PrebuiltWorkloadFor(oldJob)
 	newWlName, _ := PrebuiltWorkloadFor(newJob)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldWlName, newWlName, labelsPath.Key(constants.PrebuiltWorkloadLabel))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newWlName, oldWlName, labelsPath.Key(constants.PrebuiltWorkloadLabel))...)
 	return allErrs
 }
 
 func validateUpdateForWorkloadPriorityClassName(oldJob, newJob GenericJob) field.ErrorList {
-	allErrs := apivalidation.ValidateImmutableField(workloadPriorityClassName(oldJob), workloadPriorityClassName(newJob), workloadPriorityClassNamePath)
+	allErrs := apivalidation.ValidateImmutableField(workloadPriorityClassName(newJob), workloadPriorityClassName(oldJob), workloadPriorityClassNamePath)
 	return allErrs
 }

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -374,7 +374,31 @@ func TestValidateUpdate(t *testing.T) {
 				Suspend(false).
 				Label(constants.PrebuiltWorkloadLabel, "new-workload").
 				Obj(),
-			wantErr: apivalidation.ValidateImmutableField("old-workload", "new-workload", prebuiltWlNameLabelPath),
+			wantErr: apivalidation.ValidateImmutableField("new-workload", "old-workload", prebuiltWlNameLabelPath),
+		},
+		{
+			name: "immutable queue name not suspend",
+			oldJob: testingutil.MakeJob("job", "default").
+				Suspend(false).
+				Label(constants.QueueLabel, "old-queue").
+				Obj(),
+			newJob: testingutil.MakeJob("job", "default").
+				Suspend(false).
+				Label(constants.QueueLabel, "new-queue").
+				Obj(),
+			wantErr: apivalidation.ValidateImmutableField("new-queue", "old-queue", queueNameLabelPath),
+		},
+		{
+			name: "queue name can changes when it is  suspend",
+			oldJob: testingutil.MakeJob("job", "default").
+				Suspend(true).
+				Label(constants.QueueLabel, "old-queue").
+				Obj(),
+			newJob: testingutil.MakeJob("job", "default").
+				Suspend(true).
+				Label(constants.QueueLabel, "new-queue").
+				Obj(),
+			wantErr: nil,
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

wrong use of apivalication.ValidateImmutableField, order of parameters is (newObj,oldObj,fieldPath) not  is (oldObj,newObj,fieldPath)
add two test cases:
1. immutable queue name not suspend
2. queue name can changes when it is  suspend 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```