### PR TITLE
[kjobctl] Fix --mem-per-gpu flag

### DIFF
--- a/cmd/experimental/kjobctl/pkg/builder/slurm_builder.go
+++ b/cmd/experimental/kjobctl/pkg/builder/slurm_builder.go
@@ -125,6 +125,10 @@ func (b *slurmBuilder) validateGeneral(ctx context.Context) error {
 		return noCpusPerTaskSpecifiedErr
 	}
 
+	if b.memPerGPU != nil && b.gpusPerTask == nil {
+		return noGpusPerTaskSpecifiedErr
+	}
+
 	// check that priority class exists
 	if len(b.priority) != 0 && !b.skipPriorityValidation {
 		_, err := b.kueueClientset.KueueV1beta1().WorkloadPriorityClasses().Get(ctx, b.priority, metav1.GetOptions{})
@@ -430,7 +434,7 @@ func (b *slurmBuilder) build(ctx context.Context) (runtime.Object, []runtime.Obj
 	totalGpus.Mul(totalTasks)
 	b.totalGpus = int32(totalGpus.Value())
 
-	if b.totalGpus > 0 {
+	if b.cpusOnNode != nil && b.totalGpus > 0 {
 		cpusPerGpu := b.cpusOnNode.Value() / int64(b.totalGpus)
 		b.cpusPerGpu = resource.NewQuantity(cpusPerGpu, resource.DecimalSI)
 	}

--- a/cmd/experimental/kjobctl/pkg/cmd/create/create.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/create/create.go
@@ -527,7 +527,7 @@ func (o *CreateOptions) Complete(clientGetter util.ClientGetter, cmd *cobra.Comm
 	}
 
 	if o.SlurmFlagSet.Changed(gpusPerTaskFlagName) {
-		gpusPerTask, err := parser.GpusFlag(gpusPerTaskFlagName)
+		gpusPerTask, err := parser.GpusFlag(o.UserSpecifiedGpusPerTask)
 		if err != nil {
 			return fmt.Errorf("cannot parse '%s': %w", o.UserSpecifiedCpusPerTask, err)
 		}

--- a/cmd/experimental/kjobctl/pkg/cmd/create/create.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/create/create.go
@@ -529,7 +529,7 @@ func (o *CreateOptions) Complete(clientGetter util.ClientGetter, cmd *cobra.Comm
 	if o.SlurmFlagSet.Changed(gpusPerTaskFlagName) {
 		gpusPerTask, err := parser.GpusFlag(o.UserSpecifiedGpusPerTask)
 		if err != nil {
-			return fmt.Errorf("cannot parse '%s': %w", o.UserSpecifiedCpusPerTask, err)
+			return fmt.Errorf("cannot parse '%s': %w", o.UserSpecifiedGpusPerTask, err)
 		}
 		o.GpusPerTask = gpusPerTask
 	}

--- a/cmd/experimental/kjobctl/pkg/cmd/create/create_test.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/create/create_test.go
@@ -1489,6 +1489,29 @@ cd /mydir
 			},
 			wantOutPattern: `job\.batch\/.+ created\\nconfigmap\/.+ created`,
 		},
+		"shouldn't create slurm with --mem-per-gpu flag because --gpus-per-task flag not specified": {
+			beforeTest: beforeSlurmTest,
+			afterTest:  afterSlurmTest,
+			args: func(tc *createCmdTestCase) []string {
+				return []string{
+					"slurm",
+					"--profile", "profile",
+					"--",
+					"--mem-per-gpu", "500M",
+					tc.tempFile,
+				}
+			},
+			kjobctlObjs: []runtime.Object{
+				wrappers.MakeJobTemplate("slurm-job-template", metav1.NamespaceDefault).
+					WithContainer(*wrappers.MakeContainer("c1", "bash:4.4").Obj()).
+					WithContainer(*wrappers.MakeContainer("c2", "bash:4.4").Obj()).
+					Obj(),
+				wrappers.MakeApplicationProfile("profile", metav1.NamespaceDefault).
+					WithSupportedMode(*wrappers.MakeSupportedMode(v1alpha1.SlurmMode, "slurm-job-template").Obj()).
+					Obj(),
+			},
+			wantErr: "no gpus-per-task specified",
+		},
 		"should create slurm with --priority flag and skip workload priority class validation": {
 			beforeTest: beforeSlurmTest,
 			afterTest:  afterSlurmTest,

--- a/cmd/experimental/kjobctl/pkg/cmd/create/create_test.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/create/create_test.go
@@ -1418,6 +1418,77 @@ cd /mydir
 			},
 			wantOutPattern: `job\.batch\/.+ created\\nconfigmap\/.+ created`,
 		},
+		"should create slurm with --mem-per-gpu flag": {
+			beforeTest: beforeSlurmTest,
+			afterTest:  afterSlurmTest,
+			args: func(tc *createCmdTestCase) []string {
+				return []string{
+					"slurm",
+					"--profile", "profile",
+					"--",
+					"--gpus-per-task", "volta:3,kepler:1",
+					"--mem-per-gpu", "500M",
+					tc.tempFile,
+				}
+			},
+			kjobctlObjs: []runtime.Object{
+				wrappers.MakeJobTemplate("slurm-job-template", metav1.NamespaceDefault).
+					WithContainer(*wrappers.MakeContainer("c1", "bash:4.4").Obj()).
+					WithContainer(*wrappers.MakeContainer("c2", "bash:4.4").Obj()).
+					Obj(),
+				wrappers.MakeApplicationProfile("profile", metav1.NamespaceDefault).
+					WithSupportedMode(*wrappers.MakeSupportedMode(v1alpha1.SlurmMode, "slurm-job-template").Obj()).
+					Obj(),
+			},
+			gvks: []schema.GroupVersionKind{
+				{Group: "batch", Version: "v1", Kind: "Job"},
+				{Group: "", Version: "v1", Kind: "ConfigMap"},
+			},
+			wantLists: []runtime.Object{
+				&batchv1.JobList{
+					TypeMeta: metav1.TypeMeta{Kind: "JobList", APIVersion: "batch/v1"},
+					Items: []batchv1.Job{
+						*wrappers.MakeJob("", metav1.NamespaceDefault).
+							Completions(1).
+							CompletionMode(batchv1.IndexedCompletion).
+							Profile("profile").
+							Mode(v1alpha1.SlurmMode).
+							WithContainer(*wrappers.MakeContainer("c1", "bash:4.4").
+								Command("bash", "/slurm/scripts/entrypoint.sh").
+								WithResources(corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceMemory: resource.MustParse("2G"),
+										"volta":               resource.MustParse("3"),
+										"kepler":              resource.MustParse("1"),
+									},
+								}).
+								Obj()).
+							WithContainer(*wrappers.MakeContainer("c2", "bash:4.4").
+								Command("bash", "/slurm/scripts/entrypoint.sh").
+								WithResources(corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceMemory: resource.MustParse("2G"),
+										"volta":               resource.MustParse("3"),
+										"kepler":              resource.MustParse("1"),
+									},
+								}).
+								Obj()).
+							Obj(),
+					},
+				},
+				&corev1.ConfigMapList{},
+			},
+			cmpopts: []cmp.Option{
+				cmpopts.IgnoreFields(corev1.LocalObjectReference{}, "Name"),
+				cmpopts.IgnoreFields(metav1.OwnerReference{}, "Name"),
+				cmpopts.IgnoreFields(corev1.PodSpec{}, "InitContainers"),
+				cmpopts.IgnoreTypes([]corev1.EnvVar{}),
+				cmpopts.IgnoreTypes([]corev1.Volume{}),
+				cmpopts.IgnoreTypes([]corev1.VolumeMount{}),
+				cmpopts.IgnoreTypes(corev1.ConfigMapList{}),
+			},
+			wantOutPattern: `job\.batch\/.+ created\\nconfigmap\/.+ created`,
+		},
 		"should create slurm with --priority flag and skip workload priority class validation": {
 			beforeTest: beforeSlurmTest,
 			afterTest:  afterSlurmTest,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
Fix issue that passes the wrong value to GPUs parser when using `--mem-per-gpu`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```