### PR TITLE
Make LossLessDefaulter selective to only prevent dropping fields outside of schema.

### DIFF
--- a/pkg/controller/jobframework/webhook/defaulter.go
+++ b/pkg/controller/jobframework/webhook/defaulter.go
@@ -94,14 +94,7 @@ func fieldExistsByJSONPathHelper(object interface{}, pathParts []string) bool {
 		ft := t.Field(i)
 		fv := v.Field(i)
 
-		tag := ft.Tag.Get("json")
-		if tag == "" {
-			tag = ft.Name
-		} else if tagParts := strings.Split(tag, ","); len(tagParts) > 1 {
-			tag = tagParts[0]
-		}
-
-		if tag != pathParts[0] {
+		if getFieldName(ft) != pathParts[0] {
 			continue
 		}
 
@@ -124,6 +117,18 @@ func fieldExistsByJSONPathHelper(object interface{}, pathParts []string) bool {
 	}
 
 	return false
+}
+
+func getFieldName(fieldType reflect.StructField) string {
+	fieldName := fieldType.Tag.Get("json")
+
+	if fieldName == "" {
+		fieldName = fieldType.Name
+	} else if tagParts := strings.Split(fieldName, ","); len(tagParts) > 1 {
+		fieldName = strings.Trim(tagParts[0], " ")
+	}
+
+	return fieldName
 }
 
 func isInt(v string) bool {

--- a/pkg/controller/jobframework/webhook/defaulter.go
+++ b/pkg/controller/jobframework/webhook/defaulter.go
@@ -65,9 +65,12 @@ func (h *losslessDefaulter) Handle(ctx context.Context, req admission.Request) a
 }
 
 func fieldExistsByJSONPath(object interface{}, path string) bool {
+	// Invalid path. For more information, see https://datatracker.ietf.org/doc/html/rfc6901#section-3.
+	if !strings.HasPrefix(path, "/") {
+		return false
+	}
 	pathParts := strings.Split(path, "/")
-	// Invalid path. For more information, see https://jsonpatch.com/.
-	if len(pathParts) < 2 || len(pathParts) > 0 && pathParts[0] != "" {
+	if len(pathParts) < 2 {
 		return false
 	}
 	return fieldExistsByJSONPathHelper(object, pathParts[1:])

--- a/pkg/controller/jobframework/webhook/defaulter.go
+++ b/pkg/controller/jobframework/webhook/defaulter.go
@@ -108,8 +108,12 @@ func fieldExistsByJSONPathHelper(object interface{}, pathParts []string) bool {
 		case reflect.Struct:
 			return fieldExistsByJSONPathHelper(fv.Interface(), pathParts[1:])
 		case reflect.Array, reflect.Slice:
-			if len(pathParts) > 2 && isInt(pathParts[1]) {
-				return fieldExistsByJSONPathHelper(reflect.New(ft.Type.Elem()).Interface(), pathParts[2:])
+			if isInt(pathParts[1]) {
+				if len(pathParts) > 2 {
+					return fieldExistsByJSONPathHelper(reflect.New(ft.Type.Elem()).Interface(), pathParts[2:])
+				} else {
+					return true
+				}
 			}
 		}
 

--- a/pkg/controller/jobframework/webhook/defaulter.go
+++ b/pkg/controller/jobframework/webhook/defaulter.go
@@ -120,15 +120,13 @@ func fieldExistsByJSONPathHelper(object interface{}, pathParts []string) bool {
 }
 
 func getFieldName(fieldType reflect.StructField) string {
-	fieldName := fieldType.Tag.Get("json")
-
-	if fieldName == "" {
-		fieldName = fieldType.Name
-	} else if tagParts := strings.Split(fieldName, ","); len(tagParts) > 1 {
-		fieldName = strings.Trim(tagParts[0], " ")
+	jsonTag := fieldType.Tag.Get("json")
+	if jsonTag == "" {
+		jsonTag = fieldType.Name
+	} else if parts := strings.Split(jsonTag, ","); len(parts) > 1 {
+		jsonTag = strings.Trim(parts[0], " ")
 	}
-
-	return fieldName
+	return jsonTag
 }
 
 func isInt(v string) bool {

--- a/pkg/controller/jobframework/webhook/defaulter_test.go
+++ b/pkg/controller/jobframework/webhook/defaulter_test.go
@@ -39,13 +39,23 @@ var (
 )
 
 type TestResource struct {
-	Foo  string   `json:"foo,omitempty"`
-	Bar  string   `json:"bar,omitempty"`
-	Qux  []string `json:"qux,omitempty"`
-	Quux []string `json:"quux,omitempty"`
+	metav1.ObjectMeta `json:",inline"`
 
-	SubResource TestSubResource    `json:"subresource"`
+	Foo string   `json:"foo,omitempty"`
+	Bar string   `json:"bar,omitempty"`
+	Baz []string `json:"baz,omitempty"`
+
 	Conditions  []metav1.Condition `json:"conditions,omitempty"`
+	Items       []TestResourceItem `json:"items,omitempty"`
+	SubResource TestSubResource    `json:"subresource"`
+}
+
+type TestResourceItem struct {
+	SubItems []TestResourceSubItem `json:"subItems,omitempty"`
+}
+
+type TestResourceSubItem struct {
+	Baz []string `json:"baz,omitempty"`
 }
 
 type TestSubResource struct {
@@ -76,23 +86,21 @@ func (*TestCustomDefaulter) Default(ctx context.Context, obj runtime.Object) err
 	if d.Bar == "bar" {
 		d.Bar = ""
 	}
-	if d.SubResource.Foo == "foo" {
-		d.SubResource.Foo = ""
+	if len(d.Baz) > 0 {
+		d.Baz = nil
 	}
-	if ptr.Deref(d.SubResource.Bar, "") == "bar" {
-		d.SubResource.Bar = nil
+
+	if d.Labels != nil {
+		delete(d.Labels, "example.com/foo")
 	}
-	if len(d.Qux) > 0 {
-		d.Qux = nil
-	}
-	if len(d.Quux) > 0 {
-		quux := make([]string, 0, len(d.Quux))
-		for _, val := range d.Quux {
+	if len(d.Finalizers) > 0 {
+		finalizers := make([]string, 0, len(d.Finalizers))
+		for _, val := range d.Finalizers {
 			if val != "foo" {
-				quux = append(quux, val)
+				finalizers = append(finalizers, val)
 			}
 		}
-		d.Quux = quux
+		d.Finalizers = finalizers
 	}
 	if len(d.Conditions) > 0 {
 		conditions := make([]metav1.Condition, 0, len(d.Conditions))
@@ -104,59 +112,117 @@ func (*TestCustomDefaulter) Default(ctx context.Context, obj runtime.Object) err
 		}
 		d.Conditions = conditions
 	}
+
+	// Checking the case `/items/0/subItems/0/baz/1`.
+	if len(d.Items) > 0 && len(d.Items[0].SubItems) > 0 {
+		baz := make([]string, 0, len(d.Items[0].SubItems[0].Baz))
+		for _, val := range d.Items[0].SubItems[0].Baz {
+			if val != "foo" {
+				baz = append(baz, val)
+			}
+		}
+		d.Items[0].SubItems[0].Baz = baz
+	}
+
+	if d.SubResource.Foo == "foo" {
+		d.SubResource.Foo = ""
+	}
+	if ptr.Deref(d.SubResource.Bar, "") == "bar" {
+		d.SubResource.Bar = nil
+	}
+
 	return nil
 }
 
 func TestLossLessDefaulter(t *testing.T) {
-	sch := runtime.NewScheme()
-	builder := scheme.Builder{GroupVersion: testResourceGVK.GroupVersion()}
-	builder.Register(&TestResource{})
-	if err := builder.AddToScheme(sch); err != nil {
-		t.Fatalf("Couldn't add types to scheme: %v", err)
-	}
-
-	handler := WithLosslessDefaulter(sch, &TestResource{}, &TestCustomDefaulter{})
-
-	req := admission.Request{
-		AdmissionRequest: admissionv1.AdmissionRequest{
-			Kind: metav1.GroupVersionKind(testResourceGVK),
-			Object: runtime.RawExtension{
-				// This raw object has a field not defined in the go type.
-				// controller-runtime CustomDefaulter would have added a remove operation for it.
-				Raw: []byte(`{
-	"hoge": "hoge",
-	"fuga": ["hoge"],
+	testCases := map[string]struct {
+		request     admission.Request
+		wantAllowed bool
+		wantResult  *metav1.Status
+		wantPatches []jsonpatch.Operation
+	}{
+		"valid request with unknown fields": {
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind(testResourceGVK),
+					Object: runtime.RawExtension{
+						// This raw object has fields not defined in the go type.
+						// controller-runtime CustomDefaulter would have added remove operations for it.
+						Raw: []byte(`{
+	"unknown1": "unknown",
+	"unknown2": ["unknown"],
+	"unknown/unknown": "unknown",
 	"bar": "bar", 
-	"qux": ["foo"],
-	"quux": ["foo","bar"],
-	"subresource": {"hoge": "hoge", "fuga": ["hoge"], "foo": "foo", "bar": "bar"},
+	"baz": ["foo"],
+	"finalizers": ["foo","bar"],
+	"labels": {"example.com/foo": "foo", "example.com/bar": "bar", "unknown": "unknown"},
+	"subresource": {"unknown1": "unknown", "unknown2": ["unknown"], "foo": "foo", "bar": "bar"},
 	"conditions": [
-		{"type": "foo", "message": "foo", "reason": "", "status": "", "lastTransitionTime": null, "observedGeneration": 1}, 
-		{"type": "bar", "message": "bar", "reason": "", "status": "", "lastTransitionTime": null, "observedGeneration": 1}
-	]
+		{"type": "foo", "message": "foo", "reason": "", "status": "", "lastTransitionTime": null, "observedGeneration": 1, "unknown": "unknown"}, 
+		{"type": "bar", "message": "bar", "reason": "", "status": "", "lastTransitionTime": null, "observedGeneration": 1, "unknown": "unknown"}
+	],
+	"items": [{"subItems": [{ "unknown1": "unknown", "baz": ["foo"] }] }]	
 }`),
+					},
+				},
+			},
+			wantAllowed: true,
+			wantPatches: []jsonpatch.Operation{
+				{Operation: "add", Path: "/creationTimestamp"},
+				{Operation: "add", Path: "/foo", Value: "foo"},
+				{Operation: "remove", Path: "/bar"},
+				{Operation: "remove", Path: "/baz"},
+				{Operation: "replace", Path: "/finalizers/0", Value: "bar"},
+				{Operation: "remove", Path: "/finalizers/1"},
+				{Operation: "remove", Path: "/labels/example.com~1foo"},
+				{Operation: "replace", Path: "/subresource/foo", Value: ""},
+				{Operation: "replace", Path: "/subresource/bar"},
+				{Operation: "remove", Path: "/conditions/0/observedGeneration"},
+				{Operation: "remove", Path: "/conditions/1"},
+				{Operation: "remove", Path: "/items/0/subItems/0/baz"},
+			},
+		},
+		"invalid request": {
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind(testResourceGVK),
+					Object: runtime.RawExtension{
+						Raw: []byte(`{"foo": 1}`),
+					},
+				},
+			},
+			wantResult: &metav1.Status{
+				Message: "json: cannot unmarshal number into Go struct field TestResource.foo of type string",
+				Code:    400,
 			},
 		},
 	}
-	resp := handler.Handle(context.Background(), req)
-	if !resp.Allowed {
-		t.Errorf("Response not allowed")
-	}
-	wantPatches := []jsonpatch.Operation{
-		{Operation: "add", Path: "/foo", Value: "foo"},
-		{Operation: "remove", Path: "/bar"},
-		{Operation: "remove", Path: "/qux"},
-		{Operation: "replace", Path: "/quux/0", Value: "bar"},
-		{Operation: "remove", Path: "/quux/1"},
-		{Operation: "replace", Path: "/subresource/foo", Value: ""},
-		{Operation: "replace", Path: "/subresource/bar"},
-		{Operation: "remove", Path: "/conditions/0/observedGeneration"},
-		{Operation: "remove", Path: "/conditions/1"},
-	}
-	if diff := cmp.Diff(wantPatches, resp.Patches, cmpopts.SortSlices(func(a, b jsonpatch.Operation) bool {
-		return a.Path < b.Path
-	})); diff != "" {
-		t.Errorf("Unexpected patches (-want, +got): %s", diff)
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			sch := runtime.NewScheme()
+			builder := scheme.Builder{GroupVersion: testResourceGVK.GroupVersion()}
+			builder.Register(&TestResource{})
+			if err := builder.AddToScheme(sch); err != nil {
+				t.Fatalf("Couldn't add types to scheme: %v", err)
+			}
+
+			handler := WithLosslessDefaulter(sch, &TestResource{}, &TestCustomDefaulter{})
+			resp := handler.Handle(context.Background(), tc.request)
+
+			if diff := cmp.Diff(tc.wantAllowed, resp.Allowed); diff != "" {
+				t.Errorf("Unexpected allowed option (-want, +got): %s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantResult, resp.Result); diff != "" {
+				t.Errorf("Unexpected result (-want, +got): %s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantPatches, resp.Patches, cmpopts.SortSlices(func(a, b jsonpatch.Operation) bool {
+				return a.Path < b.Path
+			})); diff != "" {
+				t.Errorf("Unexpected patches (-want, +got): %s", diff)
+			}
+		})
 	}
 }
 
@@ -188,19 +254,17 @@ func TestFieldExistsByJSONPath(t *testing.T) {
 			obj: struct {
 				Foo struct{} `json:"foo,omitempty"`
 			}{},
-			path:       "foo/",
+			path:       "//",
 			wantExists: false,
 		},
 		"invalid path 3": {
 			obj: struct {
-				Foo struct {
-					Bar string `json:"bar,omitempty"`
-				} `json:"foo,omitempty"`
+				Foo struct{} `json:"foo,omitempty"`
 			}{},
-			path:       "foo/bar",
+			path:       "foo/",
 			wantExists: false,
 		},
-		"invalid path 4": {
+		"invalid path 5": {
 			obj: struct {
 				Foo struct{} `json:"foo,omitempty"`
 			}{},
@@ -218,6 +282,20 @@ func TestFieldExistsByJSONPath(t *testing.T) {
 				Bar string `json:"bar"`
 			}{},
 			path:       "/bar",
+			wantExists: true,
+		},
+		"exists with escaped ~": {
+			obj: struct {
+				Bar string `json:"bar~baz"`
+			}{},
+			path:       "/bar~0baz",
+			wantExists: true,
+		},
+		"exists with escaped /": {
+			obj: struct {
+				Bar string `json:"bar/baz"`
+			}{},
+			path:       "/bar~1baz",
 			wantExists: true,
 		},
 		"exists with slice": {
@@ -321,6 +399,44 @@ func TestFieldExistsByJSONPath(t *testing.T) {
 			path:       "/foo/bar",
 			wantExists: true,
 		},
+		"exists with map invalid key 1": {
+			obj: struct {
+				Foo *struct {
+					Bar map[int]string `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/bar/baz",
+			wantExists: false,
+		},
+		"exists with map": {
+			obj: struct {
+				Foo *struct {
+					Bar map[string]string `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/bar/baz",
+			wantExists: true,
+		},
+		"exists with map and dot": {
+			obj: struct {
+				Foo *struct {
+					Bar map[string]string `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/bar/baz.qux",
+			wantExists: true,
+		},
+		"exists with map struct": {
+			obj: struct {
+				Foo *struct {
+					Bar map[string]struct {
+						Qux string `json:"qux,omitempty"`
+					} `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/bar/baz/qux",
+			wantExists: true,
+		},
 		"not exists": {
 			obj:        struct{}{},
 			path:       "/foo",
@@ -390,7 +506,7 @@ func TestFieldExistsByJSONPath(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotExists := fieldExistsByJSONPath(tc.obj, tc.path)
+			gotExists := fieldExistsByJSONPointer(tc.obj, tc.path)
 			if diff := cmp.Diff(tc.wantExists, gotExists); diff != "" {
 				t.Errorf("Unexpected exists (-want, +got): %s", diff)
 			}
@@ -416,10 +532,14 @@ func TestGetFieldName(t *testing.T) {
 			field:    reflect.StructField{Name: "Foo", Tag: `json:"foo,omitempty"`},
 			wantName: "foo",
 		},
+		"with inline": {
+			field:    reflect.StructField{Name: "Foo", Tag: `json:",inline"`},
+			wantName: "",
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotName := getFieldName(tc.field)
+			gotName := getJSONFieldName(tc.field)
 			if diff := cmp.Diff(tc.wantName, gotName); diff != "" {
 				t.Errorf("Unexpected field name (-want, +got): %s", diff)
 			}
@@ -433,8 +553,8 @@ func TestIsInt(t *testing.T) {
 		wantResult bool
 	}{
 		"empty": {
-			str:        "123",
-			wantResult: true,
+			str:        "",
+			wantResult: false,
 		},
 		"int": {
 			str:        "123",

--- a/pkg/controller/jobframework/webhook/defaulter_test.go
+++ b/pkg/controller/jobframework/webhook/defaulter_test.go
@@ -175,6 +175,15 @@ func TestFieldExistsByJSONPath(t *testing.T) {
 			path:       "/foo/0/bar",
 			wantExists: true,
 		},
+		"exists with array": {
+			obj: struct {
+				Foo [0]struct {
+					Bar string `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/0/bar",
+			wantExists: true,
+		},
 		"exists without tag": {
 			obj: struct {
 				Foo string
@@ -249,6 +258,15 @@ func TestFieldExistsByJSONPath(t *testing.T) {
 		"not exists with slice": {
 			obj: struct {
 				Foo []struct {
+					Bar string `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/1/baz",
+			wantExists: false,
+		},
+		"not exists with array": {
+			obj: struct {
+				Foo [0]struct {
 					Bar string `json:"bar,omitempty"`
 				} `json:"foo,omitempty"`
 			}{},

--- a/pkg/controller/jobframework/webhook/defaulter_test.go
+++ b/pkg/controller/jobframework/webhook/defaulter_test.go
@@ -37,6 +37,7 @@ var (
 
 type TestResource struct {
 	Foo string `json:"foo,omitempty"`
+	Bar string `json:"bar,omitempty"`
 }
 
 func (d *TestResource) GetObjectKind() schema.ObjectKind { return d }
@@ -59,6 +60,9 @@ func (*TestCustomDefaulter) Default(ctx context.Context, obj runtime.Object) err
 	if d.Foo == "" {
 		d.Foo = "bar"
 	}
+	if d.Bar == "qux" {
+		d.Bar = ""
+	}
 	return nil
 }
 
@@ -78,7 +82,7 @@ func TestLossLessDefaulter(t *testing.T) {
 			Object: runtime.RawExtension{
 				// This raw object has a field not defined in the go type.
 				// controller-runtime CustomDefaulter would have added a remove operation for it.
-				Raw: []byte(`{"baz": "qux"}`),
+				Raw: []byte(`{"bar": "qux", "baz": "qux"}`),
 			},
 		},
 	}
@@ -92,8 +96,196 @@ func TestLossLessDefaulter(t *testing.T) {
 			Path:      "/foo",
 			Value:     "bar",
 		},
+		{
+			Operation: "remove",
+			Path:      "/bar",
+		},
 	}
 	if diff := cmp.Diff(wantPatches, resp.Patches); diff != "" {
 		t.Errorf("Unexpected patches (-want, +got): %s", diff)
+	}
+}
+
+func TestFieldExistsByJSONPath(t *testing.T) {
+	testCases := map[string]struct {
+		obj        interface{}
+		path       string
+		wantExists bool
+	}{
+		"nil obj type": {
+			path:       "/foo",
+			wantExists: false,
+		},
+		"empty path": {
+			obj: struct {
+				Foo struct{} `json:"foo,omitempty"`
+			}{},
+			path:       "",
+			wantExists: false,
+		},
+		"invalid path 1": {
+			obj: struct {
+				Foo struct{} `json:"foo,omitempty"`
+			}{},
+			path:       "/",
+			wantExists: false,
+		},
+		"invalid path 2": {
+			obj: struct {
+				Foo struct{} `json:"foo,omitempty"`
+			}{},
+			path:       "foo/",
+			wantExists: false,
+		},
+		"invalid path 3": {
+			obj: struct {
+				Foo struct {
+					Bar string `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{},
+			path:       "foo/bar",
+			wantExists: false,
+		},
+		"invalid path 4": {
+			obj: struct {
+				Foo struct{} `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/",
+			wantExists: false,
+		},
+		"invalid object type": {
+			obj:        "invalid",
+			path:       "/foo",
+			wantExists: false,
+		},
+		"exists": {
+			obj: struct {
+				Foo string
+				Bar string `json:"bar"`
+			}{},
+			path:       "/bar",
+			wantExists: true,
+		},
+		"exists with slice": {
+			obj: struct {
+				Foo []struct {
+					Bar string `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/0/bar",
+			wantExists: true,
+		},
+		"exists without tag": {
+			obj: struct {
+				Foo string
+			}{},
+			path:       "/Foo",
+			wantExists: true,
+		},
+		"exists number": {
+			obj: struct {
+				Foo string `json:"123,omitempty"`
+			}{},
+			path:       "/123",
+			wantExists: true,
+		},
+		"exists nested": {
+			obj: struct {
+				Foo struct {
+					Bar string `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/bar",
+			wantExists: true,
+		},
+		"exists nested with pointer": {
+			obj: struct {
+				Foo *struct {
+					Bar string `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{
+				&struct {
+					Bar string `json:"bar,omitempty"`
+				}{
+					Bar: "bar",
+				},
+			},
+			path:       "/foo/bar",
+			wantExists: true,
+		},
+		"exists nested with nil pointer": {
+			obj: struct {
+				Foo *struct {
+					Bar string `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/bar",
+			wantExists: true,
+		},
+		"not exists": {
+			obj:        struct{}{},
+			path:       "/foo",
+			wantExists: false,
+		},
+		"invalid type": {
+			obj: struct {
+				Foo func() `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/bar",
+			wantExists: false,
+		},
+		"not exists nested": {
+			obj:        struct{}{},
+			path:       "/foo/bar/quz",
+			wantExists: false,
+		},
+		"not exists nested with object": {
+			obj: struct {
+				Foo struct{} `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/bar/quz",
+			wantExists: false,
+		},
+		"not exists with slice": {
+			obj: struct {
+				Foo []struct {
+					Bar string `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/1/baz",
+			wantExists: false,
+		},
+		"not exists nested with pointer": {
+			obj: struct {
+				Foo *struct {
+					Bar string `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{
+				&struct {
+					Bar string `json:"bar,omitempty"`
+				}{
+					Bar: "bar",
+				},
+			},
+			path:       "/foo/baz",
+			wantExists: false,
+		},
+		"not exists nested with nil pointer": {
+			obj: struct {
+				Foo *struct {
+					Bar string `json:"bar,omitempty"`
+				} `json:"foo,omitempty"`
+			}{},
+			path:       "/foo/baz",
+			wantExists: false,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			gotExists := fieldExistsByJSONPath(tc.obj, tc.path)
+			if diff := cmp.Diff(tc.wantExists, gotExists); diff != "" {
+				t.Errorf("Unexpected patches (-want, +got): %s", diff)
+			}
+		})
 	}
 }

--- a/pkg/controller/jobframework/webhook/defaulter_test.go
+++ b/pkg/controller/jobframework/webhook/defaulter_test.go
@@ -18,6 +18,7 @@ package webhook
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -302,7 +303,64 @@ func TestFieldExistsByJSONPath(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			gotExists := fieldExistsByJSONPath(tc.obj, tc.path)
 			if diff := cmp.Diff(tc.wantExists, gotExists); diff != "" {
-				t.Errorf("Unexpected patches (-want, +got): %s", diff)
+				t.Errorf("Unexpected exists (-want, +got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestGetFieldName(t *testing.T) {
+	testCases := map[string]struct {
+		field    reflect.StructField
+		wantName string
+	}{
+		"empty": {},
+		"with json tag": {
+			field:    reflect.StructField{Name: "Foo", Tag: `json:"foo"`},
+			wantName: "foo",
+		},
+		"without json tag": {
+			field:    reflect.StructField{Name: "Foo", Tag: `foo:"bar"`},
+			wantName: "Foo",
+		},
+		"with json tag and omitempty": {
+			field:    reflect.StructField{Name: "Foo", Tag: `json:"foo,omitempty"`},
+			wantName: "foo",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			gotName := getFieldName(tc.field)
+			if diff := cmp.Diff(tc.wantName, gotName); diff != "" {
+				t.Errorf("Unexpected field name (-want, +got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestIsInt(t *testing.T) {
+	testCases := map[string]struct {
+		str        string
+		wantResult bool
+	}{
+		"empty": {
+			str:        "123",
+			wantResult: true,
+		},
+		"int": {
+			str:        "123",
+			wantResult: true,
+		},
+		"not int": {
+			str:        "string",
+			wantResult: false,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			gotResult := isInt(tc.str)
+			if diff := cmp.Diff(tc.wantResult, gotResult); diff != "" {
+				t.Errorf("Unexpected result (-want, +got): %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Make `LossLessDefaulter` selective to only prevent dropping fields outside of schema.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3174

#### Special notes for your reviewer:
For more information see:

- https://jsonpatch.com/
- https://datatracker.ietf.org/doc/html/rfc6902/
- https://datatracker.ietf.org/doc/html/rfc6901

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```