### PR TITLE
When the leader election is enabled, set true in leaderElectionReleaseOnCancel

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -127,6 +127,12 @@ func addLeaderElectionTo(o *ctrl.Options, cfg *configapi.Configuration) {
 	if o.RetryPeriod == nil && !equality.Semantic.DeepEqual(cfg.LeaderElection.RetryPeriod, metav1.Duration{}) {
 		o.RetryPeriod = &cfg.LeaderElection.RetryPeriod.Duration
 	}
+
+	if o.LeaderElection {
+		// When the manager is terminated, the leader manager voluntarily steps down
+		// from the leader role as soon as possible.
+		o.LeaderElectionReleaseOnCancel = true
+	}
 }
 
 func Encode(scheme *runtime.Scheme, cfg *configapi.Configuration) (string, error) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -304,12 +304,13 @@ webhook:
 		Metrics: metricsserver.Options{
 			BindAddress: configapi.DefaultMetricsBindAddress,
 		},
-		LeaderElection:             true,
-		LeaderElectionID:           configapi.DefaultLeaderElectionID,
-		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
-		LeaseDuration:              ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
-		RenewDeadline:              ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
-		RetryPeriod:                ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
+		LeaderElection:                true,
+		LeaderElectionID:              configapi.DefaultLeaderElectionID,
+		LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
+		LeaderElectionReleaseOnCancel: true,
+		LeaseDuration:                 ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
+		RenewDeadline:                 ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
+		RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 		WebhookServer: &webhook.DefaultServer{
 			Options: webhook.Options{
 				Port: configapi.DefaultWebhookPort,
@@ -394,12 +395,13 @@ webhook:
 				Metrics: metricsserver.Options{
 					BindAddress: configapi.DefaultMetricsBindAddress,
 				},
-				LeaderElection:             true,
-				LeaderElectionID:           configapi.DefaultLeaderElectionID,
-				LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
-				LeaseDuration:              ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
-				RenewDeadline:              ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
-				RetryPeriod:                ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
+				LeaderElection:                true,
+				LeaderElectionID:              configapi.DefaultLeaderElectionID,
+				LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
+				LeaderElectionReleaseOnCancel: true,
+				LeaseDuration:                 ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
+				RenewDeadline:                 ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
+				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
 						Port: configapi.DefaultWebhookPort,
@@ -469,12 +471,13 @@ webhook:
 				Metrics: metricsserver.Options{
 					BindAddress: ":38080",
 				},
-				LeaderElection:             true,
-				LeaderElectionID:           "test-id",
-				LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
-				LeaseDuration:              ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
-				RenewDeadline:              ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
-				RetryPeriod:                ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
+				LeaderElection:                true,
+				LeaderElectionID:              "test-id",
+				LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
+				LeaderElectionReleaseOnCancel: true,
+				LeaseDuration:                 ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
+				RenewDeadline:                 ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
+				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
 						Port: 9444,
@@ -540,18 +543,18 @@ webhook:
 				QueueVisibility:            defaultQueueVisibility,
 				MultiKueue:                 defaultMultiKueue,
 			},
-
 			wantOptions: ctrl.Options{
 				HealthProbeBindAddress: configapi.DefaultHealthProbeBindAddress,
 				Metrics: metricsserver.Options{
 					BindAddress: configapi.DefaultMetricsBindAddress,
 				},
-				LeaderElectionID:           configapi.DefaultLeaderElectionID,
-				LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
-				LeaseDuration:              ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
-				RenewDeadline:              ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
-				RetryPeriod:                ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
-				LeaderElection:             false,
+				LeaderElectionID:              configapi.DefaultLeaderElectionID,
+				LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
+				LeaderElectionReleaseOnCancel: false,
+				LeaseDuration:                 ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
+				RenewDeadline:                 ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
+				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
+				LeaderElection:                false,
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
 						Port: configapi.DefaultWebhookPort,
@@ -591,12 +594,13 @@ webhook:
 				Metrics: metricsserver.Options{
 					BindAddress: configapi.DefaultMetricsBindAddress,
 				},
-				LeaderElection:             true,
-				LeaderElectionID:           configapi.DefaultLeaderElectionID,
-				LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
-				LeaseDuration:              ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
-				RenewDeadline:              ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
-				RetryPeriod:                ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
+				LeaderElection:                true,
+				LeaderElectionID:              configapi.DefaultLeaderElectionID,
+				LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
+				LeaderElectionReleaseOnCancel: true,
+				LeaseDuration:                 ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
+				RenewDeadline:                 ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
+				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
 						Port: configapi.DefaultWebhookPort,
@@ -651,14 +655,15 @@ webhook:
 				Metrics: metricsserver.Options{
 					BindAddress: configapi.DefaultMetricsBindAddress,
 				},
-				PprofBindAddress:           ":8083",
-				LeaderElection:             true,
-				LeaderElectionID:           configapi.DefaultLeaderElectionID,
-				LeaderElectionNamespace:    "namespace",
-				LeaderElectionResourceLock: "lock",
-				LeaseDuration:              ptr.To(time.Second * 100),
-				RenewDeadline:              ptr.To(time.Second * 15),
-				RetryPeriod:                ptr.To(time.Second * 30),
+				PprofBindAddress:              ":8083",
+				LeaderElection:                true,
+				LeaderElectionID:              configapi.DefaultLeaderElectionID,
+				LeaderElectionNamespace:       "namespace",
+				LeaderElectionResourceLock:    "lock",
+				LeaderElectionReleaseOnCancel: true,
+				LeaseDuration:                 ptr.To(time.Second * 100),
+				RenewDeadline:                 ptr.To(time.Second * 15),
+				RetryPeriod:                   ptr.To(time.Second * 30),
 				Controller: runtimeconfig.Controller{
 					GroupKindConcurrency: map[string]int{
 						"workload": 5,
@@ -712,12 +717,13 @@ webhook:
 				Metrics: metricsserver.Options{
 					BindAddress: configapi.DefaultMetricsBindAddress,
 				},
-				LeaderElection:             true,
-				LeaderElectionID:           configapi.DefaultLeaderElectionID,
-				LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
-				LeaseDuration:              ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
-				RenewDeadline:              ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
-				RetryPeriod:                ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
+				LeaderElection:                true,
+				LeaderElectionID:              configapi.DefaultLeaderElectionID,
+				LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
+				LeaderElectionReleaseOnCancel: true,
+				LeaseDuration:                 ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
+				RenewDeadline:                 ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
+				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
 						Port: configapi.DefaultWebhookPort,
@@ -751,12 +757,13 @@ webhook:
 				Metrics: metricsserver.Options{
 					BindAddress: configapi.DefaultMetricsBindAddress,
 				},
-				LeaderElection:             true,
-				LeaderElectionID:           configapi.DefaultLeaderElectionID,
-				LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
-				LeaseDuration:              ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
-				RenewDeadline:              ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
-				RetryPeriod:                ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
+				LeaderElection:                true,
+				LeaderElectionID:              configapi.DefaultLeaderElectionID,
+				LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
+				LeaderElectionReleaseOnCancel: true,
+				LeaseDuration:                 ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
+				RenewDeadline:                 ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
+				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
 						Port: configapi.DefaultWebhookPort,
@@ -809,12 +816,13 @@ webhook:
 				Metrics: metricsserver.Options{
 					BindAddress: configapi.DefaultMetricsBindAddress,
 				},
-				LeaderElection:             true,
-				LeaderElectionID:           configapi.DefaultLeaderElectionID,
-				LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
-				LeaseDuration:              ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
-				RenewDeadline:              ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
-				RetryPeriod:                ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
+				LeaderElection:                true,
+				LeaderElectionID:              configapi.DefaultLeaderElectionID,
+				LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
+				LeaderElectionReleaseOnCancel: true,
+				LeaseDuration:                 ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
+				RenewDeadline:                 ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
+				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
 						Port: configapi.DefaultWebhookPort,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
When the manager is terminated, the leader role replica should voluntarily steps down from its own leader role
so that backup role can take the leader role as soon as possible.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```