### PR TITLE
import deployment package in jobs.go to register the deployment webhook

### DIFF
--- a/charts/kueue/templates/webhook/webhook.yaml
+++ b/charts/kueue/templates/webhook/webhook.yaml
@@ -17,6 +17,25 @@ webhooks:
       service:
         name: '{{ include "kueue.fullname" . }}-webhook-service'
         namespace: '{{ .Release.Namespace }}'
+        path: /mutate-apps-v1-deployment
+    failurePolicy: Fail
+    name: mdeployment.kb.io
+    rules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+        resources:
+          - deployments
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        namespace: '{{ .Release.Namespace }}'
         path: /mutate-batch-v1-job
     failurePolicy: Fail
     name: mjob.kb.io
@@ -241,25 +260,6 @@ webhooks:
       service:
         name: '{{ include "kueue.fullname" . }}-webhook-service'
         namespace: '{{ .Release.Namespace }}'
-        path: /mutate-apps-v1-deployment
-    failurePolicy: Fail
-    name: mdeployment.kb.io
-    rules:
-      - apiGroups:
-          - apps
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-        resources:
-          - deployments
-    sideEffects: None
-  - admissionReviewVersions:
-      - v1
-    clientConfig:
-      service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
-        namespace: '{{ .Release.Namespace }}'
         path: /mutate-kueue-x-k8s-io-v1beta1-clusterqueue
     failurePolicy: Fail
     name: mclusterqueue.kb.io
@@ -324,6 +324,26 @@ metadata:
   {{- end }}
   namespace: '{{ .Release.Namespace }}'
 webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        namespace: '{{ .Release.Namespace }}'
+        path: /validate-apps-v1-deployment
+    failurePolicy: Fail
+    name: vdeployment.kb.io
+    rules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - deployments
+    sideEffects: None
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -558,26 +578,6 @@ webhooks:
           - UPDATE
         resources:
           - rayjobs
-    sideEffects: None
-  - admissionReviewVersions:
-      - v1
-    clientConfig:
-      service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
-        namespace: '{{ .Release.Namespace }}'
-        path: /validate-apps-v1-deployment
-    failurePolicy: Fail
-    name: vdeployment.kb.io
-    rules:
-      - apiGroups:
-          - apps
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - deployments
     sideEffects: None
   - admissionReviewVersions:
       - v1

--- a/cmd/kueuectl/app/list/list_pods.go
+++ b/cmd/kueuectl/app/list/list_pods.go
@@ -228,6 +228,9 @@ func (o *PodOptions) getPodLabelSelector() (string, error) {
 		return "", nil
 	}
 
+	if cbs.NewJob == nil {
+		return "", nil
+	}
 	genericJob := cbs.NewJob()
 
 	jobWithPodLabelSelector, ok := genericJob.(jobframework.JobWithPodLabelSelector)

--- a/config/components/webhook/manifests.yaml
+++ b/config/components/webhook/manifests.yaml
@@ -10,6 +10,25 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-apps-v1-deployment
+  failurePolicy: Fail
+  name: mdeployment.kb.io
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - deployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-batch-v1-job
   failurePolicy: Fail
   name: mjob.kb.io
@@ -219,25 +238,6 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-apps-v1-deployment
-  failurePolicy: Fail
-  name: mdeployment.kb.io
-  rules:
-  - apiGroups:
-    - apps
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    resources:
-    - deployments
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
       path: /mutate-kueue-x-k8s-io-v1beta1-clusterqueue
   failurePolicy: Fail
   name: mclusterqueue.kb.io
@@ -295,6 +295,26 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration
 webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-apps-v1-deployment
+  failurePolicy: Fail
+  name: vdeployment.kb.io
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+  sideEffects: None
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -514,26 +534,6 @@ webhooks:
     - UPDATE
     resources:
     - rayjobs
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-apps-v1-deployment
-  failurePolicy: Fail
-  name: vdeployment.kb.io
-  rules:
-  - apiGroups:
-    - apps
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - deployments
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/pkg/controller/jobs/deployment/deployment_controller.go
+++ b/pkg/controller/jobs/deployment/deployment_controller.go
@@ -40,6 +40,7 @@ func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:   SetupIndexes,
 		NewReconciler:  jobframework.NewNoopReconcilerFactory(gvk),
+		GVK:            gvk,
 		SetupWebhook:   SetupWebhook,
 		JobType:        &appsv1.Deployment{},
 		AddToScheme:    appsv1.AddToScheme,

--- a/pkg/controller/jobs/jobs.go
+++ b/pkg/controller/jobs/jobs.go
@@ -18,6 +18,7 @@ package jobs
 
 // Reference the job framework integration packages to ensure linking.
 import (
+	_ "sigs.k8s.io/kueue/pkg/controller/jobs/deployment"
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes deployment webhook to allow for create/update of deployments after kueue is installed

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2987

#### Special notes for your reviewer:
Testing done:
1. enable the pod controller with following configuration option and applied the patch
```
$ cat config/components/manager/controller_manager_config.yaml
...
  - "pod"
  - "deployment"
#  externalFrameworks:
#  - "Foo.v1.example.com"
  podOptions:
    namespaceSelector:
      matchExpressions:
        - key: kubernetes.io/metadata.name
          operator: NotIn
          values: [ kube-system, kueue-system ]
...
$  kubectl patch -n kueue-system deployment kueue-controller-manager --type='json' -p='[
  {
    "op": "add",
    "path": "/spec/template/spec/containers/0/args/-",
    "value": "--feature-gates=VisibilityOnDemand=true"
  }
]'
deployment.apps/kueue-controller-manager patched
```
2. disabled the pod controller and applied the patch
```
$ cat config/components/manager/controller_manager_config.yaml
...
#  - "pod"
#  externalFrameworks:
#  - "Foo.v1.example.com"
#  podOptions:
#    namespaceSelector:
#      matchExpressions:
#        - key: kubernetes.io/metadata.name
#          operator: NotIn
#          values: [ kube-system, kueue-system ]
...
$ kubectl patch -n kueue-system deployment kueue-controller-manager --type='json' -p='[
  {
    "op": "add",
    "path": "/spec/template/spec/containers/0/args/-",
    "value": "--feature-gates=VisibilityOnDemand=true"
  }
]'
deployment.apps/kueue-controller-manager patched
```

Both the scenarios worked

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```