### PR TITLE
Revert check in hasCommonFlavorResources

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -165,7 +165,7 @@ func (cu cohortsUsage) hasCommonFlavorResources(cohort string, assignment resour
 		return false
 	}
 	for fr := range assignment {
-		if cohortUsage[fr] > 0 {
+		if _, found := cohortUsage[fr]; found {
 			return true
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind regression

#### What this PR does / why we need it:
Reverts single line in https://github.com/kubernetes-sigs/kueue/pull/2622/files#r1684180659, which introduced a logic change. After this change, multiple preemption is allowed in the case where usage is greater than nominal. See [comment thread](https://github.com/kubernetes-sigs/kueue/pull/2641#discussion_r1684183635) for explaination.

This may not be a regression, but reverting this to preserve old behavior
#### Does this PR introduce a user-facing change?
```release-note
NONE
```