### PR TITLE
Make LossLessDefaulter selective to only prevent dropping fields outside of schema (unmarshal strict solution).

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/jobset v0.6.0
+	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -144,7 +145,6 @@ require (
 	k8s.io/gengo/v2 v2.0.0-20240812201722-3b05ca7b6e59 // indirect
 	k8s.io/kms v0.31.1 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 // indirect
-	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.17.3 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.17.2 // indirect
 )

--- a/pkg/controller/jobframework/webhook/defaulter_test.go
+++ b/pkg/controller/jobframework/webhook/defaulter_test.go
@@ -134,22 +134,20 @@ func (*TestCustomDefaulter) Default(ctx context.Context, obj runtime.Object) err
 }
 
 func TestLossLessDefaulter(t *testing.T) {
-	sch := runtime.NewScheme()
-	builder := scheme.Builder{GroupVersion: testResourceGVK.GroupVersion()}
-	builder.Register(&TestResource{})
-	if err := builder.AddToScheme(sch); err != nil {
-		t.Fatalf("Couldn't add types to scheme: %v", err)
-	}
-
-	handler := WithLosslessDefaulter(sch, &TestResource{}, &TestCustomDefaulter{})
-
-	req := admission.Request{
-		AdmissionRequest: admissionv1.AdmissionRequest{
-			Kind: metav1.GroupVersionKind(testResourceGVK),
-			Object: runtime.RawExtension{
-				// This raw object has fields not defined in the go type.
-				// controller-runtime CustomDefaulter would have added remove operations for it.
-				Raw: []byte(`{
+	testCases := map[string]struct {
+		request     admission.Request
+		wantAllowed bool
+		wantResult  *metav1.Status
+		wantPatches []jsonpatch.Operation
+	}{
+		"valid request with unknown fields": {
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind(testResourceGVK),
+					Object: runtime.RawExtension{
+						// This raw object has fields not defined in the go type.
+						// controller-runtime CustomDefaulter would have added remove operations for it.
+						Raw: []byte(`{
 	"unknown1": "unknown",
 	"unknown2": ["unknown"],
 	"unknown/unknown": "unknown",
@@ -164,30 +162,65 @@ func TestLossLessDefaulter(t *testing.T) {
 	],
 	"items": [{"subItems": [{ "unknown1": "unknown", "baz": ["foo"] }] }]	
 }`),
+					},
+				},
+			},
+			wantAllowed: true,
+			wantPatches: []jsonpatch.Operation{
+				{Operation: "add", Path: "/creationTimestamp"},
+				{Operation: "add", Path: "/foo", Value: "foo"},
+				{Operation: "remove", Path: "/bar"},
+				{Operation: "remove", Path: "/baz"},
+				{Operation: "replace", Path: "/finalizers/0", Value: "bar"},
+				{Operation: "remove", Path: "/finalizers/1"},
+				{Operation: "remove", Path: "/labels/example.com~1foo"},
+				{Operation: "replace", Path: "/subresource/foo", Value: ""},
+				{Operation: "replace", Path: "/subresource/bar"},
+				{Operation: "remove", Path: "/conditions/0/observedGeneration"},
+				{Operation: "remove", Path: "/conditions/1"},
+				{Operation: "remove", Path: "/items/0/subItems/0/baz"},
+			},
+		},
+		"invalid request": {
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Kind: metav1.GroupVersionKind(testResourceGVK),
+					Object: runtime.RawExtension{
+						Raw: []byte(`{"foo": 1}`),
+					},
+				},
+			},
+			wantResult: &metav1.Status{
+				Message: "json: cannot unmarshal number into Go struct field TestResource.foo of type string",
+				Code:    400,
 			},
 		},
 	}
-	resp := handler.Handle(context.Background(), req)
-	if !resp.Allowed {
-		t.Errorf("Response not allowed")
-	}
-	wantPatches := []jsonpatch.Operation{
-		{Operation: "add", Path: "/creationTimestamp"},
-		{Operation: "add", Path: "/foo", Value: "foo"},
-		{Operation: "remove", Path: "/bar"},
-		{Operation: "remove", Path: "/baz"},
-		{Operation: "replace", Path: "/finalizers/0", Value: "bar"},
-		{Operation: "remove", Path: "/finalizers/1"},
-		{Operation: "remove", Path: "/labels/example.com~1foo"},
-		{Operation: "replace", Path: "/subresource/foo", Value: ""},
-		{Operation: "replace", Path: "/subresource/bar"},
-		{Operation: "remove", Path: "/conditions/0/observedGeneration"},
-		{Operation: "remove", Path: "/conditions/1"},
-		{Operation: "remove", Path: "/items/0/subItems/0/baz"},
-	}
-	if diff := cmp.Diff(wantPatches, resp.Patches, cmpopts.SortSlices(func(a, b jsonpatch.Operation) bool {
-		return a.Path < b.Path
-	})); diff != "" {
-		t.Errorf("Unexpected patches (-want, +got): %s", diff)
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			sch := runtime.NewScheme()
+			builder := scheme.Builder{GroupVersion: testResourceGVK.GroupVersion()}
+			builder.Register(&TestResource{})
+			if err := builder.AddToScheme(sch); err != nil {
+				t.Fatalf("Couldn't add types to scheme: %v", err)
+			}
+
+			handler := WithLosslessDefaulter(sch, &TestResource{}, &TestCustomDefaulter{})
+			resp := handler.Handle(context.Background(), tc.request)
+
+			if diff := cmp.Diff(tc.wantAllowed, resp.Allowed); diff != "" {
+				t.Errorf("Unexpected allowed option (-want, +got): %s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantResult, resp.Result); diff != "" {
+				t.Errorf("Unexpected result (-want, +got): %s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantPatches, resp.Patches, cmpopts.SortSlices(func(a, b jsonpatch.Operation) bool {
+				return a.Path < b.Path
+			})); diff != "" {
+				t.Errorf("Unexpected patches (-want, +got): %s", diff)
+			}
+		})
 	}
 }

--- a/pkg/controller/jobframework/webhook/defaulter_test.go
+++ b/pkg/controller/jobframework/webhook/defaulter_test.go
@@ -38,12 +38,12 @@ var (
 )
 
 type TestResource struct {
+	metav1.ObjectMeta `json:",inline"`
+
 	Foo string   `json:"foo,omitempty"`
 	Bar string   `json:"bar,omitempty"`
 	Baz []string `json:"baz,omitempty"`
 
-	Labels     map[string]string  `json:"labels,omitempty"`
-	Finalizers []string           `json:"finalizers,omitempty"`
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	SubResource TestSubResource `json:"subresource"`
@@ -151,6 +151,7 @@ func TestLossLessDefaulter(t *testing.T) {
 		t.Errorf("Response not allowed")
 	}
 	wantPatches := []jsonpatch.Operation{
+		{Operation: "add", Path: "/creationTimestamp"},
 		{Operation: "add", Path: "/foo", Value: "foo"},
 		{Operation: "remove", Path: "/bar"},
 		{Operation: "remove", Path: "/baz"},

--- a/pkg/controller/jobframework/webhook/defaulter_test.go
+++ b/pkg/controller/jobframework/webhook/defaulter_test.go
@@ -131,16 +131,16 @@ func TestLossLessDefaulter(t *testing.T) {
 				// This raw object has a field not defined in the go type.
 				// controller-runtime CustomDefaulter would have added a remove operation for it.
 				Raw: []byte(`{
-	"invalid1": "invalid",
-	"invalid2": ["invalid"],
+	"unknown1": "unknown",
+	"unknown2": ["unknown"],
 	"bar": "bar", 
 	"baz": ["foo"],
 	"finalizers": ["foo","bar"],
-	"labels": {"foo": "foo", "bar": "bar", "invalid": "invalid"},
-	"subresource": {"invalid1": "invalid", "invalid2": ["invalid"], "foo": "foo", "bar": "bar"},
+	"labels": {"foo": "foo", "bar": "bar", "unknown": "unknown"},
+	"subresource": {"unknown1": "unknown", "unknown2": ["unknown"], "foo": "foo", "bar": "bar"},
 	"conditions": [
-		{"type": "foo", "message": "foo", "reason": "", "status": "", "lastTransitionTime": null, "observedGeneration": 1, "invalid": "invalid"}, 
-		{"type": "bar", "message": "bar", "reason": "", "status": "", "lastTransitionTime": null, "observedGeneration": 1, "invalid": "invalid"}
+		{"type": "foo", "message": "foo", "reason": "", "status": "", "lastTransitionTime": null, "observedGeneration": 1, "unknown": "unknown"}, 
+		{"type": "bar", "message": "bar", "reason": "", "status": "", "lastTransitionTime": null, "observedGeneration": 1, "unknown": "unknown"}
 	]
 }`),
 			},

--- a/pkg/controller/jobframework/webhook/defaulter_test.go
+++ b/pkg/controller/jobframework/webhook/defaulter_test.go
@@ -90,7 +90,7 @@ func (*TestCustomDefaulter) Default(ctx context.Context, obj runtime.Object) err
 	}
 
 	if d.Labels != nil {
-		delete(d.Labels, "foo")
+		delete(d.Labels, "example.com/foo")
 	}
 	if len(d.Finalizers) > 0 {
 		finalizers := make([]string, 0, len(d.Finalizers))
@@ -152,10 +152,11 @@ func TestLossLessDefaulter(t *testing.T) {
 				Raw: []byte(`{
 	"unknown1": "unknown",
 	"unknown2": ["unknown"],
+	"unknown/unknown": "unknown",
 	"bar": "bar", 
 	"baz": ["foo"],
 	"finalizers": ["foo","bar"],
-	"labels": {"foo": "foo", "bar": "bar", "unknown": "unknown"},
+	"labels": {"example.com/foo": "foo", "example.com/bar": "bar", "unknown": "unknown"},
 	"subresource": {"unknown1": "unknown", "unknown2": ["unknown"], "foo": "foo", "bar": "bar"},
 	"conditions": [
 		{"type": "foo", "message": "foo", "reason": "", "status": "", "lastTransitionTime": null, "observedGeneration": 1, "unknown": "unknown"}, 
@@ -177,7 +178,7 @@ func TestLossLessDefaulter(t *testing.T) {
 		{Operation: "remove", Path: "/baz"},
 		{Operation: "replace", Path: "/finalizers/0", Value: "bar"},
 		{Operation: "remove", Path: "/finalizers/1"},
-		{Operation: "remove", Path: "/labels/foo"},
+		{Operation: "remove", Path: "/labels/example.com~1foo"},
 		{Operation: "replace", Path: "/subresource/foo", Value: ""},
 		{Operation: "replace", Path: "/subresource/bar"},
 		{Operation: "remove", Path: "/conditions/0/observedGeneration"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Make `LossLessDefaulter` selective to only prevent dropping fields outside of schema (unmarshal strict solution).  

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3174

#### Special notes for your reviewer:
The reflection-based solution for prevent dropping fields outside of schema is quite complex. This is an alternative solution for #3186 using `json.UnmarshalStrict()`. Thanks to @trasc for the idea.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```