### PR TITLE
Add user documentation for KEP-2937 to website

### DIFF
--- a/site/content/en/docs/tasks/manage/administer_cluster_quotas.md
+++ b/site/content/en/docs/tasks/manage/administer_cluster_quotas.md
@@ -415,7 +415,7 @@ in the Kueue configuration as a cluster-level setting.
 {{< feature-state state="alpha" for_version="v0.9" >}}
 {{% alert title="Note" color="primary" %}}
 
-`transformations` is a Alpha feature that is not enabled by default.
+`transformations` is an Alpha feature that is not enabled by default.
 
 You can enable it by setting the `ConfigurableResourceTransformations` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
 {{% /alert %}}
@@ -458,7 +458,9 @@ With this example configuration, a Pod that requests:
         example.com/gpu-type1: 2
         example.com/gpu-type2: 1
 ```
-will for quota purposes have an effective resource request of:
+
+The Workload obtains an effective resource requests for quota purposes:
+
 ```yaml
     resources:
       requests:

--- a/site/content/en/docs/tasks/troubleshooting/troubleshooting_jobs.md
+++ b/site/content/en/docs/tasks/troubleshooting/troubleshooting_jobs.md
@@ -167,7 +167,23 @@ status:
     reason: Pending
     status: "False"
     type: QuotaReserved
+  resourceRequests:
+    name: main
+    resources:
+      cpu:    3
+      Memory: 600Mi
 ```
+
+{{< feature-state state="alpha" for_version="v0.9" >}}
+{{% alert title="Note" color="primary" %}}
+
+`resourceRequests` is a Alpha feature that is not enabled by default.  If the feature is not enabled,
+the status will not contain the detailed description of the resources being requested by the Workload.
+
+You can enable it by setting the `WorkloadResourceRequestsSummary` feature gate.
+Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
+{{% /alert %}}
+
 
 ### Does my ClusterQueue have the resource requests that the job requires?
 

--- a/site/content/en/docs/tasks/troubleshooting/troubleshooting_jobs.md
+++ b/site/content/en/docs/tasks/troubleshooting/troubleshooting_jobs.md
@@ -177,7 +177,7 @@ status:
 {{< feature-state state="alpha" for_version="v0.9" >}}
 {{% alert title="Note" color="primary" %}}
 
-`resourceRequests` is a Alpha feature that is not enabled by default.  When the feature is enabled,
+`resourceRequests` is an Alpha feature that is not enabled by default.  When the feature is enabled,
 the status will contain the detailed description of the resources being requested by the Workload.
 
 You can enable it by setting the `WorkloadResourceRequestsSummary` feature gate.

--- a/site/content/en/docs/tasks/troubleshooting/troubleshooting_jobs.md
+++ b/site/content/en/docs/tasks/troubleshooting/troubleshooting_jobs.md
@@ -177,8 +177,8 @@ status:
 {{< feature-state state="alpha" for_version="v0.9" >}}
 {{% alert title="Note" color="primary" %}}
 
-`resourceRequests` is a Alpha feature that is not enabled by default.  If the feature is not enabled,
-the status will not contain the detailed description of the resources being requested by the Workload.
+`resourceRequests` is a Alpha feature that is not enabled by default.  When the feature is enabled,
+the status will contain the detailed description of the resources being requested by the Workload.
 
 You can enable it by setting the `WorkloadResourceRequestsSummary` feature gate.
 Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind documentation

#### What this PR does / why we need it:

Adds user-facing documentation on configurable resource transformations (KEP-2937) to website

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

I'm putting NONE for the release note, because #3026 which is the implementation PR contains the release note text.

Written under the assumption that we'll be merge 3026 in time to make 0.9. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```