### PR TITLE
Record an event when provisioning request fails

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -302,6 +302,7 @@ func (c *Controller) syncOwnedProvisionRequest(ctx context.Context, wl *kueue.Wo
 			}
 
 			if err := c.client.Create(ctx, req); err != nil {
+				c.record.Eventf(wl, corev1.EventTypeWarning, "ProvisioningRequestError", "Error creating ProvisioningRequest: %q", req.Name)
 				return nil, err
 			}
 			c.record.Eventf(wl, corev1.EventTypeNormal, "ProvisioningRequestCreated", "Created ProvisioningRequest: %q", req.Name)

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -302,7 +302,7 @@ func (c *Controller) syncOwnedProvisionRequest(ctx context.Context, wl *kueue.Wo
 			}
 
 			if err := c.client.Create(ctx, req); err != nil {
-				c.record.Eventf(wl, corev1.EventTypeWarning, "ProvisioningRequestError", "Error creating ProvisioningRequest: %q", req.Name)
+				c.record.Eventf(wl, corev1.EventTypeWarning, "FailedCreate", "Error creating ProvisioningRequest: %q", req.Name)
 				return nil, err
 			}
 			c.record.Eventf(wl, corev1.EventTypeNormal, "ProvisioningRequestCreated", "Created ProvisioningRequest: %q", req.Name)

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -303,10 +303,10 @@ func (c *Controller) syncOwnedProvisionRequest(ctx context.Context, wl *kueue.Wo
 			}
 
 			if err := c.client.Create(ctx, req); err != nil {
-				ac.Message = fmt.Sprintf("Error creating ProvisioningRequest: %q", requestName)
+				ac.Message = fmt.Sprintf("Error creating ProvisioningRequest %q: %v", requestName, err)
 				workload.SetAdmissionCheckState(&wl.Status.AdmissionChecks, *ac)
 
-				c.record.Eventf(wl, corev1.EventTypeWarning, "FailedCreate", "Error creating ProvisioningRequest: %q", req.Name)
+				c.record.Eventf(wl, corev1.EventTypeWarning, "FailedCreate", "Error creating ProvisioningRequest %q: %v", req.Name, err)
 				return nil, err
 			}
 			c.record.Eventf(wl, corev1.EventTypeNormal, "ProvisioningRequestCreated", "Created ProvisioningRequest: %q", req.Name)

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -306,7 +306,7 @@ func (c *Controller) syncOwnedProvisionRequest(ctx context.Context, wl *kueue.Wo
 				ac.Message = fmt.Sprintf("Error creating ProvisioningRequest %q: %v", requestName, err)
 				workload.SetAdmissionCheckState(&wl.Status.AdmissionChecks, *ac)
 
-				c.record.Eventf(wl, corev1.EventTypeWarning, "FailedCreate", "Error creating ProvisioningRequest %q: %v", req.Name, err)
+				c.record.Eventf(wl, corev1.EventTypeWarning, "FailedCreate", ac.Message)
 				return nil, err
 			}
 			c.record.Eventf(wl, corev1.EventTypeNormal, "ProvisioningRequestCreated", "Created ProvisioningRequest: %q", req.Name)

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -1211,7 +1211,7 @@ func TestReconcile(t *testing.T) {
 					Key:       client.ObjectKeyFromObject(baseWorkload),
 					EventType: corev1.EventTypeWarning,
 					Reason:    "FailedCreate",
-					Message:   `Error creating ProvisioningRequest: "wl-check1-1"`,
+					Message:   `Error creating ProvisioningRequest "wl-check1-1": invalid ProvisioningRequest error`,
 				},
 			},
 		},

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -1210,7 +1210,7 @@ func TestReconcile(t *testing.T) {
 				{
 					Key:       client.ObjectKeyFromObject(baseWorkload),
 					EventType: corev1.EventTypeWarning,
-					Reason:    "ProvisioningRequestError",
+					Reason:    "FailedCreate",
 					Message:   `Error creating ProvisioningRequest: "wl-check1-1"`,
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:
It produces an event when an error during provisioning request creation occurs.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3025

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```