### PR TITLE
Use protobuf encoding for core K8s APIs in kueue

### DIFF
--- a/cmd/experimental/kjobctl/pkg/cmd/util/client_getter.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/util/client_getter.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	rayversioned "github.com/ray-project/kuberay/ray-operator/pkg/client/clientset/versioned"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/dynamic"
@@ -57,6 +58,7 @@ func (cg *clientGetterImpl) K8sClientset() (k8s.Interface, error) {
 		return nil, err
 	}
 
+	config.ContentType = runtime.ContentTypeProtobuf
 	clientset, err := k8s.NewForConfig(config)
 	if err != nil {
 		return nil, err

--- a/cmd/kueuectl/app/util/client_getter.go
+++ b/cmd/kueuectl/app/util/client_getter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	k8s "k8s.io/client-go/kubernetes"
@@ -65,6 +66,7 @@ func (cg *clientGetterImpl) K8sClientSet() (k8s.Interface, error) {
 		return nil, err
 	}
 
+	config.ContentType = runtime.ContentTypeProtobuf
 	clientset, err := k8s.NewForConfig(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
For core K8s API objects like Pods, Nodes, etc., we can use protobuf encoding which, compared to the default JSON encoding, reduces CPU consumption related to (de)serialization, reduces overall latency of the API calls, reduces memory footprint and the work performed by the GC and results in quicker propagation of objects to event handlers of shared informers.

Core system components of K8s default their serialization method to protobuf for 8 years already: https://github.com/kubernetes/kubernetes/pull/25738.

#### Which issue(s) this PR fixes:
No issue is opened for that.

#### Special notes for your reviewer:
Some benchmarks comparing JSON vs. protobuf showcasing how the latter data format (de)serializes faster and uses less memory:

- https://medium.com/@akresling/go-benchmark-json-v-protobuf-4ec3c62ec8d4
- https://www.codingexplorations.com/blog/performance-comparison-protobuf-marshaling-vs-json-marshaling-in-go
- https://medium.com/@david_turner/protocol-buffers-just-how-fast-are-they-9ec19ea580db

#### Does this PR introduce a user-facing change?
```release-note
Use protobuf encoding for core K8s APIs.
```