### PR TITLE
[kjobctl] Add a localqueue filter to the list job command.

### DIFF
--- a/cmd/experimental/kjobctl/docs/commands/kjobctl_list/kjobctl_list_job.md
+++ b/cmd/experimental/kjobctl/docs/commands/kjobctl_list/kjobctl_list_job.md
@@ -12,7 +12,7 @@ The file is auto-generated from the Go source code of the component using the
 List Job
 
 ```
-kjobctl list job [--selector key1=value1] [--field-selector key1=value1] [--all-namespaces]
+kjobctl list job [--profile PROFILE_NAME] [--localqueue LOCALQUEUE_NAME] [--selector key1=value1] [--field-selector key1=value1] [--all-namespaces]
 ```
 
 
@@ -21,6 +21,9 @@ kjobctl list job [--selector key1=value1] [--field-selector key1=value1] [--all-
 ```
   # List Job
   kjobctl list job
+  
+  # List Job with profile filter
+  kjobctl list job --profile my-profile
 ```
 
 
@@ -67,6 +70,15 @@ kjobctl list job [--selector key1=value1] [--field-selector key1=value1] [--all-
         <td></td>
         <td style="line-height: 130%; word-wrap: break-word;">
             <p>help for job</p>
+        </td>
+    </tr>
+    <tr>
+        <td colspan="2">-q, --localqueue string</td>
+    </tr>
+    <tr>
+        <td></td>
+        <td style="line-height: 130%; word-wrap: break-word;">
+            <p>Filter by localqueue which is associated with the resource.</p>
         </td>
     </tr>
     <tr>

--- a/cmd/experimental/kjobctl/pkg/cmd/list/list_job_printer.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/list/list_job_printer.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/cmd/experimental/kjobctl/pkg/constants"
+	kueueconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 )
 
 type listJobPrinter struct {
@@ -52,6 +53,7 @@ func (p *listJobPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 		ColumnDefinitions: []metav1.TableColumnDefinition{
 			{Name: "Name", Type: "string", Format: "name"},
 			{Name: "Profile", Type: "string"},
+			{Name: "Local Queue", Type: "string"},
 			{Name: "Completions", Type: "string"},
 			{Name: "Duration", Type: "string"},
 			{Name: "Age", Type: "string"},
@@ -106,6 +108,7 @@ func (p *listJobPrinter) printJob(job *batchv1.Job) metav1.TableRow {
 	row.Cells = []any{
 		job.Name,
 		job.ObjectMeta.Labels[constants.ProfileLabel],
+		job.ObjectMeta.Labels[kueueconstants.QueueLabel],
 		fmt.Sprintf("%d/%d", job.Status.Succeeded, ptr.Deref(job.Spec.Completions, 1)),
 		durationStr,
 		duration.HumanDuration(p.clock.Since(job.CreationTimestamp.Time)),

--- a/cmd/experimental/kjobctl/pkg/cmd/list/list_job_test.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/list/list_job_test.go
@@ -52,6 +52,7 @@ func TestJobCmd(t *testing.T) {
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", "ns1").
 					Profile("profile1").
+					LocalQueue("lq1").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -59,6 +60,7 @@ func TestJobCmd(t *testing.T) {
 					Succeeded(3).
 					Obj(),
 				wrappers.MakeJob("j2", "ns2").
+					LocalQueue("lq2").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -66,8 +68,8 @@ func TestJobCmd(t *testing.T) {
 					Succeeded(3).
 					Obj(),
 			},
-			wantOut: `NAME   PROFILE    COMPLETIONS   DURATION   AGE
-j1     profile1   3/3           60m        60m
+			wantOut: `NAME   PROFILE    LOCAL QUEUE   COMPLETIONS   DURATION   AGE
+j1     profile1   lq1           3/3           60m        60m
 `,
 		},
 		"should print job list with namespace filter": {
@@ -75,6 +77,7 @@ j1     profile1   3/3           60m        60m
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", "ns1").
 					Profile("profile1").
+					LocalQueue("lq1").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -83,6 +86,7 @@ j1     profile1   3/3           60m        60m
 					Obj(),
 				wrappers.MakeJob("j2", "ns2").
 					Profile("profile2").
+					LocalQueue("lq2").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -90,8 +94,8 @@ j1     profile1   3/3           60m        60m
 					Succeeded(3).
 					Obj(),
 			},
-			wantOut: `NAME   PROFILE    COMPLETIONS   DURATION   AGE
-j1     profile1   3/3           60m        60m
+			wantOut: `NAME   PROFILE    LOCAL QUEUE   COMPLETIONS   DURATION   AGE
+j1     profile1   lq1           3/3           60m        60m
 `,
 		},
 		"should print job list with profile filter": {
@@ -99,6 +103,7 @@ j1     profile1   3/3           60m        60m
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", metav1.NamespaceDefault).
 					Profile("profile1").
+					LocalQueue("lq1").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -107,6 +112,7 @@ j1     profile1   3/3           60m        60m
 					Obj(),
 				wrappers.MakeJob("j2", metav1.NamespaceDefault).
 					Profile("profile2").
+					LocalQueue("lq2").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -114,8 +120,8 @@ j1     profile1   3/3           60m        60m
 					Succeeded(3).
 					Obj(),
 			},
-			wantOut: `NAME   PROFILE    COMPLETIONS   DURATION   AGE
-j1     profile1   3/3           60m        60m
+			wantOut: `NAME   PROFILE    LOCAL QUEUE   COMPLETIONS   DURATION   AGE
+j1     profile1   lq1           3/3           60m        60m
 `,
 		},
 		"should print job list with profile filter (short flag)": {
@@ -123,6 +129,7 @@ j1     profile1   3/3           60m        60m
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", metav1.NamespaceDefault).
 					Profile("profile1").
+					LocalQueue("lq1").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -131,6 +138,7 @@ j1     profile1   3/3           60m        60m
 					Obj(),
 				wrappers.MakeJob("j2", metav1.NamespaceDefault).
 					Profile("profile2").
+					LocalQueue("lq2").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -138,8 +146,63 @@ j1     profile1   3/3           60m        60m
 					Succeeded(3).
 					Obj(),
 			},
-			wantOut: `NAME   PROFILE    COMPLETIONS   DURATION   AGE
-j1     profile1   3/3           60m        60m
+			wantOut: `NAME   PROFILE    LOCAL QUEUE   COMPLETIONS   DURATION   AGE
+j1     profile1   lq1           3/3           60m        60m
+`,
+		},
+		"should print job list with localqueue filter": {
+			args: []string{"--localqueue", "lq1"},
+			objs: []runtime.Object{
+				wrappers.MakeJob("j1", metav1.NamespaceDefault).
+					Profile("profile1").
+					LocalQueue("lq1").
+					LocalQueue("lq1").
+					Completions(3).
+					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
+					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
+					CompletionTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
+					Succeeded(3).
+					Obj(),
+				wrappers.MakeJob("j2", metav1.NamespaceDefault).
+					Profile("profile2").
+					LocalQueue("lq2").
+					LocalQueue("lq2").
+					Completions(3).
+					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
+					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
+					CompletionTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
+					Succeeded(3).
+					Obj(),
+			},
+			wantOut: `NAME   PROFILE    LOCAL QUEUE   COMPLETIONS   DURATION   AGE
+j1     profile1   lq1           3/3           60m        60m
+`,
+		},
+		"should print job list with localqueue filter (short flag)": {
+			args: []string{"-q", "lq1"},
+			objs: []runtime.Object{
+				wrappers.MakeJob("j1", metav1.NamespaceDefault).
+					Profile("profile1").
+					LocalQueue("lq1").
+					Completions(3).
+					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
+					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
+					CompletionTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
+					Succeeded(3).
+					Obj(),
+				wrappers.MakeJob("j2", metav1.NamespaceDefault).
+					Profile("profile2").
+					LocalQueue("lq2").
+					LocalQueue("lq2").
+					Completions(3).
+					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
+					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
+					CompletionTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
+					Succeeded(3).
+					Obj(),
+			},
+			wantOut: `NAME   PROFILE    LOCAL QUEUE   COMPLETIONS   DURATION   AGE
+j1     profile1   lq1           3/3           60m        60m
 `,
 		},
 		"should print job list with label selector filter": {
@@ -147,6 +210,7 @@ j1     profile1   3/3           60m        60m
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", metav1.NamespaceDefault).
 					Profile("profile1").
+					LocalQueue("lq1").
 					Label("foo", "bar").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
@@ -156,6 +220,7 @@ j1     profile1   3/3           60m        60m
 					Obj(),
 				wrappers.MakeJob("j2", metav1.NamespaceDefault).
 					Profile("profile2").
+					LocalQueue("lq2").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -163,8 +228,8 @@ j1     profile1   3/3           60m        60m
 					Succeeded(3).
 					Obj(),
 			},
-			wantOut: `NAME   PROFILE    COMPLETIONS   DURATION   AGE
-j1     profile1   3/3           60m        60m
+			wantOut: `NAME   PROFILE    LOCAL QUEUE   COMPLETIONS   DURATION   AGE
+j1     profile1   lq1           3/3           60m        60m
 `,
 		},
 		"should print job list with label selector filter (short flag)": {
@@ -172,6 +237,7 @@ j1     profile1   3/3           60m        60m
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", metav1.NamespaceDefault).
 					Profile("profile1").
+					LocalQueue("lq1").
 					Label("foo", "bar").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
@@ -181,6 +247,7 @@ j1     profile1   3/3           60m        60m
 					Obj(),
 				wrappers.MakeJob("j2", metav1.NamespaceDefault).
 					Profile("profile2").
+					LocalQueue("lq2").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -188,8 +255,8 @@ j1     profile1   3/3           60m        60m
 					Succeeded(3).
 					Obj(),
 			},
-			wantOut: `NAME   PROFILE    COMPLETIONS   DURATION   AGE
-j1     profile1   3/3           60m        60m
+			wantOut: `NAME   PROFILE    LOCAL QUEUE   COMPLETIONS   DURATION   AGE
+j1     profile1   lq1           3/3           60m        60m
 `,
 		},
 		"should print job list with field selector filter": {
@@ -197,6 +264,7 @@ j1     profile1   3/3           60m        60m
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", metav1.NamespaceDefault).
 					Profile("profile1").
+					LocalQueue("lq1").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -205,6 +273,7 @@ j1     profile1   3/3           60m        60m
 					Obj(),
 				wrappers.MakeJob("j2", metav1.NamespaceDefault).
 					Profile("profile2").
+					LocalQueue("lq2").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -212,8 +281,8 @@ j1     profile1   3/3           60m        60m
 					Succeeded(3).
 					Obj(),
 			},
-			wantOut: `NAME   PROFILE    COMPLETIONS   DURATION   AGE
-j1     profile1   3/3           60m        60m
+			wantOut: `NAME   PROFILE    LOCAL QUEUE   COMPLETIONS   DURATION   AGE
+j1     profile1   lq1           3/3           60m        60m
 `,
 		},
 		"should print not found error": {

--- a/cmd/experimental/kjobctl/pkg/cmd/list/list_test.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/list/list_test.go
@@ -47,6 +47,7 @@ func TestListCmd(t *testing.T) {
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", "ns1").
 					Profile("profile1").
+					LocalQueue("lq1").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -55,6 +56,7 @@ func TestListCmd(t *testing.T) {
 					Obj(),
 				wrappers.MakeJob("j2", "ns2").
 					Profile("profile2").
+					LocalQueue("lq1").
 					Completions(3).
 					CreationTimestamp(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					StartTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
@@ -62,9 +64,9 @@ func TestListCmd(t *testing.T) {
 					Succeeded(3).
 					Obj(),
 			},
-			wantOut: `NAMESPACE   NAME   PROFILE    COMPLETIONS   DURATION   AGE
-ns1         j1     profile1   3/3           60m        60m
-ns2         j2     profile2   3/3           60m        60m
+			wantOut: `NAMESPACE   NAME   PROFILE    LOCAL QUEUE   COMPLETIONS   DURATION   AGE
+ns1         j1     profile1   lq1           3/3           60m        60m
+ns2         j2     profile2   lq1           3/3           60m        60m
 `,
 		},
 	}

--- a/cmd/experimental/kjobctl/test/integration/kjobctl/list_test.go
+++ b/cmd/experimental/kjobctl/test/integration/kjobctl/list_test.go
@@ -96,10 +96,10 @@ var _ = ginkgo.Describe("Kjobctl List", ginkgo.Ordered, ginkgo.ContinueOnFailure
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
 			gomega.Expect(errOutput.String()).Should(gomega.BeEmpty())
-			gomega.Expect(output.String()).Should(gomega.Equal(fmt.Sprintf(`NAME                 PROFILE    COMPLETIONS   DURATION   AGE
-j1                   profile1   0/3                      %s
-j2                   profile1   0/3                      %s
-very-long-job-name   profile1   0/3                      %s
+			gomega.Expect(output.String()).Should(gomega.Equal(fmt.Sprintf(`NAME                 PROFILE    LOCAL QUEUE   COMPLETIONS   DURATION   AGE
+j1                   profile1                 0/3                      %s
+j2                   profile1                 0/3                      %s
+very-long-job-name   profile1                 0/3                      %s
 `,
 				duration.HumanDuration(executeTime.Sub(j1.CreationTimestamp.Time)),
 				duration.HumanDuration(executeTime.Sub(j2.CreationTimestamp.Time)),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add a localqueue filter to the list job command on kjobctl.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```