### PR TITLE
[Partial Admission] Check Mode before attempting Preemption

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -473,10 +473,11 @@ func (s *Scheduler) getAssignments(log logr.Logger, wl *workload.Info, snap *cac
 			assignment := flvAssigner.Assign(log, nextCounts)
 			if assignment.RepresentativeMode() == flavorassigner.Fit {
 				return &partialAssignment{assignment: assignment}, true
-			}
-			preemptionTargets := s.preemptor.GetTargets(log, *wl, assignment, snap)
-			if len(preemptionTargets) > 0 {
-				return &partialAssignment{assignment: assignment, preemptionTargets: preemptionTargets}, true
+			} else if assignment.RepresentativeMode() == flavorassigner.Preempt {
+				preemptionTargets := s.preemptor.GetTargets(log, *wl, assignment, snap)
+				if len(preemptionTargets) > 0 {
+					return &partialAssignment{assignment: assignment, preemptionTargets: preemptionTargets}, true
+				}
 			}
 			return nil, false
 		})


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We don't check `RepresentativeMode` before attempting preemption in the `Partial Admission` path. This may result in a panic, if we enter the preemption path and find some targets.

In the existing unit tests, we exit [here](https://github.com/kubernetes-sigs/kueue/blob/00111d9aada59e1a6d8d90b9847cf7451bc5be76/pkg/scheduler/preemption/preemption.go#L110-L112), before encountering a panic [here](https://github.com/kubernetes-sigs/kueue/blob/00111d9aada59e1a6d8d90b9847cf7451bc5be76/pkg/scheduler/preemption/preemption.go#L116). See #2799 for more detail.

#### Which issue(s) this PR fixes:
Related to #2799. Leaving that issue open, as related tests need to be updated

#### Does this PR introduce a user-facing change?
```release-note
NONE
```