### PR TITLE
Optional garbage collection of finished workloads

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -76,6 +76,10 @@ type Configuration struct {
 
 	// Resources provides additional configuration options for handling the resources.
 	Resources *Resources `json:"resources,omitempty"`
+
+	// ObjectRetentionPolicies provides configuration options for retention of kueue owned
+	// resources.
+	ObjectRetentionPolicies *ObjectRetentionPolicies `json:"objectRetentionPolicies,omitempty"`
 }
 
 type ControllerManager struct {
@@ -399,4 +403,16 @@ type FairSharing struct {
 	//   newest start time first.
 	// The default strategy is ["LessThanOrEqualToFinalShare", "LessThanInitialShare"].
 	PreemptionStrategies []PreemptionStrategy `json:"preemptionStrategies,omitempty"`
+}
+
+type ObjectRetentionPolicies struct {
+	// FinishedWorkloadRetention is the duration to retain finished Workloads.
+	// A duration of 0 will delete finished Workloads immediately.
+	// A nil value will disable automatic deletion.
+	// The value is represented using the metav1.Duration format, allowing for flexible
+	// specification of time units (e.g., "24h", "1h30m", "30s").
+	//
+	// Defaults to null.
+	// +optional
+	FinishedWorkloadRetention *metav1.Duration `json:"finishedWorkloadRetention"`
 }

--- a/apis/config/v1beta1/defaults.go
+++ b/apis/config/v1beta1/defaults.go
@@ -193,4 +193,7 @@ func SetDefaults_Configuration(cfg *Configuration) {
 	if fs := cfg.FairSharing; fs != nil && fs.Enable && len(fs.PreemptionStrategies) == 0 {
 		fs.PreemptionStrategies = []PreemptionStrategy{LessThanOrEqualToFinalShare, LessThanInitialShare}
 	}
+	if cfg.ObjectRetentionPolicies == nil {
+		cfg.ObjectRetentionPolicies = &ObjectRetentionPolicies{}
+	}
 }

--- a/apis/config/v1beta1/defaults_test.go
+++ b/apis/config/v1beta1/defaults_test.go
@@ -102,6 +102,10 @@ func TestSetDefaults_Configuration(t *testing.T) {
 		WorkerLostTimeout: &metav1.Duration{Duration: DefaultMultiKueueWorkerLostTimeout},
 	}
 
+	defaultObjectRetentionPolicies := &ObjectRetentionPolicies{
+		FinishedWorkloadRetention: nil,
+	}
+
 	podsReadyTimeoutTimeout := metav1.Duration{Duration: defaultPodsReadyTimeout}
 	podsReadyTimeoutOverwrite := metav1.Duration{Duration: time.Minute}
 
@@ -121,10 +125,11 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
 				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     defaultIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
-				MultiKueue:       defaultMultiKueue,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            defaultIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"defaulting ControllerManager": {
@@ -162,10 +167,11 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
 				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     defaultIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
-				MultiKueue:       defaultMultiKueue,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            defaultIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"should not default ControllerManager": {
@@ -219,10 +225,11 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
 				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     defaultIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
-				MultiKueue:       defaultMultiKueue,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            defaultIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"should not set LeaderElectionID": {
@@ -260,10 +267,11 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
 				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     defaultIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
-				MultiKueue:       defaultMultiKueue,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            defaultIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"defaulting InternalCertManagement": {
@@ -278,10 +286,11 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					WebhookServiceName: ptr.To(DefaultWebhookServiceName),
 					WebhookSecretName:  ptr.To(DefaultWebhookSecretName),
 				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     overwriteNamespaceIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
-				MultiKueue:       defaultMultiKueue,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            overwriteNamespaceIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"should not default InternalCertManagement": {
@@ -297,10 +306,11 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
 				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     overwriteNamespaceIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
-				MultiKueue:       defaultMultiKueue,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            overwriteNamespaceIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"should not default values in custom ClientConnection": {
@@ -324,9 +334,10 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					QPS:   ptr.To[float32](123.0),
 					Burst: ptr.To[int32](456),
 				},
-				Integrations:    overwriteNamespaceIntegrations,
-				QueueVisibility: defaultQueueVisibility,
-				MultiKueue:      defaultMultiKueue,
+				Integrations:            overwriteNamespaceIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"should default empty custom ClientConnection": {
@@ -343,10 +354,11 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
 				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     overwriteNamespaceIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
-				MultiKueue:       defaultMultiKueue,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            overwriteNamespaceIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"defaulting waitForPodsReady values": {
@@ -374,10 +386,11 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
 				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     defaultIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
-				MultiKueue:       defaultMultiKueue,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            defaultIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"set waitForPodsReady.blockAdmission to false when enable is false": {
@@ -405,10 +418,11 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
 				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     defaultIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
-				MultiKueue:       defaultMultiKueue,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            defaultIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"respecting provided waitForPodsReady values": {
@@ -442,10 +456,11 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
 				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     defaultIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
-				MultiKueue:       defaultMultiKueue,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            defaultIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"integrations": {
@@ -468,8 +483,9 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Frameworks: []string{"a", "b"},
 					PodOptions: defaultIntegrations.PodOptions,
 				},
-				QueueVisibility: defaultQueueVisibility,
-				MultiKueue:      defaultMultiKueue,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"queue visibility": {
@@ -498,7 +514,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 						MaxCount: 0,
 					},
 				},
-				MultiKueue: defaultMultiKueue,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"multiKueue": {
@@ -526,6 +543,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Origin:            ptr.To("multikueue-manager1"),
 					WorkerLostTimeout: &metav1.Duration{Duration: time.Minute},
 				},
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"multiKueue GCInterval 0": {
@@ -552,6 +570,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Origin:            ptr.To("multikueue-manager1"),
 					WorkerLostTimeout: &metav1.Duration{Duration: 15 * time.Minute},
 				},
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 		},
 		"add default fair sharing configuration when enabled": {
@@ -576,6 +595,31 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				FairSharing: &FairSharing{
 					Enable:               true,
 					PreemptionStrategies: []PreemptionStrategy{LessThanOrEqualToFinalShare, LessThanInitialShare},
+				},
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
+			},
+		},
+		"set object retention policy for finished workloads": {
+			original: &Configuration{
+				InternalCertManagement: &InternalCertManagement{
+					Enable: ptr.To(false),
+				},
+				ObjectRetentionPolicies: &ObjectRetentionPolicies{
+					FinishedWorkloadRetention: &metav1.Duration{Duration: 30 * time.Minute},
+				},
+			},
+			want: &Configuration{
+				Namespace:         ptr.To(DefaultNamespace),
+				ControllerManager: defaultCtrlManagerConfigurationSpec,
+				InternalCertManagement: &InternalCertManagement{
+					Enable: ptr.To(false),
+				},
+				ClientConnection: defaultClientConnection,
+				Integrations:     defaultIntegrations,
+				QueueVisibility:  defaultQueueVisibility,
+				MultiKueue:       defaultMultiKueue,
+				ObjectRetentionPolicies: &ObjectRetentionPolicies{
+					FinishedWorkloadRetention: &metav1.Duration{Duration: 30 * time.Minute},
 				},
 			},
 		},

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -118,6 +118,8 @@ managerConfig:
     #  preemptionStrategies: [LessThanOrEqualToFinalShare, LessThanInitialShare]
     #resources:
     #  excludeResourcePrefixes: []
+    #objectRetentionPolicies:
+    #  finishedWorkloadRetention: null # null indicates infinite retention, 0 means no retention at all
 # ports definition for metricsService and webhookService.
 metricsService:
   ports:

--- a/config/components/manager/controller_manager_config.yaml
+++ b/config/components/manager/controller_manager_config.yaml
@@ -62,3 +62,5 @@ integrations:
 #  preemptionStrategies: [LessThanOrEqualToFinalShare, LessThanInitialShare]
 #resources:
 #  excludeResourcePrefixes: []
+#objectRetentionPolicies:
+#  finishedWorkloadRetention: null # null indicates infinite retention, 0 means no retention at all

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -298,6 +298,17 @@ webhook:
 		t.Fatal(err)
 	}
 
+	objectRetentionPoliciesConfig := filepath.Join(tmpDir, "objectRetentionPolicies.yaml")
+	if err := os.WriteFile(objectRetentionPoliciesConfig, []byte(`
+apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
+namespace: kueue-system
+objectRetentionPolicies:
+  finishedWorkloadRetention: 30m
+`), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
 	defaultControlOptions := ctrl.Options{
 		HealthProbeBindAddress: configapi.DefaultHealthProbeBindAddress,
 		Metrics: metricsserver.Options{
@@ -369,6 +380,10 @@ webhook:
 		WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
 	}
 
+	defaultObjectRetentionPolicies := &configapi.ObjectRetentionPolicies{
+		FinishedWorkloadRetention: nil,
+	}
+
 	testcases := []struct {
 		name              string
 		configFile        string
@@ -380,12 +395,13 @@ webhook:
 			name:       "default config",
 			configFile: "",
 			wantConfiguration: configapi.Configuration{
-				Namespace:              ptr.To(configapi.DefaultNamespace),
-				InternalCertManagement: enableDefaultInternalCertManagement,
-				ClientConnection:       defaultClientConnection,
-				Integrations:           defaultIntegrations,
-				QueueVisibility:        defaultQueueVisibility,
-				MultiKueue:             defaultMultiKueue,
+				Namespace:               ptr.To(configapi.DefaultNamespace),
+				InternalCertManagement:  enableDefaultInternalCertManagement,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            defaultIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: configapi.DefaultHealthProbeBindAddress,
@@ -441,8 +457,9 @@ webhook:
 						PodSelector: &metav1.LabelSelector{},
 					},
 				},
-				QueueVisibility: defaultQueueVisibility,
-				MultiKueue:      defaultMultiKueue,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 			wantOptions: defaultControlOptions,
 		},
@@ -461,6 +478,7 @@ webhook:
 				Integrations:               defaultIntegrations,
 				QueueVisibility:            defaultQueueVisibility,
 				MultiKueue:                 defaultMultiKueue,
+				ObjectRetentionPolicies:    defaultObjectRetentionPolicies,
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: ":38081",
@@ -495,10 +513,11 @@ webhook:
 					WebhookServiceName: ptr.To("kueue-tenant-a-webhook-service"),
 					WebhookSecretName:  ptr.To("kueue-tenant-a-webhook-server-cert"),
 				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     defaultIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
-				MultiKueue:       defaultMultiKueue,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            defaultIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 			wantOptions: defaultControlOptions,
 		},
@@ -515,10 +534,11 @@ webhook:
 				InternalCertManagement: &configapi.InternalCertManagement{
 					Enable: ptr.To(false),
 				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     defaultIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
-				MultiKueue:       defaultMultiKueue,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            defaultIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 			wantOptions: defaultControlOptions,
 		},
@@ -537,6 +557,7 @@ webhook:
 				Integrations:               defaultIntegrations,
 				QueueVisibility:            defaultQueueVisibility,
 				MultiKueue:                 defaultMultiKueue,
+				ObjectRetentionPolicies:    defaultObjectRetentionPolicies,
 			},
 
 			wantOptions: ctrl.Options{
@@ -579,10 +600,11 @@ webhook:
 						BackoffMaxSeconds:  ptr.To[int32](1800),
 					},
 				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     defaultIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
-				MultiKueue:       defaultMultiKueue,
+				ClientConnection:        defaultClientConnection,
+				Integrations:            defaultIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: configapi.DefaultHealthProbeBindAddress,
@@ -617,9 +639,10 @@ webhook:
 					QPS:   ptr.To[float32](50),
 					Burst: ptr.To[int32](100),
 				},
-				Integrations:    defaultIntegrations,
-				QueueVisibility: defaultQueueVisibility,
-				MultiKueue:      defaultMultiKueue,
+				Integrations:            defaultIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 			wantOptions: defaultControlOptions,
 		},
@@ -638,9 +661,10 @@ webhook:
 					QPS:   ptr.To[float32](50),
 					Burst: ptr.To[int32](100),
 				},
-				Integrations:    defaultIntegrations,
-				QueueVisibility: defaultQueueVisibility,
-				MultiKueue:      defaultMultiKueue,
+				Integrations:            defaultIntegrations,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: configapi.DefaultHealthProbeBindAddress,
@@ -702,8 +726,9 @@ webhook:
 						PodSelector: &metav1.LabelSelector{},
 					},
 				},
-				QueueVisibility: defaultQueueVisibility,
-				MultiKueue:      defaultMultiKueue,
+				QueueVisibility:         defaultQueueVisibility,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: configapi.DefaultHealthProbeBindAddress,
@@ -742,7 +767,8 @@ webhook:
 						MaxCount: 0,
 					},
 				},
-				MultiKueue: defaultMultiKueue,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: configapi.DefaultHealthProbeBindAddress,
@@ -800,7 +826,8 @@ webhook:
 						},
 					},
 				},
-				MultiKueue: defaultMultiKueue,
+				MultiKueue:              defaultMultiKueue,
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: configapi.DefaultHealthProbeBindAddress,
@@ -839,6 +866,7 @@ webhook:
 					Origin:            ptr.To("multikueue-manager1"),
 					WorkerLostTimeout: &metav1.Duration{Duration: 10 * time.Minute},
 				},
+				ObjectRetentionPolicies: defaultObjectRetentionPolicies,
 			},
 			wantOptions: defaultControlOptions,
 		},
@@ -849,6 +877,27 @@ webhook:
 				errors.New("unknown field \"invalidField\""),
 				errors.New("unknown field \"namespaces\""),
 			}),
+		},
+		{
+			name:       "objectRetentionPolicies config",
+			configFile: objectRetentionPoliciesConfig,
+			wantConfiguration: configapi.Configuration{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configapi.GroupVersion.String(),
+					Kind:       "Configuration",
+				},
+				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				ManageJobsWithoutQueueName: false,
+				InternalCertManagement:     enableDefaultInternalCertManagement,
+				ClientConnection:           defaultClientConnection,
+				Integrations:               defaultIntegrations,
+				QueueVisibility:            defaultQueueVisibility,
+				MultiKueue:                 defaultMultiKueue,
+				ObjectRetentionPolicies: &configapi.ObjectRetentionPolicies{
+					FinishedWorkloadRetention: &metav1.Duration{Duration: 30 * time.Minute},
+				},
+			},
+			wantOptions: defaultControlOptions,
 		},
 	}
 
@@ -961,6 +1010,9 @@ func TestEncode(t *testing.T) {
 					"gcInterval":        "1m0s",
 					"origin":            "multikueue",
 					"workerLostTimeout": "15m0s",
+				},
+				"objectRetentionPolicies": map[string]any{
+					"finishedWorkloadRetention": nil,
 				},
 			},
 		},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -380,9 +380,7 @@ objectRetentionPolicies:
 		WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
 	}
 
-	defaultObjectRetentionPolicies := &configapi.ObjectRetentionPolicies{
-		FinishedWorkloadRetention: nil,
-	}
+	defaultObjectRetentionPolicies := &configapi.ObjectRetentionPolicies{}
 
 	testcases := []struct {
 		name              string

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -57,6 +57,7 @@ var (
 	fsPreemptionStrategiesPath        = field.NewPath("fairSharing", "preemptionStrategies")
 	internalCertManagementPath        = field.NewPath("internalCertManagement")
 	queueVisibilityPath               = field.NewPath("queueVisibility")
+	objectRetentionPoliciesPath       = field.NewPath("objectRetentionPolicies")
 )
 
 func validate(c *configapi.Configuration, scheme *runtime.Scheme) field.ErrorList {
@@ -67,6 +68,7 @@ func validate(c *configapi.Configuration, scheme *runtime.Scheme) field.ErrorLis
 	allErrs = append(allErrs, validateMultiKueue(c)...)
 	allErrs = append(allErrs, validateFairSharing(c)...)
 	allErrs = append(allErrs, validateInternalCertManagement(c)...)
+	allErrs = append(allErrs, validateObjectRetentionPolicies(c)...)
 	return allErrs
 }
 
@@ -274,6 +276,19 @@ func validateFairSharing(c *configapi.Configuration) field.ErrorList {
 		}
 		if !validStrategy {
 			allErrs = append(allErrs, field.NotSupported(fsPreemptionStrategiesPath, fs.PreemptionStrategies, validStrategySetsStr))
+		}
+	}
+	return allErrs
+}
+
+func validateObjectRetentionPolicies(c *configapi.Configuration) field.ErrorList {
+	var allErrs field.ErrorList
+
+	rr := c.ObjectRetentionPolicies
+	if rr != nil {
+		if rr.FinishedWorkloadRetention != nil && rr.FinishedWorkloadRetention.Duration < 0 {
+			allErrs = append(allErrs, field.Invalid(objectRetentionPoliciesPath.Child("finishedWorkloadRetention"),
+				c.ObjectRetentionPolicies.FinishedWorkloadRetention, constants.IsNegativeErrorMsg))
 		}
 	}
 	return allErrs

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -75,6 +75,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *queue.Manager, cc *cache.Cache
 		mgr.GetEventRecorderFor(constants.WorkloadControllerName),
 		WithWorkloadUpdateWatchers(qRec, cqRec),
 		WithWaitForPodsReady(waitForPodsReady(cfg.WaitForPodsReady)),
+		WithWorkloadObjectRetention(cfg.ObjectRetentionPolicies.FinishedWorkloadRetention),
 	).SetupWithManager(mgr, cfg); err != nil {
 		return "Workload", err
 	}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -71,6 +71,7 @@ type waitForPodsReadyConfig struct {
 type options struct {
 	watchers               []WorkloadUpdateWatcher
 	waitForPodsReadyConfig *waitForPodsReadyConfig
+	objectRetention        *metav1.Duration
 }
 
 // Option configures the reconciler.
@@ -90,6 +91,13 @@ func WithWorkloadUpdateWatchers(value ...WorkloadUpdateWatcher) Option {
 	}
 }
 
+// WithWorkloadObjectRetention allows to specify retention for workload resources
+func WithWorkloadObjectRetention(value *metav1.Duration) Option {
+	return func(o *options) {
+		o.objectRetention = value
+	}
+}
+
 var defaultOptions = options{}
 
 type WorkloadUpdateWatcher interface {
@@ -106,6 +114,7 @@ type WorkloadReconciler struct {
 	waitForPodsReady *waitForPodsReadyConfig
 	recorder         record.EventRecorder
 	clock            clock.Clock
+	objectRetention  *metav1.Duration
 }
 
 func NewWorkloadReconciler(client client.Client, queues *queue.Manager, cache *cache.Cache, recorder record.EventRecorder, opts ...Option) *WorkloadReconciler {
@@ -123,6 +132,7 @@ func NewWorkloadReconciler(client client.Client, queues *queue.Manager, cache *c
 		waitForPodsReady: options.waitForPodsReadyConfig,
 		recorder:         recorder,
 		clock:            realClock,
+		objectRetention:  options.objectRetention,
 	}
 }
 
@@ -144,11 +154,30 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	log.V(2).Info("Reconciling Workload")
 
 	if len(wl.ObjectMeta.OwnerReferences) == 0 && !wl.DeletionTimestamp.IsZero() {
+		// manual deletion triggered by the user
 		return ctrl.Result{}, workload.RemoveFinalizer(ctx, r.client, &wl)
 	}
 
-	if apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadFinished) {
-		return ctrl.Result{}, nil
+	finishedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadFinished)
+	if finishedCond != nil && finishedCond.Status == metav1.ConditionTrue {
+		if r.objectRetention == nil  {
+			return ctrl.Result{}, nil
+		}
+		now := r.clock.Now()
+		expirationTime := finishedCond.LastTransitionTime.Add(r.objectRetention.Duration)
+		if now.After(expirationTime) {
+			log.V(2).Info("Deleting workload because it has finished and the retention period has elapsed", "retention", r.objectRetention.Duration)
+			err := r.client.Delete(ctx, &wl)
+			if err != nil {
+				log.Error(err, "Failed to delete workload from the API server")
+				return ctrl.Result{}, fmt.Errorf("deleting workflow from the API server: %w", err)
+			}
+			r.recorder.Eventf(&wl, corev1.EventTypeNormal, "Deleted", "Deleted workload %v", wl.Name)
+		} else {
+			remainingTime := expirationTime.Sub(now)
+			log.V(2).Info("Requeueing workload for deletion after retention period", "remainingTime", remainingTime)
+			return ctrl.Result{RequeueAfter: remainingTime}, nil
+		}
 	}
 
 	if workload.IsActive(&wl) {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -1314,6 +1314,95 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 		},
+		"shouldn't delete the workflow because, object retention not configured": {
+			workload: utiltesting.MakeWorkload("wl", "ns").
+				Condition(metav1.Condition{
+					Type:   kueue.WorkloadFinished,
+					Status: metav1.ConditionTrue,
+				}).
+				Obj(),
+			reconcilerOpts: []Option{
+				WithWorkloadObjectRetention(nil),
+			},
+			wantWorkload: utiltesting.MakeWorkload("wl", "ns").
+				Condition(metav1.Condition{
+					Type:   kueue.WorkloadFinished,
+					Status: metav1.ConditionTrue,
+				}).
+				Obj(),
+			wantError: nil,
+		},
+		"shouldn't try to delete the workload (no event emitted) because it is already being deleted by kubernetes, object retention configured": {
+			workload: utiltesting.MakeWorkload("wl", "ns").
+				Condition(metav1.Condition{
+					Type:   kueue.WorkloadFinished,
+					Status: metav1.ConditionTrue,
+					LastTransitionTime: metav1.Time{
+						Time: testStartTime,
+					},
+				}).
+				DeletionTimestamp(testStartTime).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				Obj(),
+			reconcilerOpts: []Option{
+				WithWorkloadObjectRetention(&metav1.Duration{
+					Duration: 24 * time.Hour,
+				}),
+			},
+			wantWorkload: nil,
+			wantError: nil,
+		},
+		"shouldn't try to delete the workload because the retention period hasn't elapsed yet, object retention configured": {
+			workload: utiltesting.MakeWorkload("wl", "ns").
+				Condition(metav1.Condition{
+					Type: kueue.WorkloadFinished,
+					Status: metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(testStartTime.Add(-10 * time.Second)),
+				}).
+				Obj(),
+			reconcilerOpts: []Option{
+				WithWorkloadObjectRetention(
+					&metav1.Duration{
+						Duration: 30 * time.Second,
+				}),
+			},
+			wantWorkload: utiltesting.MakeWorkload("wl", "ns").
+				Condition(metav1.Condition{
+					Type: kueue.WorkloadFinished,
+					Status: metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(testStartTime.Add(-10 * time.Second)),
+				}).
+				Obj(),
+			wantError: nil,
+		},
+		"should delete the workload because the retention period has elapsed, object retention configured": {
+			workload: utiltesting.MakeWorkload("wl", "ns").
+				Condition(metav1.Condition{
+					Type: kueue.WorkloadFinished,
+					Status: metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(testStartTime.Add(-40 * time.Second)),
+				}).
+				Obj(),
+			reconcilerOpts: []Option{
+				WithWorkloadObjectRetention(
+					&metav1.Duration{
+						Duration: 30 * time.Second,
+				}),
+			},
+			wantWorkload: nil,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key: types.NamespacedName{
+						Namespace: "ns",
+						Name: "wl",
+					},
+					EventType: corev1.EventTypeNormal,
+					Reason: "Deleted",
+					Message: "Deleted workload wl",
+				},
+			},
+			wantError: nil,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR adds an optional and configurable garbage collection of finished Workloads. If the object retention policy is configured for Workloads a completed workload will be either re-queued for later deletion (if the policy is configured but it's retention period hasn't elapsed) or deleted (both for existing Workloads that might've been created by the previous version or instance of kueue but now are expired according to the retention policy or for newly created Workloads when their retention period elapses).

It decreases both kueue's memory footprint as well as etcd's storage.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1618 

#### Special notes for your reviewer:

This PR comes with a couple of configuration scenarios:
- if the object retention policy is not configured for workloads (default) or the policy is explicitly set to null all Workloads are kept indefinitely like in the previous versions of kueue,
- if the object retention policy is configured to 0s it means that there's effectively no retention and all completed Workloads are going to be immediately delated,
- if the object retention policy is set to any other value than 0s kueue will delete Workloads when their retention period elapses (both for existing and newly created Workloads).

##### Known issue
The Workload deletion triggers a Workload delete event to be emitted. It's needed because in response to that event kueue performs its internal cleanup (e.g. caches and queues). However it seems that emitting that event automatically causes a Job related to the Workload to be paused. This is how it chronologically looks:

```py
{'level': 'Level(-2)', 'caller': 'core/workload_controller.go:154', 'msg': 'Reconciling Workload'}
{'level': 'Level(-2)', 'caller': 'core/workload_controller.go:169', 'msg': 'Deleting workload because it has finished and the retention period has elapsed'}
{'level': 'debug, 'caller': 'recorder/recorder.go:104', 'msg': 'Deleted workload job-stress-job-1-pqsxf-dd783'}
{'level': 'Level(-2)', 'caller': 'core/workload_controller.go:627', 'msg': 'Workload delete event'}
{'level': 'Level(-2)', 'caller': 'core/clusterqueue_controller.go:330', 'msg': 'Got generic event'}
{'level': 'Level(-2)', 'caller': 'jobframework/reconciler.go:313', 'msg': 'Reconciling Job'}
{'level': 'Level(-2)', 'caller': 'jobframework/reconciler.go:606', 'msg': 'job with no matching workload, suspending'}
```

The author of this PR commits to creating a fix/improvement for the showcased scenario. It's up to the reviewers to decide whether the fix should be either: part of this PR or its own subsequent issue/PR and whether this PR should be blocked or not until the fix is done.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduce ObjectRetentionPolicies.FinishedWorkloadRetention flag, which allows to configure a retention policy for Workloads, Workloads will be deleted when their retention period elapses, by default this new behavior is disabled
```