### PR TITLE
Time sleep optimization on tests.

### DIFF
--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -19,7 +19,6 @@ package pod
 import (
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -1086,11 +1085,8 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
 
 				ginkgo.By("checking that excess pod is deleted before admission", func() {
-					// Make sure that at least a second passes between
-					// creation of pods to avoid flaky behavior.
-					time.Sleep(time.Second * 1)
-
 					excessPod := excessBasePod.Clone().Obj()
+					util.WaitForNextSecondAfterCreation(pod2)
 					gomega.Expect(k8sClient.Create(ctx, excessPod)).Should(gomega.Succeed())
 
 					util.ExpectObjectToBeDeleted(ctx, k8sClient, excessPod, false)

--- a/test/integration/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/scheduler/fairsharing/fair_sharing_test.go
@@ -18,7 +18,6 @@ package fairsharing
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -116,8 +115,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectClusterQueueWeightedShareMetric(cqShared, 0)
 
 			ginkgo.By("Creating newer workloads in cq-b")
-			// Ensure workloads in cqB have a newer timestamp.
-			time.Sleep(time.Second)
+			util.WaitForNextSecondAfterCreation(aWorkloads[len(aWorkloads)-1])
 			bWorkloads := make([]*kueue.Workload, 5)
 			for i := range bWorkloads {
 				bWorkloads[i] = testing.MakeWorkload(fmt.Sprintf("b-%d", i), ns.Name).

--- a/test/integration/scheduler/podsready/scheduler_test.go
+++ b/test/integration/scheduler/podsready/scheduler_test.go
@@ -179,9 +179,8 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			ginkgo.By("creating two workloads but delaying cluster queue creation which has enough capacity")
 			prodWl := testing.MakeWorkload("prod-wl", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "11").Obj()
 			gomega.Expect(k8sClient.Create(ctx, prodWl)).Should(gomega.Succeed())
-			// wait a second to ensure the CreationTimestamps differ and scheduler picks the first created to be admitted
-			time.Sleep(time.Second)
 			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(devQueue.Name).Request(corev1.ResourceCPU, "11").Obj()
+			util.WaitForNextSecondAfterCreation(prodWl)
 			gomega.Expect(k8sClient.Create(ctx, devWl)).Should(gomega.Succeed())
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, prodWl, devWl)
 
@@ -333,9 +332,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			ginkgo.By("create the 'prod' workload")
 			prodWl := testing.MakeWorkload("prod", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
 			gomega.Expect(k8sClient.Create(ctx, prodWl)).Should(gomega.Succeed())
-
-			ginkgo.By("create the 'dev' workload after a second")
-			time.Sleep(time.Second)
+			util.WaitForNextSecondAfterCreation(prodWl)
 			devWl := testing.MakeWorkload("dev", ns.Name).Queue(devQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
 			gomega.Expect(k8sClient.Create(ctx, devWl)).Should(gomega.Succeed())
 
@@ -432,12 +429,10 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 		wl3 := testing.MakeWorkload("prod3", ns.Name).Queue(localQueueName).Request(corev1.ResourceCPU, "5").Obj()
 
 		ginkgo.By("create the workloads", func() {
-			// since metav1.Time has only second resolution, wait one second between
-			// create calls to avoid any potential creation timestamp collision
 			gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
-			time.Sleep(time.Second)
+			util.WaitForNextSecondAfterCreation(wl1)
 			gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
-			time.Sleep(time.Second)
+			util.WaitForNextSecondAfterCreation(wl2)
 			gomega.Expect(k8sClient.Create(ctx, wl3)).Should(gomega.Succeed())
 		})
 
@@ -519,12 +514,10 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(standaloneQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
 
 			ginkgo.By("create the workloads", func() {
-				// since metav1.Time has only second resolution, wait one second between
-				// create calls to avoid any potential creation timestamp collision
 				gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
-				time.Sleep(time.Second)
+				util.WaitForNextSecondAfterCreation(wl1)
 				gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
-				time.Sleep(time.Second)
+				util.WaitForNextSecondAfterCreation(wl2)
 				gomega.Expect(k8sClient.Create(ctx, wl3)).Should(gomega.Succeed())
 			})
 
@@ -726,12 +719,10 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(standaloneQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
 
 			ginkgo.By("create the workloads", func() {
-				// since metav1.Time has only second resolution, wait one second between
-				// create calls to avoid any potential creation timestamp collision
 				gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
-				time.Sleep(time.Second)
+				util.WaitForNextSecondAfterCreation(wl1)
 				gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
-				time.Sleep(time.Second)
+				util.WaitForNextSecondAfterCreation(wl2)
 				gomega.Expect(k8sClient.Create(ctx, wl3)).Should(gomega.Succeed())
 			})
 

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -18,7 +18,6 @@ package scheduler
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/ginkgo/v2"
@@ -167,10 +166,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			gomega.Expect(k8sClient.Create(ctx, wl3)).To(gomega.Succeed())
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl3)
-
-			ginkgo.By("Waiting one second, to ensure that the new workload has a later creation time")
-			time.Sleep(time.Second)
-
+			util.WaitForNextSecondAfterCreation(wl3)
 			ginkgo.By("Creating a new Workload")
 			wl4 := testing.MakeWorkload("wl-4", ns.Name).
 				Queue(q.Name).

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -729,3 +729,10 @@ func NewTestingLogger(writer io.Writer, level int) logr.Logger {
 		zap.Level(zapcore.Level(level)),
 		opts)
 }
+
+// WaitForNextSecondAfterCreation wait time between the start of the next second
+// after creationTimestamp and the current time to ensure that the new
+// created object has a later creation time.
+func WaitForNextSecondAfterCreation(obj client.Object) {
+	time.Sleep(time.Until(obj.GetCreationTimestamp().Add(time.Second).Truncate(time.Second)))
+}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -734,5 +734,5 @@ func NewTestingLogger(writer io.Writer, level int) logr.Logger {
 // after creationTimestamp and the current time to ensure that the new
 // created object has a later creation time.
 func WaitForNextSecondAfterCreation(obj client.Object) {
-	time.Sleep(time.Until(obj.GetCreationTimestamp().Add(time.Second).Truncate(time.Second)))
+	time.Sleep(time.Until(obj.GetCreationTimestamp().Add(time.Second)))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Just now we are waiting second to be ensure that the new created object has a later creation time. To be more accurate we need to wait difference between next second after last creation time of object and current time. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```