### PR TITLE
KEP-3122: Expose Flavors in LocalQueue Status.

### DIFF
--- a/keps/3122-expose-flavors-in-localqueue-status/README.md
+++ b/keps/3122-expose-flavors-in-localqueue-status/README.md
@@ -49,7 +49,7 @@ a LocalQueue (e.g., a flavor might include newer GPUs).
 
 ## Proposal
 
-Introduce a new status field `availableFlavors` in LocalQueue 
+Introduce a new status field `flavors` in LocalQueue 
 that will be updated when ClusterQueue flavors are modified.
 
 ### User Stories (Optional)
@@ -109,14 +109,13 @@ Modify `LocalQueueStatus` API object:
 // LocalQueueStatus defines the observed state of LocalQueue
 type LocalQueueStatus struct {
 	...
-	// availableFlavors lists all currently available ResourceFlavors
-	// in specified ClusterQueue.
+	// flavors lists all currently available ResourceFlavors in specified ClusterQueue.
 	//
 	// +listType=map
 	// +listMapKey=name
   // +kubebuilder:validation:MaxItems=16
   // +optional
-	Flavors []Flavor `json:"availableFlavors,omitempty"`
+	Flavors []Flavor `json:"flavors,omitempty"`
 }
 ```
 

--- a/keps/3122-expose-flavors-in-localqueue-status/README.md
+++ b/keps/3122-expose-flavors-in-localqueue-status/README.md
@@ -45,6 +45,7 @@ a LocalQueue (e.g., a flavor might include newer GPUs).
 ### Non-Goals
 
 - Verify that the ResourceFlavors exist and show only the existing flavors.
+- The stopPolicies are never considered in the LocalQueue flavors status field.
 
 ## Proposal
 
@@ -73,10 +74,10 @@ additional field does not significantly impact performance.
 
 ### API
 
-Create `AvailableFlavor` API object:
+Create `Flavor` API object:
 
 ```go
-type AvailableFlavor struct {
+type Flavor struct {
   // name of the flavor.
   Name ResourceFlavorReference `json:"name"`
   
@@ -115,7 +116,7 @@ type LocalQueueStatus struct {
 	// +listMapKey=name
   // +kubebuilder:validation:MaxItems=16
   // +optional
-	AvailableFlavors []AvailableFlavor `json:"availableFlavors,omitempty"`
+	Flavors []Flavor `json:"availableFlavors,omitempty"`
 }
 ```
 
@@ -126,12 +127,12 @@ Modify `LocalQueueUsageStats` object:
 ```go
 type LocalQueueUsageStats struct {
   ...
-	AvailableFlavors []kueue.ResourceFlavorReference
+	Flavors []kueue.ResourceFlavorReference
 }
 ```
 
 Get available `Flavors` from `cqImpl.ResourceGroups` in `cache.LocalQueueUsage(...)` 
-method and update `AvailableFlavors` field on `UpdateStatusIfChanged(...)`
+method and update `Flavors` field on `UpdateStatusIfChanged(...)`
 on each LocalQueue reconcile when it was updated.
 
 ### Future works

--- a/keps/3122-expose-flavors-in-localqueue-status/README.md
+++ b/keps/3122-expose-flavors-in-localqueue-status/README.md
@@ -13,6 +13,7 @@
 - [Design Details](#design-details)
   - [API](#api)
   - [Implementation overview](#implementation-overview)
+  - [Future works](#future-works)
   - [Test Plan](#test-plan)
       - [Prerequisite testing updates](#prerequisite-testing-updates)
     - [Unit Tests](#unit-tests)
@@ -132,6 +133,12 @@ type LocalQueueUsageStats struct {
 Get available `Flavors` from `cqImpl.ResourceGroups` in `cache.LocalQueueUsage(...)` 
 method and update `AvailableFlavors` field on `UpdateStatusIfChanged(...)`
 on each LocalQueue reconcile when it was updated.
+
+### Future works
+
+In the future, we can also add the `availableCoveredResources` field. This field allows 
+batch users to understand which resources may be available for the LocalQueue.
+
 
 ### Test Plan
 

--- a/keps/3122-expose-flavors-in-localqueue-status/README.md
+++ b/keps/3122-expose-flavors-in-localqueue-status/README.md
@@ -62,6 +62,12 @@ ClusterQueue objects directly, only LocalQueues.
 
 ### Risks and Mitigations
 
+Risk: Increased size of the status object due to adding 16 resource flavors 
+to the LocalQueue.
+
+Mitigation: The number of available flavor names is limited to 16, so this 
+additional field does not significantly impact performance.
+
 ## Design Details
 
 ### API
@@ -90,6 +96,8 @@ type LocalQueueStatus struct {
 	//
 	// +listType=map
 	// +listMapKey=name
+  // +kubebuilder:validation:MaxItems=16
+  // +optional
 	AvailableFlavors []AvailableFlavor `json:"availableFlavors,omitempty"`
 }
 ```

--- a/keps/3122-expose-flavors-in-localqueue-status/README.md
+++ b/keps/3122-expose-flavors-in-localqueue-status/README.md
@@ -70,8 +70,12 @@ Create `AvailableFlavor` API object:
 
 ```go
 type AvailableFlavor struct {
-	// name of the flavor.
-	Name ResourceFlavorReference `json:"name"`
+  // name of the flavor.
+  Name ResourceFlavorReference `json:"name"`
+  // resources used in the flavor.
+  // +listType=set
+  // +optional
+  Resources []string `json:"resources,omitempty"`
 }
 ```
 

--- a/keps/3122-expose-flavors-in-localqueue-status/README.md
+++ b/keps/3122-expose-flavors-in-localqueue-status/README.md
@@ -176,6 +176,9 @@ passed and applied on CRD.
 Existing integration tests should be updated to tests whether the new data are correctly
 passed and applied on CRD.
 
+Additionally, add an integration test case to check that Flavors are updated after 
+forcefully removing the ClusterQueue while ignoring validations.
+
 ### Graduation Criteria
 
 We will graduate this feature to stable together with the whole LocalQueue API.

--- a/keps/3122-expose-flavors-in-localqueue-status/README.md
+++ b/keps/3122-expose-flavors-in-localqueue-status/README.md
@@ -78,10 +78,26 @@ Create `AvailableFlavor` API object:
 type AvailableFlavor struct {
   // name of the flavor.
   Name ResourceFlavorReference `json:"name"`
+  
   // resources used in the flavor.
   // +listType=set
+  // +kubebuilder:validation:MaxItems=16
   // +optional
   Resources []string `json:"resources,omitempty"`
+
+  // nodeLabels are labels that associate the ResourceFlavor with Nodes that
+  // have the same labels.
+  // +mapType=atomic
+  // +kubebuilder:validation:MaxProperties=8
+  // +optional
+  NodeLabels map[string]string `json:"nodeLabels,omitempty"`
+
+  // nodeTaints are taints that the nodes associated with this ResourceFlavor
+  // have.
+  // +listType=atomic
+  // +kubebuilder:validation:MaxItems=8
+  // +optional
+  NodeTaints []corev1.Taint `json:"nodeTaints,omitempty"`
 }
 ```
 

--- a/keps/3122-expose-flavors-in-localqueue-status/kep.yaml
+++ b/keps/3122-expose-flavors-in-localqueue-status/kep.yaml
@@ -1,0 +1,28 @@
+title: Expose Flavors in LocalQueue Status
+kep-number: 3122
+authors:
+  - "@mbobrovskyi"
+status: implementable
+creation-date: 2024-10-02
+reviewers:
+  - "@mimowo"
+  - "@alculquicondor"
+  - "@tenzen-y"
+approvers:
+  - "@mimowo"
+  - "@alculquicondor"
+  - "@tenzen-y"
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: beta
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v0.9"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  beta: "v0.9"
+
+disable-supported: false

--- a/keps/3122-expose-flavors-in-localqueue-status/kep.yaml
+++ b/keps/3122-expose-flavors-in-localqueue-status/kep.yaml
@@ -25,4 +25,7 @@ latest-milestone: "v0.9"
 milestone:
   beta: "v0.9"
 
-disable-supported: false
+# List the feature gate name and the components for which it must be enabled
+feature-gates:
+  - name: ExposeFlavorsInLocalQueue
+disable-supported: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
KEP for Expose Flavors in LocalQueue Status.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #3122

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```