### PR TITLE
[KEP] Maximum Execution Time

### DIFF
--- a/keps/3125-maximum-execution-time/README.md
+++ b/keps/3125-maximum-execution-time/README.md
@@ -136,7 +136,7 @@ if wl.Spec.MaximumExecutionTimeSeconds != nil {
 }
 ```
   - If `remainingTime` > 0 , a reconcile request should be queued with a `remainingTime` delay.
-  - If `remainingTime` <= 0 , the workload should be deactivated `wl.spec.Active = *false`, the `wl.status.accumulatedPastExecutionTimeSeconds` set to 0, and a relevant event recorded.
+  - If `remainingTime` <= 0 , the workload's deactivation is triggered, the `wl.status.accumulatedPastExecutionTimeSeconds` set to 0, and a relevant event recorded.
 
 #### Jobs / Jobframework
 
@@ -148,13 +148,13 @@ Upon workload creation, the value from `kueue.x-k8s.io/max-exec-time-seconds` is
 
 If specified, validate that the value of `wl.spec.maximumExecutionTimeSeconds` is greater then 0.
 
-Optionally: `wl.spec.maximumExecutionTimeSeconds` is immutable [ while the workload is admitted ]
+Validate that `wl.spec.maximumExecutionTimeSeconds` is immutable, while the workload is admitted.
 
 #### Jobs
 
 Validate that the value provided in the `kueue.x-k8s.io/max-exec-time-seconds` label is the base 10 representation of an integer greater then 0.
 
-Optionally: The value of the `kueue.x-k8s.io/max-exec-time-seconds` label is immutable [ while the job is unsuspended ] 
+The value of the `kueue.x-k8s.io/max-exec-time-seconds` label is immutable, while the job is unsuspended.
 
 ### Test Plan
 

--- a/keps/3125-maximum-execution-time/README.md
+++ b/keps/3125-maximum-execution-time/README.md
@@ -89,7 +89,8 @@ type WorkloadSpec struct {
 
 	// MaximumExecutionTimeSeconds if provided, determines the maximum time, in seconds, the workload can be admitted  
 	// befrore it's automatically deactivated.
-	MaximumExecutionTimeSeconds int32 `json:"maximumExecutionTimeSeconds,omitempty"`
+    // +optional
+	MaximumExecutionTimeSeconds *int32 `json:"maximumExecutionTimeSeconds,omitempty"`
 }
 ```
 
@@ -103,7 +104,8 @@ type WorkloadStatus struct {
 
 	// AccumulatedPastExecutionTimeSeconds holds the total duration the workload spent in Admitted state
 	// in the previous `Admit` - `Evict` cycles.
-	AccumulatedPastExexcutionTimeSecond int32 `json:"accumulatedPastExexcutionTimeSeconds,omitempty"`
+    // +optional
+	AccumulatedPastExexcutionTimeSecond *int32 `json:"accumulatedPastExexcutionTimeSeconds,omitempty"`
 }
 
 ```
@@ -134,17 +136,17 @@ if wl.Spec.MaximumExecutionTimeSeconds != nil {
 }
 ```
   - If `remainingTime` > 0 , a reconcile request should be queued with a `remainingTime` delay.
-  - If `remainingTime` <= 0 , the workload should be deactivated `wl.spec.Active = *false`, the `wl.status,AccumulatedPastExecutionTimeSeconds` set to 0, and a relevant event recorded.
+  - If `remainingTime` <= 0 , the workload should be deactivated `wl.spec.Active = *false`, the `wl.status.accumulatedPastExecutionTimeSeconds` set to 0, and a relevant event recorded.
 
 #### Jobs / Jobframework
 
-Upon workload creation, the value from `kueue.x-k8s.io/max-exec-time-seconds` is converted to `metav1.Duration` and set into the new workload's `spec`.
+Upon workload creation, the value from `kueue.x-k8s.io/max-exec-time-seconds` is converted to `int32` and set into the new workload's `spec`.
 
 ### Webhooks
 
 #### Workload
 
-Validate that the value of `wl.spec.maximumExecutionTimeSeconds` is greater or equal to 0.
+If specified, validate that the value of `wl.spec.maximumExecutionTimeSeconds` is greater then 0.
 
 Optionally: `wl.spec.maximumExecutionTimeSeconds` is immutable [ while the workload is admitted ]
 

--- a/keps/3125-maximum-execution-time/README.md
+++ b/keps/3125-maximum-execution-time/README.md
@@ -103,7 +103,7 @@ type WorkloadStatus struct {
 
 	// AccumulatedPastAdmittedTime holds the total duration the workload spent in Admitted state
 	// in the previous `Admit` - `Evict` cycles.
-	AccumulatedPastAdmittedTime metav1.Duration `json:"AccumulatedPastAdmittedTime,omitempty"`
+	AccumulatedPastAdmittedTime *metav1.Duration `json:"AccumulatedPastAdmittedTime,omitempty"`
 }
 
 ```

--- a/keps/3125-maximum-execution-time/README.md
+++ b/keps/3125-maximum-execution-time/README.md
@@ -50,7 +50,8 @@ Introduce a Job agnostic API of setting and enforcing the maximum execution time
 
 ### Non-Goals
 
-Change the behavior of the Kueue's scheduler based on the maximum execution time.
+- Change the behavior of the Kueue's scheduler based on the maximum execution time.
+- Mitigate potential conflicting configurations between `kueue.x-k8s.io/max-exec-time-seconds` and other job specific `activeDeadline` functionalities.
 
 ## Proposal
 
@@ -78,7 +79,7 @@ As a Batch User, I want to have the ability to set a limit on how long my job ca
 
 #### Workload Spec
 
-Add a new optional filed to hold the 
+Add a new optional field to hold the 
 
 ```go
 // WorkloadSpec defines the desired state of Workload
@@ -94,7 +95,7 @@ type WorkloadSpec struct {
 
 #### Workload Status
 
-Add a optional filed to hold the 
+Add a optional field to hold the 
 ```go
 // WorkloadStatus defines the observed state of Workload
 type WorkloadStatus struct {

--- a/keps/3125-maximum-execution-time/README.md
+++ b/keps/3125-maximum-execution-time/README.md
@@ -1,0 +1,183 @@
+# KEP-3125: Workload Maximum Execution Time
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories (Optional)](#user-stories-optional)
+    - [Story 1](#story-1)
+  - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [API](#api)
+  - [Constants](#constants)
+  - [Controller](#controller)
+    - [Workload](#workload)
+    - [Jobs / Jobframework](#jobs--jobframework)
+  - [Webhooks](#webhooks)
+    - [Workload](#workload-1)
+    - [Jobs](#jobs)
+  - [Test Plan](#test-plan)
+      - [Prerequisite testing updates](#prerequisite-testing-updates)
+    - [Unit Tests](#unit-tests)
+    - [Integration tests](#integration-tests)
+      - [controller/core/workload](#controllercoreworkload)
+      - [controller/jobs/job](#controllerjobsjob)
+  - [Graduation Criteria](#graduation-criteria)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Summary
+
+Add the ability to set a maximum execution time of a Job.
+
+## Motivation
+
+Different Jobs CRDs have a field with similar semantics, but there is no standard. For example `batch/Job` has `spec.activeDeadlneSeconds`, while JobSet does not have such an API for now.
+
+
+### Goals
+
+We would like to have a common API of setting and enforcing the maximum execution time of a Job.
+
+
+### Non-Goals
+
+Change the behavior of the Kueue's scheduler based on the maximum execution time.
+
+## Proposal
+
+A new Kueue specific label is added `kueue.x-k8s.io/max-exec-time-seconds` containing
+the maximum number of seconds the Job is expected to execute.
+
+The duration is passed to the Job's Workload.
+
+If a workload stays admitted for longer that it is expected it will be Deactivated. 
+
+### User Stories (Optional)
+
+#### Story 1
+
+**TBD**
+
+### Notes/Constraints/Caveats (Optional)
+
+
+### Risks and Mitigations
+
+We can accumulate the time a Workload has spent in Admitted state in previous Admit - Evict cycles, however:
+- For a Job this counter can be easily reset by deleting it's workload.
+- It's not possible for the Job creators to account for the time lost due to potential preemptions which may make them overcompensate (especially for Jobs in which the Eviction resets its progress).
+
+## Design Details
+
+### API
+
+Add a new optional filed to hold the 
+
+```go
+// WorkloadSpec defines the desired state of Workload
+// +kubebuilder:validation:XValidation:rule="has(self.priorityClassName) ? has(self.priority) : true", message="priority should not be nil when priorityClassName is set"
+type WorkloadSpec struct {
+    // ...
+
+	// MaximumExecutionTime if provided, determines the maximum time the workload can be admitted  
+    // befrore it's automatically deactivated.
+	MaximumExecutionTime *metav1.Duration `json:"maximumExecutionTime,omitempty"`
+}
+```
+### Constants
+
+Define a new constant holding the new label name `kueue.x-k8s.io/max-exec-time-seconds`.
+
+
+### Controller
+
+#### Workload
+
+If the workload is admitted and a maximum execution time is specified compute the remaining execution execution time as:
+```
+if wl.Spec.MaximumExecutionTime != nil {
+	if cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadAdmitted); cond != nil && cond.Status == metav1.ConditionTrue {
+		remainingTime := wl.Spec.MaximumExecutionTime.Duration - time.Now().Sub(cond.LastTransitionTime.Time)
+	}
+}
+```
+
+- If `remainingTime` > 0 , a reconcile request should be queued with a `remainingTime` delay.
+- If `remainingTime` <= 0 , the workload should be deactivated `wl.spec.Active = *false`.
+
+#### Jobs / Jobframework
+
+Upon workload creation, the value from `kueue.x-k8s.io/max-exec-time-seconds` is converted to `metav1.Duration` and set into the new workload's `spec`.
+
+### Webhooks
+
+#### Workload
+
+Validate that if specified the value of `wl.spec.maximumExecutionTime` is grater then 0.
+
+Optionally: `wl.spec.maximumExecutionTime` is immutable [ while the workload is admitted ]
+
+#### Jobs
+
+Validate that the value provided in the `kueue.x-k8s.io/max-exec-time-seconds` label is the base 10 representation of an integer grater then 0.
+
+Optionally: The value of the `kueue.x-k8s.io/max-exec-time-seconds` label is immutable [ while the job is unsuspended ] 
+
+### Test Plan
+
+[x] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+##### Prerequisite testing updates
+
+No regressions in the existing tests.
+
+#### Unit Tests
+
+As needed to provide coverage fore the new code.
+
+-  pkg/controller/core: 2024-09-25 - 9.9%
+-  pkg/controller/jobframework: 2024-09-25 - 1.9%
+-  pkg/controller/jobs/deployment: 2024-09-25 - 0.4%
+-  pkg/controller/jobs/job: 2024-09-25 - 8.5%
+-  pkg/controller/jobs/jobset: 2024-09-25 - 4.2%
+-  pkg/controller/jobs/kubeflow/jobs/mxjob: 2024-09-25 - 3.6%
+-  pkg/controller/jobs/kubeflow/jobs/paddlejob: 2024-09-25 - 3.5%
+-  pkg/controller/jobs/kubeflow/jobs/pytorchjob: 2024-09-25 - 0.7%
+-  pkg/controller/jobs/kubeflow/jobs/tfjob: 2024-09-25 - 0.7%
+-  pkg/controller/jobs/kubeflow/jobs/xgboostjob: 2024-09-25 - 3.5%
+-  pkg/controller/jobs/kubeflow/kubeflowjob: 2024-09-25 - 0.0%
+-  pkg/controller/jobs/mpijob: 2024-09-25 - 2.2%
+-  pkg/controller/jobs/pod: 2024-09-25 - 8.9%
+-  pkg/controller/jobs/raycluster: 2024-09-25 - 3.8%
+-  pkg/controller/jobs/rayjob: 2024-09-25 - 1.2%
+-  pkg/webhooks: 2024-09-25 - 2.1%
+
+#### Integration tests
+
+##### controller/core/workload
+
+Add "An admitted workload is deactivated when its maximum execution time expires"
+
+##### controller/jobs/job
+
+Add "An job is suspended when its maximum execution time expires"
+
+### Graduation Criteria
+
+
+## Implementation History
+
+
+## Drawbacks
+
+
+## Alternatives
+

--- a/keps/3125-maximum-execution-time/kep.yaml
+++ b/keps/3125-maximum-execution-time/kep.yaml
@@ -1,0 +1,24 @@
+title: Workload Maximum Execution Time
+kep-number: 3125
+authors:
+  - "@trasc"
+status: implementable
+creation-date: 2024-09-25
+reviewers:
+  - "@mimowo"
+  - "@tenzen-y"
+approvers:
+  - "@alculquicondor"
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: beta
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v0.9"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  beta: "v0.9"
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Proposed KEP fo Maximum Execution Time feature.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #3125 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```