### PR TITLE
Automated cherry pick of #2476: Publish images to new staging registry

### DIFF
--- a/.github/ISSUE_TEMPLATE/NEW_RELEASE.md
+++ b/.github/ISSUE_TEMPLATE/NEW_RELEASE.md
@@ -37,7 +37,7 @@ Please do not remove items from the checklist
 - [ ] An OWNER pushes the tag with
       `git push $VERSION`
   - Triggers prow to build and publish a staging container image
-      `us-central1-docker.pkg.dev/k8s-staging-images/kueue:$VERSION`
+      `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:$VERSION`
 - [ ] Submit a PR against [k8s.io](https://github.com/kubernetes/k8s.io),
       updating `registry.k8s.io/images/k8s-staging-kueue/images.yaml` to
       [promote the container images](https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io#image-promoter)

--- a/.github/ISSUE_TEMPLATE/NEW_RELEASE.md
+++ b/.github/ISSUE_TEMPLATE/NEW_RELEASE.md
@@ -37,7 +37,7 @@ Please do not remove items from the checklist
 - [ ] An OWNER pushes the tag with
       `git push $VERSION`
   - Triggers prow to build and publish a staging container image
-      `gcr.io/k8s-staging-kueue/kueue:$VERSION`
+      `us-central1-docker.pkg.dev/k8s-staging-images/kueue:$VERSION`
 - [ ] Submit a PR against [k8s.io](https://github.com/kubernetes/k8s.io),
       updating `registry.k8s.io/images/k8s-staging-kueue/images.yaml` to
       [promote the container images](https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io#image-promoter)

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DOCKER_BUILDX_CMD ?= docker buildx
 IMAGE_BUILD_CMD ?= $(DOCKER_BUILDX_CMD) build
 IMAGE_BUILD_EXTRA_OPTS ?=
 # TODO(#52): Add kueue to k8s gcr registry
-STAGING_IMAGE_REGISTRY := gcr.io/k8s-staging-kueue
+STAGING_IMAGE_REGISTRY := us-central1-docker.pkg.dev/k8s-staging-images
 IMAGE_REGISTRY ?= $(STAGING_IMAGE_REGISTRY)
 IMAGE_NAME := kueue
 IMAGE_REPO ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME)
@@ -212,7 +212,7 @@ image-push: image-build
 
 .PHONY: helm-chart-push
 helm-chart-push: yq helm
-	EXTRA_TAG="$(EXTRA_TAG)" GIT_TAG="$(GIT_TAG)" HELM_CHART_REPO="$(HELM_CHART_REPO)" IMAGE_REPO="$(IMAGE_REPO)" HELM="$(HELM)" YQ="$(YQ)" ./hack/push-chart.sh
+	EXTRA_TAG="$(EXTRA_TAG)" GIT_TAG="$(GIT_TAG)" IMAGE_REGISTRY="$(IMAGE_REGISTRY)" HELM_CHART_REPO="$(HELM_CHART_REPO)" IMAGE_REPO="$(IMAGE_REPO)" HELM="$(HELM)" YQ="$(YQ)" ./hack/push-chart.sh
 
 # Build an amd64 image that can be used for Kind E2E tests.
 .PHONY: kind-image-build
@@ -226,7 +226,7 @@ ifndef ignore-not-found
   ignore-not-found = false
 endif
 
-clean-manifests = (cd config/components/manager && $(KUSTOMIZE) edit set image controller=gcr.io/k8s-staging-kueue/kueue:$(RELEASE_BRANCH))
+clean-manifests = (cd config/components/manager && $(KUSTOMIZE) edit set image controller=us-central1-docker.pkg.dev/k8s-staging-images/kueue:$(RELEASE_BRANCH))
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
@@ -293,10 +293,10 @@ update-security-insights: yq
 ##@ Debug
 
 # Build an image that can be used with kubectl debug
-# Developers don't need to build this image, as it will be available as gcr.io/k8s-staging-kueue/debug
+# Developers don't need to build this image, as it will be available as us-central1-docker.pkg.dev/k8s-staging-images/kueue/debug
 .PHONY: debug-image-push
 debug-image-push: ## Build and push the debug image to the registry
-	$(IMAGE_BUILD_CMD) -t $(IMAGE_REGISTRY)/debug:$(GIT_TAG) \
+	$(IMAGE_BUILD_CMD) -t $(IMAGE_REPO)/debug:$(GIT_TAG) \
 		--platform=$(PLATFORMS) \
 		--push ./hack/debugpod
 
@@ -308,8 +308,8 @@ importer-build:
 .PHONY: importer-image-build
 importer-image-build:
 	$(IMAGE_BUILD_CMD) \
-		-t $(IMAGE_REGISTRY)/importer:$(GIT_TAG) \
-		-t $(IMAGE_REGISTRY)/importer:$(RELEASE_BRANCH)-latest \
+		-t $(IMAGE_REPO)/importer:$(GIT_TAG) \
+		-t $(IMAGE_REPO)/importer:$(RELEASE_BRANCH)-latest \
 		--platform=$(PLATFORMS) \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \
@@ -321,7 +321,7 @@ importer-image-build:
 importer-image-push: PUSH=--push
 importer-image-push: importer-image-build
 
-# Build a docker local gcr.io/k8s-staging-kueue/importer image
+# Build a docker local us-central1-docker.pkg.dev/k8s-staging-images/kueue/importer image
 .PHONY: importer-image
 importer-image: PLATFORMS=linux/amd64
 importer-image: PUSH=--load

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ DOCKER_BUILDX_CMD ?= docker buildx
 IMAGE_BUILD_CMD ?= $(DOCKER_BUILDX_CMD) build
 IMAGE_BUILD_EXTRA_OPTS ?=
 # TODO(#52): Add kueue to k8s gcr registry
-STAGING_IMAGE_REGISTRY := us-central1-docker.pkg.dev/k8s-staging-images
+STAGING_IMAGE_REGISTRY := us-central1-docker.pkg.dev/k8s-staging-images/kueue
 IMAGE_REGISTRY ?= $(STAGING_IMAGE_REGISTRY)
 IMAGE_NAME := kueue
 IMAGE_REPO ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME)
@@ -226,7 +226,7 @@ ifndef ignore-not-found
   ignore-not-found = false
 endif
 
-clean-manifests = (cd config/components/manager && $(KUSTOMIZE) edit set image controller=us-central1-docker.pkg.dev/k8s-staging-images/kueue:$(RELEASE_BRANCH))
+clean-manifests = (cd config/components/manager && $(KUSTOMIZE) edit set image controller=us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:$(RELEASE_BRANCH))
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
@@ -296,7 +296,7 @@ update-security-insights: yq
 # Developers don't need to build this image, as it will be available as us-central1-docker.pkg.dev/k8s-staging-images/kueue/debug
 .PHONY: debug-image-push
 debug-image-push: ## Build and push the debug image to the registry
-	$(IMAGE_BUILD_CMD) -t $(IMAGE_REPO)/debug:$(GIT_TAG) \
+	$(IMAGE_BUILD_CMD) -t $(IMAGE_REGISTRY)/debug:$(GIT_TAG) \
 		--platform=$(PLATFORMS) \
 		--push ./hack/debugpod
 
@@ -308,8 +308,8 @@ importer-build:
 .PHONY: importer-image-build
 importer-image-build:
 	$(IMAGE_BUILD_CMD) \
-		-t $(IMAGE_REPO)/importer:$(GIT_TAG) \
-		-t $(IMAGE_REPO)/importer:$(RELEASE_BRANCH)-latest \
+		-t $(IMAGE_REGISTRY)/importer:$(GIT_TAG) \
+		-t $(IMAGE_REGISTRY)/importer:$(RELEASE_BRANCH)-latest \
 		--platform=$(PLATFORMS) \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \
 		--build-arg BUILDER_IMAGE=$(BUILDER_IMAGE) \

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -51,7 +51,7 @@ KIND_CLUSTER_NAME ?= kind
 
 GIT_TAG ?= $(shell git describe --tags --dirty --always)
 # TODO(#52): Add kueue to k8s gcr registry
-STAGING_IMAGE_REGISTRY := us-central1-docker.pkg.dev/k8s-staging-images
+STAGING_IMAGE_REGISTRY := us-central1-docker.pkg.dev/k8s-staging-images/kueue
 IMAGE_REGISTRY ?= $(STAGING_IMAGE_REGISTRY)
 IMAGE_NAME := kueue
 IMAGE_REPO ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME)

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -51,7 +51,7 @@ KIND_CLUSTER_NAME ?= kind
 
 GIT_TAG ?= $(shell git describe --tags --dirty --always)
 # TODO(#52): Add kueue to k8s gcr registry
-STAGING_IMAGE_REGISTRY := gcr.io/k8s-staging-kueue
+STAGING_IMAGE_REGISTRY := us-central1-docker.pkg.dev/k8s-staging-images
 IMAGE_REGISTRY ?= $(STAGING_IMAGE_REGISTRY)
 IMAGE_NAME := kueue
 IMAGE_REPO ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME)

--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -49,7 +49,7 @@ The following table lists the configurable parameters of the kueue chart and the
 | `enablePrometheus`                                     | enable Prometheus                                      | `false`                                     |
 | `enableCertManager`                                    | enable CertManager                                     | `false`                                     |
 | `controllerManager.kubeRbacProxy.image`                | controllerManager.kubeRbacProxy's image                | `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0` |
-| `controllerManager.manager.image`                      | controllerManager.manager's image                      | `us-central1-docker.pkg.dev/k8s-staging-images/kueue:main`       |
+| `controllerManager.manager.image`                      | controllerManager.manager's image                      | `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:main`       |
 | `controllerManager.manager.resources`                  | controllerManager.manager's resources                  | abbr.                                       |
 | `controllerManager.replicas`                           | ControllerManager's replicaCount                       | `1`                                         |
 | `controllerManager.imagePullSecrets`                   | ControllerManager's imagePullSecrets                   | `[]`                                        |

--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -49,7 +49,7 @@ The following table lists the configurable parameters of the kueue chart and the
 | `enablePrometheus`                                     | enable Prometheus                                      | `false`                                     |
 | `enableCertManager`                                    | enable CertManager                                     | `false`                                     |
 | `controllerManager.kubeRbacProxy.image`                | controllerManager.kubeRbacProxy's image                | `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0` |
-| `controllerManager.manager.image`                      | controllerManager.manager's image                      | `gcr.io/k8s-staging-kueue/kueue:main`       |
+| `controllerManager.manager.image`                      | controllerManager.manager's image                      | `us-central1-docker.pkg.dev/k8s-staging-images/kueue:main`       |
 | `controllerManager.manager.resources`                  | controllerManager.manager's resources                  | abbr.                                       |
 | `controllerManager.replicas`                           | ControllerManager's replicaCount                       | `1`                                         |
 | `controllerManager.imagePullSecrets`                   | ControllerManager's imagePullSecrets                   | `[]`                                        |

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -21,7 +21,7 @@ controllerManager:
       pullPolicy: IfNotPresent
   manager:
     image:
-      repository: us-central1-docker.pkg.dev/k8s-staging-images/kueue
+      repository: us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue
       # This should be set to 'IfNotPresent' for released version      
       pullPolicy: Always
     podAnnotations: {}

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -21,7 +21,7 @@ controllerManager:
       pullPolicy: IfNotPresent
   manager:
     image:
-      repository: gcr.io/k8s-staging-kueue/kueue
+      repository: us-central1-docker.pkg.dev/k8s-staging-images/kueue
       # This should be set to 'IfNotPresent' for released version      
       pullPolicy: Always
     podAnnotations: {}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,7 +12,7 @@ steps:
       - importer-image-push
       - helm-chart-push
     env:
-      - IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images
+      - IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/kueue
       - GIT_TAG=$_GIT_TAG
       - EXTRA_TAG=$_PULL_BASE_REF
       - DOCKER_BUILDX_CMD=/buildx-entrypoint

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,7 +12,7 @@ steps:
       - importer-image-push
       - helm-chart-push
     env:
-      - IMAGE_REGISTRY=gcr.io/$PROJECT_ID
+      - IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images
       - GIT_TAG=$_GIT_TAG
       - EXTRA_TAG=$_PULL_BASE_REF
       - DOCKER_BUILDX_CMD=/buildx-entrypoint

--- a/cmd/importer/README.md
+++ b/cmd/importer/README.md
@@ -161,8 +161,8 @@ Make the created image accessible by your cluster.
 (cd cmd/importer/run-in-cluster && kustomize edit set image importer=<image:tag>)
 ```
 You can use the image that you built in step one or one of images published in
-https://gcr.io/k8s-staging-kueue/importer, for example:
-`gcr.io/k8s-staging-kueue/importer:main-latest`
+https://us-central1-docker.pkg.dev/k8s-staging-images/kueue/importer, for example:
+`us-central1-docker.pkg.dev/k8s-staging-images/kueue/importer:main-latest`
 
 3. Update the importer args in `cmd/importer/run-in-cluster/importer.yaml` as needed.
 

--- a/cmd/importer/run-in-cluster/kustomization.yaml
+++ b/cmd/importer/run-in-cluster/kustomization.yaml
@@ -15,6 +15,6 @@ configMapGenerator:
 
 images:
 - name: importer
-  newName: gcr.io/k8s-staging-kueue/importer
+  newName: us-central1-docker.pkg.dev/k8s-staging-images/kueue/importer
 
 namespace: kueue-importer

--- a/config/components/manager/kustomization.yaml
+++ b/config/components/manager/kustomization.yaml
@@ -16,5 +16,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: gcr.io/k8s-staging-kueue/kueue
+  newName: us-central1-docker.pkg.dev/k8s-staging-images/kueue
   newTag: release-0.8

--- a/config/components/manager/kustomization.yaml
+++ b/config/components/manager/kustomization.yaml
@@ -16,5 +16,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: us-central1-docker.pkg.dev/k8s-staging-images/kueue
+  newName: us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue
   newTag: release-0.8

--- a/hack/dump_cache.sh
+++ b/hack/dump_cache.sh
@@ -22,7 +22,7 @@ set -o pipefail
 
 NAMESPACE=${NAMESPACE:-kueue-system}
 LEASE_NAME=${LEASE_NAME:-c1f6bfd2.kueue.x-k8s.io}
-DEBUG_IMAGE=${DEBUG_IMAGE:-gcr.io/k8s-staging-kueue/debug:main}
+DEBUG_IMAGE=${DEBUG_IMAGE:-us-central1-docker.pkg.dev/k8s-staging-images/kueue/debug:main}
 
 leader=$(kubectl get lease -n ${NAMESPACE} ${LEASE_NAME} -o jsonpath='{.spec.holderIdentity}' | cut -d '_' -f 1)
 

--- a/hack/push-chart.sh
+++ b/hack/push-chart.sh
@@ -18,8 +18,9 @@ DEST_CHART_DIR=${DEST_CHART_DIR:-bin/}
 
 EXTRA_TAG=${EXTRA_TAG:-$(git branch --show-current)} 
 GIT_TAG=${GIT_TAG:-$(git describe --tags --dirty --always)}
-HELM_CHART_REPO=${HELM_CHART_REPO:-gcr.io/k8s-staging-kueue/charts}
-IMAGE_REPO=${IMAGE_REPO:-gcr.io/k8s-staging-kueue/kueue}
+IMAGE_REGISTRY=${IMAGE_REGISTRY:-us-central1-docker.pkg.dev/k8s-staging-images}
+HELM_CHART_REPO=${HELM_CHART_REPO:-${IMAGE_REGISTRY}/charts}
+IMAGE_REPO=${IMAGE_REPO:-${IMAGE_REGISTRY}/kueue}
 
 HELM=${HELM:-./bin/helm}
 YQ=${YQ:-./bin/yq}

--- a/hack/push-chart.sh
+++ b/hack/push-chart.sh
@@ -18,7 +18,7 @@ DEST_CHART_DIR=${DEST_CHART_DIR:-bin/}
 
 EXTRA_TAG=${EXTRA_TAG:-$(git branch --show-current)} 
 GIT_TAG=${GIT_TAG:-$(git describe --tags --dirty --always)}
-IMAGE_REGISTRY=${IMAGE_REGISTRY:-us-central1-docker.pkg.dev/k8s-staging-images}
+IMAGE_REGISTRY=${IMAGE_REGISTRY:-us-central1-docker.pkg.dev/k8s-staging-images/kueue}
 HELM_CHART_REPO=${HELM_CHART_REPO:-${IMAGE_REGISTRY}/charts}
 IMAGE_REPO=${IMAGE_REPO:-${IMAGE_REGISTRY}/kueue}
 


### PR DESCRIPTION
Cherry pick of #2476 on release-0.8.
#2476: Publish images to new staging registry
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
Publish images via artifact registry
```