### PR TITLE
[jobs]Add max execution time

### DIFF
--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -39,4 +39,7 @@ const (
 
 	// ProvReqAnnotationPrefix is the prefix for annotations that should be pass to ProvisioningRequest as Parameters.
 	ProvReqAnnotationPrefix = "provreq.kueue.x-k8s.io/"
+
+	// MaxExecTimeSecondsLabel is the label key in the job that holds the maximum execution time.
+	MaxExecTimeSecondsLabel = `kueue.x-k8s.io/max-exec-time-seconds`
 )

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -146,7 +146,7 @@ func QueueNameForObject(object client.Object) string {
 	return object.GetAnnotations()[constants.QueueAnnotation]
 }
 
-func MaxExecTime(job GenericJob) *int32 {
+func MaximumExecutionTimeSeconds(job GenericJob) *int32 {
 	strVal, found := job.Object().GetLabels()[constants.MaxExecTimeSecondsLabel]
 	if !found {
 		return nil

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -18,12 +18,14 @@ package jobframework
 
 import (
 	"context"
+	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -142,6 +144,20 @@ func QueueNameForObject(object client.Object) string {
 	}
 	// fallback to the annotation (deprecated)
 	return object.GetAnnotations()[constants.QueueAnnotation]
+}
+
+func MaxExecTime(job GenericJob) *int32 {
+	strVal, found := job.Object().GetLabels()[constants.MaxExecTimeSecondsLabel]
+	if !found {
+		return nil
+	}
+
+	v, err := strconv.ParseInt(strVal, 10, 32)
+	if err != nil || v <= 0 {
+		return nil
+	}
+
+	return ptr.To[int32](int32(v))
 }
 
 func workloadPriorityClassName(job GenericJob) string {

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -157,7 +157,7 @@ func MaximumExecutionTimeSeconds(job GenericJob) *int32 {
 		return nil
 	}
 
-	return ptr.To[int32](int32(v))
+	return ptr.To(int32(v))
 }
 
 func workloadPriorityClassName(job GenericJob) string {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -758,6 +759,11 @@ func equivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, 
 	// Indexes don't work in unit tests, so we explicitly check for the
 	// owner here.
 	if owner.Name != job.Object().GetName() {
+		return false
+	}
+
+	defaultDuration := int32(-1)
+	if ptr.Deref(wl.Spec.MaximumExecutionTimeSeconds, defaultDuration) != ptr.Deref(MaxExecTime(job), defaultDuration) {
 		return false
 	}
 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -763,7 +763,7 @@ func equivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, 
 	}
 
 	defaultDuration := int32(-1)
-	if ptr.Deref(wl.Spec.MaximumExecutionTimeSeconds, defaultDuration) != ptr.Deref(MaxExecTime(job), defaultDuration) {
+	if ptr.Deref(wl.Spec.MaximumExecutionTimeSeconds, defaultDuration) != ptr.Deref(MaximumExecutionTimeSeconds(job), defaultDuration) {
 		return false
 	}
 
@@ -908,7 +908,7 @@ func (r *JobReconciler) constructWorkload(ctx context.Context, job GenericJob, o
 		Spec: kueue.WorkloadSpec{
 			PodSets:                     podSets,
 			QueueName:                   QueueName(job),
-			MaximumExecutionTimeSeconds: MaxExecTime(job),
+			MaximumExecutionTimeSeconds: MaximumExecutionTimeSeconds(job),
 		},
 	}
 	if wl.Labels == nil {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -900,8 +900,9 @@ func (r *JobReconciler) constructWorkload(ctx context.Context, job GenericJob, o
 			Annotations: admissioncheck.FilterProvReqAnnotations(job.Object().GetAnnotations()),
 		},
 		Spec: kueue.WorkloadSpec{
-			PodSets:   podSets,
-			QueueName: QueueName(job),
+			PodSets:                     podSets,
+			QueueName:                   QueueName(job),
+			MaximumExecutionTimeSeconds: MaxExecTime(job),
 		},
 	}
 	if wl.Labels == nil {

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -18,6 +18,7 @@ package jobframework
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	kfmpi "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
@@ -36,6 +37,7 @@ var (
 	annotationsPath               = field.NewPath("metadata", "annotations")
 	labelsPath                    = field.NewPath("metadata", "labels")
 	queueNameLabelPath            = labelsPath.Key(constants.QueueLabel)
+	maxExecTimeLabelPath          = labelsPath.Key(constants.MaxExecTimeSecondsLabel)
 	workloadPriorityClassNamePath = labelsPath.Key(constants.WorkloadPriorityClassLabel)
 	supportedPrebuiltWlJobGVKs    = sets.New(
 		batchv1.SchemeGroupVersion.WithKind("Job").String(),
@@ -49,13 +51,16 @@ var (
 
 // ValidateJobOnCreate encapsulates all GenericJob validations that must be performed on a Create operation
 func ValidateJobOnCreate(job GenericJob) field.ErrorList {
-	return validateCreateForQueueName(job)
+	allErrs := validateCreateForQueueName(job)
+	allErrs = append(allErrs, validateCreateForMaxExecTime(job)...)
+	return allErrs
 }
 
 // ValidateJobOnUpdate encapsulates all GenericJob validations that must be performed on a Update operation
 func ValidateJobOnUpdate(oldJob, newJob GenericJob) field.ErrorList {
 	allErrs := validateUpdateForQueueName(oldJob, newJob)
 	allErrs = append(allErrs, validateUpdateForWorkloadPriorityClassName(oldJob, newJob)...)
+	allErrs = append(allErrs, validateUpdateForMaxExecTime(oldJob, newJob)...)
 	return allErrs
 }
 
@@ -110,4 +115,25 @@ func validateUpdateForQueueName(oldJob, newJob GenericJob) field.ErrorList {
 func validateUpdateForWorkloadPriorityClassName(oldJob, newJob GenericJob) field.ErrorList {
 	allErrs := apivalidation.ValidateImmutableField(workloadPriorityClassName(newJob), workloadPriorityClassName(oldJob), workloadPriorityClassNamePath)
 	return allErrs
+}
+
+func validateCreateForMaxExecTime(job GenericJob) field.ErrorList {
+	if strVal, found := job.Object().GetLabels()[constants.MaxExecTimeSecondsLabel]; found {
+		v, err := strconv.Atoi(strVal)
+		if err != nil {
+			return field.ErrorList{field.Invalid(maxExecTimeLabelPath, strVal, err.Error())}
+		}
+
+		if v <= 0 {
+			return field.ErrorList{field.Invalid(maxExecTimeLabelPath, v, "should be grater then 0")}
+		}
+	}
+	return nil
+}
+
+func validateUpdateForMaxExecTime(oldJob, newJob GenericJob) field.ErrorList {
+	if !newJob.IsSuspended() || !oldJob.IsSuspended() {
+		return apivalidation.ValidateImmutableField(newJob.Object().GetLabels()[constants.MaxExecTimeSecondsLabel], oldJob.Object().GetLabels()[constants.MaxExecTimeSecondsLabel], maxExecTimeLabelPath)
+	}
+	return nil
 }

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -125,7 +125,7 @@ func validateCreateForMaxExecTime(job GenericJob) field.ErrorList {
 		}
 
 		if v <= 0 {
-			return field.ErrorList{field.Invalid(maxExecTimeLabelPath, v, "should be grater then 0")}
+			return field.ErrorList{field.Invalid(maxExecTimeLabelPath, v, "should be greater than 0")}
 		}
 	}
 	return nil

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -244,7 +244,7 @@ func TestValidateCreate(t *testing.T) {
 				Indexed(true).
 				Obj(),
 			wantErr: field.ErrorList{
-				field.Invalid(maxExecTimeLabelPath, 0, "should be grater then 0"),
+				field.Invalid(maxExecTimeLabelPath, 0, "should be greater than 0"),
 			},
 			serverVersion: "1.31.0",
 		},
@@ -257,7 +257,7 @@ func TestValidateCreate(t *testing.T) {
 				Indexed(true).
 				Obj(),
 			wantErr: field.ErrorList{
-				field.Invalid(maxExecTimeLabelPath, -10, "should be grater then 0"),
+				field.Invalid(maxExecTimeLabelPath, -10, "should be greater than 0"),
 			},
 			serverVersion: "1.31.0",
 		},
@@ -488,8 +488,18 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 			newJob: testingutil.MakeJob("job", "default").
 				Suspend(false).
-				Parallelism(5).
-				Completions(6).
+				Label(constants.MaxExecTimeSecondsLabel, "20").
+				Obj(),
+			wantErr: apivalidation.ValidateImmutableField("20", "10", maxExecTimeLabelPath),
+		},
+		{
+			name: "immutable max exec time while transitioning to unsuspended",
+			oldJob: testingutil.MakeJob("job", "default").
+				Suspend(true).
+				Label(constants.MaxExecTimeSecondsLabel, "10").
+				Obj(),
+			newJob: testingutil.MakeJob("job", "default").
+				Suspend(false).
 				Label(constants.MaxExecTimeSecondsLabel, "20").
 				Obj(),
 			wantErr: apivalidation.ValidateImmutableField("20", "10", maxExecTimeLabelPath),
@@ -502,8 +512,6 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 			newJob: testingutil.MakeJob("job", "default").
 				Suspend(true).
-				Parallelism(5).
-				Completions(6).
 				Label(constants.MaxExecTimeSecondsLabel, "20").
 				Obj(),
 		},

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -973,7 +973,7 @@ func (p *Pod) ConstructComposableWorkload(ctx context.Context, c client.Client, 
 		},
 		Spec: kueue.WorkloadSpec{
 			QueueName:                   jobframework.QueueName(p),
-			MaximumExecutionTimeSeconds: jobframework.MaxExecTime(p),
+			MaximumExecutionTimeSeconds: jobframework.MaximumExecutionTimeSeconds(p),
 		},
 	}
 
@@ -1112,7 +1112,7 @@ func (p *Pod) FindMatchingWorkloads(ctx context.Context, c client.Client, r reco
 	}
 
 	defaultDuration := int32(-1)
-	if ptr.Deref(workload.Spec.MaximumExecutionTimeSeconds, defaultDuration) != ptr.Deref(jobframework.MaxExecTime(p), defaultDuration) {
+	if ptr.Deref(workload.Spec.MaximumExecutionTimeSeconds, defaultDuration) != ptr.Deref(jobframework.MaximumExecutionTimeSeconds(p), defaultDuration) {
 		return nil, []*kueue.Workload{workload}, nil
 	}
 

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -972,7 +972,8 @@ func (p *Pod) ConstructComposableWorkload(ctx context.Context, c client.Client, 
 			Annotations: admissioncheck.FilterProvReqAnnotations(p.pod.GetAnnotations()),
 		},
 		Spec: kueue.WorkloadSpec{
-			QueueName: jobframework.QueueName(p),
+			QueueName:                   jobframework.QueueName(p),
+			MaximumExecutionTimeSeconds: jobframework.MaxExecTime(p),
 		},
 	}
 

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -1111,6 +1111,11 @@ func (p *Pod) FindMatchingWorkloads(ctx context.Context, c client.Client, r reco
 		return nil, nil, err
 	}
 
+	defaultDuration := int32(-1)
+	if ptr.Deref(workload.Spec.MaximumExecutionTimeSeconds, defaultDuration) != ptr.Deref(jobframework.MaxExecTime(p), defaultDuration) {
+		return nil, []*kueue.Workload{workload}, nil
+	}
+
 	// Cleanup excess pods for each workload pod set (role)
 	activePods := p.runnableOrSucceededPods()
 	inactivePods := p.notRunnableNorSucceededPods()

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -683,6 +683,85 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
+		"workload is composed and created for the pod group with max exec time": {
+			pods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					Label(constants.ManagedByKueueLabel, "true").
+					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
+					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
+					Group("test-group").
+					GroupTotalCount("2").
+					Obj(),
+				*basePodWrapper.
+					Clone().
+					Name("pod2").
+					Label(constants.ManagedByKueueLabel, "true").
+					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
+					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
+					Group("test-group").
+					GroupTotalCount("2").
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					Label(constants.ManagedByKueueLabel, "true").
+					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
+					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
+					Group("test-group").
+					GroupTotalCount("2").
+					Obj(),
+				*basePodWrapper.
+					Clone().
+					Name("pod2").
+					Label(constants.ManagedByKueueLabel, "true").
+					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
+					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
+					Group("test-group").
+					GroupTotalCount("2").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltesting.MakePodSet("dc85db45", 2).
+							Request(corev1.ResourceCPU, "1").
+							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
+							Obj(),
+					).
+					Queue("user-queue").
+					Priority(0).
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
+					Annotations(map[string]string{
+						"kueue.x-k8s.io/is-group-workload":                           "true",
+						controllerconsts.ProvReqAnnotationPrefix + "test-annotation": "test-val"}).
+					MaximumExecutionTimeSeconds(10).
+					Obj(),
+			},
+			workloadCmpOpts: defaultWorkloadCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "pod", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "CreatedWorkload",
+					Message:   "Created Workload: ns/test-group",
+				},
+			},
+		},
 		"workload is found for the pod group": {
 			pods: []corev1.Pod{
 				*basePodWrapper.

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -691,8 +691,6 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
-					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
 					Group("test-group").
 					GroupTotalCount("2").
 					Obj(),
@@ -703,8 +701,6 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
-					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
 					Group("test-group").
 					GroupTotalCount("2").
 					Obj(),
@@ -716,8 +712,6 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
-					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
 					Group("test-group").
 					GroupTotalCount("2").
 					Obj(),
@@ -728,8 +722,6 @@ func TestReconciler(t *testing.T) {
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
-					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
-					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
 					Group("test-group").
 					GroupTotalCount("2").
 					Obj(),
@@ -747,8 +739,8 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Annotations(map[string]string{
-						"kueue.x-k8s.io/is-group-workload":                           "true",
-						controllerconsts.ProvReqAnnotationPrefix + "test-annotation": "test-val"}).
+						"kueue.x-k8s.io/is-group-workload": "true",
+					}).
 					MaximumExecutionTimeSeconds(10).
 					Obj(),
 			},
@@ -759,6 +751,91 @@ func TestReconciler(t *testing.T) {
 					EventType: "Normal",
 					Reason:    "CreatedWorkload",
 					Message:   "Created Workload: ns/test-group",
+				},
+			},
+		},
+		"workload is recreated when max exec time changes": {
+			pods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					Label(constants.ManagedByKueueLabel, "true").
+					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					Group("test-group").
+					GroupTotalCount("2").
+					Obj(),
+				*basePodWrapper.
+					Clone().
+					Name("pod2").
+					Label(constants.ManagedByKueueLabel, "true").
+					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					Group("test-group").
+					GroupTotalCount("2").
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltesting.MakePodSet("dc85db45", 2).
+							Request(corev1.ResourceCPU, "1").
+							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
+							Obj(),
+					).
+					Queue("user-queue").
+					Priority(0).
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
+					Annotations(map[string]string{"kueue.x-k8s.io/is-group-workload": "true"}).
+					MaximumExecutionTimeSeconds(5).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					Label(constants.ManagedByKueueLabel, "true").
+					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					Group("test-group").
+					GroupTotalCount("2").
+					Obj(),
+				*basePodWrapper.
+					Clone().
+					Name("pod2").
+					Label(constants.ManagedByKueueLabel, "true").
+					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					Group("test-group").
+					GroupTotalCount("2").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltesting.MakePodSet("dc85db45", 2).
+							Request(corev1.ResourceCPU, "1").
+							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
+							Obj(),
+					).
+					Queue("user-queue").
+					Priority(0).
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
+					Annotations(map[string]string{"kueue.x-k8s.io/is-group-workload": "true"}).
+					MaximumExecutionTimeSeconds(10).
+					Obj(),
+			},
+			workloadCmpOpts: defaultWorkloadCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "pod", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "UpdatedWorkload",
+					Message:   "Updated not matching Workload for suspended job: ns/test-group",
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

[jobs] Add max execution time.

Adds a new label `kueue.x-k8s.io/max-exec-time-seconds` that can be used by any supported job to enforce
a maximum execution time for its workload.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #3125

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added a new label `kueue.x-k8s.io/max-exec-time-seconds` that can be used by any supported job to enforce
a maximum execution time for its workload.
```