### PR TITLE
Fix "SchedulerWithWaitForPodsReady Long PodsReady timeout Should block admission of one new workload if two are considered in the same scheduling cycle" test.

### DIFF
--- a/test/integration/scheduler/podsready/scheduler_test.go
+++ b/test/integration/scheduler/podsready/scheduler_test.go
@@ -97,12 +97,20 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			ResourceGroup(*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
 			Obj()
 		gomega.Expect(k8sClient.Create(ctx, prodClusterQ)).Should(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodClusterQ), prodClusterQ)).Should(gomega.Succeed())
+			g.Expect(apimeta.IsStatusConditionTrue(prodClusterQ.Status.Conditions, kueue.ClusterQueueActive)).To(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		devClusterQ = testing.MakeClusterQueue("dev-cq").
 			Cohort("all").
 			ResourceGroup(*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
 			Obj()
 		gomega.Expect(k8sClient.Create(ctx, devClusterQ)).Should(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(devClusterQ), devClusterQ)).Should(gomega.Succeed())
+			g.Expect(apimeta.IsStatusConditionTrue(devClusterQ.Status.Conditions, kueue.ClusterQueueActive)).To(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		prodQueue = testing.MakeLocalQueue("prod-queue", ns.Name).ClusterQueue(prodClusterQ.Name).Obj()
 		gomega.Expect(k8sClient.Create(ctx, prodQueue)).Should(gomega.Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix "SchedulerWithWaitForPodsReady Long PodsReady timeout Should block admission of one new workload if two are considered in the same scheduling cycle" test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3149

#### Special notes for your reviewer:
Sometimes the `Workload` is created before the `ClusterQueue` adds to the cache and reaches an active status. 

https://github.com/kubernetes-sigs/kueue/blob/0be3721486570ad2bf3a295ad00ed35c3a0f4311/pkg/controller/core/workload_controller.go#L231

https://github.com/kubernetes-sigs/kueue/blob/0be3721486570ad2bf3a295ad00ed35c3a0f4311/pkg/controller/core/workload_controller.go#L294-L299

Since we aren't using a scheduler in these test case, the `Workload` gets stuck with `Inadmissible` status. 

The solution is to wait for the `ClusterQueue` to become active.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```