### PR TITLE
[kjobctl] Describe only kjobctl owned objects.

### DIFF
--- a/cmd/experimental/kjobctl/pkg/cmd/describe/describe.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/describe/describe.go
@@ -191,6 +191,11 @@ func (o *DescribeOptions) Run(ctx context.Context) error {
 			continue
 		}
 
+		labels := obj.GetLabels()
+		if _, ok := labels[constants.ProfileLabel]; !ok {
+			continue
+		}
+
 		mapping := info.ResourceMapping()
 		describer, err := NewResourceDescriber(mapping)
 		if err != nil {
@@ -220,7 +225,7 @@ func (o *DescribeOptions) Run(ctx context.Context) error {
 		}
 	}
 
-	if len(infos) == 0 && len(allErrs) == 0 {
+	if first && len(allErrs) == 0 {
 		if o.AllNamespaces {
 			fmt.Fprintln(o.ErrOut, "No resources found")
 		} else {

--- a/cmd/experimental/kjobctl/pkg/cmd/describe/describe_test.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/describe/describe_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	cmdtesting "sigs.k8s.io/kueue/cmd/experimental/kjobctl/pkg/cmd/testing"
+	"sigs.k8s.io/kueue/cmd/experimental/kjobctl/pkg/testing/wrappers"
 )
 
 func TestDescribeCmd(t *testing.T) {
@@ -51,6 +52,17 @@ func TestDescribeCmd(t *testing.T) {
 		wantOutErr  string
 		wantErr     error
 	}{
+		"shouldn't describe none kjobctl owned jobs": {
+			args:       []string{"job", "sample-job-8c7zt"},
+			argsFormat: modeTaskArgsFormat,
+			mapperKinds: []schema.GroupVersionKind{
+				batchv1.SchemeGroupVersion.WithKind("Job"),
+			},
+			objs: []runtime.Object{
+				wrappers.MakeJob("sample-job-8c7zt", metav1.NamespaceDefault).Obj(),
+			},
+			wantOutErr: "No resources found in default namespace.\n",
+		},
 		"describe job with 'mode task' format": {
 			args:       []string{"job", "sample-job-8c7zt"},
 			argsFormat: modeTaskArgsFormat,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Describe only kjobctl owned objects on describe command.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Unfortunately, filtering by labels isn't possible when searching for resources by name. However, we can apply filters on the client side.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```