### PR TITLE
RayJob: update Finished() to account for JobDeploymentStatus

### DIFF
--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -175,8 +175,8 @@ func (j *RayJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 
 func (j *RayJob) Finished() (message string, success, finished bool) {
 	message = j.Status.Message
-	success = j.Status.JobStatus != rayv1.JobStatusFailed
-	finished = j.Status.JobStatus == rayv1.JobStatusFailed || j.Status.JobStatus == rayv1.JobStatusSucceeded
+	success = j.Status.JobStatus == rayv1.JobStatusSucceeded
+	finished = j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusFailed || j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusComplete
 	return message, success, finished
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

RayJob status has both a `JobStatus` field and a `JobDeploymentStatus` field. The former represents the status of the running Ray job and the latter represents the state of the RayCluster and RayJob. The `Finished()` implementation in Kueue for RayJob should look at the JobDeployment for "finished" since that is what represents whether resources for the job have been cleaned up. This will also catch some cases where JobStatus will remain "Running" even though JobDeploymentStatus is "Failed". This can specifically happen when `activeDeadlineSeconds` is exceeded.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
RayJob's implementation of Finished() now inspects at JobDeploymentStatus 
```