### PR TITLE
[kjobctl] Ignore kubectl.kubernetes.io/last-applied-configuration on copying annotations from template.

### DIFF
--- a/cmd/experimental/kjobctl/pkg/builder/interactive_builder.go
+++ b/cmd/experimental/kjobctl/pkg/builder/interactive_builder.go
@@ -41,7 +41,7 @@ func (b *interactiveBuilder) build(ctx context.Context) ([]runtime.Object, error
 			Kind:       "Pod",
 			APIVersion: "v1",
 		},
-		ObjectMeta: b.buildObjectMeta(template.ObjectMeta),
+		ObjectMeta: b.buildObjectMeta(template.Template.ObjectMeta),
 		Spec:       template.Template.Spec,
 	}
 

--- a/cmd/experimental/kjobctl/pkg/builder/job_builder.go
+++ b/cmd/experimental/kjobctl/pkg/builder/job_builder.go
@@ -42,7 +42,7 @@ func (b *jobBuilder) build(ctx context.Context) ([]runtime.Object, error) {
 			Kind:       "Job",
 			APIVersion: "batch/v1",
 		},
-		ObjectMeta: b.buildObjectMeta(template.ObjectMeta),
+		ObjectMeta: b.buildObjectMeta(template.Template.ObjectMeta),
 		Spec:       template.Template.Spec,
 	}
 

--- a/cmd/experimental/kjobctl/pkg/builder/ray_cluster_builder.go
+++ b/cmd/experimental/kjobctl/pkg/builder/ray_cluster_builder.go
@@ -42,7 +42,7 @@ func (b *rayClusterBuilder) build(ctx context.Context) ([]runtime.Object, error)
 			Kind:       "RayCluster",
 			APIVersion: "ray.io/v1",
 		},
-		ObjectMeta: b.buildObjectMeta(template.ObjectMeta),
+		ObjectMeta: b.buildObjectMeta(template.Template.ObjectMeta),
 		Spec:       template.Template.Spec,
 	}
 

--- a/cmd/experimental/kjobctl/pkg/builder/ray_job_builder.go
+++ b/cmd/experimental/kjobctl/pkg/builder/ray_job_builder.go
@@ -46,7 +46,7 @@ func (b *rayJobBuilder) build(ctx context.Context) ([]runtime.Object, error) {
 			Kind:       "RayJob",
 			APIVersion: "ray.io/v1",
 		},
-		ObjectMeta: b.buildObjectMeta(template.ObjectMeta),
+		ObjectMeta: b.buildObjectMeta(template.Template.ObjectMeta),
 		Spec:       template.Template.Spec,
 	}
 

--- a/cmd/experimental/kjobctl/pkg/builder/slurm_builder.go
+++ b/cmd/experimental/kjobctl/pkg/builder/slurm_builder.go
@@ -184,7 +184,7 @@ func (b *slurmBuilder) build(ctx context.Context) ([]runtime.Object, error) {
 			Kind:       "Job",
 			APIVersion: "batch/v1",
 		},
-		ObjectMeta: b.buildObjectMeta(template.ObjectMeta),
+		ObjectMeta: b.buildObjectMeta(template.Template.ObjectMeta),
 		Spec:       template.Template.Spec,
 	}
 	job.Spec.CompletionMode = ptr.To(batchv1.IndexedCompletion)
@@ -198,7 +198,7 @@ func (b *slurmBuilder) build(ctx context.Context) ([]runtime.Object, error) {
 			Kind:       "ConfigMap",
 			APIVersion: "v1",
 		},
-		ObjectMeta: b.buildObjectMeta(template.ObjectMeta),
+		ObjectMeta: b.buildObjectMeta(template.Template.ObjectMeta),
 		Data: map[string]string{
 			slurmEntrypointFilename: b.buildEntrypointScript(),
 			slurmScriptFilename:     b.scriptContent,

--- a/cmd/experimental/kjobctl/pkg/testing/wrappers/job_template_wrappers.go
+++ b/cmd/experimental/kjobctl/pkg/testing/wrappers/job_template_wrappers.go
@@ -47,19 +47,19 @@ func (j *JobTemplateWrapper) Obj() *v1alpha1.JobTemplate {
 
 // Label sets the label key and value.
 func (j *JobTemplateWrapper) Label(key, value string) *JobTemplateWrapper {
-	if j.Labels == nil {
-		j.Labels = make(map[string]string)
+	if j.Template.ObjectMeta.Labels == nil {
+		j.Template.ObjectMeta.Labels = make(map[string]string)
 	}
-	j.ObjectMeta.Labels[key] = value
+	j.Template.ObjectMeta.Labels[key] = value
 	return j
 }
 
 // Annotation sets the label key and value.
 func (j *JobTemplateWrapper) Annotation(key, value string) *JobTemplateWrapper {
-	if j.Annotations == nil {
-		j.Annotations = make(map[string]string)
+	if j.Template.ObjectMeta.Annotations == nil {
+		j.Template.ObjectMeta.Annotations = make(map[string]string)
 	}
-	j.ObjectMeta.Annotations[key] = value
+	j.Template.ObjectMeta.Annotations[key] = value
 	return j
 }
 

--- a/cmd/experimental/kjobctl/pkg/testing/wrappers/pod_template_wrappers.go
+++ b/cmd/experimental/kjobctl/pkg/testing/wrappers/pod_template_wrappers.go
@@ -48,19 +48,19 @@ func (p *PodTemplateWrapper) Clone() *PodTemplateWrapper {
 
 // Label sets the label key and value.
 func (p *PodTemplateWrapper) Label(key, value string) *PodTemplateWrapper {
-	if p.Labels == nil {
-		p.Labels = make(map[string]string)
+	if p.Template.ObjectMeta.Labels == nil {
+		p.Template.ObjectMeta.Labels = make(map[string]string)
 	}
-	p.ObjectMeta.Labels[key] = value
+	p.Template.ObjectMeta.Labels[key] = value
 	return p
 }
 
 // Annotation sets the label key and value.
 func (p *PodTemplateWrapper) Annotation(key, value string) *PodTemplateWrapper {
-	if p.Annotations == nil {
-		p.Annotations = make(map[string]string)
+	if p.Template.ObjectMeta.Annotations == nil {
+		p.Template.ObjectMeta.Annotations = make(map[string]string)
 	}
-	p.ObjectMeta.Annotations[key] = value
+	p.Template.ObjectMeta.Annotations[key] = value
 	return p
 }
 

--- a/cmd/experimental/kjobctl/pkg/testing/wrappers/ray_cluster_template_wrappers.go
+++ b/cmd/experimental/kjobctl/pkg/testing/wrappers/ray_cluster_template_wrappers.go
@@ -52,19 +52,19 @@ func (w *RayClusterTemplateWrapper) Clone() *RayClusterTemplateWrapper {
 
 // Label sets the label key and value.
 func (w *RayClusterTemplateWrapper) Label(key, value string) *RayClusterTemplateWrapper {
-	if w.Labels == nil {
-		w.Labels = make(map[string]string)
+	if w.Template.ObjectMeta.Labels == nil {
+		w.Template.ObjectMeta.Labels = make(map[string]string)
 	}
-	w.ObjectMeta.Labels[key] = value
+	w.Template.ObjectMeta.Labels[key] = value
 	return w
 }
 
 // Annotation sets the label key and value.
 func (w *RayClusterTemplateWrapper) Annotation(key, value string) *RayClusterTemplateWrapper {
-	if w.Annotations == nil {
-		w.Annotations = make(map[string]string)
+	if w.Template.ObjectMeta.Annotations == nil {
+		w.Template.ObjectMeta.Annotations = make(map[string]string)
 	}
-	w.ObjectMeta.Annotations[key] = value
+	w.Template.ObjectMeta.Annotations[key] = value
 	return w
 }
 

--- a/cmd/experimental/kjobctl/pkg/testing/wrappers/ray_job_template_wrappers.go
+++ b/cmd/experimental/kjobctl/pkg/testing/wrappers/ray_job_template_wrappers.go
@@ -52,19 +52,19 @@ func (w *RayJobTemplateWrapper) Clone() *RayJobTemplateWrapper {
 
 // Label sets the label key and value.
 func (w *RayJobTemplateWrapper) Label(key, value string) *RayJobTemplateWrapper {
-	if w.Labels == nil {
-		w.Labels = make(map[string]string)
+	if w.Template.ObjectMeta.Labels == nil {
+		w.Template.ObjectMeta.Labels = make(map[string]string)
 	}
-	w.ObjectMeta.Labels[key] = value
+	w.Template.ObjectMeta.Labels[key] = value
 	return w
 }
 
 // Annotation sets the label key and value.
 func (w *RayJobTemplateWrapper) Annotation(key, value string) *RayJobTemplateWrapper {
-	if w.Annotations == nil {
-		w.Annotations = make(map[string]string)
+	if w.Template.ObjectMeta.Annotations == nil {
+		w.Template.ObjectMeta.Annotations = make(map[string]string)
 	}
-	w.ObjectMeta.Annotations[key] = value
+	w.Template.ObjectMeta.Annotations[key] = value
 	return w
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Ignore `kubectl.kubernetes.io/last-applied-configuration` on copying annotations from template in kjobctl.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
After building objects we have unnecessary `kubectl.kubernetes.io/last-applied-configuration` annotation like this:

```
 annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"kjobctl.x-k8s.io/v1alpha1","kind":"JobTemplate","metadata":{"annotations":{},"name":"sample-slurm-template","namespace":"default"},"template":{"spec":{"completionMode":"Indexed","completions":3,"parallelism":3,"template":{"spec":{"containers":[{"image":"python:3-slim","name":"sample-container"}],"restartPolicy":"OnFailure"}}}}}
  creationTimestamp: "2024-09-24T14:51:37Z"
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```