### PR TITLE
Start JobFramework controller and webhook on new CRDs availability

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"net/http"
 	"os"
-	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -72,8 +71,6 @@ import (
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
 	// +kubebuilder:scaffold:imports
 )
-
-const retryInterval = time.Second * 20
 
 var (
 	scheme   = runtime.NewScheme()
@@ -285,7 +282,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *cache.Cache
 		jobframework.WithCache(cCache),
 		jobframework.WithQueues(queues),
 	}
-	if err := jobframework.SetupControllers(ctx, mgr, setupLog, retryInterval, opts...); err != nil {
+	if err := jobframework.SetupControllers(ctx, mgr, setupLog, opts...); err != nil {
 		setupLog.Error(err, "Unable to create controller or webhook", "kubernetesVersion", serverVersionFetcher.GetServerVersion())
 		os.Exit(1)
 	}

--- a/pkg/controller/jobframework/integrationmanager.go
+++ b/pkg/controller/jobframework/integrationmanager.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"sync"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,6 +88,7 @@ type integrationManager struct {
 	integrations         map[string]IntegrationCallbacks
 	enabledIntegrations  set.Set[string]
 	externalIntegrations map[string]runtime.Object
+	mu                   sync.RWMutex
 }
 
 var manager integrationManager
@@ -158,7 +160,15 @@ func (m *integrationManager) getExternal(kindArg string) (runtime.Object, bool) 
 	return jt, f
 }
 
+func (m *integrationManager) getEnabledIntegrations() set.Set[string] {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.enabledIntegrations.Clone()
+}
+
 func (m *integrationManager) enableIntegration(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.enabledIntegrations == nil {
 		m.enabledIntegrations = set.New(name)
 	} else {
@@ -174,7 +184,7 @@ func (m *integrationManager) getList() []string {
 }
 
 func (m *integrationManager) getJobTypeForOwner(ownerRef *metav1.OwnerReference) runtime.Object {
-	for jobKey := range m.enabledIntegrations {
+	for jobKey := range m.getEnabledIntegrations() {
 		cbs, found := m.integrations[jobKey]
 		if found && cbs.IsManagingObjectsOwner != nil && cbs.IsManagingObjectsOwner(ownerRef) {
 			return cbs.JobType
@@ -235,12 +245,14 @@ func EnableIntegration(name string) {
 // Mark the frameworks identified by names and return a revert function.
 func EnableIntegrationsForTest(tb testing.TB, names ...string) func() {
 	tb.Helper()
-	old := manager.enabledIntegrations.Clone()
+	old := manager.getEnabledIntegrations()
 	for _, name := range names {
 		manager.enableIntegration(name)
 	}
 	return func() {
+		manager.mu.Lock()
 		manager.enabledIntegrations = old
+		manager.mu.Unlock()
 	}
 }
 

--- a/pkg/controller/jobframework/integrationmanager.go
+++ b/pkg/controller/jobframework/integrationmanager.go
@@ -41,8 +41,8 @@ var (
 	errMissingMandatoryField  = errors.New("mandatory field missing")
 	errFrameworkNameFormat    = errors.New("misformatted external framework name")
 
-	errIntegrationNotFound              = errors.New("integration not found")
-	errDependecncyIntegrationNotEnabled = errors.New("integration not enabled")
+	errIntegrationNotFound             = errors.New("integration not found")
+	errDependencyIntegrationNotEnabled = errors.New("integration not enabled")
 )
 
 type JobReconcilerInterface interface {
@@ -210,7 +210,7 @@ func (m *integrationManager) checkEnabledListDependencies(enabledSet sets.Set[st
 		}
 		for _, dep := range cbs.DependencyList {
 			if !enabledSet.Has(dep) {
-				return fmt.Errorf("%q %w %q", integration, errDependecncyIntegrationNotEnabled, dep)
+				return fmt.Errorf("%q %w %q", integration, errDependencyIntegrationNotEnabled, dep)
 			}
 		}
 	}

--- a/pkg/controller/jobframework/integrationmanager_test.go
+++ b/pkg/controller/jobframework/integrationmanager_test.go
@@ -463,7 +463,7 @@ func TestEnabledIntegrationsDependencies(t *testing.T) {
 				"i1": {"i2"},
 			},
 			enabled:   []string{"i1"},
-			wantError: errDependecncyIntegrationNotEnabled,
+			wantError: errDependencyIntegrationNotEnabled,
 		},
 		"dependecncy not found": {
 			integrationsDependencies: map[string][]string{

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -35,10 +36,9 @@ import (
 
 var (
 	errFailedMappingResource = errors.New("restMapper failed mapping resource")
+	// restMapperMutex is required for unit tests to lock the RESTMapper on update.
+	restMapperMutex sync.RWMutex
 )
-
-// APIRetryInterval is the duration to wait before retrying the API request.
-var APIRetryInterval = time.Second * 20
 
 // SetupControllers setups all controllers and webhooks for integrations.
 // When the platform developers implement a separate kueue-manager to manage the in-house custom jobs,
@@ -49,11 +49,11 @@ var APIRetryInterval = time.Second * 20
 // this function needs to be called after the certs get ready because the controllers won't work
 // until the webhooks are operating, and the webhook won't work until the
 // certs are all in place.
-func SetupControllers(mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
-	return manager.setupControllers(mgr, log, opts...)
+func SetupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, retryInterval time.Duration, opts ...Option) error {
+	return manager.setupControllers(ctx, mgr, log, retryInterval, opts...)
 }
 
-func (m *integrationManager) setupControllers(mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
+func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, retryInterval time.Duration, opts ...Option) error {
 	options := ProcessOptions(opts...)
 
 	if err := m.checkEnabledListDependencies(options.EnabledFrameworks); err != nil {
@@ -80,12 +80,12 @@ func (m *integrationManager) setupControllers(mgr ctrl.Manager, log logr.Logger,
 			if err != nil {
 				return fmt.Errorf("%s: %w: %w", fwkNamePrefix, errFailedMappingResource, err)
 			}
-			if _, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
+			if _, err := getRESTMapping(mgr, gvk); err != nil {
 				if !meta.IsNoMatchError(err) {
 					return fmt.Errorf("%s: %w", fwkNamePrefix, err)
 				}
 				logger.Info("No matching API in the server for job framework, skipped setup of controller and webhook")
-				go waitForAPI(context.Background(), mgr, logger, gvk, func() {
+				go waitForAPI(ctx, mgr, log, gvk, retryInterval, func() {
 					log.Info(fmt.Sprintf("API now available, starting controller and webhook for %v", gvk))
 					if err := m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...); err != nil {
 						log.Error(err, "Failed to setup controller and webhook for job framework")
@@ -119,21 +119,35 @@ func (m *integrationManager) setupControllerAndWebhook(mgr ctrl.Manager, name st
 	return nil
 }
 
-func waitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk schema.GroupVersionKind, action func()) {
+func waitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk schema.GroupVersionKind, retryInterval time.Duration, action func()) {
+	ticker := time.NewTicker(retryInterval)
+	defer ticker.Stop()
 	for {
-		_, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
-		if err != nil {
-			select {
-			case <-ctx.Done():
-				log.Info(fmt.Sprint("Context cancelled!", "gvk", gvk))
-				return
-			case <-time.After(APIRetryInterval):
-				continue
-			}
+		_, err := getRESTMapping(mgr, gvk)
+		if err == nil {
+			action()
+			return
 		}
-		break
+		if !meta.IsNoMatchError(err) {
+			log.Error(err, "Failed to get REST mapping for gvk", "gvk", gvk)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			continue
+		}
 	}
-	action()
+}
+
+func getRESTMapping(mgr ctrl.Manager, gvk schema.GroupVersionKind) (*meta.RESTMapping, error) {
+	restMapperMutex.RLock()
+	defer restMapperMutex.RUnlock()
+	restMapping, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get REST mapping for %v: %w", gvk, err)
+	}
+	return restMapping, nil
 }
 
 // SetupIndexes setups the indexers for integrations.

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -38,7 +38,7 @@ var (
 )
 
 // APIRetryInterval is the duration to wait before retrying the API request.
-const APIRetryInterval = time.Second * 20
+var APIRetryInterval = time.Second * 20
 
 // SetupControllers setups all controllers and webhooks for integrations.
 // When the platform developers implement a separate kueue-manager to manage the in-house custom jobs,

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -21,9 +21,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -75,25 +77,17 @@ func (m *integrationManager) setupControllers(mgr ctrl.Manager, log logr.Logger,
 			if err != nil {
 				return fmt.Errorf("%s: %w: %w", fwkNamePrefix, errFailedMappingResource, err)
 			}
-			if _, err = mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
+			if _, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
 				if !meta.IsNoMatchError(err) {
 					return fmt.Errorf("%s: %w", fwkNamePrefix, err)
 				}
 				logger.Info("No matching API in the server for job framework, skipped setup of controller and webhook")
+				go waitForAPI(context.Background(), mgr, logger, gvk, func() {
+					log.Info(fmt.Sprintf("API now available, starting controller and webhook for %v", gvk))
+					m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...)
+				})
 			} else {
-				if err = cb.NewReconciler(
-					mgr.GetClient(),
-					mgr.GetEventRecorderFor(fmt.Sprintf("%s-%s-controller", name, options.ManagerName)),
-					opts...,
-				).SetupWithManager(mgr); err != nil {
-					return fmt.Errorf("%s: %w", fwkNamePrefix, err)
-				}
-				if err = cb.SetupWebhook(mgr, opts...); err != nil {
-					return fmt.Errorf("%s: unable to create webhook: %w", fwkNamePrefix, err)
-				}
-				m.enableIntegration(name)
-				logger.Info("Set up controller and webhook for job framework")
-				return nil
+				m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...)
 			}
 		}
 		if err := noop.SetupWebhook(mgr, cb.JobType); err != nil {
@@ -101,6 +95,42 @@ func (m *integrationManager) setupControllers(mgr ctrl.Manager, log logr.Logger,
 		}
 		return nil
 	})
+}
+
+func (m *integrationManager) setupControllerAndWebhook(mgr ctrl.Manager, name string, fwkNamePrefix string, cb IntegrationCallbacks, options Options, opts ...Option) error {
+	if err := cb.NewReconciler(
+		mgr.GetClient(),
+		mgr.GetEventRecorderFor(fmt.Sprintf("%s-%s-controller", name, options.ManagerName)),
+		opts...,
+	).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("%s: %w", fwkNamePrefix, err)
+	}
+	if err := cb.SetupWebhook(mgr, opts...); err != nil {
+		return fmt.Errorf("%s: unable to create webhook: %w", fwkNamePrefix, err)
+	}
+	m.enableIntegration(name)
+	return nil
+}
+
+func waitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk schema.GroupVersionKind, action func()) {
+	getRestMapping := func() (*meta.RESTMapping, error) {
+		return mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
+	}
+	var err error
+	for {
+		_, err = getRestMapping()
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				log.Info(fmt.Sprint("Context cancelled!", "gvk", gvk))
+				return
+			case <-time.After(time.Second * 5):
+				continue
+			}
+		}
+		break
+	}
+	action()
 }
 
 // SetupIndexes setups the indexers for integrations.

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -34,8 +33,6 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/controller/jobs/noop"
 )
-
-var mu sync.RWMutex
 
 const (
 	baseBackoffWaitForIntegration = 1 * time.Second
@@ -147,8 +144,6 @@ func waitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk sche
 }
 
 func restMappingExists(mgr ctrl.Manager, gvk schema.GroupVersionKind) error {
-	mu.RLock()
-	defer mu.RUnlock()
 	_, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		return fmt.Errorf("failed to get REST mapping for %v: %w", gvk, err)

--- a/pkg/controller/jobframework/setup_test.go
+++ b/pkg/controller/jobframework/setup_test.go
@@ -39,11 +39,19 @@ import (
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
-	kslices "sigs.k8s.io/kueue/pkg/util/slices"
+	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
 func TestSetupControllers(t *testing.T) {
+	// Simulate Job Framework API checks
+	defaultCheckAPIAvailable = func(mgr ctrlmgr.Manager, gvk schema.GroupVersionKind) (bool, error) {
+		// Simulate API being unavailable for MPIJob
+		if gvk.Kind == "MPIJob" {
+			return false, nil
+		}
+		return true, nil // Simulate API becoming available
+	}
 	availableIntegrations := map[string]IntegrationCallbacks{
 		"batch/job": {
 			NewReconciler:         testNewReconciler,
@@ -84,7 +92,7 @@ func TestSetupControllers(t *testing.T) {
 		mapperGVKs              []schema.GroupVersionKind
 		wantError               error
 		wantEnabledIntegrations []string
-		afterSetup              func(mgr ctrlmgr.Manager, manager *integrationManager)
+		afterSetup              func(mgr ctrlmgr.Manager, manager *integrationManager, crdName string)
 	}{
 		"setup controllers succeed": {
 			opts: []Option{
@@ -124,7 +132,7 @@ func TestSetupControllers(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			manager := &integrationManager{}
+			manager := integrationManager{}
 			for name, cbs := range availableIntegrations {
 				err := manager.register(name, cbs)
 				if err != nil {
@@ -132,7 +140,7 @@ func TestSetupControllers(t *testing.T) {
 				}
 			}
 
-			_, logger := utiltesting.ContextWithLog(t)
+			ctx, logger := utiltesting.ContextWithLog(t)
 			k8sClient := utiltesting.NewClientBuilder(jobset.AddToScheme, kubeflow.AddToScheme, kftraining.AddToScheme, rayv1.AddToScheme).Build()
 
 			mgrOpts := ctrlmgr.Options{
@@ -156,13 +164,13 @@ func TestSetupControllers(t *testing.T) {
 				t.Fatalf("Failed to setup manager: %v", err)
 			}
 
-			gotError := manager.setupControllers(context.Background(), mgr, logger, time.Millisecond*20, tc.opts...)
+			gotError := manager.setupControllers(ctx, mgr, logger, tc.opts...)
 			if diff := cmp.Diff(tc.wantError, gotError, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected error from SetupControllers (-want,+got):\n%s", diff)
 			}
 
 			if tc.afterSetup != nil {
-				tc.afterSetup(mgr, manager)
+				tc.afterSetup(mgr, &manager, "ray.io/raycluster")
 			}
 
 			diff := cmp.Diff(tc.wantEnabledIntegrations, manager.getEnabledIntegrations().SortedList())
@@ -173,14 +181,9 @@ func TestSetupControllers(t *testing.T) {
 	}
 }
 
-func testDelayedIntegration(mgr ctrlmgr.Manager, manager *integrationManager) {
-	rayGVK := schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: "RayCluster"}
-	restMapperMutex.Lock()
-	mgr.GetRESTMapper().(*apimeta.DefaultRESTMapper).Add(rayGVK, apimeta.RESTScopeNamespace)
-	restMapperMutex.Unlock()
-	// Wait for setup to complete
+func testDelayedIntegration(mgr ctrlmgr.Manager, manager *integrationManager, crdName string) {
 	for {
-		_, ok := manager.getEnabledIntegrations()["ray.io/raycluster"]
+		_, ok := manager.getEnabledIntegrations()[crdName]
 		if ok {
 			break // Exit loop if RayCluster is enabled
 		}
@@ -252,8 +255,8 @@ func TestSetupIndexes(t *testing.T) {
 			if gotListErr := k8sClient.List(ctx, gotWls, client.InNamespace(testNamespace)); gotListErr != nil {
 				t.Fatalf("Failed to list workloads without a fieldMatcher: %v", gotListErr)
 			}
-			deployedWlNames := kslices.Map(tc.workloads, func(j *kueue.Workload) string { return j.Name })
-			gotWlNames := kslices.Map(gotWls.Items, func(j *kueue.Workload) string { return j.Name })
+			deployedWlNames := slices.Map(tc.workloads, func(j *kueue.Workload) string { return j.Name })
+			gotWlNames := slices.Map(gotWls.Items, func(j *kueue.Workload) string { return j.Name })
 			if diff := cmp.Diff(deployedWlNames, gotWlNames, cmpopts.EquateEmpty(),
 				cmpopts.SortSlices(func(a, b string) bool { return a < b })); len(diff) != 0 {
 				t.Errorf("Unexpected list workloads (-want,+got):\n%s", diff)
@@ -266,7 +269,7 @@ func TestSetupIndexes(t *testing.T) {
 			}
 
 			if !tc.wantFieldMatcherError {
-				gotWlNames = kslices.Map(gotWls.Items, func(j *kueue.Workload) string { return j.Name })
+				gotWlNames = slices.Map(gotWls.Items, func(j *kueue.Workload) string { return j.Name })
 				if diff := cmp.Diff(tc.wantWorkloads, gotWlNames, cmpopts.EquateEmpty(),
 					cmpopts.SortSlices(func(a, b string) bool { return a < b })); len(diff) != 0 {
 					t.Errorf("Unexpected list workloads (-want,+got):\n%s", diff)

--- a/pkg/controller/jobframework/setup_test.go
+++ b/pkg/controller/jobframework/setup_test.go
@@ -44,7 +44,7 @@ import (
 )
 
 func TestSetupControllers(t *testing.T) {
-	APIRetryInterval = 10 * time.Millisecond
+	APIRetryInterval = 20 * time.Millisecond
 	availableIntegrations := map[string]IntegrationCallbacks{
 		"batch/job": {
 			NewReconciler:         testNewReconciler,
@@ -163,10 +163,13 @@ func TestSetupControllers(t *testing.T) {
 			if name == "mapper doesn't have ray.io/raycluster when Controllers have been setup, but eventually does" {
 				rayGVK := schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: "RayCluster"}
 				mgr.GetRESTMapper().(*apimeta.DefaultRESTMapper).Add(rayGVK, apimeta.RESTScopeNamespace)
-				if _, err := mgr.GetRESTMapper().RESTMapping(rayv1.SchemeGroupVersion.WithKind("RayCluster").GroupKind(), rayv1.SchemeGroupVersion.Version); err != nil {
-					t.Errorf("ray.io/raycluster should be available now but got error: %v", err)
+				// Wait for setup to complete
+				for {
+					if _, ok := manager.enabledIntegrations["ray.io/raycluster"]; ok {
+						break // Exit loop if RayCluster is enabled
+					}
+					time.Sleep(10 * time.Millisecond)
 				}
-				time.Sleep(20 * time.Millisecond) // Allow time for the controller to start and enable the integration
 			}
 
 			if diff := cmp.Diff(tc.wantEnabledIntegrations, manager.enabledIntegrations.SortedList()); len(diff) != 0 {

--- a/pkg/controller/jobframework/setup_test.go
+++ b/pkg/controller/jobframework/setup_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -43,6 +44,7 @@ import (
 )
 
 func TestSetupControllers(t *testing.T) {
+	APIRetryInterval = 10 * time.Millisecond
 	availableIntegrations := map[string]IntegrationCallbacks{
 		"batch/job": {
 			NewReconciler:         testNewReconciler,
@@ -64,6 +66,14 @@ func TestSetupControllers(t *testing.T) {
 			NewReconciler:         testNewReconciler,
 			SetupWebhook:          testSetupWebhook,
 			JobType:               &corev1.Pod{},
+			SetupIndexes:          testSetupIndexes,
+			AddToScheme:           testAddToScheme,
+			CanSupportIntegration: testCanSupportIntegration,
+		},
+		"ray.io/raycluster": {
+			NewReconciler:         testNewReconciler,
+			SetupWebhook:          testSetupWebhook,
+			JobType:               &rayv1.RayCluster{},
 			SetupIndexes:          testSetupIndexes,
 			AddToScheme:           testAddToScheme,
 			CanSupportIntegration: testCanSupportIntegration,
@@ -98,6 +108,17 @@ func TestSetupControllers(t *testing.T) {
 				batchv1.SchemeGroupVersion.WithKind("Job"),
 			},
 			wantEnabledIntegrations: []string{"batch/job"},
+		},
+		"mapper doesn't have ray.io/raycluster when Controllers have been setup, but eventually does": {
+			opts: []Option{
+				WithEnabledFrameworks([]string{"batch/job", "kubeflow.org/mpijob", "ray.io/raycluster"}),
+			},
+			mapperGVKs: []schema.GroupVersionKind{
+				batchv1.SchemeGroupVersion.WithKind("Job"),
+				kubeflow.SchemeGroupVersionKind,
+				// Not including RayCluster
+			},
+			wantEnabledIntegrations: []string{"batch/job", "kubeflow.org/mpijob", "ray.io/raycluster"},
 		},
 	}
 	for name, tc := range cases {
@@ -137,6 +158,15 @@ func TestSetupControllers(t *testing.T) {
 			gotError := manager.setupControllers(mgr, logger, tc.opts...)
 			if diff := cmp.Diff(tc.wantError, gotError, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected error from SetupControllers (-want,+got):\n%s", diff)
+			}
+
+			if name == "mapper doesn't have ray.io/raycluster when Controllers have been setup, but eventually does" {
+				rayGVK := schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: "RayCluster"}
+				mgr.GetRESTMapper().(*apimeta.DefaultRESTMapper).Add(rayGVK, apimeta.RESTScopeNamespace)
+				if _, err := mgr.GetRESTMapper().RESTMapping(rayv1.SchemeGroupVersion.WithKind("RayCluster").GroupKind(), rayv1.SchemeGroupVersion.Version); err != nil {
+					t.Errorf("ray.io/raycluster should be available now but got error: %v", err)
+				}
+				time.Sleep(20 * time.Millisecond) // Allow time for the controller to start and enable the integration
 			}
 
 			if diff := cmp.Diff(tc.wantEnabledIntegrations, manager.enabledIntegrations.SortedList()); len(diff) != 0 {

--- a/pkg/controller/jobframework/setup_test.go
+++ b/pkg/controller/jobframework/setup_test.go
@@ -39,12 +39,11 @@ import (
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
-	"sigs.k8s.io/kueue/pkg/util/slices"
+	kslices "sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
 func TestSetupControllers(t *testing.T) {
-	APIRetryInterval = 20 * time.Millisecond
 	availableIntegrations := map[string]IntegrationCallbacks{
 		"batch/job": {
 			NewReconciler:         testNewReconciler,
@@ -85,6 +84,7 @@ func TestSetupControllers(t *testing.T) {
 		mapperGVKs              []schema.GroupVersionKind
 		wantError               error
 		wantEnabledIntegrations []string
+		afterSetup              func(mgr ctrlmgr.Manager, manager *integrationManager)
 	}{
 		"setup controllers succeed": {
 			opts: []Option{
@@ -119,11 +119,12 @@ func TestSetupControllers(t *testing.T) {
 				// Not including RayCluster
 			},
 			wantEnabledIntegrations: []string{"batch/job", "kubeflow.org/mpijob", "ray.io/raycluster"},
+			afterSetup:              testDelayedIntegration,
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			manager := integrationManager{}
+			manager := &integrationManager{}
 			for name, cbs := range availableIntegrations {
 				err := manager.register(name, cbs)
 				if err != nil {
@@ -155,27 +156,35 @@ func TestSetupControllers(t *testing.T) {
 				t.Fatalf("Failed to setup manager: %v", err)
 			}
 
-			gotError := manager.setupControllers(mgr, logger, tc.opts...)
+			gotError := manager.setupControllers(context.Background(), mgr, logger, time.Millisecond*20, tc.opts...)
 			if diff := cmp.Diff(tc.wantError, gotError, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected error from SetupControllers (-want,+got):\n%s", diff)
 			}
 
-			if name == "mapper doesn't have ray.io/raycluster when Controllers have been setup, but eventually does" {
-				rayGVK := schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: "RayCluster"}
-				mgr.GetRESTMapper().(*apimeta.DefaultRESTMapper).Add(rayGVK, apimeta.RESTScopeNamespace)
-				// Wait for setup to complete
-				for {
-					if _, ok := manager.enabledIntegrations["ray.io/raycluster"]; ok {
-						break // Exit loop if RayCluster is enabled
-					}
-					time.Sleep(10 * time.Millisecond)
-				}
+			if tc.afterSetup != nil {
+				tc.afterSetup(mgr, manager)
 			}
 
-			if diff := cmp.Diff(tc.wantEnabledIntegrations, manager.enabledIntegrations.SortedList()); len(diff) != 0 {
+			diff := cmp.Diff(tc.wantEnabledIntegrations, manager.getEnabledIntegrations().SortedList())
+			if len(diff) != 0 {
 				t.Errorf("Unexpected enabled integrations (-want,+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func testDelayedIntegration(mgr ctrlmgr.Manager, manager *integrationManager) {
+	rayGVK := schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: "RayCluster"}
+	restMapperMutex.Lock()
+	mgr.GetRESTMapper().(*apimeta.DefaultRESTMapper).Add(rayGVK, apimeta.RESTScopeNamespace)
+	restMapperMutex.Unlock()
+	// Wait for setup to complete
+	for {
+		_, ok := manager.getEnabledIntegrations()["ray.io/raycluster"]
+		if ok {
+			break // Exit loop if RayCluster is enabled
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 
@@ -243,8 +252,8 @@ func TestSetupIndexes(t *testing.T) {
 			if gotListErr := k8sClient.List(ctx, gotWls, client.InNamespace(testNamespace)); gotListErr != nil {
 				t.Fatalf("Failed to list workloads without a fieldMatcher: %v", gotListErr)
 			}
-			deployedWlNames := slices.Map(tc.workloads, func(j *kueue.Workload) string { return j.Name })
-			gotWlNames := slices.Map(gotWls.Items, func(j *kueue.Workload) string { return j.Name })
+			deployedWlNames := kslices.Map(tc.workloads, func(j *kueue.Workload) string { return j.Name })
+			gotWlNames := kslices.Map(gotWls.Items, func(j *kueue.Workload) string { return j.Name })
 			if diff := cmp.Diff(deployedWlNames, gotWlNames, cmpopts.EquateEmpty(),
 				cmpopts.SortSlices(func(a, b string) bool { return a < b })); len(diff) != 0 {
 				t.Errorf("Unexpected list workloads (-want,+got):\n%s", diff)
@@ -257,7 +266,7 @@ func TestSetupIndexes(t *testing.T) {
 			}
 
 			if !tc.wantFieldMatcherError {
-				gotWlNames = slices.Map(gotWls.Items, func(j *kueue.Workload) string { return j.Name })
+				gotWlNames = kslices.Map(gotWls.Items, func(j *kueue.Workload) string { return j.Name })
 				if diff := cmp.Diff(tc.wantWorkloads, gotWlNames, cmpopts.EquateEmpty(),
 					cmpopts.SortSlices(func(a, b string) bool { return a < b })); len(diff) != 0 {
 					t.Errorf("Unexpected list workloads (-want,+got):\n%s", diff)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add function to wait for API availability using the RESTMapper in controller manager.

This PR checks for availability of JobFramework integrations in the Kubernetes cluster before executing the action().

The function utilises the RESTMapper from the controller-runtime manager to verify the existence of the CRD by its GroupVersionKind (GVK). If one of the CRDs become available, the respective controller and webhook will start.

The user/dev will no longer be required to restart the Kueue pod to allow for integration on new CRDs available.

No restarts on the Kueue pod is performed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2414 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Detect and enable support for job CRDs installed after Kueue starts.
```