### PR TITLE
[test][integration] Start the multikueue test clusters in parallel.

### DIFF
--- a/test/integration/controller/jobs/job/job_controller_test.go
+++ b/test/integration/controller/jobs/job/job_controller_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -167,7 +166,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			},
 			Spec: *createdWorkload.Spec.DeepCopy(),
 		}
-		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, scheme.Scheme)).Should(gomega.Succeed())
+		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
 		secondWl.Spec.PodSets[0].Count += 1
 		gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, secondWl, false)

--- a/test/integration/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/controller/jobs/jobset/jobset_controller_test.go
@@ -27,7 +27,6 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -164,7 +163,7 @@ var _ = ginkgo.Describe("JobSet controller", ginkgo.Ordered, ginkgo.ContinueOnFa
 				},
 				Spec: *createdWorkload.Spec.DeepCopy(),
 			}
-			gomega.Expect(ctrl.SetControllerReference(createdJobSet, secondWl, scheme.Scheme)).Should(gomega.Succeed())
+			gomega.Expect(ctrl.SetControllerReference(createdJobSet, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
 			secondWl.Spec.PodSets[0].Count += 1
 			gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())
 			key := types.NamespacedName{Name: secondWl.Name, Namespace: secondWl.Namespace}

--- a/test/integration/controller/jobs/kubeflow/kubeflowjob.go
+++ b/test/integration/controller/jobs/kubeflow/kubeflowjob.go
@@ -27,7 +27,6 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -106,7 +105,7 @@ func ShouldReconcileJob(ctx context.Context, k8sClient client.Client, job, creat
 		},
 		Spec: *createdWorkload.Spec.DeepCopy(),
 	}
-	gomega.Expect(ctrl.SetControllerReference(createdJob.Object(), secondWl, scheme.Scheme)).Should(gomega.Succeed())
+	gomega.Expect(ctrl.SetControllerReference(createdJob.Object(), secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
 	secondWl.Spec.PodSets[0].Count += 1
 
 	gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())

--- a/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
@@ -27,7 +27,6 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -128,7 +127,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			},
 			Spec: *createdWorkload.Spec.DeepCopy(),
 		}
-		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, scheme.Scheme)).Should(gomega.Succeed())
+		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
 		secondWl.Spec.PodSets[0].Count += 1
 
 		gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())

--- a/test/integration/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/controller/jobs/raycluster/raycluster_controller_test.go
@@ -28,7 +28,6 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -135,7 +134,7 @@ var _ = ginkgo.Describe("RayCluster controller", ginkgo.Ordered, ginkgo.Continue
 			Spec: *createdWorkload.Spec.DeepCopy(),
 		}
 
-		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, scheme.Scheme)).Should(gomega.Succeed())
+		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
 		secondWl.Spec.PodSets[0].Count += 1
 
 		gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())

--- a/test/integration/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/controller/jobs/rayjob/rayjob_controller_test.go
@@ -28,7 +28,6 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -144,7 +143,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			},
 			Spec: *createdWorkload.Spec.DeepCopy(),
 		}
-		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, scheme.Scheme)).Should(gomega.Succeed())
+		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
 		secondWl.Spec.PodSets[0].Count += 1
 
 		gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	kfmpi "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
@@ -66,8 +67,12 @@ type Framework struct {
 	managerDone   <-chan struct{}
 }
 
-func (f *Framework) Init() *rest.Config {
+var setupLogger = sync.OnceFunc(func() {
 	ctrl.SetLogger(util.NewTestingLogger(ginkgo.GinkgoWriter, -3))
+})
+
+func (f *Framework) Init() *rest.Config {
+	setupLogger()
 
 	var cfg *rest.Config
 	ginkgo.By("bootstrapping test environment", func() {

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -228,29 +228,22 @@ var _ = ginkgo.BeforeSuite(func() {
 	}
 
 	ginkgo.By("creating the clusters", func() {
-		mtx := sync.Mutex{}
 		wg := sync.WaitGroup{}
 		wg.Add(3)
 		go func() {
 			defer wg.Done()
 			// pass nil setup since the manager for the manage cluster is different in some specs.
 			c := createCluster(nil, managerFeatureGates...)
-			mtx.Lock()
-			defer mtx.Unlock()
 			managerTestCluster = c
 		}()
 		go func() {
 			defer wg.Done()
 			c := createCluster(managerSetup)
-			mtx.Lock()
-			defer mtx.Unlock()
 			worker1TestCluster = c
 		}()
 		go func() {
 			defer wg.Done()
 			c := createCluster(managerSetup)
-			mtx.Lock()
-			defer mtx.Unlock()
 			worker2TestCluster = c
 		}()
 		wg.Wait()

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -226,10 +227,34 @@ var _ = ginkgo.BeforeSuite(func() {
 		managerFeatureGates = []string{"JobManagedBy=true"}
 	}
 
-	// pass nil setup since the manager for the manage cluster is different in some specs.
-	managerTestCluster = createCluster(nil, managerFeatureGates...)
-	worker1TestCluster = createCluster(managerSetup)
-	worker2TestCluster = createCluster(managerSetup)
+	ginkgo.By("creating the clusters", func() {
+		mtx := sync.Mutex{}
+		wg := sync.WaitGroup{}
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			// pass nil setup since the manager for the manage cluster is different in some specs.
+			c := createCluster(nil, managerFeatureGates...)
+			mtx.Lock()
+			defer mtx.Unlock()
+			managerTestCluster = c
+		}()
+		go func() {
+			defer wg.Done()
+			c := createCluster(managerSetup)
+			mtx.Lock()
+			defer mtx.Unlock()
+			worker1TestCluster = c
+		}()
+		go func() {
+			defer wg.Done()
+			c := createCluster(managerSetup)
+			mtx.Lock()
+			defer mtx.Unlock()
+			worker2TestCluster = c
+		}()
+		wg.Wait()
+	})
 
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(managerTestCluster.cfg)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

[test][integration] Start the multikueue test clusters in parallel.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #2993

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```