### PR TITLE
Add redundant-import-alias check on .golangci.yaml.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,6 +25,7 @@ linters-settings:
       - name: context-as-argument
       - name: empty-lines
       - name: var-naming
+      - name: redundant-import-alias
 
 # Settings for enabling and disabling linters
 linters:

--- a/cmd/experimental/kjobctl/.golangci.yaml
+++ b/cmd/experimental/kjobctl/.golangci.yaml
@@ -24,6 +24,7 @@ linters-settings:
     rules:
       - name: empty-lines
       - name: var-naming
+      - name: redundant-import-alias
 
 # Settings for enabling and disabling linters
 linters:

--- a/cmd/experimental/kjobctl/apis/v1alpha1/job_template_types.go
+++ b/cmd/experimental/kjobctl/apis/v1alpha1/job_template_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/batch/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -31,7 +31,7 @@ type JobTemplateSpec struct {
 	// Specification of the desired behavior of the job.
 	//
 	// +kubebuilder:validation:Required
-	Spec v1.JobSpec `json:"spec"`
+	Spec batchv1.JobSpec `json:"spec"`
 }
 
 // +genclient

--- a/cmd/experimental/kjobctl/pkg/builder/builder.go
+++ b/cmd/experimental/kjobctl/pkg/builder/builder.go
@@ -22,7 +22,7 @@ import (
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8s "k8s.io/client-go/kubernetes"
 
@@ -141,7 +141,7 @@ func (b *Builder) complete(ctx context.Context) error {
 		return err
 	}
 
-	b.profile, err = b.kjobctlClientset.KjobctlV1alpha1().ApplicationProfiles(b.namespace).Get(ctx, b.profileName, v1.GetOptions{})
+	b.profile, err = b.kjobctlClientset.KjobctlV1alpha1().ApplicationProfiles(b.namespace).Get(ctx, b.profileName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -156,7 +156,7 @@ func (b *Builder) complete(ctx context.Context) error {
 		return applicationProfileModeNotConfiguredErr
 	}
 
-	volumeBundlesList, err := b.kjobctlClientset.KjobctlV1alpha1().VolumeBundles(b.profile.Namespace).List(ctx, v1.ListOptions{})
+	volumeBundlesList, err := b.kjobctlClientset.KjobctlV1alpha1().VolumeBundles(b.profile.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/cmd/kueuectl/app/version/version.go
+++ b/cmd/kueuectl/app/version/version.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	k8s "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -93,7 +93,7 @@ func (o *VersionOptions) Complete(clientGetter util.ClientGetter) error {
 func (o *VersionOptions) Run(ctx context.Context) error {
 	fmt.Fprintf(o.Out, "Client Version: %s\n", version.GitVersion)
 
-	deployment, err := o.K8sClientset.AppsV1().Deployments(kueueNamespace).Get(ctx, kueueControllerManagerName, v1.GetOptions{})
+	deployment, err := o.K8sClientset.AppsV1().Deployments(kueueNamespace).Get(ctx, kueueControllerManagerName, metav1.GetOptions{})
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}

--- a/cmd/kueuectl/app/version/version_test.go
+++ b/cmd/kueuectl/app/version/version_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -32,7 +32,7 @@ import (
 
 func TestVersionCmd(t *testing.T) {
 	testCases := map[string]struct {
-		deployment *v1.Deployment
+		deployment *appsv1.Deployment
 		args       []string
 		wantOut    string
 		wantOutErr string
@@ -43,12 +43,12 @@ func TestVersionCmd(t *testing.T) {
 			wantOut: "Client Version: v0.0.0-main\n",
 		},
 		"should print client and server versions": {
-			deployment: &v1.Deployment{
+			deployment: &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      kueueControllerManagerName,
 					Namespace: kueueNamespace,
 				},
-				Spec: v1.DeploymentSpec{
+				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{

--- a/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -55,15 +55,15 @@ func TestPriorityClass(t *testing.T) {
 					},
 					PaddleReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.PaddleJobReplicaTypeMaster: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "master-priority",
 								},
 							},
 						},
 						kftraining.PaddleJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -81,8 +81,8 @@ func TestPriorityClass(t *testing.T) {
 					},
 					PaddleReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.PaddleJobReplicaTypeMaster: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "master-priority",
 								},
 							},
@@ -97,15 +97,15 @@ func TestPriorityClass(t *testing.T) {
 				Spec: kftraining.PaddleJobSpec{
 					PaddleReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.PaddleJobReplicaTypeMaster: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "master-priority",
 								},
 							},
 						},
 						kftraining.PaddleJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -120,13 +120,13 @@ func TestPriorityClass(t *testing.T) {
 				Spec: kftraining.PaddleJobSpec{
 					PaddleReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.PaddleJobReplicaTypeMaster: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{},
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{},
 							},
 						},
 						kftraining.PaddleJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -142,8 +142,8 @@ func TestPriorityClass(t *testing.T) {
 					PaddleReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.PaddleJobReplicaTypeMaster: {},
 						kftraining.PaddleJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -159,8 +159,8 @@ func TestPriorityClass(t *testing.T) {
 					PaddleReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.PaddleJobReplicaTypeMaster: {},
 						kftraining.PaddleJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{},
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{},
 							},
 						},
 					},
@@ -281,8 +281,8 @@ func TestReconciler(t *testing.T) {
 				Queue("foo").
 				Suspend(false).
 				Parallelism(10).
-				Request(kftraining.PaddleJobReplicaTypeMaster, v1.ResourceCPU, "1").
-				Request(kftraining.PaddleJobReplicaTypeWorker, v1.ResourceCPU, "5").
+				Request(kftraining.PaddleJobReplicaTypeMaster, corev1.ResourceCPU, "1").
+				Request(kftraining.PaddleJobReplicaTypeWorker, corev1.ResourceCPU, "5").
 				NodeSelector("provisioning", "spot").
 				Active(kftraining.PaddleJobReplicaTypeMaster, 1).
 				Active(kftraining.PaddleJobReplicaTypeWorker, 10).
@@ -290,22 +290,22 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("master", 1).Request(v1.ResourceCPU, "1").Obj(),
-						*utiltesting.MakePodSet("worker", 10).Request(v1.ResourceCPU, "5").Obj(),
+						*utiltesting.MakePodSet("master", 1).Request(corev1.ResourceCPU, "1").Obj(),
+						*utiltesting.MakePodSet("worker", 10).Request(corev1.ResourceCPU, "5").Obj(),
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq").
 						PodSets(
 							kueue.PodSetAssignment{
 								Name: "master",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](1),
 							},
 							kueue.PodSetAssignment{
 								Name: "worker",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](10),
 							},
@@ -324,30 +324,30 @@ func TestReconciler(t *testing.T) {
 				Queue("foo").
 				Suspend(true).
 				Parallelism(10).
-				Request(kftraining.PaddleJobReplicaTypeMaster, v1.ResourceCPU, "1").
-				Request(kftraining.PaddleJobReplicaTypeWorker, v1.ResourceCPU, "5").
+				Request(kftraining.PaddleJobReplicaTypeMaster, corev1.ResourceCPU, "1").
+				Request(kftraining.PaddleJobReplicaTypeWorker, corev1.ResourceCPU, "5").
 				Active(kftraining.PaddleJobReplicaTypeMaster, 1).
 				Active(kftraining.PaddleJobReplicaTypeWorker, 10).
 				Obj(),
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("master", 1).Request(v1.ResourceCPU, "1").Obj(),
-						*utiltesting.MakePodSet("worker", 10).Request(v1.ResourceCPU, "5").Obj(),
+						*utiltesting.MakePodSet("master", 1).Request(corev1.ResourceCPU, "1").Obj(),
+						*utiltesting.MakePodSet("worker", 10).Request(corev1.ResourceCPU, "5").Obj(),
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq").
 						PodSets(
 							kueue.PodSetAssignment{
 								Name: "master",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](1),
 							},
 							kueue.PodSetAssignment{
 								Name: "worker",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](10),
 							},
@@ -384,7 +384,7 @@ func TestReconciler(t *testing.T) {
 					t.Fatalf("Could not create Workload: %v", err)
 				}
 			}
-			recorder := record.NewBroadcaster().NewRecorder(kClient.Scheme(), v1.EventSource{Component: "test"})
+			recorder := record.NewBroadcaster().NewRecorder(kClient.Scheme(), corev1.EventSource{Component: "test"})
 			reconciler := NewReconciler(kClient, recorder, tc.reconcilerOptions...)
 
 			jobKey := client.ObjectKeyFromObject(tc.job)

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestPriorityClass(t *testing.T) {
@@ -43,15 +43,15 @@ func TestPriorityClass(t *testing.T) {
 					},
 					PyTorchReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.PyTorchJobReplicaTypeMaster: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "master-priority",
 								},
 							},
 						},
 						kftraining.PyTorchJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -69,8 +69,8 @@ func TestPriorityClass(t *testing.T) {
 					},
 					PyTorchReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.PyTorchJobReplicaTypeMaster: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "master-priority",
 								},
 							},
@@ -85,15 +85,15 @@ func TestPriorityClass(t *testing.T) {
 				Spec: kftraining.PyTorchJobSpec{
 					PyTorchReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.PyTorchJobReplicaTypeMaster: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "master-priority",
 								},
 							},
 						},
 						kftraining.PyTorchJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -108,13 +108,13 @@ func TestPriorityClass(t *testing.T) {
 				Spec: kftraining.PyTorchJobSpec{
 					PyTorchReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.PyTorchJobReplicaTypeMaster: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{},
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{},
 							},
 						},
 						kftraining.PyTorchJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -130,8 +130,8 @@ func TestPriorityClass(t *testing.T) {
 					PyTorchReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.PyTorchJobReplicaTypeMaster: {},
 						kftraining.PyTorchJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -147,8 +147,8 @@ func TestPriorityClass(t *testing.T) {
 					PyTorchReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.PyTorchJobReplicaTypeMaster: {},
 						kftraining.PyTorchJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{},
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{},
 							},
 						},
 					},

--- a/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func TestPriorityClass(t *testing.T) {
@@ -43,15 +43,15 @@ func TestPriorityClass(t *testing.T) {
 					},
 					TFReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.TFJobReplicaTypeChief: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "chief-priority",
 								},
 							},
 						},
 						kftraining.TFJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -69,8 +69,8 @@ func TestPriorityClass(t *testing.T) {
 					},
 					TFReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.TFJobReplicaTypeChief: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "chief-priority",
 								},
 							},
@@ -85,29 +85,29 @@ func TestPriorityClass(t *testing.T) {
 				Spec: kftraining.TFJobSpec{
 					TFReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.TFJobReplicaTypeChief: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "chief-priority",
 								},
 							},
 						},
 						kftraining.TFJobReplicaTypePS: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "ps-priority",
 								},
 							},
 						},
 						kftraining.TFJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
 						},
 						kftraining.TFJobReplicaTypeEval: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "eval-priority",
 								},
 							},
@@ -122,13 +122,13 @@ func TestPriorityClass(t *testing.T) {
 				Spec: kftraining.TFJobSpec{
 					TFReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.TFJobReplicaTypeChief: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{},
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{},
 							},
 						},
 						kftraining.TFJobReplicaTypeEval: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "eval-priority",
 								},
 							},
@@ -144,8 +144,8 @@ func TestPriorityClass(t *testing.T) {
 					TFReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.TFJobReplicaTypeChief: {},
 						kftraining.TFJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -161,8 +161,8 @@ func TestPriorityClass(t *testing.T) {
 					TFReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.TFJobReplicaTypeChief: {},
 						kftraining.TFJobReplicaTypeEval: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{},
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{},
 							},
 						},
 					},

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -55,15 +55,15 @@ func TestPriorityClass(t *testing.T) {
 					},
 					XGBReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.XGBoostJobReplicaTypeMaster: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "master-priority",
 								},
 							},
 						},
 						kftraining.XGBoostJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -81,8 +81,8 @@ func TestPriorityClass(t *testing.T) {
 					},
 					XGBReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.XGBoostJobReplicaTypeMaster: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "master-priority",
 								},
 							},
@@ -97,15 +97,15 @@ func TestPriorityClass(t *testing.T) {
 				Spec: kftraining.XGBoostJobSpec{
 					XGBReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.XGBoostJobReplicaTypeMaster: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "master-priority",
 								},
 							},
 						},
 						kftraining.XGBoostJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -120,13 +120,13 @@ func TestPriorityClass(t *testing.T) {
 				Spec: kftraining.XGBoostJobSpec{
 					XGBReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.XGBoostJobReplicaTypeMaster: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{},
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{},
 							},
 						},
 						kftraining.XGBoostJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -141,8 +141,8 @@ func TestPriorityClass(t *testing.T) {
 				Spec: kftraining.XGBoostJobSpec{
 					XGBReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.XGBoostJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
 									PriorityClassName: "worker-priority",
 								},
 							},
@@ -158,8 +158,8 @@ func TestPriorityClass(t *testing.T) {
 					XGBReplicaSpecs: map[kftraining.ReplicaType]*kftraining.ReplicaSpec{
 						kftraining.XGBoostJobReplicaTypeMaster: {},
 						kftraining.XGBoostJobReplicaTypeWorker: {
-							Template: v1.PodTemplateSpec{
-								Spec: v1.PodSpec{},
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{},
 							},
 						},
 					},
@@ -279,8 +279,8 @@ func TestReconciler(t *testing.T) {
 				Queue("foo").
 				Suspend(false).
 				Parallelism(10).
-				Request(kftraining.XGBoostJobReplicaTypeMaster, v1.ResourceCPU, "1").
-				Request(kftraining.XGBoostJobReplicaTypeWorker, v1.ResourceCPU, "5").
+				Request(kftraining.XGBoostJobReplicaTypeMaster, corev1.ResourceCPU, "1").
+				Request(kftraining.XGBoostJobReplicaTypeWorker, corev1.ResourceCPU, "5").
 				NodeSelector("provisioning", "spot").
 				Active(kftraining.XGBoostJobReplicaTypeMaster, 1).
 				Active(kftraining.XGBoostJobReplicaTypeWorker, 10).
@@ -288,22 +288,22 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("master", 1).Request(v1.ResourceCPU, "1").Obj(),
-						*utiltesting.MakePodSet("worker", 10).Request(v1.ResourceCPU, "5").Obj(),
+						*utiltesting.MakePodSet("master", 1).Request(corev1.ResourceCPU, "1").Obj(),
+						*utiltesting.MakePodSet("worker", 10).Request(corev1.ResourceCPU, "5").Obj(),
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq").
 						PodSets(
 							kueue.PodSetAssignment{
 								Name: "master",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](1),
 							},
 							kueue.PodSetAssignment{
 								Name: "worker",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](10),
 							},
@@ -322,30 +322,30 @@ func TestReconciler(t *testing.T) {
 				Queue("foo").
 				Suspend(true).
 				Parallelism(10).
-				Request(kftraining.XGBoostJobReplicaTypeMaster, v1.ResourceCPU, "1").
-				Request(kftraining.XGBoostJobReplicaTypeWorker, v1.ResourceCPU, "5").
+				Request(kftraining.XGBoostJobReplicaTypeMaster, corev1.ResourceCPU, "1").
+				Request(kftraining.XGBoostJobReplicaTypeWorker, corev1.ResourceCPU, "5").
 				Active(kftraining.XGBoostJobReplicaTypeMaster, 1).
 				Active(kftraining.XGBoostJobReplicaTypeWorker, 10).
 				Obj(),
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "ns").
 					PodSets(
-						*utiltesting.MakePodSet("master", 1).Request(v1.ResourceCPU, "1").Obj(),
-						*utiltesting.MakePodSet("worker", 10).Request(v1.ResourceCPU, "5").Obj(),
+						*utiltesting.MakePodSet("master", 1).Request(corev1.ResourceCPU, "1").Obj(),
+						*utiltesting.MakePodSet("worker", 10).Request(corev1.ResourceCPU, "5").Obj(),
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq").
 						PodSets(
 							kueue.PodSetAssignment{
 								Name: "master",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](1),
 							},
 							kueue.PodSetAssignment{
 								Name: "worker",
-								Flavors: map[v1.ResourceName]kueue.ResourceFlavorReference{
-									v1.ResourceCPU: "default",
+								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+									corev1.ResourceCPU: "default",
 								},
 								Count: ptr.To[int32](10),
 							},
@@ -382,7 +382,7 @@ func TestReconciler(t *testing.T) {
 					t.Fatalf("Could not create Workload: %v", err)
 				}
 			}
-			recorder := record.NewBroadcaster().NewRecorder(kClient.Scheme(), v1.EventSource{Component: "test"})
+			recorder := record.NewBroadcaster().NewRecorder(kClient.Scheme(), corev1.EventSource{Component: "test"})
 			reconciler := NewReconciler(kClient, recorder, tc.reconcilerOptions...)
 
 			jobKey := client.ObjectKeyFromObject(tc.job)

--- a/pkg/util/priority/priority_test.go
+++ b/pkg/util/priority/priority_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -77,7 +77,7 @@ func TestGetPriorityFromPriorityClass(t *testing.T) {
 			priorityClassList: &schedulingv1.PriorityClassList{
 				Items: []schedulingv1.PriorityClass{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "test"},
+						ObjectMeta: metav1.ObjectMeta{Name: "test"},
 						Value:      50,
 					},
 				},
@@ -98,7 +98,7 @@ func TestGetPriorityFromPriorityClass(t *testing.T) {
 			priorityClassList: &schedulingv1.PriorityClassList{
 				Items: []schedulingv1.PriorityClass{
 					{
-						ObjectMeta:    v1.ObjectMeta{Name: "globalDefault"},
+						ObjectMeta:    metav1.ObjectMeta{Name: "globalDefault"},
 						GlobalDefault: true,
 						Value:         40,
 					},
@@ -112,17 +112,17 @@ func TestGetPriorityFromPriorityClass(t *testing.T) {
 			priorityClassList: &schedulingv1.PriorityClassList{
 				Items: []schedulingv1.PriorityClass{
 					{
-						ObjectMeta:    v1.ObjectMeta{Name: "globalDefault1"},
+						ObjectMeta:    metav1.ObjectMeta{Name: "globalDefault1"},
 						GlobalDefault: true,
 						Value:         90,
 					},
 					{
-						ObjectMeta:    v1.ObjectMeta{Name: "globalDefault2"},
+						ObjectMeta:    metav1.ObjectMeta{Name: "globalDefault2"},
 						GlobalDefault: true,
 						Value:         20,
 					},
 					{
-						ObjectMeta:    v1.ObjectMeta{Name: "globalDefault3"},
+						ObjectMeta:    metav1.ObjectMeta{Name: "globalDefault3"},
 						GlobalDefault: true,
 						Value:         50,
 					},
@@ -179,7 +179,7 @@ func TestGetPriorityFromWorkloadPriorityClass(t *testing.T) {
 			workloadPriorityClassList: &kueue.WorkloadPriorityClassList{
 				Items: []kueue.WorkloadPriorityClass{
 					{
-						ObjectMeta: v1.ObjectMeta{Name: "test"},
+						ObjectMeta: metav1.ObjectMeta{Name: "test"},
 						Value:      50,
 					},
 				},

--- a/pkg/visibility/api/install.go
+++ b/pkg/visibility/api/install.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 
-	v1alpha1 "sigs.k8s.io/kueue/apis/visibility/v1alpha1"
+	"sigs.k8s.io/kueue/apis/visibility/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/queue"
 	apirest "sigs.k8s.io/kueue/pkg/visibility/api/rest"
 )

--- a/pkg/visibility/api/rest/pending_workloads_cq_test.go
+++ b/pkg/visibility/api/rest/pending_workloads_cq_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -85,10 +85,10 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 			wantResp: &resp{
 				wantPendingWorkloads: []visibility.PendingWorkload{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "a",
 							Namespace:         nsName,
-							CreationTimestamp: v1.NewTime(now),
+							CreationTimestamp: metav1.NewTime(now),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,
@@ -96,10 +96,10 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 						PositionInLocalQueue:   0,
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "b",
 							Namespace:         nsName,
-							CreationTimestamp: v1.NewTime(now),
+							CreationTimestamp: metav1.NewTime(now),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               lowPrio,
@@ -129,10 +129,10 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 			wantResp: &resp{
 				wantPendingWorkloads: []visibility.PendingWorkload{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "lqA-high-prio",
 							Namespace:         nsName,
-							CreationTimestamp: v1.NewTime(now),
+							CreationTimestamp: metav1.NewTime(now),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,
@@ -140,10 +140,10 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 						PositionInLocalQueue:   0,
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "lqB-high-prio",
 							Namespace:         nsName,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 						},
 						LocalQueueName:         lqNameB,
 						Priority:               highPrio,
@@ -151,10 +151,10 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 						PositionInLocalQueue:   0,
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "lqA-low-prio",
 							Namespace:         nsName,
-							CreationTimestamp: v1.NewTime(now),
+							CreationTimestamp: metav1.NewTime(now),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               lowPrio,
@@ -162,10 +162,10 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 						PositionInLocalQueue:   1,
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "lqB-low-prio",
 							Namespace:         nsName,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 						},
 						LocalQueueName:         lqNameB,
 						Priority:               lowPrio,
@@ -195,10 +195,10 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 			wantResp: &resp{
 				wantPendingWorkloads: []visibility.PendingWorkload{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "a",
 							Namespace:         nsName,
-							CreationTimestamp: v1.NewTime(now),
+							CreationTimestamp: metav1.NewTime(now),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,
@@ -206,10 +206,10 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 						PositionInLocalQueue:   0,
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "b",
 							Namespace:         nsName,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,
@@ -240,10 +240,10 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 			wantResp: &resp{
 				wantPendingWorkloads: []visibility.PendingWorkload{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "b",
 							Namespace:         nsName,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,
@@ -251,10 +251,10 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 						PositionInLocalQueue:   1,
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "c",
 							Namespace:         nsName,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second * 2)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second * 2)),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,
@@ -285,10 +285,10 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 			wantResp: &resp{
 				wantPendingWorkloads: []visibility.PendingWorkload{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "b",
 							Namespace:         nsName,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,

--- a/pkg/visibility/api/rest/pending_workloads_lq_test.go
+++ b/pkg/visibility/api/rest/pending_workloads_lq_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
@@ -86,10 +86,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 			wantResp: &resp{
 				wantPendingWorkloads: []visibility.PendingWorkload{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "a",
 							Namespace:         nsNameA,
-							CreationTimestamp: v1.NewTime(now),
+							CreationTimestamp: metav1.NewTime(now),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,
@@ -97,10 +97,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						PositionInLocalQueue:   0,
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "b",
 							Namespace:         nsNameA,
-							CreationTimestamp: v1.NewTime(now),
+							CreationTimestamp: metav1.NewTime(now),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               lowPrio,
@@ -131,10 +131,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 			wantResp: &resp{
 				wantPendingWorkloads: []visibility.PendingWorkload{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "lqA-high-prio",
 							Namespace:         nsNameA,
-							CreationTimestamp: v1.NewTime(now),
+							CreationTimestamp: metav1.NewTime(now),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,
@@ -142,10 +142,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						PositionInLocalQueue:   0,
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "lqA-low-prio",
 							Namespace:         nsNameA,
-							CreationTimestamp: v1.NewTime(now),
+							CreationTimestamp: metav1.NewTime(now),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               lowPrio,
@@ -176,10 +176,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 			wantResp: &resp{
 				wantPendingWorkloads: []visibility.PendingWorkload{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "lqB-high-prio",
 							Namespace:         nsNameA,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 						},
 						LocalQueueName:         lqNameB,
 						Priority:               highPrio,
@@ -187,10 +187,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						PositionInLocalQueue:   0,
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "lqB-low-prio",
 							Namespace:         nsNameA,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 						},
 						LocalQueueName:         lqNameB,
 						Priority:               lowPrio,
@@ -223,10 +223,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 			wantResp: &resp{
 				wantPendingWorkloads: []visibility.PendingWorkload{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "lqA-high-prio",
 							Namespace:         nsNameA,
-							CreationTimestamp: v1.NewTime(now),
+							CreationTimestamp: metav1.NewTime(now),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,
@@ -234,10 +234,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						PositionInLocalQueue:   0,
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "lqA-low-prio",
 							Namespace:         nsNameA,
-							CreationTimestamp: v1.NewTime(now),
+							CreationTimestamp: metav1.NewTime(now),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               lowPrio,
@@ -270,10 +270,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 			wantResp: &resp{
 				wantPendingWorkloads: []visibility.PendingWorkload{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "lqB-high-prio",
 							Namespace:         nsNameB,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 						},
 						LocalQueueName:         lqNameB,
 						Priority:               highPrio,
@@ -281,10 +281,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						PositionInLocalQueue:   0,
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "lqB-low-prio",
 							Namespace:         nsNameB,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 						},
 						LocalQueueName:         lqNameB,
 						Priority:               lowPrio,
@@ -316,10 +316,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 			wantResp: &resp{
 				wantPendingWorkloads: []visibility.PendingWorkload{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "a",
 							Namespace:         nsNameA,
-							CreationTimestamp: v1.NewTime(now),
+							CreationTimestamp: metav1.NewTime(now),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,
@@ -327,10 +327,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						PositionInLocalQueue:   0,
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "b",
 							Namespace:         nsNameA,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,
@@ -363,10 +363,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 			wantResp: &resp{
 				wantPendingWorkloads: []visibility.PendingWorkload{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "b",
 							Namespace:         nsNameA,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,
@@ -374,10 +374,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 						PositionInLocalQueue:   1,
 					},
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "c",
 							Namespace:         nsNameA,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second * 2)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second * 2)),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,
@@ -410,10 +410,10 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 			wantResp: &resp{
 				wantPendingWorkloads: []visibility.PendingWorkload{
 					{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Name:              "b",
 							Namespace:         nsNameA,
-							CreationTimestamp: v1.NewTime(now.Add(time.Second)),
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 						},
 						LocalQueueName:         lqNameA,
 						Priority:               highPrio,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add redundant-import-alias check on .golangci.yaml.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```