### PR TITLE
Fixed deleted unschedulable pods are finalized unit test.

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -3956,7 +3956,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodRunning).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -3967,7 +3967,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -3977,7 +3977,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now()).
+					CreationTimestamp(now).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -4005,7 +4005,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodRunning).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4014,7 +4014,7 @@ func TestReconciler(t *testing.T) {
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now()).
+					CreationTimestamp(now).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
@@ -4058,7 +4058,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4068,7 +4068,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -4095,7 +4095,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4105,7 +4105,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
@@ -4133,7 +4133,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4143,7 +4143,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -4170,7 +4170,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4180,7 +4180,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
@@ -4214,7 +4214,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4225,7 +4225,7 @@ func TestReconciler(t *testing.T) {
 					Group("test-group").
 					Delete().
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -4252,7 +4252,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4263,7 +4263,7 @@ func TestReconciler(t *testing.T) {
 					Delete().
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
@@ -4297,7 +4297,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4308,7 +4308,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -4342,7 +4342,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4352,7 +4352,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
@@ -4394,7 +4394,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4405,7 +4405,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -4444,7 +4444,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4454,7 +4454,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
@@ -4494,7 +4494,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4504,7 +4504,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -4545,7 +4545,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4555,7 +4555,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
@@ -4597,7 +4597,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4607,7 +4607,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -4640,7 +4640,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 				*basePodWrapper.
 					Clone().
@@ -4650,7 +4650,7 @@ func TestReconciler(t *testing.T) {
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
 					GroupTotalCount("2").
-					CreationTimestamp(time.Now().Add(-time.Hour)).
+					CreationTimestamp(now.Add(-time.Hour)).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -933,25 +933,25 @@ func TestPreemption(t *testing.T) {
 					Obj(),
 				*utiltesting.MakeWorkload("wl2", "").
 					Priority(1).
-					Creation(time.Now()).
+					Creation(now).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("preventStarvation").Assignment(corev1.ResourceCPU, "default", "2").Obj()).
 					SetOrReplaceCondition(metav1.Condition{
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionTrue,
-						LastTransitionTime: metav1.NewTime(time.Now().Add(time.Second)),
+						LastTransitionTime: metav1.NewTime(now.Add(time.Second)),
 					}).
 					Obj(),
 				*utiltesting.MakeWorkload("wl3", "").
 					Priority(1).
-					Creation(time.Now()).
+					Creation(now).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("preventStarvation").Assignment(corev1.ResourceCPU, "default", "2").Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("in", "").
 				Priority(1).
-				Creation(time.Now().Add(-15 * time.Second)).
+				Creation(now.Add(-15 * time.Second)).
 				PodSets(
 					*utiltesting.MakePodSet("launcher", 1).
 						Request(corev1.ResourceCPU, "2").Obj(),

--- a/pkg/workload/admissionchecks_test.go
+++ b/pkg/workload/admissionchecks_test.go
@@ -227,8 +227,9 @@ func TestSyncAdmittedCondition(t *testing.T) {
 }
 
 func TestSetCheckState(t *testing.T) {
-	t0 := metav1.NewTime(time.Now().Add(-5 * time.Second))
-	t1 := metav1.NewTime(time.Now())
+	now := time.Now()
+	t0 := metav1.NewTime(now.Add(-5 * time.Second))
+	t1 := metav1.NewTime(now)
 	ps1Updates := kueue.PodSetUpdate{
 		Name: "ps1",
 		Labels: map[string]string{
@@ -387,7 +388,7 @@ func TestSetCheckState(t *testing.T) {
 				if updatedCheck := FindAdmissionCheck(gotStates, tc.state.Name); updatedCheck == nil {
 					t.Error("Cannot find the updated check state")
 				} else {
-					if diff := cmp.Diff(metav1.NewTime(time.Now()), updatedCheck.LastTransitionTime, opts...); diff != "" {
+					if diff := cmp.Diff(metav1.NewTime(now), updatedCheck.LastTransitionTime, opts...); diff != "" {
 						t.Errorf("Unexpected LastTransitionTime (- want/+ got):\n%s", diff)
 					}
 				}

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -307,7 +307,7 @@ func TestGetQueueOrderTimestamp(t *testing.T) {
 	)
 
 	creationTime := metav1.Now()
-	conditionTime := metav1.NewTime(time.Now().Add(time.Hour))
+	conditionTime := metav1.NewTime(creationTime.Add(time.Hour))
 
 	cases := map[string]struct {
 		wl   *kueue.Workload


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixed "deleted unschedulable pods are finalized" unit test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2635

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```