### PR TITLE
Flatten several usages of FlavorResourceQuantities

### DIFF
--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -664,12 +664,12 @@ func (c *ClusterQueueSnapshot) DominantResourceShare() (int, corev1.ResourceName
 	return dominantResourceShare(c, nil, 0)
 }
 
-func (c *ClusterQueueSnapshot) DominantResourceShareWith(wlReq resources.FlavorResourceQuantities) (int, corev1.ResourceName) {
+func (c *ClusterQueueSnapshot) DominantResourceShareWith(wlReq resources.FlavorResourceQuantitiesFlat) (int, corev1.ResourceName) {
 	return dominantResourceShare(c, wlReq, 1)
 }
 
-func (c *ClusterQueueSnapshot) DominantResourceShareWithout(w *workload.Info) (int, corev1.ResourceName) {
-	return dominantResourceShare(c, w.FlavorResourceUsage(), -1)
+func (c *ClusterQueueSnapshot) DominantResourceShareWithout(wlReq resources.FlavorResourceQuantitiesFlat) (int, corev1.ResourceName) {
+	return dominantResourceShare(c, wlReq, -1)
 }
 
 type dominantResourceShareNode interface {
@@ -680,7 +680,7 @@ type dominantResourceShareNode interface {
 	netQuotaNode
 }
 
-func dominantResourceShare(node dominantResourceShareNode, wlReq resources.FlavorResourceQuantities, m int64) (int, corev1.ResourceName) {
+func dominantResourceShare(node dominantResourceShareNode, wlReq resources.FlavorResourceQuantitiesFlat, m int64) (int, corev1.ResourceName) {
 	if !node.hasCohort() {
 		return 0, ""
 	}
@@ -690,7 +690,7 @@ func dominantResourceShare(node dominantResourceShareNode, wlReq resources.Flavo
 
 	borrowing := make(map[corev1.ResourceName]int64)
 	for fr, quota := range remainingQuota(node) {
-		b := m*wlReq[fr.Flavor][fr.Resource] - quota
+		b := m*wlReq[fr] - quota
 		if b > 0 {
 			borrowing[fr.Resource] += b
 		}

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -716,7 +716,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 func TestDominantResourceShare(t *testing.T) {
 	cases := map[string]struct {
 		cq          ClusterQueueSnapshot
-		flvResQ     resources.FlavorResourceQuantities
+		flvResQ     resources.FlavorResourceQuantitiesFlat
 		wantDRValue int
 		wantDRName  corev1.ResourceName
 	}{
@@ -885,7 +885,7 @@ func TestDominantResourceShare(t *testing.T) {
 			flvResQ: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
 				{Flavor: "default", Resource: "example.com/gpu"}:  4,
-			}.Unflatten(),
+			},
 			wantDRName:  corev1.ResourceCPU,
 			wantDRValue: 300, // (1+4-2)*1000/10
 		},
@@ -925,7 +925,7 @@ func TestDominantResourceShare(t *testing.T) {
 			flvResQ: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
 				{Flavor: "default", Resource: "example.com/gpu"}:  4,
-			}.Unflatten(),
+			},
 			wantDRName:  corev1.ResourceCPU,
 			wantDRValue: 300, // (1+4-2)*1000/10
 		},
@@ -967,7 +967,7 @@ func TestDominantResourceShare(t *testing.T) {
 			},
 			flvResQ: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10_000,
-			}.Unflatten(),
+			},
 			wantDRName:  corev1.ResourceCPU,
 			wantDRValue: 25, // ((15+10-20)+0)*1000/200 (spot under nominal)
 		},

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -106,17 +106,12 @@ func (a *Assignment) ToAPI() []kueue.PodSetAssignment {
 	return psFlavors
 }
 
-func (a *Assignment) TotalRequestsFor(wl *workload.Info) resources.FlavorResourceQuantities {
-	usage := make(resources.FlavorResourceQuantities)
+func (a *Assignment) TotalRequestsFor(wl *workload.Info) resources.FlavorResourceQuantitiesFlat {
+	usage := make(resources.FlavorResourceQuantitiesFlat)
 	for i, ps := range wl.TotalRequests {
 		for res, q := range ps.Requests {
 			flv := a.PodSets[i].Flavors[res].Name
-			resUsage := usage[flv]
-			if resUsage == nil {
-				resUsage = make(map[corev1.ResourceName]int64)
-				usage[flv] = resUsage
-			}
-			resUsage[res] += q
+			usage[resources.FlavorResource{Flavor: flv, Resource: res}] += q
 		}
 	}
 	return usage

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -206,21 +206,15 @@ func (i *Info) CanBePartiallyAdmitted() bool {
 
 // FlavorResourceUsage returns the total resource usage for the workload,
 // per flavor (if assigned, otherwise flavor shows as empty string), per resource.
-func (i *Info) FlavorResourceUsage() resources.FlavorResourceQuantities {
-	if i == nil || len(i.TotalRequests) == 0 {
-		return nil
+func (i *Info) FlavorResourceUsage() resources.FlavorResourceQuantitiesFlat {
+	total := make(resources.FlavorResourceQuantitiesFlat)
+	if i == nil {
+		return total
 	}
-	total := make(resources.FlavorResourceQuantities)
 	for _, psReqs := range i.TotalRequests {
 		for res, q := range psReqs.Requests {
 			flv := psReqs.Flavors[res]
-			if requests, found := total[flv]; found {
-				requests[res] += q
-			} else {
-				total[flv] = resources.Requests{
-					res: q,
-				}
-			}
+			total[resources.FlavorResource{Flavor: flv, Resource: res}] += q
 		}
 	}
 	return total

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -593,9 +593,11 @@ func TestIsEvictedByPodsReadyTimeout(t *testing.T) {
 func TestFlavorResourceUsage(t *testing.T) {
 	cases := map[string]struct {
 		info *Info
-		want resources.FlavorResourceQuantities
+		want resources.FlavorResourceQuantitiesFlat
 	}{
-		"nil": {},
+		"nil": {
+			want: resources.FlavorResourceQuantitiesFlat{},
+		},
 		"one podset, no flavors": {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
@@ -605,11 +607,9 @@ func TestFlavorResourceUsage(t *testing.T) {
 					},
 				}},
 			},
-			want: map[kueue.ResourceFlavorReference]resources.Requests{
-				"": {
-					corev1.ResourceCPU: 1_000,
-					"example.com/gpu":  3,
-				},
+			want: resources.FlavorResourceQuantitiesFlat{
+				{Flavor: "", Resource: "cpu"}:             1_000,
+				{Flavor: "", Resource: "example.com/gpu"}: 3,
 			},
 		},
 		"one podset, multiple flavors": {
@@ -625,13 +625,9 @@ func TestFlavorResourceUsage(t *testing.T) {
 					},
 				}},
 			},
-			want: map[kueue.ResourceFlavorReference]resources.Requests{
-				"default": {
-					corev1.ResourceCPU: 1_000,
-				},
-				"gpu": {
-					"example.com/gpu": 3,
-				},
+			want: resources.FlavorResourceQuantitiesFlat{
+				{Flavor: "default", Resource: "cpu"}:         1_000,
+				{Flavor: "gpu", Resource: "example.com/gpu"}: 3,
 			},
 		},
 		"multiple podsets, multiple flavors": {
@@ -667,17 +663,11 @@ func TestFlavorResourceUsage(t *testing.T) {
 					},
 				},
 			},
-			want: map[kueue.ResourceFlavorReference]resources.Requests{
-				"default": {
-					corev1.ResourceCPU:    3_000,
-					corev1.ResourceMemory: 2 * utiltesting.Gi,
-				},
-				"model_a": {
-					"example.com/gpu": 3,
-				},
-				"model_b": {
-					"example.com/gpu": 1,
-				},
+			want: resources.FlavorResourceQuantitiesFlat{
+				{Flavor: "default", Resource: "cpu"}:             3_000,
+				{Flavor: "default", Resource: "memory"}:          2 * utiltesting.Gi,
+				{Flavor: "model_a", Resource: "example.com/gpu"}: 3,
+				{Flavor: "model_b", Resource: "example.com/gpu"}: 1,
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
`FlavorResourceUsage` will be used in subsequent PR to simplify logic, e.g. [here](https://github.com/kubernetes-sigs/kueue/blob/e1e6c59bfaf71c89d0fad02ed6c130a8b9de71c0/pkg/cache/clusterqueue.go#L476-L511)

see detailed motivation in #2447

#### Does this PR introduce a user-facing change?
```release-note
NONE
```