### PR TITLE
[site] Update classic preemption candidates selection description.

### DIFF
--- a/site/content/en/docs/concepts/preemption.md
+++ b/site/content/en/docs/concepts/preemption.md
@@ -54,11 +54,14 @@ Kueue offers two preemption algorithms. The main difference between them is the 
 preemptions from a ClusterQueue to others in the Cohort, when the usage of the preempting ClusterQueue is
 already above the nominal quota. The algorithms are:
 
-- **[Classic Preemption](#classic-preemption)**: Preemption in the cohort only happens when the usage of the preempting ClusterQueue
-  will be under the nominal quota after the ongoing admission process, or when all the candidates for preemption belong to
-  the same ClusterQueue as the preempting Workload. In other words, ClusterQueues
-  can only borrow quota from others in the cohort if they do not preempt admitted Workloads from
-  other ClusterQueues. ClusterQueues in a cohort borrow resources in a first-come first-served fashion.
+- **[Classic Preemption](#classic-preemption)**: Preemption in the cohort only happens when:
+  - all the candidates for preemption belong to the same ClusterQueue as the preempting Workload 
+    or other borrowing ClusterQueues within the same cohort matching the preemptor's queue `borrowWithinCohort` policy.
+  - the usage of the preempting ClusterQueue will be under the nominal quota after the ongoing admission process
+
+
+  In other words, ClusterQueues can only borrow quota from others in the cohort if they do not preempt admitted Workloads from
+  other ClusterQueues that are not borrowing. ClusterQueues in a cohort borrow resources in a first-come first-served fashion.
   This algorithm is the most lightweight of the two.
 - **[Fair sharing](#fair-sharing)**: ClusterQueues with pending Workloads can preempt other Workloads in their cohort
   until the preempting ClusterQueue obtains an equal or weighted share of the borrowable resources.
@@ -73,9 +76,9 @@ to issue preemptions when one of the following is true:
 
 ### Candidates
 
-The list of preemption candidates is compiled from Workloads within the Cluster
-Queue satisfying the `withinClusterQueue` policy, and Workloads within the
-cohort which satisfy the `reclaimWithinCohort` policy.
+The list of preemption candidates is compiled from Workloads within the Cluster Queue satisfying 
+the `withinClusterQueue` policy, and Workloads within the cohort which satisfy the `reclaimWithinCohort`
+policy of other ClusterQueues that are actively borrowing.
 
 The list of candidates is sorted based on the following preference checks for
 tie-breaking:

--- a/site/content/en/docs/concepts/preemption.md
+++ b/site/content/en/docs/concepts/preemption.md
@@ -54,10 +54,10 @@ Kueue offers two preemption algorithms. The main difference between them is the 
 preemptions from a ClusterQueue to others in the Cohort, when the usage of the preempting ClusterQueue is
 already above the nominal quota. The algorithms are:
 
-- **[Classic Preemption](#classic-preemption)**: Preemption in the cohort only happens when:
+- **[Classic Preemption](#classic-preemption)**: Preemption in the cohort only happens when either of the following occurs:
+  - the usage of the preempting ClusterQueue will be under the nominal quota after the ongoing admission process
   - all the candidates for preemption belong to the same ClusterQueue as the preempting Workload 
     or other borrowing ClusterQueues within the same cohort matching the preemptor's queue `borrowWithinCohort` policy.
-  - the usage of the preempting ClusterQueue will be under the nominal quota after the ongoing admission process
 
 
   In other words, ClusterQueues can only borrow quota from others in the cohort if they do not preempt admitted Workloads from

--- a/site/content/en/docs/concepts/preemption.md
+++ b/site/content/en/docs/concepts/preemption.md
@@ -54,15 +54,17 @@ Kueue offers two preemption algorithms. The main difference between them is the 
 preemptions from a ClusterQueue to others in the Cohort, when the usage of the preempting ClusterQueue is
 already above the nominal quota. The algorithms are:
 
-- **[Classic Preemption](#classic-preemption)**: Preemption in the cohort only happens when either of the following occurs:
-  - the usage of the preempting ClusterQueue will be under the nominal quota after the ongoing admission process
-  - all the candidates for preemption belong to the same ClusterQueue as the preempting Workload 
-    or other borrowing ClusterQueues within the same cohort matching the preemptor's queue `borrowWithinCohort` policy.
+- **[Classic Preemption](#classic-preemption)**: Preemption in the cohort can only happen when any of the following occurs:
+  - The usage of the ClusterQueue for the incoming workload will be under the nominal quota after the ongoing admission process
+  - Preemption while borrowing is enabled for the workload's ClusterQueue
+  - All candidates for preemption belong to the same ClusterQueue as the preempting Workload
 
-
-  In other words, ClusterQueues can only borrow quota from others in the cohort if they do not preempt admitted Workloads from
-  other ClusterQueues that are not borrowing. ClusterQueues in a cohort borrow resources in a first-come first-served fashion.
+  In the above scenarios, a workload can only be considered for preemption, in favor a workload from another ClusterQueue, 
+  if it belongs to a ClusterQueue which is running over its nominal quota. 
+  ClusterQueues in a cohort borrow resources in a first-come first-served fashion.
+  
   This algorithm is the most lightweight of the two.
+
 - **[Fair sharing](#fair-sharing)**: ClusterQueues with pending Workloads can preempt other Workloads in their cohort
   until the preempting ClusterQueue obtains an equal or weighted share of the borrowable resources.
   The borrowable resources are the unused nominal quota of all the ClusterQueues in the cohort.

--- a/site/content/en/docs/concepts/preemption.md
+++ b/site/content/en/docs/concepts/preemption.md
@@ -76,9 +76,9 @@ to issue preemptions when one of the following is true:
 
 ### Candidates
 
-The list of preemption candidates is compiled from Workloads within the Cluster Queue satisfying 
-the `withinClusterQueue` policy, and Workloads within the cohort which satisfy the `reclaimWithinCohort`
-policy of other ClusterQueues that are actively borrowing.
+The list of preemption candidates is compiled from Workloads which either:
+- belong to the same ClusterQueue as the preemptor Workload, and satisfying the `withinClusterQueue` policy of the preemptor's Cluster Queue
+- belong to other ClusterQueues in the cohort, which are actively borrowing, and satisfying the `reclaimWithinCohort` and `borrowWithinCohort` policies of the preemptor's Cluster Queue.
 
 The list of candidates is sorted based on the following preference checks for
 tie-breaking:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Update classic preemption candidates selection description.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2681

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```