### PR TITLE
Align the retryDelayMinutes deprecation notice with the standard form

### DIFF
--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -52,12 +52,12 @@ type AdmissionCheckSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="field is immutable"
 	ControllerName string `json:"controllerName"`
 
-	// RetryDelayMinutes **deprecated** specifies how long to keep the workload suspended after
+	// RetryDelayMinutes specifies how long to keep the workload suspended after
 	// a failed check (after it transitioned to False). When the delay period has passed, the check
 	// state goes to "Unknown". The default is 15 min.
-	// The default is 15 min.
 	// +optional
 	// +kubebuilder:default=15
+	// Deprecated: retryDelayMinutes has already been deprecated since v0.8 and will be removed in v1beta2.
 	RetryDelayMinutes *int64 `json:"retryDelayMinutes,omitempty"`
 
 	// Parameters identifies a configuration with additional parameters for the

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -90,10 +90,10 @@ spec:
               retryDelayMinutes:
                 default: 15
                 description: |-
-                  RetryDelayMinutes **deprecated** specifies how long to keep the workload suspended after
+                  RetryDelayMinutes specifies how long to keep the workload suspended after
                   a failed check (after it transitioned to False). When the delay period has passed, the check
                   state goes to "Unknown". The default is 15 min.
-                  The default is 15 min.
+                  Deprecated: retryDelayMinutes has already been deprecated since v0.8 and will be removed in v1beta2.
                 format: int64
                 type: integer
             required:

--- a/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_admissionchecks.yaml
@@ -75,10 +75,10 @@ spec:
               retryDelayMinutes:
                 default: 15
                 description: |-
-                  RetryDelayMinutes **deprecated** specifies how long to keep the workload suspended after
+                  RetryDelayMinutes specifies how long to keep the workload suspended after
                   a failed check (after it transitioned to False). When the delay period has passed, the check
                   state goes to "Unknown". The default is 15 min.
-                  The default is 15 min.
+                  Deprecated: retryDelayMinutes has already been deprecated since v0.8 and will be removed in v1beta2.
                 format: int64
                 type: integer
             required:

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -340,10 +340,10 @@ not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.</p>
 <code>int64</code>
 </td>
 <td>
-   <p>RetryDelayMinutes <strong>deprecated</strong> specifies how long to keep the workload suspended after
+   <p>RetryDelayMinutes specifies how long to keep the workload suspended after
 a failed check (after it transitioned to False). When the delay period has passed, the check
 state goes to &quot;Unknown&quot;. The default is 15 min.
-The default is 15 min.</p>
+Deprecated: retryDelayMinutes has already been deprecated since v0.8 and will be removed in v1beta2.</p>
 </td>
 </tr>
 <tr><td><code>parameters</code><br/>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
API deprecation notice should be aligned with standardized form so that linter can detect the deprecation comment in external projects.

https://go.dev/wiki/Deprecated

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```