### PR TITLE
Support Hierarchical Cohorts in Cache/Snapshot

### DIFF
--- a/pkg/controller/core/cohort_controller.go
+++ b/pkg/controller/core/cohort_controller.go
@@ -104,7 +104,9 @@ func (r *CohortReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	log.V(2).Info("Cohort is being created or updated", "resources", cohort.Spec.ResourceGroups)
-	r.cache.AddOrUpdateCohort(&cohort)
+	if err := r.cache.AddOrUpdateCohort(&cohort); err != nil {
+		log.V(2).Error(err, "Error adding or updating cohort in the cache")
+	}
 	r.qManager.AddOrUpdateCohort(ctx, &cohort)
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Support HierarchicalCohorts (#79), with cycle-detection, in the cache and snapshot. 

#### Special notes for your reviewer:
I wrote tests which check resource usage. I will add them to this PR once #3005 merges.

#### Does this PR introduce a user-facing change?
```release-note
Hierarchical Cohorts
```