### PR TITLE
Support Cohorts with Resources in cache/hierarchy packages

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -57,6 +57,9 @@ issues:
       - staticcheck
       # TODO(#768): Drop when incrementing the API version.
       text: "SA1019: constants.QueueAnnotation is deprecated"
+    - linters:
+      - unused
+      path: "^pkg/hierarchy.cohort.go"
   # Show all issues from a linter
   max-issues-per-linter: 0
   # Show all issues with the same text

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -134,13 +134,17 @@ var defaultFlavorFungibility = kueue.FlavorFungibility{WhenCanBorrow: kueue.Borr
 
 func (c *clusterQueue) updateClusterQueue(in *kueue.ClusterQueue, resourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor, admissionChecks map[string]AdmissionCheck, oldParent *cohort) error {
 	if c.updateQuotasAndResourceGroups(in.Spec.ResourceGroups) || oldParent != c.Parent() {
-		updateClusterQueueResourceNode(c)
 		c.AllocatableResourceGeneration += 1
 		if oldParent != nil && oldParent != c.Parent() {
 			updateCohortResourceNode(oldParent)
 		}
 		if c.HasParent() {
+			// clusterQueue will be updated as part of tree update.
 			updateCohortResourceNode(c.Parent())
+		} else {
+			// since ClusterQueue has no parent, it won't be updated
+			// as part of tree update.
+			updateClusterQueueResourceNode(c)
 		}
 	}
 

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
-	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
@@ -100,51 +99,6 @@ func (c *clusterQueue) parentHRN() hierarchicalResourceNode {
 	return c.Parent()
 }
 
-// cohort is a set of ClusterQueues that can borrow resources from each other.
-type cohort struct {
-	Name string
-	hierarchy.Cohort[*clusterQueue, *cohort]
-
-	resourceNode ResourceNode
-}
-
-func (c *cohort) GetName() string {
-	return c.Name
-}
-
-// implements hierarchicalResourceNode interface.
-
-func (c *cohort) getResourceNode() ResourceNode {
-	return c.resourceNode
-}
-
-func (c *cohort) parentHRN() hierarchicalResourceNode {
-	return c.Parent()
-}
-
-type ResourceGroup struct {
-	CoveredResources sets.Set[corev1.ResourceName]
-	Flavors          []kueue.ResourceFlavorReference
-	// The set of key labels from all flavors.
-	// Those keys define the affinity terms of a workload
-	// that can be matched against the flavors.
-	LabelKeys sets.Set[string]
-}
-
-func (rg *ResourceGroup) Clone() ResourceGroup {
-	return ResourceGroup{
-		CoveredResources: rg.CoveredResources.Clone(),
-		Flavors:          rg.Flavors,
-		LabelKeys:        rg.LabelKeys.Clone(),
-	}
-}
-
-type ResourceQuota struct {
-	Nominal        int64
-	BorrowingLimit *int64
-	LendingLimit   *int64
-}
-
 type queue struct {
 	key                string
 	reservingWorkloads int
@@ -152,14 +106,6 @@ type queue struct {
 	//TODO: rename this to better distinguish between reserved and "in use" quantities
 	usage         resources.FlavorResourceQuantities
 	admittedUsage resources.FlavorResourceQuantities
-}
-
-func newCohort(name string) *cohort {
-	return &cohort{
-		name,
-		hierarchy.NewCohort[*clusterQueue, *cohort](),
-		NewResourceNode(),
-	}
 }
 
 // FitInCohort supports the legacy
@@ -237,38 +183,28 @@ func (c *clusterQueue) updateClusterQueue(in *kueue.ClusterQueue, resourceFlavor
 	return nil
 }
 
+func createdResourceGroups(kueueRgs []kueue.ResourceGroup) []ResourceGroup {
+	rgs := make([]ResourceGroup, len(kueueRgs))
+	for i, kueueRg := range kueueRgs {
+		rgs[i] = ResourceGroup{
+			CoveredResources: sets.New(kueueRg.CoveredResources...),
+			Flavors:          make([]kueue.ResourceFlavorReference, 0, len(kueueRg.Flavors)),
+		}
+		for _, fIn := range kueueRg.Flavors {
+			rgs[i].Flavors = append(rgs[i].Flavors, fIn.Name)
+		}
+	}
+	return rgs
+}
+
 // updateQuotasAndResourceGroups updates Quotas and ResourceGroups.
 // It returns true if any changes were made.
 func (c *clusterQueue) updateQuotasAndResourceGroups(in []kueue.ResourceGroup) bool {
 	oldRG := c.ResourceGroups
 	oldQuotas := c.resourceNode.Quotas
+	c.ResourceGroups = createdResourceGroups(in)
+	c.resourceNode.Quotas = createResourceQuotas(in)
 
-	c.ResourceGroups = make([]ResourceGroup, len(in))
-	c.resourceNode.Quotas = make(map[resources.FlavorResource]ResourceQuota, 0)
-	for i, rgIn := range in {
-		rg := &c.ResourceGroups[i]
-		*rg = ResourceGroup{
-			CoveredResources: sets.New(rgIn.CoveredResources...),
-			Flavors:          make([]kueue.ResourceFlavorReference, 0, len(rgIn.Flavors)),
-		}
-		for i := range rgIn.Flavors {
-			fIn := &rgIn.Flavors[i]
-			for _, rIn := range fIn.Resources {
-				nominal := resources.ResourceValue(rIn.Name, rIn.NominalQuota)
-				rQuota := ResourceQuota{
-					Nominal: nominal,
-				}
-				if rIn.BorrowingLimit != nil {
-					rQuota.BorrowingLimit = ptr.To(resources.ResourceValue(rIn.Name, *rIn.BorrowingLimit))
-				}
-				if features.Enabled(features.LendingLimit) && rIn.LendingLimit != nil {
-					rQuota.LendingLimit = ptr.To(resources.ResourceValue(rIn.Name, *rIn.LendingLimit))
-				}
-				c.resourceNode.Quotas[resources.FlavorResource{Flavor: fIn.Name, Resource: rIn.Name}] = rQuota
-			}
-			rg.Flavors = append(rg.Flavors, fIn.Name)
-		}
-	}
 	// Start at 1, for backwards compatibility.
 	return c.AllocatableResourceGeneration == 0 ||
 		!equality.Semantic.DeepEqual(oldRG, c.ResourceGroups) ||

--- a/pkg/cache/cohort.go
+++ b/pkg/cache/cohort.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"sigs.k8s.io/kueue/pkg/hierarchy"
+)
+
+// cohort is a set of ClusterQueues that can borrow resources from each other.
+type cohort struct {
+	Name string
+	hierarchy.Cohort[*clusterQueue, *cohort]
+
+	resourceNode ResourceNode
+}
+
+func newCohort(name string) *cohort {
+	return &cohort{
+		name,
+		hierarchy.NewCohort[*clusterQueue, *cohort](),
+		NewResourceNode(),
+	}
+}
+
+func (c *cohort) GetName() string {
+	return c.Name
+}
+
+// implements hierarchicalResourceNode interface.
+
+func (c *cohort) getResourceNode() ResourceNode {
+	return c.resourceNode
+}
+
+func (c *cohort) parentHRN() hierarchicalResourceNode {
+	return c.Parent()
+}

--- a/pkg/cache/cohort.go
+++ b/pkg/cache/cohort.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 )
 
@@ -34,6 +35,11 @@ func newCohort(name string) *cohort {
 		hierarchy.NewCohort[*clusterQueue, *cohort](),
 		NewResourceNode(),
 	}
+}
+
+func (c *cohort) updateCohort(apiCohort *kueuealpha.Cohort) {
+	c.resourceNode.Quotas = createResourceQuotas(apiCohort.Spec.ResourceGroups)
+	updateCohortResourceNode(c)
 }
 
 func (c *cohort) GetName() string {

--- a/pkg/cache/resource.go
+++ b/pkg/cache/resource.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
+
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"

--- a/pkg/cache/resource.go
+++ b/pkg/cache/resource.go
@@ -17,8 +17,61 @@ limitations under the License.
 package cache
 
 import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 )
+
+type ResourceGroup struct {
+	CoveredResources sets.Set[corev1.ResourceName]
+	Flavors          []kueue.ResourceFlavorReference
+	// The set of key labels from all flavors.
+	// Those keys define the affinity terms of a workload
+	// that can be matched against the flavors.
+	LabelKeys sets.Set[string]
+}
+
+func (rg *ResourceGroup) Clone() ResourceGroup {
+	return ResourceGroup{
+		CoveredResources: rg.CoveredResources.Clone(),
+		Flavors:          rg.Flavors,
+		LabelKeys:        rg.LabelKeys.Clone(),
+	}
+}
+
+type ResourceQuota struct {
+	Nominal        int64
+	BorrowingLimit *int64
+	LendingLimit   *int64
+}
+
+func createResourceQuotas(kueueRgs []kueue.ResourceGroup) map[resources.FlavorResource]ResourceQuota {
+	frCount := 0
+	for _, rg := range kueueRgs {
+		frCount += len(rg.Flavors) * len(rg.CoveredResources)
+	}
+	quotas := make(map[resources.FlavorResource]ResourceQuota, frCount)
+	for _, kueueRg := range kueueRgs {
+		for _, kueueFlavor := range kueueRg.Flavors {
+			for _, kueueQuota := range kueueFlavor.Resources {
+				quota := ResourceQuota{
+					Nominal: resources.ResourceValue(kueueQuota.Name, kueueQuota.NominalQuota),
+				}
+				if kueueQuota.BorrowingLimit != nil {
+					quota.BorrowingLimit = ptr.To(resources.ResourceValue(kueueQuota.Name, *kueueQuota.BorrowingLimit))
+				}
+				if features.Enabled(features.LendingLimit) && kueueQuota.LendingLimit != nil {
+					quota.LendingLimit = ptr.To(resources.ResourceValue(kueueQuota.Name, *kueueQuota.LendingLimit))
+				}
+				quotas[resources.FlavorResource{Flavor: kueueFlavor.Name, Resource: kueueQuota.Name}] = quota
+			}
+		}
+	}
+	return quotas
+}
 
 type resourceGroupNode interface {
 	resourceGroups() []ResourceGroup

--- a/pkg/cache/resource_node.go
+++ b/pkg/cache/resource_node.go
@@ -163,7 +163,12 @@ func updateClusterQueueResourceNode(cq *clusterQueue) {
 func updateCohortResourceNode(cohort *cohort) {
 	cohort.resourceNode.SubtreeQuota = make(resources.FlavorResourceQuantities, len(cohort.resourceNode.SubtreeQuota))
 	cohort.resourceNode.Usage = make(resources.FlavorResourceQuantities, len(cohort.resourceNode.Usage))
+
+	for fr, quota := range cohort.resourceNode.Quotas {
+		cohort.resourceNode.SubtreeQuota[fr] = quota.Nominal
+	}
 	for _, child := range cohort.ChildCQs() {
+		updateClusterQueueResourceNode(child)
 		for fr, childQuota := range child.resourceNode.SubtreeQuota {
 			cohort.resourceNode.SubtreeQuota[fr] += childQuota - child.resourceNode.guaranteedQuota(fr)
 		}

--- a/pkg/hierarchy/cohort.go
+++ b/pkg/hierarchy/cohort.go
@@ -20,6 +20,9 @@ import "k8s.io/apimachinery/pkg/util/sets"
 
 type Cohort[CQ, C nodeBase] struct {
 	childCqs sets.Set[CQ]
+	// Indicates whether this Cohort is backed
+	// by an API object.
+	explicit bool
 }
 
 func (c *Cohort[CQ, C]) Parent() C {
@@ -51,4 +54,12 @@ func (c *Cohort[CQ, C]) deleteClusterQueue(cq CQ) {
 
 func (c *Cohort[CQ, C]) childCount() int {
 	return c.childCqs.Len()
+}
+
+func (c *Cohort[CQ, C]) isExplicit() bool {
+	return c.explicit
+}
+
+func (c *Cohort[CQ, C]) markExplicit() {
+	c.explicit = true
 }

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -584,6 +584,28 @@ func (q *LocalQueueWrapper) Generation(num int64) *LocalQueueWrapper {
 	return q
 }
 
+type CohortWrapper struct {
+	kueuealpha.Cohort
+}
+
+func MakeCohort(name string) *CohortWrapper {
+	return &CohortWrapper{kueuealpha.Cohort{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}}
+}
+
+func (c *CohortWrapper) Obj() *kueuealpha.Cohort {
+	return &c.Cohort
+}
+
+// ResourceGroup adds a ResourceGroup with flavors.
+func (c *CohortWrapper) ResourceGroup(flavors ...kueue.FlavorQuotas) *CohortWrapper {
+	c.Spec.ResourceGroups = append(c.Spec.ResourceGroups, createResourceGroup(flavors...))
+	return c
+}
+
 // ClusterQueueWrapper wraps a ClusterQueue.
 type ClusterQueueWrapper struct{ kueue.ClusterQueue }
 
@@ -624,8 +646,7 @@ func (c *ClusterQueueWrapper) AdmissionCheckStrategy(acs ...kueue.AdmissionCheck
 	return c
 }
 
-// ResourceGroup adds a ResourceGroup with flavors.
-func (c *ClusterQueueWrapper) ResourceGroup(flavors ...kueue.FlavorQuotas) *ClusterQueueWrapper {
+func createResourceGroup(flavors ...kueue.FlavorQuotas) kueue.ResourceGroup {
 	rg := kueue.ResourceGroup{
 		Flavors: flavors,
 	}
@@ -646,7 +667,12 @@ func (c *ClusterQueueWrapper) ResourceGroup(flavors ...kueue.FlavorQuotas) *Clus
 		}
 		rg.CoveredResources = resources
 	}
-	c.Spec.ResourceGroups = append(c.Spec.ResourceGroups, rg)
+	return rg
+}
+
+// ResourceGroup adds a ResourceGroup with flavors.
+func (c *ClusterQueueWrapper) ResourceGroup(flavors ...kueue.FlavorQuotas) *ClusterQueueWrapper {
+	c.Spec.ResourceGroups = append(c.Spec.ResourceGroups, createResourceGroup(flavors...))
 	return c
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Update cache to support Cohorts with resources. Update hierarchy to support explicit Cohorts. Part of #79

#### Special notes for your reviewer:
commit 1 : move files and refactor parsing
commit 2: support Cohorts which provide resources in `cache`. support explicit Cohorts in `hierarchy`

Users cannot use this functionality until we wire up reconciler and webhook. In the interest of keeping PRs small, I will publish those in separate PRs.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```