### PR TITLE
Support for new ProvisioningRequest annotations

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/constants.go
+++ b/pkg/controller/admissionchecks/provisioning/constants.go
@@ -19,8 +19,8 @@ package provisioning
 const (
 	ConfigKind             = "ProvisioningRequestConfig"
 	ControllerName         = "kueue.x-k8s.io/provisioning-request"
-	ConsumesAnnotationKey  = "cluster-autoscaler.kubernetes.io/consume-provisioning-request"
-	ClassNameAnnotationKey = "cluster-autoscaler.kubernetes.io/provisioning-class-name"
+	ConsumesAnnotationKey  = "autoscaling.x-k8s.io/consume-provisioning-request"
+	ClassNameAnnotationKey = "autoscaling.x-k8s.io/provisioning-class-name"
 
 	CheckInactiveMessage = "the check is not active"
 	NoRequestNeeded      = "the provisioning request is not needed"

--- a/pkg/controller/admissionchecks/provisioning/constants.go
+++ b/pkg/controller/admissionchecks/provisioning/constants.go
@@ -17,10 +17,12 @@ limitations under the License.
 package provisioning
 
 const (
-	ConfigKind             = "ProvisioningRequestConfig"
-	ControllerName         = "kueue.x-k8s.io/provisioning-request"
-	ConsumesAnnotationKey  = "autoscaling.x-k8s.io/consume-provisioning-request"
-	ClassNameAnnotationKey = "autoscaling.x-k8s.io/provisioning-class-name"
+	ConfigKind                       = "ProvisioningRequestConfig"
+	ControllerName                   = "kueue.x-k8s.io/provisioning-request"
+	DeprecatedConsumesAnnotationKey  = "cluster-autoscaler.kubernetes.io/consume-provisioning-request"
+	DeprecatedClassNameAnnotationKey = "cluster-autoscaler.kubernetes.io/provisioning-class-name"
+	ConsumesAnnotationKey            = "autoscaling.x-k8s.io/consume-provisioning-request"
+	ClassNameAnnotationKey           = "autoscaling.x-k8s.io/provisioning-class-name"
 
 	CheckInactiveMessage = "the check is not active"
 	NoRequestNeeded      = "the provisioning request is not needed"

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -592,8 +592,10 @@ func podSetUpdates(wl *kueue.Workload, pr *autoscaling.ProvisioningRequest) []ku
 		return kueue.PodSetUpdate{
 			Name: refMap[ps.PodTemplateRef.Name],
 			Annotations: map[string]string{
-				ConsumesAnnotationKey:  pr.Name,
-				ClassNameAnnotationKey: pr.Spec.ProvisioningClassName},
+				DeprecatedConsumesAnnotationKey:  pr.Name,
+				DeprecatedClassNameAnnotationKey: pr.Spec.ProvisioningClassName,
+				ConsumesAnnotationKey:            pr.Name,
+				ClassNameAnnotationKey:           pr.Spec.ProvisioningClassName},
 		}
 	})
 }

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -550,13 +550,20 @@ func TestReconcile(t *testing.T) {
 							{
 								Name: "ps1",
 								Annotations: map[string]string{
-									"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1-1",
-									"cluster-autoscaler.kubernetes.io/provisioning-class-name":      "class1"},
+									DeprecatedConsumesAnnotationKey:  "wl-check1-1",
+									DeprecatedClassNameAnnotationKey: "class1",
+									ConsumesAnnotationKey:            "wl-check1-1",
+									ClassNameAnnotationKey:           "class1",
+								},
 							},
 							{
 								Name: "ps2",
-								Annotations: map[string]string{"cluster-autoscaler.kubernetes.io/consume-provisioning-request": "wl-check1-1",
-									"cluster-autoscaler.kubernetes.io/provisioning-class-name": "class1"},
+								Annotations: map[string]string{
+									DeprecatedConsumesAnnotationKey:  "wl-check1-1",
+									DeprecatedClassNameAnnotationKey: "class1",
+									ConsumesAnnotationKey:            "wl-check1-1",
+									ClassNameAnnotationKey:           "class1",
+								},
 							},
 						},
 					}, kueue.AdmissionCheckState{

--- a/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
@@ -401,15 +401,19 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 						{
 							Name: "ps1",
 							Annotations: map[string]string{
-								provisioning.ConsumesAnnotationKey:  provReqKey.Name,
-								provisioning.ClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
+								provisioning.ConsumesAnnotationKey:            provReqKey.Name,
+								provisioning.DeprecatedConsumesAnnotationKey:  provReqKey.Name,
+								provisioning.ClassNameAnnotationKey:           prc.Spec.ProvisioningClassName,
+								provisioning.DeprecatedClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
 							},
 						},
 						{
 							Name: "ps2",
 							Annotations: map[string]string{
-								provisioning.ConsumesAnnotationKey:  provReqKey.Name,
-								provisioning.ClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
+								provisioning.ConsumesAnnotationKey:            provReqKey.Name,
+								provisioning.DeprecatedConsumesAnnotationKey:  provReqKey.Name,
+								provisioning.ClassNameAnnotationKey:           prc.Spec.ProvisioningClassName,
+								provisioning.DeprecatedClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
 							},
 						},
 					}))
@@ -1032,15 +1036,19 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 						{
 							Name: "ps1",
 							Annotations: map[string]string{
-								provisioning.ConsumesAnnotationKey:  provReqKey.Name,
-								provisioning.ClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
+								provisioning.ConsumesAnnotationKey:            provReqKey.Name,
+								provisioning.DeprecatedConsumesAnnotationKey:  provReqKey.Name,
+								provisioning.ClassNameAnnotationKey:           prc.Spec.ProvisioningClassName,
+								provisioning.DeprecatedClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
 							},
 						},
 						{
 							Name: "ps2",
 							Annotations: map[string]string{
-								provisioning.ConsumesAnnotationKey:  provReqKey.Name,
-								provisioning.ClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
+								provisioning.ConsumesAnnotationKey:            provReqKey.Name,
+								provisioning.DeprecatedConsumesAnnotationKey:  provReqKey.Name,
+								provisioning.ClassNameAnnotationKey:           prc.Spec.ProvisioningClassName,
+								provisioning.DeprecatedClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
 							},
 						},
 					}))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
To be compatible with the latest version of the Cluster Autoscaler

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```