### PR TITLE
Update Cohort Documentation; Delete Unused Variable

### DIFF
--- a/apis/kueue/v1alpha1/cohort_types.go
+++ b/apis/kueue/v1alpha1/cohort_types.go
@@ -62,12 +62,6 @@ type CohortSpec struct {
 	ResourceGroups []kueuebeta.ResourceGroup `json:"resourceGroups,omitempty"`
 }
 
-const (
-	// Condition indicating that a Cohort is correctly configured,
-	// for example, there is no cycle.
-	CohortActive = "Active"
-)
-
 // CohortStatus defines the observed state of Cohort
 type CohortStatus struct {
 
@@ -82,7 +76,9 @@ type CohortStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:scope=Cluster
 
-// Cohort is the Schema for the cohorts API
+// Cohort is the Schema for the cohorts API. Using Hierarchical
+// Cohorts (any Cohort which has a parent) with Fair Sharing
+// results in undefined behavior in 0.9
 type Cohort struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
@@ -32,7 +32,10 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Cohort is the Schema for the cohorts API
+        description: |-
+          Cohort is the Schema for the cohorts API. Using Hierarchical
+          Cohorts (any Cohort which has a parent) with Fair Sharing
+          results in undefined behavior in 0.9
         properties:
           apiVersion:
             description: |-

--- a/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
@@ -17,7 +17,10 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Cohort is the Schema for the cohorts API
+        description: |-
+          Cohort is the Schema for the cohorts API. Using Hierarchical
+          Cohorts (any Cohort which has a parent) with Fair Sharing
+          results in undefined behavior in 0.9
         properties:
           apiVersion:
             description: |-

--- a/site/content/en/docs/reference/kueue-alpha.v1alpha1.md
+++ b/site/content/en/docs/reference/kueue-alpha.v1alpha1.md
@@ -81,7 +81,9 @@ description: Generated API reference documentation for kueue.x-k8s.io/v1alpha1.
 
 
 
-<p>Cohort is the Schema for the cohorts API</p>
+<p>Cohort is the Schema for the cohorts API. Using Hierarchical
+Cohorts (any Cohort which has a parent) with Fair Sharing
+results in undefined behavior in 0.9</p>
 
 
 <table class="table">


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:
Document incompatibility of Fair Sharing with Hierarchical Cohorts. Cleanup unused variable - this can be added back when we update status when cycles exist. Related to #79

#### Does this PR introduce a user-facing change?
```release-note
NONE
```