### PR TITLE
Automated cherry pick of #3153: [batch/job] Fix parallelism restoration after partial admission.

### DIFF
--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -189,7 +189,7 @@ func (w *JobWebhook) validateUpdate(oldJob, newJob *Job) field.ErrorList {
 func validatePartialAdmissionUpdate(oldJob, newJob *Job) field.ErrorList {
 	var allErrs field.ErrorList
 	if _, found := oldJob.Annotations[JobMinParallelismAnnotation]; found {
-		if !oldJob.IsSuspended() && ptr.Deref(oldJob.Spec.Parallelism, 1) != ptr.Deref(newJob.Spec.Parallelism, 1) {
+		if !ptr.Deref(oldJob.Spec.Suspend, false) && ptr.Deref(oldJob.Spec.Parallelism, 1) != ptr.Deref(newJob.Spec.Parallelism, 1) {
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "parallelism"), "cannot change when partial admission is enabled and the job is not suspended"))
 		}
 	}

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -314,6 +314,7 @@ func TestValidateUpdate(t *testing.T) {
 				Parallelism(4).
 				Completions(6).
 				SetAnnotation(JobMinParallelismAnnotation, "3").
+				SetAnnotation(StoppingAnnotation, "true").
 				Obj(),
 			newJob: testingutil.MakeJob("job", "default").
 				Parallelism(5).

--- a/test/integration/controller/jobs/job/job_webhook_test.go
+++ b/test/integration/controller/jobs/job/job_webhook_test.go
@@ -225,5 +225,23 @@ var _ = ginkgo.Describe("Job Webhook", func() {
 			createdJob.Spec.Suspend = ptr.To(false)
 			gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
 		})
+
+		ginkgo.It("should allow restoring parallelism", func() {
+			originalJob := testingjob.MakeJob("job-with-queue-name", ns.Name).Queue("queue").
+				Parallelism(3).
+				Completions(6).
+				SetAnnotation(job.StoppingAnnotation, "true").
+				SetAnnotation(job.JobMinParallelismAnnotation, "2").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, originalJob)).Should(gomega.Succeed())
+
+			lookupKey := types.NamespacedName{Name: originalJob.Name, Namespace: originalJob.Namespace}
+			updatedJob := &batchv1.Job{}
+			gomega.Expect(k8sClient.Get(ctx, lookupKey, updatedJob)).Should(gomega.Succeed())
+
+			updatedJob.Spec.Parallelism = ptr.To[int32](6)
+			delete(updatedJob.Annotations, job.StoppingAnnotation)
+			gomega.Expect(k8sClient.Update(ctx, updatedJob)).Should(gomega.Succeed())
+		})
 	})
 })


### PR DESCRIPTION
Cherry pick of #3153 on release-0.8.

#3153: [batch/job] Fix parallelism restoration after partial admission.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix restoring parallelism on eviction for partially admitted batch/Jobs.
```