### PR TITLE
Update "KEP-168-pending-workload-visibility" before deprecation.

### DIFF
--- a/keps/168-pending-workloads-visibility/README.md
+++ b/keps/168-pending-workloads-visibility/README.md
@@ -43,8 +43,8 @@ tags, and then generate with `hack/update-toc.sh`.
     - [Unit Tests](#unit-tests)
     - [Integration tests](#integration-tests)
   - [Graduation Criteria](#graduation-criteria)
-    - [Beta](#beta)
-    - [Stable](#stable)
+    - [Alpha](#alpha)
+    - [Deprecation](#deprecation)
 - [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
@@ -515,7 +515,7 @@ After the implementation PR is merged, add the names of the tests here.
 
 ### Graduation Criteria
 
-#### Beta
+#### Alpha
 
 First iteration (0.5):
 
@@ -530,9 +530,19 @@ Third iteration (0.7):
 
 - reevaluate the need for exposing positions and support if needed
 
-#### Stable
+#### Deprecation
 
-- drop the feature gate
+We deprecate the feature, and going to remove it in feature versions of the API,
+in favor of monitoring pending workloads using the [on-demand visibility API](https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/).
+
+First iteration (0.9):
+
+- deprecate the QueueVisibility feature gate and corresponding API.
+
+Second iteration (v1beta2):
+
+- remove the QueueVisibility feature gate,
+- remove PendingWorkloadsStatus field from ClusterQueue object and QueueVisibility field from Config object on bumping the API version.
 
 <!--
 

--- a/keps/168-pending-workloads-visibility/kep.yaml
+++ b/keps/168-pending-workloads-visibility/kep.yaml
@@ -12,13 +12,16 @@ approvers:
   - "@ahg-g"
   - "@alculquicondor"
 
-stage: beta
+see-also:
+  - "/keps/168-2-pending-workloads-visibility"
 
-latest-milestone: "v0.5"
+stage: deprecated
+
+latest-milestone: "v0.9"
 
 milestone:
-  beta: "v0.5"
-  stable: "v0.8"
+  alpha: "v0.5"
+  deprecated: "v0.9"
 
 disable-supported: true
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #2256

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```