### PR TITLE
Maintain shellcheck dependency by dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -118,3 +118,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # Maintain shellcheck dependency
+  - package-ecosystem: "docker"
+    directory: "/hack/shellcheck"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "release-note-none"

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ lint-fix: golangci-lint
 
 .PHONY: shell-lint
 shell-lint: ## Run shell linting.
-	$(PROJECT_DIR)/hack/verify-shellcheck.sh
+	$(PROJECT_DIR)/hack/shellcheck/verify.sh
 
 .PHONY: verify
 verify: gomod-verify ci-lint fmt-verify shell-lint toc-verify manifests generate update-helm generate-apiref generate-kueuectl-docs prepare-release-branch

--- a/hack/shellcheck/Dockerfile
+++ b/hack/shellcheck/Dockerfile
@@ -1,0 +1,1 @@
+FROM docker.io/koalaman/shellcheck-alpine:v0.10.0

--- a/hack/shellcheck/verify.sh
+++ b/hack/shellcheck/verify.sh
@@ -20,8 +20,9 @@ set -o pipefail
 
 # allow overriding docker cli, which should work fine for this script
 DOCKER="${DOCKER:-docker}"
+CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-SHELLCHECK_IMAGE="docker.io/koalaman/shellcheck-alpine:v0.10.0"
+SHELLCHECK_IMAGE=$(grep '^FROM' "${CURRENT_DIR}/Dockerfile" | awk '{print $2}')
 
 # Initialize an empty array for scripts to check
 scripts_to_check=()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Maintain shellcheck dependency by dependabot.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```