### PR TITLE
Graduate LendingLimit to Beta

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -235,8 +235,7 @@ type ResourceQuota struct {
 	// all the nominalQuota can be borrowed by other clusterQueues in the cohort.
 	// If not null, it must be non-negative.
 	// lendingLimit must be null if spec.cohort is empty.
-	// This field is in alpha stage. To be able to use this field,
-	// enable the feature gate LendingLimit, which is disabled by default.
+	// This field is in beta stage and is enabled by default.
 	// +optional
 	LendingLimit *resource.Quantity `json:"lendingLimit,omitempty"`
 }

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -434,8 +434,7 @@ spec:
                                     all the nominalQuota can be borrowed by other clusterQueues in the cohort.
                                     If not null, it must be non-negative.
                                     lendingLimit must be null if spec.cohort is empty.
-                                    This field is in alpha stage. To be able to use this field,
-                                    enable the feature gate LendingLimit, which is disabled by default.
+                                    This field is in beta stage and is enabled by default.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 name:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
@@ -160,8 +160,7 @@ spec:
                                     all the nominalQuota can be borrowed by other clusterQueues in the cohort.
                                     If not null, it must be non-negative.
                                     lendingLimit must be null if spec.cohort is empty.
-                                    This field is in alpha stage. To be able to use this field,
-                                    enable the feature gate LendingLimit, which is disabled by default.
+                                    This field is in beta stage and is enabled by default.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 name:

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -419,8 +419,7 @@ spec:
                                     all the nominalQuota can be borrowed by other clusterQueues in the cohort.
                                     If not null, it must be non-negative.
                                     lendingLimit must be null if spec.cohort is empty.
-                                    This field is in alpha stage. To be able to use this field,
-                                    enable the feature gate LendingLimit, which is disabled by default.
+                                    This field is in beta stage and is enabled by default.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 name:

--- a/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
@@ -145,8 +145,7 @@ spec:
                                     all the nominalQuota can be borrowed by other clusterQueues in the cohort.
                                     If not null, it must be non-negative.
                                     lendingLimit must be null if spec.cohort is empty.
-                                    This field is in alpha stage. To be able to use this field,
-                                    enable the feature gate LendingLimit, which is disabled by default.
+                                    This field is in beta stage and is enabled by default.
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                                 name:

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -81,6 +81,7 @@ const (
 	// owners: @B1F030, @kerthcet
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/1224-lending-limit
 	// alpha: v0.6
+	// beta: v0.9
 	//
 	// Enables lending limit.
 	LendingLimit featuregate.Feature = "LendingLimit"
@@ -118,7 +119,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	VisibilityOnDemand:              {Default: false, PreRelease: featuregate.Alpha},
 	PrioritySortingWithinCohort:     {Default: true, PreRelease: featuregate.Beta},
 	MultiKueue:                      {Default: false, PreRelease: featuregate.Alpha},
-	LendingLimit:                    {Default: false, PreRelease: featuregate.Alpha},
+	LendingLimit:                    {Default: true, PreRelease: featuregate.Beta},
 	MultiKueueBatchJobWithManagedBy: {Default: false, PreRelease: featuregate.Alpha},
 	MultiplePreemptions:             {Default: true, PreRelease: featuregate.Beta},
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/testing/metrics"
 )
 
@@ -47,7 +46,6 @@ func TestGenerateExponentialBuckets(t *testing.T) {
 }
 
 func TestReportAndCleanupClusterQueueMetrics(t *testing.T) {
-	defer features.SetFeatureGateDuringTest(t, features.LendingLimit, true)()
 	ReportClusterQueueQuotas("cohort", "queue", "flavor", "res", 5, 10, 3)
 	ReportClusterQueueQuotas("cohort", "queue", "flavor2", "res", 1, 2, 1)
 
@@ -74,7 +72,6 @@ func TestReportAndCleanupClusterQueueMetrics(t *testing.T) {
 }
 
 func TestReportAndCleanupClusterQueueQuotas(t *testing.T) {
-	defer features.SetFeatureGateDuringTest(t, features.LendingLimit, true)()
 	ReportClusterQueueQuotas("cohort", "queue", "flavor", "res", 5, 10, 3)
 	ReportClusterQueueQuotas("cohort", "queue", "flavor", "res2", 5, 10, 3)
 	ReportClusterQueueQuotas("cohort", "queue", "flavor2", "res", 1, 2, 1)

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -66,15 +66,15 @@ func TestAssignFlavors(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		wlPods             []kueue.PodSet
-		wlReclaimablePods  []kueue.ReclaimablePod
-		clusterQueue       kueue.ClusterQueue
-		clusterQueueUsage  resources.FlavorResourceQuantities
-		cohortResources    *cohortResources
-		wantRepMode        FlavorAssignmentMode
-		wantAssignment     Assignment
-		enableLendingLimit bool
-		enableFairSharing  bool
+		wlPods              []kueue.PodSet
+		wlReclaimablePods   []kueue.ReclaimablePod
+		clusterQueue        kueue.ClusterQueue
+		clusterQueueUsage   resources.FlavorResourceQuantities
+		cohortResources     *cohortResources
+		wantRepMode         FlavorAssignmentMode
+		wantAssignment      Assignment
+		disableLendingLimit bool
+		enableFairSharing   bool
 	}{
 		"single flavor, fits": {
 			wlPods: []kueue.PodSet{
@@ -1726,7 +1726,6 @@ func TestAssignFlavors(t *testing.T) {
 					{Flavor: "two", Resource: corev1.ResourcePods}: 1,
 				},
 			},
-			enableLendingLimit: true,
 		},
 		"lend try next flavor, found the first flavor": {
 			wlPods: []kueue.PodSet{
@@ -1781,7 +1780,6 @@ func TestAssignFlavors(t *testing.T) {
 					{Flavor: "one", Resource: corev1.ResourcePods}: 1,
 				},
 			},
-			enableLendingLimit: true,
 		},
 		"quota exhausted, but can preempt in cohort and ClusterQueue": {
 			wlPods: []kueue.PodSet{
@@ -1830,7 +1828,6 @@ func TestAssignFlavors(t *testing.T) {
 					{Flavor: "one", Resource: corev1.ResourcePods}: 1,
 				},
 			},
-			enableLendingLimit: true,
 		},
 		"when borrowing while preemption is needed for flavor one, fair sharing enabled, reclaimWithinCohort=Any": {
 			enableFairSharing: true,
@@ -1927,7 +1924,9 @@ func TestAssignFlavors(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			defer features.SetFeatureGateDuringTest(t, features.LendingLimit, tc.enableLendingLimit)()
+			if tc.disableLendingLimit {
+				defer features.SetFeatureGateDuringTest(t, features.LendingLimit, false)()
+			}
 			log := testr.NewWithOptions(t, testr.Options{
 				Verbosity: 2,
 			})

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -358,12 +358,12 @@ To limit the amount of resources that a ClusterQueue can lend in the cohort,
 you can set the `.spec.resourcesGroup[*].flavors[*].resource[*].lendingLimit`
 [quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/) field.
 
-{{< feature-state state="alpha" for_version="v0.6" >}}
+{{< feature-state state="beta" for_version="v0.9" >}}
 {{% alert title="Warning" color="warning" %}}
 
-`LendingLimit` is an Alpha feature disabled by default.
+`LendingLimit` is a Beta feature enabled by default.
 
-You can enable it by setting the `LendingLimit` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
+You can disable it by setting the `LendingLimit` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
 {{% /alert %}}
 
 As an example, assume you created the following two ClusterQueues:

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -255,7 +255,8 @@ The currently supported features are:
 | `QueueVisibility` | `false` | Alpha | 0.5 |  |
 | `VisibilityOnDemand` | `false` | Alpha | 0.6 | |
 | `PrioritySortingWithinCohort` | `true` | Beta | 0.6 |  |
-| `LendingLimit` | `false` | Alpha | 0.6 | |
+| `LendingLimit` | `false` | Alpha | 0.6 | 0.8 |
+| `LendingLimit` | `true` | Beta | 0.9 | |
 | `MultiplePreemptions` | `false` | Alpha | 0.8 | 0.8 |
 | `MultiplePreemptions` | `true` | Beta | 0.9 | |
 

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -1787,8 +1787,7 @@ If null, it means that there is no lending limit, meaning that
 all the nominalQuota can be borrowed by other clusterQueues in the cohort.
 If not null, it must be non-negative.
 lendingLimit must be null if spec.cohort is empty.
-This field is in alpha stage. To be able to use this field,
-enable the feature gate LendingLimit, which is disabled by default.</p>
+This field is in beta stage and is enabled by default.</p>
 </td>
 </tr>
 </tbody>

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -722,18 +722,13 @@ var _ = ginkgo.Describe("Preemption", func() {
 		})
 	})
 
-	ginkgo.Context("When lending limit enabled", func() {
+	ginkgo.Context("With lending limit", func() {
 		var (
 			prodCQ *kueue.ClusterQueue
 			devCQ  *kueue.ClusterQueue
 		)
 
-		ginkgo.BeforeEach(func() {
-			_ = features.SetEnable(features.LendingLimit, true)
-		})
-
 		ginkgo.AfterEach(func() {
-			_ = features.SetEnable(features.LendingLimit, false)
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, prodCQ, true)
 			if devCQ != nil {

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -1407,19 +1407,17 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		})
 	})
 
-	ginkgo.When("Using cohorts for sharing when LendingLimit enabled", func() {
+	ginkgo.When("Using cohorts for sharing with LendingLimit", func() {
 		var (
 			prodCQ *kueue.ClusterQueue
 			devCQ  *kueue.ClusterQueue
 		)
 
 		ginkgo.BeforeEach(func() {
-			_ = features.SetEnable(features.LendingLimit, true)
 			gomega.Expect(k8sClient.Create(ctx, onDemandFlavor)).Should(gomega.Succeed())
 		})
 
 		ginkgo.AfterEach(func() {
-			_ = features.SetEnable(features.LendingLimit, false)
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, prodCQ, true)
 			if devCQ != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Graduate LendingLimit feature to beta and enable it by default.

Feature flag is now enabled by default also in the tests. Added new test cases to verify a cases when `LendingLimit` field is set without a feature flag enabled.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Graduated LendingLimit to Beta and enabled by default.
```