### PR TITLE
[website] Using docsy instead GitHub style Note.

### DIFF
--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -231,9 +231,11 @@ semantics:
 - For each pod set resource in a Workload, a ClusterQueue can only borrow quota
   for one flavor.
 
-**Note:** Within a Cohort, Kueue prioritizes scheduling workloads that will fit under `nominalQuota`.
+{{% alert title="Note" color="primary" %}}
+Within a Cohort, Kueue prioritizes scheduling workloads that will fit under `nominalQuota`.
 By default, if multiple workloads require `borrowing`, Kueue will try to schedule workloads with higher [priority](/docs/concepts/workload#priority) first.
 If the feature gate `PrioritySortingWithinCohort=false` is set, Kueue will try to schedule workloads with the earliest `.metadata.creationTimestamp`.
+{{% /alert %}}
 
 You can influence some semantics of flavor selection and borrowing
 by setting a [`flavorFungibility`](/docs/concepts/cluster_queue#flavorfungibility) in ClusterQueue.

--- a/site/content/en/docs/concepts/resource_flavor.md
+++ b/site/content/en/docs/concepts/resource_flavor.md
@@ -16,8 +16,10 @@ Resources in a cluster are typically not homogeneous. Resources could differ in:
 A ResourceFlavor is an object that represents these resource variations and
 allows you to associate them with cluster nodes through labels, taints and tolerations.
 
-**Note**: If the resources in your cluster are homogeneous, you can use 
+{{% alert title="Note" color="primary" %}}
+If the resources in your cluster are homogeneous, you can use 
 an [empty ResourceFlavor](#empty-resourceflavor) instead of adding labels to custom ResourceFlavors.
+{{% /alert %}}
 
 A sample ResourceFlavor looks like the following:
 

--- a/site/content/en/docs/tasks/manage/setup_wait_for_pods_ready.md
+++ b/site/content/en/docs/tasks/manage/setup_wait_for_pods_ready.md
@@ -115,9 +115,10 @@ We create two jobs which both require all their pods to be running at the same
 time to complete. The cluster has enough resources to support running one of the
 jobs at the same time, but not both.
 
-> **Note**
-> In this example we use a cluster with autoscaling disabled in order to simulate
+{{% alert title="Note" color="primary" %}}
+In this example we use a cluster with autoscaling disabled in order to simulate
 issues with resource provisioning to satisfy the configured cluster quota.
+{{% /alert %}}
 
 ### 1. Preparation
 

--- a/site/content/en/docs/tasks/run/jobs.md
+++ b/site/content/en/docs/tasks/run/jobs.md
@@ -214,4 +214,6 @@ For example, a Job defined by the following manifest:
 
 When queued in a ClusterQueue with only 9 CPUs available, it will be admitted with `parallelism=9`. Note that the number of completions doesn't change.
 
-**NOTE:** PartialAdmission is an `Alpha` feature disabled by default, check the [Change the feature gates configuration](/docs/installation/#change-the-feature-gates-configuration) section of the [Installation](/docs/installation/) for details.
+{{% alert title="Note" color="primary" %}}
+PartialAdmission is an `Alpha` feature disabled by default, check the [Change the feature gates configuration](/docs/installation/#change-the-feature-gates-configuration) section of the [Installation](/docs/installation/) for details.
+{{% /alert %}}

--- a/site/content/en/docs/tasks/run/plain_pods.md
+++ b/site/content/en/docs/tasks/run/plain_pods.md
@@ -140,8 +140,10 @@ When a Kueue needs to preempt a workload that represents a Pod group, kueue send
 delete requests for all of the Pods in the group. It is the responsibility of the
 user or controller that created the original Pods to create replacement Pods.
 
-**NOTE:** We recommend using the kubernetes Job API or similar CRDs such as
+{{% alert title="Note" color="primary" %}}
+We recommend using the kubernetes Job API or similar CRDs such as
 JobSet, MPIJob, RayJob (see more [here](/docs/tasks/#batch-user)).
+{{% /alert %}}
 
 ### Termination
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Using docsy instead GitHub style Note.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1755

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```