### PR TITLE
Extract Quota from ResourceGroup

### DIFF
--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -28,6 +28,7 @@ type ClusterQueueSnapshot struct {
 	// In case its empty, it means an AdmissionCheck should apply to all ResourceFlavor
 	AdmissionChecks map[string]sets.Set[kueue.ResourceFlavorReference]
 	Status          metrics.ClusterQueueStatus
+	Quotas          map[resources.FlavorResource]*ResourceQuota
 	// GuaranteedQuota records how much resource quota the ClusterQueue reserved
 	// when feature LendingLimit is enabled and flavor's lendingLimit is not nil.
 	GuaranteedQuota resources.FlavorResourceQuantities
@@ -45,6 +46,10 @@ func (c *ClusterQueueSnapshot) RGByResource(resource corev1.ResourceName) *Resou
 		}
 	}
 	return nil
+}
+
+func (c *ClusterQueueSnapshot) QuotaFor(fr resources.FlavorResource) *ResourceQuota {
+	return c.Quotas[fr]
 }
 
 // The methods below implement several interfaces. See

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -227,22 +227,13 @@ func TestSnapshot(t *testing.T) {
 							ResourceGroups: []ResourceGroup{
 								{
 									CoveredResources: sets.New(corev1.ResourceCPU),
-									Flavors: []FlavorQuotas{
-										{
-											Name: "demand",
-											Resources: map[corev1.ResourceName]*ResourceQuota{
-												corev1.ResourceCPU: {Nominal: 100_000},
-											},
-										},
-										{
-											Name: "spot",
-											Resources: map[corev1.ResourceName]*ResourceQuota{
-												corev1.ResourceCPU: {Nominal: 200_000},
-											},
-										},
-									},
-									LabelKeys: sets.New("instance"),
+									Flavors:          []kueue.ResourceFlavorReference{"demand", "spot"},
+									LabelKeys:        sets.New("instance"),
 								},
+							},
+							Quotas: map[resources.FlavorResource]*ResourceQuota{
+								{Flavor: "demand", Resource: corev1.ResourceCPU}: {Nominal: 100_000},
+								{Flavor: "spot", Resource: corev1.ResourceCPU}:   {Nominal: 200_000},
 							},
 							FlavorFungibility: defaultFlavorFungibility,
 							Usage: resources.FlavorResourceQuantitiesFlat{
@@ -271,23 +262,17 @@ func TestSnapshot(t *testing.T) {
 							ResourceGroups: []ResourceGroup{
 								{
 									CoveredResources: sets.New(corev1.ResourceCPU),
-									Flavors: []FlavorQuotas{{
-										Name: "spot",
-										Resources: map[corev1.ResourceName]*ResourceQuota{
-											corev1.ResourceCPU: {Nominal: 100_000},
-										},
-									}},
-									LabelKeys: sets.New("instance"),
+									Flavors:          []kueue.ResourceFlavorReference{"spot"},
+									LabelKeys:        sets.New("instance"),
 								},
 								{
 									CoveredResources: sets.New[corev1.ResourceName]("example.com/gpu"),
-									Flavors: []FlavorQuotas{{
-										Name: "default",
-										Resources: map[corev1.ResourceName]*ResourceQuota{
-											"example.com/gpu": {Nominal: 50},
-										},
-									}},
+									Flavors:          []kueue.ResourceFlavorReference{"default"},
 								},
+							},
+							Quotas: map[resources.FlavorResource]*ResourceQuota{
+								{Flavor: "spot", Resource: corev1.ResourceCPU}:   {Nominal: 100_000},
+								{Flavor: "default", Resource: "example.com/gpu"}: {Nominal: 50},
 							},
 							FlavorFungibility: defaultFlavorFungibility,
 							Usage: resources.FlavorResourceQuantitiesFlat{
@@ -330,13 +315,11 @@ func TestSnapshot(t *testing.T) {
 							ResourceGroups: []ResourceGroup{
 								{
 									CoveredResources: sets.New(corev1.ResourceCPU),
-									Flavors: []FlavorQuotas{{
-										Name: "default",
-										Resources: map[corev1.ResourceName]*ResourceQuota{
-											corev1.ResourceCPU: {Nominal: 100_000},
-										},
-									}},
+									Flavors:          []kueue.ResourceFlavorReference{"default"},
 								},
+							},
+							Quotas: map[resources.FlavorResource]*ResourceQuota{
+								{Flavor: "default", Resource: corev1.ResourceCPU}: {Nominal: 100_000},
 							},
 							FlavorFungibility: defaultFlavorFungibility,
 							Usage: resources.FlavorResourceQuantitiesFlat{
@@ -471,30 +454,13 @@ func TestSnapshot(t *testing.T) {
 							ResourceGroups: []ResourceGroup{
 								{
 									CoveredResources: sets.New(corev1.ResourceCPU),
-									Flavors: []FlavorQuotas{
-										{
-											Name: "arm",
-											Resources: map[corev1.ResourceName]*ResourceQuota{
-												corev1.ResourceCPU: {
-													Nominal:        10_000,
-													BorrowingLimit: nil,
-													LendingLimit:   ptr.To[int64](5_000),
-												},
-											},
-										},
-										{
-											Name: "x86",
-											Resources: map[corev1.ResourceName]*ResourceQuota{
-												corev1.ResourceCPU: {
-													Nominal:        20_000,
-													BorrowingLimit: nil,
-													LendingLimit:   ptr.To[int64](10_000),
-												},
-											},
-										},
-									},
-									LabelKeys: sets.New("arch"),
+									Flavors:          []kueue.ResourceFlavorReference{"arm", "x86"},
+									LabelKeys:        sets.New("arch"),
 								},
+							},
+							Quotas: map[resources.FlavorResource]*ResourceQuota{
+								{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](5_000)},
+								{Flavor: "x86", Resource: corev1.ResourceCPU}: {Nominal: 20_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](10_000)},
 							},
 							FlavorFungibility: defaultFlavorFungibility,
 							FairWeight:        oneQuantity,
@@ -540,30 +506,13 @@ func TestSnapshot(t *testing.T) {
 							ResourceGroups: []ResourceGroup{
 								{
 									CoveredResources: sets.New(corev1.ResourceCPU),
-									Flavors: []FlavorQuotas{
-										{
-											Name: "arm",
-											Resources: map[corev1.ResourceName]*ResourceQuota{
-												corev1.ResourceCPU: {
-													Nominal:        10_000,
-													BorrowingLimit: nil,
-													LendingLimit:   ptr.To[int64](5_000),
-												},
-											},
-										},
-										{
-											Name: "x86",
-											Resources: map[corev1.ResourceName]*ResourceQuota{
-												corev1.ResourceCPU: {
-													Nominal:        20_000,
-													BorrowingLimit: nil,
-													LendingLimit:   ptr.To[int64](10_000),
-												},
-											},
-										},
-									},
-									LabelKeys: sets.New("arch"),
+									Flavors:          []kueue.ResourceFlavorReference{"arm", "x86"},
+									LabelKeys:        sets.New("arch"),
 								},
+							},
+							Quotas: map[resources.FlavorResource]*ResourceQuota{
+								{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](5_000)},
+								{Flavor: "x86", Resource: corev1.ResourceCPU}: {Nominal: 20_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](10_000)},
 							},
 							FlavorFungibility: defaultFlavorFungibility,
 							FairWeight:        oneQuantity,
@@ -863,7 +812,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 		},
 	}
 	cmpOpts := append(snapCmpOpts,
-		cmpopts.IgnoreFields(ClusterQueueSnapshot{}, "NamespaceSelector", "Preemption", "Status"),
+		cmpopts.IgnoreFields(ClusterQueueSnapshot{}, "NamespaceSelector", "Preemption", "Status", "Quotas"),
 		cmpopts.IgnoreFields(Snapshot{}, "ResourceFlavors"),
 		cmpopts.IgnoreTypes(&workload.Info{}))
 	for name, tc := range cases {
@@ -1313,7 +1262,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 		},
 	}
 	cmpOpts := append(snapCmpOpts,
-		cmpopts.IgnoreFields(ClusterQueueSnapshot{}, "NamespaceSelector", "Preemption", "Status"),
+		cmpopts.IgnoreFields(ClusterQueueSnapshot{}, "NamespaceSelector", "Preemption", "Status", "Quotas"),
 		cmpopts.IgnoreFields(Snapshot{}, "ResourceFlavors"),
 		cmpopts.IgnoreTypes(&workload.Info{}))
 	for name, tc := range cases {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -385,14 +385,7 @@ func resourcesToReserve(e *entry, cq *cache.ClusterQueueSnapshot) resources.Flav
 	for flavor, resourceUsage := range e.assignment.Usage {
 		reservedUsage[flavor] = make(map[corev1.ResourceName]int64)
 		for resource, usage := range resourceUsage {
-			rg := cq.RGByResource(resource)
-			cqQuota := cache.ResourceQuota{}
-			for _, cqFlavor := range rg.Flavors {
-				if cqFlavor.Name == flavor {
-					cqQuota = *cqFlavor.Resources[resource]
-					break
-				}
-			}
+			cqQuota := cq.QuotaFor(resources.FlavorResource{Flavor: flavor, Resource: resource})
 			if !e.assignment.Borrowing {
 				reservedUsage[flavor][resource] = max(0, min(usage, cqQuota.Nominal-cq.Usage[flavor][resource]))
 			} else {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
In preparation for #79, we will change the Scheduler, FlavorAssigner, and Preemption logic to only interact with the `ClusterQueueSnapshot`'s capacity through high level queries. E.g. "am I borrowing" or "how much capacity do I have left". This PR prepares us to bring all access of `Quota`/`Usage` behind the `ClusterQueueSnapshot` interface.

We don't want to rely on iteration through `ResourceGroups` to determine our `Quota`/`Limits`, but rather, should be able to make O(1) queries to a flat data structure. See [this code](https://github.com/kubernetes-sigs/kueue/blob/542b90cfe294e41b0d677b2606fd2485c704b48a/pkg/scheduler/scheduler.go#L388-L395) for an example how we currently have to find a resource group (if we are already not looping through them).

#### Special notes for your reviewer:
I intentionally avoided _any_ simplifications when possible, to keep the diff small

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```