### PR TITLE
Define hierarchy.Manager

### DIFF
--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -104,7 +104,7 @@ func (c *ClusterQueueSnapshot) borrowingLimit(fr resources.FlavorResource) *int6
 // The methods below implement several interfaces. See
 // dominantResourceShareNode, resourceGroupNode, and netQuotaNode.
 
-func (c *ClusterQueueSnapshot) hasCohort() bool {
+func (c *ClusterQueueSnapshot) HasCohort() bool {
 	return c.Cohort != nil
 }
 func (c *ClusterQueueSnapshot) fairWeight() *resource.Quantity {

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -1048,7 +1048,7 @@ func TestDominantResourceShare(t *testing.T) {
 				i += 1
 			}
 
-			drVal, drNameCache := dominantResourceShare(cache.clusterQueues["cq"], tc.flvResQ, 1)
+			drVal, drNameCache := dominantResourceShare(cache.hm.ClusterQueues["cq"], tc.flvResQ, 1)
 			if drVal != tc.wantDRValue {
 				t.Errorf("cache.DominantResourceShare(_) returned value %d, want %d", drVal, tc.wantDRValue)
 			}
@@ -1099,7 +1099,7 @@ func TestCohortLendable(t *testing.T) {
 		"example.com/gpu":  3,
 	}
 
-	lendable := cache.clusterQueues["cq1"].Cohort.CalculateLendable()
+	lendable := cache.hm.ClusterQueues["cq1"].Cohort().CalculateLendable()
 	if diff := cmp.Diff(wantLendable, lendable); diff != "" {
 		t.Errorf("Unexpected cohort lendable (-want,+got):\n%s", diff)
 	}

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -634,7 +634,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 		}
 	}
 	wlInfos := make(map[string]*workload.Info, len(workloads))
-	for _, cq := range cqCache.clusterQueues {
+	for _, cq := range cqCache.hm.ClusterQueues {
 		for _, wl := range cq.Workloads {
 			wlInfos[workload.Key(wl.Obj)] = wl
 		}
@@ -674,7 +674,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							Name:                          "c1",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["c1"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["c1"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -688,7 +688,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							Name:                          "c2",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["c2"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["c2"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -727,7 +727,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								"/c1-memory-beta":  nil,
 							},
 							AllocatableResourceGeneration: 1,
-							ResourceGroups:                cqCache.clusterQueues["c1"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["c1"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							Usage: resources.FlavorResourceQuantities{
@@ -743,7 +743,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								"/c2-cpu-1": nil,
 								"/c2-cpu-2": nil,
 							},
-							ResourceGroups:                cqCache.clusterQueues["c2"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["c2"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -782,7 +782,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								"/c1-memory-beta":  nil,
 							},
 							AllocatableResourceGeneration: 1,
-							ResourceGroups:                cqCache.clusterQueues["c1"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["c1"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							Usage: resources.FlavorResourceQuantities{
@@ -799,7 +799,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								"/c2-cpu-2": nil,
 							},
 							AllocatableResourceGeneration: 1,
-							ResourceGroups:                cqCache.clusterQueues["c2"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["c2"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							Usage: resources.FlavorResourceQuantities{
@@ -890,7 +890,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 		}
 	}
 	wlInfos := make(map[string]*workload.Info, len(workloads))
-	for _, cq := range cqCache.clusterQueues {
+	for _, cq := range cqCache.hm.ClusterQueues {
 		for _, wl := range cq.Workloads {
 			wlInfos[workload.Key(wl.Obj)] = wl
 		}
@@ -927,7 +927,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-a",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-a"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -942,7 +942,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-b",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-b"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -977,7 +977,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-a",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-a"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -992,7 +992,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-b",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-b"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -1027,7 +1027,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-a",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-a"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -1042,7 +1042,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-b",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-b"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -1077,7 +1077,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-a",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-a"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -1092,7 +1092,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-b",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-b"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -1128,7 +1128,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-a",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-a"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -1143,7 +1143,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-b",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-b"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -1179,7 +1179,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-a",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-a"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -1194,7 +1194,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-b",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-b"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -1230,7 +1230,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-a",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-a"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,
@@ -1245,7 +1245,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							Name:                          "lend-b",
 							Cohort:                        cohort,
 							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.clusterQueues["lend-b"].ResourceGroups,
+							ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
 							FlavorFungibility:             defaultFlavorFungibility,
 							FairWeight:                    oneQuantity,
 							AllocatableResourceGeneration: 1,

--- a/pkg/hierarchy/manager.go
+++ b/pkg/hierarchy/manager.go
@@ -1,0 +1,80 @@
+package hierarchy
+
+// Manager stores Cohorts and ClusterQueues, and maintains the edges
+// between them.
+type Manager[CQ cqNode[CQ, C], C cohortNode[CQ, C]] struct {
+	Cohorts       map[string]C
+	ClusterQueues map[string]CQ
+	cohortFactory func(string) C
+}
+
+// NewManager creates a new Manager.  A Cohort factory
+// function must be provided to instantiate Cohorts in the case that a
+// ClusterQueue references a Cohort not backed by an API object.
+func NewManager[CQ cqNode[CQ, C], C cohortNode[CQ, C]](cohortFactory func(string) C) Manager[CQ, C] {
+	return Manager[CQ, C]{
+		make(map[string]C),
+		make(map[string]CQ),
+		cohortFactory,
+	}
+}
+
+func (c *Manager[CQ, C]) AddClusterQueue(cq CQ) {
+	c.ClusterQueues[cq.GetName()] = cq
+}
+
+func (c *Manager[CQ, C]) UpdateClusterQueueEdge(name, parentName string) {
+	cq := c.ClusterQueues[name]
+	c.unwireClusterQueue(cq)
+	if parentName != "" {
+		cohort := c.getCohort(parentName)
+		cohort.Wired().members.Insert(cq)
+		cq.Wired().cohort = cohort
+	}
+}
+
+func (c *Manager[CQ, C]) DeleteClusterQueue(name string) {
+	if cq, ok := c.ClusterQueues[name]; ok {
+		c.unwireClusterQueue(cq)
+		delete(c.ClusterQueues, name)
+		return
+	}
+}
+
+func (c *Manager[CQ, C]) unwireClusterQueue(cq CQ) {
+	if cq.Wired().HasCohort() {
+		cohort := cq.Wired().Cohort()
+		cohort.Wired().members.Delete(cq)
+		c.cleanupCohort(cohort)
+		var zero C
+		cq.Wired().cohort = zero
+	}
+}
+
+func (c *Manager[CQ, C]) getCohort(cohortName string) C {
+	if _, ok := c.Cohorts[cohortName]; !ok {
+		c.Cohorts[cohortName] = c.cohortFactory(cohortName)
+	}
+	return c.Cohorts[cohortName]
+}
+
+func (c *Manager[CQ, C]) cleanupCohort(cohort C) {
+	if cohort.Wired().members.Len() == 0 {
+		delete(c.Cohorts, cohort.GetName())
+	}
+}
+
+type nodeBase interface {
+	GetName() string
+	comparable
+}
+
+type cqNode[CQ, C nodeBase] interface {
+	Wired() *WiredClusterQueue[CQ, C]
+	nodeBase
+}
+
+type cohortNode[CQ, C nodeBase] interface {
+	Wired() *WiredCohort[CQ, C]
+	nodeBase
+}

--- a/pkg/hierarchy/manager_test.go
+++ b/pkg/hierarchy/manager_test.go
@@ -1,0 +1,214 @@
+package hierarchy
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestManager(t *testing.T) {
+	type M = Manager[*testClusterQueue, *testCohort]
+	type cqEdge struct {
+		cq     string
+		cohort string
+	}
+	tests := map[string]struct {
+		operations  func(M)
+		wantCqs     sets.Set[string]
+		wantCohorts sets.Set[string]
+		wantCqEdge  []cqEdge
+	}{
+		"create queues": {
+			operations: func(m M) {
+				m.AddClusterQueue(newCq("queue1"))
+				m.AddClusterQueue(newCq("queue2"))
+			},
+			wantCqs: sets.New("queue1", "queue2"),
+		},
+		"delete queue": {
+			operations: func(m M) {
+				m.AddClusterQueue(newCq("queue1"))
+				m.AddClusterQueue(newCq("queue2"))
+				m.DeleteClusterQueue("queue2")
+			},
+			wantCqs: sets.New("queue1"),
+		},
+		"create queues with cohorts": {
+			operations: func(m M) {
+				m.AddClusterQueue(newCq("queue1"))
+				m.AddClusterQueue(newCq("queue2"))
+				m.AddClusterQueue(newCq("queue3"))
+
+				m.UpdateClusterQueueEdge("queue1", "cohort-a")
+				m.UpdateClusterQueueEdge("queue2", "cohort-a")
+				m.UpdateClusterQueueEdge("queue3", "cohort-b")
+			},
+			wantCqs: sets.New(
+				"queue1",
+				"queue2",
+				"queue3",
+			),
+			wantCohorts: sets.New(
+				"cohort-a",
+				"cohort-b",
+			),
+			wantCqEdge: []cqEdge{
+				{"queue1", "cohort-a"},
+				{"queue2", "cohort-a"},
+				{"queue3", "cohort-b"},
+			},
+		},
+		"update cohorts": {
+			operations: func(m M) {
+				m.AddClusterQueue(newCq("queue1"))
+				m.AddClusterQueue(newCq("queue2"))
+				m.UpdateClusterQueueEdge("queue1", "cohort-a")
+				m.UpdateClusterQueueEdge("queue2", "cohort-b")
+
+				m.UpdateClusterQueueEdge("queue1", "cohort-b")
+				m.UpdateClusterQueueEdge("queue2", "cohort-c")
+			},
+			wantCqs:     sets.New("queue1", "queue2"),
+			wantCohorts: sets.New("cohort-b", "cohort-c"),
+			wantCqEdge: []cqEdge{
+				{"queue1", "cohort-b"},
+				{"queue2", "cohort-c"},
+			},
+		},
+		"updating idempotent": {
+			operations: func(m M) {
+				m.AddClusterQueue(newCq("queue1"))
+				m.AddClusterQueue(newCq("queue2"))
+				m.UpdateClusterQueueEdge("queue1", "cohort-a")
+				m.UpdateClusterQueueEdge("queue2", "cohort-b")
+
+				m.UpdateClusterQueueEdge("queue1", "cohort-b")
+				m.UpdateClusterQueueEdge("queue2", "cohort-c")
+				m.UpdateClusterQueueEdge("queue1", "cohort-b")
+				m.UpdateClusterQueueEdge("queue2", "cohort-c")
+				m.UpdateClusterQueueEdge("queue2", "cohort-c")
+				m.UpdateClusterQueueEdge("queue1", "cohort-b")
+			},
+			wantCqs:     sets.New("queue1", "queue2"),
+			wantCohorts: sets.New("cohort-b", "cohort-c"),
+			wantCqEdge: []cqEdge{
+				{"queue1", "cohort-b"},
+				{"queue2", "cohort-c"},
+			},
+		},
+		"delete cohorts": {
+			operations: func(m M) {
+				m.AddClusterQueue(newCq("queue1"))
+				m.AddClusterQueue(newCq("queue2"))
+
+				m.UpdateClusterQueueEdge("queue1", "cohort-a")
+				m.UpdateClusterQueueEdge("queue2", "cohort-b")
+
+				// Delete cohort-a by deleting edge.
+				// Delete cohort-b by deleting cq.
+				m.UpdateClusterQueueEdge("queue1", "")
+				m.DeleteClusterQueue("queue2")
+			},
+			wantCqs: sets.New("queue1"),
+		},
+		"deletion idempotent": {
+			operations: func(m M) {
+				m.DeleteClusterQueue("doesnt-exist")
+
+				m.AddClusterQueue(newCq("deleted-once"))
+				m.AddClusterQueue(newCq("deleted-twice"))
+
+				m.DeleteClusterQueue("doesnt-exist2")
+				m.DeleteClusterQueue("deleted-once")
+				m.DeleteClusterQueue("deleted-twice")
+				m.DeleteClusterQueue("deleted-twice")
+			},
+			wantCqs: sets.New[string](),
+		},
+		"cohort remains as long as one of its children remains": {
+			operations: func(m M) {
+				m.AddClusterQueue(newCq("queue1"))
+				m.AddClusterQueue(newCq("queue2"))
+				m.AddClusterQueue(newCq("queue3"))
+				m.UpdateClusterQueueEdge("queue1", "cohort")
+				m.UpdateClusterQueueEdge("queue2", "cohort")
+				m.UpdateClusterQueueEdge("queue3", "to-be-deleted-cohort")
+
+				m.DeleteClusterQueue("queue2")
+				m.DeleteClusterQueue("queue3")
+			},
+			wantCqs:     sets.New("queue1"),
+			wantCohorts: sets.New("cohort"),
+			wantCqEdge:  []cqEdge{{"queue1", "cohort"}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mgr := NewManager[*testClusterQueue, *testCohort](cohortFactory)
+			tc.operations(mgr)
+			t.Run("verify clusterqueues", func(t *testing.T) {
+				gotCqs := sets.New[string]()
+				gotEdges := make([]cqEdge, 0, len(tc.wantCqEdge))
+				for _, cq := range mgr.ClusterQueues {
+					gotCqs.Insert(cq.GetName())
+					if cq.HasCohort() {
+						gotEdges = append(gotEdges, cqEdge{cq.GetName(), cq.Cohort().GetName()})
+					}
+				}
+				if diff := cmp.Diff(tc.wantCqs, gotCqs); diff != "" {
+					t.Fatalf("Unexpected cqs -want +got %s", diff)
+				}
+				if diff := cmp.Diff(sets.New(tc.wantCqEdge...), sets.New(gotEdges...)); diff != "" {
+					t.Fatalf("Unexpected CQ->Cohort edges -want +got %s", diff)
+				}
+			})
+			t.Run("verify cohorts", func(t *testing.T) {
+				gotCohorts := sets.New[string]()
+				gotEdges := make([]cqEdge, 0, len(tc.wantCqEdge))
+				for _, cohort := range mgr.Cohorts {
+					gotCohorts.Insert(cohort.GetName())
+					for _, cq := range cohort.Members() {
+						gotEdges = append(gotEdges, cqEdge{cq.GetName(), cohort.GetName()})
+					}
+				}
+				if diff := cmp.Diff(tc.wantCohorts, gotCohorts); diff != "" {
+					t.Fatalf("Unexpected cohorts -want +got %s", diff)
+				}
+				if diff := cmp.Diff(sets.New(tc.wantCqEdge...), sets.New(gotEdges...)); diff != "" {
+					t.Fatalf("Unexpected Cohort->CQ edges -want +got %s", diff)
+				}
+			})
+		})
+	}
+}
+
+type testCohort struct {
+	name string
+	WiredCohort[*testClusterQueue, *testCohort]
+}
+
+func cohortFactory(name string) *testCohort {
+	return &testCohort{
+		name:        name,
+		WiredCohort: NewWiredCohort[*testClusterQueue, *testCohort](),
+	}
+}
+
+func (t *testCohort) GetName() string {
+	return t.name
+}
+
+type testClusterQueue struct {
+	name string
+	WiredClusterQueue[*testClusterQueue, *testCohort]
+}
+
+func newCq(name string) *testClusterQueue {
+	return &testClusterQueue{name: name}
+}
+
+func (t *testClusterQueue) GetName() string {
+	return t.name
+}

--- a/pkg/hierarchy/wired_clusterqueue.go
+++ b/pkg/hierarchy/wired_clusterqueue.go
@@ -1,0 +1,19 @@
+package hierarchy
+
+type WiredClusterQueue[CQ, Cohort nodeBase] struct {
+	cohort Cohort
+}
+
+func (c *WiredClusterQueue[CQ, Cohort]) Cohort() Cohort {
+	return c.cohort
+}
+
+func (c *WiredClusterQueue[CQ, Cohort]) HasCohort() bool {
+	var zero Cohort
+	return c.Cohort() != zero
+}
+
+// Wired implements interface for Manager
+func (c *WiredClusterQueue[CQ, Cohort]) Wired() *WiredClusterQueue[CQ, Cohort] {
+	return c
+}

--- a/pkg/hierarchy/wired_cohort.go
+++ b/pkg/hierarchy/wired_cohort.go
@@ -1,0 +1,20 @@
+package hierarchy
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+type WiredCohort[CQ, Cohort nodeBase] struct {
+	members sets.Set[CQ]
+}
+
+func (c *WiredCohort[CQ, Cohort]) Members() []CQ {
+	return c.members.UnsortedList()
+}
+
+func NewWiredCohort[CQ, Cohort nodeBase]() WiredCohort[CQ, Cohort] {
+	return WiredCohort[CQ, Cohort]{members: sets.New[CQ]()}
+}
+
+// Wired implements interface for Manager
+func (c *WiredCohort[CQ, Cohort]) Wired() *WiredCohort[CQ, Cohort] {
+	return c
+}

--- a/pkg/queue/cohort.go
+++ b/pkg/queue/cohort.go
@@ -1,0 +1,21 @@
+package queue
+
+import "sigs.k8s.io/kueue/pkg/hierarchy"
+
+// cohort is a set of ClusterQueues that can borrow resources from
+// each other.
+type cohort struct {
+	Name string
+	hierarchy.WiredCohort[*ClusterQueue, *cohort]
+}
+
+func cohortFactory(name string) *cohort {
+	return &cohort{
+		name,
+		hierarchy.NewWiredCohort[*ClusterQueue, *cohort](),
+	}
+}
+
+func (c *cohort) GetName() string {
+	return c.Name
+}

--- a/pkg/queue/dumper.go
+++ b/pkg/queue/dumper.go
@@ -26,7 +26,7 @@ import (
 func (m *Manager) LogDump(log logr.Logger) {
 	m.Lock()
 	defer m.Unlock()
-	for name, cq := range m.clusterQueues {
+	for name, cq := range m.hm.ClusterQueues {
 		pending, _ := cq.Dump()
 		inadmissible, _ := cq.DumpInadmissible()
 		log.Info("Found pending and inadmissible workloads in ClusterQueue",
@@ -41,11 +41,11 @@ func (m *Manager) LogDump(log logr.Logger) {
 func (m *Manager) Dump() map[string][]string {
 	m.Lock()
 	defer m.Unlock()
-	if len(m.clusterQueues) == 0 {
+	if len(m.hm.ClusterQueues) == 0 {
 		return nil
 	}
-	dump := make(map[string][]string, len(m.clusterQueues))
-	for key, cq := range m.clusterQueues {
+	dump := make(map[string][]string, len(m.hm.ClusterQueues))
+	for key, cq := range m.hm.ClusterQueues {
 		if elements, ok := cq.Dump(); ok {
 			dump[key] = elements
 		}
@@ -61,11 +61,11 @@ func (m *Manager) Dump() map[string][]string {
 func (m *Manager) DumpInadmissible() map[string][]string {
 	m.Lock()
 	defer m.Unlock()
-	if len(m.clusterQueues) == 0 {
+	if len(m.hm.ClusterQueues) == 0 {
 		return nil
 	}
-	dump := make(map[string][]string, len(m.clusterQueues))
-	for key, cq := range m.clusterQueues {
+	dump := make(map[string][]string, len(m.hm.ClusterQueues))
+	for key, cq := range m.hm.ClusterQueues {
 		if elements, ok := cq.DumpInadmissible(); ok {
 			dump[key] = elements
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
We define `hierarchy.Manager`, which manages `ClusterQueues`, `Cohorts`, and their edges. Currently, we duplicate logic which creates and updates edges, and creates/deletes implicit Cohorts (those without backing API objects). This change moves all of the relevant logic into a new package, `hierarchy`.

This change is important for the implementation of #79. With Hierarchical Cohorts, we have to account for both implicit and explicit Cohorts, in addition to new edges (Cohorts as parents and children of other Cohorts).

Additionally, the `hierarchy` package does not export the edges' fields, preventing unintentional manipulation outside of the `hierarchy.Manager` interface.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```