### PR TITLE
Update Snapshoting to use hierarchy.Manager

### DIFF
--- a/pkg/cache/cohort_snapshot.go
+++ b/pkg/cache/cohort_snapshot.go
@@ -16,27 +16,25 @@ limitations under the License.
 
 package cache
 
-import (
-	"k8s.io/apimachinery/pkg/util/sets"
-)
+import "sigs.k8s.io/kueue/pkg/hierarchy"
 
 type CohortSnapshot struct {
-	Name    string
-	Members sets.Set[*ClusterQueueSnapshot]
+	Name string
 
 	ResourceNode ResourceNode
+	hierarchy.Cohort[*ClusterQueueSnapshot, *CohortSnapshot]
+}
+
+func (c *CohortSnapshot) GetName() string {
+	return c.Name
 }
 
 // The methods below implement hierarchicalResourceNode interface.
-
-func (c *CohortSnapshot) HasParent() bool {
-	return false
-}
 
 func (c *CohortSnapshot) getResourceNode() ResourceNode {
 	return c.ResourceNode
 }
 
 func (c *CohortSnapshot) parentHRN() hierarchicalResourceNode {
-	return nil
+	return c.Parent()
 }

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -613,7 +613,7 @@ func (a *FlavorAssigner) fitsResourceQuota(log logr.Logger, fr resources.FlavorR
 
 	lackQuantity := resources.ResourceQuantity(fr.Resource, lack)
 	msg := fmt.Sprintf("insufficient unused quota in cohort for %s in flavor %s, %s more needed", fr.Resource, fr.Flavor, &lackQuantity)
-	if a.cq.Cohort == nil {
+	if !a.cq.HasParent() {
 		if mode == noFit {
 			msg = fmt.Sprintf("insufficient quota for %s in flavor %s in ClusterQueue", fr.Resource, fr.Flavor)
 		} else {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -1954,11 +1954,11 @@ func TestAssignFlavors(t *testing.T) {
 			}
 
 			if tc.cohortResources != nil {
-				if clusterQueue.Cohort == nil {
+				if !clusterQueue.HasParent() {
 					t.Fatalf("Test case has cohort resources, but cluster queue doesn't have cohort")
 				}
-				clusterQueue.Cohort.ResourceNode.Usage = tc.cohortResources.usage
-				clusterQueue.Cohort.ResourceNode.SubtreeQuota = tc.cohortResources.requestableResources
+				clusterQueue.Parent().ResourceNode.Usage = tc.cohortResources.usage
+				clusterQueue.Parent().ResourceNode.SubtreeQuota = tc.cohortResources.requestableResources
 			}
 			clusterQueue.ResourceNode.Usage = tc.clusterQueueUsage
 
@@ -2269,7 +2269,6 @@ func TestLastAssignmentOutdated(t *testing.T) {
 					},
 				},
 				cq: &cache.ClusterQueueSnapshot{
-					Cohort:                        nil,
 					AllocatableResourceGeneration: 1,
 				},
 			},

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -510,9 +510,9 @@ func (p *Preemptor) findCandidates(wl *kueue.Workload, cq *cache.ClusterQueueSna
 		}
 	}
 
-	if cq.Cohort != nil && cq.Preemption.ReclaimWithinCohort != kueue.PreemptionPolicyNever {
+	if cq.HasParent() && cq.Preemption.ReclaimWithinCohort != kueue.PreemptionPolicyNever {
 		onlyLowerPriority := cq.Preemption.ReclaimWithinCohort != kueue.PreemptionPolicyAny
-		for cohortCQ := range cq.Cohort.Members {
+		for _, cohortCQ := range cq.Parent().ChildCQs() {
 			if cq == cohortCQ || !cqIsBorrowing(cohortCQ, frsNeedPreemption) {
 				// Can't reclaim quota from itself or ClusterQueues that are not borrowing.
 				continue
@@ -532,7 +532,7 @@ func (p *Preemptor) findCandidates(wl *kueue.Workload, cq *cache.ClusterQueueSna
 }
 
 func cqIsBorrowing(cq *cache.ClusterQueueSnapshot, frsNeedPreemption sets.Set[resources.FlavorResource]) bool {
-	if cq.Cohort == nil {
+	if !cq.HasParent() {
 		return false
 	}
 	for fr := range frsNeedPreemption {

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/hierarchy"
 	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -49,7 +50,9 @@ import (
 
 var snapCmpOpts = []cmp.Option{
 	cmpopts.EquateEmpty(),
-	cmpopts.IgnoreUnexported(cache.ClusterQueueSnapshot{}),
+	cmpopts.IgnoreUnexported(hierarchy.Cohort[*cache.ClusterQueueSnapshot, *cache.CohortSnapshot]{}),
+	cmpopts.IgnoreUnexported(hierarchy.ClusterQueue[*cache.CohortSnapshot]{}),
+	cmpopts.IgnoreUnexported(hierarchy.Manager[*cache.ClusterQueueSnapshot, *cache.CohortSnapshot]{}),
 	cmpopts.IgnoreFields(cache.ClusterQueueSnapshot{}, "AllocatableResourceGeneration"),
 	cmp.Transformer("Cohort.Members", func(s sets.Set[*cache.ClusterQueueSnapshot]) sets.Set[string] {
 		result := make(sets.Set[string], len(s))


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This change simplifies edge management in the Snapshot. This will allow us, in a simple manner, to snapshot and create edges between HierarchicalCohorts (#79) in a subsequent PR.

#### Special notes for your reviewer:
Hide ws diff when reviewing snapshot_test.go

#### Does this PR introduce a user-facing change?
```release-note
NONE
```