### PR TITLE
Fast admission annotation

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -678,21 +678,17 @@ func (p *Pod) constructGroupPodSets() ([]kueue.PodSet, error) {
 }
 
 func constructGroupPodSetsFast(p *Pod, groupTotalCount int) ([]kueue.PodSet, error) {
-	podSets := make([]kueue.PodSet, 1)
-	for i, podInGroup := range p.list.Items {
+	for _, podInGroup := range p.list.Items {
 		if !isPodRunnableOrSucceeded(&podInGroup) {
 			continue
 		}
-
 		roleHash, err := getRoleHash(podInGroup)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate pod role hash: %w", err)
 		}
-
-		podSet := FromObject(&podInGroup).PodSets()
-		podSet[0].Name = roleHash
-		podSet[0].Count = int32(groupTotalCount)
-		podSets[i] = podSet[0]
+		podSets := FromObject(&podInGroup).PodSets()
+		podSets[0].Name = roleHash
+		podSets[0].Count = int32(groupTotalCount)
 		return podSets, nil
 	}
 

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -40,13 +40,14 @@ import (
 )
 
 const (
-	ManagedLabelKey            = constants.ManagedByKueueLabel
-	ManagedLabelValue          = "true"
-	PodFinalizer               = ManagedLabelKey
-	GroupNameLabel             = "kueue.x-k8s.io/pod-group-name"
-	GroupTotalCountAnnotation  = "kueue.x-k8s.io/pod-group-total-count"
-	RoleHashAnnotation         = "kueue.x-k8s.io/role-hash"
-	RetriableInGroupAnnotation = "kueue.x-k8s.io/retriable-in-group"
+	ManagedLabelKey              = constants.ManagedByKueueLabel
+	ManagedLabelValue            = "true"
+	PodFinalizer                 = ManagedLabelKey
+	GroupNameLabel               = "kueue.x-k8s.io/pod-group-name"
+	GroupTotalCountAnnotation    = "kueue.x-k8s.io/pod-group-total-count"
+	GroupFastAdmissionAnnotation = "kueue.x-k8s.io/pod-group-fast-admission"
+	RoleHashAnnotation           = "kueue.x-k8s.io/role-hash"
+	RetriableInGroupAnnotation   = "kueue.x-k8s.io/retriable-in-group"
 )
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The PodGroup integration waits until all pods are created, but StatefulSet creates second pod only after all previous pods are running, so there was a deadlock. The solution to this is to introduce the kueue.x-k8s.io/fast-pod-group-admission annotation, when true, then the Pod group does not need to wait for all pods with ungating. Part of https://github.com/kubernetes-sigs/kueue/issues/2717

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```