### PR TITLE
[kueuectl] Fix resource flavor name pattern on create cq

### DIFF
--- a/cmd/kueuectl/app/create/create_clusterqueue.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue.go
@@ -308,7 +308,7 @@ func (o *ClusterQueueOptions) parseResourceGroups() error {
 func parseUserSpecifiedResourceQuotas(resources []string, quotaType string) ([]v1beta1.ResourceGroup, error) {
 	var resourceGroups []v1beta1.ResourceGroup
 
-	regex := regexp.MustCompile(`^(\w+):((\w+[\.-]?)*\/?\w+=\w+;)*(\w+[\.-]?)*\/?\w+=\w+;?$`)
+	regex := regexp.MustCompile(`^([a-z0-9][a-z0-9\-\.]{0,252}):((\w+[\.-]?)*\/?\w+=\w+;)*(\w+[\.-]?)*\/?\w+=\w+;?$`)
 	for _, r := range resources {
 		if !regex.MatchString(r) {
 			return resourceGroups, errInvalidResourcesSpec

--- a/cmd/kueuectl/app/create/create_clusterqueue_test.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue_test.go
@@ -102,14 +102,15 @@ func TestParseResourceQuotas(t *testing.T) {
 		wantResourceGroups []v1beta1.ResourceGroup
 	}{
 		"should create one resource group with one flavor and nominalQuota set": {
-			quotaArgs: []string{"alpha:cpu=1;memory=1"},
+			quotaArgs: []string{"alpha-2.0:cpu=1;memory=1;example-1.org/memory=5Gi"},
 			wantResourceGroups: []v1beta1.ResourceGroup{
 				{
-					CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+					CoveredResources: []corev1.ResourceName{"cpu", "memory", "example-1.org/memory"},
 					Flavors: []v1beta1.FlavorQuotas{
-						*utiltesting.MakeFlavorQuotas("alpha").
+						*utiltesting.MakeFlavorQuotas("alpha-2.0").
 							Resource("cpu", "1").
 							Resource("memory", "1").
+							Resource("example-1.org/memory", "5Gi").
 							Obj(),
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix resource flavor name pattern used on `create clusterqueue` to better support [DNS Subdomain Names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2701

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
CLI: Support `-` and `.` in the resource flavor name on `create cq`
```