### PR TITLE
Rename Cohort to Parent

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -624,7 +624,7 @@ func getUsage(frq resources.FlavorResourceQuantities, cq *clusterQueue) []kueue.
 					Total: resources.ResourceQuantity(rName, used),
 				}
 				// Enforce `borrowed=0` if the clusterQueue doesn't belong to a cohort.
-				if cq.HasCohort() {
+				if cq.HasParent() {
 					borrowed := used - rQuota.Nominal
 					if borrowed > 0 {
 						rUsage.Borrowed = resources.ResourceQuantity(rName, borrowed)

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -611,7 +611,7 @@ func (c *clusterQueue) fairWeight() *resource.Quantity {
 }
 
 func (c *clusterQueue) lendableResourcesInCohort() map[corev1.ResourceName]int64 {
-	return c.Cohort().CalculateLendable()
+	return c.Parent().CalculateLendable()
 }
 
 func (c *clusterQueue) usageFor(fr resources.FlavorResource) int64 {
@@ -645,7 +645,7 @@ func (c *ClusterQueueSnapshot) DominantResourceShareWithout(wlReq resources.Flav
 }
 
 type dominantResourceShareNode interface {
-	HasCohort() bool
+	HasParent() bool
 	fairWeight() *resource.Quantity
 	lendableResourcesInCohort() map[corev1.ResourceName]int64
 
@@ -653,7 +653,7 @@ type dominantResourceShareNode interface {
 }
 
 func dominantResourceShare(node dominantResourceShareNode, wlReq resources.FlavorResourceQuantities, m int64) (int, corev1.ResourceName) {
-	if !node.HasCohort() {
+	if !node.HasParent() {
 		return 0, ""
 	}
 	if node.fairWeight().IsZero() {

--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -104,7 +104,7 @@ func (c *ClusterQueueSnapshot) borrowingLimit(fr resources.FlavorResource) *int6
 // The methods below implement several interfaces. See
 // dominantResourceShareNode, resourceGroupNode, and netQuotaNode.
 
-func (c *ClusterQueueSnapshot) HasCohort() bool {
+func (c *ClusterQueueSnapshot) HasParent() bool {
 	return c.Cohort != nil
 }
 func (c *ClusterQueueSnapshot) fairWeight() *resource.Quantity {

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -1099,7 +1099,7 @@ func TestCohortLendable(t *testing.T) {
 		"example.com/gpu":  3,
 	}
 
-	lendable := cache.hm.ClusterQueues["cq1"].Cohort().CalculateLendable()
+	lendable := cache.hm.ClusterQueues["cq1"].Parent().CalculateLendable()
 	if diff := cmp.Diff(wantLendable, lendable); diff != "" {
 		t.Errorf("Unexpected cohort lendable (-want,+got):\n%s", diff)
 	}

--- a/pkg/hierarchy/manager.go
+++ b/pkg/hierarchy/manager.go
@@ -42,8 +42,8 @@ func (c *Manager[CQ, C]) DeleteClusterQueue(name string) {
 }
 
 func (c *Manager[CQ, C]) unwireClusterQueue(cq CQ) {
-	if cq.Wired().HasCohort() {
-		cohort := cq.Wired().Cohort()
+	if cq.Wired().HasParent() {
+		cohort := cq.Wired().Parent()
 		cohort.Wired().members.Delete(cq)
 		c.cleanupCohort(cohort)
 		var zero C

--- a/pkg/hierarchy/manager_test.go
+++ b/pkg/hierarchy/manager_test.go
@@ -153,8 +153,8 @@ func TestManager(t *testing.T) {
 				gotEdges := make([]cqEdge, 0, len(tc.wantCqEdge))
 				for _, cq := range mgr.ClusterQueues {
 					gotCqs.Insert(cq.GetName())
-					if cq.HasCohort() {
-						gotEdges = append(gotEdges, cqEdge{cq.GetName(), cq.Cohort().GetName()})
+					if cq.HasParent() {
+						gotEdges = append(gotEdges, cqEdge{cq.GetName(), cq.Parent().GetName()})
 					}
 				}
 				if diff := cmp.Diff(tc.wantCqs, gotCqs); diff != "" {

--- a/pkg/hierarchy/wired_clusterqueue.go
+++ b/pkg/hierarchy/wired_clusterqueue.go
@@ -4,13 +4,13 @@ type WiredClusterQueue[CQ, Cohort nodeBase] struct {
 	cohort Cohort
 }
 
-func (c *WiredClusterQueue[CQ, Cohort]) Cohort() Cohort {
+func (c *WiredClusterQueue[CQ, Cohort]) Parent() Cohort {
 	return c.cohort
 }
 
-func (c *WiredClusterQueue[CQ, Cohort]) HasCohort() bool {
+func (c *WiredClusterQueue[CQ, Cohort]) HasParent() bool {
 	var zero Cohort
-	return c.Cohort() != zero
+	return c.Parent() != zero
 }
 
 // Wired implements interface for Manager

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -436,12 +436,12 @@ func (m *Manager) QueueInadmissibleWorkloads(ctx context.Context, cqNames sets.S
 // 2. add events of any cluster queue in the cohort.
 // 3. update events of any cluster queue in the cohort.
 func (m *Manager) queueAllInadmissibleWorkloadsInCohort(ctx context.Context, cq *ClusterQueue) bool {
-	if !cq.HasCohort() {
+	if !cq.HasParent() {
 		return cq.QueueInadmissibleWorkloads(ctx, m.client)
 	}
 
 	queued := false
-	for _, clusterQueue := range cq.Cohort().Members() {
+	for _, clusterQueue := range cq.Parent().Members() {
 		queued = clusterQueue.QueueInadmissibleWorkloads(ctx, m.client) || queued
 	}
 	return queued


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
As we implement #79, we define algorithms which work recursively on both `ClusterQueues` and `Cohorts`. `Cohorts` will have a `Parent`, as `Cohort.HasCohort()` is confusing.

This rename will allow algorithms to work on both types.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```