### PR TITLE
Support Hierarchical Cohorts in hierarchy.Manager

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -401,8 +401,8 @@ func (c *Cache) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 func (c *Cache) AddCohort(apiCohort *kueuealpha.Cohort) {
 	c.Lock()
 	defer c.Unlock()
-	cohort := newCohort(apiCohort.Name)
-	c.hm.AddCohort(cohort)
+	c.hm.AddCohort(apiCohort.Name)
+	cohort := c.hm.Cohorts[apiCohort.Name]
 	cohort.updateCohort(apiCohort)
 }
 

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -85,7 +85,8 @@ func (c *Cache) Snapshot() Snapshot {
 		InactiveClusterQueueSets: sets.New[string](),
 	}
 	for _, cohort := range c.hm.Cohorts {
-		snap.AddCohort(snapshotCohort(cohort))
+		snap.AddCohort(cohort.Name)
+		snap.Cohorts[cohort.Name].ResourceNode = cohort.resourceNode.Clone()
 	}
 	for _, cq := range c.hm.ClusterQueues {
 		if !cq.Active() {
@@ -124,12 +125,6 @@ func snapshotClusterQueue(c *clusterQueue) *ClusterQueueSnapshot {
 		cc.ResourceGroups[i] = rg.Clone()
 	}
 	return cc
-}
-
-func snapshotCohort(c *cohort) *CohortSnapshot {
-	snapshot := newCohortSnapshot(c.Name)
-	snapshot.ResourceNode = c.resourceNode.Clone()
-	return snapshot
 }
 
 func newCohortSnapshot(name string) *CohortSnapshot {

--- a/pkg/hierarchy/cohort.go
+++ b/pkg/hierarchy/cohort.go
@@ -19,30 +19,51 @@ package hierarchy
 import "k8s.io/apimachinery/pkg/util/sets"
 
 type Cohort[CQ, C nodeBase] struct {
-	childCqs sets.Set[CQ]
+	parent       C
+	childCohorts sets.Set[C]
+	childCqs     sets.Set[CQ]
 	// Indicates whether this Cohort is backed
 	// by an API object.
 	explicit bool
 }
 
 func (c *Cohort[CQ, C]) Parent() C {
-	var zero C
-	return zero
+	return c.parent
 }
 
 func (c *Cohort[CQ, C]) HasParent() bool {
-	return false
+	var zero C
+	return c.Parent() != zero
 }
 
 func (c *Cohort[CQ, C]) ChildCQs() []CQ {
 	return c.childCqs.UnsortedList()
 }
 
+func (c *Cohort[CQ, C]) ChildCohorts() []C {
+	return c.childCohorts.UnsortedList()
+}
+
 func NewCohort[CQ, C nodeBase]() Cohort[CQ, C] {
-	return Cohort[CQ, C]{childCqs: sets.New[CQ]()}
+	return Cohort[CQ, C]{
+		childCohorts: sets.New[C](),
+		childCqs:     sets.New[CQ](),
+	}
 }
 
 // implement cohortNode interface
+
+func (c *Cohort[CQ, C]) setParent(cohort C) {
+	c.parent = cohort
+}
+
+func (c *Cohort[CQ, C]) insertCohortChild(cohort C) {
+	c.childCohorts.Insert(cohort)
+}
+
+func (c *Cohort[CQ, C]) deleteCohortChild(cohort C) {
+	c.childCohorts.Delete(cohort)
+}
 
 func (c *Cohort[CQ, C]) insertClusterQueue(cq CQ) {
 	c.childCqs.Insert(cq)
@@ -52,8 +73,8 @@ func (c *Cohort[CQ, C]) deleteClusterQueue(cq CQ) {
 	c.childCqs.Delete(cq)
 }
 
-func (c *Cohort[CQ, C]) childCount() int {
-	return c.childCqs.Len()
+func (c *Cohort[CQ, C]) hasChildren() bool {
+	return c.childCqs.Len()+c.childCohorts.Len() > 0
 }
 
 func (c *Cohort[CQ, C]) isExplicit() bool {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This will be used by `cache` and `queue` packages as part of HierarchicalCohorts (#79) implementation.

#### Special notes for your reviewer:
Sending this out as a separate PR to keep PR size small.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```