### PR TITLE
Automated cherry pick of #2919: Add gauge for skipped preemptions within a cycle

### DIFF
--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -155,7 +155,7 @@ func TestReportAndCleanupClusterQueueEvictedNumber(t *testing.T) {
 	expectFilteredMetricsCount(t, EvictedWorkloadsTotal, 1, "cluster_queue", "cluster_queue1", "reason", "Preempted")
 	expectFilteredMetricsCount(t, EvictedWorkloadsTotal, 1, "cluster_queue", "cluster_queue1", "reason", "Evicted")
 
-	ClearQueueSystemMetrics("cluster_queue1")
+	ClearClusterQueueMetrics("cluster_queue1")
 	expectFilteredMetricsCount(t, EvictedWorkloadsTotal, 0, "cluster_queue", "cluster_queue1")
 }
 
@@ -172,7 +172,7 @@ func TestReportAndCleanupClusterQueuePreemptedNumber(t *testing.T) {
 	expectFilteredMetricsCount(t, PreemptedWorkloadsTotal, 1, "preempting_cluster_queue", "cluster_queue1", "reason", "InCohortReclamation")
 	expectFilteredMetricsCount(t, PreemptedWorkloadsTotal, 1, "preempting_cluster_queue", "cluster_queue1", "reason", "InCohortReclaimWhileBorrowing")
 
-	ClearQueueSystemMetrics("cluster_queue1")
+	ClearClusterQueueMetrics("cluster_queue1")
 	expectFilteredMetricsCount(t, PreemptedWorkloadsTotal, 0, "preempting_cluster_queue", "cluster_queue1")
 	expectFilteredMetricsCount(t, EvictedWorkloadsTotal, 0, "cluster_queue", "cluster_queue1")
 }

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -189,7 +189,7 @@ func (m *Manager) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 		return
 	}
 	delete(m.clusterQueues, cq.Name)
-	metrics.ClearQueueSystemMetrics(cq.Name)
+	metrics.ClearClusterQueueMetrics(cq.Name)
 
 	cohort := cq.Spec.Cohort
 	m.deleteCohort(cohort, cq.Name)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -183,6 +183,12 @@ func setSkipped(e *entry, inadmissibleMsg string) {
 	e.LastAssignment = nil
 }
 
+func reportSkippedPreemptions(p map[string]int) {
+	for cqName, count := range p {
+		metrics.AdmissionCyclePreemptionSkips.WithLabelValues(cqName).Set(float64(count))
+	}
+}
+
 func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	s.attemptCount++
 	log := ctrl.LoggerFrom(ctx).WithValues("attemptCount", s.attemptCount)
@@ -219,6 +225,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	cycleCohortsUsage := cohortsUsage{}
 	cycleCohortsSkipPreemption := sets.New[string]()
 	preemptedWorkloads := sets.New[string]()
+	skippedPreemptions := make(map[string]int)
 	for i := range entries {
 		e := &entries[i]
 		mode := e.assignment.RepresentativeMode()
@@ -247,12 +254,16 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 			}
 			if preemptedWorkloads.HasAny(pendingPreemptions...) {
 				setSkipped(e, "Workload has overlapping preemption targets with another workload")
+				skippedPreemptions[cq.Name]++
 				continue
 			}
 
 			usage := e.netUsage()
 			if !cq.Fits(usage) {
 				setSkipped(e, "Workload no longer fits after processing another workload")
+				if mode == flavorassigner.Preempt {
+					skippedPreemptions[cq.Name]++
+				}
 				continue
 			}
 			preemptedWorkloads.Insert(pendingPreemptions...)
@@ -269,6 +280,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 				}
 				if mode == flavorassigner.Preempt && cycleCohortsSkipPreemption.Has(cq.Cohort.Name) {
 					setSkipped(e, "Workload skipped because its preemption calculations were invalidated by another workload")
+					skippedPreemptions[cq.Name]++
 					continue
 				}
 			}
@@ -327,6 +339,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 			result = metrics.AdmissionResultSuccess
 		}
 	}
+	reportSkippedPreemptions(skippedPreemptions)
 	metrics.AdmissionAttempt(result, time.Since(startTime))
 	if result != metrics.AdmissionResultSuccess {
 		return wait.SlowDown


### PR DESCRIPTION
Cherry pick of #2919 on release-0.8.

#2919: Add gauge for skipped preemptions within a cycle

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Add gauge metric admission_cycle_preemption_skips that reports the number of Workloads in a ClusterQueue
that got preemptions candidates, but had to be skipped in the last cycle.
```