### PR TITLE
KEP: Introduce a new timeout to WaitForPodsReady config

### DIFF
--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -233,13 +233,13 @@ type WaitForPodsReady struct {
 	// +optional
 	RequeuingStrategy *RequeuingStrategy `json:"requeuingStrategy,omitempty"`
 
-	// recoveryTimeoutSeconds defines optional time duration in seconds, relative to
+	// recoveryTimeout defines optional time duration, relative to
 	// pod's failure expressed by PodsReady=false condition, after a Workload is Admitted and running.
 	// After exceeding the timeout the corresponding job gets suspended again
 	// and moved to the ClusterQueue's inadmissibleWorkloads list. The timeout is
 	// enforced only if waitForPodsReady.enable=true. Defaults to 3 mins.
 	// +optional
-	RecoveryTimeoutSeconds *int64 `json:"recoveryTimeoutSeconds,omitempty"`
+	RecoveryTimeout *metav1.Duration `json:"recoveryTimeout,omitempty"`
 }
 
 type RequeuingStrategy struct {
@@ -331,7 +331,7 @@ condition, so the corresponding job is unsuspended without further waiting.
 ### Timeout on reaching the PodsReady condition
 
 
-We introduce two timeouts defined in the `waitForPodsReady.timeoutSeconds` and `waitForPodsReady.recoveryTimeoutSeconds` fields.
+We introduce two timeouts defined in the `waitForPodsReady.timeoutSeconds` and `waitForPodsReady.recoveryTimeout` fields.
 
 First one applies before the job has started. It tracks the time between job getting unsuspended for the first time (the time of unsuspending a job is marked by the Job's
 `job.status.startTime` field) and reaching the `PodsReady=true` condition (marked by condition's `.lastTransitionTime`).
@@ -364,7 +364,7 @@ flowchart TD;
 	id3(PodsReady=true);
 	id4("PodsReady=false(2nd)
 	waits for
-	.recoveryTimeoutSeconds");
+	.recoveryTimeout");
 	id5("Suspended=true (Requeued)");
 
 
@@ -449,8 +449,8 @@ extending the production code to implement this enhancement.
 The following scenarios will be covered with integration tests when `waitForPodsReady` is enabled:
 - no workloads are admitted if there is already an admitted workload which is not in the `PodsReady` condition
 - a workload gets admitted if all other admitted workloads are in the `PodsReady` condition
-- a workload which exceeds the `waitForPodsReady.timeoutSeconds` timeout is suspended and put into the `inadmissibleWorkloads` list
-- a workload which exceeds the `waitForPodsReady.recoveryTimeoutSeconds` timeout is suspended and put into the `inadmissibleWorkloads` list
+- a workload which exceeds the `waitForPodsReady.timeout` timeout is suspended and put into the `inadmissibleWorkloads` list
+- a workload which exceeds the `waitForPodsReady.recoveryTimeout` timeout is suspended and put into the `inadmissibleWorkloads` list
 
 <!--
 Describe what tests will be added to ensure proper quality of the enhancement.

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -234,13 +234,13 @@ type WaitForPodsReady struct {
 	// +optional
 	RequeuingStrategy *RequeuingStrategy `json:"requeuingStrategy,omitempty"`
 
-	// replacementTimeoutSeconds defines optional time duration in seconds, relative to
+	// recoveryTimeoutSeconds defines optional time duration in seconds, relative to
 	// pod's failure expressed by PodsReady=false condition, after a Workload is Admitted and running.
 	// After exceeding the timeout the corresponding job gets suspended again
 	// and moved to the ClusterQueue's inadmissibleWorkloads list. The timeout is
 	// enforced only if waitForPodsReady.enable=true. Defaults to 3 mins.
 	// +optional
-	ReplacementTimeoutSeconds *int64
+	recoveryTimeoutSeconds *int64 `json:"recoveryTimeoutSeconds,omitempty"`
 }
 
 type RequeuingStrategy struct {
@@ -331,21 +331,61 @@ condition, so the corresponding job is unsuspended without further waiting.
 
 ### Timeout on reaching the PodsReady condition
 
-We introduce two timeouts defined in the `waitForPodsReady.timeoutSeconds` and `waitForPodsReady.replacementTimeoutSeconds` fields.
 
-First one tracks the time between job getting unsuspended (the time of unsuspending a job is marked by the Job's
-`job.status.startTime` field) and reaching the `PodsReady=true` condition.
+We introduce two timeouts defined in the `waitForPodsReady.timeoutSeconds` and `waitForPodsReady.recoveryTimeoutSeconds` fields.
 
-Second one tracks the time between changing `PodsReady` condition to `false` after the job is running and reaching the
+First one applies before the job has started. It tracks the time between job getting unsuspended for the first time (the time of unsuspending a job is marked by the Job's
+`job.status.startTime` field) and reaching the `PodsReady=true` condition (marked by condition's `.lastTransitionTime`).
+
+```mermaid
+flowchart TD;
+	start@{ shape: f-circ};
+	id1(Suspended=true);
+	id2("PodsReady=false
+	waits for .timeoutSeconds");
+	id3(PodsReady=true);
+	id4("Suspended=true (Requeued)");
+
+	start--Workload gets admitted-->id1;
+	id1 --> id2;
+
+	id2 --"Doesn't exceed the timeout" --> id3
+	id2 --"Exceeds the timeout" --> id4
+```
+
+
+Second one applies when the job has already started and some pod failed while the job is running. It tracks the time between changing `PodsReady` condition to `false` and reaching the
 `PodsReady=true` condition once again.
 
-We introduce new `WorkloadWaitForPodsReadyStart` and `WorkloadWaitForPodsReadyReplacement` reasons to distinguish the reasons of setting the `PodsReady=false` condition.
-`WorkloadWaitForPodsReadyStart` will be set before the job started, and `WorkloadWaitForPodsReadyReplacement` after.
+```mermaid
+flowchart TD;
+	start@{ shape: f-circ};
+	id1(Suspended=true);
+	id2("PodsReady=false(1st)");
+	id3(PodsReady=true);
+	id4("PodsReady=false(2nd)
+	waits for
+	.recoveryTimeoutSeconds");
+	id5("Suspended=true (Requeued)");
+
+
+	start--Workload gets admitted-->id1;
+	id1 --> id2;
+
+	id2 --"Job started" --> id3
+	id3 --"Pod failed"--> id4
+	id4 --"Pod recovered"--> id3
+	id4 --"timeout	exceeded"--> id5
+```
+
+We introduce new `WorkloadWaitForPodsReadyStart` and `WorkloadWaitForPodsReadyRecovery` reasons to distinguish the reasons of setting the `PodsReady=false` condition.
+`WorkloadWaitForPodsReadyStart` will be set before the job started, and `WorkloadWaitForPodsReadyRecovery` after.
 
 When any of the timeouts is exceeded, the Kueue's Job
 Controller suspends the Job corresponding to the workload and puts into the
-ClusterQueue's `inadmissibleWorkloads` list. The timeouts are enforced only when
+ClusterQueue's `inadmissibleWorkloads` list. The timeouts apply only when
 `waitForPodsReady` is enabled.
+
 
 ### Test Plan
 
@@ -408,7 +448,7 @@ The following scenarios will be covered with integration tests when `waitForPods
 - no workloads are admitted if there is already an admitted workload which is not in the `PodsReady` condition
 - a workload gets admitted if all other admitted workloads are in the `PodsReady` condition
 - a workload which exceeds the `waitForPodsReady.timeoutSeconds` timeout is suspended and put into the `inadmissibleWorkloads` list
-- a workload which exceeds the `waitForPodsReady.replacementTimeoutSeconds` timeout is suspended and put into the `inadmissibleWorkloads` list
+- a workload which exceeds the `waitForPodsReady.recoveryTimeoutSeconds` timeout is suspended and put into the `inadmissibleWorkloads` list
 
 <!--
 Describe what tests will be added to ensure proper quality of the enhancement.

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -235,10 +235,10 @@ type WaitForPodsReady struct {
 	RequeuingStrategy *RequeuingStrategy `json:"requeuingStrategy,omitempty"`
 
 	// replacementTimeoutSeconds defines optional time duration in seconds, relative to
-	// pod's failure after a Workload is Admitted and running.
+	// pod's failure expressed by PodsReady=false condition, after a Workload is Admitted and running.
 	// After exceeding the timeout the corresponding job gets suspended again
 	// and moved to the ClusterQueue's inadmissibleWorkloads list. The timeout is
-	// enforced only if waitForPodsReady.enable=true. If unspecified, it defaults to 5min.
+	// enforced only if waitForPodsReady.enable=true. Defaults to 3 mins.
 	// +optional
 	ReplacementTimeoutSeconds *int64
 }
@@ -301,6 +301,8 @@ We introduce a new workload condition, called `PodsReady`, to indicate
 if the workload's startup requirements are satisfied. More precisely, we add
 the condition when `job.status.ready + job.status.uncountedTerimnatedPods + job.status.succeeded` is greater or equal
 than `job.spec.parallelism`.
+
+Note that we count `job.status.uncountedTerminatedPods` - this is meant to prevent flickering of the `PodsReady` condition when pods are transitioning to the `Succeeded` state.
 
 Note that, we don't take failed pods into account when verifying if the
 `PodsReady` condition should be added. However, a buggy admitted workload is

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -337,6 +337,9 @@ First one tracks the time between job getting unsuspended (the time of unsuspend
 Second one tracks the time between changing `PodsReady` condition to `false` after the job is running and reaching the
 `PodsReady=true` condition once again.
 
+We introduce new `WorkloadWaitForPodsReadyStart` and `WorkloadWaitForPodsReadyReplacement` reasons to distinguish the reasons of setting the `PodsReady=false` condition.
+`WorkloadWaitForPodsReadyStart` will be set before the job started, and `WorkloadWaitForPodsReadyReplacement` after.
+
 When any of the timeouts is exceeded, the Kueue's Job
 Controller suspends the Job corresponding to the workload and puts into the
 ClusterQueue's `inadmissibleWorkloads` list. The timeouts are enforced only when

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -381,7 +381,8 @@ flowchart TD;
 ```
 
 We introduce new `WorkloadWaitForPodsStart` and `WorkloadWaitForPodsRecovery` reasons to distinguish the reasons of setting the `PodsReady=false` condition.
-`WorkloadWaitForPodsStart` will be set before the job started, and `WorkloadWaitForPodsRecovery` after.
+`WorkloadWaitForPodsStart` will be set before the job started and is replacement for the old `PodsReady` reason. 
+`WorkloadWaitForPodsRecovery` will be set after the job started.
 
 When any of the timeouts is exceeded, the Kueue's Job
 Controller suspends the Job corresponding to the workload and puts into the

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -239,6 +239,7 @@ type WaitForPodsReady struct {
 	// After exceeding the timeout the corresponding job gets suspended again
 	// and moved to the ClusterQueue's inadmissibleWorkloads list. The timeout is
 	// enforced only if waitForPodsReady.enable=true. If unspecified, it defaults to 5min.
+	// +optional
 	ReplacementTimeoutSeconds *int64
 }
 

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -233,7 +233,7 @@ type WaitForPodsReady struct {
 	// +optional
 	RequeuingStrategy *RequeuingStrategy `json:"requeuingStrategy,omitempty"`
 
-	// recoveryTimeout defines an optional timeout, measured since the
+	// RecoveryTimeout defines an optional timeout, measured since the
 	// last transition to the PodsReady=false condition after a Workload is Admitted and running.
 	// Such a transition may happen when a Pod failed and the replacement Pod 
 	// is awaited to be scheduled.
@@ -333,7 +333,7 @@ condition, so the corresponding job is unsuspended without further waiting.
 ### Timeout on reaching the PodsReady condition
 
 
-We introduce two timeouts defined in the `waitForPodsReady.timeoutSeconds` and `waitForPodsReady.recoveryTimeout` fields.
+We introduce two timeouts defined in the `waitForPodsReady.timeout` and `waitForPodsReady.recoveryTimeout` fields.
 
 First one applies before the job has started. It tracks the time between job getting unsuspended for the first time (the time of unsuspending a job is marked by the Job's
 `job.status.startTime` field) and reaching the `PodsReady=true` condition (marked by condition's `.lastTransitionTime`).

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -379,8 +379,8 @@ flowchart TD;
 	id4 --"timeout	exceeded"--> id5
 ```
 
-We introduce new `WorkloadWaitForPodsReadyStart` and `WorkloadWaitForPodsReadyRecovery` reasons to distinguish the reasons of setting the `PodsReady=false` condition.
-`WorkloadWaitForPodsReadyStart` will be set before the job started, and `WorkloadWaitForPodsReadyRecovery` after.
+We introduce new `WorkloadWaitForPodsStart` and `WorkloadWaitForPodsRecovery` reasons to distinguish the reasons of setting the `PodsReady=false` condition.
+`WorkloadWaitForPodsStart` will be set before the job started, and `WorkloadWaitForPodsRecovery` after.
 
 When any of the timeouts is exceeded, the Kueue's Job
 Controller suspends the Job corresponding to the workload and puts into the

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -299,11 +299,12 @@ const (
 ### PodsReady workload condition
 
 We introduce a new workload condition, called `PodsReady`, to indicate
-if the workload's startup requirements are satisfied. More precisely, we add
+if the workload's startup requirements are satisfied. More precisely, for a batch/v1 Job we add
 the condition when `job.status.ready + len(job.status.uncountedTerimnatedPods.succeeded) + job.status.succeeded` is greater or equal
 than `job.spec.parallelism`.
 
 Note that we count `job.status.uncountedTerminatedPods` - this is meant to prevent flickering of the `PodsReady` condition when pods are transitioning to the `Succeeded` state.
+This applies only for batch/v1 Job, since Kueue doesn't count active pods for other Job types, and delegate it to third-party Job types operators.
 
 Note that, we don't take failed pods into account when verifying if the
 `PodsReady` condition should be added. However, a buggy admitted workload is

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -29,7 +29,6 @@ tags, and then generate with `hack/update-toc.sh`.
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [Kueue Configuration API](#kueue-configuration-api)
-  - [Workload API changes](#workload-api-changes)
   - [PodsReady workload condition](#podsready-workload-condition)
   - [Waiting for PodsReady condition](#waiting-for-podsready-condition)
   - [Timeout on reaching the PodsReady condition](#timeout-on-reaching-the-podsready-condition)
@@ -246,13 +245,13 @@ type WaitForPodsReady struct {
 	// +optional
 	RequeuingStrategy *RequeuingStrategy `json:"requeuingStrategy,omitempty"`
 
-	// RecoveryTimeout defines an optional timeout, measured since the
+	// RecoveryTimeout defines an opt-in timeout, measured since the
 	// last transition to the PodsReady=false condition after a Workload is Admitted and running.
-	// Such a transition may happen when a Pod failed and the replacement Pod 
+	// Such a transition may happen when a Pod failed and the replacement Pod
 	// is awaited to be scheduled.
 	// After exceeding the timeout the corresponding job gets suspended again
-	// and requeued after the backoff delay. The timeout is enforced only if waitForPodsReady.enable=true. 
-	// Defaults to 3 mins.
+	// and requeued after the backoff delay. The timeout is enforced only if waitForPodsReady.enable=true.
+	// If not set, there is no timeout.
 	// +optional
 	RecoveryTimeout *metav1.Duration `json:"recoveryTimeout,omitempty"`
 }

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -104,7 +104,7 @@ know that this has succeeded?
 
 - guarantee that two jobs would not schedule pods concurrently. Example
 scenarios in which two jobs may still concurrently schedule their pods:
-- when succeeded pods are replaced with new because job's parallelism is less than its completions.
+  - when succeeded pods are replaced with new because job's parallelism is less than its completions.
 
 <!--
 What is out of scope for this KEP? Listing non-goals helps to focus discussion

--- a/keps/349-all-or-nothing/kep.yaml
+++ b/keps/349-all-or-nothing/kep.yaml
@@ -2,13 +2,17 @@ title: All-or-nothing semantics for workload resource assignment
 kep-number: 349
 authors:
   - "@mimowo"
+  - "@pbundyra"           # for recoveryTimeout extension
 status: provisional
 creation-date: 2022-11-23
 reviewers:
   - "@kerthcet"
   - "@alculquicondor"
+  - "@mimowo" # for recoveryTimeout extension
+  - "@yaroslava-serdiuk"  # for recoveryTimeout extension
 approvers:
   - "@ahg-g"
+  - "@mimowo" # for recoveryTimeout extension
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: stable


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Described in #2732 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #2732 

#### Special notes for your reviewer:
As an alternative,  instead of adding a new timeout, we could reuse the existing one to provide the needed functionality

Pros:
- no API changes requried

Cons:
- Users cannot set different timeouts for different scenarios

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```