### PR TITLE
Fix `has malformed LC_DYSYMTAB` warning on darwin platform.

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -15,11 +15,16 @@
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 ARTIFACTS ?= $(PROJECT_DIR)/bin
 
+ifeq ($(shell uname),Darwin)
+    GOFLAGS ?= -ldflags=-extldflags=-Wl,-ld_classic
+endif
+
 ifeq (,$(shell go env GOBIN))
 	GOBIN=$(shell go env GOPATH)/bin
 else
 	GOBIN=$(shell go env GOBIN)
 endif
+
 GO_CMD ?= go
 GO_TEST_FLAGS ?= -race
 version_pkg = sigs.k8s.io/kueue/pkg/version
@@ -70,7 +75,7 @@ KUBEFLOW_MPI_VERSION = $(shell $(GO_CMD) list -m -f "{{.Version}}" github.com/ku
 
 .PHONY: test
 test: gotestsum ## Run tests.
-	$(GOTESTSUM) --junitfile $(ARTIFACTS)/junit.xml -- $(GO_TEST_FLAGS) $(shell $(GO_CMD) list ./... | grep -v '/test/') -coverpkg=./... -coverprofile $(ARTIFACTS)/cover.out
+	$(GOTESTSUM) --junitfile $(ARTIFACTS)/junit.xml -- $(GOFLAGS) $(GO_TEST_FLAGS) $(shell $(GO_CMD) list ./... | grep -v '/test/') -coverpkg=./... -coverprofile $(ARTIFACTS)/cover.out
 
 .PHONY: test-integration
 test-integration: gomod-download envtest ginkgo dep-crds kueuectl ginkgo-top ## Run tests.

--- a/cmd/experimental/kjobctl/Makefile
+++ b/cmd/experimental/kjobctl/Makefile
@@ -1,6 +1,10 @@
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
 
+ifeq ($(shell uname),Darwin)
+    GOFLAGS ?= -ldflags=-extldflags=-Wl,-ld_classic
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -118,7 +122,7 @@ test: verify vet test-unit test-integration ## Run all tests.
 
 .PHONY: test-unit
 test-unit: gomod-download gotestsum embeded-manifest ## Run unit tests.
-	$(GOTESTSUM) --junitfile $(ARTIFACTS)/junit-unit.xml -- $(GO_TEST_FLAGS) $(shell $(GO_CMD) list ./... | grep -v '/test/') -coverpkg=./... -coverprofile $(ARTIFACTS)/cover.out
+	$(GOTESTSUM) --junitfile $(ARTIFACTS)/junit-unit.xml -- $(GOFLAGS) $(GO_TEST_FLAGS) $(shell $(GO_CMD) list ./... | grep -v '/test/') -coverpkg=./... -coverprofile $(ARTIFACTS)/cover.out
 
 .PHONY: test-integration
 test-integration: gomod-download envtest ginkgo embeded-manifest ray-operator-crd ## Run integration tests.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix `has malformed LC_DYSYMTAB` warning on darwin platform.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3196

#### Special notes for your reviewer:

When we running `make test` on Darwing platform we have warnings:

```
=== Errors
ld: warning: '/private/var/folders/y3/rwbwnplx2cz9gf0t71dhp5k00000gn/T/go-link-3229174941/000012.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
ld: warning: '/private/var/folders/y3/rwbwnplx2cz9gf0t71dhp5k00000gn/T/go-link-2692282886/000012.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
ld: warning: '/private/var/folders/y3/rwbwnplx2cz9gf0t71dhp5k00000gn/T/go-link-3121826813/000012.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
ld: warning: '/private/var/folders/y3/rwbwnplx2cz9gf0t71dhp5k00000gn/T/go-link-103183806/000012.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
ld: warning: '/private/var/folders/y3/rwbwnplx2cz9gf0t71dhp5k00000gn/T/go-link-4253876968/000012.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
```

We can fix it using  GOFLAGS="-ldflags=-extldflags=-Wl,-ld_classic" as described [here](https://github.com/golang/go/issues/61229#issuecomment-1988965927).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```