### PR TITLE
Cherry-pick of #2807 to 0.8

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -334,6 +334,25 @@ const (
 	WorkloadDeactivationTarget = "DeactivationTarget"
 )
 
+// Reasons for the WorkloadPreempted condition.
+const (
+	// InClusterQueueReason indicates the Workload was preempted due to
+	// prioritization in the ClusterQueue.
+	InClusterQueueReason string = "InClusterQueue"
+
+	// InCohortReclamationReason indicates the Workload was preempted due to
+	// reclamation within the Cohort.
+	InCohortReclamationReason string = "InCohortReclamation"
+
+	// InCohortFairSharingReason indicates the Workload was preempted due to
+	// fair sharing within the cohort.
+	InCohortFairSharingReason string = "InCohortFairSharing"
+
+	// InCohortReclaimWhileBorrowingReason indicates the Workload was preempted
+	// due to reclamation within the cohort while borrowing.
+	InCohortReclaimWhileBorrowingReason string = "InCohortReclaimWhileBorrowing"
+)
+
 const (
 	// WorkloadInadmissible means that the Workload can't reserve quota
 	// due to LocalQueue or ClusterQueue doesn't exist or inactive.

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -174,23 +174,11 @@ func canBorrowWithinCohort(cq *cache.ClusterQueueSnapshot, wl *kueue.Workload) (
 	return true, &threshold
 }
 
-// In cluster queue preemption reasons
-const (
-	InClusterQueueReason string = "InClusterQueue"
-)
-
-// In cohort preemption reasons
-const (
-	InCohortReclamationReason           string = "InCohortReclamation"
-	InCohortFairSharingReason           string = "InCohortFairSharing"
-	InCohortReclaimWhileBorrowingReason string = "InCohortReclaimWhileBorrowing"
-)
-
 var HumanReadablePreemptionReasons = map[string]string{
-	InClusterQueueReason:                "prioritization in the ClusterQueue",
-	InCohortReclamationReason:           "reclamation within the cohort",
-	InCohortFairSharingReason:           "fair sharing within the cohort",
-	InCohortReclaimWhileBorrowingReason: "reclamation within the cohort while borrowing",
+	kueue.InClusterQueueReason:                "prioritization in the ClusterQueue",
+	kueue.InCohortReclamationReason:           "reclamation within the cohort",
+	kueue.InCohortFairSharingReason:           "fair sharing within the cohort",
+	kueue.InCohortReclaimWhileBorrowingReason: "reclamation within the cohort while borrowing",
 }
 
 // IssuePreemptions marks the target workloads as evicted.
@@ -245,12 +233,12 @@ func minimalPreemptions(log logr.Logger, requests resources.FlavorResourceQuanti
 	fits := false
 	for _, candWl := range candidates {
 		candCQ := snapshot.ClusterQueues[candWl.ClusterQueue]
-		reason := InClusterQueueReason
+		reason := kueue.InClusterQueueReason
 		if cq != candCQ {
 			if !cqIsBorrowing(candCQ, frsNeedPreemption) {
 				continue
 			}
-			reason = InCohortReclamationReason
+			reason = kueue.InCohortReclamationReason
 			if allowBorrowingBelowPriority != nil {
 				if priority.Priority(candWl.Obj) >= *allowBorrowingBelowPriority {
 					// We set allowBorrowing=false if there is a candidate with priority
@@ -267,7 +255,7 @@ func minimalPreemptions(log logr.Logger, requests resources.FlavorResourceQuanti
 					// the function.
 					allowBorrowing = false
 				} else {
-					reason = InCohortReclaimWhileBorrowingReason
+					reason = kueue.InCohortReclaimWhileBorrowingReason
 				}
 			}
 		}
@@ -360,7 +348,7 @@ func (p *Preemptor) fairPreemptions(log logr.Logger, wl workload.Info, requests 
 			snapshot.RemoveWorkload(candWl)
 			targets = append(targets, &Target{
 				WorkloadInfo: candWl,
-				Reason:       InClusterQueueReason,
+				Reason:       kueue.InClusterQueueReason,
 			})
 			if workloadFits(requests, nominatedCQ, true) {
 				fits = true
@@ -381,9 +369,9 @@ func (p *Preemptor) fairPreemptions(log logr.Logger, wl workload.Info, requests 
 			strategy := p.fsStrategies[0](newNominatedShareValue, candCQ.share, newCandShareVal)
 			if belowThreshold || strategy {
 				snapshot.RemoveWorkload(candWl)
-				reason := InCohortFairSharingReason
+				reason := kueue.InCohortFairSharingReason
 				if !strategy {
-					reason = InCohortReclaimWhileBorrowingReason
+					reason = kueue.InCohortReclaimWhileBorrowingReason
 				}
 
 				targets = append(targets, &Target{
@@ -420,7 +408,7 @@ func (p *Preemptor) fairPreemptions(log logr.Logger, wl workload.Info, requests 
 				snapshot.RemoveWorkload(candWl)
 				targets = append(targets, &Target{
 					WorkloadInfo: candWl,
-					Reason:       InCohortFairSharingReason,
+					Reason:       kueue.InCohortFairSharingReason,
 				})
 				if workloadFits(requests, nominatedCQ, true) {
 					fits = true

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -310,7 +310,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/low", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/low", kueue.InClusterQueueReason)),
 		},
 		"preempt multiple": {
 			admitted: []kueue.Workload{
@@ -340,7 +340,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/low", InClusterQueueReason), targetKeyReason("/mid", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/low", kueue.InClusterQueueReason), targetKeyReason("/mid", kueue.InClusterQueueReason)),
 		},
 
 		"no preemption for low priority": {
@@ -418,7 +418,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/low", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/low", kueue.InClusterQueueReason)),
 		},
 		"minimal set excludes low priority": {
 			admitted: []kueue.Workload{
@@ -448,7 +448,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/mid", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/mid", kueue.InClusterQueueReason)),
 		},
 		"only preempt workloads using the chosen flavor": {
 			admitted: []kueue.Workload{
@@ -483,7 +483,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/mid", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/mid", kueue.InClusterQueueReason)),
 		},
 		"reclaim quota from borrower": {
 			admitted: []kueue.Workload{
@@ -513,7 +513,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/c2-mid", InCohortReclamationReason)),
+			wantPreempted: sets.New(targetKeyReason("/c2-mid", kueue.InCohortReclamationReason)),
 		},
 		"reclaim quota if workload requests 0 resources for a resource at nominal quota": {
 			admitted: []kueue.Workload{
@@ -549,7 +549,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Fit,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/c2-mid", InCohortReclamationReason)),
+			wantPreempted: sets.New(targetKeyReason("/c2-mid", kueue.InCohortReclamationReason)),
 		},
 		"no workloads borrowing": {
 			admitted: []kueue.Workload{
@@ -640,7 +640,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/c1-low", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/c1-low", kueue.InClusterQueueReason)),
 		},
 		"preempting locally and borrowing same resource in cohort": {
 			admitted: []kueue.Workload{
@@ -671,7 +671,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/c1-low", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/c1-low", kueue.InClusterQueueReason)),
 		},
 		"preempting locally and borrowing same resource in cohort; no borrowing limit in the cohort": {
 			admitted: []kueue.Workload{
@@ -702,7 +702,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/d1-low", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/d1-low", kueue.InClusterQueueReason)),
 		},
 		"preempting locally and borrowing other resources in cohort, with cohort candidates": {
 			admitted: []kueue.Workload{
@@ -743,7 +743,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/c1-med", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/c1-med", kueue.InClusterQueueReason)),
 		},
 		"preempting locally and not borrowing same resource in 1-queue cohort": {
 			admitted: []kueue.Workload{
@@ -769,7 +769,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/l1-med", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/l1-med", kueue.InClusterQueueReason)),
 		},
 		"do not reclaim borrowed quota from same priority for withinCohort=ReclaimFromLowerPriority": {
 			admitted: []kueue.Workload{
@@ -823,7 +823,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/c1-1", InCohortReclamationReason)),
+			wantPreempted: sets.New(targetKeyReason("/c1-1", kueue.InCohortReclamationReason)),
 		},
 		"preempt from all ClusterQueues in cohort": {
 			admitted: []kueue.Workload{
@@ -856,7 +856,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/c1-low", InClusterQueueReason), targetKeyReason("/c2-low", InCohortReclamationReason)),
+			wantPreempted: sets.New(targetKeyReason("/c1-low", kueue.InClusterQueueReason), targetKeyReason("/c2-low", kueue.InCohortReclamationReason)),
 		},
 		"can't preempt workloads in ClusterQueue for withinClusterQueue=Never": {
 			admitted: []kueue.Workload{
@@ -922,7 +922,7 @@ func TestPreemption(t *testing.T) {
 					},
 				},
 			},
-			wantPreempted: sets.New(targetKeyReason("/low-alpha", InClusterQueueReason), targetKeyReason("/low-beta", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/low-alpha", kueue.InClusterQueueReason), targetKeyReason("/low-beta", kueue.InClusterQueueReason)),
 		},
 		"preempt newer workloads with the same priority": {
 			admitted: []kueue.Workload{
@@ -971,7 +971,7 @@ func TestPreemption(t *testing.T) {
 					},
 				},
 			},
-			wantPreempted: sets.New(targetKeyReason("/wl2", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/wl2", kueue.InClusterQueueReason)),
 		},
 		"use BorrowWithinCohort; allow preempting a lower-priority workload from another ClusterQueue while borrowing": {
 			admitted: []kueue.Workload{
@@ -996,7 +996,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/a_best_effort_low", InCohortReclaimWhileBorrowingReason)),
+			wantPreempted: sets.New(targetKeyReason("/a_best_effort_low", kueue.InCohortReclaimWhileBorrowingReason)),
 		},
 		"use BorrowWithinCohort; don't allow preempting a lower-priority workload with priority above MaxPriorityThreshold, if borrowing is required even after the preemption": {
 			admitted: []kueue.Workload{
@@ -1039,7 +1039,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/b_standard", InCohortReclamationReason)),
+			wantPreempted: sets.New(targetKeyReason("/b_standard", kueue.InCohortReclamationReason)),
 		},
 		"use BorrowWithinCohort; don't allow for preemption of lower-priority workload from the same ClusterQueue": {
 			admitted: []kueue.Workload{
@@ -1095,7 +1095,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/b_standard_1", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/b_standard_1", kueue.InClusterQueueReason)),
 		},
 		"use BorrowWithinCohort; preempt from CQ and from other CQs with workloads below threshold": {
 			admitted: []kueue.Workload{
@@ -1131,7 +1131,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/b_standard_mid", InClusterQueueReason), targetKeyReason("/a_best_effort_lower", InCohortReclaimWhileBorrowingReason)),
+			wantPreempted: sets.New(targetKeyReason("/b_standard_mid", kueue.InClusterQueueReason), targetKeyReason("/a_best_effort_lower", kueue.InCohortReclaimWhileBorrowingReason)),
 		},
 		"reclaim quota from lender": {
 			admitted: []kueue.Workload{
@@ -1161,7 +1161,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted:      sets.New(targetKeyReason("/lend2-mid", InCohortReclamationReason)),
+			wantPreempted:      sets.New(targetKeyReason("/lend2-mid", kueue.InCohortReclamationReason)),
 			enableLendingLimit: true,
 		},
 		"preempt from all ClusterQueues in cohort-lend": {
@@ -1195,7 +1195,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted:      sets.New(targetKeyReason("/lend1-low", InClusterQueueReason), targetKeyReason("/lend2-low", InCohortReclamationReason)),
+			wantPreempted:      sets.New(targetKeyReason("/lend1-low", kueue.InClusterQueueReason), targetKeyReason("/lend2-low", kueue.InCohortReclamationReason)),
 			enableLendingLimit: true,
 		},
 		"cannot preempt from other ClusterQueues if exceeds requestable quota including lending limit": {
@@ -1263,7 +1263,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/a1", InClusterQueueReason), targetKeyReason("/a2", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/a1", kueue.InClusterQueueReason), targetKeyReason("/a2", kueue.InClusterQueueReason)),
 		},
 		"preemptions from cq when target queue is exhausted for two requested resources": {
 			admitted: []kueue.Workload{
@@ -1320,7 +1320,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/a1", InClusterQueueReason), targetKeyReason("/a2", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/a1", kueue.InClusterQueueReason), targetKeyReason("/a2", kueue.InClusterQueueReason)),
 		},
 		"preemptions from cq when target queue is exhausted for one requested resource, but not the other": {
 			admitted: []kueue.Workload{
@@ -1371,7 +1371,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/a1", InClusterQueueReason), targetKeyReason("/a2", InClusterQueueReason)),
+			wantPreempted: sets.New(targetKeyReason("/a1", kueue.InClusterQueueReason), targetKeyReason("/a2", kueue.InClusterQueueReason)),
 		},
 		"allow preemption from other cluster queues if target cq is not exhausted for the requested resource": {
 			admitted: []kueue.Workload{
@@ -1416,7 +1416,7 @@ func TestPreemption(t *testing.T) {
 					Mode: flavorassigner.Preempt,
 				},
 			}),
-			wantPreempted: sets.New(targetKeyReason("/a1", InClusterQueueReason), targetKeyReason("/b5", InCohortReclamationReason)),
+			wantPreempted: sets.New(targetKeyReason("/a1", kueue.InClusterQueueReason), targetKeyReason("/b5", kueue.InCohortReclamationReason)),
 		},
 	}
 	for name, tc := range cases {
@@ -1551,7 +1551,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      unitWl.Clone().Name("c_incoming").Obj(),
 			targetCQ:      "c",
-			wantPreempted: sets.New(targetKeyReason("/b1", InCohortFairSharingReason)),
+			wantPreempted: sets.New(targetKeyReason("/b1", kueue.InCohortFairSharingReason)),
 		},
 		"can reclaim from queue using less, if taking the latest workload from user using the most isn't enough": {
 			clusterQueues: baseCQs,
@@ -1563,7 +1563,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      utiltesting.MakeWorkload("c_incoming", "").Request(corev1.ResourceCPU, "3").SimpleReserveQuota("a", "default", now).Obj(),
 			targetCQ:      "c",
-			wantPreempted: sets.New(targetKeyReason("/a1", InCohortFairSharingReason)), // attempts to preempt b1, but it's not enough.
+			wantPreempted: sets.New(targetKeyReason("/a1", kueue.InCohortFairSharingReason)), // attempts to preempt b1, but it's not enough.
 		},
 		"reclaim borrowable quota from user using the most": {
 			clusterQueues: baseCQs,
@@ -1580,7 +1580,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      unitWl.Clone().Name("a_incoming").Obj(),
 			targetCQ:      "a",
-			wantPreempted: sets.New(targetKeyReason("/b1", InCohortFairSharingReason)),
+			wantPreempted: sets.New(targetKeyReason("/b1", kueue.InCohortFairSharingReason)),
 		},
 		"preempt one from each CQ borrowing": {
 			clusterQueues: baseCQs,
@@ -1595,8 +1595,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("c_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ: "c",
 			wantPreempted: sets.New(
-				targetKeyReason("/a1", InCohortFairSharingReason),
-				targetKeyReason("/b1", InCohortFairSharingReason),
+				targetKeyReason("/a1", kueue.InCohortFairSharingReason),
+				targetKeyReason("/b1", kueue.InCohortFairSharingReason),
 			),
 		},
 		"can't preempt when everyone under nominal": {
@@ -1646,8 +1646,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReason("/a1_low", InClusterQueueReason),
-				targetKeyReason("/a2_low", InClusterQueueReason),
+				targetKeyReason("/a1_low", kueue.InClusterQueueReason),
+				targetKeyReason("/a2_low", kueue.InClusterQueueReason),
 			),
 		},
 		"can preempt a combination of same CQ and highest user": {
@@ -1666,8 +1666,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReason("/a_low", InClusterQueueReason),
-				targetKeyReason("/b1", InCohortFairSharingReason),
+				targetKeyReason("/a_low", kueue.InClusterQueueReason),
+				targetKeyReason("/b1", kueue.InCohortFairSharingReason),
 			),
 		},
 		"preempt huge workload if there is no other option, as long as the target CQ gets a lower share": {
@@ -1677,7 +1677,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ:      "a",
-			wantPreempted: sets.New(targetKeyReason("/b1", InCohortFairSharingReason)),
+			wantPreempted: sets.New(targetKeyReason("/b1", kueue.InCohortFairSharingReason)),
 		},
 		"can't preempt huge workload if the incoming is also huge": {
 			clusterQueues: baseCQs,
@@ -1709,8 +1709,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "4").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReason("/a1_low", InClusterQueueReason),
-				targetKeyReason("/b1", InCohortFairSharingReason),
+				targetKeyReason("/a1_low", kueue.InClusterQueueReason),
+				targetKeyReason("/b1", kueue.InCohortFairSharingReason),
 			),
 		},
 		"prefer to preempt workloads that don't make the target CQ have the biggest share": {
@@ -1724,7 +1724,7 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "3.5").Obj(),
 			targetCQ: "a",
 			// It would have been possible to preempt "/b1" under rule S2-b, but S2-a was possible first.
-			wantPreempted: sets.New(targetKeyReason("/b2", InCohortFairSharingReason)),
+			wantPreempted: sets.New(targetKeyReason("/b2", kueue.InCohortFairSharingReason)),
 		},
 		"preempt from different cluster queues if the end result has a smaller max share": {
 			clusterQueues: baseCQs,
@@ -1737,8 +1737,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "3.5").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReason("/b1", InCohortFairSharingReason),
-				targetKeyReason("/c1", InCohortFairSharingReason),
+				targetKeyReason("/b1", kueue.InCohortFairSharingReason),
+				targetKeyReason("/c1", kueue.InCohortFairSharingReason),
 			),
 		},
 		"scenario above does not flap": {
@@ -1777,8 +1777,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReason("/preemptible1", InCohortFairSharingReason),
-				targetKeyReason("/preemptible2", InCohortReclaimWhileBorrowingReason),
+				targetKeyReason("/preemptible1", kueue.InCohortFairSharingReason),
+				targetKeyReason("/preemptible2", kueue.InCohortReclaimWhileBorrowingReason),
 			),
 		},
 		"preempt lower priority first, even if big": {
@@ -1791,7 +1791,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "1").Obj(),
 			targetCQ:      "a",
-			wantPreempted: sets.New(targetKeyReason("/b_low", InCohortFairSharingReason)),
+			wantPreempted: sets.New(targetKeyReason("/b_low", kueue.InCohortFairSharingReason)),
 		},
 		"preempt workload that doesn't transfer the imbalance, even if high priority": {
 			clusterQueues: baseCQs,
@@ -1803,7 +1803,7 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming:      utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "1").Obj(),
 			targetCQ:      "a",
-			wantPreempted: sets.New(targetKeyReason("/b_high", InCohortFairSharingReason)),
+			wantPreempted: sets.New(targetKeyReason("/b_high", kueue.InCohortFairSharingReason)),
 		},
 		"CQ with higher weight can preempt more": {
 			clusterQueues: []*kueue.ClusterQueue{
@@ -1850,8 +1850,8 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReason("/b1", InCohortFairSharingReason),
-				targetKeyReason("/b2", InCohortFairSharingReason),
+				targetKeyReason("/b1", kueue.InCohortFairSharingReason),
+				targetKeyReason("/b2", kueue.InCohortFairSharingReason),
 			),
 		},
 		"can preempt anything borrowing from CQ with 0 weight": {
@@ -1899,9 +1899,9 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: utiltesting.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "3").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReason("/b1", InCohortFairSharingReason),
-				targetKeyReason("/b2", InCohortFairSharingReason),
-				targetKeyReason("/b3", InCohortFairSharingReason),
+				targetKeyReason("/b1", kueue.InCohortFairSharingReason),
+				targetKeyReason("/b2", kueue.InCohortFairSharingReason),
+				targetKeyReason("/b3", kueue.InCohortFairSharingReason),
 			),
 		},
 		"can't preempt nominal from CQ with 0 weight": {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2751,45 +2751,153 @@ func TestEntryOrdering(t *testing.T) {
 			},
 		},
 	}
+	inputForOrderingPreemptedWorkloads := []entry{
+		{
+			Info: workload.Info{
+				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+					Name:              "old-mid-recently-preempted-in-queue",
+					CreationTimestamp: metav1.NewTime(now),
+				}, Spec: kueue.WorkloadSpec{
+					Priority: ptr.To[int32](1),
+				}, Status: kueue.WorkloadStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               kueue.WorkloadPreempted,
+							Status:             metav1.ConditionTrue,
+							Reason:             kueue.InClusterQueueReason,
+							LastTransitionTime: metav1.NewTime(now.Add(5 * time.Second)),
+						},
+					},
+				}},
+			},
+		},
+		{
+			Info: workload.Info{
+				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+					Name:              "old-mid-recently-reclaimed-while-borrowing",
+					CreationTimestamp: metav1.NewTime(now),
+				}, Spec: kueue.WorkloadSpec{
+					Priority: ptr.To[int32](1),
+				}, Status: kueue.WorkloadStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               kueue.WorkloadPreempted,
+							Status:             metav1.ConditionTrue,
+							Reason:             kueue.InCohortReclaimWhileBorrowingReason,
+							LastTransitionTime: metav1.NewTime(now.Add(6 * time.Second)),
+						},
+					},
+				}},
+			},
+		},
+		{
+			Info: workload.Info{
+				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+					Name:              "old-mid-more-recently-reclaimed-while-borrowing",
+					CreationTimestamp: metav1.NewTime(now),
+				}, Spec: kueue.WorkloadSpec{
+					Priority: ptr.To[int32](1),
+				}, Status: kueue.WorkloadStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               kueue.WorkloadPreempted,
+							Status:             metav1.ConditionTrue,
+							Reason:             kueue.InCohortReclaimWhileBorrowingReason,
+							LastTransitionTime: metav1.NewTime(now.Add(7 * time.Second)),
+						},
+					},
+				}},
+			},
+		},
+		{
+			Info: workload.Info{
+				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+					Name:              "old-mid-not-preempted-yet",
+					CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
+				}, Spec: kueue.WorkloadSpec{
+					Priority: ptr.To[int32](1),
+				}},
+			},
+		},
+		{
+			Info: workload.Info{
+				Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{
+					Name:              "preemptor",
+					CreationTimestamp: metav1.NewTime(now.Add(7 * time.Second)),
+				}, Spec: kueue.WorkloadSpec{
+					Priority: ptr.To[int32](2),
+				}},
+			},
+		},
+	}
 	for _, tc := range []struct {
 		name             string
+		input            []entry
 		prioritySorting  bool
 		workloadOrdering workload.Ordering
 		wantOrder        []string
 	}{
 		{
 			name:             "Priority sorting is enabled (default) using pods-ready Eviction timestamp (default)",
+			input:            input,
 			prioritySorting:  true,
 			workloadOrdering: workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
 			wantOrder:        []string{"new_high_pri", "old", "recently_evicted", "new", "high_pri_borrowing", "old_borrowing", "evicted_borrowing", "new_borrowing"},
 		},
 		{
 			name:             "Priority sorting is enabled (default) using pods-ready Creation timestamp",
+			input:            input,
 			prioritySorting:  true,
 			workloadOrdering: workload.Ordering{PodsReadyRequeuingTimestamp: config.CreationTimestamp},
 			wantOrder:        []string{"new_high_pri", "recently_evicted", "old", "new", "high_pri_borrowing", "old_borrowing", "evicted_borrowing", "new_borrowing"},
 		},
 		{
 			name:             "Priority sorting is disabled using pods-ready Eviction timestamp",
+			input:            input,
 			prioritySorting:  false,
 			workloadOrdering: workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
 			wantOrder:        []string{"old", "recently_evicted", "new", "new_high_pri", "old_borrowing", "evicted_borrowing", "high_pri_borrowing", "new_borrowing"},
 		},
 		{
 			name:             "Priority sorting is disabled using pods-ready Creation timestamp",
+			input:            input,
 			prioritySorting:  false,
 			workloadOrdering: workload.Ordering{PodsReadyRequeuingTimestamp: config.CreationTimestamp},
 			wantOrder:        []string{"recently_evicted", "old", "new", "new_high_pri", "old_borrowing", "evicted_borrowing", "high_pri_borrowing", "new_borrowing"},
+		},
+		{
+			name:            "Some workloads are preempted; Priority sorting is disabled",
+			input:           inputForOrderingPreemptedWorkloads,
+			prioritySorting: false,
+			wantOrder: []string{
+				"old-mid-recently-preempted-in-queue",
+				"old-mid-not-preempted-yet",
+				"old-mid-recently-reclaimed-while-borrowing",
+				"preemptor",
+				"old-mid-more-recently-reclaimed-while-borrowing",
+			},
+		},
+		{
+			name:            "Some workloads are preempted; Priority sorting is enabled",
+			input:           inputForOrderingPreemptedWorkloads,
+			prioritySorting: true,
+			wantOrder: []string{
+				"preemptor",
+				"old-mid-recently-preempted-in-queue",
+				"old-mid-recently-reclaimed-while-borrowing",
+				"old-mid-more-recently-reclaimed-while-borrowing",
+				"old-mid-not-preempted-yet",
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Cleanup(features.SetFeatureGateDuringTest(t, features.PrioritySortingWithinCohort, tc.prioritySorting))
 			sort.Sort(entryOrdering{
-				entries:          input,
+				entries:          tc.input,
 				workloadOrdering: tc.workloadOrdering},
 			)
-			order := make([]string, len(input))
-			for i, e := range input {
+			order := make([]string, len(tc.input))
+			for i, e := range tc.input {
 				order[i] = e.Obj.Name
 			}
 			if diff := cmp.Diff(tc.wantOrder, order); diff != "" {

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -138,7 +138,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			util.FinishEvictionForWorkloads(ctx, k8sClient, lowWl1, lowWl2)
 			util.ExpectEvictedWorkloadsTotalMetric(cq.Name, kueue.WorkloadEvictedByPreemption, 2)
-			util.ExpectPreemptedWorkloadsTotalMetric(cq.Name, preemption.InClusterQueueReason, 2)
+			util.ExpectPreemptedWorkloadsTotalMetric(cq.Name, kueue.InClusterQueueReason, 2)
 
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, highWl2)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, lowWl1, lowWl2)
@@ -282,12 +282,12 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			conditionCmpOpts := cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime")
 			ginkgo.By("Verify the Preempted condition", func() {
-				util.ExpectPreemptedCondition(ctx, k8sClient, preemption.InClusterQueueReason, metav1.ConditionTrue, alphaLowWl, alphaMidWl)
-				util.ExpectPreemptedCondition(ctx, k8sClient, preemption.InCohortReclamationReason, metav1.ConditionTrue, betaMidWl, alphaMidWl)
-				util.ExpectPreemptedWorkloadsTotalMetric(alphaCQ.Name, preemption.InClusterQueueReason, 1)
-				util.ExpectPreemptedWorkloadsTotalMetric(alphaCQ.Name, preemption.InCohortReclamationReason, 1)
-				util.ExpectPreemptedWorkloadsTotalMetric(betaCQ.Name, preemption.InClusterQueueReason, 0)
-				util.ExpectPreemptedWorkloadsTotalMetric(betaCQ.Name, preemption.InCohortReclamationReason, 0)
+				util.ExpectPreemptedCondition(ctx, k8sClient, kueue.InClusterQueueReason, metav1.ConditionTrue, alphaLowWl, alphaMidWl)
+				util.ExpectPreemptedCondition(ctx, k8sClient, kueue.InCohortReclamationReason, metav1.ConditionTrue, betaMidWl, alphaMidWl)
+				util.ExpectPreemptedWorkloadsTotalMetric(alphaCQ.Name, kueue.InClusterQueueReason, 1)
+				util.ExpectPreemptedWorkloadsTotalMetric(alphaCQ.Name, kueue.InCohortReclamationReason, 1)
+				util.ExpectPreemptedWorkloadsTotalMetric(betaCQ.Name, kueue.InClusterQueueReason, 0)
+				util.ExpectPreemptedWorkloadsTotalMetric(betaCQ.Name, kueue.InCohortReclamationReason, 0)
 			})
 
 			ginkgo.By("Verify the Preempted condition on re-admission, as the preemptor is finished", func() {
@@ -301,7 +301,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 						Type:    kueue.WorkloadPreempted,
 						Status:  metav1.ConditionFalse,
 						Reason:  "QuotaReserved",
-						Message: fmt.Sprintf("Previously: Preempted to accommodate a workload (UID: %s) due to %s", alphaMidWl.UID, preemption.HumanReadablePreemptionReasons[preemption.InClusterQueueReason]),
+						Message: fmt.Sprintf("Previously: Preempted to accommodate a workload (UID: %s) due to %s", alphaMidWl.UID, preemption.HumanReadablePreemptionReasons[kueue.InClusterQueueReason]),
 					}, conditionCmpOpts))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -311,7 +311,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 						Type:    kueue.WorkloadPreempted,
 						Status:  metav1.ConditionFalse,
 						Reason:  "QuotaReserved",
-						Message: fmt.Sprintf("Previously: Preempted to accommodate a workload (UID: %s) due to %s", alphaMidWl.UID, preemption.HumanReadablePreemptionReasons[preemption.InCohortReclamationReason]),
+						Message: fmt.Sprintf("Previously: Preempted to accommodate a workload (UID: %s) due to %s", alphaMidWl.UID, preemption.HumanReadablePreemptionReasons[kueue.InCohortReclamationReason]),
 					}, conditionCmpOpts))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -693,9 +693,9 @@ var _ = ginkgo.Describe("Preemption", func() {
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, aStandardVeryHighWl)).To(gomega.Succeed())
 
-			util.ExpectPreemptedCondition(ctx, k8sClient, preemption.InCohortReclaimWhileBorrowingReason, metav1.ConditionTrue, aBestEffortLowWl, aStandardVeryHighWl)
-			util.ExpectPreemptedWorkloadsTotalMetric(aStandardCQ.Name, preemption.InCohortReclaimWhileBorrowingReason, 1)
-			util.ExpectPreemptedWorkloadsTotalMetric(aBestEffortCQ.Name, preemption.InCohortReclaimWhileBorrowingReason, 0)
+			util.ExpectPreemptedCondition(ctx, k8sClient, kueue.InCohortReclaimWhileBorrowingReason, metav1.ConditionTrue, aBestEffortLowWl, aStandardVeryHighWl)
+			util.ExpectPreemptedWorkloadsTotalMetric(aStandardCQ.Name, kueue.InCohortReclaimWhileBorrowingReason, 1)
+			util.ExpectPreemptedWorkloadsTotalMetric(aBestEffortCQ.Name, kueue.InCohortReclaimWhileBorrowingReason, 0)
 
 			ginkgo.By("Finish eviction fo the a-best-effort-low workload")
 			util.FinishEvictionForWorkloads(ctx, k8sClient, aBestEffortLowWl)

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -783,4 +783,121 @@ var _ = ginkgo.Describe("Preemption", func() {
 				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "alpha", "4").Obj())
 		})
 	})
+
+	ginkgo.Context("When borrowWithinCohort is used and PrioritySortingWithinCohort disabled", func() {
+		var (
+			aCQ, bCQ, cCQ *kueue.ClusterQueue
+			aLQ, bLQ      *kueue.LocalQueue
+			defaultFlavor *kueue.ResourceFlavor
+		)
+
+		ginkgo.BeforeEach(func() {
+			gomega.Expect(features.SetEnable(features.PrioritySortingWithinCohort, false)).To(gomega.Succeed())
+			defaultFlavor = testing.MakeResourceFlavor("default").Obj()
+			gomega.Expect(k8sClient.Create(ctx, defaultFlavor)).To(gomega.Succeed())
+
+			aCQ = testing.MakeClusterQueue("a-cq").
+				Cohort("all").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "0", "10").Obj(),
+				).
+				FlavorFungibility(kueue.FlavorFungibility{
+					WhenCanBorrow:  kueue.Borrow,
+					WhenCanPreempt: kueue.Preempt,
+				}).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				}).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, aCQ)).To(gomega.Succeed())
+			aLQ = testing.MakeLocalQueue("a-lq", ns.Name).ClusterQueue(aCQ.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, aLQ)).To(gomega.Succeed())
+
+			bCQ = testing.MakeClusterQueue("b-cq").
+				Cohort("all").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5", "5").Obj(),
+				).
+				FlavorFungibility(kueue.FlavorFungibility{
+					WhenCanBorrow:  kueue.Borrow,
+					WhenCanPreempt: kueue.Preempt,
+				}).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+					BorrowWithinCohort: &kueue.BorrowWithinCohort{
+						Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
+						MaxPriorityThreshold: ptr.To(veryHighPriority),
+					},
+				}).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, bCQ)).To(gomega.Succeed())
+			bLQ = testing.MakeLocalQueue("b-lq", ns.Name).ClusterQueue(bCQ.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, bLQ)).To(gomega.Succeed())
+
+			cCQ = testing.MakeClusterQueue("c-cq").
+				Cohort("all").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj(),
+				).
+				FlavorFungibility(kueue.FlavorFungibility{
+					WhenCanBorrow:  kueue.Borrow,
+					WhenCanPreempt: kueue.Preempt,
+				}).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				}).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, cCQ)).To(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(features.SetEnable(features.PrioritySortingWithinCohort, true)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, aCQ, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, bCQ, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cCQ, true)
+		})
+
+		ginkgo.It("should allow preempting workloads while borrowing", func() {
+			var aWl, b1Wl, b2Wl *kueue.Workload
+
+			ginkgo.By("Create a mid priority workload in aCQ and await for admission", func() {
+				aWl = testing.MakeWorkload("a-low", ns.Name).
+					Queue(aLQ.Name).
+					Priority(midPriority).
+					Request(corev1.ResourceCPU, "4").
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, aWl)).To(gomega.Succeed())
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, aWl)
+			})
+
+			ginkgo.By("Create a high priority workload b1 in bCQ and await for admission", func() {
+				b1Wl = testing.MakeWorkload("b1-high", ns.Name).
+					Queue(bLQ.Name).
+					Priority(highPriority).
+					Request(corev1.ResourceCPU, "4").
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, b1Wl)).To(gomega.Succeed())
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, b1Wl)
+			})
+
+			ginkgo.By("Create a high priority workload b2 in bCQ", func() {
+				b2Wl = testing.MakeWorkload("b2-high", ns.Name).
+					Queue(bLQ.Name).
+					Priority(highPriority).
+					Request(corev1.ResourceCPU, "4").
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, b2Wl)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("Await for preemption of the workload in aCQ and admission of b2", func() {
+				util.FinishEvictionForWorkloads(ctx, k8sClient, aWl)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, aWl)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, b2Wl)
+			})
+		})
+	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Cherry-pick https://github.com/kubernetes-sigs/kueue/pull/2807 to 0.8

#### Special notes for your reviewer:

There are commits from two PRs:
- preparatory PR https://github.com/kubernetes-sigs/kueue/pull/2814/
- actual fix: https://github.com/kubernetes-sigs/kueue/pull/2807

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Prevent infinite preemption loop when PrioritySortingWithingCohort=false
is used together with borrowWithinCohort.
```