### PR TITLE
[batch/job] Allow unsuspending a job with a parallelism equal or less then minimum.

### DIFF
--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -400,6 +400,36 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 			wantErr: nil,
 		},
+		{
+			name: "can update the kueue.x-k8s.io/job-min-parallelism  annotation",
+			oldJob: testingutil.MakeJob("job", "default").
+				Parallelism(4).
+				Completions(6).
+				SetAnnotation(JobMinParallelismAnnotation, "3").
+				Obj(),
+			newJob: testingutil.MakeJob("job", "default").
+				Parallelism(4).
+				Completions(6).
+				SetAnnotation(JobMinParallelismAnnotation, "2").
+				Obj(),
+			wantErr: nil,
+		},
+		{
+			name: "validates kueue.x-k8s.io/job-min-parallelism annotation value (bad format)",
+			oldJob: testingutil.MakeJob("job", "default").
+				Parallelism(4).
+				Completions(6).
+				SetAnnotation(JobMinParallelismAnnotation, "3").
+				Obj(),
+			newJob: testingutil.MakeJob("job", "default").
+				Parallelism(4).
+				Completions(6).
+				SetAnnotation(JobMinParallelismAnnotation, "NaN").
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(minPodsCountAnnotationsPath, "NaN", "strconv.Atoi: parsing \"NaN\": invalid syntax"),
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/test/integration/webhook/jobs/job_webhook_test.go
+++ b/test/integration/webhook/jobs/job_webhook_test.go
@@ -174,4 +174,43 @@ var _ = ginkgo.Describe("Job Webhook with manageJobsWithoutQueueName disabled", 
 		createdJob.Spec.Suspend = ptr.To(false)
 		gomega.Expect(k8sClient.Update(ctx, createdJob)).ShouldNot(gomega.Succeed())
 	})
+
+	ginkgo.It("should allow unsuspending a partially admissible job with its minimum parallelism", func() {
+		job := testingjob.MakeJob("job-with-queue-name", ns.Name).Queue("queue").
+			Parallelism(6).
+			Completions(6).
+			SetAnnotation(job.JobMinParallelismAnnotation, "4").
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+
+		lookupKey := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
+		createdJob := &batchv1.Job{}
+		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+
+		createdJob.Spec.Parallelism = ptr.To[int32](4)
+		createdJob.Spec.Suspend = ptr.To(false)
+		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("should allow unsuspending a partially admissible job with a parallelism lower then minimum", func() {
+		// This can happen if the job:
+		// 1. Is admitted
+		// 2. Makes progress and increments the reclaimable counts
+		// 3. Is evicted
+		// 4. Is re-admitted (the parallelism being less then min due to reclaim)
+		job := testingjob.MakeJob("job-with-queue-name", ns.Name).Queue("queue").
+			Parallelism(6).
+			Completions(6).
+			SetAnnotation(job.JobMinParallelismAnnotation, "4").
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+
+		lookupKey := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
+		createdJob := &batchv1.Job{}
+		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+
+		createdJob.Spec.Parallelism = ptr.To[int32](3)
+		createdJob.Spec.Suspend = ptr.To(false)
+		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
+	})
 })


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[batch/job] Allow unsuspending a job with a parallelism equal or less then min.

The minimum can be reached in the usual partial admission operation. Values less then minimum can be reached in case of readmitting jobs which have marked a good part of their pods as reclaimable.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3140

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix webook validation for batch/Job to allow partial admission of a Job to use all available resources.
It also fixes a scenario of partial re-admission when some of the Pods are already reclaimed.
```