### PR TITLE
[kueuectl] Add EXEC TIME column on list workload command.

### DIFF
--- a/cmd/kueuectl/app/list/list_test.go
+++ b/cmd/kueuectl/app/list/list_test.go
@@ -125,9 +125,9 @@ cq2    cohort2   0                   0                    false    120m
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAMESPACE   NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-ns1         wl1               j1         lq1          cq1            PENDING                                  60m
-ns2         wl2               j2         lq2          cq2            PENDING                                  120m
+			wantOut: `NAMESPACE   NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+ns1         wl1               j1         lq1          cq1            PENDING                                   60m
+ns2         wl2               j2         lq2          cq2            PENDING                                   120m
 `,
 		},
 		"should print workload list with all namespaces (short command and flag)": {
@@ -148,9 +148,9 @@ ns2         wl2               j2         lq2          cq2            PENDING    
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAMESPACE   NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-ns1         wl1               j1         lq1          cq1            PENDING                                  60m
-ns2         wl2               j2         lq2          cq2            PENDING                                  120m
+			wantOut: `NAMESPACE   NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+ns1         wl1               j1         lq1          cq1            PENDING                                   60m
+ns2         wl2               j2         lq2          cq2            PENDING                                   120m
 `,
 		},
 	}

--- a/cmd/kueuectl/app/list/list_test.go
+++ b/cmd/kueuectl/app/list/list_test.go
@@ -125,9 +125,9 @@ cq2    cohort2   0                   0                    false    120m
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAMESPACE   NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-ns1         wl1               j1         lq1          cq1            PENDING                       60m
-ns2         wl2               j2         lq2          cq2            PENDING                       120m
+			wantOut: `NAMESPACE   NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+ns1         wl1               j1         lq1          cq1            PENDING                                  60m
+ns2         wl2               j2         lq2          cq2            PENDING                                  120m
 `,
 		},
 		"should print workload list with all namespaces (short command and flag)": {
@@ -148,9 +148,9 @@ ns2         wl2               j2         lq2          cq2            PENDING    
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAMESPACE   NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-ns1         wl1               j1         lq1          cq1            PENDING                       60m
-ns2         wl2               j2         lq2          cq2            PENDING                       120m
+			wantOut: `NAMESPACE   NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+ns1         wl1               j1         lq1          cq1            PENDING                                  60m
+ns2         wl2               j2         lq2          cq2            PENDING                                  120m
 `,
 		},
 	}

--- a/cmd/kueuectl/app/list/list_workload_printer.go
+++ b/cmd/kueuectl/app/list/list_workload_printer.go
@@ -141,10 +141,12 @@ func (p *listWorkloadPrinter) printWorkload(wl *v1beta1.Workload) metav1.TableRo
 	}
 
 	var duration string
-	if admittedCond := apimeta.FindStatusCondition(wl.Status.Conditions, v1beta1.WorkloadAdmitted); admittedCond != nil {
+	if admittedCond := apimeta.FindStatusCondition(wl.Status.Conditions, v1beta1.WorkloadAdmitted); admittedCond != nil &&
+		admittedCond.Status == metav1.ConditionTrue {
 		finishedTime := p.clock.Now()
 
-		if finishedCond := apimeta.FindStatusCondition(wl.Status.Conditions, v1beta1.WorkloadFinished); finishedCond != nil {
+		if finishedCond := apimeta.FindStatusCondition(wl.Status.Conditions, v1beta1.WorkloadFinished); finishedCond != nil &&
+			finishedCond.Status == metav1.ConditionTrue {
 			finishedTime = finishedCond.LastTransitionTime.Time
 		}
 

--- a/cmd/kueuectl/app/list/list_workload_printer.go
+++ b/cmd/kueuectl/app/list/list_workload_printer.go
@@ -25,7 +25,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	durationutil "k8s.io/apimachinery/pkg/util/duration"
+	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/utils/clock"
@@ -76,7 +76,7 @@ func (p *listWorkloadPrinter) PrintObj(obj runtime.Object, out io.Writer) error 
 			{Name: "ClusterQueue", Type: "string"},
 			{Name: "Status", Type: "string"},
 			{Name: "Position in Queue", Type: "string"},
-			{Name: "Duration", Type: "string"},
+			{Name: "Exec Time", Type: "string"},
 			{Name: "Age", Type: "string"},
 		},
 		Rows: p.printWorkloadList(list),
@@ -140,7 +140,7 @@ func (p *listWorkloadPrinter) printWorkload(wl *v1beta1.Workload) metav1.TableRo
 		positionInQueue = fmt.Sprintf("%d", pendingWorkload.PositionInLocalQueue)
 	}
 
-	var duration string
+	var execTime string
 	if admittedCond := apimeta.FindStatusCondition(wl.Status.Conditions, v1beta1.WorkloadAdmitted); admittedCond != nil &&
 		admittedCond.Status == metav1.ConditionTrue {
 		finishedTime := p.clock.Now()
@@ -150,7 +150,7 @@ func (p *listWorkloadPrinter) printWorkload(wl *v1beta1.Workload) metav1.TableRo
 			finishedTime = finishedCond.LastTransitionTime.Time
 		}
 
-		duration = durationutil.HumanDuration(finishedTime.Sub(admittedCond.LastTransitionTime.Time))
+		execTime = duration.HumanDuration(finishedTime.Sub(admittedCond.LastTransitionTime.Time))
 	}
 
 	row.Cells = []any{
@@ -161,8 +161,8 @@ func (p *listWorkloadPrinter) printWorkload(wl *v1beta1.Workload) metav1.TableRo
 		clusterQueueName,
 		strings.ToUpper(workload.Status(wl)),
 		positionInQueue,
-		duration,
-		durationutil.HumanDuration(p.clock.Since(wl.CreationTimestamp.Time)),
+		execTime,
+		duration.HumanDuration(p.clock.Since(wl.CreationTimestamp.Time)),
 	}
 
 	return row

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -84,8 +84,8 @@ func TestWorkloadCmd(t *testing.T) {
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1               j1         lq1          cq1            PENDING                                  60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            PENDING                                   60m
 `,
 		},
 		"should print workload list with localqueue filter": {
@@ -106,8 +106,8 @@ wl1               j1         lq1          cq1            PENDING                
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1               j1         lq1          cq1            PENDING                                  60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            PENDING                                   60m
 `,
 		},
 		"should print workload list with localqueue filter (short flag)": {
@@ -128,8 +128,8 @@ wl1               j1         lq1          cq1            PENDING                
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1               j1         lq1          cq1            PENDING                                  60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            PENDING                                   60m
 `,
 		},
 		"should print workload list with clusterqueue filter": {
@@ -150,8 +150,8 @@ wl1               j1         lq1          cq1            PENDING                
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1               j1         lq1          cq1            PENDING                                  60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            PENDING                                   60m
 `,
 		},
 		"should print workload list with clusterqueue filter (short flag)": {
@@ -172,8 +172,8 @@ wl1               j1         lq1          cq1            PENDING                
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1               j1         lq1          cq1            PENDING                                  60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            PENDING                                   60m
 `,
 		},
 		"should print workload list with all status flag": {
@@ -253,12 +253,12 @@ wl1               j1         lq1          cq1            PENDING                
 					}...).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   DURATION   AGE
-wl1               j1         lq1          cq1            PENDING                                   60m
-wl2               j2         lq2          cq2            ADMITTED                       60m        120m
-wl3               j3         lq3          cq3            PENDING                                   120m
-wl4               j4         lq4          cq4            FINISHED                       60m        3h
-wl5               j5         lq5          cq5            ADMITTED                       120m       3h
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            PENDING                                    60m
+wl2               j2         lq2          cq2            ADMITTED                       60m         120m
+wl3               j3         lq3          cq3            PENDING                                    120m
+wl4               j4         lq4          cq4            FINISHED                       60m         3h
+wl5               j5         lq5          cq5            ADMITTED                       120m        3h
 `,
 		},
 		"should print workload list with only admitted and finished status flags": {
@@ -305,9 +305,9 @@ wl5               j5         lq5          cq5            ADMITTED               
 					}...).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   DURATION   AGE
-wl2               j2         lq2          cq2            ADMITTED                       60m        120m
-wl3               j3         lq3          cq3            FINISHED                       60m        3h
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   EXEC TIME   AGE
+wl2               j2         lq2          cq2            ADMITTED                       60m         120m
+wl3               j3         lq3          cq3            FINISHED                       60m         3h
 `,
 		},
 		"should print workload list with only pending filter": {
@@ -334,8 +334,8 @@ wl3               j3         lq3          cq3            FINISHED               
 					}...).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1               j1         lq1          cq1            PENDING                                  60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            PENDING                                   60m
 `,
 		},
 		"should print workload list with only quotareserved filter": {
@@ -368,8 +368,8 @@ wl1               j1         lq1          cq1            PENDING                
 					}...).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS          POSITION IN QUEUE   DURATION   AGE
-wl1               j1         lq1          cq1            QUOTARESERVED                                  60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS          POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            QUOTARESERVED                                   60m
 `,
 		},
 		"should print workload list with only admitted filter": {
@@ -404,8 +404,8 @@ wl1               j1         lq1          cq1            QUOTARESERVED          
 					}...).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   DURATION   AGE
-wl1               j1         lq1          cq1            ADMITTED                       60m        60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            ADMITTED                       60m         60m
 `,
 		},
 		"should print workload list with only finished status filter": {
@@ -450,8 +450,8 @@ wl1               j1         lq1          cq1            ADMITTED               
 					}...).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   DURATION   AGE
-wl1               j1         lq1          cq1            FINISHED                       60m        60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            FINISHED                       60m         60m
 `,
 		},
 		"should print workload list with label selector filter": {
@@ -474,8 +474,8 @@ wl1               j1         lq1          cq1            FINISHED               
 					Label("key", "value2").
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1               j1         lq1          cq1            PENDING                                  60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            PENDING                                   60m
 `,
 		},
 		"should print workload list with label selector filter (short flag)": {
@@ -498,8 +498,8 @@ wl1               j1         lq1          cq1            PENDING                
 					Label("key", "value2").
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1               j1         lq1          cq1            PENDING                                  60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            PENDING                                   60m
 `,
 		},
 		"should print workload list with Job types": {
@@ -557,10 +557,10 @@ wl1               j1         lq1          cq1            PENDING                
 					Creation(testStartTime.Add(-3 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE                  JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1    job                       j1         lq1          cq1            PENDING                                  60m
-wl2    rayjob.ray.io             j2         lq2          cq2            PENDING                                  120m
-wl3    pytorchjob.kubeflow....   j3         lq3          cq3            PENDING                                  3h
+			wantOut: `NAME   JOB TYPE                  JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1    job                       j1         lq1          cq1            PENDING                                   60m
+wl2    rayjob.ray.io             j2         lq2          cq2            PENDING                                   120m
+wl3    pytorchjob.kubeflow....   j3         lq3          cq3            PENDING                                   3h
 `,
 		},
 		"should print workload list with resource filter": {
@@ -616,8 +616,8 @@ wl3    pytorchjob.kubeflow....   j3         lq3          cq3            PENDING 
 					},
 				},
 			},
-			wantOut: `NAME   JOB TYPE    JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1    job.batch   job-test   lq1          cq1            PENDING                                  120m
+			wantOut: `NAME   JOB TYPE    JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1    job.batch   job-test   lq1          cq1            PENDING                                   120m
 `,
 		},
 		"should print workload list with resource filter and composable jobs": {
@@ -682,8 +682,8 @@ wl1    job.batch   job-test   lq1          cq1            PENDING               
 					},
 				},
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME     LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl2    pod        pod-test-1   lq2          cq2            PENDING                                  3h
+			wantOut: `NAME   JOB TYPE   JOB NAME     LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl2    pod        pod-test-1   lq2          cq2            PENDING                                   3h
 `,
 		},
 		"should print workload list with custom resource filter": {
@@ -750,8 +750,8 @@ wl2    pod        pod-test-1   lq2          cq2            PENDING              
 					},
 				},
 			},
-			wantOut: `NAME   JOB TYPE        JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1    rayjob.ray.io   job-test   lq1          cq1            PENDING                                  120m
+			wantOut: `NAME   JOB TYPE        JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1    rayjob.ray.io   job-test   lq1          cq1            PENDING                                   120m
 `,
 		},
 		"should print workload list with full resource filter": {
@@ -818,8 +818,8 @@ wl1    rayjob.ray.io   job-test   lq1          cq1            PENDING           
 					},
 				},
 			},
-			wantOut: `NAME   JOB TYPE        JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1    rayjob.ray.io   job-test   lq1          cq1            PENDING                                  120m
+			wantOut: `NAME   JOB TYPE        JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1    rayjob.ray.io   job-test   lq1          cq1            PENDING                                   120m
 `,
 		},
 		"should print workload list with position in queue": {
@@ -861,9 +861,9 @@ wl1    rayjob.ray.io   job-test   lq1          cq1            PENDING           
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1               j1         lq1          cq1            PENDING   12                             60m
-wl2               j2         lq2          cq2            PENDING   22                             120m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1               j1         lq1          cq1            PENDING   12                              60m
+wl2               j2         lq2          cq2            PENDING   22                              120m
 `,
 		},
 		"should print not found error": {

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -201,10 +201,24 @@ wl1               j1         lq1          cq1            PENDING                
 					}...).
 					Obj(),
 				utiltesting.MakeWorkload("wl3", metav1.NamespaceDefault).
-					OwnerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "j3", "test-uid").
+					OwnerReference(rayv1.GroupVersion.WithKind("RayJob"), "j3", "test-uid").
 					Queue("lq3").
 					Active(true).
 					Admission(utiltesting.MakeAdmission("cq3").Obj()).
+					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
+					Conditions([]metav1.Condition{
+						{
+							Type:               kueue.WorkloadAdmitted,
+							Status:             metav1.ConditionFalse,
+							LastTransitionTime: metav1.NewTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)),
+						},
+					}...).
+					Obj(),
+				utiltesting.MakeWorkload("wl4", metav1.NamespaceDefault).
+					OwnerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "j4", "test-uid").
+					Queue("lq4").
+					Active(true).
+					Admission(utiltesting.MakeAdmission("cq4").Obj()).
 					Creation(testStartTime.Add(-3 * time.Hour).Truncate(time.Second)).
 					Conditions([]metav1.Condition{
 						{
@@ -219,11 +233,32 @@ wl1               j1         lq1          cq1            PENDING                
 						},
 					}...).
 					Obj(),
+				utiltesting.MakeWorkload("wl5", metav1.NamespaceDefault).
+					OwnerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "j5", "test-uid").
+					Queue("lq5").
+					Active(true).
+					Admission(utiltesting.MakeAdmission("cq5").Obj()).
+					Creation(testStartTime.Add(-3 * time.Hour).Truncate(time.Second)).
+					Conditions([]metav1.Condition{
+						{
+							Type:               kueue.WorkloadAdmitted,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)),
+						},
+						{
+							Type:               kueue.WorkloadFinished,
+							Status:             metav1.ConditionFalse,
+							LastTransitionTime: metav1.NewTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)),
+						},
+					}...).
+					Obj(),
 			},
 			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   DURATION   AGE
 wl1               j1         lq1          cq1            PENDING                                   60m
 wl2               j2         lq2          cq2            ADMITTED                       60m        120m
-wl3               j3         lq3          cq3            FINISHED                       60m        3h
+wl3               j3         lq3          cq3            PENDING                                   120m
+wl4               j4         lq4          cq4            FINISHED                       60m        3h
+wl5               j5         lq5          cq5            ADMITTED                       120m       3h
 `,
 		},
 		"should print workload list with only admitted and finished status flags": {

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -84,8 +84,8 @@ func TestWorkloadCmd(t *testing.T) {
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1               j1         lq1          cq1            PENDING                       60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1               j1         lq1          cq1            PENDING                                  60m
 `,
 		},
 		"should print workload list with localqueue filter": {
@@ -106,8 +106,8 @@ wl1               j1         lq1          cq1            PENDING                
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1               j1         lq1          cq1            PENDING                       60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1               j1         lq1          cq1            PENDING                                  60m
 `,
 		},
 		"should print workload list with localqueue filter (short flag)": {
@@ -128,8 +128,8 @@ wl1               j1         lq1          cq1            PENDING                
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1               j1         lq1          cq1            PENDING                       60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1               j1         lq1          cq1            PENDING                                  60m
 `,
 		},
 		"should print workload list with clusterqueue filter": {
@@ -150,8 +150,8 @@ wl1               j1         lq1          cq1            PENDING                
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1               j1         lq1          cq1            PENDING                       60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1               j1         lq1          cq1            PENDING                                  60m
 `,
 		},
 		"should print workload list with clusterqueue filter (short flag)": {
@@ -172,8 +172,8 @@ wl1               j1         lq1          cq1            PENDING                
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1               j1         lq1          cq1            PENDING                       60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1               j1         lq1          cq1            PENDING                                  60m
 `,
 		},
 		"should print workload list with all status flag": {
@@ -194,8 +194,9 @@ wl1               j1         lq1          cq1            PENDING                
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Conditions([]metav1.Condition{
 						{
-							Type:   kueue.WorkloadAdmitted,
-							Status: metav1.ConditionTrue,
+							Type:               kueue.WorkloadAdmitted,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)),
 						},
 					}...).
 					Obj(),
@@ -207,16 +208,22 @@ wl1               j1         lq1          cq1            PENDING                
 					Creation(testStartTime.Add(-3 * time.Hour).Truncate(time.Second)).
 					Conditions([]metav1.Condition{
 						{
-							Type:   kueue.WorkloadFinished,
-							Status: metav1.ConditionTrue,
+							Type:               kueue.WorkloadAdmitted,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)),
+						},
+						{
+							Type:               kueue.WorkloadFinished,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)),
 						},
 					}...).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   AGE
-wl1               j1         lq1          cq1            PENDING                        60m
-wl2               j2         lq2          cq2            ADMITTED                       120m
-wl3               j3         lq3          cq3            FINISHED                       3h
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   DURATION   AGE
+wl1               j1         lq1          cq1            PENDING                                   60m
+wl2               j2         lq2          cq2            ADMITTED                       60m        120m
+wl3               j3         lq3          cq3            FINISHED                       60m        3h
 `,
 		},
 		"should print workload list with only admitted and finished status flags": {
@@ -237,8 +244,9 @@ wl3               j3         lq3          cq3            FINISHED               
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Conditions([]metav1.Condition{
 						{
-							Type:   kueue.WorkloadAdmitted,
-							Status: metav1.ConditionTrue,
+							Type:               kueue.WorkloadAdmitted,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)),
 						},
 					}...).
 					Obj(),
@@ -250,15 +258,21 @@ wl3               j3         lq3          cq3            FINISHED               
 					Creation(testStartTime.Add(-3 * time.Hour).Truncate(time.Second)).
 					Conditions([]metav1.Condition{
 						{
-							Type:   kueue.WorkloadFinished,
-							Status: metav1.ConditionTrue,
+							Type:               kueue.WorkloadAdmitted,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)),
+						},
+						{
+							Type:               kueue.WorkloadFinished,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)),
 						},
 					}...).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   AGE
-wl2               j2         lq2          cq2            ADMITTED                       120m
-wl3               j3         lq3          cq3            FINISHED                       3h
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   DURATION   AGE
+wl2               j2         lq2          cq2            ADMITTED                       60m        120m
+wl3               j3         lq3          cq3            FINISHED                       60m        3h
 `,
 		},
 		"should print workload list with only pending filter": {
@@ -285,8 +299,8 @@ wl3               j3         lq3          cq3            FINISHED               
 					}...).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1               j1         lq1          cq1            PENDING                       60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1               j1         lq1          cq1            PENDING                                  60m
 `,
 		},
 		"should print workload list with only quotareserved filter": {
@@ -319,8 +333,8 @@ wl1               j1         lq1          cq1            PENDING                
 					}...).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS          POSITION IN QUEUE   AGE
-wl1               j1         lq1          cq1            QUOTARESERVED                       60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS          POSITION IN QUEUE   DURATION   AGE
+wl1               j1         lq1          cq1            QUOTARESERVED                                  60m
 `,
 		},
 		"should print workload list with only admitted filter": {
@@ -334,8 +348,9 @@ wl1               j1         lq1          cq1            QUOTARESERVED          
 					Creation(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					Conditions([]metav1.Condition{
 						{
-							Type:   kueue.WorkloadAdmitted,
-							Status: metav1.ConditionTrue,
+							Type:               kueue.WorkloadAdmitted,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)),
 						},
 					}...).
 					Obj(),
@@ -347,14 +362,15 @@ wl1               j1         lq1          cq1            QUOTARESERVED          
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Conditions([]metav1.Condition{
 						{
-							Type:   kueue.WorkloadAdmitted,
-							Status: metav1.ConditionFalse,
+							Type:               kueue.WorkloadAdmitted,
+							Status:             metav1.ConditionFalse,
+							LastTransitionTime: metav1.NewTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)),
 						},
 					}...).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   AGE
-wl1               j1         lq1          cq1            ADMITTED                       60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   DURATION   AGE
+wl1               j1         lq1          cq1            ADMITTED                       60m        60m
 `,
 		},
 		"should print workload list with only finished status filter": {
@@ -368,8 +384,14 @@ wl1               j1         lq1          cq1            ADMITTED               
 					Creation(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)).
 					Conditions([]metav1.Condition{
 						{
-							Type:   kueue.WorkloadFinished,
-							Status: metav1.ConditionTrue,
+							Type:               kueue.WorkloadAdmitted,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)),
+						},
+						{
+							Type:               kueue.WorkloadFinished,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(testStartTime.Truncate(time.Second)),
 						},
 					}...).
 					Obj(),
@@ -381,14 +403,20 @@ wl1               j1         lq1          cq1            ADMITTED               
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Conditions([]metav1.Condition{
 						{
-							Type:   kueue.WorkloadFinished,
-							Status: metav1.ConditionFalse,
+							Type:               kueue.WorkloadAdmitted,
+							Status:             metav1.ConditionTrue,
+							LastTransitionTime: metav1.NewTime(testStartTime.Add(-1 * time.Hour).Truncate(time.Second)),
+						},
+						{
+							Type:               kueue.WorkloadFinished,
+							Status:             metav1.ConditionFalse,
+							LastTransitionTime: metav1.NewTime(testStartTime.Truncate(time.Second)),
 						},
 					}...).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   AGE
-wl1               j1         lq1          cq1            FINISHED                       60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS     POSITION IN QUEUE   DURATION   AGE
+wl1               j1         lq1          cq1            FINISHED                       60m        60m
 `,
 		},
 		"should print workload list with label selector filter": {
@@ -411,8 +439,8 @@ wl1               j1         lq1          cq1            FINISHED               
 					Label("key", "value2").
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1               j1         lq1          cq1            PENDING                       60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1               j1         lq1          cq1            PENDING                                  60m
 `,
 		},
 		"should print workload list with label selector filter (short flag)": {
@@ -435,8 +463,8 @@ wl1               j1         lq1          cq1            PENDING                
 					Label("key", "value2").
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1               j1         lq1          cq1            PENDING                       60m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1               j1         lq1          cq1            PENDING                                  60m
 `,
 		},
 		"should print workload list with Job types": {
@@ -494,10 +522,10 @@ wl1               j1         lq1          cq1            PENDING                
 					Creation(testStartTime.Add(-3 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE                  JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1    job                       j1         lq1          cq1            PENDING                       60m
-wl2    rayjob.ray.io             j2         lq2          cq2            PENDING                       120m
-wl3    pytorchjob.kubeflow....   j3         lq3          cq3            PENDING                       3h
+			wantOut: `NAME   JOB TYPE                  JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1    job                       j1         lq1          cq1            PENDING                                  60m
+wl2    rayjob.ray.io             j2         lq2          cq2            PENDING                                  120m
+wl3    pytorchjob.kubeflow....   j3         lq3          cq3            PENDING                                  3h
 `,
 		},
 		"should print workload list with resource filter": {
@@ -553,8 +581,8 @@ wl3    pytorchjob.kubeflow....   j3         lq3          cq3            PENDING 
 					},
 				},
 			},
-			wantOut: `NAME   JOB TYPE    JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1    job.batch   job-test   lq1          cq1            PENDING                       120m
+			wantOut: `NAME   JOB TYPE    JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1    job.batch   job-test   lq1          cq1            PENDING                                  120m
 `,
 		},
 		"should print workload list with resource filter and composable jobs": {
@@ -619,8 +647,8 @@ wl1    job.batch   job-test   lq1          cq1            PENDING               
 					},
 				},
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME     LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl2    pod        pod-test-1   lq2          cq2            PENDING                       3h
+			wantOut: `NAME   JOB TYPE   JOB NAME     LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl2    pod        pod-test-1   lq2          cq2            PENDING                                  3h
 `,
 		},
 		"should print workload list with custom resource filter": {
@@ -687,8 +715,8 @@ wl2    pod        pod-test-1   lq2          cq2            PENDING              
 					},
 				},
 			},
-			wantOut: `NAME   JOB TYPE        JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1    rayjob.ray.io   job-test   lq1          cq1            PENDING                       120m
+			wantOut: `NAME   JOB TYPE        JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1    rayjob.ray.io   job-test   lq1          cq1            PENDING                                  120m
 `,
 		},
 		"should print workload list with full resource filter": {
@@ -755,8 +783,8 @@ wl1    rayjob.ray.io   job-test   lq1          cq1            PENDING           
 					},
 				},
 			},
-			wantOut: `NAME   JOB TYPE        JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1    rayjob.ray.io   job-test   lq1          cq1            PENDING                       120m
+			wantOut: `NAME   JOB TYPE        JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1    rayjob.ray.io   job-test   lq1          cq1            PENDING                                  120m
 `,
 		},
 		"should print workload list with position in queue": {
@@ -798,9 +826,9 @@ wl1    rayjob.ray.io   job-test   lq1          cq1            PENDING           
 					Creation(testStartTime.Add(-2 * time.Hour).Truncate(time.Second)).
 					Obj(),
 			},
-			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1               j1         lq1          cq1            PENDING   12                  60m
-wl2               j2         lq2          cq2            PENDING   22                  120m
+			wantOut: `NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1               j1         lq1          cq1            PENDING   12                             60m
+wl2               j2         lq2          cq2            PENDING   22                             120m
 `,
 		},
 		"should print not found error": {

--- a/test/integration/kueuectl/list_test.go
+++ b/test/integration/kueuectl/list_test.go
@@ -216,8 +216,8 @@ very-long-cluster-queue-name            0                   0                   
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
 			gomega.Expect(errOutput.String()).Should(gomega.BeEmpty())
-			gomega.Expect(output.String()).Should(gomega.Equal(fmt.Sprintf(`NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-wl1                          lq1                         PENDING                                  %s
+			gomega.Expect(output.String()).Should(gomega.Equal(fmt.Sprintf(`NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+wl1                          lq1                         PENDING                                   %s
 `,
 				duration.HumanDuration(executeTime.Sub(wl1.CreationTimestamp.Time)))))
 		})
@@ -235,10 +235,10 @@ wl1                          lq1                         PENDING                
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
 			gomega.Expect(errOutput.String()).Should(gomega.BeEmpty())
-			gomega.Expect(output.String()).Should(gomega.Equal(fmt.Sprintf(`NAME                      JOB TYPE   JOB NAME   LOCALQUEUE                   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
-very-long-workload-name                         lq1                                         PENDING                                  %s
-wl1                                             lq1                                         PENDING                                  %s
-wl2                                             very-long-local-queue-name                  PENDING                                  %s
+			gomega.Expect(output.String()).Should(gomega.Equal(fmt.Sprintf(`NAME                      JOB TYPE   JOB NAME   LOCALQUEUE                   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   EXEC TIME   AGE
+very-long-workload-name                         lq1                                         PENDING                                   %s
+wl1                                             lq1                                         PENDING                                   %s
+wl2                                             very-long-local-queue-name                  PENDING                                   %s
 `,
 				duration.HumanDuration(executeTime.Sub(wl3.CreationTimestamp.Time)),
 				duration.HumanDuration(executeTime.Sub(wl1.CreationTimestamp.Time)),

--- a/test/integration/kueuectl/list_test.go
+++ b/test/integration/kueuectl/list_test.go
@@ -216,8 +216,8 @@ very-long-cluster-queue-name            0                   0                   
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
 			gomega.Expect(errOutput.String()).Should(gomega.BeEmpty())
-			gomega.Expect(output.String()).Should(gomega.Equal(fmt.Sprintf(`NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-wl1                          lq1                         PENDING                       %s
+			gomega.Expect(output.String()).Should(gomega.Equal(fmt.Sprintf(`NAME   JOB TYPE   JOB NAME   LOCALQUEUE   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+wl1                          lq1                         PENDING                                  %s
 `,
 				duration.HumanDuration(executeTime.Sub(wl1.CreationTimestamp.Time)))))
 		})
@@ -235,10 +235,10 @@ wl1                          lq1                         PENDING                
 
 			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "%s: %s", err, output)
 			gomega.Expect(errOutput.String()).Should(gomega.BeEmpty())
-			gomega.Expect(output.String()).Should(gomega.Equal(fmt.Sprintf(`NAME                      JOB TYPE   JOB NAME   LOCALQUEUE                   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   AGE
-very-long-workload-name                         lq1                                         PENDING                       %s
-wl1                                             lq1                                         PENDING                       %s
-wl2                                             very-long-local-queue-name                  PENDING                       %s
+			gomega.Expect(output.String()).Should(gomega.Equal(fmt.Sprintf(`NAME                      JOB TYPE   JOB NAME   LOCALQUEUE                   CLUSTERQUEUE   STATUS    POSITION IN QUEUE   DURATION   AGE
+very-long-workload-name                         lq1                                         PENDING                                  %s
+wl1                                             lq1                                         PENDING                                  %s
+wl2                                             very-long-local-queue-name                  PENDING                                  %s
 `,
 				duration.HumanDuration(executeTime.Sub(wl3.CreationTimestamp.Time)),
 				duration.HumanDuration(executeTime.Sub(wl1.CreationTimestamp.Time)),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add EXEC TIME column on kueuectl list workload command.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2972

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
CLI: Added EXEC TIME column on kueuectl list workload command.
```