### PR TITLE
Enable Multiple Preemptions within Cohort in a single Scheduling Cycle

### DIFF
--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -48,6 +48,19 @@ func (c *ClusterQueueSnapshot) RGByResource(resource corev1.ResourceName) *Resou
 	return nil
 }
 
+func (c *ClusterQueueSnapshot) AddUsage(frq resources.FlavorResourceQuantitiesFlat) {
+	c.addOrRemoveUsage(frq, 1)
+}
+
+func (c *ClusterQueueSnapshot) Fits(frq resources.FlavorResourceQuantitiesFlat) bool {
+	for fr, q := range frq {
+		if c.Available(fr) < q {
+			return false
+		}
+	}
+	return true
+}
+
 func (c *ClusterQueueSnapshot) QuotaFor(fr resources.FlavorResource) *ResourceQuota {
 	return c.Quotas[fr]
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -90,6 +90,13 @@ const (
 	//
 	// Enable the usage of batch.Job spec.managedBy field its MultiKueue integration.
 	MultiKueueBatchJobWithManagedBy featuregate.Feature = "MultiKueueBatchJobWithManagedBy"
+
+	// owner: @gabesaba
+	// alpha: v0.8
+	//
+	// Enable more than one workload sharing flavors to preempt within a Cohort,
+	// as long as the preemption targets don't overlap.
+	MultiplePreemptions featuregate.Feature = "MultiplePreemptions"
 )
 
 func init() {
@@ -112,6 +119,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	MultiKueue:                      {Default: false, PreRelease: featuregate.Alpha},
 	LendingLimit:                    {Default: false, PreRelease: featuregate.Alpha},
 	MultiKueueBatchJobWithManagedBy: {Default: false, PreRelease: featuregate.Alpha},
+	MultiplePreemptions:             {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) func() {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 	"time"
@@ -172,6 +173,16 @@ func (cu cohortsUsage) hasCommonFlavorResources(cohort string, assignment resour
 	return false
 }
 
+func setSkipped(e *entry, inadmissibleMsg string) {
+	e.status = skipped
+	e.inadmissibleMsg = inadmissibleMsg
+	// Reset assignment so that we retry all flavors
+	// after skipping due to Fit no longer fitting,
+	// or Preempt being skipped due to an overlapping
+	// earlier admission.
+	e.LastAssignment = nil
+}
+
 func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	s.attemptCount++
 	log := ctrl.LoggerFrom(ctx).WithValues("attemptCount", s.attemptCount)
@@ -207,6 +218,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	// of other clusterQueues.
 	cycleCohortsUsage := cohortsUsage{}
 	cycleCohortsSkipPreemption := sets.New[string]()
+	preemptedWorkloads := sets.New[string]()
 	for i := range entries {
 		e := &entries[i]
 		mode := e.assignment.RepresentativeMode()
@@ -215,7 +227,37 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 		}
 
 		cq := snapshot.ClusterQueues[e.ClusterQueue]
-		if cq.Cohort != nil {
+		log := log.WithValues("workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", e.ClusterQueue))
+		ctx := ctrl.LoggerInto(ctx, log)
+
+		if features.Enabled(features.MultiplePreemptions) {
+			if mode == flavorassigner.Preempt && len(e.preemptionTargets) == 0 {
+				log.V(2).Info("Workload requires preemption, but there are no candidate workloads allowed for preemption", "preemption", cq.Preemption)
+				// we use resourcesToReserve to block capacity up to either the nominal capacity,
+				// or the borrowing limit when borrowing, so that a lower priority workload cannot
+				// admit before us.
+				cq.AddUsage(resourcesToReserve(e, cq))
+				continue
+			}
+
+			// We skip multiple-preemptions per cohort if any of the targets are overlapping
+			pendingPreemptions := make([]string, 0, len(e.preemptionTargets))
+			for _, target := range e.preemptionTargets {
+				pendingPreemptions = append(pendingPreemptions, workload.Key(target.WorkloadInfo.Obj))
+			}
+			if preemptedWorkloads.HasAny(pendingPreemptions...) {
+				setSkipped(e, "Workload has overlapping preemption targets with another workload")
+				continue
+			}
+
+			usage := e.netUsage()
+			if !cq.Fits(usage) {
+				setSkipped(e, "Workload no longer fits after processing other workloads")
+				continue
+			}
+			preemptedWorkloads.Insert(pendingPreemptions...)
+			cq.AddUsage(usage)
+		} else if cq.Cohort != nil {
 			sum := cycleCohortsUsage.totalUsageForCommonFlavorResources(cq.Cohort.Name, e.assignment.Usage)
 			// Check whether there was an assignment in this cycle that could render the next assignments invalid:
 			// - If the workload no longer fits in the cohort.
@@ -223,20 +265,13 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 			if cycleCohortsUsage.hasCommonFlavorResources(cq.Cohort.Name, e.assignment.Usage) &&
 				((mode == flavorassigner.Fit && !cq.FitInCohort(sum)) ||
 					(mode == flavorassigner.Preempt && cycleCohortsSkipPreemption.Has(cq.Cohort.Name))) {
-				e.status = skipped
-				e.inadmissibleMsg = "other workloads in the cohort were prioritized"
-				// When the workload needs borrowing and there is another workload in cohort doesn't
-				// need borrowing, the workload needborrowing will come again. In this case we should
-				// not skip the previous flavors.
-				e.LastAssignment = nil
+				setSkipped(e, "other workloads in the cohort were prioritized")
 				continue
 			}
 			// Even if the workload will not be admitted after this point, due to preemption pending or other failures,
 			// we should still account for its usage.
 			cycleCohortsUsage.add(cq.Cohort.Name, resourcesToReserve(e, cq))
 		}
-		log := log.WithValues("workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", e.ClusterQueue))
-		ctx := ctrl.LoggerInto(ctx, log)
 		if e.assignment.RepresentativeMode() != flavorassigner.Fit {
 			if len(e.preemptionTargets) != 0 {
 				// If preemptions are issued, the next attempt should try all the flavors.
@@ -320,6 +355,26 @@ type entry struct {
 	inadmissibleMsg       string
 	requeueReason         queue.RequeueReason
 	preemptionTargets     []*preemption.Target
+}
+
+// netUsage returns how much capacity this entry will require from the ClusterQueue/Cohort.
+// When a workload is preempting, it subtracts the preempted resources from the resources
+// required, as the remaining quota is all we need from the CQ/Cohort.
+func (e *entry) netUsage() resources.FlavorResourceQuantitiesFlat {
+	if e.assignment.RepresentativeMode() == flavorassigner.Fit {
+		return e.assignment.Usage
+	}
+
+	usage := maps.Clone(e.assignment.Usage)
+	for target := range e.preemptionTargets {
+		for fr, v := range e.preemptionTargets[target].WorkloadInfo.FlavorResourceUsage() {
+			if _, uses := usage[fr]; !uses {
+				continue
+			}
+			usage[fr] = max(0, usage[fr]-v)
+		}
+	}
+	return usage
 }
 
 // nominate returns the workloads with their requirements (resource flavors, borrowing) if

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -252,6 +252,7 @@ The currently supported features are:
 | `VisibilityOnDemand` | `false` | Alpha | 0.6 | |
 | `PrioritySortingWithinCohort` | `true` | Beta | 0.6 |  |
 | `LendingLimit` | `false` | Alpha | 0.6 | |
+| `MultiplePreemptions` | `false` | Alpha | 0.8 | |
 
 ## What's next
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
When scheduling a `Preempt` workload, if conflicting workload (same cohort, overlapping resource flavors) was processed before, we would skip this preemption as our calculations [were invalidated](https://github.com/kubernetes-sigs/kueue/blob/1b8ec34eca4d07af9e91c22f163e90567226c5c7/pkg/scheduler/scheduler.go#L220-L222).

In this PR, we introduce less conservative calculations, to allow multiple preemptions within a cohort within one cycle, as long as the preemption targets do not overlap, and the workload still fits.

Additionally, we allow a `Preempt` fit workload to proceed, even if a `Fit` mode workload was previously processed, as long as the workload still fits.

Finally we improve logging in the old logic, to differentiate "No Longer Fits" from "Preemptions Invalidated"

#### Which issue(s) this PR fixes:
Fixes #2596
Contributes to #1867

#### Special notes for your reviewer:
See initial round of comments [here](https://github.com/gabesaba/kueue/commit/c3277c97cadc5653505b6a86add07d0c1f1b5dc6)

#### Does this PR introduce a user-facing change?
```release-note
Introduce the MultiplePreemptions flag, which allows more than one
preemption to occur in the same scheduling cycle, even with overlapping
FlavorResources
```