### PR TITLE
[test][integration] Drop `fwk.RunManager` in favor of `SetupClient` and `StartManager`

### DIFF
--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -207,12 +207,6 @@ func (f *Framework) StopManager(ctx context.Context) {
 	})
 }
 
-func (f *Framework) RunManager(cfg *rest.Config, managerSetup ManagerSetup) (context.Context, client.Client) {
-	ctx, k8sClient := f.SetupClient(cfg)
-	f.StartManager(ctx, cfg, managerSetup)
-	return ctx, k8sClient
-}
-
 func (f *Framework) Teardown() {
 	ginkgo.By("tearing down the test environment")
 	if f.cancel != nil {

--- a/test/integration/kueuectl/suite_test.go
+++ b/test/integration/kueuectl/suite_test.go
@@ -60,7 +60,8 @@ func TestKueuectl(t *testing.T) {
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{CRDPath: crdPath, WebhookPath: webhookPath}
 	cfg = fwk.Init()
-	ctx, k8sClient = fwk.RunManager(cfg, managerSetup)
+	ctx, k8sClient = fwk.SetupClient(cfg)
+	fwk.StartManager(ctx, cfg, managerSetup)
 
 	kassetsPath = os.Getenv("KUBEBUILDER_ASSETS")
 	kueuectlPath = path.Join(os.Getenv("KUEUE_BIN"), "kubectl-kueue")

--- a/test/integration/scheduler/fairsharing/suite_test.go
+++ b/test/integration/scheduler/fairsharing/suite_test.go
@@ -60,7 +60,8 @@ var _ = ginkgo.BeforeSuite(func() {
 		WebhookPath: filepath.Join("..", "..", "..", "..", "config", "components", "webhook"),
 	}
 	cfg = fwk.Init()
-	ctx, k8sClient = fwk.RunManager(cfg, managerAndSchedulerSetup)
+	ctx, k8sClient = fwk.SetupClient(cfg)
+	fwk.StartManager(ctx, cfg, managerAndSchedulerSetup)
 })
 
 var _ = ginkgo.AfterSuite(func() {

--- a/test/integration/scheduler/suite_test.go
+++ b/test/integration/scheduler/suite_test.go
@@ -60,7 +60,8 @@ var _ = ginkgo.BeforeSuite(func() {
 		WebhookPath: filepath.Join("..", "..", "..", "config", "components", "webhook"),
 	}
 	cfg = fwk.Init()
-	ctx, k8sClient = fwk.RunManager(cfg, managerAndSchedulerSetup)
+	ctx, k8sClient = fwk.SetupClient(cfg)
+	fwk.StartManager(ctx, cfg, managerAndSchedulerSetup)
 })
 
 var _ = ginkgo.AfterSuite(func() {

--- a/test/integration/webhook/core/suite_test.go
+++ b/test/integration/webhook/core/suite_test.go
@@ -56,7 +56,8 @@ var _ = ginkgo.BeforeSuite(func() {
 		WebhookPath: filepath.Join("..", "..", "..", "..", "config", "components", "webhook"),
 	}
 	cfg = fwk.Init()
-	ctx, k8sClient = fwk.RunManager(cfg, func(ctx context.Context, mgr manager.Manager) {
+	ctx, k8sClient = fwk.SetupClient(cfg)
+	fwk.StartManager(ctx, cfg, func(ctx context.Context, mgr manager.Manager) {
 		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/test/integration/webhook/jobs/pod_webhook_test.go
+++ b/test/integration/webhook/jobs/pod_webhook_test.go
@@ -179,7 +179,7 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 			err = serverVersionFetcher.FetchServerVersion()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-			fwk.RunManager(cfg, managerSetup(
+			fwk.StartManager(ctx, cfg, managerSetup(
 				pod.SetupWebhook,
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithKubeServerVersion(serverVersionFetcher),

--- a/test/integration/webhook/jobs/raycluster_webhook_test.go
+++ b/test/integration/webhook/jobs/raycluster_webhook_test.go
@@ -71,7 +71,7 @@ var _ = ginkgo.Describe("RayCluster Webhook", func() {
 
 	ginkgo.When("With manageJobsWithoutQueueName enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 		ginkgo.BeforeAll(func() {
-			fwk.RunManager(cfg, managerSetup(func(mgr ctrl.Manager, opts ...jobframework.Option) error {
+			fwk.StartManager(ctx, cfg, managerSetup(func(mgr ctrl.Manager, opts ...jobframework.Option) error {
 				reconciler := raycluster.NewReconciler(
 					mgr.GetClient(),
 					mgr.GetEventRecorderFor(constants.JobControllerName),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
[test][integration] Drop the framework's `RunManager` in favor of `SetupClient` and `StartManager`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to:  #2993

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```