### PR TITLE
[cache] Add more details in the clusterQueues inactive message.

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -22,6 +22,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ClusterQueue Active condition reasons.
+const (
+	ClusterQueueActiveReasonTerminating                                     = "Terminating"
+	ClusterQueueActiveReasonStopped                                         = "Stopped"
+	ClusterQueueActiveReasonFlavorNotFound                                  = "FlavorNotFound"
+	ClusterQueueActiveReasonAdmissionCheckNotFound                          = "AdmissionCheckNotFound"
+	ClusterQueueActiveReasonAdmissionCheckInactive                          = "AdmissionCheckInactive"
+	ClusterQueueActiveReasonMultipleSingleInstanceControllerAdmissionChecks = "MultipleSingleInstanceControllerAdmissionChecks"
+	ClusterQueueActiveReasonFlavorIndependentAdmissionCheckAppliedPerFlavor = "FlavorIndependentAdmissionCheckAppliedPerFlavor"
+	ClusterQueueActiveReasonUnknown                                         = "Unknown"
+	ClusterQueueActiveReasonReady                                           = "Ready"
+)
+
 // ClusterQueueSpec defines the desired state of ClusterQueue
 // +kubebuilder:validation:XValidation:rule="!has(self.cohort) && has(self.resourceGroups) ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r, !has(r.borrowingLimit)))) : true", message="borrowingLimit must be nil when cohort is empty"
 type ClusterQueueSpec struct {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3280,7 +3280,7 @@ func TestClusterQueueReadiness(t *testing.T) {
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
 			wantReason:       "FlavorNotFound",
-			wantMessage:      "Can't admit new workloads: References missing ResourceFlavor [flavor1].",
+			wantMessage:      "Can't admit new workloads: references missing ResourceFlavor(s): [flavor1].",
 		},
 		"check not found": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
@@ -3288,7 +3288,7 @@ func TestClusterQueueReadiness(t *testing.T) {
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
 			wantReason:       "AdmissionCheckNotFound",
-			wantMessage:      "Can't admit new workloads: References missing AdmissionChecks [check1].",
+			wantMessage:      "Can't admit new workloads: references missing AdmissionCheck(s): [check1].",
 		},
 		"check inactive": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
@@ -3297,14 +3297,14 @@ func TestClusterQueueReadiness(t *testing.T) {
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
 			wantReason:       "AdmissionCheckInactive",
-			wantMessage:      "Can't admit new workloads: References inactive AdmissionChecks [check1].",
+			wantMessage:      "Can't admit new workloads: references inactive AdmissionCheck(s): [check1].",
 		},
 		"flavor and check not found": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
 			wantReason:       "FlavorNotFound",
-			wantMessage:      "Can't admit new workloads: References missing ResourceFlavor [flavor1]. References missing AdmissionChecks [check1].",
+			wantMessage:      "Can't admit new workloads: references missing ResourceFlavor(s): [flavor1], references missing AdmissionCheck(s): [check1].",
 		},
 		"terminating": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
@@ -3332,7 +3332,7 @@ func TestClusterQueueReadiness(t *testing.T) {
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
 			wantReason:       "Stopped",
-			wantMessage:      "Can't admit new workloads: Is stopped.",
+			wantMessage:      "Can't admit new workloads: is stopped.",
 		},
 	}
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3280,15 +3280,15 @@ func TestClusterQueueReadiness(t *testing.T) {
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
 			wantReason:       "FlavorNotFound",
-			wantMessage:      "Can't admit new workloads: FlavorNotFound",
+			wantMessage:      "Can't admit new workloads: References missing ResourceFlavor [flavor1].",
 		},
 		"check not found": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
 			resourceFlavors:  []*kueue.ResourceFlavor{baseFlavor},
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
-			wantReason:       "CheckNotFoundOrInactive",
-			wantMessage:      "Can't admit new workloads: CheckNotFoundOrInactive",
+			wantReason:       "AdmissionCheckNotFound",
+			wantMessage:      "Can't admit new workloads: References missing AdmissionChecks [check1].",
 		},
 		"check inactive": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
@@ -3296,15 +3296,15 @@ func TestClusterQueueReadiness(t *testing.T) {
 			admissionChecks:  []*kueue.AdmissionCheck{utiltesting.MakeAdmissionCheck("check1").Obj()},
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
-			wantReason:       "CheckNotFoundOrInactive",
-			wantMessage:      "Can't admit new workloads: CheckNotFoundOrInactive",
+			wantReason:       "AdmissionCheckInactive",
+			wantMessage:      "Can't admit new workloads: References inactive AdmissionChecks [check1].",
 		},
 		"flavor and check not found": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
 			wantReason:       "FlavorNotFound",
-			wantMessage:      "Can't admit new workloads: FlavorNotFound, CheckNotFoundOrInactive",
+			wantMessage:      "Can't admit new workloads: References missing ResourceFlavor [flavor1]. References missing AdmissionChecks [check1].",
 		},
 		"terminating": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
@@ -3332,7 +3332,7 @@ func TestClusterQueueReadiness(t *testing.T) {
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
 			wantReason:       "Stopped",
-			wantMessage:      "Can't admit new workloads: Stopped",
+			wantMessage:      "Can't admit new workloads: Is stopped.",
 		},
 	}
 

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -18,7 +18,10 @@ package cache
 
 import (
 	"errors"
+	"fmt"
+	"maps"
 	"math"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +38,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
 	utilac "sigs.k8s.io/kueue/pkg/util/admissioncheck"
+	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -65,15 +69,16 @@ type clusterQueue struct {
 
 	AdmittedUsage resources.FlavorResourceQuantities
 	// localQueues by (namespace/name).
-	localQueues                                        map[string]*queue
-	podsReadyTracking                                  bool
-	hasMissingFlavors                                  bool
-	hasMissingOrInactiveAdmissionChecks                bool
-	hasMultipleSingleInstanceControllersChecks         bool
-	hasFlavorIndependentAdmissionCheckAppliedPerFlavor bool
-	admittedWorkloadsCount                             int
-	isStopped                                          bool
-	workloadInfoOptions                                []workload.InfoOption
+	localQueues                                     map[string]*queue
+	podsReadyTracking                               bool
+	missingFlavors                                  []kueue.ResourceFlavorReference
+	missingAdmissionChecks                          []string
+	inactiveAdmissionChecks                         []string
+	multipleSingleInstanceControllersChecks         map[string][]string // key = controllerName
+	flavorIndependentAdmissionCheckAppliedPerFlavor []string
+	admittedWorkloadsCount                          int
+	isStopped                                       bool
+	workloadInfoOptions                             []workload.InfoOption
 
 	resourceNode ResourceNode
 	hierarchy.ClusterQueue[*cohort]
@@ -219,7 +224,12 @@ func (c *clusterQueue) updateQuotasAndResourceGroups(in []kueue.ResourceGroup) b
 
 func (c *clusterQueue) updateQueueStatus() {
 	status := active
-	if c.hasMissingFlavors || c.hasMissingOrInactiveAdmissionChecks || c.isStopped || c.hasMultipleSingleInstanceControllersChecks || c.hasFlavorIndependentAdmissionCheckAppliedPerFlavor {
+	if c.isStopped ||
+		len(c.missingFlavors) > 0 ||
+		len(c.missingAdmissionChecks) > 0 ||
+		len(c.inactiveAdmissionChecks) > 0 ||
+		len(c.multipleSingleInstanceControllersChecks) > 0 ||
+		len(c.flavorIndependentAdmissionCheckAppliedPerFlavor) > 0 {
 		status = pending
 	}
 	if c.Status == terminating {
@@ -237,42 +247,53 @@ func (c *clusterQueue) inactiveReason() (string, string) {
 		return "Terminating", "Can't admit new workloads; clusterQueue is terminating"
 	case pending:
 		reasons := make([]string, 0, 3)
+		messages := make([]string, 0, 3)
 		if c.isStopped {
 			reasons = append(reasons, "Stopped")
+			messages = append(messages, "Is stopped.")
 		}
-		if c.hasMissingFlavors {
+		if len(c.missingFlavors) > 0 {
 			reasons = append(reasons, "FlavorNotFound")
+			messages = append(messages, fmt.Sprintf("References missing ResourceFlavor %v.", c.missingFlavors))
 		}
-		if c.hasMissingOrInactiveAdmissionChecks {
-			reasons = append(reasons, "CheckNotFoundOrInactive")
+		if len(c.missingAdmissionChecks) > 0 {
+			reasons = append(reasons, "AdmissionCheckNotFound")
+			messages = append(messages, fmt.Sprintf("References missing AdmissionChecks %v.", c.missingAdmissionChecks))
+		}
+		if len(c.inactiveAdmissionChecks) > 0 {
+			reasons = append(reasons, "AdmissionCheckInactive")
+			messages = append(messages, fmt.Sprintf("References inactive AdmissionChecks %v.", c.inactiveAdmissionChecks))
+		}
+		if len(c.multipleSingleInstanceControllersChecks) > 0 {
+			reasons = append(reasons, "MultipleSingleInstanceControllerAdmissionChecks")
+			for _, controller := range utilmaps.SortedKeys(c.multipleSingleInstanceControllersChecks) {
+				messages = append(messages, fmt.Sprintf("Only one AdmissionChecks of %v can be reference for controller %q.", c.multipleSingleInstanceControllersChecks[controller], controller))
+			}
 		}
 
-		if c.hasMultipleSingleInstanceControllersChecks {
-			reasons = append(reasons, "MultipleSingleInstanceControllerChecks")
-		}
-
-		if c.hasFlavorIndependentAdmissionCheckAppliedPerFlavor {
+		if len(c.flavorIndependentAdmissionCheckAppliedPerFlavor) > 0 {
 			reasons = append(reasons, "FlavorIndependentAdmissionCheckAppliedPerFlavor")
+			messages = append(messages, fmt.Sprintf("AdmissionChecks %v cannot be set at flavor level.", c.flavorIndependentAdmissionCheckAppliedPerFlavor))
 		}
 
 		if len(reasons) == 0 {
 			return "Unknown", "Can't admit new workloads."
 		}
 
-		return reasons[0], strings.Join([]string{"Can't admit new workloads:", strings.Join(reasons, ", ")}, " ")
+		return reasons[0], strings.Join([]string{"Can't admit new workloads:", strings.Join(messages, " ")}, " ")
 	}
-	return "Ready", "Can admit new flavors"
+	return "Ready", "Can admit new workloads"
 }
 
 // UpdateWithFlavors updates a ClusterQueue based on the passed ResourceFlavors set.
 // Exported only for testing.
 func (c *clusterQueue) UpdateWithFlavors(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
-	c.hasMissingFlavors = c.updateLabelKeys(flavors)
+	c.updateLabelKeys(flavors)
 	c.updateQueueStatus()
 }
 
-func (c *clusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) bool {
-	var flavorNotFound bool
+func (c *clusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
+	c.missingFlavors = nil
 	for i := range c.ResourceGroups {
 		rg := &c.ResourceGroups[i]
 		if len(rg.Flavors) == 0 {
@@ -286,7 +307,7 @@ func (c *clusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference
 					keys.Insert(k)
 				}
 			} else {
-				flavorNotFound = true
+				c.missingFlavors = append(c.missingFlavors, fName)
 			}
 		}
 
@@ -294,53 +315,65 @@ func (c *clusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference
 			rg.LabelKeys = keys
 		}
 	}
-
-	return flavorNotFound
 }
 
 // updateWithAdmissionChecks updates a ClusterQueue based on the passed AdmissionChecks set.
 func (c *clusterQueue) updateWithAdmissionChecks(checks map[string]AdmissionCheck) {
-	hasMissing := false
-	hasSpecificChecks := false
-	checksPerController := make(map[string]int, len(c.AdmissionChecks))
+	checksPerController := make(map[string][]string, len(c.AdmissionChecks))
 	singleInstanceControllers := sets.New[string]()
+	var missing []string
+	var inactive []string
+	var flavorIndependentCheckOnFlavors []string
 	for acName, flavors := range c.AdmissionChecks {
 		if ac, found := checks[acName]; !found {
-			hasMissing = true
+			missing = append(missing, acName)
 		} else {
 			if !ac.Active {
-				hasMissing = true
+				inactive = append(inactive, acName)
 			}
-			checksPerController[ac.Controller]++
+			checksPerController[ac.Controller] = append(checksPerController[ac.Controller], acName)
 			if ac.SingleInstanceInClusterQueue {
 				singleInstanceControllers.Insert(ac.Controller)
 			}
 			if ac.FlavorIndependent && flavors.Len() != 0 {
-				hasSpecificChecks = true
+				flavorIndependentCheckOnFlavors = append(flavorIndependentCheckOnFlavors, acName)
 			}
 		}
 	}
 
+	// sort the lists since c.AdmissionChecks is a map
+	slices.Sort(missing)
+	slices.Sort(inactive)
+	slices.Sort(flavorIndependentCheckOnFlavors)
+
 	update := false
-	if hasMissing != c.hasMissingOrInactiveAdmissionChecks {
-		c.hasMissingOrInactiveAdmissionChecks = hasMissing
+	if !slices.Equal(c.missingAdmissionChecks, missing) {
+		c.missingAdmissionChecks = missing
 		update = true
 	}
 
-	hasMultipleSICC := false
-	for controller, checks := range checksPerController {
-		if singleInstanceControllers.Has(controller) && checks > 1 {
-			hasMultipleSICC = true
-		}
-	}
-
-	if c.hasMultipleSingleInstanceControllersChecks != hasMultipleSICC {
-		c.hasMultipleSingleInstanceControllersChecks = hasMultipleSICC
+	if !slices.Equal(c.inactiveAdmissionChecks, inactive) {
+		c.inactiveAdmissionChecks = inactive
 		update = true
 	}
 
-	if c.hasFlavorIndependentAdmissionCheckAppliedPerFlavor != hasSpecificChecks {
-		c.hasFlavorIndependentAdmissionCheckAppliedPerFlavor = hasSpecificChecks
+	// remove the controllers which don't have more then one AC or are not single instance.
+	maps.DeleteFunc(checksPerController, func(controller string, acs []string) bool {
+		return len(acs) < 2 || !singleInstanceControllers.Has(controller)
+	})
+
+	// sort the remaining set
+	for c := range checksPerController {
+		slices.Sort(checksPerController[c])
+	}
+
+	if !maps.EqualFunc(checksPerController, c.multipleSingleInstanceControllersChecks, slices.Equal) {
+		c.multipleSingleInstanceControllersChecks = checksPerController
+		update = true
+	}
+
+	if !slices.Equal(c.flavorIndependentAdmissionCheckAppliedPerFlavor, flavorIndependentCheckOnFlavors) {
+		c.flavorIndependentAdmissionCheckAppliedPerFlavor = flavorIndependentCheckOnFlavors
 		update = true
 	}
 

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -268,7 +268,7 @@ func (c *clusterQueue) inactiveReason() (string, string) {
 		if len(c.multipleSingleInstanceControllersChecks) > 0 {
 			reasons = append(reasons, kueue.ClusterQueueActiveReasonMultipleSingleInstanceControllerAdmissionChecks)
 			for _, controller := range utilmaps.SortedKeys(c.multipleSingleInstanceControllersChecks) {
-				messages = append(messages, fmt.Sprintf("only one AdmissionChecks of %v can be reference for controller %q", c.multipleSingleInstanceControllersChecks[controller], controller))
+				messages = append(messages, fmt.Sprintf("only one AdmissionCheck of %v can be referenced for controller %q", c.multipleSingleInstanceControllersChecks[controller], controller))
 			}
 		}
 

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -564,7 +564,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "AdmissionCheckNotFound",
-			wantMessage: "Can't admit new workloads: References missing AdmissionChecks [check3].",
+			wantMessage: "Can't admit new workloads: references missing AdmissionCheck(s): [check3].",
 		},
 		{
 			name:     "Active clusterQueue with an AC strategy updated with not found AC",
@@ -582,7 +582,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "AdmissionCheckNotFound",
-			wantMessage: "Can't admit new workloads: References missing AdmissionChecks [check3].",
+			wantMessage: "Can't admit new workloads: references missing AdmissionCheck(s): [check3].",
 		},
 		{
 			name:     "Active clusterQueue updated with inactive AC",
@@ -604,7 +604,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "AdmissionCheckInactive",
-			wantMessage: "Can't admit new workloads: References inactive AdmissionChecks [check3].",
+			wantMessage: "Can't admit new workloads: references inactive AdmissionCheck(s): [check3].",
 		},
 		{
 			name:     "Active clusterQueue with an AC strategy updated with inactive AC",
@@ -626,7 +626,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "AdmissionCheckInactive",
-			wantMessage: "Can't admit new workloads: References inactive AdmissionChecks [check3].",
+			wantMessage: "Can't admit new workloads: references inactive AdmissionCheck(s): [check3].",
 		},
 		{
 			name:     "Active clusterQueue updated with duplicate single instance AC Controller",
@@ -650,7 +650,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "MultipleSingleInstanceControllerAdmissionChecks",
-			wantMessage: `Can't admit new workloads: Only one AdmissionChecks of [check2 check3] can be reference for controller "controller2".`,
+			wantMessage: `Can't admit new workloads: only one AdmissionChecks of [check2 check3] can be reference for controller "controller2".`,
 		},
 		{
 			name:     "Active clusterQueue with an AC strategy updated with duplicate single instance AC Controller",
@@ -674,7 +674,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "MultipleSingleInstanceControllerAdmissionChecks",
-			wantMessage: `Can't admit new workloads: Only one AdmissionChecks of [check2 check3] can be reference for controller "controller2".`,
+			wantMessage: `Can't admit new workloads: only one AdmissionChecks of [check2 check3] can be reference for controller "controller2".`,
 		},
 		{
 			name:     "Active clusterQueue with a FlavorIndependent AC applied per ResourceFlavor",
@@ -689,7 +689,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "FlavorIndependentAdmissionCheckAppliedPerFlavor",
-			wantMessage: "Can't admit new workloads: AdmissionChecks [check1] cannot be set at flavor level.",
+			wantMessage: "Can't admit new workloads: AdmissionCheck(s): [check1] cannot be set at flavor level.",
 		},
 		{
 			name:     "Terminating clusterQueue updated with valid AC list",

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -650,7 +650,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "MultipleSingleInstanceControllerAdmissionChecks",
-			wantMessage: `Can't admit new workloads: only one AdmissionChecks of [check2 check3] can be reference for controller "controller2".`,
+			wantMessage: `Can't admit new workloads: only one AdmissionCheck of [check2 check3] can be referenced for controller "controller2".`,
 		},
 		{
 			name:     "Active clusterQueue with an AC strategy updated with duplicate single instance AC Controller",
@@ -674,7 +674,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "MultipleSingleInstanceControllerAdmissionChecks",
-			wantMessage: `Can't admit new workloads: only one AdmissionChecks of [check2 check3] can be reference for controller "controller2".`,
+			wantMessage: `Can't admit new workloads: only one AdmissionCheck of [check2 check3] can be referenced for controller "controller2".`,
 		},
 		{
 			name:     "Active clusterQueue with a FlavorIndependent AC applied per ResourceFlavor",

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -502,6 +502,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 		admissionChecks map[string]AdmissionCheck
 		wantStatus      metrics.ClusterQueueStatus
 		wantReason      string
+		wantMessage     string
 	}{
 		{
 			name:     "Pending clusterQueue updated valid AC list",
@@ -521,8 +522,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					Controller: "controller3",
 				},
 			},
-			wantStatus: active,
-			wantReason: "Ready",
+			wantStatus:  active,
+			wantReason:  "Ready",
+			wantMessage: "Can admit new workloads",
 		},
 		{
 			name:     "Pending clusterQueue with an AC strategy updated valid AC list",
@@ -542,8 +544,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					Controller: "controller3",
 				},
 			},
-			wantStatus: active,
-			wantReason: "Ready",
+			wantStatus:  active,
+			wantReason:  "Ready",
+			wantMessage: "Can admit new workloads",
 		},
 		{
 			name:     "Active clusterQueue updated with not found AC",
@@ -559,8 +562,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					Controller: "controller2",
 				},
 			},
-			wantStatus: pending,
-			wantReason: "CheckNotFoundOrInactive",
+			wantStatus:  pending,
+			wantReason:  "AdmissionCheckNotFound",
+			wantMessage: "Can't admit new workloads: References missing AdmissionChecks [check3].",
 		},
 		{
 			name:     "Active clusterQueue with an AC strategy updated with not found AC",
@@ -576,8 +580,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					Controller: "controller2",
 				},
 			},
-			wantStatus: pending,
-			wantReason: "CheckNotFoundOrInactive",
+			wantStatus:  pending,
+			wantReason:  "AdmissionCheckNotFound",
+			wantMessage: "Can't admit new workloads: References missing AdmissionChecks [check3].",
 		},
 		{
 			name:     "Active clusterQueue updated with inactive AC",
@@ -597,8 +602,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					Controller: "controller3",
 				},
 			},
-			wantStatus: pending,
-			wantReason: "CheckNotFoundOrInactive",
+			wantStatus:  pending,
+			wantReason:  "AdmissionCheckInactive",
+			wantMessage: "Can't admit new workloads: References inactive AdmissionChecks [check3].",
 		},
 		{
 			name:     "Active clusterQueue with an AC strategy updated with inactive AC",
@@ -618,8 +624,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					Controller: "controller3",
 				},
 			},
-			wantStatus: pending,
-			wantReason: "CheckNotFoundOrInactive",
+			wantStatus:  pending,
+			wantReason:  "AdmissionCheckInactive",
+			wantMessage: "Can't admit new workloads: References inactive AdmissionChecks [check3].",
 		},
 		{
 			name:     "Active clusterQueue updated with duplicate single instance AC Controller",
@@ -641,8 +648,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					SingleInstanceInClusterQueue: true,
 				},
 			},
-			wantStatus: pending,
-			wantReason: "MultipleSingleInstanceControllerChecks",
+			wantStatus:  pending,
+			wantReason:  "MultipleSingleInstanceControllerAdmissionChecks",
+			wantMessage: `Can't admit new workloads: Only one AdmissionChecks of [check2 check3] can be reference for controller "controller2".`,
 		},
 		{
 			name:     "Active clusterQueue with an AC strategy updated with duplicate single instance AC Controller",
@@ -664,8 +672,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					SingleInstanceInClusterQueue: true,
 				},
 			},
-			wantStatus: pending,
-			wantReason: "MultipleSingleInstanceControllerChecks",
+			wantStatus:  pending,
+			wantReason:  "MultipleSingleInstanceControllerAdmissionChecks",
+			wantMessage: `Can't admit new workloads: Only one AdmissionChecks of [check2 check3] can be reference for controller "controller2".`,
 		},
 		{
 			name:     "Active clusterQueue with a FlavorIndependent AC applied per ResourceFlavor",
@@ -678,8 +687,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					FlavorIndependent: true,
 				},
 			},
-			wantStatus: pending,
-			wantReason: "FlavorIndependentAdmissionCheckAppliedPerFlavor",
+			wantStatus:  pending,
+			wantReason:  "FlavorIndependentAdmissionCheckAppliedPerFlavor",
+			wantMessage: "Can't admit new workloads: AdmissionChecks [check1] cannot be set at flavor level.",
 		},
 		{
 			name:     "Terminating clusterQueue updated with valid AC list",
@@ -699,8 +709,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					Controller: "controller3",
 				},
 			},
-			wantStatus: terminating,
-			wantReason: "Terminating",
+			wantStatus:  terminating,
+			wantReason:  "Terminating",
+			wantMessage: "Can't admit new workloads; clusterQueue is terminating",
 		},
 		{
 			name:     "Terminating clusterQueue with an AC strategy updated with valid AC list",
@@ -720,8 +731,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					Controller: "controller3",
 				},
 			},
-			wantStatus: terminating,
-			wantReason: "Terminating",
+			wantStatus:  terminating,
+			wantReason:  "Terminating",
+			wantMessage: "Can't admit new workloads; clusterQueue is terminating",
 		},
 		{
 			name:     "Terminating clusterQueue updated with not found AC",
@@ -737,8 +749,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					Controller: "controller2",
 				},
 			},
-			wantStatus: terminating,
-			wantReason: "Terminating",
+			wantStatus:  terminating,
+			wantReason:  "Terminating",
+			wantMessage: "Can't admit new workloads; clusterQueue is terminating",
 		},
 		{
 			name:     "Terminating clusterQueue with an AC strategy updated with not found AC",
@@ -754,8 +767,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					Controller: "controller2",
 				},
 			},
-			wantStatus: terminating,
-			wantReason: "Terminating",
+			wantStatus:  terminating,
+			wantReason:  "Terminating",
+			wantMessage: "Can't admit new workloads; clusterQueue is terminating",
 		},
 	}
 
@@ -771,13 +785,15 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 
 			// Align the admission check related internals to the desired Status.
 			if tc.cqStatus == active {
-				cq.hasMultipleSingleInstanceControllersChecks = false
-				cq.hasMissingOrInactiveAdmissionChecks = false
-				cq.hasFlavorIndependentAdmissionCheckAppliedPerFlavor = false
+				cq.multipleSingleInstanceControllersChecks = nil
+				cq.missingAdmissionChecks = nil
+				cq.inactiveAdmissionChecks = nil
+				cq.flavorIndependentAdmissionCheckAppliedPerFlavor = nil
 			} else {
-				cq.hasMultipleSingleInstanceControllersChecks = true
-				cq.hasMissingOrInactiveAdmissionChecks = true
-				cq.hasFlavorIndependentAdmissionCheckAppliedPerFlavor = true
+				cq.multipleSingleInstanceControllersChecks = map[string][]string{"c1": {"ac1", "ac2"}}
+				cq.missingAdmissionChecks = []string{"missing-ac"}
+				cq.inactiveAdmissionChecks = []string{"inactive-ac"}
+				cq.flavorIndependentAdmissionCheckAppliedPerFlavor = []string{"not-on-flavor"}
 			}
 			cq.updateWithAdmissionChecks(tc.admissionChecks)
 
@@ -785,9 +801,12 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 				t.Errorf("got different status, want: %v, got: %v", tc.wantStatus, cq.Status)
 			}
 
-			gotReason, _ := cq.inactiveReason()
+			gotReason, gotMessage := cq.inactiveReason()
 			if diff := cmp.Diff(tc.wantReason, gotReason); diff != "" {
 				t.Errorf("Unexpected inactiveReason (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantMessage, gotMessage); diff != "" {
+				t.Errorf("Unexpected inactiveMessage (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/util/maps/maps.go
+++ b/pkg/util/maps/maps.go
@@ -17,8 +17,10 @@ limitations under the License.
 package maps
 
 import (
+	"cmp"
 	"fmt"
 	"maps"
+	"slices"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -93,6 +95,13 @@ func Keys[K comparable, V any, M ~map[K]V](m M) []K {
 	for k := range m {
 		ret = append(ret, k)
 	}
+	return ret
+}
+
+// SortedKeys returns a slice containing the sorted m keys
+func SortedKeys[K cmp.Ordered, V any, M ~map[K]V](m M) []K {
+	ret := Keys(m)
+	slices.Sort(ret)
 	return ret
 }
 

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -201,7 +201,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 						Type:    kueue.ClusterQueueActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "FlavorNotFound",
-						Message: "Can't admit new workloads: FlavorNotFound",
+						Message: "Can't admit new workloads: References missing ResourceFlavor [on-demand spot model-a model-b].",
 					},
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration, ignorePendingWorkloadsStatus))
@@ -384,7 +384,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 						Type:    kueue.ClusterQueueActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "FlavorNotFound",
-						Message: "Can't admit new workloads: FlavorNotFound",
+						Message: "Can't admit new workloads: References missing ResourceFlavor [on-demand spot model-a model-b].",
 					},
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration, ignorePendingWorkloadsStatus))
@@ -410,7 +410,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 						Type:    kueue.ClusterQueueActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "FlavorNotFound",
-						Message: "Can't admit new workloads: FlavorNotFound",
+						Message: "Can't admit new workloads: References missing ResourceFlavor [on-demand spot model-a model-b].",
 					},
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration, ignorePendingWorkloadsStatus))
@@ -652,7 +652,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
 					Reason:  "FlavorNotFound",
-					Message: "Can't admit new workloads: FlavorNotFound",
+					Message: "Can't admit new workloads: References missing ResourceFlavor [arch-a arch-b].",
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 
@@ -668,7 +668,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
 					Reason:  "FlavorNotFound",
-					Message: "Can't admit new workloads: FlavorNotFound",
+					Message: "Can't admit new workloads: References missing ResourceFlavor [arch-b].",
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 
@@ -706,8 +706,8 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 				{
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
-					Reason:  "CheckNotFoundOrInactive",
-					Message: "Can't admit new workloads: CheckNotFoundOrInactive",
+					Reason:  "AdmissionCheckNotFound",
+					Message: "Can't admit new workloads: References missing AdmissionChecks [check1 check2].",
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 
@@ -723,8 +723,8 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 				{
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
-					Reason:  "CheckNotFoundOrInactive",
-					Message: "Can't admit new workloads: CheckNotFoundOrInactive",
+					Reason:  "AdmissionCheckNotFound",
+					Message: "Can't admit new workloads: References missing AdmissionChecks [check2].",
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 
@@ -739,8 +739,8 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 				{
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
-					Reason:  "CheckNotFoundOrInactive",
-					Message: "Can't admit new workloads: CheckNotFoundOrInactive",
+					Reason:  "AdmissionCheckInactive",
+					Message: "Can't admit new workloads: References inactive AdmissionChecks [check2].",
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -201,7 +201,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 						Type:    kueue.ClusterQueueActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "FlavorNotFound",
-						Message: "Can't admit new workloads: References missing ResourceFlavor [on-demand spot model-a model-b].",
+						Message: "Can't admit new workloads: references missing ResourceFlavor(s): [on-demand spot model-a model-b].",
 					},
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration, ignorePendingWorkloadsStatus))
@@ -384,7 +384,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 						Type:    kueue.ClusterQueueActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "FlavorNotFound",
-						Message: "Can't admit new workloads: References missing ResourceFlavor [on-demand spot model-a model-b].",
+						Message: "Can't admit new workloads: references missing ResourceFlavor(s): [on-demand spot model-a model-b].",
 					},
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration, ignorePendingWorkloadsStatus))
@@ -410,7 +410,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 						Type:    kueue.ClusterQueueActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "FlavorNotFound",
-						Message: "Can't admit new workloads: References missing ResourceFlavor [on-demand spot model-a model-b].",
+						Message: "Can't admit new workloads: references missing ResourceFlavor(s): [on-demand spot model-a model-b].",
 					},
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration, ignorePendingWorkloadsStatus))
@@ -652,7 +652,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
 					Reason:  "FlavorNotFound",
-					Message: "Can't admit new workloads: References missing ResourceFlavor [arch-a arch-b].",
+					Message: "Can't admit new workloads: references missing ResourceFlavor(s): [arch-a arch-b].",
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 
@@ -668,7 +668,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
 					Reason:  "FlavorNotFound",
-					Message: "Can't admit new workloads: References missing ResourceFlavor [arch-b].",
+					Message: "Can't admit new workloads: references missing ResourceFlavor(s): [arch-b].",
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 
@@ -707,7 +707,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
 					Reason:  "AdmissionCheckNotFound",
-					Message: "Can't admit new workloads: References missing AdmissionChecks [check1 check2].",
+					Message: "Can't admit new workloads: references missing AdmissionCheck(s): [check1 check2].",
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 
@@ -724,7 +724,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
 					Reason:  "AdmissionCheckNotFound",
-					Message: "Can't admit new workloads: References missing AdmissionChecks [check2].",
+					Message: "Can't admit new workloads: references missing AdmissionCheck(s): [check2].",
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 
@@ -740,7 +740,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
 					Reason:  "AdmissionCheckInactive",
-					Message: "Can't admit new workloads: References inactive AdmissionChecks [check2].",
+					Message: "Can't admit new workloads: references inactive AdmissionCheck(s): [check2].",
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[cache] Add more details in the clusterQueues inactive message.

Enhance the detail level in the ClusterQueues `status.conditions[Active].message` to possibly incorporate the Flavors and/or AdmissionChecks that are causing the inactive status.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3099 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Provides more details on the reasons for ClusterQueues being inactive.
ACTION REQUIRED: If you were watching for the reason `CheckNotFoundOrInactive` in the ClusterQueue condition, watch `AdmissionCheckNotFound` and `AdmissionCheckInactive` instead.
```