### PR TITLE
Add a note about the need to restart the kueue pod

### DIFF
--- a/site/content/en/docs/tasks/run/jobsets.md
+++ b/site/content/en/docs/tasks/run/jobsets.md
@@ -17,6 +17,11 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 2. See [JobSet Installation](https://jobset.sigs.k8s.io/docs/installation/) for installation and configuration details of JobSet Operator.
 
+{{% alert title="Note" color="note" %}}
+In order to use JobSet you need to restart Kueue after the installation.
+You can do it by running: `kubectl delete pods -lcontrol-plane=controller-manager -nkueue-system`.
+{{% /alert %}}
+
 ## JobSet definition
 
 When running [JobSets](https://jobset.sigs.k8s.io/docs/concepts/) on

--- a/site/content/en/docs/tasks/run/kubeflow/mpijobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/mpijobs.md
@@ -16,7 +16,12 @@ Check [administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) 
 
 Check [the MPI Operator installation guide](https://github.com/kubeflow/mpi-operator#installation).
 
-You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include MPIJobs as an allowed workload.  
+You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include MPIJobs as an allowed workload.
+
+{{% alert title="Note" color="note" %}}
+In order to use MPIJob you need to restart Kueue after the installation.
+You can do it by running: `kubectl delete pods -lcontrol-plane=controller-manager -nkueue-system`.
+{{% /alert %}}
 
 ## MPI Operator definition
 

--- a/site/content/en/docs/tasks/run/kubeflow/mxjobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/mxjobs.md
@@ -20,6 +20,11 @@ Note that the minimum requirement training-operator version is v1.7.0.
 
 You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include MXJobs as an allowed workload.
 
+{{% alert title="Note" color="note" %}}
+In order to use Training Operator you need to restart Kueue after the installation.
+You can do it by running: `kubectl delete pods -lcontrol-plane=controller-manager -nkueue-system`.
+{{% /alert %}}
+
 ## MXJob definition
 
 ### a. Queue selection

--- a/site/content/en/docs/tasks/run/kubeflow/paddlejobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/paddlejobs.md
@@ -20,6 +20,11 @@ Note that the minimum requirement training-operator version is v1.7.0.
 
 You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include PaddleJobs as an allowed workload.
 
+{{% alert title="Note" color="note" %}}
+In order to use Training Operator you need to restart Kueue after the installation.
+You can do it by running: `kubectl delete pods -lcontrol-plane=controller-manager -nkueue-system`.
+{{% /alert %}}
+
 ## PaddleJob definition
 
 ### a. Queue selection

--- a/site/content/en/docs/tasks/run/kubeflow/pytorchjobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/pytorchjobs.md
@@ -20,6 +20,11 @@ Note that the minimum requirement training-operator version is v1.7.0.
 
 You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include PyTorchJobs as an allowed workload.
 
+{{% alert title="Note" color="note" %}}
+In order to use Training Operator you need to restart Kueue after the installation.
+You can do it by running: `kubectl delete pods -lcontrol-plane=controller-manager -nkueue-system`.
+{{% /alert %}}
+
 ## PyTorchJob definition
 
 ### a. Queue selection

--- a/site/content/en/docs/tasks/run/kubeflow/tfjobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/tfjobs.md
@@ -20,6 +20,11 @@ Note that the minimum requirement training-operator version is v1.7.0.
 
 You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include TFJobs as an allowed workload.
 
+{{% alert title="Note" color="note" %}}
+In order to use Training Operator you need to restart Kueue after the installation.
+You can do it by running: `kubectl delete pods -lcontrol-plane=controller-manager -nkueue-system`.
+{{% /alert %}}
+
 ## TFJob definition
 
 ### a. Queue selection

--- a/site/content/en/docs/tasks/run/kubeflow/xgboostjobs.md
+++ b/site/content/en/docs/tasks/run/kubeflow/xgboostjobs.md
@@ -20,6 +20,11 @@ Note that the minimum requirement training-operator version is v1.7.0.
 
 You can [modify kueue configurations from installed releases](/docs/installation#install-a-custom-configured-released-version) to include XGBoostJobs as an allowed workload.
 
+{{% alert title="Note" color="note" %}}
+In order to use Training Operator you need to restart Kueue after the installation.
+You can do it by running: `kubectl delete pods -lcontrol-plane=controller-manager -nkueue-system`.
+{{% /alert %}}
+
 ## XGBoostJob definition
 
 ### a. Queue selection

--- a/site/content/en/docs/tasks/run/rayclusters.md
+++ b/site/content/en/docs/tasks/run/rayclusters.md
@@ -19,6 +19,11 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 3. See [KubeRay Installation](https://ray-project.github.io/kuberay/deploy/installation/) for installation and configuration details of KubeRay.
 
+{{% alert title="Note" color="note" %}}
+In order to use RayCluster you need to restart Kueue after the installation.
+You can do it by running: `kubectl delete pods -lcontrol-plane=controller-manager -nkueue-system`.
+{{% /alert %}}
+
 ## RayCluster definition
 
 When running [RayClusters](https://docs.ray.io/en/latest/cluster/getting-started.html) on

--- a/site/content/en/docs/tasks/run/rayjobs.md
+++ b/site/content/en/docs/tasks/run/rayjobs.md
@@ -18,6 +18,11 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 2. See [KubeRay Installation](https://ray-project.github.io/kuberay/deploy/installation/) for installation and configuration details of KubeRay.
 
+{{% alert title="Note" color="note" %}}
+In order to use RayJob you need to restart Kueue after the installation.
+You can do it by running: `kubectl delete pods -lcontrol-plane=controller-manager -nkueue-system`.
+{{% /alert %}}
+
 ## RayJob definition
 
 When running [RayJobs](https://ray-project.github.io/kuberay/guidance/rayjob/) on


### PR DESCRIPTION
#### What type of PR is this?


/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

To avoid users confusion when the CRDs don't work. 
This is needed until https://github.com/kubernetes-sigs/kueue/issues/2414 is fixed

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes-sigs/kueue/issues/2414

#### Special notes for your reviewer:

We can remove the notes once the issue is fixed, if cherry-picked. If not cherry-picked, we can update the docs to say that this is needed prior to 0.9.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```