### PR TITLE
Move Requests from workload to resources package

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -628,13 +628,13 @@ func getUsage(frq resources.FlavorResourceQuantities, rgs []ResourceGroup, cohor
 				used := flvUsage[rName]
 				rUsage := kueue.ResourceUsage{
 					Name:  rName,
-					Total: workload.ResourceQuantity(rName, used),
+					Total: resources.ResourceQuantity(rName, used),
 				}
 				// Enforce `borrowed=0` if the clusterQueue doesn't belong to a cohort.
 				if cohort != nil {
 					borrowed := used - rQuota.Nominal
 					if borrowed > 0 {
-						rUsage.Borrowed = workload.ResourceQuantity(rName, borrowed)
+						rUsage.Borrowed = resources.ResourceQuantity(rName, borrowed)
 					}
 				}
 				outFlvUsage.Resources = append(outFlvUsage.Resources, rUsage)
@@ -689,7 +689,7 @@ func filterLocalQueueUsage(orig resources.FlavorResourceQuantities, resourceGrou
 			for rName := range flvQuotas.Resources {
 				outFlvUsage.Resources = append(outFlvUsage.Resources, kueue.LocalQueueResourceUsage{
 					Name:  rName,
-					Total: workload.ResourceQuantity(rName, flvUsage[rName]),
+					Total: resources.ResourceQuantity(rName, flvUsage[rName]),
 				})
 			}
 			// The resourceUsages should be in a stable order to avoid endless creation of update events.

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -912,7 +912,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							TotalRequests: []workload.PodSetResources{
 								{
 									Name:     "main",
-									Requests: workload.Requests{corev1.ResourceCPU: 1000},
+									Requests: resources.Requests{corev1.ResourceCPU: 1000},
 									Count:    1,
 									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 										corev1.ResourceCPU: "f1",
@@ -925,7 +925,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							TotalRequests: []workload.PodSetResources{
 								{
 									Name:     "main",
-									Requests: workload.Requests{corev1.ResourceCPU: 1000},
+									Requests: resources.Requests{corev1.ResourceCPU: 1000},
 									Count:    1,
 									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 										corev1.ResourceCPU: "f1",
@@ -2296,14 +2296,14 @@ func TestCacheQueueOperations(t *testing.T) {
 			reservingWorkloads: 1,
 			admittedWorkloads:  1,
 			usage: resources.FlavorResourceQuantitiesFlat{
-				{Flavor: "spot", Resource: corev1.ResourceCPU}:    workload.ResourceValue(corev1.ResourceCPU, resource.MustParse("2")),
-				{Flavor: "spot", Resource: corev1.ResourceMemory}: workload.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi")),
-				{Flavor: "model-a", Resource: "example.com/gpu"}:  workload.ResourceValue("example.com/gpu", resource.MustParse("0")),
+				{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2")),
+				{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi")),
+				{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.ResourceValue("example.com/gpu", resource.MustParse("0")),
 			}.Unflatten(),
 			admittedUsage: resources.FlavorResourceQuantitiesFlat{
-				{Flavor: "spot", Resource: corev1.ResourceCPU}:    workload.ResourceValue(corev1.ResourceCPU, resource.MustParse("2")),
-				{Flavor: "spot", Resource: corev1.ResourceMemory}: workload.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi")),
-				{Flavor: "model-a", Resource: "example.com/gpu"}:  workload.ResourceValue("example.com/gpu", resource.MustParse("0")),
+				{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("2")),
+				{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("8Gi")),
+				{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.ResourceValue("example.com/gpu", resource.MustParse("0")),
 			}.Unflatten(),
 		},
 		"ns2/beta": {
@@ -2311,14 +2311,14 @@ func TestCacheQueueOperations(t *testing.T) {
 			reservingWorkloads: 2,
 			admittedWorkloads:  1,
 			usage: resources.FlavorResourceQuantitiesFlat{
-				{Flavor: "spot", Resource: corev1.ResourceCPU}:    workload.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
-				{Flavor: "spot", Resource: corev1.ResourceMemory}: workload.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
-				{Flavor: "model-a", Resource: "example.com/gpu"}:  workload.ResourceValue("example.com/gpu", resource.MustParse("7")),
+				{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
+				{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
+				{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.ResourceValue("example.com/gpu", resource.MustParse("7")),
 			}.Unflatten(),
 			admittedUsage: resources.FlavorResourceQuantitiesFlat{
-				{Flavor: "spot", Resource: corev1.ResourceCPU}:    workload.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
-				{Flavor: "spot", Resource: corev1.ResourceMemory}: workload.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
-				{Flavor: "model-a", Resource: "example.com/gpu"}:  workload.ResourceValue("example.com/gpu", resource.MustParse("2")),
+				{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
+				{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
+				{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.ResourceValue("example.com/gpu", resource.MustParse("2")),
 			}.Unflatten(),
 		},
 		"ns1/gamma": {
@@ -2326,14 +2326,14 @@ func TestCacheQueueOperations(t *testing.T) {
 			reservingWorkloads: 1,
 			admittedWorkloads:  0,
 			usage: resources.FlavorResourceQuantitiesFlat{
-				{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    workload.ResourceValue(corev1.ResourceCPU, resource.MustParse("5")),
-				{Flavor: "ondemand", Resource: corev1.ResourceMemory}: workload.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi")),
-				{Flavor: "model-b", Resource: "example.com/gpu"}:      workload.ResourceValue("example.com/gpu", resource.MustParse("0")),
+				{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("5")),
+				{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("16Gi")),
+				{Flavor: "model-b", Resource: "example.com/gpu"}:      resources.ResourceValue("example.com/gpu", resource.MustParse("0")),
 			}.Unflatten(),
 			admittedUsage: resources.FlavorResourceQuantitiesFlat{
-				{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    workload.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
-				{Flavor: "ondemand", Resource: corev1.ResourceMemory}: workload.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
-				{Flavor: "model-b", Resource: "example.com/gpu"}:      workload.ResourceValue("example.com/gpu", resource.MustParse("0")),
+				{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
+				{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
+				{Flavor: "model-b", Resource: "example.com/gpu"}:      resources.ResourceValue("example.com/gpu", resource.MustParse("0")),
 			}.Unflatten(),
 		},
 	}
@@ -2343,14 +2343,14 @@ func TestCacheQueueOperations(t *testing.T) {
 			reservingWorkloads: 0,
 			admittedWorkloads:  0,
 			usage: resources.FlavorResourceQuantitiesFlat{
-				{Flavor: "spot", Resource: corev1.ResourceCPU}:    workload.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
-				{Flavor: "spot", Resource: corev1.ResourceMemory}: workload.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
-				{Flavor: "model-a", Resource: "example.com/gpu"}:  workload.ResourceValue("example.com/gpu", resource.MustParse("0")),
+				{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
+				{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
+				{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.ResourceValue("example.com/gpu", resource.MustParse("0")),
 			}.Unflatten(),
 			admittedUsage: resources.FlavorResourceQuantitiesFlat{
-				{Flavor: "spot", Resource: corev1.ResourceCPU}:    workload.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
-				{Flavor: "spot", Resource: corev1.ResourceMemory}: workload.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
-				{Flavor: "model-a", Resource: "example.com/gpu"}:  workload.ResourceValue("example.com/gpu", resource.MustParse("0")),
+				{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
+				{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
+				{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.ResourceValue("example.com/gpu", resource.MustParse("0")),
 			}.Unflatten(),
 		},
 		"ns2/beta": {
@@ -2358,14 +2358,14 @@ func TestCacheQueueOperations(t *testing.T) {
 			reservingWorkloads: 0,
 			admittedWorkloads:  0,
 			usage: resources.FlavorResourceQuantitiesFlat{
-				{Flavor: "spot", Resource: corev1.ResourceCPU}:    workload.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
-				{Flavor: "spot", Resource: corev1.ResourceMemory}: workload.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
-				{Flavor: "model-a", Resource: "example.com/gpu"}:  workload.ResourceValue("example.com/gpu", resource.MustParse("0")),
+				{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
+				{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
+				{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.ResourceValue("example.com/gpu", resource.MustParse("0")),
 			}.Unflatten(),
 			admittedUsage: resources.FlavorResourceQuantitiesFlat{
-				{Flavor: "spot", Resource: corev1.ResourceCPU}:    workload.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
-				{Flavor: "spot", Resource: corev1.ResourceMemory}: workload.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
-				{Flavor: "model-a", Resource: "example.com/gpu"}:  workload.ResourceValue("example.com/gpu", resource.MustParse("0")),
+				{Flavor: "spot", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
+				{Flavor: "spot", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
+				{Flavor: "model-a", Resource: "example.com/gpu"}:  resources.ResourceValue("example.com/gpu", resource.MustParse("0")),
 			}.Unflatten(),
 		},
 		"ns1/gamma": {
@@ -2373,14 +2373,14 @@ func TestCacheQueueOperations(t *testing.T) {
 			reservingWorkloads: 0,
 			admittedWorkloads:  0,
 			usage: resources.FlavorResourceQuantitiesFlat{
-				{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    workload.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
-				{Flavor: "ondemand", Resource: corev1.ResourceMemory}: workload.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
-				{Flavor: "model-b", Resource: "example.com/gpu"}:      workload.ResourceValue("example.com/gpu", resource.MustParse("0")),
+				{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
+				{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
+				{Flavor: "model-b", Resource: "example.com/gpu"}:      resources.ResourceValue("example.com/gpu", resource.MustParse("0")),
 			}.Unflatten(),
 			admittedUsage: resources.FlavorResourceQuantitiesFlat{
-				{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    workload.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
-				{Flavor: "ondemand", Resource: corev1.ResourceMemory}: workload.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
-				{Flavor: "model-b", Resource: "example.com/gpu"}:      workload.ResourceValue("example.com/gpu", resource.MustParse("0")),
+				{Flavor: "ondemand", Resource: corev1.ResourceCPU}:    resources.ResourceValue(corev1.ResourceCPU, resource.MustParse("0")),
+				{Flavor: "ondemand", Resource: corev1.ResourceMemory}: resources.ResourceValue(corev1.ResourceMemory, resource.MustParse("0")),
+				{Flavor: "model-b", Resource: "example.com/gpu"}:      resources.ResourceValue("example.com/gpu", resource.MustParse("0")),
 			}.Unflatten(),
 		},
 	}

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -259,15 +259,15 @@ func (c *clusterQueue) updateResourceGroups(in []kueue.ResourceGroup) {
 				Resources: make(map[corev1.ResourceName]*ResourceQuota, len(fIn.Resources)),
 			}
 			for _, rIn := range fIn.Resources {
-				nominal := workload.ResourceValue(rIn.Name, rIn.NominalQuota)
+				nominal := resources.ResourceValue(rIn.Name, rIn.NominalQuota)
 				rQuota := ResourceQuota{
 					Nominal: nominal,
 				}
 				if rIn.BorrowingLimit != nil {
-					rQuota.BorrowingLimit = ptr.To(workload.ResourceValue(rIn.Name, *rIn.BorrowingLimit))
+					rQuota.BorrowingLimit = ptr.To(resources.ResourceValue(rIn.Name, *rIn.BorrowingLimit))
 				}
 				if features.Enabled(features.LendingLimit) && rIn.LendingLimit != nil {
-					rQuota.LendingLimit = ptr.To(workload.ResourceValue(rIn.Name, *rIn.LendingLimit))
+					rQuota.LendingLimit = ptr.To(resources.ResourceValue(rIn.Name, *rIn.LendingLimit))
 					c.Lendable[rIn.Name] += *rQuota.LendingLimit
 				} else {
 					c.Lendable[rIn.Name] += nominal

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// The following resources calculations are inspired on
+// https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/types.go
+
+// Requests maps ResourceName to flavor to value; for CPU it is tracked in MilliCPU.
+type Requests map[corev1.ResourceName]int64
+
+func NewRequests(rl corev1.ResourceList) Requests {
+	r := Requests{}
+	for name, quant := range rl {
+		r[name] = ResourceValue(name, quant)
+	}
+	return r
+}
+
+func (r Requests) ToResourceList() corev1.ResourceList {
+	ret := make(corev1.ResourceList, len(r))
+	for k, v := range r {
+		ret[k] = ResourceQuantity(k, v)
+	}
+	return ret
+}
+
+// ResourceValue returns the integer value for the resource name.
+// It's milli-units for CPU and absolute units for everything else.
+func ResourceValue(name corev1.ResourceName, q resource.Quantity) int64 {
+	if name == corev1.ResourceCPU {
+		return q.MilliValue()
+	}
+	return q.Value()
+}
+
+func ResourceQuantity(name corev1.ResourceName, v int64) resource.Quantity {
+	switch name {
+	case corev1.ResourceCPU:
+		return *resource.NewMilliQuantity(v, resource.DecimalSI)
+	case corev1.ResourceMemory, corev1.ResourceEphemeralStorage:
+		return *resource.NewQuantity(v, resource.BinarySI)
+	default:
+		if strings.HasPrefix(string(name), corev1.ResourceHugePagesPrefix) {
+			return *resource.NewQuantity(v, resource.BinarySI)
+		}
+		return *resource.NewQuantity(v, resource.DecimalSI)
+	}
+}

--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -20,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
-	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 type FlavorResource struct {
@@ -28,14 +27,14 @@ type FlavorResource struct {
 	Resource corev1.ResourceName
 }
 
-type FlavorResourceQuantities map[kueue.ResourceFlavorReference]workload.Requests
+type FlavorResourceQuantities map[kueue.ResourceFlavorReference]Requests
 type FlavorResourceQuantitiesFlat map[FlavorResource]int64
 
 func (f FlavorResourceQuantitiesFlat) Unflatten() FlavorResourceQuantities {
 	out := make(FlavorResourceQuantities)
 	for flavorResource, value := range f {
 		if _, ok := out[flavorResource.Flavor]; !ok {
-			out[flavorResource.Flavor] = make(workload.Requests)
+			out[flavorResource.Flavor] = make(Requests)
 		}
 		out[flavorResource.Flavor][flavorResource.Resource] = value
 	}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -358,7 +358,7 @@ func (psa *PodSetAssignment) append(flavors ResourceAssignment, status *Status) 
 	}
 }
 
-func (a *Assignment) append(requests workload.Requests, psAssignment *PodSetAssignment) {
+func (a *Assignment) append(requests resources.Requests, psAssignment *PodSetAssignment) {
 	flavorIdx := make(map[corev1.ResourceName]int, len(psAssignment.Flavors))
 	a.PodSets = append(a.PodSets, *psAssignment)
 	for resource, flvAssignment := range psAssignment.Flavors {
@@ -382,7 +382,7 @@ func (a *Assignment) append(requests workload.Requests, psAssignment *PodSetAssi
 func (a *FlavorAssigner) findFlavorForPodSetResource(
 	log logr.Logger,
 	psID int,
-	requests workload.Requests,
+	requests resources.Requests,
 	resName corev1.ResourceName,
 	assignmentUsage resources.FlavorResourceQuantities,
 ) (ResourceAssignment, *Status) {
@@ -602,7 +602,7 @@ func (a *FlavorAssigner) fitsResourceQuota(fName kueue.ResourceFlavorReference, 
 		return Fit, used+val > rQuota.Nominal, nil
 	}
 
-	lackQuantity := workload.ResourceQuantity(rName, lack)
+	lackQuantity := resources.ResourceQuantity(rName, lack)
 	msg := fmt.Sprintf("insufficient unused quota in cohort for %s in flavor %s, %s more needed", rName, fName, &lackQuantity)
 	if a.cq.Cohort == nil {
 		if mode == NoFit {
@@ -620,8 +620,8 @@ func (a *FlavorAssigner) canPreemptWhileBorrowing() bool {
 		(a.enableFairSharing && a.cq.Preemption.ReclaimWithinCohort != kueue.PreemptionPolicyNever)
 }
 
-func filterRequestedResources(req workload.Requests, allowList sets.Set[corev1.ResourceName]) workload.Requests {
-	filtered := make(workload.Requests)
+func filterRequestedResources(req resources.Requests, allowList sets.Set[corev1.ResourceName]) resources.Requests {
+	filtered := make(resources.Requests)
 	for n, v := range req {
 		if allowList.Has(n) {
 			filtered[n] = v

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -163,7 +163,7 @@ func (cu *cohortsUsage) add(cohort string, assignment resources.FlavorResourceQu
 }
 
 func (cu *cohortsUsage) totalUsageForCommonFlavorResources(cohort string, assignment resources.FlavorResourceQuantities) resources.FlavorResourceQuantities {
-	return utilmaps.Intersect((*cu)[cohort], assignment, func(a, b workload.Requests) workload.Requests {
+	return utilmaps.Intersect((*cu)[cohort], assignment, func(a, b resources.Requests) resources.Requests {
 		return utilmaps.Intersect(a, b, func(a, b int64) int64 { return a + b })
 	})
 }

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -34,6 +34,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -229,7 +230,7 @@ func validateAdmission(obj *kueue.Workload, path *field.Path) field.ErrorList {
 		}
 		if count := ptr.Deref(ps.Count, 0); count > 0 {
 			for k, v := range ps.ResourceUsage {
-				if (workload.ResourceValue(k, v) % int64(count)) != 0 {
+				if (resources.ResourceValue(k, v) % int64(count)) != 0 {
 					allErrs = append(allErrs, field.Invalid(psaPath.Child("resourceUsage").Key(string(k)), v, fmt.Sprintf("is not a multiple of %d", ps.Count)))
 				}
 			}

--- a/pkg/workload/resources_test.go
+++ b/pkg/workload/resources_test.go
@@ -23,6 +23,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
@@ -37,8 +38,8 @@ func TestAdjustResources(t *testing.T) {
 			runtimeClasses: []nodev1.RuntimeClass{
 				utiltesting.MakeRuntimeClass("runtime-a", "handler-a").
 					PodOverhead(corev1.ResourceList{
-						corev1.ResourceCPU:    ResourceQuantity(corev1.ResourceCPU, 1),
-						corev1.ResourceMemory: ResourceQuantity(corev1.ResourceMemory, 1024),
+						corev1.ResourceCPU:    resources.ResourceQuantity(corev1.ResourceCPU, 1),
+						corev1.ResourceMemory: resources.ResourceQuantity(corev1.ResourceMemory, 1024),
 					}).
 					RuntimeClass,
 			},
@@ -53,8 +54,8 @@ func TestAdjustResources(t *testing.T) {
 						RuntimeClass("runtime-a").
 						PodOverHead(
 							corev1.ResourceList{
-								corev1.ResourceCPU:    ResourceQuantity(corev1.ResourceCPU, 2),
-								corev1.ResourceMemory: ResourceQuantity(corev1.ResourceMemory, 2048),
+								corev1.ResourceCPU:    resources.ResourceQuantity(corev1.ResourceCPU, 2),
+								corev1.ResourceMemory: resources.ResourceQuantity(corev1.ResourceMemory, 2048),
 							}).
 						Obj(),
 					*utiltesting.MakePodSet("d", 1).
@@ -64,8 +65,8 @@ func TestAdjustResources(t *testing.T) {
 						RuntimeClass("runtime-e").
 						PodOverHead(
 							corev1.ResourceList{
-								corev1.ResourceCPU:    ResourceQuantity(corev1.ResourceCPU, 2),
-								corev1.ResourceMemory: ResourceQuantity(corev1.ResourceMemory, 2048),
+								corev1.ResourceCPU:    resources.ResourceQuantity(corev1.ResourceCPU, 2),
+								corev1.ResourceMemory: resources.ResourceQuantity(corev1.ResourceMemory, 2048),
 							}).
 						Obj(),
 				).
@@ -76,8 +77,8 @@ func TestAdjustResources(t *testing.T) {
 						RuntimeClass("runtime-a").
 						PodOverHead(
 							corev1.ResourceList{
-								corev1.ResourceCPU:    ResourceQuantity(corev1.ResourceCPU, 1),
-								corev1.ResourceMemory: ResourceQuantity(corev1.ResourceMemory, 1024),
+								corev1.ResourceCPU:    resources.ResourceQuantity(corev1.ResourceCPU, 1),
+								corev1.ResourceMemory: resources.ResourceQuantity(corev1.ResourceMemory, 1024),
 							}).
 						Obj(),
 					*utiltesting.MakePodSet("b", 1).
@@ -86,8 +87,8 @@ func TestAdjustResources(t *testing.T) {
 						RuntimeClass("runtime-a").
 						PodOverHead(
 							corev1.ResourceList{
-								corev1.ResourceCPU:    ResourceQuantity(corev1.ResourceCPU, 2),
-								corev1.ResourceMemory: ResourceQuantity(corev1.ResourceMemory, 2048),
+								corev1.ResourceCPU:    resources.ResourceQuantity(corev1.ResourceCPU, 2),
+								corev1.ResourceMemory: resources.ResourceQuantity(corev1.ResourceMemory, 2048),
 							}).
 						Obj(),
 					*utiltesting.MakePodSet("d", 1).
@@ -97,8 +98,8 @@ func TestAdjustResources(t *testing.T) {
 						RuntimeClass("runtime-e").
 						PodOverHead(
 							corev1.ResourceList{
-								corev1.ResourceCPU:    ResourceQuantity(corev1.ResourceCPU, 2),
-								corev1.ResourceMemory: ResourceQuantity(corev1.ResourceMemory, 2048),
+								corev1.ResourceCPU:    resources.ResourceQuantity(corev1.ResourceCPU, 2),
+								corev1.ResourceMemory: resources.ResourceQuantity(corev1.ResourceMemory, 2048),
 							}).
 						Obj(),
 				).
@@ -120,8 +121,8 @@ func TestAdjustResources(t *testing.T) {
 						RuntimeClass("runtime-a").
 						PodOverHead(
 							corev1.ResourceList{
-								corev1.ResourceCPU:    ResourceQuantity(corev1.ResourceCPU, 1),
-								corev1.ResourceMemory: ResourceQuantity(corev1.ResourceMemory, 1024),
+								corev1.ResourceCPU:    resources.ResourceQuantity(corev1.ResourceCPU, 1),
+								corev1.ResourceMemory: resources.ResourceQuantity(corev1.ResourceMemory, 1024),
 							}).
 						Obj(),
 					*utiltesting.MakePodSet("d", 1).
@@ -131,8 +132,8 @@ func TestAdjustResources(t *testing.T) {
 						RuntimeClass("runtime-e").
 						PodOverHead(
 							corev1.ResourceList{
-								corev1.ResourceCPU:    ResourceQuantity(corev1.ResourceCPU, 1),
-								corev1.ResourceMemory: ResourceQuantity(corev1.ResourceMemory, 1024),
+								corev1.ResourceCPU:    resources.ResourceQuantity(corev1.ResourceCPU, 1),
+								corev1.ResourceMemory: resources.ResourceQuantity(corev1.ResourceMemory, 1024),
 							}).
 						Obj(),
 				).
@@ -148,8 +149,8 @@ func TestAdjustResources(t *testing.T) {
 						RuntimeClass("runtime-a").
 						PodOverHead(
 							corev1.ResourceList{
-								corev1.ResourceCPU:    ResourceQuantity(corev1.ResourceCPU, 1),
-								corev1.ResourceMemory: ResourceQuantity(corev1.ResourceMemory, 1024),
+								corev1.ResourceCPU:    resources.ResourceQuantity(corev1.ResourceCPU, 1),
+								corev1.ResourceMemory: resources.ResourceQuantity(corev1.ResourceMemory, 1024),
 							}).
 						Obj(),
 					*utiltesting.MakePodSet("d", 1).
@@ -159,8 +160,8 @@ func TestAdjustResources(t *testing.T) {
 						RuntimeClass("runtime-e").
 						PodOverHead(
 							corev1.ResourceList{
-								corev1.ResourceCPU:    ResourceQuantity(corev1.ResourceCPU, 1),
-								corev1.ResourceMemory: ResourceQuantity(corev1.ResourceMemory, 1024),
+								corev1.ResourceCPU:    resources.ResourceQuantity(corev1.ResourceCPU, 1),
+								corev1.ResourceMemory: resources.ResourceQuantity(corev1.ResourceMemory, 1024),
 							}).
 						Obj(),
 				).

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -26,7 +26,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
@@ -40,6 +39,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
+	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	"sigs.k8s.io/kueue/pkg/util/limitrange"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
@@ -154,7 +154,7 @@ type Info struct {
 type PodSetResources struct {
 	Name string
 	// Requests incorporates the requests from all pods in the podset.
-	Requests Requests
+	Requests resources.Requests
 	// Count indicates how many pods are in the podset.
 	Count int32
 
@@ -169,8 +169,9 @@ func (psr *PodSetResources) ScaledTo(newCount int32) *PodSetResources {
 		Count:    psr.Count,
 		Flavors:  maps.Clone(psr.Flavors),
 	}
-	ret.Requests.scaleDown(int64(ret.Count))
-	ret.Requests.scaleUp(int64(newCount))
+
+	scaleDown(ret.Requests, int64(ret.Count))
+	scaleUp(ret.Requests, int64(newCount))
 	ret.Count = newCount
 	return ret
 }
@@ -205,18 +206,18 @@ func (i *Info) CanBePartiallyAdmitted() bool {
 
 // FlavorResourceUsage returns the total resource usage for the workload,
 // per flavor (if assigned, otherwise flavor shows as empty string), per resource.
-func (i *Info) FlavorResourceUsage() map[kueue.ResourceFlavorReference]Requests {
+func (i *Info) FlavorResourceUsage() resources.FlavorResourceQuantities {
 	if i == nil || len(i.TotalRequests) == 0 {
 		return nil
 	}
-	total := make(map[kueue.ResourceFlavorReference]Requests)
+	total := make(resources.FlavorResourceQuantities)
 	for _, psReqs := range i.TotalRequests {
 		for res, q := range psReqs.Requests {
 			flv := psReqs.Flavors[res]
 			if requests, found := total[flv]; found {
 				requests[res] += q
 			} else {
-				total[flv] = Requests{
+				total[flv] = resources.Requests{
 					res: q,
 				}
 			}
@@ -301,8 +302,8 @@ func totalRequestsFromPodSets(wl *kueue.Workload) []PodSetResources {
 			Name:  ps.Name,
 			Count: count,
 		}
-		setRes.Requests = newRequests(limitrange.TotalRequests(&ps.Template.Spec))
-		setRes.Requests.scaleUp(int64(count))
+		setRes.Requests = resources.NewRequests(limitrange.TotalRequests(&ps.Template.Spec))
+		scaleUp(setRes.Requests, int64(count))
 		res = append(res, setRes)
 	}
 	return res
@@ -320,12 +321,12 @@ func totalRequestsFromAdmission(wl *kueue.Workload) []PodSetResources {
 			Name:     psa.Name,
 			Flavors:  psa.Flavors,
 			Count:    ptr.Deref(psa.Count, totalCounts[psa.Name]),
-			Requests: newRequests(psa.ResourceUsage),
+			Requests: resources.NewRequests(psa.ResourceUsage),
 		}
 
 		if count := currentCounts[psa.Name]; count != setRes.Count {
-			setRes.Requests.scaleDown(int64(setRes.Count))
-			setRes.Requests.scaleUp(int64(count))
+			scaleDown(setRes.Requests, int64(setRes.Count))
+			scaleUp(setRes.Requests, int64(count))
 			setRes.Count = count
 		}
 
@@ -334,58 +335,13 @@ func totalRequestsFromAdmission(wl *kueue.Workload) []PodSetResources {
 	return res
 }
 
-// The following resources calculations are inspired on
-// https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/types.go
-
-// Requests maps ResourceName to flavor to value; for CPU it is tracked in MilliCPU.
-type Requests map[corev1.ResourceName]int64
-
-func newRequests(rl corev1.ResourceList) Requests {
-	r := Requests{}
-	for name, quant := range rl {
-		r[name] = ResourceValue(name, quant)
-	}
-	return r
-}
-
-func (r Requests) ToResourceList() corev1.ResourceList {
-	ret := make(corev1.ResourceList, len(r))
-	for k, v := range r {
-		ret[k] = ResourceQuantity(k, v)
-	}
-	return ret
-}
-
-// ResourceValue returns the integer value for the resource name.
-// It's milli-units for CPU and absolute units for everything else.
-func ResourceValue(name corev1.ResourceName, q resource.Quantity) int64 {
-	if name == corev1.ResourceCPU {
-		return q.MilliValue()
-	}
-	return q.Value()
-}
-
-func ResourceQuantity(name corev1.ResourceName, v int64) resource.Quantity {
-	switch name {
-	case corev1.ResourceCPU:
-		return *resource.NewMilliQuantity(v, resource.DecimalSI)
-	case corev1.ResourceMemory, corev1.ResourceEphemeralStorage:
-		return *resource.NewQuantity(v, resource.BinarySI)
-	default:
-		if strings.HasPrefix(string(name), corev1.ResourceHugePagesPrefix) {
-			return *resource.NewQuantity(v, resource.BinarySI)
-		}
-		return *resource.NewQuantity(v, resource.DecimalSI)
-	}
-}
-
-func (r Requests) scaleUp(f int64) {
+func scaleUp(r resources.Requests, f int64) {
 	for name := range r {
 		r[name] *= f
 	}
 }
 
-func (r Requests) scaleDown(f int64) {
+func scaleDown(r resources.Requests, f int64) {
 	for name := range r {
 		r[name] /= f
 	}

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -32,6 +32,7 @@ import (
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/resources"
 	utilac "sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
@@ -51,7 +52,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "main",
-						Requests: Requests{
+						Requests: resources.Requests{
 							corev1.ResourceCPU:    10,
 							corev1.ResourceMemory: 512 * 1024,
 						},
@@ -79,7 +80,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "main",
-						Requests: Requests{
+						Requests: resources.Requests{
 							corev1.ResourceCPU:    3 * 10,
 							corev1.ResourceMemory: 3 * 512 * 1024,
 						},
@@ -131,7 +132,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "driver",
-						Requests: Requests{
+						Requests: resources.Requests{
 							corev1.ResourceCPU:    10,
 							corev1.ResourceMemory: 512 * 1024,
 						},
@@ -142,7 +143,7 @@ func TestNewInfo(t *testing.T) {
 					},
 					{
 						Name: "workers",
-						Requests: Requests{
+						Requests: resources.Requests{
 							corev1.ResourceCPU:    15,
 							corev1.ResourceMemory: 3 * 1024 * 1024,
 							"ex.com/gpu":          3,
@@ -182,7 +183,7 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: Requests{
+						Requests: resources.Requests{
 							corev1.ResourceCPU:    3 * 10,
 							corev1.ResourceMemory: 3 * 10 * 1024,
 						},
@@ -202,7 +203,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "main",
-						Requests: Requests{
+						Requests: resources.Requests{
 							corev1.ResourceCPU:    10,
 							corev1.ResourceMemory: 512 * 1024,
 						},
@@ -592,19 +593,19 @@ func TestIsEvictedByPodsReadyTimeout(t *testing.T) {
 func TestFlavorResourceUsage(t *testing.T) {
 	cases := map[string]struct {
 		info *Info
-		want map[kueue.ResourceFlavorReference]Requests
+		want resources.FlavorResourceQuantities
 	}{
 		"nil": {},
 		"one podset, no flavors": {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
-					Requests: Requests{
+					Requests: resources.Requests{
 						corev1.ResourceCPU: 1_000,
 						"example.com/gpu":  3,
 					},
 				}},
 			},
-			want: map[kueue.ResourceFlavorReference]Requests{
+			want: map[kueue.ResourceFlavorReference]resources.Requests{
 				"": {
 					corev1.ResourceCPU: 1_000,
 					"example.com/gpu":  3,
@@ -614,7 +615,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 		"one podset, multiple flavors": {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
-					Requests: Requests{
+					Requests: resources.Requests{
 						corev1.ResourceCPU: 1_000,
 						"example.com/gpu":  3,
 					},
@@ -624,7 +625,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 					},
 				}},
 			},
-			want: map[kueue.ResourceFlavorReference]Requests{
+			want: map[kueue.ResourceFlavorReference]resources.Requests{
 				"default": {
 					corev1.ResourceCPU: 1_000,
 				},
@@ -637,7 +638,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{
 					{
-						Requests: Requests{
+						Requests: resources.Requests{
 							corev1.ResourceCPU: 1_000,
 							"example.com/gpu":  3,
 						},
@@ -647,7 +648,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 						},
 					},
 					{
-						Requests: Requests{
+						Requests: resources.Requests{
 							corev1.ResourceCPU:    2_000,
 							corev1.ResourceMemory: 2 * utiltesting.Gi,
 						},
@@ -657,7 +658,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 						},
 					},
 					{
-						Requests: Requests{
+						Requests: resources.Requests{
 							"example.com/gpu": 1,
 						},
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
@@ -666,7 +667,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 					},
 				},
 			},
-			want: map[kueue.ResourceFlavorReference]Requests{
+			want: map[kueue.ResourceFlavorReference]resources.Requests{
 				"default": {
 					corev1.ResourceCPU:    3_000,
 					corev1.ResourceMemory: 2 * utiltesting.Gi,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
Break the dependency of `requests` package on `workload`, so we can continue updating usages to requests.FlavorResourceQuantitiesFlat #2447
#### Does this PR introduce a user-facing change?
```release-note
NONE
```