### PR TITLE
Add gauge for skipped preemptions within a cycle

### DIFF
--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -152,7 +152,7 @@ func TestReportAndCleanupClusterQueueEvictedNumber(t *testing.T) {
 	expectFilteredMetricsCount(t, EvictedWorkloadsTotal, 1, "cluster_queue", "cluster_queue1", "reason", "Preempted")
 	expectFilteredMetricsCount(t, EvictedWorkloadsTotal, 1, "cluster_queue", "cluster_queue1", "reason", "Evicted")
 
-	ClearQueueSystemMetrics("cluster_queue1")
+	ClearClusterQueueMetrics("cluster_queue1")
 	expectFilteredMetricsCount(t, EvictedWorkloadsTotal, 0, "cluster_queue", "cluster_queue1")
 }
 
@@ -169,7 +169,7 @@ func TestReportAndCleanupClusterQueuePreemptedNumber(t *testing.T) {
 	expectFilteredMetricsCount(t, PreemptedWorkloadsTotal, 1, "preempting_cluster_queue", "cluster_queue1", "reason", "InCohortReclamation")
 	expectFilteredMetricsCount(t, PreemptedWorkloadsTotal, 1, "preempting_cluster_queue", "cluster_queue1", "reason", "InCohortReclaimWhileBorrowing")
 
-	ClearQueueSystemMetrics("cluster_queue1")
+	ClearClusterQueueMetrics("cluster_queue1")
 	expectFilteredMetricsCount(t, PreemptedWorkloadsTotal, 0, "preempting_cluster_queue", "cluster_queue1")
 	expectFilteredMetricsCount(t, EvictedWorkloadsTotal, 0, "cluster_queue", "cluster_queue1")
 }

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -179,7 +179,7 @@ func (m *Manager) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 		return
 	}
 	m.hm.DeleteClusterQueue(cq.Name)
-	metrics.ClearQueueSystemMetrics(cq.Name)
+	metrics.ClearClusterQueueMetrics(cq.Name)
 }
 
 func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -44,6 +45,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
@@ -281,6 +283,8 @@ func TestSchedule(t *testing.T) {
 		wantPreempted sets.Set[string]
 		// wantEvents ignored if empty, the Message is ignored (it contains the duration)
 		wantEvents []utiltesting.EventRecord
+
+		wantSkippedPreemptions map[string]int
 	}{
 		"workload fits in single clusterQueue, with check state ready": {
 			workloads: []kueue.Workload{
@@ -1060,6 +1064,11 @@ func TestSchedule(t *testing.T) {
 			wantLeft: map[string][]string{
 				"eng-gamma": {"eng-gamma/new-gamma"},
 			},
+			wantSkippedPreemptions: map[string]int{
+				"eng-alpha": 0,
+				"eng-beta":  0,
+				"eng-gamma": 1,
+			},
 		},
 		"no overadmission while borrowing (duplicated from above)": {
 			// duplicate of test case above, as new logic
@@ -1179,6 +1188,11 @@ func TestSchedule(t *testing.T) {
 			wantScheduled: []string{"eng-beta/new", "eng-alpha/new-alpha"},
 			wantInadmissibleLeft: map[string][]string{
 				"eng-gamma": {"eng-gamma/new-gamma"},
+			},
+			wantSkippedPreemptions: map[string]int{
+				"eng-alpha": 0,
+				"eng-beta":  0,
+				"eng-gamma": 0,
 			},
 		},
 		"partial admission single variable pod set": {
@@ -1885,6 +1899,10 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
 				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
 			},
+			wantSkippedPreemptions: map[string]int{
+				"other-alpha": 0,
+				"other-beta":  0,
+			},
 		},
 		"multiple preemptions preemption possible after earlier workload fits": {
 			// When one workload is assigned Fit,
@@ -1944,6 +1962,10 @@ func TestSchedule(t *testing.T) {
 				"eng-beta/b1":   *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
 			},
 			wantScheduled: []string{"eng-alpha/fit"},
+			wantSkippedPreemptions: map[string]int{
+				"other-alpha": 0,
+				"other-beta":  0,
+			},
 		},
 		"multiple preemptions skip preemption when shared limited resource": {
 			// The two preempting workloads, each requesting 3 CPU,
@@ -2026,6 +2048,10 @@ func TestSchedule(t *testing.T) {
 			wantAssignments: map[string]kueue.Admission{
 				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
 				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
+			},
+			wantSkippedPreemptions: map[string]int{
+				"other-alpha": 0,
+				"other-beta":  1,
 			},
 		},
 		"multiple preemptions within cq when fair sharing": {
@@ -2132,6 +2158,11 @@ func TestSchedule(t *testing.T) {
 					Assignment(corev1.ResourceCPU, "default", "3").Obj(),
 				"eng-gamma/c1": *utiltesting.MakeAdmission("other-gamma").
 					Assignment(corev1.ResourceCPU, "default", "3").Obj(),
+			},
+			wantSkippedPreemptions: map[string]int{
+				"other-alpha": 0,
+				"other-beta":  0,
+				"other-gamma": 0,
 			},
 		},
 		"multiple preemptions skip overlapping preemption targets": {
@@ -2241,6 +2272,11 @@ func TestSchedule(t *testing.T) {
 					Assignment("beta-resource", "default", "1").Obj(),
 				"eng-gamma/c1": *utiltesting.MakeAdmission("other-gamma").
 					Assignment(corev1.ResourceCPU, "default", "9").Obj(),
+			},
+			wantSkippedPreemptions: map[string]int{
+				"other-alpha": 0,
+				"other-beta":  1,
+				"other-gamma": 0,
 			},
 		},
 		"not enough resources": {
@@ -2525,6 +2561,7 @@ func TestSchedule(t *testing.T) {
 
 	for name, tc := range cases {
 		tc.multiplePreemptions.runTest(name, t, func(t *testing.T) {
+			metrics.AdmissionCyclePreemptionSkips.Reset()
 			if tc.disableLendingLimit {
 				defer features.SetFeatureGateDuringTest(t, features.LendingLimit, false)()
 			}
@@ -2656,6 +2693,17 @@ func TestSchedule(t *testing.T) {
 			if len(tc.wantEvents) > 0 {
 				if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents, cmpopts.IgnoreFields(utiltesting.EventRecord{}, "Message")); diff != "" {
 					t.Errorf("unexpected events (-want/+got):\n%s", diff)
+				}
+			}
+
+			for cqName, want := range tc.wantSkippedPreemptions {
+				val, err := testutil.GetGaugeMetricValue(metrics.AdmissionCyclePreemptionSkips.WithLabelValues(cqName))
+				if err != nil {
+					t.Fatalf("Couldn't get value for metric admission_cycle_preemption_skips for %q: %v", cqName, err)
+				}
+				got := int(val)
+				if want != got {
+					t.Errorf("Counted %d skips for %q, want %d", got, cqName, want)
 				}
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

We now allow multiple preemptions within a cohort to happen in a cycle if they have non-overlapping preemption targets.
However, it was immediately obvious how to track if this was working.

Adding a metric allows to check that less preemptions get skipped than before. It can also be used to track whether a CQ is getting their preemptions continuously skipped, so it can be used in alerts.

#### Which issue(s) this PR fixes:

Follow up to #2641

#### Special notes for your reviewer:

I also considered reporting skips that don't require preemptions, but those skips should require preemptions in the next iteration, so they will be covered. And preemption seems to be the primary pain point.

I also considered using a counter, instead of a gauge, but, because admission cycles are not capped, the number could grow too fast.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add gauge metric admission_cycle_preemption_skips that reports the number of Workloads in a ClusterQueue
that got preemptions candidates, but had to be skipped in the last cycle.
```