### PR TITLE
[jobframework] Add integration's framework dependencies.

### DIFF
--- a/pkg/controller/jobframework/integrationmanager.go
+++ b/pkg/controller/jobframework/integrationmanager.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/set"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -37,6 +39,10 @@ var (
 	errDuplicateFrameworkName = errors.New("duplicate framework name")
 	errMissingMandatoryField  = errors.New("mandatory field missing")
 	errFrameworkNameFormat    = errors.New("misformatted external framework name")
+
+	errIntegrationNotFound           = errors.New("integration not found")
+	errIntegrationNotEnabled         = errors.New("integration not enabled")
+	errCircularIntegrationDependency = errors.New("circular integration dependency")
 )
 
 type JobReconcilerInterface interface {
@@ -69,6 +75,8 @@ type IntegrationCallbacks struct {
 	CanSupportIntegration func(opts ...Option) (bool, error)
 	// The job's MultiKueue adapter (optional)
 	MultiKueueAdapter MultiKueueAdapter
+	// The list of integration that need to be enabled along with the current one.
+	DependencyList []string
 }
 
 type integrationManager struct {
@@ -176,6 +184,40 @@ func (m *integrationManager) getJobTypeForOwner(ownerRef *metav1.OwnerReference)
 		}
 	}
 
+	return nil
+}
+
+func (m *integrationManager) checkEnabledListDependencies(enabledSet sets.Set[string]) error {
+	enabled := enabledSet.UnsortedList()
+	slices.Sort(enabled)
+	for _, integration := range enabled {
+		if err := m.canEnableIntegration(integration, enabledSet, sets.New[string]()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *integrationManager) canEnableIntegration(integration string, enabledSet, visited sets.Set[string]) error {
+	// is the integration real?
+	cbs, found := m.integrations[integration]
+	if !found {
+		return fmt.Errorf("%q %w", integration, errIntegrationNotFound)
+	}
+	if len(cbs.DependencyList) != 0 {
+		newVisited := visited.Clone().Insert(integration)
+		for _, dep := range cbs.DependencyList {
+			if !enabledSet.Has(dep) {
+				return fmt.Errorf("%q: %q %w", integration, dep, errIntegrationNotEnabled)
+			}
+			if newVisited.Has(dep) {
+				return fmt.Errorf("%q: %q %w", integration, dep, errCircularIntegrationDependency)
+			}
+			if err := m.canEnableIntegration(dep, enabledSet, newVisited); err != nil {
+				return fmt.Errorf("%q: %w", integration, err)
+			}
+		}
+	}
 	return nil
 }
 

--- a/pkg/controller/jobframework/integrationmanager_test.go
+++ b/pkg/controller/jobframework/integrationmanager_test.go
@@ -463,7 +463,7 @@ func TestEnabledIntegrationsDependencies(t *testing.T) {
 				"i1": {"i2"},
 			},
 			enabled:   []string{"i1"},
-			wantError: errIntegrationNotEnabled,
+			wantError: errDependecncyIntegrationNotEnabled,
 		},
 		"dependecncy not found": {
 			integrationsDependencies: map[string][]string{
@@ -471,15 +471,6 @@ func TestEnabledIntegrationsDependencies(t *testing.T) {
 			},
 			enabled:   []string{"i1", "i2"},
 			wantError: errIntegrationNotFound,
-		},
-		"circular dependecncy": {
-			integrationsDependencies: map[string][]string{
-				"i1": {"i2"},
-				"i2": {"i3"},
-				"i3": {"i1"},
-			},
-			enabled:   []string{"i1", "i2", "i3"},
-			wantError: errCircularIntegrationDependency,
 		},
 		"no error": {
 			integrationsDependencies: map[string][]string{

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -51,6 +51,10 @@ func SetupControllers(mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
 func (m *integrationManager) setupControllers(mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
 	options := ProcessOptions(opts...)
 
+	if err := m.checkEnabledListDependencies(options.EnabledFrameworks); err != nil {
+		return fmt.Errorf("check enabled frameworks list: %w", err)
+	}
+
 	for fwkName := range options.EnabledExternalFrameworks {
 		if err := RegisterExternalJobType(fwkName); err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds a way to specify dependencies between job integrations.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Needed by #2717 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added a way to specify dependencies between job integrations.
```