### PR TITLE
Rename/Refactor Hierarchy Package

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -113,7 +113,7 @@ func New(client client.Client, opts ...Option) *Cache {
 		podsReadyTracking:   options.podsReadyTracking,
 		workloadInfoOptions: options.workloadInfoOptions,
 		fairSharingEnabled:  options.fairSharingEnabled,
-		hm:                  hierarchy.NewManager[*clusterQueue, *cohort](cohortFactory),
+		hm:                  hierarchy.NewManager[*clusterQueue, *cohort](newCohort),
 	}
 	c.podsReadyCond.L = &c.RWMutex
 	return c

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1008,7 +1008,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			if diff := cmp.Diff(tc.wantClusterQueues, cache.hm.ClusterQueues,
 				cmpopts.IgnoreFields(clusterQueue{}, "ResourceGroups"),
 				cmpopts.IgnoreFields(workload.Info{}, "Obj", "LastAssignment"),
-				cmpopts.IgnoreUnexported(clusterQueue{}, hierarchy.WiredClusterQueue[*clusterQueue, *cohort]{}),
+				cmpopts.IgnoreUnexported(clusterQueue{}, hierarchy.ClusterQueue[*cohort]{}),
 				cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Unexpected clusterQueues (-want,+got):\n%s", diff)
 			}
@@ -1016,7 +1016,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			gotCohorts := make(map[string]sets.Set[string], len(cache.hm.Cohorts))
 			for name, cohort := range cache.hm.Cohorts {
 				gotCohort := sets.New[string]()
-				for _, cq := range cohort.Members() {
+				for _, cq := range cohort.ChildCQs() {
 					gotCohort.Insert(cq.Name)
 				}
 				gotCohorts[name] = gotCohort

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -143,13 +143,13 @@ func (c *clusterQueue) snapshot() *ClusterQueueSnapshot {
 func (c *cohort) snapshotInto(cqs map[string]*ClusterQueueSnapshot) {
 	cohortSnap := &CohortSnapshot{
 		Name:                 c.Name,
-		Members:              make(sets.Set[*ClusterQueueSnapshot], len(c.Members())),
+		Members:              make(sets.Set[*ClusterQueueSnapshot], len(c.ChildCQs())),
 		Lendable:             c.CalculateLendable(),
 		Usage:                make(resources.FlavorResourceQuantities),
 		RequestableResources: make(resources.FlavorResourceQuantities),
 	}
 	cohortSnap.AllocatableResourceGeneration = 0
-	for _, cq := range c.Members() {
+	for _, cq := range c.ChildCQs() {
 		if cq.Active() {
 			cqSnap := cqs[cq.Name]
 			cqSnap.accumulateResources(cohortSnap)

--- a/pkg/hierarchy/clusterqueue.go
+++ b/pkg/hierarchy/clusterqueue.go
@@ -16,21 +16,21 @@ limitations under the License.
 
 package hierarchy
 
-import "k8s.io/apimachinery/pkg/util/sets"
-
-type WiredCohort[CQ, Cohort nodeBase] struct {
-	members sets.Set[CQ]
+type ClusterQueue[C nodeBase] struct {
+	cohort C
 }
 
-func (c *WiredCohort[CQ, Cohort]) Members() []CQ {
-	return c.members.UnsortedList()
+func (c *ClusterQueue[C]) Parent() C {
+	return c.cohort
 }
 
-func NewWiredCohort[CQ, Cohort nodeBase]() WiredCohort[CQ, Cohort] {
-	return WiredCohort[CQ, Cohort]{members: sets.New[CQ]()}
+func (c *ClusterQueue[C]) HasParent() bool {
+	var zero C
+	return c.Parent() != zero
 }
 
-// Wired implements interface for Manager
-func (c *WiredCohort[CQ, Cohort]) Wired() *WiredCohort[CQ, Cohort] {
-	return c
+// implements clusterQueueNode interface
+
+func (c *ClusterQueue[C]) setParent(cohort C) {
+	c.cohort = cohort
 }

--- a/pkg/hierarchy/cohort.go
+++ b/pkg/hierarchy/cohort.go
@@ -16,20 +16,30 @@ limitations under the License.
 
 package hierarchy
 
-type WiredClusterQueue[CQ, Cohort nodeBase] struct {
-	cohort Cohort
+import "k8s.io/apimachinery/pkg/util/sets"
+
+type Cohort[CQ, C nodeBase] struct {
+	childCqs sets.Set[CQ]
 }
 
-func (c *WiredClusterQueue[CQ, Cohort]) Parent() Cohort {
-	return c.cohort
+func (c *Cohort[CQ, C]) ChildCQs() []CQ {
+	return c.childCqs.UnsortedList()
 }
 
-func (c *WiredClusterQueue[CQ, Cohort]) HasParent() bool {
-	var zero Cohort
-	return c.Parent() != zero
+func NewCohort[CQ, C nodeBase]() Cohort[CQ, C] {
+	return Cohort[CQ, C]{childCqs: sets.New[CQ]()}
 }
 
-// Wired implements interface for Manager
-func (c *WiredClusterQueue[CQ, Cohort]) Wired() *WiredClusterQueue[CQ, Cohort] {
-	return c
+// implement cohortNode interface
+
+func (c *Cohort[CQ, C]) insertClusterQueue(cq CQ) {
+	c.childCqs.Insert(cq)
+}
+
+func (c *Cohort[CQ, C]) deleteClusterQueue(cq CQ) {
+	c.childCqs.Delete(cq)
+}
+
+func (c *Cohort[CQ, C]) childCount() int {
+	return c.childCqs.Len()
 }

--- a/pkg/hierarchy/manager_test.go
+++ b/pkg/hierarchy/manager_test.go
@@ -185,7 +185,7 @@ func TestManager(t *testing.T) {
 				gotEdges := make([]cqEdge, 0, len(tc.wantCqEdge))
 				for _, cohort := range mgr.Cohorts {
 					gotCohorts.Insert(cohort.GetName())
-					for _, cq := range cohort.Members() {
+					for _, cq := range cohort.ChildCQs() {
 						gotEdges = append(gotEdges, cqEdge{cq.GetName(), cohort.GetName()})
 					}
 				}
@@ -202,13 +202,13 @@ func TestManager(t *testing.T) {
 
 type testCohort struct {
 	name string
-	WiredCohort[*testClusterQueue, *testCohort]
+	Cohort[*testClusterQueue, *testCohort]
 }
 
 func cohortFactory(name string) *testCohort {
 	return &testCohort{
-		name:        name,
-		WiredCohort: NewWiredCohort[*testClusterQueue, *testCohort](),
+		name:   name,
+		Cohort: NewCohort[*testClusterQueue, *testCohort](),
 	}
 }
 
@@ -218,7 +218,7 @@ func (t *testCohort) GetName() string {
 
 type testClusterQueue struct {
 	name string
-	WiredClusterQueue[*testClusterQueue, *testCohort]
+	ClusterQueue[*testCohort]
 }
 
 func newCq(name string) *testClusterQueue {

--- a/pkg/queue/cluster_queue.go
+++ b/pkg/queue/cluster_queue.go
@@ -51,7 +51,7 @@ var (
 )
 
 type ClusterQueue struct {
-	hierarchy.WiredClusterQueue[*ClusterQueue, *cohort]
+	hierarchy.ClusterQueue[*cohort]
 	name              string
 	heap              heap.Heap[workload.Info]
 	namespaceSelector labels.Selector

--- a/pkg/queue/cohort.go
+++ b/pkg/queue/cohort.go
@@ -22,13 +22,13 @@ import "sigs.k8s.io/kueue/pkg/hierarchy"
 // each other.
 type cohort struct {
 	Name string
-	hierarchy.WiredCohort[*ClusterQueue, *cohort]
+	hierarchy.Cohort[*ClusterQueue, *cohort]
 }
 
-func cohortFactory(name string) *cohort {
+func newCohort(name string) *cohort {
 	return &cohort{
 		name,
-		hierarchy.NewWiredCohort[*ClusterQueue, *cohort](),
+		hierarchy.NewCohort[*ClusterQueue, *cohort](),
 	}
 }
 

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -103,7 +103,7 @@ func NewManager(client client.Client, checker StatusChecker, opts ...Option) *Ma
 			PodsReadyRequeuingTimestamp: options.podsReadyRequeuingTimestamp,
 		},
 		workloadInfoOptions: options.workloadInfoOptions,
-		hm:                  hierarchy.NewManager[*ClusterQueue, *cohort](cohortFactory),
+		hm:                  hierarchy.NewManager[*ClusterQueue, *cohort](newCohort),
 	}
 	m.cond.L = &m.RWMutex
 	return m
@@ -441,7 +441,7 @@ func (m *Manager) queueAllInadmissibleWorkloadsInCohort(ctx context.Context, cq 
 	}
 
 	queued := false
-	for _, clusterQueue := range cq.Parent().Members() {
+	for _, clusterQueue := range cq.Parent().ChildCQs() {
 		queued = clusterQueue.QueueInadmissibleWorkloads(ctx, m.client) || queued
 	}
 	return queued

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -176,7 +176,7 @@ func TestUpdateClusterQueue(t *testing.T) {
 	gotCohorts := make(map[string]sets.Set[string])
 	for name, cohort := range manager.hm.Cohorts {
 		gotCohorts[name] = sets.New[string]()
-		for _, cq := range cohort.Members() {
+		for _, cq := range cohort.ChildCQs() {
 			gotCohorts[name].Insert(cq.GetName())
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Address @alculquicondor comments in #2824, and update the names to be more consistent

- Delete the name Wired from `WiredClusterQueue` and `WiredCohort`
- Define (unexported) methods for accessing state of these types inside the hierarchy package
- Consistently refer to Cohort as C in generic type parameter
- Rename Members to childCqs, as soon there will be childCohorts
- Rename Cohort to Parent
- Rename cohortFactory to newCohort

#### Does this PR introduce a user-facing change?
```release-note
NONE
```