### PR TITLE
Update ClusterQueue and Cohort Resource Accounting for Hierarchical Cohorts

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -372,14 +372,11 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				"e": {
 					Name:                          "e",
 					AllocatableResourceGeneration: 2,
-					GuaranteedQuota: resources.FlavorResourceQuantities{
-						{Flavor: "default", Resource: "cpu"}: 1_000,
-					},
-					NamespaceSelector: labels.Nothing(),
-					FlavorFungibility: defaultFlavorFungibility,
-					Status:            active,
-					Preemption:        defaultPreemption,
-					FairWeight:        oneQuantity,
+					NamespaceSelector:             labels.Nothing(),
+					FlavorFungibility:             defaultFlavorFungibility,
+					Status:                        active,
+					Preemption:                    defaultPreemption,
+					FairWeight:                    oneQuantity,
 				},
 				"f": {
 					Name:                          "f",
@@ -447,8 +444,10 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AllocatableResourceGeneration: 2,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
-					Usage: resources.FlavorResourceQuantities{
-						{Flavor: "default", Resource: corev1.ResourceCPU}: 5000,
+					resourceNode: ResourceNode{
+						Usage: resources.FlavorResourceQuantities{
+							{Flavor: "default", Resource: corev1.ResourceCPU}: 5000,
+						},
 					},
 					AdmittedUsage: resources.FlavorResourceQuantities{
 						{Flavor: "default", Resource: corev1.ResourceCPU}: 5000,
@@ -528,7 +527,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"c": {
 					Name:                          "c",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 2,
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
 					Preemption:                    defaultPreemption,
@@ -884,13 +883,15 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					Preemption:                    defaultPreemption,
 					AllocatableResourceGeneration: 1,
 					FlavorFungibility:             defaultFlavorFungibility,
-					Usage: resources.FlavorResourceQuantities{
-						{Flavor: "f1", Resource: corev1.ResourceCPU}: 2000,
-					},
 					AdmittedUsage: resources.FlavorResourceQuantities{
 						{Flavor: "f1", Resource: corev1.ResourceCPU}: 1000,
 					},
 					FairWeight: oneQuantity,
+					resourceNode: ResourceNode{
+						Usage: resources.FlavorResourceQuantities{
+							{Flavor: "f1", Resource: corev1.ResourceCPU}: 2000,
+						},
+					},
 					Workloads: map[string]*workload.Info{
 						"ns/reserving": {
 							ClusterQueue: "cq1",
@@ -983,13 +984,6 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AllocatableResourceGeneration: 1,
 					FlavorFungibility:             defaultFlavorFungibility,
 					FairWeight:                    oneQuantity,
-					GuaranteedQuota: resources.FlavorResourceQuantities{
-						{Flavor: "on-demand", Resource: corev1.ResourceCPU}:    2_000,
-						{Flavor: "on-demand", Resource: corev1.ResourceMemory}: 2 * utiltesting.Gi,
-						{Flavor: "spot", Resource: corev1.ResourceCPU}:         0,
-						{Flavor: "spot", Resource: corev1.ResourceMemory}:      0,
-						{Flavor: "license", Resource: "license"}:               4,
-					},
 				},
 			},
 		},
@@ -1054,7 +1048,6 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AllocatableResourceGeneration: 1,
 					FlavorFungibility:             defaultFlavorFungibility,
 					FairWeight:                    oneQuantity,
-					GuaranteedQuota:               nil,
 				},
 			},
 		},
@@ -1646,7 +1639,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			for name, cq := range cache.hm.ClusterQueues {
 				gotResult[name] = result{
 					Workloads:     sets.KeySet(cq.Workloads),
-					UsedResources: cq.Usage,
+					UsedResources: cq.resourceNode.Usage,
 				}
 			}
 			if diff := cmp.Diff(step.wantResults, gotResult, cmpopts.EquateEmpty()); diff != "" {

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -1131,7 +1131,7 @@ func TestCohortLendable(t *testing.T) {
 		"example.com/gpu":  3,
 	}
 
-	lendable := cache.hm.ClusterQueues["cq1"].Parent().CalculateLendable()
+	lendable := cache.hm.Cohorts["test-cohort"].resourceNode.calculateLendable()
 	if diff := cmp.Diff(wantLendable, lendable); diff != "" {
 		t.Errorf("Unexpected cohort lendable (-want,+got):\n%s", diff)
 	}

--- a/pkg/cache/cohort_snapshot.go
+++ b/pkg/cache/cohort_snapshot.go
@@ -17,22 +17,30 @@ limitations under the License.
 package cache
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-
-	"sigs.k8s.io/kueue/pkg/resources"
 )
 
 type CohortSnapshot struct {
 	Name    string
 	Members sets.Set[*ClusterQueueSnapshot]
 
-	// RequestableResources equals to the sum of LendingLimit when feature LendingLimit enabled.
-	RequestableResources resources.FlavorResourceQuantities
-	Usage                resources.FlavorResourceQuantities
-	Lendable             map[corev1.ResourceName]int64
+	ResourceNode ResourceNode
 
 	// AllocatableResourceGeneration equals to
 	// the sum of allocatable generation among its members.
 	AllocatableResourceGeneration int64
+}
+
+// The methods below implement hierarchicalResourceNode interface.
+
+func (c *CohortSnapshot) HasParent() bool {
+	return false
+}
+
+func (c *CohortSnapshot) getResourceNode() ResourceNode {
+	return c.ResourceNode
+}
+
+func (c *CohortSnapshot) parentHRN() hierarchicalResourceNode {
+	return nil
 }

--- a/pkg/cache/resource.go
+++ b/pkg/cache/resource.go
@@ -47,7 +47,7 @@ func flavorResources(r resourceGroupNode) []resources.FlavorResource {
 
 type netQuotaNode interface {
 	usageFor(resources.FlavorResource) int64
-	QuotaFor(resources.FlavorResource) *ResourceQuota
+	QuotaFor(resources.FlavorResource) ResourceQuota
 	resourceGroups() []ResourceGroup
 }
 

--- a/pkg/cache/resource_node.go
+++ b/pkg/cache/resource_node.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"maps"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/kueue/pkg/resources"
+)
+
+type ResourceNode struct {
+	// Quotas are the ResourceQuotas specified for the current
+	// node.
+	Quotas map[resources.FlavorResource]ResourceQuota
+	// SubtreeQuota is the sum of the node's quota, as well as
+	// resources available from its children, constrained by
+	// LendingLimits.
+	SubtreeQuota resources.FlavorResourceQuantities
+	// Usage is the quantity which counts against this node's
+	// SubtreeQuota. For ClusterQueues, this is simply its
+	// usage. For Cohorts, this is the sum of childrens'
+	// usages past childrens' guaranteedQuotas.
+	Usage resources.FlavorResourceQuantities
+}
+
+func NewResourceNode() ResourceNode {
+	return ResourceNode{
+		Quotas:       make(map[resources.FlavorResource]ResourceQuota),
+		SubtreeQuota: make(resources.FlavorResourceQuantities),
+		Usage:        make(resources.FlavorResourceQuantities),
+	}
+}
+
+// Clone clones the mutable field Usage, while returning copies to
+// Quota and SubtreeQuota (these are replaced with new maps upon update).
+func (r ResourceNode) Clone() ResourceNode {
+	return ResourceNode{
+		Quotas:       r.Quotas,
+		SubtreeQuota: r.SubtreeQuota,
+		Usage:        maps.Clone(r.Usage),
+	}
+}
+
+// guaranteedQuota is the capacity which will not be lent the node's
+// Cohort.
+func (r ResourceNode) guaranteedQuota(fr resources.FlavorResource) int64 {
+	if lendingLimit := r.Quotas[fr].LendingLimit; lendingLimit != nil {
+		return max(0, r.SubtreeQuota[fr]-*lendingLimit)
+	}
+	return 0
+}
+
+type hierarchicalResourceNode interface {
+	getResourceNode() ResourceNode
+
+	HasParent() bool
+	parentHRN() hierarchicalResourceNode
+}
+
+// available determines how much capacity remains for the current
+// node, taking into account usage and BorrowingLimits. It finds remaining
+// capacity which is stored locally. If the node has a parent, it
+// queries the parent's capacity, limiting this amount by the borrowing
+// limit - and by how much capacity the node is storing/using in its parent.
+//
+// This function may return a negative number in the case of
+// overadmission - e.g. capacity was removed or the node moved to
+// another Cohort.
+//
+// We add an option to ignore the borrowing limit, to support
+// features.MultiplePreemptions=false path. This will be cleaned up in
+// v0.10, when we delete legacy logic.
+func available(node hierarchicalResourceNode, fr resources.FlavorResource, enforceBorrowLimit bool) int64 {
+	r := node.getResourceNode()
+	if !node.HasParent() {
+		return r.SubtreeQuota[fr] - r.Usage[fr]
+	}
+	localAvailable := max(0, r.guaranteedQuota(fr)-r.Usage[fr])
+	parentAvailable := available(node.parentHRN(), fr, enforceBorrowLimit)
+
+	if borrowingLimit := r.Quotas[fr].BorrowingLimit; enforceBorrowLimit && borrowingLimit != nil {
+		storedInParent := r.SubtreeQuota[fr] - r.guaranteedQuota(fr)
+		usedInParent := max(0, r.Usage[fr]-r.guaranteedQuota(fr))
+		withMaxFromParent := storedInParent - usedInParent + *borrowingLimit
+		parentAvailable = min(withMaxFromParent, parentAvailable)
+	}
+	return localAvailable + parentAvailable
+}
+
+// potentialAvailable returns the maximum capacity available to this node,
+// assuming no usage, while respecting BorrowingLimits.
+func potentialAvailable(node hierarchicalResourceNode, fr resources.FlavorResource) int64 {
+	r := node.getResourceNode()
+	if !node.HasParent() {
+		return r.SubtreeQuota[fr]
+	}
+	available := r.guaranteedQuota(fr) + potentialAvailable(node.parentHRN(), fr)
+	if borrowingLimit := r.Quotas[fr].BorrowingLimit; borrowingLimit != nil {
+		maxWithBorrowing := r.SubtreeQuota[fr] + *borrowingLimit
+		available = min(maxWithBorrowing, available)
+	}
+	return available
+}
+
+// addUsage adds usage to the current node, and bubbles up usage to
+// its Cohort when usage exceeds guaranteedQuota.
+func addUsage(node hierarchicalResourceNode, fr resources.FlavorResource, val int64) {
+	r := node.getResourceNode()
+	localAvailable := max(0, r.guaranteedQuota(fr)-r.Usage[fr])
+	r.Usage[fr] += val
+	if node.HasParent() && val > localAvailable {
+		deltaParentUsage := val - localAvailable
+		addUsage(node.parentHRN(), fr, deltaParentUsage)
+	}
+}
+
+// removeUsage removes usage from the current node, and removes usage
+// past guaranteedQuota that it was storing in its Cohort.
+func removeUsage(node hierarchicalResourceNode, fr resources.FlavorResource, val int64) {
+	r := node.getResourceNode()
+	usageStoredInParent := r.Usage[fr] - r.guaranteedQuota(fr)
+	r.Usage[fr] -= val
+	if usageStoredInParent <= 0 || !node.HasParent() {
+		return
+	}
+	deltaParentUsage := min(val, usageStoredInParent)
+	removeUsage(node.parentHRN(), fr, deltaParentUsage)
+}
+
+// calculateLendable aggregates capacity for resources across all
+// FlavorResources.
+func (r ResourceNode) calculateLendable() map[corev1.ResourceName]int64 {
+	lendable := make(map[corev1.ResourceName]int64, len(r.SubtreeQuota))
+	for fr, q := range r.SubtreeQuota {
+		lendable[fr.Resource] += q
+	}
+	return lendable
+}
+
+func updateClusterQueueResourceNode(cq *clusterQueue) {
+	cq.resourceNode.SubtreeQuota = make(resources.FlavorResourceQuantities, len(cq.resourceNode.Quotas))
+	for fr, quota := range cq.resourceNode.Quotas {
+		cq.resourceNode.SubtreeQuota[fr] = quota.Nominal
+	}
+}
+
+func updateCohortResourceNode(cohort *cohort) {
+	cohort.resourceNode.SubtreeQuota = make(resources.FlavorResourceQuantities, len(cohort.resourceNode.SubtreeQuota))
+	cohort.resourceNode.Usage = make(resources.FlavorResourceQuantities, len(cohort.resourceNode.Usage))
+	for _, child := range cohort.ChildCQs() {
+		for fr, childQuota := range child.resourceNode.SubtreeQuota {
+			cohort.resourceNode.SubtreeQuota[fr] += childQuota - child.resourceNode.guaranteedQuota(fr)
+		}
+		for fr, childUsage := range child.resourceNode.Usage {
+			cohort.resourceNode.Usage[fr] += max(0, childUsage-child.resourceNode.guaranteedQuota(fr))
+		}
+	}
+}

--- a/pkg/hierarchy/cohort.go
+++ b/pkg/hierarchy/cohort.go
@@ -22,6 +22,15 @@ type Cohort[CQ, C nodeBase] struct {
 	childCqs sets.Set[CQ]
 }
 
+func (c *Cohort[CQ, C]) Parent() C {
+	var zero C
+	return zero
+}
+
+func (c *Cohort[CQ, C]) HasParent() bool {
+	return false
+}
+
 func (c *Cohort[CQ, C]) ChildCQs() []CQ {
 	return c.childCqs.UnsortedList()
 }

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -45,7 +45,7 @@ type cohortResources struct {
 type testOracle struct{}
 
 func (f *testOracle) IsReclaimPossible(log logr.Logger, cq *cache.ClusterQueueSnapshot, wl workload.Info, fr resources.FlavorResource, quantity int64) bool {
-	return cq.QuotaFor(fr).Nominal >= quantity+cq.Usage[fr]
+	return !cq.BorrowingWith(fr, quantity)
 }
 
 func TestAssignFlavors(t *testing.T) {
@@ -1957,10 +1957,10 @@ func TestAssignFlavors(t *testing.T) {
 				if clusterQueue.Cohort == nil {
 					t.Fatalf("Test case has cohort resources, but cluster queue doesn't have cohort")
 				}
-				clusterQueue.Cohort.Usage = tc.cohortResources.usage
-				clusterQueue.Cohort.RequestableResources = tc.cohortResources.requestableResources
+				clusterQueue.Cohort.ResourceNode.Usage = tc.cohortResources.usage
+				clusterQueue.Cohort.ResourceNode.SubtreeQuota = tc.cohortResources.requestableResources
 			}
-			clusterQueue.Usage = tc.clusterQueueUsage
+			clusterQueue.ResourceNode.Usage = tc.clusterQueueUsage
 
 			flvAssigner := New(wlInfo, clusterQueue, resourceFlavors, tc.enableFairSharing, &testOracle{})
 			assignment := flvAssigner.Assign(log, nil)

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -571,7 +571,7 @@ func workloadFits(requests resources.FlavorResourceQuantities, cq *cache.Cluster
 
 func queueUnderNominalInResourcesNeedingPreemption(frsNeedPreemption sets.Set[resources.FlavorResource], cq *cache.ClusterQueueSnapshot) bool {
 	for fr := range frsNeedPreemption {
-		if cq.Usage[fr] >= cq.QuotaFor(fr).Nominal {
+		if cq.ResourceNode.Usage[fr] >= cq.QuotaFor(fr).Nominal {
 			return false
 		}
 	}

--- a/pkg/scheduler/preemption/preemption_oracle.go
+++ b/pkg/scheduler/preemption/preemption_oracle.go
@@ -38,7 +38,7 @@ type PreemptionOracle struct {
 // FlavorResource by reclaiming its nominal quota which it lent to its
 // Cohort.
 func (p *PreemptionOracle) IsReclaimPossible(log logr.Logger, cq *cache.ClusterQueueSnapshot, wl workload.Info, fr resources.FlavorResource, quantity int64) bool {
-	if cq.Usage[fr]+quantity > cq.QuotaFor(fr).Nominal {
+	if cq.BorrowingWith(fr, quantity) {
 		return false
 	}
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -439,10 +439,10 @@ func resourcesToReserve(e *entry, cq *cache.ClusterQueueSnapshot) resources.Flav
 			if cqQuota.BorrowingLimit == nil {
 				reservedUsage[fr] = usage
 			} else {
-				reservedUsage[fr] = min(usage, cqQuota.Nominal+*cqQuota.BorrowingLimit-cq.Usage[fr])
+				reservedUsage[fr] = min(usage, cqQuota.Nominal+*cqQuota.BorrowingLimit-cq.ResourceNode.Usage[fr])
 			}
 		} else {
-			reservedUsage[fr] = max(0, min(usage, cqQuota.Nominal-cq.Usage[fr]))
+			reservedUsage[fr] = max(0, min(usage, cqQuota.Nominal-cq.ResourceNode.Usage[fr]))
 		}
 	}
 	return reservedUsage


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
We define `cache.ResourceNode`, which is the new way of accounting capacity
and usage that is compatible with Hierarchical Cohorts. See #79

We define `SubtreeQuota`, which is the capacity available to a certain
node in the tree, respecting `LendingLimits` of its children.

The notion of `Usage` remains the same: `Usage` past
`GuaranteedQuota` is bubbled up the parent.

We delete the field `GuaranteedQuota`, as it can be derived
from `SubtreeQuota` and `LendingLimit`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```