### PR TITLE
Add steps how to access VisibilityOnDemand via curl

### DIFF
--- a/site/content/en/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
+++ b/site/content/en/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand.md
@@ -37,14 +37,14 @@ If you want to directly access the Visibility API with a http client like
 `curl` or `wget`, or a browser, there are multiple ways you can locate and 
 authenticate against the Visibility API server:
 
-#### Using kubectl proxy
+#### (Recommended) Using kubectl proxy
 
-Run kubectl in proxy mode (recommended). This method is recommended, since it uses 
+Run kubectl in proxy mode. This method is recommended, since it uses 
 the stored API server location and verifies the identity of the API server using 
 a self-signed certificate. No man-in-the-middle (MITM) attack is possible using 
 this method. 
 
-For more details, see [here](https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/#using-kubectl-proxy).
+For more details, see [kubectl documentation](https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/#using-kubectl-proxy).
 
 #### Without kubectl proxy
 
@@ -52,9 +52,9 @@ Alternatively, you can provide the location and credentials directly to the http
 This works with client code that is confused by proxies. To protect against man in 
 the middle attacks, you'll need to import a root cert into your browser.
 
-For more details, see [here](https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/#without-kubectl-proxy).
+For more details, see [kubectl documentation](https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/#without-kubectl-proxy).
 
-You then need to create `ClusterRole` and `ClusterRoleBinding` for that same account
+You then need to create `ClusterRole` and `ClusterRoleBinding` for that same (default) k8s service account
 
 {{< include "examples/visibility/cluster-role-and-binding.yaml" "yaml" >}}
 

--- a/site/static/examples/visibility/cluster-role-and-binding.yaml
+++ b/site/static/examples/visibility/cluster-role-and-binding.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kueue-visibility-server-api
+rules:
+- apiGroups:
+  - "visibility.kueue.x-k8s.io"
+  resources:
+  - "clusterqueues/pendingworkloads"
+  - "localqueues/pendingworkloads"
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kueue-visibility-server-api
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: kueue-visibility-server-api
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add steps how to access VisibilityOnDemand via curl.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Review remarks for #1824

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```