### PR TITLE
Automated cherry pick of #3007: Update latest version to v0.8.1

### DIFF
--- a/CHANGELOG/CHANGELOG-0.8.md
+++ b/CHANGELOG/CHANGELOG-0.8.md
@@ -1,3 +1,25 @@
+## v0.8.1
+
+Changes since `v0.8.0`:
+
+### Feature
+
+- Add gauge metric admission_cycle_preemption_skips that reports the number of Workloads in a ClusterQueue
+  that got preemptions candidates, but had to be skipped in the last cycle. (#2942, @alculquicondor)
+- Publish images via artifact registry (#2832, @alculquicondor)
+
+### Bug or Regression
+
+- CLI: Support `-` and `.` in the resource flavor name on `create cq` (#2706, @trasc)
+- Detect and enable support for job CRDs installed after Kueue starts. (#2991, @ChristianZaccaria)
+- Fix over-admission after deleting resources from borrowing ClusterQueue. (#2879, @mbobrovskyi)
+- Fix support for kuberay 1.2.x (#2983, @mbobrovskyi)
+- Helm: Fix a bug for "unclosed action error". (#2688, @mbobrovskyi)
+- Prevent infinite preemption loop when PrioritySortingWithinCohort=false
+  is used together with borrowWithinCohort. (#2831, @mimowo)
+- Support for helm charts in the us-central1-docker.pkg.dev/k8s-staging-images/charts repository (#2834, @IrvingMg)
+- Update Flavor selection logic to prefer Flavors which allow reclamation of lent nominal quota, over Flavors which require preempting workloads within the ClusterQueue. This matches the behavior in the single Flavor case. (#2829, @gabesaba)
+
 ## v0.8.0
 
 Changes since `v0.7.0`:

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ LD_FLAGS += -X '$(version_pkg).GitCommit=$(shell git rev-parse HEAD)'
 
 # Update these variables when preparing a new release or a release branch.
 # Then run `make prepare-release-branch`
-RELEASE_VERSION=v0.8.0
+RELEASE_VERSION=v0.8.1
 RELEASE_BRANCH=main
 
 .PHONY: all

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) to learn more.
 To install the latest release of Kueue in your cluster, run the following command:
 
 ```shell
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.8.0/manifests.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.8.1/manifests.yaml
 ```
 
 The controller runs in the `kueue-system` namespace.

--- a/SECURITY-INSIGHTS.yaml
+++ b/SECURITY-INSIGHTS.yaml
@@ -1,11 +1,11 @@
 header:
   schema-version: 1.0.0
   expiration-date: '2024-09-28T01:00:00.000Z'
-  last-updated: '2024-07-19'
-  last-reviewed: '2024-07-19'
-  commit-hash: 58ef31e6ef674db0aa04cb587d41862570ad1d12
+  last-updated: '2024-09-05'
+  last-reviewed: '2024-09-05'
+  commit-hash: 7cb1dfb41e178aeb0674e36c996e17c711325e89
   project-url: 'https://github.com/kubernetes-sigs/kueue'
-  project-release: 0.8.0
+  project-release: 0.8.1
   changelog: 'https://github.com/kubernetes-sigs/kueue/tree/main/CHANGELOG'
   license: 'https://github.com/kubernetes-sigs/kueue/blob/main/LICENSE'
 project-lifecycle:
@@ -28,7 +28,7 @@ documentation:
   - 'https://kueue.sigs.k8s.io/docs/'
 distribution-points:
   - >-
-    https://github.com/kubernetes-sigs/kueue/releases/download/v0.8.0/manifests.yaml
+    https://github.com/kubernetes-sigs/kueue/releases/download/v0.8.1/manifests.yaml
 security-artifacts:
   threat-model:
     threat-model-created: false
@@ -62,5 +62,5 @@ dependencies:
   dependencies-lists:
     - 'https://github.com/kubernetes-sigs/kueue/blob/main/go.mod'
   sbom:
-    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.8.0/kueue-v0.8.0.spdx.json
+    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.8.1/kueue-v0.8.1.spdx.json
       sbom-format: SPDX

--- a/charts/kueue/Chart.yaml
+++ b/charts/kueue/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.8.0"
+appVersion: "v0.8.1"

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -90,7 +90,7 @@ ignoreFiles = []
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
   # version number for this doc set.
-  version = "v0.8.0"
+  version = "v0.8.1"
 
   # Flag used in the "version-banner" partial to decide whether to display a
   # banner on every page indicating that this is an archived version of the docs.


### PR DESCRIPTION
Cherry pick of #3007 on website.

#3007: Update latest version to v0.8.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```