### PR TITLE
Update AllocatableResourceGeneration

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -108,7 +108,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			wantClusterQueues: map[string]*clusterQueue{
 				"a": {
 					Name:                          "a",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 2,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
@@ -126,7 +126,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"c": {
 					Name:                          "c",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 3,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
@@ -144,7 +144,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"e": {
 					Name:                          "e",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 2,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        pending,
@@ -234,7 +234,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			wantClusterQueues: map[string]*clusterQueue{
 				"a": {
 					Name:                          "a",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 2,
 					FlavorFungibility:             defaultFlavorFungibility,
 					NamespaceSelector:             labels.Nothing(),
 					Status:                        active,
@@ -252,7 +252,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"c": {
 					Name:                          "c",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 3,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
@@ -270,7 +270,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"e": {
 					Name:                          "e",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 2,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        pending,
@@ -335,7 +335,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			wantClusterQueues: map[string]*clusterQueue{
 				"a": {
 					Name:                          "a",
-					AllocatableResourceGeneration: 2,
+					AllocatableResourceGeneration: 4,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
@@ -344,7 +344,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"b": {
 					Name:                          "b",
-					AllocatableResourceGeneration: 2,
+					AllocatableResourceGeneration: 3,
 					NamespaceSelector:             labels.Everything(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
@@ -353,7 +353,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"c": {
 					Name:                          "c",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 5,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
@@ -371,7 +371,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"e": {
 					Name:                          "e",
-					AllocatableResourceGeneration: 2,
+					AllocatableResourceGeneration: 4,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
@@ -380,7 +380,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"f": {
 					Name:                          "f",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 3,
 					NamespaceSelector:             labels.Nothing(),
 					Status:                        active,
 					Preemption:                    defaultPreemption,
@@ -509,7 +509,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			wantClusterQueues: map[string]*clusterQueue{
 				"a": {
 					Name:                          "a",
-					AllocatableResourceGeneration: 2,
+					AllocatableResourceGeneration: 4,
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
 					Preemption:                    defaultPreemption,
@@ -518,7 +518,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"b": {
 					Name:                          "b",
-					AllocatableResourceGeneration: 2,
+					AllocatableResourceGeneration: 3,
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
 					Preemption:                    defaultPreemption,
@@ -527,7 +527,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"c": {
 					Name:                          "c",
-					AllocatableResourceGeneration: 2,
+					AllocatableResourceGeneration: 4,
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
 					Preemption:                    defaultPreemption,
@@ -567,7 +567,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"c": {
 					Name:                          "c",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 3,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
@@ -576,7 +576,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"e": {
 					Name:                          "e",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 2,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        pending,
@@ -616,7 +616,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			wantClusterQueues: map[string]*clusterQueue{
 				"a": {
 					Name:                          "a",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 2,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
@@ -634,7 +634,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"c": {
 					Name:                          "c",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 3,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
@@ -652,7 +652,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				},
 				"e": {
 					Name:                          "e",
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 2,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,
@@ -1089,7 +1089,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector:             labels.Everything(),
 					Status:                        active,
 					Preemption:                    defaultPreemption,
-					AllocatableResourceGeneration: 1,
+					AllocatableResourceGeneration: 2,
 					FlavorFungibility:             defaultFlavorFungibility,
 					FairWeight:                    oneQuantity,
 				},

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -134,7 +134,6 @@ var defaultFlavorFungibility = kueue.FlavorFungibility{WhenCanBorrow: kueue.Borr
 
 func (c *clusterQueue) updateClusterQueue(in *kueue.ClusterQueue, resourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor, admissionChecks map[string]AdmissionCheck, oldParent *cohort) error {
 	if c.updateQuotasAndResourceGroups(in.Spec.ResourceGroups) || oldParent != c.Parent() {
-		c.AllocatableResourceGeneration += 1
 		if oldParent != nil && oldParent != c.Parent() {
 			updateCohortResourceNode(oldParent)
 		}

--- a/pkg/cache/cohort_snapshot.go
+++ b/pkg/cache/cohort_snapshot.go
@@ -25,10 +25,6 @@ type CohortSnapshot struct {
 	Members sets.Set[*ClusterQueueSnapshot]
 
 	ResourceNode ResourceNode
-
-	// AllocatableResourceGeneration equals to
-	// the sum of allocatable generation among its members.
-	AllocatableResourceGeneration int64
 }
 
 // The methods below implement hierarchicalResourceNode interface.

--- a/pkg/cache/resource_node.go
+++ b/pkg/cache/resource_node.go
@@ -154,6 +154,7 @@ func (r ResourceNode) calculateLendable() map[corev1.ResourceName]int64 {
 }
 
 func updateClusterQueueResourceNode(cq *clusterQueue) {
+	cq.AllocatableResourceGeneration += 1
 	cq.resourceNode.SubtreeQuota = make(resources.FlavorResourceQuantities, len(cq.resourceNode.Quotas))
 	for fr, quota := range cq.resourceNode.Quotas {
 		cq.resourceNode.SubtreeQuota[fr] = quota.Nominal

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -130,13 +130,11 @@ func (c *cohort) snapshotInto(cqs map[string]*ClusterQueueSnapshot) {
 		Members:      make(sets.Set[*ClusterQueueSnapshot], len(c.ChildCQs())),
 		ResourceNode: c.resourceNode.Clone(),
 	}
-	cohortSnap.AllocatableResourceGeneration = 0
 	for _, cq := range c.ChildCQs() {
 		if cq.Active() {
 			cqSnap := cqs[cq.Name]
 			cqSnap.Cohort = cohortSnap
 			cohortSnap.Members.Insert(cqSnap)
-			cohortSnap.AllocatableResourceGeneration += cqSnap.AllocatableResourceGeneration
 		}
 	}
 }

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -203,8 +203,7 @@ func TestSnapshot(t *testing.T) {
 			},
 			wantSnapshot: func() Snapshot {
 				cohort := &CohortSnapshot{
-					Name:                          "borrowing",
-					AllocatableResourceGeneration: 2,
+					Name: "borrowing",
 					ResourceNode: ResourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "demand", Resource: corev1.ResourceCPU}: 10_000,
@@ -223,7 +222,7 @@ func TestSnapshot(t *testing.T) {
 						"a": {
 							Name:                          "a",
 							Cohort:                        cohort,
-							AllocatableResourceGeneration: 1,
+							AllocatableResourceGeneration: 2,
 							ResourceGroups: []ResourceGroup{
 								{
 									CoveredResources: sets.New(corev1.ResourceCPU),
@@ -445,8 +444,7 @@ func TestSnapshot(t *testing.T) {
 			},
 			wantSnapshot: func() Snapshot {
 				cohort := &CohortSnapshot{
-					Name:                          "lending",
-					AllocatableResourceGeneration: 2,
+					Name: "lending",
 					ResourceNode: ResourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
@@ -462,7 +460,7 @@ func TestSnapshot(t *testing.T) {
 						"a": {
 							Name:                          "a",
 							Cohort:                        cohort,
-							AllocatableResourceGeneration: 1,
+							AllocatableResourceGeneration: 2,
 							ResourceGroups: []ResourceGroup{
 								{
 									CoveredResources: sets.New(corev1.ResourceCPU),
@@ -597,8 +595,7 @@ func TestSnapshot(t *testing.T) {
 			},
 			wantSnapshot: func() Snapshot {
 				cohort := &CohortSnapshot{
-					Name:                          "lending",
-					AllocatableResourceGeneration: 2,
+					Name: "lending",
 					ResourceNode: ResourceNode{
 						SubtreeQuota: resources.FlavorResourceQuantities{
 							{Flavor: "arm", Resource: corev1.ResourceCPU}: 20_000,
@@ -615,7 +612,7 @@ func TestSnapshot(t *testing.T) {
 						"a": {
 							Name:                          "a",
 							Cohort:                        cohort,
-							AllocatableResourceGeneration: 1,
+							AllocatableResourceGeneration: 2,
 							ResourceGroups: []ResourceGroup{
 								{
 									CoveredResources: sets.New(corev1.ResourceCPU),
@@ -730,7 +727,7 @@ func TestSnapshot(t *testing.T) {
 				ClusterQueues: map[string]*ClusterQueueSnapshot{
 					"cq": {
 						Name:                          "cq",
-						AllocatableResourceGeneration: 1,
+						AllocatableResourceGeneration: 2,
 						ResourceGroups: []ResourceGroup{
 							{
 								CoveredResources: sets.New(corev1.ResourceCPU),
@@ -753,8 +750,7 @@ func TestSnapshot(t *testing.T) {
 						NamespaceSelector: labels.Everything(),
 						Status:            active,
 						Cohort: &CohortSnapshot{
-							Name:                          "cohort",
-							AllocatableResourceGeneration: 1,
+							Name: "cohort",
 							ResourceNode: ResourceNode{
 								Quotas: map[resources.FlavorResource]ResourceQuota{
 									{Flavor: "arm", Resource: corev1.ResourceCPU}:  {Nominal: 10_000, BorrowingLimit: nil, LendingLimit: nil},
@@ -900,8 +896,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 			remove: []string{"/c1-cpu", "/c1-memory-alpha", "/c1-memory-beta", "/c2-cpu-1", "/c2-cpu-2"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
-					Name:                          "cohort",
-					AllocatableResourceGeneration: 2,
+					Name: "cohort",
 					ResourceNode: ResourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}:  0,
@@ -914,13 +909,12 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 				return Snapshot{
 					ClusterQueues: map[string]*ClusterQueueSnapshot{
 						"c1": {
-							Name:                          "c1",
-							Cohort:                        cohort,
-							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.hm.ClusterQueues["c1"].ResourceGroups,
-							FlavorFungibility:             defaultFlavorFungibility,
-							FairWeight:                    oneQuantity,
-							AllocatableResourceGeneration: 1,
+							Name:              "c1",
+							Cohort:            cohort,
+							Workloads:         make(map[string]*workload.Info),
+							ResourceGroups:    cqCache.hm.ClusterQueues["c1"].ResourceGroups,
+							FlavorFungibility: defaultFlavorFungibility,
+							FairWeight:        oneQuantity,
 							ResourceNode: ResourceNode{
 								Usage: resources.FlavorResourceQuantities{
 									{Flavor: "default", Resource: corev1.ResourceCPU}:  0,
@@ -959,8 +953,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 			remove: []string{"/c1-cpu"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
-					Name:                          "cohort",
-					AllocatableResourceGeneration: 2,
+					Name: "cohort",
 					ResourceNode: ResourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}:  2_000,
@@ -979,10 +972,9 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								"/c1-memory-alpha": nil,
 								"/c1-memory-beta":  nil,
 							},
-							AllocatableResourceGeneration: 1,
-							ResourceGroups:                cqCache.hm.ClusterQueues["c1"].ResourceGroups,
-							FlavorFungibility:             defaultFlavorFungibility,
-							FairWeight:                    oneQuantity,
+							ResourceGroups:    cqCache.hm.ClusterQueues["c1"].ResourceGroups,
+							FlavorFungibility: defaultFlavorFungibility,
+							FairWeight:        oneQuantity,
 							ResourceNode: ResourceNode{
 								Usage: resources.FlavorResourceQuantities{
 									{Flavor: "default", Resource: corev1.ResourceCPU}:  0,
@@ -1024,8 +1016,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 			remove: []string{"/c1-memory-alpha"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
-					Name:                          "cohort",
-					AllocatableResourceGeneration: 2,
+					Name: "cohort",
 					ResourceNode: ResourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}:  3_000,
@@ -1044,10 +1035,9 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								"/c1-memory-alpha": nil,
 								"/c1-memory-beta":  nil,
 							},
-							AllocatableResourceGeneration: 1,
-							ResourceGroups:                cqCache.hm.ClusterQueues["c1"].ResourceGroups,
-							FlavorFungibility:             defaultFlavorFungibility,
-							FairWeight:                    oneQuantity,
+							ResourceGroups:    cqCache.hm.ClusterQueues["c1"].ResourceGroups,
+							FlavorFungibility: defaultFlavorFungibility,
+							FairWeight:        oneQuantity,
 							ResourceNode: ResourceNode{
 								Usage: resources.FlavorResourceQuantities{
 									{Flavor: "default", Resource: corev1.ResourceCPU}:  1_000,
@@ -1068,10 +1058,9 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								"/c2-cpu-1": nil,
 								"/c2-cpu-2": nil,
 							},
-							AllocatableResourceGeneration: 1,
-							ResourceGroups:                cqCache.hm.ClusterQueues["c2"].ResourceGroups,
-							FlavorFungibility:             defaultFlavorFungibility,
-							FairWeight:                    oneQuantity,
+							ResourceGroups:    cqCache.hm.ClusterQueues["c2"].ResourceGroups,
+							FlavorFungibility: defaultFlavorFungibility,
+							FairWeight:        oneQuantity,
 							ResourceNode: ResourceNode{
 								Usage: resources.FlavorResourceQuantities{
 									{Flavor: "default", Resource: corev1.ResourceCPU}: 2_000,
@@ -1087,7 +1076,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 		},
 	}
 	cmpOpts := append(snapCmpOpts,
-		cmpopts.IgnoreFields(ClusterQueueSnapshot{}, "NamespaceSelector", "Preemption", "Status"),
+		cmpopts.IgnoreFields(ClusterQueueSnapshot{}, "NamespaceSelector", "Preemption", "Status", "AllocatableResourceGeneration"),
 		cmpopts.IgnoreFields(ResourceNode{}, "Quotas"),
 		cmpopts.IgnoreFields(Snapshot{}, "ResourceFlavors"),
 		cmpopts.IgnoreTypes(&workload.Info{}))
@@ -1186,8 +1175,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			remove: []string{"/lend-a-1", "/lend-a-2", "/lend-a-3", "/lend-b-1"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
-					Name:                          "lend",
-					AllocatableResourceGeneration: 2,
+					Name: "lend",
 					ResourceNode: ResourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
@@ -1198,13 +1186,12 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				return Snapshot{
 					ClusterQueues: map[string]*ClusterQueueSnapshot{
 						"lend-a": {
-							Name:                          "lend-a",
-							Cohort:                        cohort,
-							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
-							FlavorFungibility:             defaultFlavorFungibility,
-							FairWeight:                    oneQuantity,
-							AllocatableResourceGeneration: 1,
+							Name:              "lend-a",
+							Cohort:            cohort,
+							Workloads:         make(map[string]*workload.Info),
+							ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+							FlavorFungibility: defaultFlavorFungibility,
+							FairWeight:        oneQuantity,
 							ResourceNode: ResourceNode{
 								Usage: resources.FlavorResourceQuantities{
 									{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
@@ -1215,13 +1202,12 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							},
 						},
 						"lend-b": {
-							Name:                          "lend-b",
-							Cohort:                        cohort,
-							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
-							FlavorFungibility:             defaultFlavorFungibility,
-							FairWeight:                    oneQuantity,
-							AllocatableResourceGeneration: 1,
+							Name:              "lend-b",
+							Cohort:            cohort,
+							Workloads:         make(map[string]*workload.Info),
+							ResourceGroups:    cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
+							FlavorFungibility: defaultFlavorFungibility,
+							FairWeight:        oneQuantity,
 							ResourceNode: ResourceNode{
 								Usage: resources.FlavorResourceQuantities{
 									{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
@@ -1239,8 +1225,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			remove: []string{"/lend-a-2"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
-					Name:                          "lend",
-					AllocatableResourceGeneration: 2,
+					Name: "lend",
 					ResourceNode: ResourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
@@ -1251,13 +1236,12 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				return Snapshot{
 					ClusterQueues: map[string]*ClusterQueueSnapshot{
 						"lend-a": {
-							Name:                          "lend-a",
-							Cohort:                        cohort,
-							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
-							FlavorFungibility:             defaultFlavorFungibility,
-							FairWeight:                    oneQuantity,
-							AllocatableResourceGeneration: 1,
+							Name:              "lend-a",
+							Cohort:            cohort,
+							Workloads:         make(map[string]*workload.Info),
+							ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+							FlavorFungibility: defaultFlavorFungibility,
+							FairWeight:        oneQuantity,
 							ResourceNode: ResourceNode{
 								Usage: resources.FlavorResourceQuantities{
 									{Flavor: "default", Resource: corev1.ResourceCPU}: 7_000,
@@ -1292,8 +1276,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			remove: []string{"/lend-a-1", "/lend-a-2"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
-					Name:                          "lend",
-					AllocatableResourceGeneration: 2,
+					Name: "lend",
 					ResourceNode: ResourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
@@ -1304,13 +1287,12 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				return Snapshot{
 					ClusterQueues: map[string]*ClusterQueueSnapshot{
 						"lend-a": {
-							Name:                          "lend-a",
-							Cohort:                        cohort,
-							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
-							FlavorFungibility:             defaultFlavorFungibility,
-							FairWeight:                    oneQuantity,
-							AllocatableResourceGeneration: 1,
+							Name:              "lend-a",
+							Cohort:            cohort,
+							Workloads:         make(map[string]*workload.Info),
+							ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+							FlavorFungibility: defaultFlavorFungibility,
+							FairWeight:        oneQuantity,
 							ResourceNode: ResourceNode{
 								Usage: resources.FlavorResourceQuantities{
 									{Flavor: "default", Resource: corev1.ResourceCPU}: 6_000,
@@ -1345,8 +1327,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			remove: []string{"/lend-a-2", "/lend-a-3"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
-					Name:                          "lend",
-					AllocatableResourceGeneration: 2,
+					Name: "lend",
 					ResourceNode: ResourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
@@ -1357,13 +1338,12 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				return Snapshot{
 					ClusterQueues: map[string]*ClusterQueueSnapshot{
 						"lend-a": {
-							Name:                          "lend-a",
-							Cohort:                        cohort,
-							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
-							FlavorFungibility:             defaultFlavorFungibility,
-							FairWeight:                    oneQuantity,
-							AllocatableResourceGeneration: 1,
+							Name:              "lend-a",
+							Cohort:            cohort,
+							Workloads:         make(map[string]*workload.Info),
+							ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+							FlavorFungibility: defaultFlavorFungibility,
+							FairWeight:        oneQuantity,
 							ResourceNode: ResourceNode{
 								Usage: resources.FlavorResourceQuantities{
 									{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
@@ -1399,8 +1379,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			add:    []string{"/lend-a-1"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
-					Name:                          "lend",
-					AllocatableResourceGeneration: 2,
+					Name: "lend",
 					ResourceNode: ResourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
@@ -1411,13 +1390,12 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				return Snapshot{
 					ClusterQueues: map[string]*ClusterQueueSnapshot{
 						"lend-a": {
-							Name:                          "lend-a",
-							Cohort:                        cohort,
-							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
-							FlavorFungibility:             defaultFlavorFungibility,
-							FairWeight:                    oneQuantity,
-							AllocatableResourceGeneration: 1,
+							Name:              "lend-a",
+							Cohort:            cohort,
+							Workloads:         make(map[string]*workload.Info),
+							ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+							FlavorFungibility: defaultFlavorFungibility,
+							FairWeight:        oneQuantity,
 							ResourceNode: ResourceNode{
 								Usage: resources.FlavorResourceQuantities{
 									{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
@@ -1453,8 +1431,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			add:    []string{"/lend-a-3"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
-					Name:                          "lend",
-					AllocatableResourceGeneration: 2,
+					Name: "lend",
 					ResourceNode: ResourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
@@ -1465,13 +1442,12 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				return Snapshot{
 					ClusterQueues: map[string]*ClusterQueueSnapshot{
 						"lend-a": {
-							Name:                          "lend-a",
-							Cohort:                        cohort,
-							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
-							FlavorFungibility:             defaultFlavorFungibility,
-							FairWeight:                    oneQuantity,
-							AllocatableResourceGeneration: 1,
+							Name:              "lend-a",
+							Cohort:            cohort,
+							Workloads:         make(map[string]*workload.Info),
+							ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+							FlavorFungibility: defaultFlavorFungibility,
+							FairWeight:        oneQuantity,
 							ResourceNode: ResourceNode{
 								Usage: resources.FlavorResourceQuantities{
 									{Flavor: "default", Resource: corev1.ResourceCPU}: 6_000,
@@ -1482,13 +1458,12 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							},
 						},
 						"lend-b": {
-							Name:                          "lend-b",
-							Cohort:                        cohort,
-							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
-							FlavorFungibility:             defaultFlavorFungibility,
-							FairWeight:                    oneQuantity,
-							AllocatableResourceGeneration: 1,
+							Name:              "lend-b",
+							Cohort:            cohort,
+							Workloads:         make(map[string]*workload.Info),
+							ResourceGroups:    cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
+							FlavorFungibility: defaultFlavorFungibility,
+							FairWeight:        oneQuantity,
 							ResourceNode: ResourceNode{
 								Usage: resources.FlavorResourceQuantities{
 									{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
@@ -1507,8 +1482,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			add:    []string{"/lend-a-2"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
-					Name:                          "lend",
-					AllocatableResourceGeneration: 2,
+					Name: "lend",
 					ResourceNode: ResourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 3_000,
@@ -1519,13 +1493,12 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				return Snapshot{
 					ClusterQueues: map[string]*ClusterQueueSnapshot{
 						"lend-a": {
-							Name:                          "lend-a",
-							Cohort:                        cohort,
-							Workloads:                     make(map[string]*workload.Info),
-							ResourceGroups:                cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
-							FlavorFungibility:             defaultFlavorFungibility,
-							FairWeight:                    oneQuantity,
-							AllocatableResourceGeneration: 1,
+							Name:              "lend-a",
+							Cohort:            cohort,
+							Workloads:         make(map[string]*workload.Info),
+							ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+							FlavorFungibility: defaultFlavorFungibility,
+							FairWeight:        oneQuantity,
 							ResourceNode: ResourceNode{
 								Usage: resources.FlavorResourceQuantities{
 									{Flavor: "default", Resource: corev1.ResourceCPU}: 9_000,
@@ -1558,7 +1531,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 		},
 	}
 	cmpOpts := append(snapCmpOpts,
-		cmpopts.IgnoreFields(ClusterQueueSnapshot{}, "NamespaceSelector", "Preemption", "Status"),
+		cmpopts.IgnoreFields(ClusterQueueSnapshot{}, "NamespaceSelector", "Preemption", "Status", "AllocatableResourceGeneration"),
 		cmpopts.IgnoreFields(ResourceNode{}, "Quotas"),
 		cmpopts.IgnoreFields(Snapshot{}, "ResourceFlavors"),
 		cmpopts.IgnoreTypes(&workload.Info{}))

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -2276,36 +2276,14 @@ func TestLastAssignmentOutdated(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "Cohort allocatableResourceIncreasedGen increased",
-			args: args{
-				wl: &workload.Info{
-					LastAssignment: &workload.AssignmentClusterQueueState{
-						ClusterQueueGeneration: 0,
-						CohortGeneration:       0,
-					},
-				},
-				cq: &cache.ClusterQueueSnapshot{
-					Cohort: &cache.CohortSnapshot{
-						AllocatableResourceGeneration: 1,
-					},
-					AllocatableResourceGeneration: 0,
-				},
-			},
-			want: true,
-		},
-		{
 			name: "AllocatableResourceGeneration not increased",
 			args: args{
 				wl: &workload.Info{
 					LastAssignment: &workload.AssignmentClusterQueueState{
 						ClusterQueueGeneration: 0,
-						CohortGeneration:       0,
 					},
 				},
 				cq: &cache.ClusterQueueSnapshot{
-					Cohort: &cache.CohortSnapshot{
-						AllocatableResourceGeneration: 0,
-					},
 					AllocatableResourceGeneration: 0,
 				},
 			},

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -50,7 +50,6 @@ import (
 var snapCmpOpts = []cmp.Option{
 	cmpopts.EquateEmpty(),
 	cmpopts.IgnoreUnexported(cache.ClusterQueueSnapshot{}),
-	cmpopts.IgnoreFields(cache.CohortSnapshot{}, "AllocatableResourceGeneration"),
 	cmpopts.IgnoreFields(cache.ClusterQueueSnapshot{}, "AllocatableResourceGeneration"),
 	cmp.Transformer("Cohort.Members", func(s sets.Set[*cache.ClusterQueueSnapshot]) sets.Set[string] {
 		result := make(sets.Set[string], len(s))

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -78,7 +78,6 @@ func Status(w *kueue.Workload) string {
 
 type AssignmentClusterQueueState struct {
 	LastTriedFlavorIdx     []map[corev1.ResourceName]int
-	CohortGeneration       int64
 	ClusterQueueGeneration int64
 }
 
@@ -100,7 +99,6 @@ func WithExcludedResourcePrefixes(n []string) InfoOption {
 func (s *AssignmentClusterQueueState) Clone() *AssignmentClusterQueueState {
 	c := AssignmentClusterQueueState{
 		LastTriedFlavorIdx:     make([]map[corev1.ResourceName]int, len(s.LastTriedFlavorIdx)),
-		CohortGeneration:       s.CohortGeneration,
 		ClusterQueueGeneration: s.ClusterQueueGeneration,
 	}
 	for ps, flavorIdx := range s.LastTriedFlavorIdx {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:
We update `AllocatableResourceGeneration` to be compatible with `HierarchicalCohorts` (#79). We delete this number from Cohorts, and only store it in the ClusterQueue. After this change, f an update occurs in any part of the tree, we bump the ClusterQueues' number when running the resource update.

The previous implementation would be complex with `HierarchicalCohorts` - we would have to do a root traversal to see if any of the generations increased. Additionally, it was non-monotonic (wrong): if a ClusterQueue was deleted, the Cohort's generation could decrease, despite the available resources of the Cohort having had changed.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```