### PR TITLE
Simplify scheduler.cohortsUsage; Cleanup FlavorResourceQuantities

### DIFF
--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -143,16 +143,10 @@ func (c *cohort) CalculateLendable() map[corev1.ResourceName]int64 {
 	return lendable
 }
 
-func (c *ClusterQueueSnapshot) FitInCohort(q resources.FlavorResourceQuantities) bool {
-	for flavor, qResources := range q {
-		if _, flavorFound := c.Cohort.RequestableResources[flavor]; flavorFound {
-			for resource, value := range qResources {
-				available := c.RequestableCohortQuota(flavor, resource) - c.UsedCohortQuota(flavor, resource)
-				if available < value {
-					return false
-				}
-			}
-		} else {
+func (c *ClusterQueueSnapshot) FitInCohort(q resources.FlavorResourceQuantitiesFlat) bool {
+	for fr, value := range q {
+		available := c.RequestableCohortQuota(fr.Flavor, fr.Resource) - c.UsedCohortQuota(fr.Flavor, fr.Resource)
+		if available < value {
 			return false
 		}
 	}

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -96,13 +96,13 @@ func TestClusterQueueUpdateWithFlavors(t *testing.T) {
 
 func TestFitInCohort(t *testing.T) {
 	cases := map[string]struct {
-		request            resources.FlavorResourceQuantities
+		request            resources.FlavorResourceQuantitiesFlat
 		wantFit            bool
 		cq                 *ClusterQueueSnapshot
 		enableLendingLimit bool
 	}{
 		"full cohort, empty request": {
-			request: resources.FlavorResourceQuantities{},
+			request: resources.FlavorResourceQuantitiesFlat{},
 			wantFit: true,
 			cq: &ClusterQueueSnapshot{
 				Name: "CQ",
@@ -128,7 +128,7 @@ func TestFitInCohort(t *testing.T) {
 			request: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: "f2", Resource: corev1.ResourceCPU}:    1,
 				{Flavor: "f2", Resource: corev1.ResourceMemory}: 1,
-			}.Unflatten(),
+			},
 			wantFit: true,
 			cq: &ClusterQueueSnapshot{
 				Name: "CQ",
@@ -156,7 +156,7 @@ func TestFitInCohort(t *testing.T) {
 				{Flavor: "f1", Resource: corev1.ResourceMemory}: 1,
 				{Flavor: "f2", Resource: corev1.ResourceCPU}:    1,
 				{Flavor: "f2", Resource: corev1.ResourceMemory}: 1,
-			}.Unflatten(),
+			},
 			wantFit: false,
 			cq: &ClusterQueueSnapshot{
 				Name: "CQ",
@@ -184,7 +184,7 @@ func TestFitInCohort(t *testing.T) {
 				{Flavor: "f1", Resource: corev1.ResourceMemory}: 1,
 				{Flavor: "f2", Resource: corev1.ResourceCPU}:    2,
 				{Flavor: "f2", Resource: corev1.ResourceMemory}: 1,
-			}.Unflatten(),
+			},
 			wantFit: false,
 			cq: &ClusterQueueSnapshot{
 				Name: "CQ",
@@ -210,7 +210,7 @@ func TestFitInCohort(t *testing.T) {
 			request: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: "f2", Resource: corev1.ResourceCPU}:    1,
 				{Flavor: "f2", Resource: corev1.ResourceMemory}: 1,
-			}.Unflatten(),
+			},
 			wantFit: false,
 			cq: &ClusterQueueSnapshot{
 				Name: "CQ",
@@ -232,7 +232,7 @@ func TestFitInCohort(t *testing.T) {
 			request: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: "f1", Resource: corev1.ResourceCPU}:    1,
 				{Flavor: "f1", Resource: corev1.ResourceMemory}: 1,
-			}.Unflatten(),
+			},
 			wantFit: false,
 			cq: &ClusterQueueSnapshot{
 				Name: "CQ",
@@ -251,7 +251,7 @@ func TestFitInCohort(t *testing.T) {
 		"lendingLimit enabled can't fit": {
 			request: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: "f1", Resource: corev1.ResourceCPU}: 3,
-			}.Unflatten(),
+			},
 			wantFit: false,
 			cq: &ClusterQueueSnapshot{
 				Name: "CQ-A",
@@ -276,7 +276,7 @@ func TestFitInCohort(t *testing.T) {
 		"lendingLimit enabled can fit": {
 			request: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: "f1", Resource: corev1.ResourceCPU}: 3,
-			}.Unflatten(),
+			},
 			wantFit: true,
 			cq: &ClusterQueueSnapshot{
 				Name: "CQ-A",

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -102,7 +102,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "default", Resource: corev1.ResourceCPU}:    1_000,
 					{Flavor: "default", Resource: corev1.ResourceMemory}: utiltesting.Mi,
-				}.Unflatten(),
+				},
 			},
 		},
 		"single flavor, fits tainted flavor": {
@@ -138,7 +138,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "tainted", Resource: corev1.ResourceCPU}: 1_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"single flavor, used resources, doesn't fit": {
@@ -173,7 +173,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "default", Resource: corev1.ResourceCPU}: 2_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"multiple resource groups, fits": {
@@ -218,7 +218,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "two", Resource: corev1.ResourceCPU}:      3_000,
 					{Flavor: "b_one", Resource: corev1.ResourceMemory}: 10 * utiltesting.Mi,
-				}.Unflatten(),
+				},
 			},
 		},
 		"multiple resource groups, one could fit with preemption, other doesn't fit": {
@@ -257,7 +257,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: resources.FlavorResourceQuantities{},
+				Usage: resources.FlavorResourceQuantitiesFlat{},
 			},
 		},
 		"multiple resource groups with multiple resources, fits": {
@@ -307,7 +307,7 @@ func TestAssignFlavors(t *testing.T) {
 					{Flavor: "two", Resource: corev1.ResourceCPU}:    3_000,
 					{Flavor: "two", Resource: corev1.ResourceMemory}: 10 * utiltesting.Mi,
 					{Flavor: "b_one", Resource: "example.com/gpu"}:   3,
-				}.Unflatten(),
+				},
 			},
 		},
 		"multiple resource groups with multiple resources, fits with different modes": {
@@ -377,7 +377,7 @@ func TestAssignFlavors(t *testing.T) {
 					{Flavor: "two", Resource: corev1.ResourceCPU}:    3_000,
 					{Flavor: "two", Resource: corev1.ResourceMemory}: 10 * utiltesting.Mi,
 					{Flavor: "b_one", Resource: "example.com/gpu"}:   3,
-				}.Unflatten(),
+				},
 			},
 		},
 		"multiple resources in a group, doesn't fit": {
@@ -413,7 +413,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: resources.FlavorResourceQuantities{},
+				Usage: resources.FlavorResourceQuantitiesFlat{},
 			},
 		},
 		"multiple flavors, fits while skipping tainted flavor": {
@@ -445,7 +445,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: 3_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"multiple flavors, fits a node selector": {
@@ -503,7 +503,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: 1_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"multiple flavors, fits with node affinity": {
@@ -566,7 +566,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "two", Resource: corev1.ResourceCPU}:    1_000,
 					{Flavor: "two", Resource: corev1.ResourceMemory}: utiltesting.Mi,
-				}.Unflatten(),
+				},
 			},
 		},
 		"multiple flavors, node affinity fits any flavor": {
@@ -635,7 +635,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: 1_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"multiple flavors, doesn't fit node affinity": {
@@ -691,7 +691,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: resources.FlavorResourceQuantities{},
+				Usage: resources.FlavorResourceQuantitiesFlat{},
 			},
 		},
 		"multiple specs, fit different flavors": {
@@ -740,7 +740,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: 3_000,
 					{Flavor: "two", Resource: corev1.ResourceCPU}: 5_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"multiple specs, fits borrowing": {
@@ -801,7 +801,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "default", Resource: corev1.ResourceCPU}:    10_000,
 					{Flavor: "default", Resource: corev1.ResourceMemory}: 5 * utiltesting.Gi,
-				}.Unflatten(),
+				},
 			},
 		},
 		"not enough space to borrow": {
@@ -836,7 +836,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: resources.FlavorResourceQuantities{},
+				Usage: resources.FlavorResourceQuantitiesFlat{},
 			},
 		},
 		"past max, but can preempt in ClusterQueue": {
@@ -881,7 +881,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"past min, but can preempt in ClusterQueue": {
@@ -916,7 +916,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"past min, but can preempt in cohort and ClusterQueue": {
@@ -959,7 +959,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"can only preempt flavors that match affinity": {
@@ -1010,7 +1010,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: 2_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"each podset requires preemption on a different flavor": {
@@ -1080,7 +1080,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: corev1.ResourceCPU}:     2_000,
 					{Flavor: "tainted", Resource: corev1.ResourceCPU}: 10_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"resource not listed in clusterQueue": {
@@ -1106,7 +1106,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: resources.FlavorResourceQuantities{},
+				Usage: resources.FlavorResourceQuantitiesFlat{},
 			},
 		},
 		"num pods fit": {
@@ -1140,7 +1140,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "default", Resource: corev1.ResourcePods}: 3,
 					{Flavor: "default", Resource: corev1.ResourceCPU}:  3_000,
-				}.Unflatten(),
+				},
 			},
 			wantRepMode: Fit,
 		},
@@ -1170,7 +1170,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 3,
 				}},
-				Usage: resources.FlavorResourceQuantities{},
+				Usage: resources.FlavorResourceQuantitiesFlat{},
 			},
 		},
 		"with reclaimable pods": {
@@ -1209,7 +1209,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "default", Resource: corev1.ResourcePods}: 3,
 					{Flavor: "default", Resource: corev1.ResourceCPU}:  3_000,
-				}.Unflatten(),
+				},
 			},
 			wantRepMode: Fit,
 		},
@@ -1254,7 +1254,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: "cpu"}:  9_000,
 					{Flavor: "one", Resource: "pods"}: 1,
-				}.Unflatten(),
+				},
 			},
 		},
 		"preempt try next flavor": {
@@ -1294,7 +1294,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "two", Resource: "cpu"}:  9_000,
 					{Flavor: "two", Resource: "pods"}: 1,
-				}.Unflatten(),
+				},
 			},
 		},
 		"borrow try next flavor, found the first flavor": {
@@ -1348,7 +1348,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: corev1.ResourceCPU}:  9_000,
 					{Flavor: "one", Resource: corev1.ResourcePods}: 1,
-				}.Unflatten(),
+				},
 			},
 		},
 		"borrow try next flavor, found the second flavor": {
@@ -1402,7 +1402,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "two", Resource: corev1.ResourceCPU}:  9_000,
 					{Flavor: "two", Resource: corev1.ResourcePods}: 1,
-				}.Unflatten(),
+				},
 			},
 		},
 		"borrow before try next flavor": {
@@ -1456,7 +1456,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: "cpu"}:  9_000,
 					{Flavor: "one", Resource: "pods"}: 1,
-				}.Unflatten(),
+				},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one; WhenCanBorrow=Borrow": {
@@ -1512,7 +1512,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: 12_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one, no borrowingLimit; WhenCanBorrow=Borrow": {
@@ -1567,7 +1567,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: 12_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one; WhenCanBorrow=TryNextFlavor": {
@@ -1619,7 +1619,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: 12_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"when borrowing while preemption is needed, but borrowingLimit exceeds the quota available in the cohort": {
@@ -1652,7 +1652,7 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			wantRepMode: NoFit,
 			wantAssignment: Assignment{
-				Usage: resources.FlavorResourceQuantities{},
+				Usage: resources.FlavorResourceQuantitiesFlat{},
 				PodSets: []PodSetAssignment{
 					{
 						Name: "main",
@@ -1717,7 +1717,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "two", Resource: corev1.ResourceCPU}:  9_000,
 					{Flavor: "two", Resource: corev1.ResourcePods}: 1,
-				}.Unflatten(),
+				},
 			},
 			enableLendingLimit: true,
 		},
@@ -1772,7 +1772,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: corev1.ResourceCPU}:  9_000,
 					{Flavor: "one", Resource: corev1.ResourcePods}: 1,
-				}.Unflatten(),
+				},
 			},
 			enableLendingLimit: true,
 		},
@@ -1821,7 +1821,7 @@ func TestAssignFlavors(t *testing.T) {
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: corev1.ResourceCPU}:  9_000,
 					{Flavor: "one", Resource: corev1.ResourcePods}: 1,
-				}.Unflatten(),
+				},
 			},
 			enableLendingLimit: true,
 		},
@@ -1870,7 +1870,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: 12_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one, fair sharing enabled, reclaimWithinCohor=Never": {
@@ -1914,7 +1914,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: 12_000,
-				}.Unflatten(),
+				},
 			},
 		},
 	}
@@ -2008,7 +2008,7 @@ func TestDeletedFlavors(t *testing.T) {
 				}},
 				Usage: resources.FlavorResourceQuantitiesFlat{
 					{Flavor: "flavor", Resource: corev1.ResourceCPU}: 3_000,
-				}.Unflatten(),
+				},
 			},
 		},
 		"flavor not found": {
@@ -2034,7 +2034,7 @@ func TestDeletedFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: resources.FlavorResourceQuantities{},
+				Usage: resources.FlavorResourceQuantitiesFlat{},
 			},
 		},
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2646,9 +2646,9 @@ func TestResourcesToReserve(t *testing.T) {
 		name            string
 		assignmentMode  flavorassigner.FlavorAssignmentMode
 		borrowing       bool
-		assignmentUsage resources.FlavorResourceQuantities
+		assignmentUsage resources.FlavorResourceQuantitiesFlat
 		cqUsage         resources.FlavorResourceQuantitiesFlat
-		wantReserved    resources.FlavorResourceQuantities
+		wantReserved    resources.FlavorResourceQuantitiesFlat
 	}{
 		{
 			name:           "Reserved memory and gpu less than assignment usage, assignment preempts",
@@ -2656,7 +2656,7 @@ func TestResourcesToReserve(t *testing.T) {
 			assignmentUsage: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 50,
 				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   6,
-			}.Unflatten(),
+			},
 			cqUsage: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 60,
 				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      50,
@@ -2666,7 +2666,7 @@ func TestResourcesToReserve(t *testing.T) {
 			wantReserved: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 40,
 				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   4,
-			}.Unflatten(),
+			},
 		},
 		{
 			name:           "Reserved memory equal assignment usage, assignment preempts",
@@ -2674,7 +2674,7 @@ func TestResourcesToReserve(t *testing.T) {
 			assignmentUsage: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 30,
 				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   2,
-			}.Unflatten(),
+			},
 			cqUsage: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 60,
 				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      50,
@@ -2684,7 +2684,7 @@ func TestResourcesToReserve(t *testing.T) {
 			wantReserved: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 30,
 				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   2,
-			}.Unflatten(),
+			},
 		},
 		{
 			name:           "Reserved memory equal assignment usage, assignment fits",
@@ -2692,7 +2692,7 @@ func TestResourcesToReserve(t *testing.T) {
 			assignmentUsage: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 50,
 				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   2,
-			}.Unflatten(),
+			},
 			cqUsage: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 60,
 				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      50,
@@ -2702,7 +2702,7 @@ func TestResourcesToReserve(t *testing.T) {
 			wantReserved: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 50,
 				{Flavor: kueue.ResourceFlavorReference("model-a"), Resource: "gpu"}:                   2,
-			}.Unflatten(),
+			},
 		},
 		{
 			name:           "Reserved memory is 0, CQ is borrowing, assignment preempts without borrowing",
@@ -2710,7 +2710,7 @@ func TestResourcesToReserve(t *testing.T) {
 			assignmentUsage: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}: 50,
 				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:              2,
-			}.Unflatten(),
+			},
 			cqUsage: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 60,
 				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      60,
@@ -2720,7 +2720,7 @@ func TestResourcesToReserve(t *testing.T) {
 			wantReserved: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}: 0,
 				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:              0,
-			}.Unflatten(),
+			},
 		},
 		{
 			name:           "Reserved memory cut by nominal+borrowing quota, assignment preempts and borrows",
@@ -2729,7 +2729,7 @@ func TestResourcesToReserve(t *testing.T) {
 			assignmentUsage: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}: 50,
 				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:              2,
-			}.Unflatten(),
+			},
 			cqUsage: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 60,
 				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      60,
@@ -2739,7 +2739,7 @@ func TestResourcesToReserve(t *testing.T) {
 			wantReserved: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}: 40,
 				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:              2,
-			}.Unflatten(),
+			},
 		},
 		{
 			name:           "Reserved memory equal assignment usage, CQ borrowing limit is nil",
@@ -2748,7 +2748,7 @@ func TestResourcesToReserve(t *testing.T) {
 			assignmentUsage: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 50,
 				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   2,
-			}.Unflatten(),
+			},
 			cqUsage: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 60,
 				{Flavor: kueue.ResourceFlavorReference("spot"), Resource: corev1.ResourceMemory}:      60,
@@ -2758,7 +2758,7 @@ func TestResourcesToReserve(t *testing.T) {
 			wantReserved: resources.FlavorResourceQuantitiesFlat{
 				{Flavor: kueue.ResourceFlavorReference("on-demand"), Resource: corev1.ResourceMemory}: 50,
 				{Flavor: kueue.ResourceFlavorReference("model-b"), Resource: "gpu"}:                   2,
-			}.Unflatten(),
+			},
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Simplify cohortsUsage, by no longer taking it as a pointer receiver. We also change it to `FlavorResourceQuantitiesFlat`, so we no longer have to do allocations/null checks inside of loops.

Make more progress towards flattening `FlavorResourceQuantities` #2447

#### Does this PR introduce a user-facing change?
```release-note
NONE
```