### PR TITLE
[hack] Add compare performance script

### DIFF
--- a/hack/compare-performance.sh
+++ b/hack/compare-performance.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ "$#" -lt 2 ]]; then
+	echo "Usage: ${0} rev1 rev2 [num-iterations [summary-dir]]
+	To be run from kueue's root dir."
+	exit 1
+fi
+
+REV_1="$1"
+REV_2="$2"
+NUM_IT=${3:-5}
+SUMMARY_DIR=${4:-$(mktemp -d)}
+
+STATS_FILE="${SUMMARY_DIR}/perf_stats.yaml"
+SUMMARY_FILE="${SUMMARY_DIR}/perf_stats.yaml}"
+
+if [ -f "${STATS_FILE}" ]; then
+	rm "${STATS_FILE}" 
+fi
+
+if [ -f "${SUMMARY_FILE}" ]; then
+	rm "${SUMMARY_FILE}" 
+fi
+
+echo "
+Using:
+Stats file: $STATS_FILE
+Summary file: $SUMMARY_FILE
+"
+
+#$1 - iteration
+#$2 - git-rev 
+function run_and_store {
+	git reset --hard 
+	git checkout "${2}" 
+	make run-performance-scheduler
+	run="${1}" git_rev="$2" yq ' .flat.run = env(run) | .flat.rev = env(git_rev) |
+		.flat.maxrss = .maxrss |
+		.flat.sysMs = .sysMs |
+		.flat.userMs = .userMs |
+		.flat.wallMs = .wallMs |
+		.flat.mCPU = ((.sysMs + .userMs) * 1000 / .wallMs) |
+		.flat | [] + . ' bin/run-performance-scheduler/minimalkueue.stats.yaml >> "${STATS_FILE}"
+
+	run="${1}" git_rev="$2" yq ' .flat.run = env(run) |.flat.rev = env(git_rev) | 
+		.flat.largeMsToAdm = .workloadClasses.large.averageTimeToAdmissionMs | 
+		.flat.mediumMsToAdm = .workloadClasses.medium.averageTimeToAdmissionMs |
+		.flat.smallMsToAdm = .workloadClasses.small.averageTimeToAdmissionMs | 
+		.flat.largeEvictions = .workloadClasses.large.totalEvictions | 
+		.flat.mediumEvictions = .workloadClasses.medium.totalEvictions | 
+		.flat.smallEvictions = .workloadClasses.small.totalEvictions | 
+		.flat.resUsage = .clusterQueueClasses.cq.cpuAverageUsage * 100 / .clusterQueueClasses.cq.nominalQuota | 
+		.flat |  [] + . ' bin/run-performance-scheduler/summary.yaml >> "$SUMMARY_FILE" 
+
+}
+
+for i in $(seq 1 "$NUM_IT"); do
+	echo "
+	**********************
+	Start loop iteration ${i} "
+	run_and_store "$i" "$REV_1"
+	run_and_store "$i" "$REV_2"
+
+	echo "
+	**********************
+	After iteration ${i}"
+	echo "Stats (csv):"
+ 	yq "${STATS_FILE}" -oc
+	echo "Summary (csv):"
+ 	yq "${SUMMARY_FILE}" -oc
+done
+

--- a/hack/compare-performance.sh
+++ b/hack/compare-performance.sh
@@ -24,6 +24,14 @@ if [[ "$#" -lt 2 ]]; then
 	exit 1
 fi
 
+git --no-pager diff --exit-code || {
+	echo "
+
+The git tree is not clean.
+Commit your changes or reset the git tree before running $0"
+	exit 1
+}
+
 REV_1="$1"
 REV_2="$2"
 NUM_IT=${3:-5}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add a script that can be used to run `make run-performance-scheduler` on two git revisions, for **N** times and print out a summary for each iteration.

Running it like:

```bash
./hack/compare-performance.sh 27468c60 e8d2ff59 5
```

will:
- checkout 27468c60
- run `make run-performance-scheduler` 
- checkout e8d2ff59
- run `make run-performance-scheduler` 
- print a partial summary like
  ```bash
	**********************
	After iteration 1
	Stats (csv):
	run,rev,maxrss,sysMs,userMs,wallMs,mCPU
	1,27468c60,457212,10914,63022,345534,213.9760486667014
	1,e8d2ff59,452212,12751,66912,359273,221.73389038419253
	Summary (csv):
	run,rev,largeMsToAdm,mediumMsToAdm,smallMsToAdm,largeEvictions,mediumEvictions,smallEvictions,resUsage
	1,27468c60,7450,76610,214689,0,0,0,58.885
	1,e8d2ff59,9148,81192,223622,0,0,0,57.876
  ```
five times.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #2775

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```