### PR TITLE
[test][int][multikueue] Ignore error on config namespace multiple creation.

### DIFF
--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -213,7 +213,7 @@ func managerAndMultiKueueSetup(ctx context.Context, mgr manager.Manager, gcInter
 			Name: "kueue-system",
 		},
 	}
-	gomega.Expect(mgr.GetClient().Create(ctx, managersConfigNamespace)).To(gomega.Succeed())
+	gomega.Expect(client.IgnoreAlreadyExists(mgr.GetClient().Create(ctx, managersConfigNamespace))).To(gomega.Succeed())
 
 	err := multikueue.SetupIndexer(ctx, mgr.GetFieldIndexer(), managersConfigNamespace.Name)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -208,18 +208,7 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 func managerAndMultiKueueSetup(ctx context.Context, mgr manager.Manager, gcInterval time.Duration) {
 	managerSetup(ctx, mgr)
 
-	managersConfigNamespace = &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "kueue-system",
-		},
-	}
-	err := mgr.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(managersConfigNamespace), managersConfigNamespace)
-	gomega.Expect(client.IgnoreNotFound(err)).To(gomega.Succeed())
-	if err != nil {
-		gomega.Expect(client.IgnoreAlreadyExists(mgr.GetClient().Create(ctx, managersConfigNamespace))).To(gomega.Succeed())
-	}
-
-	err = multikueue.SetupIndexer(ctx, mgr.GetFieldIndexer(), managersConfigNamespace.Name)
+	err := multikueue.SetupIndexer(ctx, mgr.GetFieldIndexer(), managersConfigNamespace.Name)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = multikueue.SetupControllers(mgr, managersConfigNamespace.Name,
@@ -246,6 +235,13 @@ var _ = ginkgo.BeforeSuite(func() {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	managerK8sVersion, err = kubeversion.FetchServerVersion(discoveryClient)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	managersConfigNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kueue-system",
+		},
+	}
+	gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managersConfigNamespace)).To(gomega.Succeed())
 })
 
 var _ = ginkgo.AfterSuite(func() {

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -213,9 +213,13 @@ func managerAndMultiKueueSetup(ctx context.Context, mgr manager.Manager, gcInter
 			Name: "kueue-system",
 		},
 	}
-	gomega.Expect(client.IgnoreAlreadyExists(mgr.GetClient().Create(ctx, managersConfigNamespace))).To(gomega.Succeed())
+	err := mgr.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(managersConfigNamespace), managersConfigNamespace)
+	gomega.Expect(client.IgnoreNotFound(err)).To(gomega.Succeed())
+	if err != nil {
+		gomega.Expect(client.IgnoreAlreadyExists(mgr.GetClient().Create(ctx, managersConfigNamespace))).To(gomega.Succeed())
+	}
 
-	err := multikueue.SetupIndexer(ctx, mgr.GetFieldIndexer(), managersConfigNamespace.Name)
+	err = multikueue.SetupIndexer(ctx, mgr.GetFieldIndexer(), managersConfigNamespace.Name)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = multikueue.SetupControllers(mgr, managersConfigNamespace.Name,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[test][int][multikueue] Ignore error on config namespace multiple creation.

Ignore Already Exists error when creating the kueue config namespace.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```