### PR TITLE
Fix using PrioritySortingWithinCohort=false and borrowWithinCohort

### DIFF
--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -783,4 +783,121 @@ var _ = ginkgo.Describe("Preemption", func() {
 				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "alpha", "4").Obj())
 		})
 	})
+
+	ginkgo.Context("When borrowWithinCohort is used and PrioritySortingWithinCohort disabled", func() {
+		var (
+			aCQ, bCQ, cCQ *kueue.ClusterQueue
+			aLQ, bLQ      *kueue.LocalQueue
+			defaultFlavor *kueue.ResourceFlavor
+		)
+
+		ginkgo.BeforeEach(func() {
+			gomega.Expect(features.SetEnable(features.PrioritySortingWithinCohort, false)).To(gomega.Succeed())
+			defaultFlavor = testing.MakeResourceFlavor("default").Obj()
+			gomega.Expect(k8sClient.Create(ctx, defaultFlavor)).To(gomega.Succeed())
+
+			aCQ = testing.MakeClusterQueue("a-cq").
+				Cohort("all").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "0", "10").Obj(),
+				).
+				FlavorFungibility(kueue.FlavorFungibility{
+					WhenCanBorrow:  kueue.Borrow,
+					WhenCanPreempt: kueue.Preempt,
+				}).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				}).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, aCQ)).To(gomega.Succeed())
+			aLQ = testing.MakeLocalQueue("a-lq", ns.Name).ClusterQueue(aCQ.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, aLQ)).To(gomega.Succeed())
+
+			bCQ = testing.MakeClusterQueue("b-cq").
+				Cohort("all").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5", "5").Obj(),
+				).
+				FlavorFungibility(kueue.FlavorFungibility{
+					WhenCanBorrow:  kueue.Borrow,
+					WhenCanPreempt: kueue.Preempt,
+				}).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+					BorrowWithinCohort: &kueue.BorrowWithinCohort{
+						Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
+						MaxPriorityThreshold: ptr.To(veryHighPriority),
+					},
+				}).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, bCQ)).To(gomega.Succeed())
+			bLQ = testing.MakeLocalQueue("b-lq", ns.Name).ClusterQueue(bCQ.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, bLQ)).To(gomega.Succeed())
+
+			cCQ = testing.MakeClusterQueue("c-cq").
+				Cohort("all").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj(),
+				).
+				FlavorFungibility(kueue.FlavorFungibility{
+					WhenCanBorrow:  kueue.Borrow,
+					WhenCanPreempt: kueue.Preempt,
+				}).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				}).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, cCQ)).To(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(features.SetEnable(features.PrioritySortingWithinCohort, true)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, aCQ, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, bCQ, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cCQ, true)
+		})
+
+		ginkgo.It("should allow preempting workloads while borrowing", func() {
+			var aWl, b1Wl, b2Wl *kueue.Workload
+
+			ginkgo.By("Create a mid priority workload in aCQ and await for admission", func() {
+				aWl = testing.MakeWorkload("a-low", ns.Name).
+					Queue(aLQ.Name).
+					Priority(midPriority).
+					Request(corev1.ResourceCPU, "4").
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, aWl)).To(gomega.Succeed())
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, aWl)
+			})
+
+			ginkgo.By("Create a high priority workload b1 in bCQ and await for admission", func() {
+				b1Wl = testing.MakeWorkload("b1-high", ns.Name).
+					Queue(bLQ.Name).
+					Priority(highPriority).
+					Request(corev1.ResourceCPU, "4").
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, b1Wl)).To(gomega.Succeed())
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, b1Wl)
+			})
+
+			ginkgo.By("Create a high priority workload b2 in bCQ", func() {
+				b2Wl = testing.MakeWorkload("b2-high", ns.Name).
+					Queue(bLQ.Name).
+					Priority(highPriority).
+					Request(corev1.ResourceCPU, "4").
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, b2Wl)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("Await for preemption of the workload in aCQ and admission of b2", func() {
+				util.FinishEvictionForWorkloads(ctx, k8sClient, aWl)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, aWl)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, b2Wl)
+			})
+		})
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

To prevent infinite preemption loop when borrowWithinCohort is used with `PrioritySortingWithingCohort=false`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2821

#### Special notes for your reviewer:

In the scenario described in #2821 when `PrioritySortingWithingCohort=false` we re-admit repeatedly workload-A (lower priority) which blocks the admission of the Workload-B2 (higher priority). 

Ideally, we would like workload-B to be scheduled, which would break the cycle. Workload-B2 would not get preempted  by Workload-A.

The code that is important for relative prioritization of the two workloads is [here](https://github.com/kubernetes-sigs/kueue/blob/21e9ac330cb6624f555668ccaca347a61c1f81ac/pkg/scheduler/scheduler.go#L625-L654):
1. [L630-634] both `Workload-A` and `Workload-B2` need to borrow to get admitted
2. [L637-639] fair sharing is not configured here, so this block is not relevant
3. [L641-648]  `PrioritySortingWithingCohort=false`  so this block is not relevant
4. [L651-653] `Workload-A` currently "wins" here because it is older

The idea for the fix in to modify the formula for `GetQueueOrderTimestamp` at the last step and use the timestamp to discriminate in favor of `Workload-B2`. In this order we use the `EvictionTimestamp` rather than creation timestamp. This idea is not entirely new as we do something similar to penalize workload evicted due to PodsReady timeout already.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Prevent infinite preemption loop when PrioritySortingWithingCohort=false
is used together with borrowWithinCohort.
```