### PR TITLE
Automated cherry pick of #2574: Start Controller and Webhook on new CRDs availability

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"net/http"
 	"os"
-	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -72,8 +71,6 @@ import (
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
 	// +kubebuilder:scaffold:imports
 )
-
-const retryInterval = time.Second * 20
 
 var (
 	scheme   = runtime.NewScheme()
@@ -285,7 +282,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *cache.Cache
 		jobframework.WithCache(cCache),
 		jobframework.WithQueues(queues),
 	}
-	if err := jobframework.SetupControllers(ctx, mgr, setupLog, retryInterval, opts...); err != nil {
+	if err := jobframework.SetupControllers(ctx, mgr, setupLog, opts...); err != nil {
 		setupLog.Error(err, "Unable to create controller or webhook", "kubernetesVersion", serverVersionFetcher.GetServerVersion())
 		os.Exit(1)
 	}

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -38,7 +38,7 @@ var (
 )
 
 // APIRetryInterval is the duration to wait before retrying the API request.
-const APIRetryInterval = time.Second * 20
+var APIRetryInterval = time.Second * 20
 
 // SetupControllers setups all controllers and webhooks for integrations.
 // When the platform developers implement a separate kueue-manager to manage the in-house custom jobs,

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -21,12 +21,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -34,10 +34,15 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobs/noop"
 )
 
+type fetchRestMapperFunc func(mgr ctrl.Manager, gvk schema.GroupVersionKind) (bool, error)
+
+const (
+	baseBackoffWaitForIntegration = 1 * time.Second
+	maxBackoffWaitForIntegration  = 2 * time.Minute
+)
+
 var (
 	errFailedMappingResource = errors.New("restMapper failed mapping resource")
-	// restMapperMutex is required for unit tests to lock the RESTMapper on update.
-	restMapperMutex sync.RWMutex
 )
 
 // SetupControllers setups all controllers and webhooks for integrations.
@@ -49,11 +54,11 @@ var (
 // this function needs to be called after the certs get ready because the controllers won't work
 // until the webhooks are operating, and the webhook won't work until the
 // certs are all in place.
-func SetupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, retryInterval time.Duration, opts ...Option) error {
-	return manager.setupControllers(ctx, mgr, log, retryInterval, opts...)
+func SetupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
+	return manager.setupControllers(ctx, mgr, log, opts...)
 }
 
-func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, retryInterval time.Duration, opts ...Option) error {
+func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
 	options := ProcessOptions(opts...)
 
 	for fwkName := range options.EnabledExternalFrameworks {
@@ -81,7 +86,7 @@ func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Mana
 					return fmt.Errorf("%s: %w", fwkNamePrefix, err)
 				}
 				logger.Info("No matching API in the server for job framework, skipped setup of controller and webhook")
-				go waitForAPI(ctx, mgr, log, gvk, retryInterval, func() {
+				go waitForAPI(ctx, mgr, defaultCheckAPIAvailable, log, gvk, func() {
 					log.Info(fmt.Sprintf("API now available, starting controller and webhook for %v", gvk))
 					if err := m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...); err != nil {
 						log.Error(err, "Failed to setup controller and webhook for job framework")
@@ -115,35 +120,43 @@ func (m *integrationManager) setupControllerAndWebhook(mgr ctrl.Manager, name st
 	return nil
 }
 
-func waitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk schema.GroupVersionKind, retryInterval time.Duration, action func()) {
-	ticker := time.NewTicker(retryInterval)
-	defer ticker.Stop()
+func waitForAPI(ctx context.Context, mgr ctrl.Manager, checkAPIAvailable fetchRestMapperFunc, log logr.Logger, gvk schema.GroupVersionKind, action func()) {
+	rateLimiter := workqueue.NewItemExponentialFailureRateLimiter(baseBackoffWaitForIntegration, maxBackoffWaitForIntegration)
+	item := gvk.String()
+
 	for {
-		_, err := getRESTMapping(mgr, gvk)
-		if err == nil {
+		isAvailable, err := checkAPIAvailable(mgr, gvk)
+		if isAvailable {
+			rateLimiter.Forget(item)
 			action()
 			return
 		}
-		if !meta.IsNoMatchError(err) {
+		if err != nil && !meta.IsNoMatchError(err) {
 			log.Error(err, "Failed to get REST mapping for gvk", "gvk", gvk)
 		}
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-time.After(rateLimiter.When(item)):
 			continue
 		}
 	}
 }
 
 func getRESTMapping(mgr ctrl.Manager, gvk schema.GroupVersionKind) (*meta.RESTMapping, error) {
-	restMapperMutex.RLock()
-	defer restMapperMutex.RUnlock()
 	restMapping, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get REST mapping for %v: %w", gvk, err)
 	}
 	return restMapping, nil
+}
+
+var defaultCheckAPIAvailable fetchRestMapperFunc = func(mgr ctrl.Manager, gvk schema.GroupVersionKind) (bool, error) {
+	_, err := getRESTMapping(mgr, gvk)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // SetupIndexes setups the indexers for integrations.

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -34,7 +35,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobs/noop"
 )
 
-type fetchRestMapperFunc func(mgr ctrl.Manager, gvk schema.GroupVersionKind) (bool, error)
+var mu sync.RWMutex
 
 const (
 	baseBackoffWaitForIntegration = 1 * time.Second
@@ -81,13 +82,13 @@ func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Mana
 			if err != nil {
 				return fmt.Errorf("%s: %w: %w", fwkNamePrefix, errFailedMappingResource, err)
 			}
-			if _, err := getRESTMapping(mgr, gvk); err != nil {
+			if err := restMappingExists(mgr, gvk); err != nil {
 				if !meta.IsNoMatchError(err) {
 					return fmt.Errorf("%s: %w", fwkNamePrefix, err)
 				}
 				logger.Info("No matching API in the server for job framework, skipped setup of controller and webhook")
-				go waitForAPI(ctx, mgr, defaultCheckAPIAvailable, log, gvk, func() {
-					log.Info(fmt.Sprintf("API now available, starting controller and webhook for %v", gvk))
+				go waitForAPI(ctx, mgr, log, gvk, func() {
+					log.Info("API now available, starting controller and webhook", "gvk", gvk)
 					if err := m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...); err != nil {
 						log.Error(err, "Failed to setup controller and webhook for job framework")
 					}
@@ -120,18 +121,16 @@ func (m *integrationManager) setupControllerAndWebhook(mgr ctrl.Manager, name st
 	return nil
 }
 
-func waitForAPI(ctx context.Context, mgr ctrl.Manager, checkAPIAvailable fetchRestMapperFunc, log logr.Logger, gvk schema.GroupVersionKind, action func()) {
+func waitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk schema.GroupVersionKind, action func()) {
 	rateLimiter := workqueue.NewItemExponentialFailureRateLimiter(baseBackoffWaitForIntegration, maxBackoffWaitForIntegration)
 	item := gvk.String()
-
 	for {
-		isAvailable, err := checkAPIAvailable(mgr, gvk)
-		if isAvailable {
+		err := restMappingExists(mgr, gvk)
+		if err == nil {
 			rateLimiter.Forget(item)
 			action()
 			return
-		}
-		if err != nil && !meta.IsNoMatchError(err) {
+		} else if !meta.IsNoMatchError(err) {
 			log.Error(err, "Failed to get REST mapping for gvk", "gvk", gvk)
 		}
 		select {
@@ -143,20 +142,14 @@ func waitForAPI(ctx context.Context, mgr ctrl.Manager, checkAPIAvailable fetchRe
 	}
 }
 
-func getRESTMapping(mgr ctrl.Manager, gvk schema.GroupVersionKind) (*meta.RESTMapping, error) {
-	restMapping, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
+func restMappingExists(mgr ctrl.Manager, gvk schema.GroupVersionKind) error {
+	mu.RLock()
+	defer mu.RUnlock()
+	_, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get REST mapping for %v: %w", gvk, err)
+		return fmt.Errorf("failed to get REST mapping for %v: %w", gvk, err)
 	}
-	return restMapping, nil
-}
-
-var defaultCheckAPIAvailable fetchRestMapperFunc = func(mgr ctrl.Manager, gvk schema.GroupVersionKind) (bool, error) {
-	_, err := getRESTMapping(mgr, gvk)
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return nil
 }
 
 // SetupIndexes setups the indexers for integrations.

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -34,8 +33,6 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/controller/jobs/noop"
 )
-
-var mu sync.RWMutex
 
 const (
 	baseBackoffWaitForIntegration = 1 * time.Second
@@ -143,8 +140,6 @@ func waitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk sche
 }
 
 func restMappingExists(mgr ctrl.Manager, gvk schema.GroupVersionKind) error {
-	mu.RLock()
-	defer mu.RUnlock()
 	_, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		return fmt.Errorf("failed to get REST mapping for %v: %w", gvk, err)

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -37,6 +37,9 @@ var (
 	errFailedMappingResource = errors.New("restMapper failed mapping resource")
 )
 
+// APIRetryInterval is the duration to wait before retrying the API request.
+const APIRetryInterval = time.Second * 20
+
 // SetupControllers setups all controllers and webhooks for integrations.
 // When the platform developers implement a separate kueue-manager to manage the in-house custom jobs,
 // they can easily setup controllers and webhooks for the in-house custom jobs.
@@ -80,10 +83,14 @@ func (m *integrationManager) setupControllers(mgr ctrl.Manager, log logr.Logger,
 				logger.Info("No matching API in the server for job framework, skipped setup of controller and webhook")
 				go waitForAPI(context.Background(), mgr, logger, gvk, func() {
 					log.Info(fmt.Sprintf("API now available, starting controller and webhook for %v", gvk))
-					m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...)
+					if err := m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...); err != nil {
+						log.Error(err, "Failed to setup controller and webhook for job framework")
+					}
 				})
 			} else {
-				m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...)
+				if err := m.setupControllerAndWebhook(mgr, name, fwkNamePrefix, cb, options, opts...); err != nil {
+					return err
+				}
 			}
 		}
 		if err := noop.SetupWebhook(mgr, cb.JobType); err != nil {
@@ -109,18 +116,14 @@ func (m *integrationManager) setupControllerAndWebhook(mgr ctrl.Manager, name st
 }
 
 func waitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk schema.GroupVersionKind, action func()) {
-	getRestMapping := func() (*meta.RESTMapping, error) {
-		return mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
-	}
-	var err error
 	for {
-		_, err = getRestMapping()
+		_, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
 		if err != nil {
 			select {
 			case <-ctx.Done():
 				log.Info(fmt.Sprint("Context cancelled!", "gvk", gvk))
 				return
-			case <-time.After(time.Second * 5):
+			case <-time.After(APIRetryInterval):
 				continue
 			}
 		}

--- a/pkg/controller/jobframework/setup_test.go
+++ b/pkg/controller/jobframework/setup_test.go
@@ -19,6 +19,7 @@ package jobframework
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,14 +45,6 @@ import (
 )
 
 func TestSetupControllers(t *testing.T) {
-	// Simulate Job Framework API checks
-	defaultCheckAPIAvailable = func(mgr ctrlmgr.Manager, gvk schema.GroupVersionKind) (bool, error) {
-		// Simulate API being unavailable for MPIJob
-		if gvk.Kind == "MPIJob" {
-			return false, nil
-		}
-		return true, nil // Simulate API becoming available
-	}
 	availableIntegrations := map[string]IntegrationCallbacks{
 		"batch/job": {
 			NewReconciler:         testNewReconciler,
@@ -90,9 +83,9 @@ func TestSetupControllers(t *testing.T) {
 	cases := map[string]struct {
 		opts                    []Option
 		mapperGVKs              []schema.GroupVersionKind
+		delayedGVKs             []*schema.GroupVersionKind
 		wantError               error
 		wantEnabledIntegrations []string
-		afterSetup              func(mgr ctrlmgr.Manager, manager *integrationManager, crdName string)
 	}{
 		"setup controllers succeed": {
 			opts: []Option{
@@ -126,8 +119,10 @@ func TestSetupControllers(t *testing.T) {
 				kubeflow.SchemeGroupVersionKind,
 				// Not including RayCluster
 			},
+			delayedGVKs: []*schema.GroupVersionKind{
+				{Group: "ray.io", Version: "v1", Kind: "RayCluster"},
+			},
 			wantEnabledIntegrations: []string{"batch/job", "kubeflow.org/mpijob", "ray.io/raycluster"},
-			afterSetup:              testDelayedIntegration,
 		},
 	}
 	for name, tc := range cases {
@@ -170,8 +165,12 @@ func TestSetupControllers(t *testing.T) {
 				t.Errorf("Unexpected error from SetupControllers (-want,+got):\n%s", diff)
 			}
 
-			if tc.afterSetup != nil {
-				tc.afterSetup(mgr, &manager, "ray.io/raycluster")
+			if len(tc.delayedGVKs) > 0 {
+				// Simulate the delayed addition of RayCluster
+				simulateDelayedIntegration(mgr, tc.delayedGVKs)
+				for _, gvk := range tc.delayedGVKs {
+					testDelayedIntegration(&manager, gvk.Group+"/"+strings.ToLower(gvk.Kind))
+				}
 			}
 
 			diff := cmp.Diff(tc.wantEnabledIntegrations, manager.getEnabledIntegrations().SortedList())
@@ -182,7 +181,18 @@ func TestSetupControllers(t *testing.T) {
 	}
 }
 
-func testDelayedIntegration(mgr ctrlmgr.Manager, manager *integrationManager, crdName string) {
+// Simulates the delayed availability of GVKs
+func simulateDelayedIntegration(mgr ctrlmgr.Manager, delayedGVKs []*schema.GroupVersionKind) {
+	mu.Lock()
+	defer mu.Unlock()
+	mapper := mgr.GetRESTMapper().(*apimeta.DefaultRESTMapper)
+
+	for _, gvk := range delayedGVKs {
+		mapper.Add(*gvk, apimeta.RESTScopeNamespace)
+	}
+}
+
+func testDelayedIntegration(manager *integrationManager, crdName string) {
 	for {
 		_, ok := manager.getEnabledIntegrations()[crdName]
 		if ok {

--- a/pkg/controller/jobframework/setup_test.go
+++ b/pkg/controller/jobframework/setup_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -149,10 +150,14 @@ func TestSetupControllers(t *testing.T) {
 						gvs = append(gvs, gvk.GroupVersion())
 					}
 					mapper := apimeta.NewDefaultRESTMapper(gvs)
-					for _, gvk := range tc.mapperGVKs {
-						mapper.Add(gvk, apimeta.RESTScopeNamespace)
+					testMapper := &TestRESTMapper{
+						DefaultRESTMapper: mapper,
+						lock:              sync.RWMutex{},
 					}
-					return mapper, nil
+					for _, gvk := range tc.mapperGVKs {
+						testMapper.Add(gvk, apimeta.RESTScopeNamespace)
+					}
+					return testMapper, nil
 				},
 			}
 			mgr, err := ctrlmgr.New(&rest.Config{}, mgrOpts)
@@ -166,7 +171,6 @@ func TestSetupControllers(t *testing.T) {
 			}
 
 			if len(tc.delayedGVKs) > 0 {
-				// Simulate the delayed addition of RayCluster
 				simulateDelayedIntegration(mgr, tc.delayedGVKs)
 				for _, gvk := range tc.delayedGVKs {
 					testDelayedIntegration(&manager, gvk.Group+"/"+strings.ToLower(gvk.Kind))
@@ -181,11 +185,22 @@ func TestSetupControllers(t *testing.T) {
 	}
 }
 
+type TestRESTMapper struct {
+	*apimeta.DefaultRESTMapper
+	lock sync.RWMutex
+}
+
+func (m *TestRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*apimeta.RESTMapping, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.DefaultRESTMapper.RESTMapping(gk, versions...)
+}
+
 // Simulates the delayed availability of GVKs
 func simulateDelayedIntegration(mgr ctrlmgr.Manager, delayedGVKs []*schema.GroupVersionKind) {
-	mu.Lock()
-	defer mu.Unlock()
-	mapper := mgr.GetRESTMapper().(*apimeta.DefaultRESTMapper)
+	mapper := mgr.GetRESTMapper().(*TestRESTMapper)
+	mapper.lock.Lock()
+	defer mapper.lock.Unlock()
 
 	for _, gvk := range delayedGVKs {
 		mapper.Add(*gvk, apimeta.RESTScopeNamespace)
@@ -196,7 +211,7 @@ func testDelayedIntegration(manager *integrationManager, crdName string) {
 	for {
 		_, ok := manager.getEnabledIntegrations()[crdName]
 		if ok {
-			break // Exit loop if RayCluster is enabled
+			break
 		}
 		time.Sleep(10 * time.Millisecond)
 	}


### PR DESCRIPTION
Cherry pick of #2574 on release-0.8.
#2574: Start Controller and Webhook on new CRDs availability
For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
Detect and enable support for job CRDs installed after Kueue starts.
```