### PR TITLE
Fix ResourceFlavorReconciler.AddUpdateWatcher

### DIFF
--- a/pkg/controller/core/resourceflavor_controller.go
+++ b/pkg/controller/core/resourceflavor_controller.go
@@ -111,7 +111,7 @@ func (r *ResourceFlavorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 func (r *ResourceFlavorReconciler) AddUpdateWatcher(watchers ...ResourceFlavorUpdateWatcher) {
-	r.watchers = watchers
+	r.watchers = append(r.watchers, watchers...)
 }
 
 func (r *ResourceFlavorReconciler) notifyWatchers(oldRF, newRF *kueue.ResourceFlavor) {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Function name didn't match semantics. There was no bug, as we only call this function once.

The other option is to rename this to SetUpdateWatcher (additionally AdmissionCheckController, which has a similar method but only uses it once)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```