### PR TITLE
Update "KEP-168-2: Pending-workloads-visibility" before graduation to Beta

### DIFF
--- a/keps/168-2-pending-workloads-visibility/README.md
+++ b/keps/168-2-pending-workloads-visibility/README.md
@@ -47,6 +47,8 @@ tags, and then generate with `hack/update-toc.sh`.
     - [Integration tests](#integration-tests)
     - [E2E tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
+    - [Alpha](#alpha)
+    - [Beta](#beta)
     - [GA](#ga)
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
@@ -257,17 +259,21 @@ We plan on adding sanity e2e tests, and RBAC e2e tests. The e2e RBAC tests shoul
 
 ### Graduation Criteria
 
-First iteration (0.6):
+#### Alpha
 - Release the new API in alpha. This allows us to adjust the API according to users' and reviewers' feedback,
 - Release it with a feature gate.
 
-Second iteration (0.7):
+#### Beta
+First iteration (0.9):
 - Release the API in beta and guarantee backwards compatibility,
-- Reconsider introducing a throttling mechanism based on user and review feedback,
+- Merge the visibility-api.yaml into the main manifests.yaml,
 - Consider introducing FlowScheme and PriorityLevelConfiguration to allow admins to easily tune API priorities.
 
+Second iteration (0.10):
+- Drop the alpha API version.
+
 #### GA
-The feature can graduate to GA after addressing feedback for at least 1 release. We will then drop the feature gate.
+- Reconsider introducing a throttling mechanism,
 
 ## Implementation History
 

--- a/keps/168-2-pending-workloads-visibility/kep.yaml
+++ b/keps/168-2-pending-workloads-visibility/kep.yaml
@@ -14,17 +14,17 @@ replaces:
   - "/keps/168-pending-workloads-visibility"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.6"
+latest-milestone: "v0.9"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v0.6"
-  beta: "v0.7"
+  beta: "v0.9"
   stable: 
 
 # The following PRR answers are required at alpha release


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Update "KEP-168-2: Pending-workloads-visibility" before graduation to Beta.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #3008

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```