### PR TITLE
Automated cherry pick of #2602: Import auth plugins for K8s

### DIFF
--- a/cmd/kueuectl/app/util/client_getter.go
+++ b/cmd/kueuectl/app/util/client_getter.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"sigs.k8s.io/kueue/client-go/clientset/versioned"
 )


### PR DESCRIPTION
Cherry pick of #2602 on release-0.7.
#2602: Import auth plugins for K8s
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
CLI: Fixed no Auth Provider found for name "oidc" error.
```