### PR TITLE
Change example Job Admission Policy to use matchLabels

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_job_admission_policy.md
+++ b/site/content/en/docs/tasks/manage/setup_job_admission_policy.md
@@ -45,7 +45,7 @@ To create the binding, download the above file and run the following command:
 kubectl create -f sample-validating-policy-binding.yaml
 ```
 
-Label each namespace where you want this policy to be enforced by doing:
+Run the following command to label each namespace where you want this policy to be enforced:
 
 ```shell
 kubectl label namespace my-user-namespace 'kueue-managed=true'

--- a/site/content/en/docs/tasks/manage/setup_job_admission_policy.md
+++ b/site/content/en/docs/tasks/manage/setup_job_admission_policy.md
@@ -19,10 +19,10 @@ Ensure the following conditions are met:
 ## Example
 
 The example below shows you how to set up the Job Admission Policy to reject early all Job or JobSets
-without the queue-name if sent to a namespace other than `admin-namespace`.
+without the queue-name if sent to a namespace labeled as a `kueue-managed` namespace.
 
 You should set `manageJobsWithoutQueueName` to `false` in the Kueue Configuration to let an admin
-to execute Jobs in the `admin-namespace`. Jobs sent to this namespace aren't rejected, or managed
+to execute Jobs in any namespace that is not labeled as `kueue-managed`. Jobs sent to unlabeled namespaces aren't rejected, or managed
 by Kueue.
 
 {{< include "examples/sample-validating-policy.yaml" "yaml" >}}
@@ -45,8 +45,14 @@ To create the binding, download the above file and run the following command:
 kubectl create -f sample-validating-policy-binding.yaml
 ```
 
-Now, when you try to create a `Job` or a `JobSet` without the `kueue.x-k8s.io/queue-name` label or value in any namespace other than `admin-namespace`,
-the error message will be similar to the following:
+Label each namespace where you want this policy to be enforced by doing:
+
+```shell
+kubectl label namespace my-user-namespace 'kueue-managed=true'
+```
+
+Now, when you try to create a `Job` or a `JobSet` without the `kueue.x-k8s.io/queue-name` label or value in any namespace
+that is labeled as `kueue-managed`, the error message will be similar to the following:
 
 ```
 ValidatingAdmissionPolicy 'sample-validating-admission-policy' with binding 'sample-validating-admission-policy-binding' denied request: The label 'kueue.x-k8s.io/queue-name' is either missing or does not have a value set.

--- a/site/static/examples/sample-validating-policy-binding.yaml
+++ b/site/static/examples/sample-validating-policy-binding.yaml
@@ -7,7 +7,5 @@ spec:
   validationActions: [Deny]
   matchResources:
     namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values: ["admin-namespace"]
+      matchLabels:
+        kueue-managed: "true"

--- a/site/static/examples/sample-validating-policy.yaml
+++ b/site/static/examples/sample-validating-policy.yaml
@@ -15,5 +15,5 @@ spec:
       operations:  ["CREATE", "UPDATE"]
       resources:   ["jobsets"]
   validations:
-    - expression: "'kueue.x-k8s.io/queue-name' in object.metadata.labels && object.metadata.labels['kueue.x-k8s.io/queue-name'] != ''"
+    - expression: "has(object.metadata.labels) && 'kueue.x-k8s.io/queue-name' in object.metadata.labels && object.metadata.labels['kueue.x-k8s.io/queue-name'] != ''"
       message: "The label 'kueue.x-k8s.io/queue-name' is either missing or does not have a value set."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

#### What this PR does / why we need it:

Making the example policy be "opt-in" instead of "opt-out" seems more likely to be useful to users trying to adapt the example to their own use cases. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```