### PR TITLE
[performance] Relax ClusterQueueClassesMinUsage.

### DIFF
--- a/test/performance/scheduler/checker/checker_test.go
+++ b/test/performance/scheduler/checker/checker_test.go
@@ -92,13 +92,13 @@ func TestScalability(t *testing.T) {
 	})
 
 	t.Run("ClusterQueueClasses", func(t *testing.T) {
-		for c, cqcSummarry := range summary.ClusterQueueClasses {
+		for c, cqcSummary := range summary.ClusterQueueClasses {
 			t.Run(c, func(t *testing.T) {
 				expected, found := rangeSpec.ClusterQueueClassesMinUsage[c]
 				if !found {
 					t.Fatalf("Unexpected class")
 				}
-				actual := float64(cqcSummarry.CPUUsed) * 100 / (float64(cqcSummarry.NominalQuota) * float64(cqcSummarry.LastEventTime.Sub(cqcSummarry.FirstEventTime).Milliseconds()))
+				actual := float64(cqcSummary.CPUUsed) * 100 / (float64(cqcSummary.NominalQuota) * float64(cqcSummary.LastEventTime.Sub(cqcSummary.FirstEventTime).Milliseconds()))
 				if actual < expected {
 					t.Errorf("Usage %.2f%% is less then expected %.2f%%", actual, expected)
 				}

--- a/test/performance/scheduler/default_rangespec.yaml
+++ b/test/performance/scheduler/default_rangespec.yaml
@@ -15,8 +15,8 @@ cmd:
   maxrss: 468_000
 
 clusterQueueClassesMinUsage:
-  # Average value 58.7 (+/- 1.2%), setting at -5%
-  cq: 56 #%
+  # Average value 58.7 (+/- 1.2%), setting at -7%
+  cq: 55 #%
 
 wlClassesMaxAvgTimeToAdmissionMs:
   # Average value 6666 (+/- 14%), setting at +35% + 1s accounting for observed failures


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adjusted ClusterQueueClassesMinUsage due to experienced failures.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2638

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```