### PR TITLE
Deprecate QueueVisibility feature and corresponding API.

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -66,6 +66,9 @@ type Configuration struct {
 
 	// QueueVisibility is configuration to expose the information about the top
 	// pending workloads.
+	// Deprecated: This field will be removed on v1beta2, use VisibilityOnDemand
+	// (https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)
+	// instead.
 	QueueVisibility *QueueVisibility `json:"queueVisibility,omitempty"`
 
 	// MultiKueue controls the behaviour of the MultiKueue AdmissionCheck Controller.

--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -289,6 +289,9 @@ type ClusterQueueStatus struct {
 
 	// PendingWorkloadsStatus contains the information exposed about the current
 	// status of the pending workloads in the cluster queue.
+	// Deprecated: This field will be removed on v1beta2, use VisibilityOnDemand
+	// (https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)
+	// instead.
 	// +optional
 	PendingWorkloadsStatus *ClusterQueuePendingWorkloadsStatus `json:"pendingWorkloadsStatus"`
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -706,6 +706,9 @@ spec:
                 description: |-
                   PendingWorkloadsStatus contains the information exposed about the current
                   status of the pending workloads in the cluster queue.
+                  Deprecated: This field will be removed on v1beta2, use VisibilityOnDemand
+                  (https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)
+                  instead.
                 properties:
                   clusterQueuePendingWorkload:
                     description: Head contains the list of top pending workloads.

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -691,6 +691,9 @@ spec:
                 description: |-
                   PendingWorkloadsStatus contains the information exposed about the current
                   status of the pending workloads in the cluster queue.
+                  Deprecated: This field will be removed on v1beta2, use VisibilityOnDemand
+                  (https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)
+                  instead.
                 properties:
                   clusterQueuePendingWorkload:
                     description: Head contains the list of top pending workloads.

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -39,6 +39,7 @@ const (
 	// owner: @stuton
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/168-pending-workloads-visibility
 	// alpha: v0.5
+	// Deprecated: v0.9
 	//
 	// Enables queue visibility.
 	QueueVisibility featuregate.Feature = "QueueVisibility"

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -233,23 +233,24 @@ spec:
 
 The currently supported features are:
 
-| Feature                           | Default | Stage | Since | Until |
-|-----------------------------------|---------|-------|-------|-------|
-| `FlavorFungibility`               | `true`  | Beta  | 0.5   |       |
-| `MultiKueue`                      | `false` | Alpha | 0.6   |       |
-| `MultiKueueBatchJobWithManagedBy` | `false` | Alpha | 0.8   |       |
-| `PartialAdmission`                | `false` | Alpha | 0.4   | 0.4   |
-| `PartialAdmission`                | `true`  | Beta  | 0.5   |       |
-| `ProvisioningACC`                 | `false` | Alpha | 0.5   | 0.6   |
-| `ProvisioningACC`                 | `true`  | Beta  | 0.7   |       |
-| `QueueVisibility`                 | `false` | Alpha | 0.5   |       |
-| `VisibilityOnDemand`              | `false` | Alpha | 0.6   |  0.8  |
-| `VisibilityOnDemand`              | `true`  | Beta  | 0.9   |       |
-| `PrioritySortingWithinCohort`     | `true`  | Beta  | 0.6   |       |
-| `LendingLimit`                    | `false` | Alpha | 0.6   | 0.8   |
-| `LendingLimit`                    | `true`  | Beta  | 0.9   |       |
-| `MultiplePreemptions`             | `false` | Alpha | 0.8   | 0.8   |
-| `MultiplePreemptions`             | `true`  | Beta  | 0.9   |       |
+| Feature                           | Default | Stage      | Since | Until |
+|-----------------------------------|---------|------------|-------|-------|
+| `FlavorFungibility`               | `true`  | Beta       | 0.5   |       |
+| `MultiKueue`                      | `false` | Alpha      | 0.6   |       |
+| `MultiKueueBatchJobWithManagedBy` | `false` | Alpha      | 0.8   |       |
+| `PartialAdmission`                | `false` | Alpha      | 0.4   | 0.4   |
+| `PartialAdmission`                | `true`  | Beta       | 0.5   |       |
+| `ProvisioningACC`                 | `false` | Alpha      | 0.5   | 0.6   |
+| `ProvisioningACC`                 | `true`  | Beta       | 0.7   |       |
+| `QueueVisibility`                 | `false` | Alpha      | 0.5   | 0.9   |
+| `QueueVisibility`                 | `false` | Deprecated | 0.9   |       |
+| `VisibilityOnDemand`              | `false` | Alpha      | 0.6   |  0.8  |
+| `VisibilityOnDemand`              | `true`  | Beta       | 0.9   |       |
+| `PrioritySortingWithinCohort`     | `true`  | Beta       | 0.6   |       |
+| `LendingLimit`                    | `false` | Alpha      | 0.6   | 0.8   |
+| `LendingLimit`                    | `true`  | Beta       | 0.9   |       |
+| `MultiplePreemptions`             | `false` | Alpha      | 0.8   | 0.8   |
+| `MultiplePreemptions`             | `true`  | Beta       | 0.9   |       |
 
 ## What's next
 

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -153,7 +153,10 @@ integrations (including K8S job).</p>
 </td>
 <td>
    <p>QueueVisibility is configuration to expose the information about the top
-pending workloads.</p>
+pending workloads.
+Deprecated: This field will be removed on v1beta2, use VisibilityOnDemand
+(https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)
+instead.</p>
 </td>
 </tr>
 <tr><td><code>multiKueue</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -922,7 +922,10 @@ current state.</p>
 </td>
 <td>
    <p>PendingWorkloadsStatus contains the information exposed about the current
-status of the pending workloads in the cluster queue.</p>
+status of the pending workloads in the cluster queue.
+Deprecated: This field will be removed on v1beta2, use VisibilityOnDemand
+(https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)
+instead.</p>
 </td>
 </tr>
 <tr><td><code>fairSharing</code><br/>

--- a/site/content/en/docs/tasks/manage/monitor_pending_workloads/pending_workloads_in_status.md
+++ b/site/content/en/docs/tasks/manage/monitor_pending_workloads/pending_workloads_in_status.md
@@ -1,6 +1,6 @@
 ---
 title: "Pending workloads in Status"
-date: 2023-09-27
+date: 2024-09-23
 weight: 3
 description: >
   Obtain the pending workloads in ClusterQueue and LocalQueue statuses.
@@ -28,7 +28,12 @@ QueueVisibility is an `Alpha` feature disabled by default, check the [Change the
 
 ## Monitor pending workloads
 
-{{< feature-state state="alpha" for_version="v0.5" >}}
+{{< feature-state state="deprecated" for_version="v0.9" >}}
+
+{{% alert title="Warning" color="warning" %}}
+This feature is deprecated and will be deleted on v1beta2. 
+Please use [Pending Workloads on-demand](/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/) instead.
+{{% /alert %}}
 
 To install a simple setup of cluster queue, run the following command:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Deprecate QueueVisibility feature and corresponding API.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2256

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The QueueVisibility feature and its corresponding API was deprecated.

ACTION REQUIRED: The QueueVisibility feature and its corresponding API was deprecated and will be removed in the v1beta2. Please use VisibilityOnDemand (https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/) instead.
```