### PR TITLE
Deep clone ResourceGroups instead shallow copy on snapshot clusterQueue.

### DIFF
--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -107,6 +107,14 @@ type ResourceGroup struct {
 	LabelKeys sets.Set[string]
 }
 
+func (rg *ResourceGroup) Clone() ResourceGroup {
+	return ResourceGroup{
+		CoveredResources: rg.CoveredResources.Clone(),
+		Flavors:          rg.Flavors,
+		LabelKeys:        rg.LabelKeys.Clone(),
+	}
+}
+
 type ResourceQuota struct {
 	Nominal        int64
 	BorrowingLimit *int64

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -120,6 +120,7 @@ func (c *Cache) Snapshot() Snapshot {
 func (c *clusterQueue) snapshot() *ClusterQueueSnapshot {
 	cc := &ClusterQueueSnapshot{
 		Name:                          c.Name,
+		ResourceGroups:                make([]ResourceGroup, len(c.ResourceGroups)),
 		FlavorFungibility:             c.FlavorFungibility,
 		FairWeight:                    c.FairWeight,
 		AllocatableResourceGeneration: c.AllocatableResourceGeneration,
@@ -132,8 +133,8 @@ func (c *clusterQueue) snapshot() *ClusterQueueSnapshot {
 		Quotas:                        c.quotas,
 	}
 
-	for _, rg := range c.ResourceGroups {
-		cc.ResourceGroups = append(cc.ResourceGroups, rg.Clone())
+	for i, rg := range c.ResourceGroups {
+		cc.ResourceGroups[i] = rg.Clone()
 	}
 
 	if features.Enabled(features.LendingLimit) {

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -120,7 +120,6 @@ func (c *Cache) Snapshot() Snapshot {
 func (c *clusterQueue) snapshot() *ClusterQueueSnapshot {
 	cc := &ClusterQueueSnapshot{
 		Name:                          c.Name,
-		ResourceGroups:                c.ResourceGroups, // Shallow copy is enough.
 		FlavorFungibility:             c.FlavorFungibility,
 		FairWeight:                    c.FairWeight,
 		AllocatableResourceGeneration: c.AllocatableResourceGeneration,
@@ -131,6 +130,10 @@ func (c *clusterQueue) snapshot() *ClusterQueueSnapshot {
 		Status:                        c.Status,
 		AdmissionChecks:               utilmaps.DeepCopySets[kueue.ResourceFlavorReference](c.AdmissionChecks),
 		Quotas:                        c.quotas,
+	}
+
+	for _, rg := range c.ResourceGroups {
+		cc.ResourceGroups = append(cc.ResourceGroups, rg.Clone())
 	}
 
 	if features.Enabled(features.LendingLimit) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We need to perform a deep clone of `ResourceGroups` instead of a shallow copy when taking a snapshot of `clusterQueue` to prevent race conditions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2901

#### Special notes for your reviewer:
When running `make test-integration`, sometimes happens a race condition in the `LabelKeys`  within the `ResourceGroups` structure. 

Write on clusterQueue:
```
WARNING: DATA RACE
  Write at 0x00c000c6a680 by goroutine 424:
    sigs.k8s.io/kueue/pkg/cache.(*clusterQueue).updateLabelKeys()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/cache/clusterqueue.go:336 +0x215
    sigs.k8s.io/kueue/pkg/cache.(*clusterQueue).UpdateWithFlavors()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/cache/clusterqueue.go:312 +0x33
    sigs.k8s.io/kueue/pkg/cache.(*Cache).updateClusterQueues()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/cache/cache.go:205 +0x1a5
    sigs.k8s.io/kueue/pkg/cache.(*Cache).AddOrUpdateResourceFlavor()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/cache/cache.go:219 +0x14b
    sigs.k8s.io/kueue/pkg/controller/core.(*ResourceFlavorReconciler).Update()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/controller/core/resourceflavor_controller.go:179 +0x3c4
    sigs.k8s.io/controller-runtime/pkg/internal/source.(*EventHandler).OnUpdate()
```

https://github.com/kubernetes-sigs/kueue/blob/24d442300b3b0fb3ca6fdbeff61e1d6f8c6b2ba4/pkg/cache/clusterqueue.go#L335-L337



Read on ClusterQueueSnapshot:
```
Previous read at 0x00c000c6a680 by goroutine 186:
    sigs.k8s.io/kueue/pkg/scheduler/flavorassigner.(*FlavorAssigner).findFlavorForPodSetResource()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/scheduler/flavorassigner/flavorassigner.go:428 +0x6cd
    sigs.k8s.io/kueue/pkg/scheduler/flavorassigner.(*FlavorAssigner).assignFlavors()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/scheduler/flavorassigner/flavorassigner.go:359 +0xb24
    sigs.k8s.io/kueue/pkg/scheduler/flavorassigner.(*FlavorAssigner).Assign()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/scheduler/flavorassigner/flavorassigner.go:317 +0x911
    sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).getAssignments()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/scheduler/scheduler.go:454 +0x330
    sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).nominate()
        /home/prow/go/src/sigs.k8s.io/kueue/pkg/scheduler/scheduler.go:413 +0xee4
    sigs.k8s.io/kueue/pkg/scheduler.(*Scheduler).schedule()
```

https://github.com/kubernetes-sigs/kueue/blob/24d442300b3b0fb3ca6fdbeff61e1d6f8c6b2ba4/pkg/scheduler/flavorassigner/flavorassigner.go#L428



This issue arises because a shallow copy of `ResourceGroups` is created  when taking a snapshot, leading to shared references for the LabelKeys set. To prevent this, we need to perform a deep copy of the ResourceGroups structure during the snapshot process.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```