### PR TITLE
Automated cherry pick of #3010: Use Note instead Warning on the LendingLimit is enabled by default info.

### DIFF
--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -359,7 +359,7 @@ you can set the `.spec.resourcesGroup[*].flavors[*].resource[*].lendingLimit`
 [quantity](https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/) field.
 
 {{< feature-state state="alpha" for_version="v0.6" >}}
-{{% alert title="Warning" color="warning" %}}
+{{% alert title="Note" color="primary" %}}
 
 `LendingLimit` is an Alpha feature disabled by default.
 


### PR DESCRIPTION
Cherry pick of #3010 on website.

#3010: Use Note instead Warning on the LendingLimit is enabled by default info.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```