### PR TITLE
Add the `kueue.x-k8s.io/managed` label to PodTemplates created by Kueue

### DIFF
--- a/cmd/experimental/podtaintstolerations/test/util/pod.go
+++ b/cmd/experimental/podtaintstolerations/test/util/pod.go
@@ -23,7 +23,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
+
+	"sigs.k8s.io/kueue/pkg/constants"
+	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 )
 
 // PodWrapper wraps a Pod.
@@ -68,7 +70,7 @@ func (p *PodWrapper) Queue(queue string) *PodWrapper {
 	if p.Labels == nil {
 		p.Labels = make(map[string]string)
 	}
-	p.Labels[constants.QueueLabel] = queue
+	p.Labels[controllerconsts.QueueLabel] = queue
 	return p
 }
 
@@ -88,7 +90,7 @@ func (p *PodWrapper) Annotation(key, content string) *PodWrapper {
 
 // ParentWorkload sets the parent-workload annotation
 func (p *PodWrapper) ParentWorkload(parentWorkload string) *PodWrapper {
-	p.Annotations[constants.ParentWorkloadAnnotation] = parentWorkload
+	p.Annotations[controllerconsts.ParentWorkloadAnnotation] = parentWorkload
 	return p
 }
 
@@ -106,7 +108,7 @@ func (p *PodWrapper) KueueFinalizer() *PodWrapper {
 	if p.ObjectMeta.Finalizers == nil {
 		p.ObjectMeta.Finalizers = make([]string, 0)
 	}
-	p.ObjectMeta.Finalizers = append(p.ObjectMeta.Finalizers, "kueue.x-k8s.io/managed")
+	p.ObjectMeta.Finalizers = append(p.ObjectMeta.Finalizers, constants.ManagedByKueueLabel)
 	return p
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -43,5 +43,6 @@ const (
 
 	IsNegativeErrorMsg string = `must be greater than or equal to 0`
 
+	// Label that signalize that an object is managed by Kueue
 	ManagedByKueueLabel = "kueue.x-k8s.io/managed"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -42,4 +42,6 @@ const (
 	DefaultPendingWorkloadsLimit = 1000
 
 	IsNegativeErrorMsg string = `must be greater than or equal to 0`
+
+	ManagedByKueueLabel = "kueue.x-k8s.io/managed"
 )

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -383,6 +383,9 @@ func (c *Controller) syncProvisionRequestsPodTemplates(ctx context.Context, wl *
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      ptKey.Name,
 					Namespace: ptKey.Namespace,
+					Labels: map[string]string{
+						"kueue.x-k8s.io/managed": "true",
+					},
 				},
 				Template: ps.Template,
 			}

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/podset"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	"sigs.k8s.io/kueue/pkg/util/api"
@@ -268,6 +269,9 @@ func (c *Controller) syncOwnedProvisionRequest(ctx context.Context, wl *kueue.Wo
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      requestName,
 					Namespace: wl.Namespace,
+					Labels: map[string]string{
+						constants.ManagedByKueueLabel: "true",
+					},
 				},
 				Spec: autoscaling.ProvisioningRequestSpec{
 					ProvisioningClassName: prc.Spec.ProvisioningClassName,
@@ -384,7 +388,7 @@ func (c *Controller) syncProvisionRequestsPodTemplates(ctx context.Context, wl *
 					Name:      ptKey.Name,
 					Namespace: ptKey.Namespace,
 					Labels: map[string]string{
-						"kueue.x-k8s.io/managed": "true",
+						constants.ManagedByKueueLabel: "true",
 					},
 				},
 				Template: ps.Template,

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/constants"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -146,6 +147,9 @@ func TestReconcile(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: TestNamespace,
 			Name:      "wl-check1-1",
+			Labels: map[string]string{
+				constants.ManagedByKueueLabel: "true",
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Name: "wl",
@@ -179,7 +183,7 @@ func TestReconcile(t *testing.T) {
 			Namespace: TestNamespace,
 			Name:      "ppt-wl-check1-1-ps1",
 			Labels: map[string]string{
-				"kueue.x-k8s.io/managed": "true",
+				constants.ManagedByKueueLabel: "true",
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -217,7 +221,7 @@ func TestReconcile(t *testing.T) {
 			Namespace: TestNamespace,
 			Name:      "ppt-wl-check1-1-ps2",
 			Labels: map[string]string{
-				"kueue.x-k8s.io/managed": "true",
+				constants.ManagedByKueueLabel: "true",
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -346,6 +350,9 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: TestNamespace,
 						Name:      ProvisioningRequestName("wl", baseCheck.Name, 1),
+						Labels: map[string]string{
+							constants.ManagedByKueueLabel: "true",
+						},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Name: "wl",
@@ -631,6 +638,11 @@ func TestReconcile(t *testing.T) {
 			},
 			wantRequests: map[string]*autoscaling.ProvisioningRequest{
 				"wl-check1-1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							constants.ManagedByKueueLabel: "true",
+						},
+					},
 					Spec: autoscaling.ProvisioningRequestSpec{
 						PodSets: []autoscaling.PodSet{
 							{
@@ -681,6 +693,11 @@ func TestReconcile(t *testing.T) {
 			},
 			wantRequests: map[string]*autoscaling.ProvisioningRequest{
 				"wl-check1-1": {
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							constants.ManagedByKueueLabel: "true",
+						},
+					},
 					Spec: autoscaling.ProvisioningRequestSpec{
 						PodSets: []autoscaling.PodSet{
 							{
@@ -703,7 +720,7 @@ func TestReconcile(t *testing.T) {
 						Namespace: TestNamespace,
 						Name:      "ppt-wl-check1-1-ps1",
 						Labels: map[string]string{
-							"kueue.x-k8s.io/managed": "true",
+							constants.ManagedByKueueLabel: "true",
 						},
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -1066,6 +1083,9 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: TestNamespace,
 						Name:      "wl-check1-2",
+						Labels: map[string]string{
+							constants.ManagedByKueueLabel: "true",
+						},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Name: "wl",
@@ -1210,6 +1230,9 @@ func TestReconcile(t *testing.T) {
 
 				if diff := cmp.Diff(wantRequest, gotRequest, reqCmpOptions...); diff != "" {
 					t.Errorf("unexpected request %q (-want/+got):\n%s", name, diff)
+				}
+				if diff := cmp.Diff(wantRequest.GetLabels(), gotRequest.GetLabels()); diff != "" {
+					t.Errorf("unexpected request labels %q (-want/+got):\n%s", name, diff)
 				}
 			}
 

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -178,6 +178,9 @@ func TestReconcile(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: TestNamespace,
 			Name:      "ppt-wl-check1-1-ps1",
+			Labels: map[string]string{
+				"kueue.x-k8s.io/managed": "true",
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Name: "wl-check1-1",
@@ -213,6 +216,9 @@ func TestReconcile(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: TestNamespace,
 			Name:      "ppt-wl-check1-1-ps2",
+			Labels: map[string]string{
+				"kueue.x-k8s.io/managed": "true",
+			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Name: "wl-check1-1",
@@ -696,6 +702,9 @@ func TestReconcile(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: TestNamespace,
 						Name:      "ppt-wl-check1-1-ps1",
+						Labels: map[string]string{
+							"kueue.x-k8s.io/managed": "true",
+						},
 						OwnerReferences: []metav1.OwnerReference{
 							{
 								Name: "wl-check1-1",
@@ -1212,6 +1221,9 @@ func TestReconcile(t *testing.T) {
 
 				if diff := cmp.Diff(wantTemplate, gotTemplate, tmplCmpOptions...); diff != "" {
 					t.Errorf("unexpected template %q (-want/+got):\n%s", name, diff)
+				}
+				if diff := cmp.Diff(wantTemplate.GetLabels(), gotTemplate.GetLabels()); diff != "" {
+					t.Errorf("unexpected template labels %q (-want/+got):\n%s", name, diff)
 				}
 			}
 

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs/job"
@@ -172,13 +173,13 @@ func TestReconciler(t *testing.T) {
 			},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueFinalizer().
 				KueueSchedulingGate().
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				NodeSelector("kubernetes.io/arch", "arm64").
 				KueueFinalizer().
 				Obj()},
@@ -221,7 +222,7 @@ func TestReconciler(t *testing.T) {
 		"non-matching admitted workload is deleted and pod is finalized": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueFinalizer().
 				Obj()},
 			wantPods: nil,
@@ -253,14 +254,14 @@ func TestReconciler(t *testing.T) {
 		"the workload is created when queue name is set": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueFinalizer().
 				KueueSchedulingGate().
 				Queue("test-queue").
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueFinalizer().
 				KueueSchedulingGate().
 				Queue("test-queue").
@@ -304,13 +305,13 @@ func TestReconciler(t *testing.T) {
 		"pod is stopped when workload is evicted": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueFinalizer().
 				Queue("test-queue").
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueFinalizer().
 				Queue("test-queue").
 				StatusConditions(corev1.PodCondition{
@@ -361,14 +362,14 @@ func TestReconciler(t *testing.T) {
 		"pod is finalized when it's succeeded": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueFinalizer().
 				StatusPhase(corev1.PodSucceeded).
 				StatusMessage("Job finished successfully").
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				StatusPhase(corev1.PodSucceeded).
 				StatusMessage("Job finished successfully").
 				Obj()},
@@ -416,13 +417,13 @@ func TestReconciler(t *testing.T) {
 		"workload status condition is added even if the pod is finalized": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				StatusPhase(corev1.PodSucceeded).
 				StatusMessage("Job finished successfully").
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				StatusPhase(corev1.PodSucceeded).
 				StatusMessage("Job finished successfully").
 				Obj()},
@@ -461,12 +462,12 @@ func TestReconciler(t *testing.T) {
 		"pod without scheduling gate is terminated if workload is not admitted": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueFinalizer().
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueFinalizer().
 				StatusConditions(corev1.PodCondition{
 					Type:    "TerminationTarget",
@@ -506,7 +507,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
@@ -517,7 +518,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
@@ -550,7 +551,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
@@ -561,7 +562,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
@@ -573,7 +574,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
@@ -584,7 +585,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
@@ -624,7 +625,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -633,7 +634,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -643,7 +644,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -652,7 +653,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -696,7 +697,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -705,7 +706,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -715,7 +716,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -724,7 +725,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -779,7 +780,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -788,7 +789,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -797,7 +798,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -806,7 +807,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -848,7 +849,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -857,7 +858,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -867,7 +868,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -875,7 +876,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -928,14 +929,14 @@ func TestReconciler(t *testing.T) {
 		"workload is not deleted if the pod in group has been deleted after admission": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueFinalizer().
 				Group("test-group").
 				GroupTotalCount("2").
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueFinalizer().
 				Group("test-group").
 				GroupTotalCount("2").
@@ -984,7 +985,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
@@ -994,7 +995,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
@@ -1005,7 +1006,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
@@ -1015,7 +1016,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
@@ -1060,7 +1061,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					KueueFinalizer().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -1069,7 +1070,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -1140,7 +1141,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
@@ -1150,7 +1151,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("new-test-queue").
@@ -1161,7 +1162,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
@@ -1171,7 +1172,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("new-test-queue").
@@ -1188,7 +1189,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Queue("test-queue").
 					Group("test-group").
@@ -1197,7 +1198,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Queue("test-queue").
 					Group("test-group").
@@ -1242,7 +1243,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -1251,7 +1252,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -1261,7 +1262,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -1270,7 +1271,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -1330,7 +1331,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -1339,7 +1340,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -1348,7 +1349,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -1357,7 +1358,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -1383,7 +1384,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -1392,7 +1393,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodFailed).
@@ -1400,7 +1401,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -1409,7 +1410,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -1456,7 +1457,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1465,7 +1466,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1474,7 +1475,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1484,7 +1485,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
@@ -1492,7 +1493,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -1500,7 +1501,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -1556,7 +1557,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -1567,7 +1568,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -1635,7 +1636,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -1646,7 +1647,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -1734,7 +1735,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Queue("test-queue").
 					Group("test-group").
@@ -1745,7 +1746,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Queue("test-queue").
 					Group("test-group").
@@ -1757,7 +1758,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Queue("test-queue").
 					Group("test-group").
@@ -1768,7 +1769,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Queue("test-queue").
 					Group("test-group").
@@ -1815,7 +1816,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1824,7 +1825,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1834,7 +1835,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1843,7 +1844,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1896,7 +1897,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1906,7 +1907,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1963,7 +1964,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1972,7 +1973,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1982,7 +1983,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -1990,7 +1991,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -2004,7 +2005,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2013,7 +2014,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2023,7 +2024,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2032,7 +2033,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2069,7 +2070,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2078,7 +2079,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2088,7 +2089,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2097,7 +2098,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
@@ -2120,7 +2121,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Annotation("kueue.x-k8s.io/retriable-in-group", "false").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2129,7 +2130,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2138,7 +2139,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
@@ -2150,7 +2151,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Annotation("kueue.x-k8s.io/retriable-in-group", "false").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodFailed).
@@ -2158,7 +2159,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodSucceeded).
@@ -2166,7 +2167,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
 					GroupTotalCount("3").
@@ -2245,7 +2246,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2254,7 +2255,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2263,7 +2264,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
@@ -2274,7 +2275,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2283,7 +2284,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2292,7 +2293,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
@@ -2357,7 +2358,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2367,7 +2368,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2378,7 +2379,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2421,7 +2422,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2431,7 +2432,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2441,7 +2442,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2452,7 +2453,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2462,7 +2463,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2512,7 +2513,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2521,7 +2522,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2532,7 +2533,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2601,7 +2602,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -2611,7 +2612,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					UID("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2621,7 +2622,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2632,7 +2633,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -2642,7 +2643,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					UID("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2652,7 +2653,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2694,7 +2695,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2704,7 +2705,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					UID("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					CreationTimestamp(now.Add(time.Minute)).
@@ -2713,7 +2714,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2724,7 +2725,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2734,7 +2735,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					UID("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					CreationTimestamp(now.Add(time.Minute)).
@@ -2787,7 +2788,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2797,7 +2798,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueSchedulingGate().
 					Finalizer("kubernetes").
 					Group("test-group").
@@ -2809,7 +2810,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2819,7 +2820,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueSchedulingGate().
 					Finalizer("kubernetes").
 					Group("test-group").
@@ -2859,7 +2860,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("p1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("group").
@@ -2870,7 +2871,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("p2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("group").
@@ -2908,7 +2909,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
@@ -2916,7 +2917,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Delete().
 					Group("test-group").
@@ -2925,7 +2926,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement-for-pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2935,7 +2936,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
@@ -2943,7 +2944,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Delete().
 					Group("test-group").
@@ -2952,7 +2953,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement-for-pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3014,7 +3015,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -3022,7 +3023,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Delete().
 					Group("test-group").
@@ -3031,7 +3032,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -3041,7 +3042,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -3055,7 +3056,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Delete().
 					Group("test-group").
@@ -3064,7 +3065,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -3151,7 +3152,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -3161,7 +3162,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -3236,7 +3237,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("active-pod").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3244,7 +3245,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3259,7 +3260,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("deleted").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3275,7 +3276,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3290,7 +3291,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3298,7 +3299,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3308,7 +3309,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("active-pod").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3316,7 +3317,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("4").
 					StatusPhase(corev1.PodFailed).
@@ -3330,7 +3331,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3345,7 +3346,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3353,7 +3354,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3420,7 +3421,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("active-pod").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3428,7 +3429,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3443,7 +3444,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3453,7 +3454,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("active-pod").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3461,7 +3462,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3476,7 +3477,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3521,7 +3522,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3536,7 +3537,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error-no-finalizer").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
@@ -3550,7 +3551,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3560,7 +3561,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3575,7 +3576,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error-no-finalizer").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
@@ -3589,7 +3590,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3649,7 +3650,7 @@ func TestReconciler(t *testing.T) {
 		"workload is created with correct labels for a single pod": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				Label("toCopyKey", "toCopyValue").
 				Label("dontCopyKey", "dontCopyValue").
 				KueueFinalizer().
@@ -3691,7 +3692,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Label("toCopyKey1", "toCopyValue1").
 					Label("dontCopyKey", "dontCopyValue").
 					KueueFinalizer().
@@ -3702,7 +3703,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Label("toCopyKey1", "toCopyValue1").
 					Label("toCopyKey2", "toCopyValue2").
 					Label("dontCopyKey", "dontCopyValue").
@@ -3750,7 +3751,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Label("toCopyKey1", "toCopyValue1").
 					Label("dontCopyKey", "dontCopyValue").
 					KueueFinalizer().
@@ -3761,7 +3762,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Label("toCopyKey1", "otherValue").
 					Label("toCopyKey2", "toCopyValue2").
 					Label("dontCopyKey", "dontCopyValue").
@@ -3781,7 +3782,7 @@ func TestReconciler(t *testing.T) {
 		"admission check message is recorded as event for a single pod": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueFinalizer().
 				KueueSchedulingGate().
 				Obj()},
@@ -3861,7 +3862,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -3870,7 +3871,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -3951,7 +3952,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodRunning).
 					Group("test-group").
@@ -3961,7 +3962,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Delete().
 					StatusPhase(corev1.PodPending).
@@ -3972,7 +3973,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -4000,7 +4001,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodRunning).
 					Group("test-group").
@@ -4010,7 +4011,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -4053,7 +4054,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4063,7 +4064,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4090,7 +4091,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4100,7 +4101,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4128,7 +4129,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4138,7 +4139,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4165,7 +4166,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4175,7 +4176,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4209,7 +4210,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4219,7 +4220,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4247,7 +4248,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4257,7 +4258,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Delete().
@@ -4292,7 +4293,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4302,7 +4303,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Delete().
 					StatusPhase(corev1.PodPending).
@@ -4337,7 +4338,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4347,7 +4348,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4389,7 +4390,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4399,7 +4400,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					Delete().
 					StatusPhase(corev1.PodPending).
@@ -4439,7 +4440,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4449,7 +4450,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4489,7 +4490,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4499,7 +4500,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4540,7 +4541,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4550,7 +4551,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4592,7 +4593,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4602,7 +4603,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4635,7 +4636,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4645,7 +4646,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4773,7 +4774,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 
 	pod := *basePodWrapper.
 		Clone().
-		Label("kueue.x-k8s.io/managed", "true").
+		Label(constants.ManagedByKueueLabel, "true").
 		KueueFinalizer().
 		StatusPhase(corev1.PodSucceeded).
 		StatusMessage("Job finished successfully").
@@ -4845,7 +4846,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 	// Validate that pod has no finalizer after the second reconcile
 	wantPod := *basePodWrapper.
 		Clone().
-		Label("kueue.x-k8s.io/managed", "true").
+		Label(constants.ManagedByKueueLabel, "true").
 		StatusPhase(corev1.PodSucceeded).
 		StatusMessage("Job finished successfully").
 		Obj()
@@ -4966,7 +4967,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 	pods := []corev1.Pod{
 		*basePodWrapper.
 			Clone().
-			Label("kueue.x-k8s.io/managed", "true").
+			Label(constants.ManagedByKueueLabel, "true").
 			KueueFinalizer().
 			Group("test-group").
 			GroupTotalCount("2").
@@ -4975,7 +4976,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 		*basePodWrapper.
 			Clone().
 			Name("pod2").
-			Label("kueue.x-k8s.io/managed", "true").
+			Label(constants.ManagedByKueueLabel, "true").
 			KueueFinalizer().
 			Group("test-group").
 			CreationTimestamp(now.Add(time.Minute)).
@@ -4984,7 +4985,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 		*basePodWrapper.
 			Clone().
 			Name("excessPod").
-			Label("kueue.x-k8s.io/managed", "true").
+			Label(constants.ManagedByKueueLabel, "true").
 			KueueFinalizer().
 			Group("test-group").
 			CreationTimestamp(now.Add(time.Minute * 2)).

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -35,11 +35,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 )
 
 const (
-	ManagedLabelKey            = "kueue.x-k8s.io/managed"
+	ManagedLabelKey            = constants.ManagedByKueueLabel
 	ManagedLabelValue          = "true"
 	PodFinalizer               = ManagedLabelKey
 	GroupNameLabel             = "kueue.x-k8s.io/pod-group-name"

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs"
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
@@ -86,7 +87,7 @@ func TestDefault(t *testing.T) {
 			podSelector:       &metav1.LabelSelector{},
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueSchedulingGate().
 				KueueFinalizer().
 				Obj(),
@@ -99,7 +100,7 @@ func TestDefault(t *testing.T) {
 			namespaceSelector:          defaultNamespaceSelector,
 			podSelector:                &metav1.LabelSelector{},
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueSchedulingGate().
 				KueueFinalizer().
 				Obj(),
@@ -114,7 +115,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueSchedulingGate().
 				KueueFinalizer().
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
@@ -260,7 +261,7 @@ func TestDefault(t *testing.T) {
 				Queue("test-queue").
 				Group("test-group").
 				RoleHash("a9f06f3a").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueSchedulingGate().
 				KueueFinalizer().
 				Obj(),
@@ -277,7 +278,7 @@ func TestDefault(t *testing.T) {
 				Queue("test-queue").
 				Group("test-group").
 				RoleHash("a9f06f3a").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				KueueSchedulingGate().
 				KueueFinalizer().
 				Obj(),
@@ -320,7 +321,7 @@ func TestGetRoleHash(t *testing.T) {
 		"kueue.x-k8s.io/* labels shouldn't affect the role": {
 			pods: []*Pod{
 				{pod: *testingpod.MakePod("pod1", "test-ns").
-					Label("kueue.x-k8s.io/managed", "true").
+					Label(constants.ManagedByKueueLabel, "true").
 					Obj()},
 				{pod: *testingpod.MakePod("pod2", "test-ns").
 					Obj()},
@@ -408,7 +409,7 @@ func TestValidateCreate(t *testing.T) {
 	}{
 		"pod owner is managed by kueue": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
 			wantWarns: admission.Warnings{
@@ -417,7 +418,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"pod with group name and no group total count": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				Group("test-group").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -429,7 +430,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"pod with group total count and no group name": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				GroupTotalCount("3").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -441,7 +442,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"pod with 0 group total count": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				Group("test-group").
 				GroupTotalCount("0").
 				Obj(),
@@ -454,7 +455,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"pod with empty group total count": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				Group("test-group").
 				GroupTotalCount("").
 				Obj(),
@@ -467,7 +468,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"pod with incorrect group name": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				Group("notAdns1123Subdomain*").
 				GroupTotalCount("2").
 				Obj(),
@@ -512,11 +513,11 @@ func TestValidateUpdate(t *testing.T) {
 	}{
 		"pods owner is managed by kueue, managed label is set for both pods": {
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
 			wantWarns: admission.Warnings{
@@ -528,7 +529,7 @@ func TestValidateUpdate(t *testing.T) {
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
 			wantWarns: admission.Warnings{
@@ -538,7 +539,7 @@ func TestValidateUpdate(t *testing.T) {
 		"pod with group name and no group total count": {
 			oldPod: testingpod.MakePod("test-pod", "test-ns").Group("test-group").Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				Group("test-group").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -551,7 +552,7 @@ func TestValidateUpdate(t *testing.T) {
 		"pod with 0 group total count": {
 			oldPod: testingpod.MakePod("test-pod", "test-ns").Group("test-group").Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				Group("test-group").
 				GroupTotalCount("0").
 				Obj(),
@@ -565,7 +566,7 @@ func TestValidateUpdate(t *testing.T) {
 		"pod with empty group total count": {
 			oldPod: testingpod.MakePod("test-pod", "test-ns").Group("test-group").Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				Group("test-group").
 				GroupTotalCount("").
 				Obj(),

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -28,7 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
-	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/constants"
+	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 )
 
 // PodWrapper wraps a Pod.
@@ -81,7 +82,7 @@ func (p *PodWrapper) Clone() *PodWrapper {
 
 // Queue updates the queue name of the Pod
 func (p *PodWrapper) Queue(q string) *PodWrapper {
-	return p.Label(constants.QueueLabel, q)
+	return p.Label(controllerconsts.QueueLabel, q)
 }
 
 // PriorityClass updates the priority class name of the Pod
@@ -145,7 +146,7 @@ func (p *PodWrapper) Finalizer(f string) *PodWrapper {
 
 // KueueFinalizer adds kueue finalizer to the Pod
 func (p *PodWrapper) KueueFinalizer() *PodWrapper {
-	return p.Finalizer("kueue.x-k8s.io/managed")
+	return p.Finalizer(constants.ManagedByKueueLabel)
 }
 
 // NodeSelector adds a node selector to the Pod.

--- a/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/admissionchecks/provisioning"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -265,6 +266,7 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 					"ValidUntilSeconds": "0",
 				}))
 				gomega.Expect(createdRequest.Spec.PodSets).To(gomega.HaveLen(2))
+				gomega.Expect(createdRequest.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabel: "true"}))
 
 				ps1 := createdRequest.Spec.PodSets[0]
 				gomega.Expect(ps1.Count).To(gomega.Equal(int32(3)))
@@ -281,7 +283,7 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				gomega.Expect(createdTemplate.Template.Spec.Containers).To(gomega.BeComparableTo(updatedWl.Spec.PodSets[0].Template.Spec.Containers, ignoreContainersDefaults))
 				gomega.Expect(createdTemplate.Template.Spec.NodeSelector).To(gomega.BeComparableTo(map[string]string{"ns1": "ns1v"}))
-				gomega.Expect(createdTemplate.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{"kueue.x-k8s.io/managed": "true"}))
+				gomega.Expect(createdTemplate.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabel: "true"}))
 
 				ps2 := createdRequest.Spec.PodSets[1]
 				gomega.Expect(ps2.Count).To(gomega.Equal(int32(4)))
@@ -294,7 +296,7 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				gomega.Expect(createdTemplate.Template.Spec.Containers).To(gomega.BeComparableTo(updatedWl.Spec.PodSets[1].Template.Spec.Containers, ignoreContainersDefaults))
 				gomega.Expect(createdTemplate.Template.Spec.NodeSelector).To(gomega.BeComparableTo(map[string]string{"ns1": "ns1v"}))
-				gomega.Expect(createdTemplate.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{"kueue.x-k8s.io/managed": "true"}))
+				gomega.Expect(createdTemplate.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabel: "true"}))
 			})
 
 			ginkgo.By("Removing the quota reservation from the workload", func() {

--- a/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/controller/admissionchecks/provisioning/provisioning_test.go
@@ -281,6 +281,7 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				gomega.Expect(createdTemplate.Template.Spec.Containers).To(gomega.BeComparableTo(updatedWl.Spec.PodSets[0].Template.Spec.Containers, ignoreContainersDefaults))
 				gomega.Expect(createdTemplate.Template.Spec.NodeSelector).To(gomega.BeComparableTo(map[string]string{"ns1": "ns1v"}))
+				gomega.Expect(createdTemplate.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{"kueue.x-k8s.io/managed": "true"}))
 
 				ps2 := createdRequest.Spec.PodSets[1]
 				gomega.Expect(ps2.Count).To(gomega.Equal(int32(4)))
@@ -293,6 +294,7 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				gomega.Expect(createdTemplate.Template.Spec.Containers).To(gomega.BeComparableTo(updatedWl.Spec.PodSets[1].Template.Spec.Containers, ignoreContainersDefaults))
 				gomega.Expect(createdTemplate.Template.Spec.NodeSelector).To(gomega.BeComparableTo(map[string]string{"ns1": "ns1v"}))
+				gomega.Expect(createdTemplate.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{"kueue.x-k8s.io/managed": "true"}))
 			})
 
 			ginkgo.By("Removing the quota reservation from the workload", func() {

--- a/test/integration/controller/jobs/pod/pod_webhook_test.go
+++ b/test/integration/controller/jobs/pod/pod_webhook_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/discovery"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -108,11 +109,11 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				)
 
 				gomega.Expect(createdPod.Labels).To(
-					gomega.HaveKeyWithValue("kueue.x-k8s.io/managed", "true"),
+					gomega.HaveKeyWithValue(constants.ManagedByKueueLabel, "true"),
 					"Pod should have the label",
 				)
 
-				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement("kueue.x-k8s.io/managed"),
+				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement(constants.ManagedByKueueLabel),
 					"Pod should have finalizer set")
 			})
 
@@ -132,11 +133,11 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				)
 
 				gomega.Expect(createdPod.Labels).NotTo(
-					gomega.HaveKeyWithValue("kueue.x-k8s.io/managed", "true"),
+					gomega.HaveKeyWithValue(constants.ManagedByKueueLabel, "true"),
 					"Pod shouldn't have the label",
 				)
 
-				gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement("kueue.x-k8s.io/managed"),
+				gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabel),
 					"Pod shouldn't have finalizer set")
 			})
 		})
@@ -166,11 +167,11 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				)
 
 				gomega.Expect(createdPod.Labels).NotTo(
-					gomega.HaveKeyWithValue("kueue.x-k8s.io/managed", "true"),
+					gomega.HaveKeyWithValue(constants.ManagedByKueueLabel, "true"),
 					"Pod shouldn't have the label",
 				)
 
-				gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement("kueue.x-k8s.io/managed"),
+				gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabel),
 					"Pod shouldn't have finalizer set")
 			})
 		})
@@ -246,11 +247,11 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				)
 
 				gomega.Expect(createdPod.Labels).To(
-					gomega.HaveKeyWithValue("kueue.x-k8s.io/managed", "true"),
+					gomega.HaveKeyWithValue(constants.ManagedByKueueLabel, "true"),
 					"Pod should have the label",
 				)
 
-				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement("kueue.x-k8s.io/managed"),
+				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement(constants.ManagedByKueueLabel),
 					"Pod should have finalizer set")
 			})
 
@@ -270,11 +271,11 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				)
 
 				gomega.Expect(createdPod.Labels).NotTo(
-					gomega.HaveKeyWithValue("kueue.x-k8s.io/managed", "true"),
+					gomega.HaveKeyWithValue(constants.ManagedByKueueLabel, "true"),
 					"Pod shouldn't have the label",
 				)
 
-				gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement("kueue.x-k8s.io/managed"),
+				gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabel),
 					"Pod shouldn't have finalizer set")
 			})
 		})

--- a/test/integration/importer/importer_test.go
+++ b/test/integration/importer/importer_test.go
@@ -27,6 +27,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	importerpod "sigs.k8s.io/kueue/cmd/importer/pod"
 	importerutil "sigs.k8s.io/kueue/cmd/importer/util"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -123,7 +124,7 @@ var _ = ginkgo.Describe("Importer", func() {
 
 			pod3 := utiltestingpod.MakePod("pod3", ns.Name).
 				Queue("lq1").
-				Label("kueue.x-k8s.io/managed", "true").
+				Label(constants.ManagedByKueueLabel, "true").
 				Request(corev1.ResourceCPU, "2").
 				KueueSchedulingGate().
 				Obj()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds the `kueue.x-k8s.io/managed` label to PodTemplates created by Kueue

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2856 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Label `kueue.x-k8s.io/managed` is now added to PodTemplates created via ProvisioningRequest by Kueue
```