### PR TITLE
Refactor update(Flavor|Cohort)Usage to take FlavorResourceQuantitiesFlat

### DIFF
--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -42,7 +42,7 @@ type Snapshot struct {
 func (s *Snapshot) RemoveWorkload(wl *workload.Info) {
 	cq := s.ClusterQueues[wl.ClusterQueue]
 	delete(cq.Workloads, workload.Key(wl.Obj))
-	cq.addOrRemoveWorkload(wl, -1)
+	cq.addOrRemoveUsage(wl.FlavorResourceUsage(), -1)
 }
 
 // AddWorkload adds a workload from its corresponding ClusterQueue and
@@ -50,16 +50,16 @@ func (s *Snapshot) RemoveWorkload(wl *workload.Info) {
 func (s *Snapshot) AddWorkload(wl *workload.Info) {
 	cq := s.ClusterQueues[wl.ClusterQueue]
 	cq.Workloads[workload.Key(wl.Obj)] = wl
-	cq.addOrRemoveWorkload(wl, 1)
+	cq.addOrRemoveUsage(wl.FlavorResourceUsage(), 1)
 }
 
-func (c *ClusterQueueSnapshot) addOrRemoveWorkload(wl *workload.Info, m int64) {
-	updateFlavorUsage(wl, c.Usage, m)
+func (c *ClusterQueueSnapshot) addOrRemoveUsage(usage resources.FlavorResourceQuantitiesFlat, m int64) {
+	updateFlavorUsage(usage, c.Usage, m)
 	if c.Cohort != nil {
 		if features.Enabled(features.LendingLimit) {
-			updateCohortUsage(wl, c, m)
+			updateCohortUsage(usage, c, m)
 		} else {
-			updateFlavorUsage(wl, c.Cohort.Usage, m)
+			updateFlavorUsage(usage, c.Cohort.Usage, m)
 		}
 	}
 }

--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -43,8 +43,17 @@ func (f FlavorResourceQuantitiesFlat) Unflatten() FlavorResourceQuantities {
 
 // For attempts to access nested value, returning 0 if absent.
 func (f FlavorResourceQuantities) For(fr FlavorResource) int64 {
-	if f == nil || f[fr.Flavor] == nil {
-		return 0
-	}
 	return f[fr.Flavor][fr.Resource]
+}
+
+// Add adds the Quantity v for the FlavorResource fr, allocating
+// as needed.
+func (f *FlavorResourceQuantities) Add(fr FlavorResource, v int64) {
+	if *f == nil {
+		*f = make(FlavorResourceQuantities)
+	}
+	if (*f)[fr.Flavor] == nil {
+		(*f)[fr.Flavor] = make(Requests)
+	}
+	(*f)[fr.Flavor][fr.Resource] += v
 }

--- a/pkg/resources/resource_test.go
+++ b/pkg/resources/resource_test.go
@@ -1,0 +1,40 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSafeAdd(t *testing.T) {
+	var a FlavorResourceQuantities = nil
+	fr := FlavorResource{Flavor: "Hello", Resource: "World"}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Panic while assigning to nil map")
+		}
+	}()
+	a.Add(fr, 5)
+	a.Add(fr, -7)
+
+	expected := FlavorResourceQuantitiesFlat{fr: -2}.Unflatten()
+	if diff := cmp.Diff(a, expected); diff != "" {
+		t.Fatalf("Unexpected diff %s", diff)
+	}
+}
+
+func TestFor(t *testing.T) {
+	var a FlavorResourceQuantities = nil
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Panic while accessing nil map")
+		}
+	}()
+	result := a.For(FlavorResource{Flavor: "Hello", Resource: "World"})
+
+	if result != 0 {
+		t.Fatalf("Unexpected result: %d != 0", result)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Preparation for #2596, where we want to add usage to Cohort without needing a workload. See [WIP Commit](https://github.com/gabesaba/kueue/commit/c3277c97cadc5653505b6a86add07d0c1f1b5dc6) for example of intended usage.

Additionally, gets us closer to #2447 cleanup.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```