### PR TITLE
Allow an empty PodIntegrationOptions

### DIFF
--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -58,7 +58,6 @@ var (
 	retriableInGroupAnnotationPath = annotationsPath.Key(RetriableInGroupAnnotation)
 
 	errPodOptsTypeAssertion = errors.New("options are not of type PodIntegrationOptions")
-	errPodOptsNotFound      = errors.New("podIntegrationOptions not found in options")
 )
 
 type PodWebhook struct {
@@ -88,16 +87,16 @@ func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		Complete()
 }
 
-func getPodOptions(integrationOpts map[string]any) (configapi.PodIntegrationOptions, error) {
+func getPodOptions(integrationOpts map[string]any) (*configapi.PodIntegrationOptions, error) {
 	opts, ok := integrationOpts[corev1.SchemeGroupVersion.WithKind("Pod").String()]
 	if !ok {
-		return configapi.PodIntegrationOptions{}, errPodOptsNotFound
+		return &configapi.PodIntegrationOptions{}, nil
 	}
 	podOpts, ok := opts.(*configapi.PodIntegrationOptions)
 	if !ok {
-		return configapi.PodIntegrationOptions{}, fmt.Errorf("%w, got %T", errPodOptsTypeAssertion, opts)
+		return nil, fmt.Errorf("%w, got %T", errPodOptsTypeAssertion, opts)
 	}
-	return *podOpts, nil
+	return podOpts, nil
 }
 
 // +kubebuilder:webhook:path=/mutate--v1-pod,mutating=true,failurePolicy=fail,sideEffects=None,groups="",resources=pods,verbs=create,versions=v1,name=mpod.kb.io,admissionReviewVersions=v1

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -655,7 +655,7 @@ func TestValidateUpdate(t *testing.T) {
 func TestGetPodOptions(t *testing.T) {
 	cases := map[string]struct {
 		integrationOpts map[string]any
-		wantOpts        configapi.PodIntegrationOptions
+		wantOpts        *configapi.PodIntegrationOptions
 		wantError       error
 	}{
 		"proper podIntegrationOptions exists": {
@@ -670,7 +670,7 @@ func TestGetPodOptions(t *testing.T) {
 				},
 				batchv1.SchemeGroupVersion.WithKind("Job").String(): nil,
 			},
-			wantOpts: configapi.PodIntegrationOptions{
+			wantOpts: &configapi.PodIntegrationOptions{
 				PodSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"podKey": "podValue"},
 				},
@@ -683,7 +683,7 @@ func TestGetPodOptions(t *testing.T) {
 			integrationOpts: map[string]any{
 				batchv1.SchemeGroupVersion.WithKind("Job").String(): nil,
 			},
-			wantError: errPodOptsNotFound,
+			wantOpts: &configapi.PodIntegrationOptions{},
 		},
 		"podIntegrationOptions isn't of type PodIntegrationOptions": {
 			integrationOpts: map[string]any{

--- a/test/integration/controller/jobs/deployment/deployment_webhook_test.go
+++ b/test/integration/controller/jobs/deployment/deployment_webhook_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
@@ -56,10 +55,6 @@ var _ = ginkgo.Describe("Deployment Webhook", func() {
 				nil,
 				jobframework.WithManageJobsWithoutQueueName(false),
 				jobframework.WithKubeServerVersion(serverVersionFetcher),
-				jobframework.WithIntegrationOptions(
-					corev1.SchemeGroupVersion.WithKind("Pod").String(),
-					&configapi.PodIntegrationOptions{},
-				),
 			))
 		})
 		ginkgo.BeforeEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The PodInterationOptions are optional parameters. So, we should allow an empty of the parameters.

This is not a bug since even if there is not this commit, user can specify an empty PodIntegrationOptons in the Config API:

https://github.com/kubernetes-sigs/kueue/blob/47f79fbdd5b74cc5ab1d44a26c66482af3e674ca/cmd/kueue/main.go#L277

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Followup of #2813

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```