### PR TITLE
Implement Cohort cycle detection in hierarchy.Manager

### DIFF
--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -43,6 +43,7 @@ var snapCmpOpts = []cmp.Option{
 	cmpopts.IgnoreUnexported(hierarchy.Cohort[*ClusterQueueSnapshot, *CohortSnapshot]{}),
 	cmpopts.IgnoreUnexported(hierarchy.ClusterQueue[*CohortSnapshot]{}),
 	cmpopts.IgnoreUnexported(hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{}),
+	cmpopts.IgnoreUnexported(hierarchy.CycleChecker{}),
 	cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
 }
 

--- a/pkg/hierarchy/cycle.go
+++ b/pkg/hierarchy/cycle.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hierarchy
+
+// cycleChecker checks for cycles in Cohorts, while memoizing the
+// result.
+type CycleChecker struct {
+	cycles map[string]bool
+}
+
+type CycleCheckable interface {
+	GetName() string
+	HasParent() bool
+	CCParent() CycleCheckable
+}
+
+func (c *CycleChecker) HasCycle(cohort CycleCheckable) bool {
+	if cycle, seen := c.cycles[cohort.GetName()]; seen {
+		return cycle
+	}
+	if !cohort.HasParent() {
+		c.cycles[cohort.GetName()] = false
+		return c.cycles[cohort.GetName()]
+	}
+	c.cycles[cohort.GetName()] = true
+	c.cycles[cohort.GetName()] = c.HasCycle(cohort.CCParent())
+	return c.cycles[cohort.GetName()]
+}

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -53,6 +53,7 @@ var snapCmpOpts = []cmp.Option{
 	cmpopts.IgnoreUnexported(hierarchy.Cohort[*cache.ClusterQueueSnapshot, *cache.CohortSnapshot]{}),
 	cmpopts.IgnoreUnexported(hierarchy.ClusterQueue[*cache.CohortSnapshot]{}),
 	cmpopts.IgnoreUnexported(hierarchy.Manager[*cache.ClusterQueueSnapshot, *cache.CohortSnapshot]{}),
+	cmpopts.IgnoreUnexported(hierarchy.CycleChecker{}),
 	cmpopts.IgnoreFields(cache.ClusterQueueSnapshot{}, "AllocatableResourceGeneration"),
 	cmp.Transformer("Cohort.Members", func(s sets.Set[*cache.ClusterQueueSnapshot]) sets.Set[string] {
 		result := make(sets.Set[string], len(s))


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Cycle checking logic in hierarchy.Manager. Will be used by both `queue.manager` and `cache.Cache`. I'm pulling it out of #3006 to reduce diff. Part of #79

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```