### PR TITLE
Automated cherry pick of #2555: Update latest version to v0.7.1

### DIFF
--- a/CHANGELOG/CHANGELOG-0.7.md
+++ b/CHANGELOG/CHANGELOG-0.7.md
@@ -1,3 +1,28 @@
+## v0.7.1
+
+Changes since `v0.7.0`:
+
+### Feature
+
+- Improved logging for scheduling and preemption in levels 4 and 5 (#2510, @gabesaba, @alculquicondor)
+- MultiKueue: Remove remote objects synchronously when the worker cluster is reachable. (#2360, @trasc)
+
+### Bug or Regression
+
+- Fix check that prevents preemptions when a workload requests 0 for a resource that is at nominal or over it. (#2524, @mbobrovskyi, @alculquicondor)
+- Fix for the scenario when a workload doesn't match some resource flavors due to affinity or taints
+  could cause the workload to be continuously retried. (#2440, @KunWuLuan)
+- Fix missing fairSharingStatus in ClusterQueue (#2432, @mbobrovskyi)
+- Fix missing metric cluster_queue_status. (#2475, @mbobrovskyi)
+- Fix panic that could occur when a ClusterQueue is deleted while Kueue was updating the ClusterQueue status. (#2464, @mbobrovskyi)
+- Fix panic when there is not enough quota to assign flavors to a Workload in the cohort, when FairSharing is enabled. (#2449, @mbobrovskyi)
+- Fix performance issue in logging when processing LocalQueues. (#2492, @alexandear)
+- Fix race condition on delete workload from queue manager. (#2465, @mbobrovskyi)
+- MultiKueue: Do not reject a JobSet if the corresponding cluster queue doesn't exist (#2442, @vladikkuzn)
+- MultiKueue: Skip garbage collection for disconnected clients which could occasionally result in panic. (#2370, @trasc)
+- Show weightedShare in ClusterQueue status.fairSharing even if the value is zero (#2522, @alculquicondor)
+- Skip duplicate Tolerations when an admission check introduces a toleration that the job also set. (#2499, @trasc)
+
 ## v0.7.0
 
 Changes since `v0.6.0`:

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ LD_FLAGS += -X '$(version_pkg).GitCommit=$(shell git rev-parse HEAD)'
 
 # Update these variables when preparing a new release or a release branch.
 # Then run `make prepare-release-branch`
-RELEASE_VERSION=v0.7.0
+RELEASE_VERSION=v0.7.1
 RELEASE_BRANCH=main
 
 .PHONY: all

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) to learn more.
 To install the latest release of Kueue in your cluster, run the following command:
 
 ```shell
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.7.0/manifests.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.7.1/manifests.yaml
 ```
 
 The controller runs in the `kueue-system` namespace.

--- a/SECURITY-INSIGHTS.yaml
+++ b/SECURITY-INSIGHTS.yaml
@@ -1,11 +1,11 @@
 header:
   schema-version: 1.0.0
   expiration-date: '2024-09-28T01:00:00.000Z'
-  last-updated: '2024-06-03'
-  last-reviewed: '2024-06-03'
-  commit-hash: 132dd0bb51229f920c26d35687959083ca78b33f
+  last-updated: '2024-07-08'
+  last-reviewed: '2024-07-08'
+  commit-hash: 9ad6cfe0d859be004a99e366a0c32470d512dec0
   project-url: 'https://github.com/kubernetes-sigs/kueue'
-  project-release: 0.7.0
+  project-release: 0.7.1
   changelog: 'https://github.com/kubernetes-sigs/kueue/tree/main/CHANGELOG'
   license: 'https://github.com/kubernetes-sigs/kueue/blob/main/LICENSE'
 project-lifecycle:
@@ -28,7 +28,7 @@ documentation:
   - 'https://kueue.sigs.k8s.io/docs/'
 distribution-points:
   - >-
-    https://github.com/kubernetes-sigs/kueue/releases/download/v0.7.0/manifests.yaml
+    https://github.com/kubernetes-sigs/kueue/releases/download/v0.7.1/manifests.yaml
 security-artifacts:
   threat-model:
     threat-model-created: false
@@ -61,3 +61,6 @@ dependencies:
   third-party-packages: true
   dependencies-lists:
     - 'https://github.com/kubernetes-sigs/kueue/blob/main/go.mod'
+  sbom:
+    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.7.1/kueue-v0.7.1.spdx.json
+      sbom-format: SPDX

--- a/charts/kueue/Chart.yaml
+++ b/charts/kueue/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.7.0"
+appVersion: "v0.7.1"

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -89,7 +89,7 @@ ignoreFiles = []
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
   # version number for this doc set.
-  version = "v0.7.0"
+  version = "v0.7.1"
 
   # Flag used in the "version-banner" partial to decide whether to display a
   # banner on every page indicating that this is an archived version of the docs.


### PR DESCRIPTION
Cherry pick of #2555 on website.
#2555: Update latest version to v0.7.1
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
```