### PR TITLE
[kjobctl] Add --chdir flag to Slurm mode

### DIFF
--- a/cmd/experimental/kjobctl/pkg/builder/builder.go
+++ b/cmd/experimental/kjobctl/pkg/builder/builder.go
@@ -113,6 +113,7 @@ type Builder struct {
 	ignoreUnknown            bool
 	skipLocalQueueValidation bool
 	skipPriorityValidation   bool
+	changeDir                string
 
 	profile       *v1alpha1.ApplicationProfile
 	mode          *v1alpha1.SupportedMode
@@ -267,6 +268,11 @@ func (b *Builder) WithInitImage(initImage string) *Builder {
 
 func (b *Builder) WithIgnoreUnknown(ignoreUnknown bool) *Builder {
 	b.ignoreUnknown = ignoreUnknown
+	return b
+}
+
+func (b *Builder) WithChangeDir(chdir string) *Builder {
+	b.changeDir = chdir
 	return b
 }
 

--- a/cmd/experimental/kjobctl/pkg/builder/slurm_builder.go
+++ b/cmd/experimental/kjobctl/pkg/builder/slurm_builder.go
@@ -560,6 +560,7 @@ type slurmEntrypointScript struct {
 	SbatchEnvFilename      string
 	SlurmEnvFilename       string
 	UnmaskFilenameFunction string
+	ChangeDir              string
 	BuildEntrypointCommand string
 }
 
@@ -569,6 +570,7 @@ func (b *slurmBuilder) buildEntrypointScript() (string, error) {
 		SbatchEnvFilename:      slurmSbatchEnvFilename,
 		SlurmEnvFilename:       slurmSlurmEnvFilename,
 		UnmaskFilenameFunction: unmaskFilenameFunction,
+		ChangeDir:              b.changeDir,
 		BuildEntrypointCommand: b.buildEntrypointCommand(),
 	}
 

--- a/cmd/experimental/kjobctl/pkg/builder/templates/slurm_entrypoint_script.sh.tmpl
+++ b/cmd/experimental/kjobctl/pkg/builder/templates/slurm_entrypoint_script.sh.tmpl
@@ -20,5 +20,7 @@ export $(cat {{.EnvsPath}}/$JOB_CONTAINER_INDEX/{{.SlurmEnvFilename}} | xargs)
 input_file=$(unmask_filename "$SBATCH_INPUT")
 output_file=$(unmask_filename "$SBATCH_OUTPUT")
 error_path=$(unmask_filename "$SBATCH_ERROR")
-
+{{if .ChangeDir }}
+cd {{.ChangeDir}}
+{{end}}
 {{.BuildEntrypointCommand}}

--- a/cmd/experimental/kjobctl/pkg/cmd/create/create.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/create/create.go
@@ -59,6 +59,7 @@ const (
 	initImageFlagName                = "init-image"
 	skipLocalQueueValidationFlagName = "skip-localqueue-validation"
 	skipPriorityValidationFlagName   = "skip-priority-validation"
+	changeDirFlagName                = "chdir"
 
 	commandFlagName     = string(v1alpha1.CmdFlag)
 	parallelismFlagName = string(v1alpha1.ParallelismFlag)
@@ -162,6 +163,7 @@ type CreateOptions struct {
 	InitImage            string
 	PodRunningTimeout    time.Duration
 	RemoveInteractivePod bool
+	ChangeDir            string
 
 	SlurmFlagSet *pflag.FlagSet
 
@@ -383,6 +385,8 @@ The minimum index value is 0. The maximum index value is 2147483647.`)
 				"Local queue name.")
 			o.SlurmFlagSet.StringVar(&o.Priority, priorityFlagName, "",
 				"Apply priority for the entire workload.")
+			o.SlurmFlagSet.StringVarP(&o.ChangeDir, changeDirFlagName, "D", "",
+				"Change directory before executing the script.")
 		},
 	},
 }
@@ -623,6 +627,7 @@ func (o *CreateOptions) Run(ctx context.Context, clientGetter util.ClientGetter,
 		WithIgnoreUnknown(o.IgnoreUnknown).
 		WithSkipLocalQueueValidation(o.SkipLocalQueueValidation).
 		WithSkipPriorityValidation(o.SkipPriorityValidation).
+		WithChangeDir(o.ChangeDir).
 		Do(ctx)
 	if err != nil {
 		return err

--- a/cmd/experimental/kjobctl/pkg/cmd/create/create_test.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/create/create_test.go
@@ -913,6 +913,7 @@ error_path=$(unmask_filename "$SBATCH_ERROR")
 					"--input", "/slurm/input.txt",
 					"--job-name", "job-name",
 					"--partition", "lq1",
+					"--chdir", "/mydir",
 					tc.tempFile,
 				}
 			},
@@ -1117,6 +1118,8 @@ unmask_filename () {
 input_file=$(unmask_filename "$SBATCH_INPUT")
 output_file=$(unmask_filename "$SBATCH_OUTPUT")
 error_path=$(unmask_filename "$SBATCH_ERROR")
+
+cd /mydir
 
 /slurm/scripts/script <$input_file 1>$output_file 2>$error_file
 `,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Add `--chdir` flag to Slurm for changing directory before executing the script.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```