### PR TITLE
WIP: Implementation for Topology Aware Scheduling [prototype for testing e2e, DO NOT MERGE]

### DIFF
--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -19,6 +19,7 @@ rules:
     resources:
       - limitranges
       - namespaces
+      - nodes
     verbs:
       - get
       - list
@@ -247,6 +248,7 @@ rules:
       - multikueueclusters
       - multikueueconfigs
       - provisioningrequestconfigs
+      - topologies
       - workloadpriorityclasses
     verbs:
       - get

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -18,6 +18,7 @@ rules:
   resources:
   - limitranges
   - namespaces
+  - nodes
   verbs:
   - get
   - list
@@ -246,6 +247,7 @@ rules:
   - multikueueclusters
   - multikueueconfigs
   - provisioningrequestconfigs
+  - topologies
   - workloadpriorityclasses
   verbs:
   - get

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -229,9 +229,9 @@ func (c *Cache) updateClusterQueues() sets.Set[string] {
 	return cqs
 }
 
-func (c *Cache) GetActiveClusterQueues() sets.Set[string] {
-	c.Lock()
-	defer c.Unlock()
+func (c *Cache) ActiveClusterQueues() sets.Set[string] {
+	c.RLock()
+	defer c.RUnlock()
 	cqs := sets.New[string]()
 	for _, cq := range c.hm.ClusterQueues {
 		if cq.Status == active {
@@ -241,7 +241,7 @@ func (c *Cache) GetActiveClusterQueues() sets.Set[string] {
 	return cqs
 }
 
-func (c *Cache) GetTASCache() *TASCache {
+func (c *Cache) TASCache() *TASCache {
 	return &c.tasCache
 }
 

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -85,8 +85,7 @@ type clusterQueue struct {
 	resourceNode ResourceNode
 	hierarchy.ClusterQueue[*cohort]
 
-	tasFlavors []kueue.ResourceFlavorReference
-	tasCache   *TASCache
+	tasCache *TASCache
 }
 
 func (c *clusterQueue) GetName() string {
@@ -295,15 +294,6 @@ func (c *clusterQueue) inactiveReason() (string, string) {
 func (c *clusterQueue) UpdateWithFlavors(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
 	c.updateLabelKeys(flavors)
 	c.updateQueueStatus()
-	if features.Enabled(features.TopologyAwareScheduling) {
-		for flavorName, rf := range flavors {
-			if rf.Spec.TopologyName != nil {
-				if !slices.Contains(c.tasFlavors, flavorName) {
-					c.tasFlavors = append(c.tasFlavors, flavorName)
-				}
-			}
-		}
-	}
 }
 
 func (c *clusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
@@ -474,10 +464,7 @@ func (c *clusterQueue) tasFlavorCache(flvName kueue.ResourceFlavorReference) *TA
 	if !features.Enabled(features.TopologyAwareScheduling) {
 		return nil
 	}
-	if c.tasFlavors == nil || c.tasCache == nil {
-		return nil
-	}
-	if !slices.Contains(c.tasFlavors, flvName) {
+	if c.tasCache == nil {
 		return nil
 	}
 	return c.tasCache.Get(flvName)

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
@@ -83,6 +84,9 @@ type clusterQueue struct {
 
 	resourceNode ResourceNode
 	hierarchy.ClusterQueue[*cohort]
+
+	tasFlavors []kueue.ResourceFlavorReference
+	tasCache   *TASCache
 }
 
 func (c *clusterQueue) GetName() string {
@@ -291,6 +295,15 @@ func (c *clusterQueue) inactiveReason() (string, string) {
 func (c *clusterQueue) UpdateWithFlavors(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
 	c.updateLabelKeys(flavors)
 	c.updateQueueStatus()
+	if features.Enabled(features.TopologyAwareScheduling) {
+		for flavorName, rf := range flavors {
+			if rf.Spec.TopologyName != nil {
+				if !slices.Contains(c.tasFlavors, flavorName) {
+					c.tasFlavors = append(c.tasFlavors, flavorName)
+				}
+			}
+		}
+	}
 }
 
 func (c *clusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
@@ -426,12 +439,20 @@ func (c *clusterQueue) reportActiveWorkloads() {
 func (c *clusterQueue) updateWorkloadUsage(wi *workload.Info, m int64) {
 	admitted := workload.IsAdmitted(wi.Obj)
 	frUsage := wi.FlavorResourceUsage()
+	tasUsage := wi.TASUsage()
 	for fr, q := range frUsage {
+		tasFlvCache := c.tasFlavorCache(fr.Flavor)
 		if m == 1 {
 			addUsage(c, fr, q)
+			if tasFlvCache != nil {
+				tasFlvCache.addUsage(tasUsage)
+			}
 		}
 		if m == -1 {
 			removeUsage(c, fr, q)
+			if tasFlvCache != nil {
+				tasFlvCache.removeUsage(tasUsage)
+			}
 		}
 	}
 	if admitted {
@@ -447,6 +468,19 @@ func (c *clusterQueue) updateWorkloadUsage(wi *workload.Info, m int64) {
 			lq.admittedWorkloads += int(m)
 		}
 	}
+}
+
+func (c *clusterQueue) tasFlavorCache(flvName kueue.ResourceFlavorReference) *TASFlavorCache {
+	if !features.Enabled(features.TopologyAwareScheduling) {
+		return nil
+	}
+	if c.tasFlavors == nil || c.tasCache == nil {
+		return nil
+	}
+	if !slices.Contains(c.tasFlavors, flvName) {
+		return nil
+	}
+	return c.tasCache.Get(flvName)
 }
 
 func updateFlavorUsage(newUsage resources.FlavorResourceQuantities, oldUsage resources.FlavorResourceQuantities, m int64) {

--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -50,7 +50,7 @@ type ClusterQueueSnapshot struct {
 	ResourceNode ResourceNode
 	hierarchy.ClusterQueue[*CohortSnapshot]
 
-	TASFlavorSnapshots map[kueue.ResourceFlavorReference]*TASFlavorSnapshot
+	TASFlavors map[kueue.ResourceFlavorReference]*TASFlavorSnapshot
 }
 
 // RGByResource returns the ResourceGroup which contains capacity

--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -49,6 +49,8 @@ type ClusterQueueSnapshot struct {
 
 	ResourceNode ResourceNode
 	hierarchy.ClusterQueue[*CohortSnapshot]
+
+	TASFlavorSnapshots map[kueue.ResourceFlavorReference]*TASFlavorSnapshot
 }
 
 // RGByResource returns the ResourceGroup which contains capacity

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -100,6 +100,12 @@ func (c *Cache) SnapshotWithCtx(ctx context.Context) Snapshot {
 			snap.UpdateCohortEdge(cohort.Name, cohort.Parent().Name)
 		}
 	}
+	tasSnapshotsMap := make(map[kueue.ResourceFlavorReference]*TASFlavorSnapshot)
+	if features.Enabled(features.TopologyAwareScheduling) {
+		for key, cache := range c.tasCache.Clone() {
+			tasSnapshotsMap[key] = cache.snapshot(ctx)
+		}
+	}
 	for _, cq := range c.hm.ClusterQueues {
 		if !cq.Active() || (cq.HasParent() && c.hm.CycleChecker.HasCycle(cq.Parent())) {
 			snap.InactiveClusterQueueSets.Insert(cq.Name)
@@ -111,15 +117,9 @@ func (c *Cache) SnapshotWithCtx(ctx context.Context) Snapshot {
 			snap.UpdateClusterQueueEdge(cq.Name, cq.Parent().Name)
 		}
 		if features.Enabled(features.TopologyAwareScheduling) {
-			tasSnapshotsMap := make(map[kueue.ResourceFlavorReference]*TASFlavorSnapshot)
-			for _, tasFlv := range c.tasCache.GetKeys() {
-				if tasCacheRF := c.tasCache.Get(tasFlv); tasCacheRF != nil {
-					tasSnapshotsMap[tasFlv] = tasCacheRF.snapshot(ctx)
-				}
-			}
-			for _, tasFlv := range cq.tasFlavors {
-				if s := tasSnapshotsMap[tasFlv]; s != nil {
-					cqSnapshot.TASFlavorSnapshots[tasFlv] = s
+			for tasFlv, s := range tasSnapshotsMap {
+				if cq.flavorInUse(string(tasFlv)) {
+					cqSnapshot.TASFlavors[tasFlv] = s
 				}
 			}
 		}
@@ -146,7 +146,7 @@ func snapshotClusterQueue(c *clusterQueue) *ClusterQueueSnapshot {
 		Status:                        c.Status,
 		AdmissionChecks:               utilmaps.DeepCopySets[kueue.ResourceFlavorReference](c.AdmissionChecks),
 		ResourceNode:                  c.resourceNode.Clone(),
-		TASFlavorSnapshots:            make(map[kueue.ResourceFlavorReference]*TASFlavorSnapshot),
+		TASFlavors:                    make(map[kueue.ResourceFlavorReference]*TASFlavorSnapshot),
 	}
 	for i, rg := range c.ResourceGroups {
 		cc.ResourceGroups[i] = rg.Clone()

--- a/pkg/cache/tas_cache.go
+++ b/pkg/cache/tas_cache.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"maps"
+	"slices"
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/resources"
+	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+)
+
+type TASCache struct {
+	sync.RWMutex
+	client client.Client
+	Map    map[kueue.ResourceFlavorReference]*TASFlavorCache
+}
+
+func NewTASCache(client client.Client) TASCache {
+	return TASCache{
+		client: client,
+		Map:    make(map[kueue.ResourceFlavorReference]*TASFlavorCache),
+	}
+}
+
+func (t *TASCache) NewFlavorCache(labels []string, nodeLabels map[string]string) *TASFlavorCache {
+	return &TASFlavorCache{
+		client:     t.client,
+		Levels:     slices.Clone(labels),
+		NodeLabels: maps.Clone(nodeLabels),
+		usageMap:   make(map[utiltas.TopologyDomainID]resources.Requests),
+	}
+}
+
+func (t *TASCache) Get(name kueue.ResourceFlavorReference) *TASFlavorCache {
+	t.RLock()
+	defer t.RUnlock()
+	return t.Map[name]
+}
+
+func (t *TASCache) GetKeys() []kueue.ResourceFlavorReference {
+	t.RLock()
+	defer t.RUnlock()
+	return utilmaps.Keys(t.Map)
+}
+
+func (t *TASCache) Set(name kueue.ResourceFlavorReference, info *TASFlavorCache) {
+	t.Lock()
+	defer t.Unlock()
+	t.Map[name] = info
+}
+
+func (t *TASCache) Delete(name kueue.ResourceFlavorReference) {
+	t.Lock()
+	defer t.Unlock()
+	delete(t.Map, name)
+}

--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -1,0 +1,702 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/resources"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+func TestFindTopologyAssignment(t *testing.T) {
+	const (
+		tasBlockLabel = "cloud.com/topology-block"
+		tasRackLabel  = "cloud.com/topology-rack"
+		tasHostLabel  = "kubernetes.io/hostname"
+	)
+
+	defaultNodes := []corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b1-r1-x1",
+				Labels: map[string]string{
+					tasBlockLabel: "b1",
+					tasRackLabel:  "r1",
+					tasHostLabel:  "x1",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b1-r2-x2",
+				Labels: map[string]string{
+					tasBlockLabel: "b1",
+					tasRackLabel:  "r2",
+					tasHostLabel:  "x1",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b1-r2-x3",
+				Labels: map[string]string{
+					tasBlockLabel: "b1",
+					tasRackLabel:  "r2",
+					tasHostLabel:  "x3",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b1-r2-x4",
+				Labels: map[string]string{
+					tasBlockLabel: "b1",
+					tasRackLabel:  "r2",
+					tasHostLabel:  "x4",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b2-r1-x5",
+				Labels: map[string]string{
+					tasBlockLabel: "b2",
+					tasRackLabel:  "r1",
+					tasHostLabel:  "x5",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b2-r2-x6",
+				Labels: map[string]string{
+					tasBlockLabel: "b2",
+					tasRackLabel:  "r2",
+					tasHostLabel:  "x6",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("2"),
+					corev1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+		},
+	}
+	defaultOneLevel := []string{
+		tasHostLabel,
+	}
+	defaultTwoLevels := []string{
+		tasBlockLabel,
+		tasRackLabel,
+	}
+	defaultThreeLevels := []string{
+		tasBlockLabel,
+		tasRackLabel,
+		tasHostLabel,
+	}
+
+	cases := map[string]struct {
+		request        kueue.PodSetTopologyRequest
+		levels         []string
+		nodeLabels     map[string]string
+		nodes          []corev1.Node
+		requests       resources.Requests
+		count          int32
+		wantAssignment *kueue.TopologyAssignment
+	}{
+		"minimize the number of used racks before optimizing the number of nodes": {
+			// Solution by optimizing the number of racks then nodes: [r3]: [x3,x4,x5,x6]
+			// Solution by optimizing the number of nodes: [r1,r2]: [x1,x2]
+			//
+			//       b1
+			//   /   |    \
+			//  r1   r2   r3
+			//  |     |    |   \   \     \
+			// x1:2,x2:2,x3:1,x4:1,x5:1,x6:1
+			//
+			nodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "b1-r1-x1",
+						Labels: map[string]string{
+							tasBlockLabel: "b1",
+							tasRackLabel:  "r1",
+							tasHostLabel:  "x1",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "b1-r2-x2",
+						Labels: map[string]string{
+							tasBlockLabel: "b1",
+							tasRackLabel:  "r2",
+							tasHostLabel:  "x2",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "b1-r3-x3",
+						Labels: map[string]string{
+							tasBlockLabel: "b1",
+							tasRackLabel:  "r3",
+							tasHostLabel:  "x3",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "b1-r3-x4",
+						Labels: map[string]string{
+							tasBlockLabel: "b1",
+							tasRackLabel:  "r3",
+							tasHostLabel:  "x4",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "b1-r3-x5",
+						Labels: map[string]string{
+							tasBlockLabel: "b1",
+							tasRackLabel:  "r3",
+							tasHostLabel:  "x5",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "b1-r3-x6",
+						Labels: map[string]string{
+							tasBlockLabel: "b1",
+							tasRackLabel:  "r3",
+							tasHostLabel:  "x6",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("1"),
+						},
+					},
+				},
+			},
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasBlockLabel),
+			},
+			levels: defaultThreeLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 4,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultThreeLevels,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r3",
+							"x3",
+						},
+					},
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r3",
+							"x4",
+						},
+					},
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r3",
+							"x5",
+						},
+					},
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r3",
+							"x6",
+						},
+					},
+				},
+			},
+		},
+		"host required; single Pod fits in the host": {
+			nodes: defaultNodes,
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasHostLabel),
+			},
+			levels: defaultThreeLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 1,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultThreeLevels,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 1,
+						Values: []string{
+							"b2",
+							"r2",
+							"x6",
+						},
+					},
+				},
+			},
+		},
+		"rack required; single Pod fits in a rack": {
+			nodes: defaultNodes,
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasRackLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 1,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultTwoLevels,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r2",
+						},
+					},
+				},
+			},
+		},
+		"rack required; multiple Pods fits in a rack": {
+			nodes: defaultNodes,
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasRackLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 3,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultTwoLevels,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 3,
+						Values: []string{
+							"b1",
+							"r2",
+						},
+					},
+				},
+			},
+		},
+		"rack required; too many pods to fit in any rack": {
+			nodes: defaultNodes,
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasRackLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count:          4,
+			wantAssignment: nil,
+		},
+		"block required; single Pod fits in a block": {
+			nodes: defaultNodes,
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasBlockLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 1,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: []string{
+					tasBlockLabel,
+					tasRackLabel,
+				},
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r2",
+						},
+					},
+				},
+			},
+		},
+		"block required; Pods fit in a block spread across two racks": {
+			nodes: defaultNodes,
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasBlockLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 4,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultTwoLevels,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 3,
+						Values: []string{
+							"b1",
+							"r2",
+						},
+					},
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r1",
+						},
+					},
+				},
+			},
+		},
+		"block required; single Pod which cannot be split": {
+			nodes: defaultNodes,
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasBlockLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 4000,
+			},
+			count:          1,
+			wantAssignment: nil,
+		},
+		"block required; too many Pods to fit requested": {
+			nodes: defaultNodes,
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasBlockLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count:          5,
+			wantAssignment: nil,
+		},
+		"rack required; single Pod requiring memory": {
+			nodes: defaultNodes,
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasRackLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceMemory: 1024,
+			},
+			count: 4,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultTwoLevels,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 4,
+						Values: []string{
+							"b2",
+							"r2",
+						},
+					},
+				},
+			},
+		},
+		"rack preferred; but only block can accommodate the workload": {
+			nodes: defaultNodes,
+			request: kueue.PodSetTopologyRequest{
+				Preferred: ptr.To(tasRackLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 4,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultTwoLevels,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 3,
+						Values: []string{
+							"b1",
+							"r2",
+						},
+					},
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r1",
+						},
+					},
+				},
+			},
+		},
+		"rack preferred; but only multiple blocks can accommodate the workload": {
+			nodes: defaultNodes,
+			request: kueue.PodSetTopologyRequest{
+				Preferred: ptr.To(tasRackLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 6,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultTwoLevels,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 3,
+						Values: []string{
+							"b1",
+							"r2",
+						},
+					},
+					{
+						Count: 2,
+						Values: []string{
+							"b2",
+							"r2",
+						},
+					},
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r1",
+						},
+					},
+				},
+			},
+		},
+		"block preferred; but only multiple blocks can accommodate the workload": {
+			nodes: defaultNodes,
+			request: kueue.PodSetTopologyRequest{
+				Preferred: ptr.To(tasBlockLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 6,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultTwoLevels,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 3,
+						Values: []string{
+							"b1",
+							"r2",
+						},
+					},
+					{
+						Count: 2,
+						Values: []string{
+							"b2",
+							"r2",
+						},
+					},
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r1",
+						},
+					},
+				},
+			},
+		},
+		"block preferred; but the workload cannot be accommodate in entire topology": {
+			nodes: defaultNodes,
+			request: kueue.PodSetTopologyRequest{
+				Preferred: ptr.To(tasBlockLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count:          10,
+			wantAssignment: nil,
+		},
+		"only nodes with matching labels are considered; no matching node": {
+			nodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "b1-r1-x1",
+						Labels: map[string]string{
+							"zone":       "zone-a",
+							tasHostLabel: "x1",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasHostLabel),
+			},
+			nodeLabels: map[string]string{
+				"zone": "zone-b",
+			},
+			levels: defaultOneLevel,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count:          1,
+			wantAssignment: nil,
+		},
+		"only nodes with matching labels are considered; matching node is found": {
+			nodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "b1-r1-x1",
+						Labels: map[string]string{
+							"zone":       "zone-a",
+							tasHostLabel: "x1",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasHostLabel),
+			},
+			nodeLabels: map[string]string{
+				"zone": "zone-a",
+			},
+			levels: defaultOneLevel,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 1,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultOneLevel,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 1,
+						Values: []string{
+							"x1",
+						},
+					},
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+
+			initialObjects := make([]client.Object, 0)
+			for i := range tc.nodes {
+				initialObjects = append(initialObjects, &tc.nodes[i])
+			}
+			client := utiltesting.NewFakeClient(initialObjects...)
+			tasCache := NewTASCache(client)
+			tasFlavorCache := tasCache.NewFlavorCache(tc.levels, tc.nodeLabels)
+			snapshot := tasFlavorCache.snapshot(ctx)
+			gotAssignment := snapshot.FindTopologyAssignment(&tc.request, tc.requests, tc.count)
+			if diff := cmp.Diff(tc.wantAssignment, gotAssignment); diff != "" {
+				t.Errorf("unexpected topology assignment: %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/cache/tas_flavor.go
+++ b/pkg/cache/tas_flavor.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kueue/pkg/resources"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+type TASFlavorCache struct {
+	sync.RWMutex
+
+	client     client.Client
+	NodeLabels map[string]string
+	Levels     []string
+	usageMap   map[utiltas.TopologyDomainID]resources.Requests
+}
+
+func (c *TASFlavorCache) snapshot(ctx context.Context) *TASFlavorSnapshot {
+	log := ctrl.LoggerFrom(ctx)
+	nodeList := &corev1.NodeList{}
+	matcher := client.MatchingLabels{}
+	for k, v := range c.NodeLabels {
+		matcher[k] = v
+	}
+	err := c.client.List(ctx, nodeList, matcher)
+	if err != nil {
+		log.Error(err, "failed to list nodes for TAS", "nodeLabels", c.NodeLabels)
+	}
+	log.V(3).Info("Constructing TAS snapshot", "nodeLabels", c.NodeLabels,
+		"levels", c.Levels, "nodeCount", len(nodeList.Items))
+	return c.snapshotForNodes(nodeList.Items)
+}
+
+func (c *TASFlavorCache) snapshotForNodes(nodes []corev1.Node) *TASFlavorSnapshot {
+	c.RLock()
+	defer c.RUnlock()
+	snapshot := newTASFlavorSnapshot(c.Levels)
+	for _, node := range nodes {
+		levelValues := utiltas.LevelValues(c.Levels, node.Labels)
+		capacity := resources.NewRequests(node.Status.Allocatable)
+		domainID := utiltas.DomainID(levelValues)
+		snapshot.levelValuesPerDomain[domainID] = levelValues
+		snapshot.addCapacity(domainID, capacity)
+	}
+	snapshot.initialize()
+	for domainID, usage := range c.usageMap {
+		snapshot.addUsage(domainID, usage)
+	}
+	return snapshot
+}
+
+func (c *TASFlavorCache) addUsage(topologyRequests []workload.TopologyDomainRequests) {
+	c.updateUsage(topologyRequests, 1)
+}
+
+func (c *TASFlavorCache) removeUsage(topologyRequests []workload.TopologyDomainRequests) {
+	c.updateUsage(topologyRequests, -1)
+}
+
+func (c *TASFlavorCache) updateUsage(topologyRequests []workload.TopologyDomainRequests, m int64) {
+	c.Lock()
+	defer c.Unlock()
+	for _, tr := range topologyRequests {
+		domainID := utiltas.DomainID(tr.Values)
+		_, found := c.usageMap[domainID]
+		if !found {
+			c.usageMap[domainID] = resources.Requests{}
+		}
+		if m < 0 {
+			c.usageMap[domainID].Sub(tr.Requests)
+		} else {
+			c.usageMap[domainID].Add(tr.Requests)
+		}
+	}
+}

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -1,0 +1,310 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/resources"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+)
+
+type info struct {
+	// count is a temporary state of the topology domain during the topology
+	// assignment algorithm.
+	//
+	// In the first phase of the algorithm (traversal to the top the topology to
+	// determine the level to fit the workload) it denotes the number of pods
+	// which can fit in a given domain.
+	//
+	// In the second phase of the algorithm (traversal to the bottom to
+	// determine the actual assignments) it denotes the number of pods actually
+	// assigned to the given domain.
+	count int32
+
+	// sortName indicates name used for sorting when two domains can fit
+	// the same number of pods
+	sortName string
+
+	// id is the globally unique id of the domain
+	id utiltas.TopologyDomainID
+
+	// parentID is the global ID of the parent domain
+	parentID utiltas.TopologyDomainID
+
+	// childIDs at the global IDs of the child domains
+	childIDs []utiltas.TopologyDomainID
+}
+
+type infoPerDomain map[utiltas.TopologyDomainID]*info
+
+type TASFlavorSnapshot struct {
+	levelKeys             []string
+	freeCapacityPerDomain map[utiltas.TopologyDomainID]resources.Requests
+	levelValuesPerDomain  map[utiltas.TopologyDomainID][]string
+	infoPerLevel          []infoPerDomain
+}
+
+func newTASFlavorSnapshot(levels []string) *TASFlavorSnapshot {
+	labelsCopy := slices.Clone(levels)
+	snapshot := &TASFlavorSnapshot{
+		levelKeys:             labelsCopy,
+		freeCapacityPerDomain: make(map[utiltas.TopologyDomainID]resources.Requests),
+		levelValuesPerDomain:  make(map[utiltas.TopologyDomainID][]string),
+		infoPerLevel:          make([]infoPerDomain, len(levels)),
+	}
+	return snapshot
+}
+
+// initialize prepares the infoPerLevel tree structure which is used during the
+// algorithm for multiple workloads.
+func (s *TASFlavorSnapshot) initialize() {
+	levelCount := len(s.levelKeys)
+	lastLevelIdx := levelCount - 1
+	for levelIdx := 0; levelIdx < len(s.levelKeys); levelIdx++ {
+		s.infoPerLevel[levelIdx] = make(map[utiltas.TopologyDomainID]*info)
+	}
+	for childID := range s.freeCapacityPerDomain {
+		childInfo := &info{
+			sortName: s.sortName(lastLevelIdx, childID),
+			id:       childID,
+			childIDs: make([]utiltas.TopologyDomainID, 0),
+		}
+		s.infoPerLevel[lastLevelIdx][childID] = childInfo
+		parentFound := false
+		var parentInfo *info
+		for levelIdx := lastLevelIdx - 1; levelIdx >= 0 && !parentFound; levelIdx-- {
+			parentValues := s.levelValuesPerDomain[childID][:levelIdx+1]
+			parentID := utiltas.DomainID(parentValues)
+			s.levelValuesPerDomain[parentID] = parentValues
+			parentInfo, parentFound = s.infoPerLevel[levelIdx][parentID]
+			if !parentFound {
+				parentInfo = &info{
+					sortName: s.sortName(levelIdx, parentID),
+					id:       parentID,
+					childIDs: make([]utiltas.TopologyDomainID, 0),
+				}
+				s.infoPerLevel[levelIdx][parentID] = parentInfo
+			}
+			childInfo.parentID = parentID
+			parentInfo.childIDs = append(parentInfo.childIDs, childID)
+			childID = parentID
+		}
+	}
+}
+
+func (s *TASFlavorSnapshot) sortName(levelIdx int, domainID utiltas.TopologyDomainID) string {
+	levelValues := s.levelValuesPerDomain[domainID]
+	if len(levelValues) <= levelIdx {
+		panic(fmt.Sprintf("levelValues count=%d, levelIdx=%d, domainID=%v, levelValuesPerDomain=%v, freeCapacityPerDomain=%v",
+			len(levelValues), levelIdx, domainID, s.levelValuesPerDomain, s.freeCapacityPerDomain))
+	}
+	// we prefix with the node label value to make it ordered naturally, but
+	// append also domain ID as the node label value may not be globally unique.
+	return s.levelValuesPerDomain[domainID][levelIdx] + " " + string(domainID)
+}
+
+func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.Requests) {
+	s.ensureDomainExists(domainID)
+	s.freeCapacityPerDomain[domainID].Add(capacity)
+}
+
+func (s *TASFlavorSnapshot) addUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
+	s.ensureDomainExists(domainID)
+	s.freeCapacityPerDomain[domainID].Sub(usage)
+}
+
+func (s *TASFlavorSnapshot) ensureDomainExists(domainID utiltas.TopologyDomainID) {
+	if _, found := s.freeCapacityPerDomain[domainID]; !found {
+		s.freeCapacityPerDomain[domainID] = resources.Requests{}
+	}
+}
+
+// Algorithm steps:
+// 1. determine pod counts at each topology domain at the lowest level
+// 2. bubble up the pod counts to the top level
+// 3. select the domain at requested level with count >= requestedCount
+// 4. step down level-by-level optimizing the number of used domains at each level
+func (s *TASFlavorSnapshot) FindTopologyAssignment(
+	topologyRequest *kueue.PodSetTopologyRequest,
+	requests resources.Requests,
+	count int32) *kueue.TopologyAssignment {
+	required := topologyRequest.Required != nil
+	levelIdx, found := s.resolveLevelIdx(topologyRequest)
+	if !found {
+		return nil
+	}
+	s.fillInCounts(requests)
+	fitLevelIdx, currFitInfos := s.findLevelWithFitInfos(levelIdx, required, count)
+	if len(currFitInfos) == 0 {
+		return nil
+	}
+	currFitInfos = s.minLevelInfos(currFitInfos, count)
+	for currLevelIdx := fitLevelIdx; currLevelIdx+1 < len(s.infoPerLevel); currLevelIdx++ {
+		lowerFitInfos := s.lowerLevelInfos(currLevelIdx, currFitInfos)
+		sortedLowerInfos := s.sortedInfos(lowerFitInfos)
+		currFitInfos = s.minLevelInfos(sortedLowerInfos, count)
+	}
+	return s.buildAssignment(currFitInfos)
+}
+
+func (s *TASFlavorSnapshot) resolveLevelIdx(
+	topologyRequest *kueue.PodSetTopologyRequest) (int, bool) {
+	var levelKey string
+	if topologyRequest.Required != nil {
+		levelKey = *topologyRequest.Required
+	} else if topologyRequest.Preferred != nil {
+		levelKey = *topologyRequest.Preferred
+	}
+	levelIdx := slices.Index(s.levelKeys, levelKey)
+	if levelIdx < 0 {
+		return levelIdx, false
+	}
+	return levelIdx, true
+}
+
+func (s *TASFlavorSnapshot) findLevelWithFitInfos(levelIdx int, required bool, count int32) (int, []*info) {
+	levelInfos := s.infosForLevel(levelIdx)
+	if len(levelInfos) == 0 {
+		return 0, nil
+	}
+	sortedInfos := s.sortedInfos(levelInfos)
+	topInfo := sortedInfos[0]
+	if topInfo.count < count {
+		if required {
+			return 0, nil
+		} else if levelIdx > 0 {
+			return s.findLevelWithFitInfos(levelIdx-1, required, count)
+		}
+		lastIdx := 0
+		remainingCount := count - sortedInfos[lastIdx].count
+		for remainingCount > 0 && lastIdx < len(sortedInfos)-1 {
+			lastIdx++
+			remainingCount -= sortedInfos[lastIdx].count
+		}
+		if remainingCount > 0 {
+			return 0, nil
+		}
+		return 0, sortedInfos[:lastIdx+1]
+	}
+	return levelIdx, []*info{topInfo}
+}
+
+func (s *TASFlavorSnapshot) minLevelInfos(infos []*info, count int32) []*info {
+	result := make([]*info, 0)
+	remainingCount := count
+	for i := 0; i < len(infos); i++ {
+		info := infos[i]
+		if info.count >= remainingCount {
+			info.count = remainingCount
+			result = append(result, info)
+			return result
+		} else if info.count > 0 {
+			remainingCount -= info.count
+			result = append(result, info)
+		}
+	}
+	panic("unexpected remaining count")
+}
+
+func (s *TASFlavorSnapshot) buildAssignment(infos []*info) *kueue.TopologyAssignment {
+	assignment := kueue.TopologyAssignment{
+		Levels:  s.levelKeys,
+		Domains: make([]kueue.TopologyDomainAssignment, 0),
+	}
+	for i := 0; i < len(infos); i++ {
+		assignment.Domains = append(assignment.Domains, kueue.TopologyDomainAssignment{
+			Values: s.asLevelValues(infos[i].id),
+			Count:  infos[i].count,
+		})
+	}
+	return &assignment
+}
+
+func (s *TASFlavorSnapshot) asLevelValues(domainID utiltas.TopologyDomainID) []string {
+	result := make([]string, len(s.levelKeys))
+	for i := range s.levelKeys {
+		result[i] = s.levelValuesPerDomain[domainID][i]
+	}
+	return result
+}
+
+func (s *TASFlavorSnapshot) lowerLevelInfos(levelIdx int, infos []*info) []*info {
+	result := make([]*info, 0, len(infos))
+	for _, info := range infos {
+		for _, childDomainID := range info.childIDs {
+			if childDomain := s.infoPerLevel[levelIdx+1][childDomainID]; childDomain != nil {
+				result = append(result, childDomain)
+			}
+		}
+	}
+	return result
+}
+
+func (s *TASFlavorSnapshot) infosForLevel(levelIdx int) []*info {
+	infosMap := s.infoPerLevel[levelIdx]
+	result := make([]*info, len(infosMap))
+	index := 0
+	for _, info := range infosMap {
+		result[index] = info
+		index++
+	}
+	return result
+}
+
+func (s *TASFlavorSnapshot) sortedInfos(infos []*info) []*info {
+	result := make([]*info, len(infos))
+	copy(result, infos)
+	slices.SortFunc(result, func(a, b *info) int {
+		switch {
+		case a.count == b.count:
+			return strings.Compare(a.sortName, b.sortName)
+		case a.count > b.count:
+			return -1
+		default:
+			return 1
+		}
+	})
+	return result
+}
+
+func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests) {
+	s.fillInLeafCounts(requests)
+	s.fillInInnerCounts()
+}
+
+func (s *TASFlavorSnapshot) fillInInnerCounts() {
+	lastLevelIdx := len(s.infoPerLevel) - 1
+	for levelIdx := lastLevelIdx - 1; levelIdx >= 0; levelIdx-- {
+		for _, info := range s.infoPerLevel[levelIdx] {
+			info.count = 0
+			for _, childDomainID := range info.childIDs {
+				info.count += s.infoPerLevel[levelIdx+1][childDomainID].count
+			}
+		}
+	}
+}
+
+func (tasRf *TASFlavorSnapshot) fillInLeafCounts(requests resources.Requests) {
+	lastLevelIdx := len(tasRf.infoPerLevel) - 1
+	for domainID, capacity := range tasRf.freeCapacityPerDomain {
+		tasRf.infoPerLevel[lastLevelIdx][domainID].count = requests.CountIn(capacity)
+	}
+}

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -26,19 +26,9 @@ import (
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
-type info struct {
-	// count is a temporary state of the topology domain during the topology
-	// assignment algorithm.
-	//
-	// In the first phase of the algorithm (traversal to the top the topology to
-	// determine the level to fit the workload) it denotes the number of pods
-	// which can fit in a given domain.
-	//
-	// In the second phase of the algorithm (traversal to the bottom to
-	// determine the actual assignments) it denotes the number of pods actually
-	// assigned to the given domain.
-	count int32
-
+// topologyDomainNode holds the static information about placement of a topology
+// domain in the hierarchy of topology domains.
+type topologyDomainNode struct {
 	// sortName indicates name used for sorting when two domains can fit
 	// the same number of pods
 	sortName string
@@ -53,58 +43,80 @@ type info struct {
 	childIDs []utiltas.TopologyDomainID
 }
 
-type infoPerDomain map[utiltas.TopologyDomainID]*info
+type nodePerDomain map[utiltas.TopologyDomainID]*topologyDomainNode
+type statePerDomain map[utiltas.TopologyDomainID]int32
 
 type TASFlavorSnapshot struct {
-	levelKeys             []string
+	levelKeys []string
+
+	// freeCapacityPerDomain stores the free capacity per domain, only for the
+	// lowest level of topology
 	freeCapacityPerDomain map[utiltas.TopologyDomainID]resources.Requests
-	levelValuesPerDomain  map[utiltas.TopologyDomainID][]string
-	infoPerLevel          []infoPerDomain
+
+	// levelValuesPerDomain stores the mapping from domain ID back to the
+	// ordered list of values. It stores the information for all levels.
+	levelValuesPerDomain map[utiltas.TopologyDomainID][]string
+
+	// nodePerLevel stores the static tree information
+	nodePerLevel []nodePerDomain
+
+	// statePerLevel is a temporary state of the topology domains during the
+	// assignment algorithm.
+	//
+	// In the first phase of the algorithm (traversal to the top the topology to
+	// determine the level to fit the workload) it denotes the number of pods
+	// which can fit in a given domain.
+	//
+	// In the second phase of the algorithm (traversal to the bottom to
+	// determine the actual assignments) it denotes the number of pods actually
+	// assigned to the given domain.
+	state statePerDomain
 }
 
 func newTASFlavorSnapshot(levels []string) *TASFlavorSnapshot {
-	labelsCopy := slices.Clone(levels)
 	snapshot := &TASFlavorSnapshot{
-		levelKeys:             labelsCopy,
+		levelKeys:             slices.Clone(levels),
 		freeCapacityPerDomain: make(map[utiltas.TopologyDomainID]resources.Requests),
 		levelValuesPerDomain:  make(map[utiltas.TopologyDomainID][]string),
-		infoPerLevel:          make([]infoPerDomain, len(levels)),
+		nodePerLevel:          make([]nodePerDomain, len(levels)),
+		state:                 make(statePerDomain),
 	}
 	return snapshot
 }
 
-// initialize prepares the infoPerLevel tree structure which is used during the
-// algorithm for multiple workloads.
+// initialize prepares the nodePerLevel tree structure. This structure holds
+// for a given the list of topology domains with additional static and dynamic
+// information. This function initializes the static information which
+// represents the edges to the parent and child domains. This structure is
+// reused for multiple workloads during a single scheduling cycle.
 func (s *TASFlavorSnapshot) initialize() {
 	levelCount := len(s.levelKeys)
 	lastLevelIdx := levelCount - 1
 	for levelIdx := 0; levelIdx < len(s.levelKeys); levelIdx++ {
-		s.infoPerLevel[levelIdx] = make(map[utiltas.TopologyDomainID]*info)
+		s.nodePerLevel[levelIdx] = make(nodePerDomain)
 	}
 	for childID := range s.freeCapacityPerDomain {
-		childInfo := &info{
+		childNode := &topologyDomainNode{
 			sortName: s.sortName(lastLevelIdx, childID),
 			id:       childID,
-			childIDs: make([]utiltas.TopologyDomainID, 0),
 		}
-		s.infoPerLevel[lastLevelIdx][childID] = childInfo
+		s.nodePerLevel[lastLevelIdx][childID] = childNode
 		parentFound := false
-		var parentInfo *info
+		var parent *topologyDomainNode
 		for levelIdx := lastLevelIdx - 1; levelIdx >= 0 && !parentFound; levelIdx-- {
 			parentValues := s.levelValuesPerDomain[childID][:levelIdx+1]
 			parentID := utiltas.DomainID(parentValues)
 			s.levelValuesPerDomain[parentID] = parentValues
-			parentInfo, parentFound = s.infoPerLevel[levelIdx][parentID]
+			parent, parentFound = s.nodePerLevel[levelIdx][parentID]
 			if !parentFound {
-				parentInfo = &info{
+				parent = &topologyDomainNode{
 					sortName: s.sortName(levelIdx, parentID),
 					id:       parentID,
-					childIDs: make([]utiltas.TopologyDomainID, 0),
 				}
-				s.infoPerLevel[levelIdx][parentID] = parentInfo
+				s.nodePerLevel[levelIdx][parentID] = parent
 			}
-			childInfo.parentID = parentID
-			parentInfo.childIDs = append(parentInfo.childIDs, childID)
+			childNode.parentID = parentID
+			parent.childIDs = append(parent.childIDs, childID)
 			childID = parentID
 		}
 	}
@@ -137,11 +149,17 @@ func (s *TASFlavorSnapshot) ensureDomainExists(domainID utiltas.TopologyDomainID
 	}
 }
 
-// Algorithm steps:
-// 1. determine pod counts at each topology domain at the lowest level
-// 2. bubble up the pod counts to the top level
-// 3. select the domain at requested level with count >= requestedCount
-// 4. step down level-by-level optimizing the number of used domains at each level
+// Algorithm overview:
+// Phase 1:
+//
+//	determine pod counts for each topology domain. Start at the lowest level
+//	and bubble up the numbers to the top level
+//
+// Phase 2:
+//
+//	a) select the domain at requested level with count >= requestedCount
+//	b) traverse the structure down level-by-level optimizing the number of used
+//	  domains at each level
 func (s *TASFlavorSnapshot) FindTopologyAssignment(
 	topologyRequest *kueue.PodSetTopologyRequest,
 	requests resources.Requests,
@@ -151,18 +169,25 @@ func (s *TASFlavorSnapshot) FindTopologyAssignment(
 	if !found {
 		return nil
 	}
+	// phase 1 - determine the number of pods which can fit in each topology domain
 	s.fillInCounts(requests)
-	fitLevelIdx, currFitInfos := s.findLevelWithFitInfos(levelIdx, required, count)
-	if len(currFitInfos) == 0 {
+
+	// phase 2a: determine the level at which the assignment is done along with
+	// the nodes which can fit the
+	fitLevelIdx, currFitNodes := s.findLevelWithFitNodes(levelIdx, required, count)
+	if len(currFitNodes) == 0 {
 		return nil
 	}
-	currFitInfos = s.minLevelInfos(currFitInfos, count)
-	for currLevelIdx := fitLevelIdx; currLevelIdx+1 < len(s.infoPerLevel); currLevelIdx++ {
-		lowerFitInfos := s.lowerLevelInfos(currLevelIdx, currFitInfos)
-		sortedLowerInfos := s.sortedInfos(lowerFitInfos)
-		currFitInfos = s.minLevelInfos(sortedLowerInfos, count)
+
+	// phase 2b: traverse the tree down level-by-level optimizing the number of
+	// topology domains at each level
+	currFitNodes = s.updateCountsToMinimum(currFitNodes, count)
+	for levelIdx := fitLevelIdx; levelIdx+1 < len(s.nodePerLevel); levelIdx++ {
+		lowerFitNodes := s.lowerLevelNodes(levelIdx, currFitNodes)
+		sortedLowerNodes := s.sortedNodes(lowerFitNodes)
+		currFitNodes = s.updateCountsToMinimum(sortedLowerNodes, count)
 	}
-	return s.buildAssignment(currFitInfos)
+	return s.buildAssignment(currFitNodes)
 }
 
 func (s *TASFlavorSnapshot) resolveLevelIdx(
@@ -180,59 +205,59 @@ func (s *TASFlavorSnapshot) resolveLevelIdx(
 	return levelIdx, true
 }
 
-func (s *TASFlavorSnapshot) findLevelWithFitInfos(levelIdx int, required bool, count int32) (int, []*info) {
-	levelInfos := s.infosForLevel(levelIdx)
-	if len(levelInfos) == 0 {
+func (s *TASFlavorSnapshot) findLevelWithFitNodes(levelIdx int, required bool, count int32) (int, []*topologyDomainNode) {
+	levelNodes := s.nodesForLevel(levelIdx)
+	if len(levelNodes) == 0 {
 		return 0, nil
 	}
-	sortedInfos := s.sortedInfos(levelInfos)
-	topInfo := sortedInfos[0]
-	if topInfo.count < count {
+	sortedNodes := s.sortedNodes(levelNodes)
+	topNode := sortedNodes[0]
+	if s.state[topNode.id] < count {
 		if required {
 			return 0, nil
 		} else if levelIdx > 0 {
-			return s.findLevelWithFitInfos(levelIdx-1, required, count)
+			return s.findLevelWithFitNodes(levelIdx-1, required, count)
 		}
 		lastIdx := 0
-		remainingCount := count - sortedInfos[lastIdx].count
-		for remainingCount > 0 && lastIdx < len(sortedInfos)-1 {
+		remainingCount := count - s.state[sortedNodes[lastIdx].id]
+		for remainingCount > 0 && lastIdx < len(sortedNodes)-1 {
 			lastIdx++
-			remainingCount -= sortedInfos[lastIdx].count
+			remainingCount -= s.state[sortedNodes[lastIdx].id]
 		}
 		if remainingCount > 0 {
 			return 0, nil
 		}
-		return 0, sortedInfos[:lastIdx+1]
+		return 0, sortedNodes[:lastIdx+1]
 	}
-	return levelIdx, []*info{topInfo}
+	return levelIdx, []*topologyDomainNode{topNode}
 }
 
-func (s *TASFlavorSnapshot) minLevelInfos(infos []*info, count int32) []*info {
-	result := make([]*info, 0)
+func (s *TASFlavorSnapshot) updateCountsToMinimum(nodes []*topologyDomainNode, count int32) []*topologyDomainNode {
+	result := make([]*topologyDomainNode, 0)
 	remainingCount := count
-	for i := 0; i < len(infos); i++ {
-		info := infos[i]
-		if info.count >= remainingCount {
-			info.count = remainingCount
-			result = append(result, info)
+	for i := 0; i < len(nodes); i++ {
+		node := nodes[i]
+		if s.state[node.id] >= remainingCount {
+			s.state[node.id] = remainingCount
+			result = append(result, node)
 			return result
-		} else if info.count > 0 {
-			remainingCount -= info.count
-			result = append(result, info)
+		} else if s.state[node.id] > 0 {
+			remainingCount -= s.state[node.id]
+			result = append(result, node)
 		}
 	}
 	panic("unexpected remaining count")
 }
 
-func (s *TASFlavorSnapshot) buildAssignment(infos []*info) *kueue.TopologyAssignment {
+func (s *TASFlavorSnapshot) buildAssignment(nodes []*topologyDomainNode) *kueue.TopologyAssignment {
 	assignment := kueue.TopologyAssignment{
 		Levels:  s.levelKeys,
 		Domains: make([]kueue.TopologyDomainAssignment, 0),
 	}
-	for i := 0; i < len(infos); i++ {
+	for i := 0; i < len(nodes); i++ {
 		assignment.Domains = append(assignment.Domains, kueue.TopologyDomainAssignment{
-			Values: s.asLevelValues(infos[i].id),
-			Count:  infos[i].count,
+			Values: s.asLevelValues(nodes[i].id),
+			Count:  s.state[nodes[i].id],
 		})
 	}
 	return &assignment
@@ -246,11 +271,11 @@ func (s *TASFlavorSnapshot) asLevelValues(domainID utiltas.TopologyDomainID) []s
 	return result
 }
 
-func (s *TASFlavorSnapshot) lowerLevelInfos(levelIdx int, infos []*info) []*info {
-	result := make([]*info, 0, len(infos))
+func (s *TASFlavorSnapshot) lowerLevelNodes(levelIdx int, infos []*topologyDomainNode) []*topologyDomainNode {
+	result := make([]*topologyDomainNode, 0, len(infos))
 	for _, info := range infos {
 		for _, childDomainID := range info.childIDs {
-			if childDomain := s.infoPerLevel[levelIdx+1][childDomainID]; childDomain != nil {
+			if childDomain := s.nodePerLevel[levelIdx+1][childDomainID]; childDomain != nil {
 				result = append(result, childDomain)
 			}
 		}
@@ -258,9 +283,9 @@ func (s *TASFlavorSnapshot) lowerLevelInfos(levelIdx int, infos []*info) []*info
 	return result
 }
 
-func (s *TASFlavorSnapshot) infosForLevel(levelIdx int) []*info {
-	infosMap := s.infoPerLevel[levelIdx]
-	result := make([]*info, len(infosMap))
+func (s *TASFlavorSnapshot) nodesForLevel(levelIdx int) []*topologyDomainNode {
+	infosMap := s.nodePerLevel[levelIdx]
+	result := make([]*topologyDomainNode, len(infosMap))
 	index := 0
 	for _, info := range infosMap {
 		result[index] = info
@@ -269,14 +294,16 @@ func (s *TASFlavorSnapshot) infosForLevel(levelIdx int) []*info {
 	return result
 }
 
-func (s *TASFlavorSnapshot) sortedInfos(infos []*info) []*info {
-	result := make([]*info, len(infos))
+func (s *TASFlavorSnapshot) sortedNodes(infos []*topologyDomainNode) []*topologyDomainNode {
+	result := make([]*topologyDomainNode, len(infos))
 	copy(result, infos)
-	slices.SortFunc(result, func(a, b *info) int {
+	slices.SortFunc(result, func(a, b *topologyDomainNode) int {
+		aCount := s.state[a.id]
+		bCount := s.state[b.id]
 		switch {
-		case a.count == b.count:
+		case aCount == bCount:
 			return strings.Compare(a.sortName, b.sortName)
-		case a.count > b.count:
+		case aCount > bCount:
 			return -1
 		default:
 			return 1
@@ -286,25 +313,15 @@ func (s *TASFlavorSnapshot) sortedInfos(infos []*info) []*info {
 }
 
 func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests) {
-	s.fillInLeafCounts(requests)
-	s.fillInInnerCounts()
-}
-
-func (s *TASFlavorSnapshot) fillInInnerCounts() {
-	lastLevelIdx := len(s.infoPerLevel) - 1
+	for domainID, capacity := range s.freeCapacityPerDomain {
+		s.state[domainID] = requests.CountIn(capacity)
+	}
+	lastLevelIdx := len(s.nodePerLevel) - 1
 	for levelIdx := lastLevelIdx - 1; levelIdx >= 0; levelIdx-- {
-		for _, info := range s.infoPerLevel[levelIdx] {
-			info.count = 0
+		for _, info := range s.nodePerLevel[levelIdx] {
 			for _, childDomainID := range info.childIDs {
-				info.count += s.infoPerLevel[levelIdx+1][childDomainID].count
+				s.state[info.id] += s.state[childDomainID]
 			}
 		}
-	}
-}
-
-func (tasRf *TASFlavorSnapshot) fillInLeafCounts(requests resources.Requests) {
-	lastLevelIdx := len(tasRf.infoPerLevel) - 1
-	for domainID, capacity := range tasRf.freeCapacityPerDomain {
-		tasRf.infoPerLevel[lastLevelIdx][domainID].count = requests.CountIn(capacity)
 	}
 }

--- a/pkg/controller/jobframework/tas.go
+++ b/pkg/controller/jobframework/tas.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+)
+
+func PodSetTopologyRequest(template *corev1.PodTemplateSpec) *kueue.PodSetTopologyRequest {
+	requiredValue, requiredFound := template.Annotations[kueuealpha.PodSetRequiredTopologyAnnotation]
+	preferredValue, preferredFound := template.Annotations[kueuealpha.PodSetPreferredTopologyAnnotation]
+	if requiredFound {
+		return &kueue.PodSetTopologyRequest{
+			Required: ptr.To(requiredValue),
+		}
+	} else if preferredFound {
+		return &kueue.PodSetTopologyRequest{
+			Preferred: ptr.To(preferredValue),
+		}
+	}
+	return nil
+}

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -249,10 +249,11 @@ func cleanManagedLabels(pt *corev1.PodTemplateSpec) *corev1.PodTemplateSpec {
 func (j *Job) PodSets() []kueue.PodSet {
 	return []kueue.PodSet{
 		{
-			Name:     kueue.DefaultPodSetName,
-			Template: *cleanManagedLabels(j.Spec.Template.DeepCopy()),
-			Count:    j.podsCount(),
-			MinCount: j.minPodsCount(),
+			Name:            kueue.DefaultPodSetName,
+			Template:        *cleanManagedLabels(j.Spec.Template.DeepCopy()),
+			Count:           j.podsCount(),
+			MinCount:        j.minPodsCount(),
+			TopologyRequest: jobframework.PodSetTopologyRequest(&j.Spec.Template),
 		},
 	}
 }

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -118,9 +118,10 @@ func (j *JobSet) PodSets() []kueue.PodSet {
 	podSets := make([]kueue.PodSet, len(j.Spec.ReplicatedJobs))
 	for index, replicatedJob := range j.Spec.ReplicatedJobs {
 		podSets[index] = kueue.PodSet{
-			Name:     replicatedJob.Name,
-			Template: *replicatedJob.Template.Spec.Template.DeepCopy(),
-			Count:    podsCount(&replicatedJob),
+			Name:            replicatedJob.Name,
+			Template:        *replicatedJob.Template.Spec.Template.DeepCopy(),
+			Count:           podsCount(&replicatedJob),
+			TopologyRequest: jobframework.PodSetTopologyRequest(&replicatedJob.Template.Spec.Template),
 		}
 	}
 	return podSets

--- a/pkg/controller/tas/constants.go
+++ b/pkg/controller/tas/constants.go
@@ -17,6 +17,6 @@ limitations under the License.
 package tas
 
 const (
-	TASTopologyUngater          = "tas-topology-ungater"
 	TASResourceFlavorController = "tas-resource-flavor-controller"
+	TASTopologyUngater          = "tas-topology-ungater"
 )

--- a/pkg/controller/tas/constants.go
+++ b/pkg/controller/tas/constants.go
@@ -17,5 +17,6 @@ limitations under the License.
 package tas
 
 const (
-	TASTopologyUngater = "tas-topology-ungater"
+	TASTopologyUngater          = "tas-topology-ungater"
+	TASResourceFlavorController = "tas-resource-flavor-controller"
 )

--- a/pkg/controller/tas/controllers.go
+++ b/pkg/controller/tas/controllers.go
@@ -25,6 +25,11 @@ import (
 )
 
 func SetupControllers(mgr ctrl.Manager, queues *queue.Manager, cache *cache.Cache, cfg *configapi.Configuration) (string, error) {
+	recorder := mgr.GetEventRecorderFor(TASResourceFlavorController)
+	rfRec := newRfReconciler(mgr.GetClient(), queues, cache, recorder)
+	if ctrlName, err := rfRec.setupWithManager(mgr, cache, cfg); err != nil {
+		return ctrlName, err
+	}
 	topologyUngater := newTopologyUngater(mgr.GetClient())
 	if ctrlName, err := topologyUngater.setupWithManager(mgr, cfg); err != nil {
 		return ctrlName, err

--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tas
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/queue"
+)
+
+const (
+	nodeBatchPeriod = time.Second
+)
+
+type rfReconciler struct {
+	queues   *queue.Manager
+	cache    *cache.Cache
+	tasCache *cache.TASCache
+	client   client.Client
+	recorder record.EventRecorder
+}
+
+var _ reconcile.Reconciler = (*rfReconciler)(nil)
+
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=topologies,verbs=get;list;watch
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=resourceflavors,verbs=get;list;watch
+
+func newRfReconciler(c client.Client, queues *queue.Manager, cache *cache.Cache, recorder record.EventRecorder) *rfReconciler {
+	return &rfReconciler{
+		client:   c,
+		queues:   queues,
+		cache:    cache,
+		tasCache: cache.GetTASCache(),
+		recorder: recorder,
+	}
+}
+
+func (r *rfReconciler) setupWithManager(mgr ctrl.Manager, cache *cache.Cache, cfg *configapi.Configuration) (string, error) {
+	nodeHandler := nodeHandler{
+		tasCache: cache.GetTASCache(),
+	}
+	return TASResourceFlavorController, ctrl.NewControllerManagedBy(mgr).
+		Named(TASResourceFlavorController).
+		For(&kueue.ResourceFlavor{}).
+		Watches(&corev1.Node{}, &nodeHandler).
+		WithOptions(controller.Options{NeedLeaderElection: ptr.To(false)}).
+		WithEventFilter(r).
+		Complete(core.WithLeadingManager(mgr, r, &kueue.ClusterQueue{}, cfg))
+}
+
+var _ handler.EventHandler = (*nodeHandler)(nil)
+
+// nodeHandler handles node update events.
+type nodeHandler struct {
+	tasCache *cache.TASCache
+}
+
+func (h *nodeHandler) Create(_ context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	node, isNode := e.Object.(*corev1.Node)
+	if !isNode {
+		return
+	}
+	h.queueReconcileForNode(node, q)
+}
+
+func (h *nodeHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	oldNode, isOldNode := e.ObjectOld.(*corev1.Node)
+	newNode, isNewNode := e.ObjectNew.(*corev1.Node)
+	if !isOldNode || !isNewNode {
+		return
+	}
+	h.queueReconcileForNode(oldNode, q)
+	h.queueReconcileForNode(newNode, q)
+}
+
+func (h *nodeHandler) Delete(_ context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	node, isNode := e.Object.(*corev1.Node)
+	if !isNode {
+		return
+	}
+	h.queueReconcileForNode(node, q)
+}
+
+func (h *nodeHandler) queueReconcileForNode(node *corev1.Node, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	if node == nil {
+		return
+	}
+	// trigger reconcile for TAS flavors affected by the node being created or updated
+	for _, name := range h.tasCache.GetKeys() {
+		if flavor := h.tasCache.Get(name); flavor != nil {
+			if isFlavorAffectedByNode(node, flavor.NodeLabels, flavor.Levels) {
+				q.AddAfter(reconcile.Request{NamespacedName: types.NamespacedName{
+					Name: string(name),
+				}}, nodeBatchPeriod)
+			}
+		}
+	}
+}
+
+func (h *nodeHandler) Generic(context.Context, event.GenericEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (r *rfReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx).WithValues("name", req.NamespacedName.Name)
+	log.V(2).Info("Reconcile TAS Resource Flavor")
+
+	flv := &kueue.ResourceFlavor{}
+	if err := r.client.Get(ctx, req.NamespacedName, flv); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return reconcile.Result{}, err
+		}
+		r.tasCache.Delete(kueue.ResourceFlavorReference(req.NamespacedName.Name))
+	}
+	if flv.Spec.TopologyName != nil {
+		if r.tasCache.Get(kueue.ResourceFlavorReference(flv.Name)) == nil {
+			topology := kueuealpha.Topology{}
+			if err := r.client.Get(ctx, types.NamespacedName{
+				Name: *flv.Spec.TopologyName,
+			}, &topology); err != nil {
+				return reconcile.Result{}, err
+			}
+			levels := r.levels(&topology)
+			tasInfo := r.tasCache.NewFlavorCache(levels, flv.Spec.NodeLabels)
+			r.tasCache.Set(kueue.ResourceFlavorReference(flv.Name), tasInfo)
+		}
+
+		// requeue inadmissible workloads as a change to the resource flavor
+		// or the set of nodes can allow admitting a workload which was
+		// previously inadmissible.
+		if cqNames := r.cache.GetActiveClusterQueues(); len(cqNames) > 0 {
+			r.queues.QueueInadmissibleWorkloads(ctx, cqNames)
+			r.queues.Broadcast()
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *rfReconciler) Create(event event.CreateEvent) bool {
+	rf, isRf := event.Object.(*kueue.ResourceFlavor)
+	if isRf {
+		return rf.Spec.TopologyName != nil
+	}
+	_, isNode := event.Object.(*corev1.Node)
+	return isNode
+}
+
+func (r *rfReconciler) Delete(event event.DeleteEvent) bool {
+	rf, isRf := event.Object.(*kueue.ResourceFlavor)
+	if isRf {
+		if rf.Spec.TopologyName != nil {
+			r.tasCache.Delete(kueue.ResourceFlavorReference(rf.Name))
+		}
+		return false
+	}
+	_, isNode := event.Object.(*corev1.Node)
+	return isNode
+}
+
+func (r *rfReconciler) Update(event event.UpdateEvent) bool {
+	oldRf, isOldRf := event.ObjectOld.(*kueue.ResourceFlavor)
+	newRf, isNewRf := event.ObjectNew.(*kueue.ResourceFlavor)
+	if isOldRf && isNewRf {
+		switch {
+		case ptr.Equal(oldRf.Spec.TopologyName, newRf.Spec.TopologyName):
+			return false
+		case oldRf.Spec.TopologyName == nil:
+			return true
+		default:
+			// topologyName was set so is changed or removed
+			r.tasCache.Delete(kueue.ResourceFlavorReference(*oldRf.Spec.TopologyName))
+			return newRf.Spec.TopologyName != nil
+		}
+	}
+	_, isOldNode := event.ObjectOld.(*corev1.Node)
+	_, isNewNode := event.ObjectNew.(*corev1.Node)
+	return isOldNode && isNewNode
+}
+
+func (r *rfReconciler) Generic(event event.GenericEvent) bool {
+	return false
+}
+
+func isFlavorAffectedByNode(node *corev1.Node, nodeLabels map[string]string, levels []string) bool {
+	for k, v := range nodeLabels {
+		if node.Labels[k] != v {
+			return false
+		}
+	}
+	for i := range levels {
+		if _, ok := node.Labels[levels[i]]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *rfReconciler) levels(topology *kueuealpha.Topology) []string {
+	result := make([]string, len(topology.Spec.Levels))
+	for i, level := range topology.Spec.Levels {
+		result[i] = level.NodeLabel
+	}
+	return result
+}

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -264,6 +264,9 @@ func TestMergeRestore(t *testing.T) {
 			Value:    "t0v",
 			Effect:   corev1.TaintEffectNoSchedule,
 		}).
+		SchedulingGates(corev1.PodSchedulingGate{
+			Name: "example.com/gate",
+		}).
 		Obj()
 
 	cases := map[string]struct {
@@ -297,6 +300,11 @@ func TestMergeRestore(t *testing.T) {
 						Effect:   corev1.TaintEffectNoSchedule,
 					},
 				},
+				SchedulingGates: []corev1.PodSchedulingGate{
+					{
+						Name: "example.com/gate2",
+					},
+				},
 			},
 			wantPodSet: utiltesting.MakePodSet("", 1).
 				NodeSelector(map[string]string{"ns0": "ns0v", "ns1": "ns1v"}).
@@ -313,6 +321,11 @@ func TestMergeRestore(t *testing.T) {
 					Operator: corev1.TolerationOpEqual,
 					Value:    "t1v",
 					Effect:   corev1.TaintEffectNoSchedule,
+				}).
+				SchedulingGates(corev1.PodSchedulingGate{
+					Name: "example.com/gate",
+				}, corev1.PodSchedulingGate{
+					Name: "example.com/gate2",
 				}).
 				Obj(),
 			wantRestoreChanges: true,
@@ -347,6 +360,43 @@ func TestMergeRestore(t *testing.T) {
 					Operator: corev1.TolerationOpEqual,
 					Value:    "t0v",
 					Effect:   corev1.TaintEffectNoSchedule,
+				}).
+				SchedulingGates(corev1.PodSchedulingGate{
+					Name: "example.com/gate",
+				}).
+				Obj(),
+			wantRestoreChanges: true,
+		},
+		"don't duplicate schedulingGate": {
+			podSet: basePodSet.DeepCopy(),
+			info: PodSetInfo{
+				Annotations: map[string]string{
+					"a1": "a1v",
+				},
+				Labels: map[string]string{
+					"l1": "l1v",
+				},
+				NodeSelector: map[string]string{
+					"ns1": "ns1v",
+				},
+				SchedulingGates: []corev1.PodSchedulingGate{
+					{
+						Name: "example.com/gate",
+					},
+				},
+			},
+			wantPodSet: utiltesting.MakePodSet("", 1).
+				NodeSelector(map[string]string{"ns0": "ns0v", "ns1": "ns1v"}).
+				Labels(map[string]string{"l0": "l0v", "l1": "l1v"}).
+				Annotations(map[string]string{"a0": "a0v", "a1": "a1v"}).
+				Toleration(corev1.Toleration{
+					Key:      "t0",
+					Operator: corev1.TolerationOpEqual,
+					Value:    "t0v",
+					Effect:   corev1.TaintEffectNoSchedule,
+				}).
+				SchedulingGates(corev1.PodSchedulingGate{
+					Name: "example.com/gate",
 				}).
 				Obj(),
 			wantRestoreChanges: true,

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -44,13 +44,13 @@ func (r Requests) Clone() Requests {
 }
 
 func (r Requests) Divide(f int64) {
-	for name := range r {
-		r[name] /= f
+	for k := range r {
+		r[k] /= f
 	}
 }
 
-func (r Requests) Add(newRequests Requests) {
-	for k, v := range newRequests {
+func (r Requests) Add(addRequests Requests) {
+	for k, v := range addRequests {
 		r[k] += v
 	}
 }

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -17,10 +17,12 @@ limitations under the License.
 package resources
 
 import (
+	"maps"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
 )
 
 // The following resources calculations are inspired on
@@ -35,6 +37,28 @@ func NewRequests(rl corev1.ResourceList) Requests {
 		r[name] = ResourceValue(name, quant)
 	}
 	return r
+}
+
+func (r Requests) Clone() Requests {
+	return maps.Clone(r)
+}
+
+func (r Requests) Divide(f int64) {
+	for name := range r {
+		r[name] /= f
+	}
+}
+
+func (r Requests) Add(newRequests Requests) {
+	for k, v := range newRequests {
+		r[k] += v
+	}
+}
+
+func (r Requests) Sub(subRequests Requests) {
+	for k, v := range subRequests {
+		r[k] -= v
+	}
 }
 
 func (r Requests) ToResourceList() corev1.ResourceList {
@@ -66,4 +90,19 @@ func ResourceQuantity(name corev1.ResourceName, v int64) resource.Quantity {
 		}
 		return *resource.NewQuantity(v, resource.DecimalSI)
 	}
+}
+
+func (req Requests) CountIn(capacity Requests) int32 {
+	var result *int32
+	for rName, rValue := range req {
+		capacity, found := capacity[rName]
+		if !found {
+			return 0
+		}
+		count := int32(capacity / rValue)
+		if result == nil || count < *result {
+			result = ptr.To(count)
+		}
+	}
+	return ptr.Deref(result, 0)
 }

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestCountIn(t *testing.T) {
+	cases := map[string]struct {
+		requests   Requests
+		capacity   Requests
+		wantResult int32
+	}{
+		"requests equal capacity": {
+			requests: Requests{
+				corev1.ResourceCPU:    1,
+				corev1.ResourceMemory: 1,
+			},
+			capacity: Requests{
+				corev1.ResourceCPU:    1,
+				corev1.ResourceMemory: 1,
+			},
+			wantResult: 1,
+		},
+		"requests with extra resource": {
+			requests: Requests{
+				corev1.ResourceCPU:    1,
+				corev1.ResourceMemory: 1,
+			},
+			capacity: Requests{
+				corev1.ResourceCPU: 1,
+			},
+			wantResult: 0,
+		},
+		"first resource is bottleneck": {
+			requests: Requests{
+				corev1.ResourceCPU:    5,
+				corev1.ResourceMemory: 1,
+			},
+			capacity: Requests{
+				corev1.ResourceCPU:    12,
+				corev1.ResourceMemory: 8,
+			},
+			wantResult: 2,
+		},
+		"second resource is bottleneck": {
+			requests: Requests{
+				corev1.ResourceCPU:    1,
+				corev1.ResourceMemory: 5,
+			},
+			capacity: Requests{
+				corev1.ResourceCPU:    8,
+				corev1.ResourceMemory: 12,
+			},
+			wantResult: 2,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotResult := tc.requests.CountIn(tc.capacity)
+			if tc.wantResult != gotResult {
+				t.Errorf("unexpected result, want=%d, got=%d", tc.wantResult, gotResult)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -35,7 +35,7 @@ func assignTopology(log logr.Logger,
 	switch {
 	case psAssignment.Status.IsError():
 		log.Info("There is no resource quota assignment for the workload. No need to check TAS.", "message", psAssignment.Status.Message())
-	case len(cq.TASFlavorSnapshots) == 0:
+	case len(cq.TASFlavors) == 0:
 		if psAssignment.Status == nil {
 			psAssignment.Status = &Status{}
 		}
@@ -54,7 +54,7 @@ func assignTopology(log logr.Logger,
 			psAssignment.Flavors = nil
 			return
 		} else {
-			snapshot := cq.TASFlavorSnapshots[*tasFlvr]
+			snapshot := cq.TASFlavors[*tasFlvr]
 			if snapshot == nil {
 				if psAssignment.Status == nil {
 					psAssignment.Status = &Status{}

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flavorassigner
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func assignTopology(log logr.Logger,
+	psAssignment *PodSetAssignment,
+	cq *cache.ClusterQueueSnapshot,
+	psResources workload.PodSetResources,
+	podSet *kueue.PodSet) {
+	switch {
+	case psAssignment.Status.IsError():
+		log.Info("There is no resource quota assignment for the workload. No need to check TAS.", "message", psAssignment.Status.Message())
+	case len(cq.TASFlavorSnapshots) == 0:
+		if psAssignment.Status == nil {
+			psAssignment.Status = &Status{}
+		}
+		psAssignment.Status.append("Workload requires Topology, but there is no TAS cache information")
+		psAssignment.Flavors = nil
+	default:
+		singlePodRequests := psResources.Requests.Clone()
+		singlePodRequests.Divide(int64(psResources.Count))
+		podCount := psAssignment.Count
+		tasFlvr, err := onlyFlavor(psAssignment.Flavors)
+		if err != nil {
+			if psAssignment.Status == nil {
+				psAssignment.Status = &Status{}
+			}
+			psAssignment.Status.err = err
+			psAssignment.Flavors = nil
+			return
+		} else {
+			snapshot := cq.TASFlavorSnapshots[*tasFlvr]
+			if snapshot == nil {
+				if psAssignment.Status == nil {
+					psAssignment.Status = &Status{}
+				}
+				psAssignment.Status.append("Workload requires Topology, but there is no TAS cache information for the assigned flavor")
+				psAssignment.Flavors = nil
+				return
+			}
+			psAssignment.TopologyAssignment = snapshot.FindTopologyAssignment(podSet.TopologyRequest,
+				singlePodRequests, podCount)
+			if psAssignment.TopologyAssignment == nil {
+				if psAssignment.Status == nil {
+					psAssignment.Status = &Status{}
+				}
+				psAssignment.Status.append("Workload cannot fit within the TAS ResourceFlavor")
+				psAssignment.Flavors = nil
+			}
+			log.Info("TAS PodSet assignment", "tasAssignment", psAssignment.TopologyAssignment)
+		}
+	}
+}
+
+func onlyFlavor(ra ResourceAssignment) (*kueue.ResourceFlavorReference, error) {
+	var result *kueue.ResourceFlavorReference
+	for _, v := range ra {
+		if result == nil {
+			result = &v.Name
+		} else if *result != v.Name {
+			return nil, fmt.Errorf("more than one flavor assigned: %s, %s", v.Name, *result)
+		}
+	}
+	if result != nil {
+		return result, nil
+	}
+	return nil, errors.New("no flavor assigned")
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -209,7 +209,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	startTime := time.Now()
 
 	// 2. Take a snapshot of the cache.
-	snapshot := s.cache.Snapshot()
+	snapshot := s.cache.SnapshotWithCtx(ctx)
 	logSnapshotIfVerbose(log, &snapshot)
 
 	// 3. Calculate requirements (resource flavors, borrowing) for admitting workloads.

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -919,7 +919,7 @@ func MakeTopology(name string) *TopologyWrapper {
 	}}
 }
 
-// Creation sets the creation timestamp of the LocalQueue.
+// Levels sets the levels for a Topology.
 func (t *TopologyWrapper) Levels(levels []string) *TopologyWrapper {
 	t.Spec.Levels = make([]kueuealpha.TopologyLevel, len(levels))
 	for i, level := range levels {

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -868,6 +868,12 @@ func (rf *ResourceFlavorWrapper) Obj() *kueue.ResourceFlavor {
 	return &rf.ResourceFlavor
 }
 
+// TopologyLevels sets the topology name
+func (rf *ResourceFlavorWrapper) TopologyName(name string) *ResourceFlavorWrapper {
+	rf.ResourceFlavor.Spec.TopologyName = ptr.To(name)
+	return rf
+}
+
 // Label sets the label on the ResourceFlavor.
 func (rf *ResourceFlavorWrapper) Label(k, v string) *ResourceFlavorWrapper {
 	if rf.ObjectMeta.Labels == nil {
@@ -899,6 +905,33 @@ func (rf *ResourceFlavorWrapper) Toleration(t corev1.Toleration) *ResourceFlavor
 func (rf *ResourceFlavorWrapper) Creation(t time.Time) *ResourceFlavorWrapper {
 	rf.CreationTimestamp = metav1.NewTime(t)
 	return rf
+}
+
+// TopologyWrapper wraps a Topology.
+type TopologyWrapper struct{ kueuealpha.Topology }
+
+// MakeTopology creates a wrapper for a Topology.
+func MakeTopology(name string) *TopologyWrapper {
+	return &TopologyWrapper{kueuealpha.Topology{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}}
+}
+
+// Creation sets the creation timestamp of the LocalQueue.
+func (t *TopologyWrapper) Levels(levels []string) *TopologyWrapper {
+	t.Spec.Levels = make([]kueuealpha.TopologyLevel, len(levels))
+	for i, level := range levels {
+		t.Spec.Levels[i] = kueuealpha.TopologyLevel{
+			NodeLabel: level,
+		}
+	}
+	return t
+}
+
+func (t *TopologyWrapper) Obj() *kueuealpha.Topology {
+	return &t.Topology
 }
 
 // RuntimeClassWrapper wraps a RuntimeClass.

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -135,7 +135,8 @@ func (p *PodWrapper) KueueSchedulingGate() *PodWrapper {
 
 // TopologySchedulingGate adds kueue scheduling gate to the Pod
 func (p *PodWrapper) TopologySchedulingGate() *PodWrapper {
-	return p.Gate(kueuealpha.TopologySchedulingGate)
+	utilpod.Gate(&p.Pod, kueuealpha.TopologySchedulingGate)
+	return p
 }
 
 // Gate adds kueue scheduling gate to the Pod by the gate name

--- a/test/e2e/config/common/manager_e2e_patch.yaml
+++ b/test/e2e/config/common/manager_e2e_patch.yaml
@@ -3,4 +3,4 @@
   value: IfNotPresent
 - op: add
   path: /spec/template/spec/containers/0/args/-
-  value: --feature-gates=MultiKueueBatchJobWithManagedBy=true
+  value: --feature-gates=MultiKueueBatchJobWithManagedBy=true,TopologyAwareScheduling=true

--- a/test/e2e/singlecluster/e2e_test.go
+++ b/test/e2e/singlecluster/e2e_test.go
@@ -48,7 +48,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 	ginkgo.BeforeEach(func() {
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "e2e-",
+				GenerateName: "e2e-tas-",
 			},
 		}
 		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())

--- a/test/e2e/singlecluster/tas_test.go
+++ b/test/e2e/singlecluster/tas_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	"sigs.k8s.io/kueue/pkg/util/testing"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	"sigs.k8s.io/kueue/pkg/workload"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+// +kubebuilder:docs-gen:collapse=Imports
+
+const (
+	topologyLevel = "kubernetes.io/hostname"
+)
+
+var _ = ginkgo.Describe("Kueue", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "e2e-tas-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+	})
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.When("Creating a Job With Queueing", func() {
+		var (
+			topology     *kueuealpha.Topology
+			onDemandRF   *kueue.ResourceFlavor
+			localQueue   *kueue.LocalQueue
+			clusterQueue *kueue.ClusterQueue
+		)
+		ginkgo.BeforeEach(func() {
+			topology = testing.MakeTopology("hostname").Levels([]string{
+				topologyLevel,
+			}).Obj()
+			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
+
+			onDemandRF = testing.MakeResourceFlavor("on-demand").
+				NodeLabel("instance-type", "on-demand").TopologyName(topology.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, onDemandRF)).Should(gomega.Succeed())
+			clusterQueue = testing.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("on-demand").
+						Resource(corev1.ResourceCPU, "1").
+						Resource(corev1.ResourceMemory, "1Gi").
+						Obj(),
+				).
+				Preemption(kueue.ClusterQueuePreemption{
+					WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+				}).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).Should(gomega.Succeed())
+			localQueue = testing.MakeLocalQueue("main", ns.Name).ClusterQueue("cluster-queue").Obj()
+			gomega.Expect(k8sClient.Create(ctx, localQueue)).Should(gomega.Succeed())
+		})
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			// Force remove workloads to be sure that cluster queue can be removed.
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, topology)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandRF, true)
+		})
+
+		ginkgo.It("should admit a Job via TAS", func() {
+			sampleJob := testingjob.MakeJob("test-job", ns.Name).
+				Queue(localQueue.Name).
+				Request("cpu", "700m").
+				Request("memory", "20Mi").
+				Obj()
+			jobKey := client.ObjectKeyFromObject(sampleJob)
+			sampleJob = (&testingjob.JobWrapper{Job: *sampleJob}).
+				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, topologyLevel).
+				Image(util.E2eTestSleepImage, []string{"1ms"}).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, sampleJob)).Should(gomega.Succeed())
+
+			createdWorkload := &kueue.Workload{}
+
+			// The job might have finished at this point. That shouldn't be a problem for the purpose of this test
+			expectJobUnsuspendedWithNodeSelectors(jobKey, map[string]string{
+				"instance-type": "on-demand",
+			})
+			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(sampleJob.Name, sampleJob.UID), Namespace: ns.Name}
+
+			ginkgo.By(fmt.Sprintf("await for admission of workload %q and verify TopologyAssignment", wlLookupKey), func() {
+				gomega.Eventually(func() bool {
+					if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
+						return false
+					}
+					return createdWorkload.Status.Admission != nil
+				}, util.LongTimeout, util.Interval).Should(gomega.BeTrue())
+				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
+				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+					&kueue.TopologyAssignment{
+						Levels: []string{
+							topologyLevel,
+						},
+						Domains: []kueue.TopologyDomainAssignment{
+							{
+								Count: 1,
+								Values: []string{
+									"kind-worker",
+								},
+							},
+						},
+					},
+				))
+			})
+
+			ginkgo.By(fmt.Sprintf("verify the workload %q gets finished", wlLookupKey), func() {
+				gomega.Eventually(func() bool {
+					if err := k8sClient.Get(ctx, wlLookupKey, createdWorkload); err != nil {
+						return false
+					}
+					return workload.HasQuotaReservation(createdWorkload) &&
+						apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadFinished)
+				}, util.LongTimeout, util.Interval).Should(gomega.BeTrue())
+			})
+		})
+
+		ginkgo.It("should allow to evict a TAS Job", func() {
+			ginkgo.By("Create the high-priority")
+			highPriorityClass := testing.MakePriorityClass("high").PriorityValue(100).Obj()
+			gomega.Expect(k8sClient.Create(ctx, highPriorityClass)).Should(gomega.Succeed())
+			ginkgo.DeferCleanup(func() {
+				gomega.Expect(k8sClient.Delete(ctx, highPriorityClass)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("Create the low priority Job")
+			lowPriorityJob := testingjob.MakeJob("low-priority-test-job", ns.Name).
+				Queue(localQueue.Name).
+				Request("cpu", "700m").
+				Request("memory", "20Mi").
+				Obj()
+			lowPriorityJob = (&testingjob.JobWrapper{Job: *lowPriorityJob}).
+				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, topologyLevel).
+				Image(util.E2eTestSleepImage, []string{"-termination-code=1", "10m"}).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, lowPriorityJob)).Should(gomega.Succeed())
+
+			ginkgo.By("Verify the low-priority Job is running", func() {
+				lowPriorityKey := client.ObjectKeyFromObject(lowPriorityJob)
+				expectJobUnsuspendedWithNodeSelectors(lowPriorityKey, map[string]string{
+					"instance-type": "on-demand",
+				})
+			})
+
+			ginkgo.By("Create the high-priority Job")
+			highPriorityJob := testingjob.MakeJob("high-priority-test-job", ns.Name).
+				PriorityClass(highPriorityClass.Name).
+				Queue(localQueue.Name).
+				Request("cpu", "700m").
+				Request("memory", "20Mi").
+				Obj()
+			highPriorityJob = (&testingjob.JobWrapper{Job: *highPriorityJob}).
+				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, topologyLevel).
+				Image(util.E2eTestSleepImage, []string{"1ms"}).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, highPriorityJob)).Should(gomega.Succeed())
+
+			highPriorityWlKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(highPriorityJob.Name, highPriorityJob.UID), Namespace: ns.Name}
+			ginkgo.By(fmt.Sprintf("verify the high-priority workload %q gets finished", highPriorityWlKey), func() {
+				highPriorityWorkload := &kueue.Workload{}
+				gomega.Eventually(func() bool {
+					if err := k8sClient.Get(ctx, highPriorityWlKey, highPriorityWorkload); err != nil {
+						return false
+					}
+					return workload.HasQuotaReservation(highPriorityWorkload) &&
+						apimeta.IsStatusConditionTrue(highPriorityWorkload.Status.Conditions, kueue.WorkloadFinished)
+				}, util.LongTimeout, util.Interval).Should(gomega.BeTrue())
+			})
+		})
+	})
+})

--- a/test/integration/tas/suite_test.go
+++ b/test/integration/tas/suite_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta1"
+	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/controller/tas"
+	"sigs.k8s.io/kueue/pkg/queue"
+	"sigs.k8s.io/kueue/pkg/scheduler"
+	"sigs.k8s.io/kueue/pkg/webhooks"
+	"sigs.k8s.io/kueue/test/integration/framework"
+)
+
+var (
+	cfg         *rest.Config
+	k8sClient   client.Client
+	ctx         context.Context
+	fwk         *framework.Framework
+	crdPath     = filepath.Join("..", "..", "..", "config", "components", "crd", "bases")
+	webhookPath = filepath.Join("..", "..", "..", "config", "components", "webhook")
+)
+
+func TestAPIs(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	ginkgo.RunSpecs(t,
+		"TopologyAwareScheduling Suite",
+	)
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	fwk = &framework.Framework{CRDPath: crdPath, WebhookPath: webhookPath}
+	cfg = fwk.Init()
+	ctx, k8sClient = fwk.SetupClient(cfg)
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	fwk.Teardown()
+})
+
+func managerSetup(ctx context.Context, mgr manager.Manager) {
+	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	failedWebhook, err := webhooks.Setup(mgr)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
+
+	controllersCfg := &config.Configuration{}
+	mgr.GetScheme().Default(controllersCfg)
+
+	cacheOptions := []cache.Option{}
+	cCache := cache.New(mgr.GetClient(), cacheOptions...)
+	queues := queue.NewManager(mgr.GetClient(), cCache)
+
+	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, controllersCfg)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "Core controller", failedCtrl)
+
+	failedCtrl, err = tas.SetupControllers(mgr, queues, cCache, controllersCfg)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "TAS controller", failedCtrl)
+
+	sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName))
+	err = sched.Start(ctx)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}

--- a/test/integration/tas/tas_job_test.go
+++ b/test/integration/tas/tas_job_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Kubernetes Authors.
+Copyright 2024 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/integration/tas/tas_job_test.go
+++ b/test/integration/tas/tas_job_test.go
@@ -1,0 +1,602 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+// +kubebuilder:docs-gen:collapse=Imports
+
+const (
+	tasBlockLabel = "cloud.com/topology-block"
+	tasRackLabel  = "cloud.com/topology-rack"
+)
+
+var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
+	var (
+		ns *corev1.Namespace
+	)
+
+	ginkgo.BeforeAll(func() {
+		fwk.StartManager(ctx, cfg, managerSetup)
+	})
+
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		_ = features.SetEnable(features.TopologyAwareScheduling, true)
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "tas-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		_ = features.SetEnable(features.TopologyAwareScheduling, false)
+	})
+
+	ginkgo.When("Single TAS Resource Flavor", func() {
+		var (
+			tasFlavor    *kueue.ResourceFlavor
+			topology     *kueuealpha.Topology
+			localQueue   *kueue.LocalQueue
+			clusterQueue *kueue.ClusterQueue
+		)
+
+		ginkgo.When("Nodes are created before test", func() {
+			var (
+				nodes []corev1.Node
+			)
+
+			ginkgo.BeforeEach(func() {
+				nodes = []corev1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "b1-r1",
+							Labels: map[string]string{
+								tasBlockLabel: "b1",
+								tasRackLabel:  "r1",
+							},
+						},
+						Status: corev1.NodeStatus{
+							Allocatable: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "b1-r2",
+							Labels: map[string]string{
+								tasBlockLabel: "b1",
+								tasRackLabel:  "r2",
+							},
+						},
+						Status: corev1.NodeStatus{
+							Allocatable: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "b2-r1",
+							Labels: map[string]string{
+								tasBlockLabel: "b2",
+								tasRackLabel:  "r1",
+							},
+						},
+						Status: corev1.NodeStatus{
+							Allocatable: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "b2-r2",
+							Labels: map[string]string{
+								tasBlockLabel: "b2",
+								tasRackLabel:  "r2",
+							},
+						},
+						Status: corev1.NodeStatus{
+							Allocatable: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				}
+				for _, node := range nodes {
+					gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
+					gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
+				}
+
+				topology = testing.MakeTopology("default").Levels([]string{
+					tasBlockLabel,
+					tasRackLabel,
+				}).Obj()
+				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
+
+				tasFlavor = testing.MakeResourceFlavor("tas-flavor").TopologyName("default").Obj()
+				gomega.Expect(k8sClient.Create(ctx, tasFlavor)).Should(gomega.Succeed())
+
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj()).
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, clusterQueue)).Should(gomega.Succeed())
+
+				localQueue = testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+				gomega.Expect(k8sClient.Create(ctx, localQueue)).Should(gomega.Succeed())
+			})
+
+			ginkgo.AfterEach(func() {
+				gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteObject(ctx, k8sClient, topology)).Should(gomega.Succeed())
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+				for _, node := range nodes {
+					gomega.Expect(util.DeleteObject(ctx, k8sClient, &node)).Should(gomega.Succeed())
+				}
+			})
+
+			ginkgo.It("should not admit workload which does not fit to the required topology domain", func() {
+				ginkgo.By("creating a workload which requires rack, but does not fit in any", func() {
+					wl1 := testing.MakeWorkload("wl1-inadmissible", ns.Name).
+						Queue(localQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					}
+					gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify the workload is inadmissible", func() {
+					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+				})
+			})
+
+			ginkgo.It("should admit workload which fits in a required topology domain", func() {
+				var wl1, wl2, wl3, wl4 *kueue.Workload
+				ginkgo.By("creating a workload which requires block and can fit", func() {
+					wl1 = testing.MakeWorkload("wl1", ns.Name).
+						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+					wl1.Spec.PodSets[0].Count = 2
+					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasBlockLabel),
+					}
+					gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify the workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+				})
+
+				ginkgo.By("verify admission for the workload1", func() {
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+					gomega.Expect(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						&kueue.TopologyAssignment{
+							Levels: []string{
+								tasBlockLabel,
+								tasRackLabel,
+							},
+							Domains: []kueue.TopologyDomainAssignment{
+								{
+									Count: 1,
+									Values: []string{
+										"b1",
+										"r1",
+									},
+								},
+								{
+									Count: 1,
+									Values: []string{
+										"b1",
+										"r2",
+									},
+								},
+							},
+						},
+					))
+				})
+
+				ginkgo.By("creating the second workload to see it lands on another rack", func() {
+					wl2 = testing.MakeWorkload("wl2", ns.Name).
+						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+					wl2.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					}
+					gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify the workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
+					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 2)
+				})
+
+				ginkgo.By("verify admission for the workload2", func() {
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), wl2)).To(gomega.Succeed())
+					gomega.Expect(wl2.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						&kueue.TopologyAssignment{
+							Levels: []string{
+								tasBlockLabel,
+								tasRackLabel,
+							},
+							Domains: []kueue.TopologyDomainAssignment{
+								{
+									Count: 1,
+									Values: []string{
+										"b2",
+										"r1",
+									},
+								},
+							},
+						},
+					))
+				})
+
+				ginkgo.By("creating the wl3", func() {
+					wl3 = testing.MakeWorkload("wl3", ns.Name).
+						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+					wl3.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					}
+					gomega.Expect(k8sClient.Create(ctx, wl3)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify the wl3 is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2, wl3)
+					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 3)
+				})
+
+				ginkgo.By("verify admission for the wl3", func() {
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl3), wl3)).To(gomega.Succeed())
+					gomega.Expect(wl3.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						&kueue.TopologyAssignment{
+							Levels: []string{
+								tasBlockLabel,
+								tasRackLabel,
+							},
+							Domains: []kueue.TopologyDomainAssignment{
+								{
+									Count: 1,
+									Values: []string{
+										"b2",
+										"r2",
+									},
+								},
+							},
+						},
+					))
+				})
+
+				ginkgo.By("creating wl4", func() {
+					wl4 = testing.MakeWorkload("wl4", ns.Name).
+						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+					wl4.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					}
+					gomega.Expect(k8sClient.Create(ctx, wl4)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("finish wl3", func() {
+					util.FinishWorkloads(ctx, k8sClient, wl3)
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
+				})
+
+				ginkgo.By("verify the wl4 is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2, wl4)
+					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 3)
+				})
+
+				ginkgo.By("verify admission for the wl4", func() {
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl4), wl4)).To(gomega.Succeed())
+					gomega.Expect(wl4.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						&kueue.TopologyAssignment{
+							Levels: []string{
+								tasBlockLabel,
+								tasRackLabel,
+							},
+							Domains: []kueue.TopologyDomainAssignment{
+								{
+									Count: 1,
+									Values: []string{
+										"b2",
+										"r2",
+									},
+								},
+							},
+						},
+					))
+				})
+			})
+		})
+
+		ginkgo.When("Nodes node structure is mutated during test cases", func() {
+			ginkgo.BeforeEach(func() {
+				ns = &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "tas-",
+					},
+				}
+				gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+				topology = testing.MakeTopology("default").Levels([]string{
+					tasBlockLabel,
+					tasRackLabel,
+				}).Obj()
+				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
+
+				tasFlavor = testing.MakeResourceFlavor("tas-flavor").TopologyName("default").Obj()
+				gomega.Expect(k8sClient.Create(ctx, tasFlavor)).Should(gomega.Succeed())
+
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj()).
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, clusterQueue)).Should(gomega.Succeed())
+
+				localQueue = testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+				gomega.Expect(k8sClient.Create(ctx, localQueue)).Should(gomega.Succeed())
+			})
+
+			ginkgo.AfterEach(func() {
+				gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteObject(ctx, k8sClient, topology)).Should(gomega.Succeed())
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+			})
+
+			ginkgo.It("should admit workload when nodes become available", func() {
+				var (
+					nodes []corev1.Node
+					wl1   *kueue.Workload
+				)
+
+				ginkgo.By("creating a workload which requires rack, but does not fit in any", func() {
+					wl1 = testing.MakeWorkload("wl1", ns.Name).
+						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					}
+					gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify the workload is inadmissible", func() {
+					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+				})
+
+				ginkgo.By("Create nodes to allow scheduling", func() {
+					nodes = []corev1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "b1-r1",
+								Labels: map[string]string{
+									tasBlockLabel: "b1",
+									tasRackLabel:  "r1",
+								},
+							},
+							Status: corev1.NodeStatus{
+								Allocatable: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					}
+					for _, node := range nodes {
+						gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
+						gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
+					}
+				})
+
+				ginkgo.By("verify the workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
+				})
+
+				ginkgo.By("Delete the node for cleanup", func() {
+					for _, node := range nodes {
+						gomega.Expect(k8sClient.Delete(ctx, &node)).Should(gomega.Succeed())
+					}
+				})
+			})
+		})
+	})
+
+	ginkgo.When("Multiple TAS Resource Flavors in queue", func() {
+		var (
+			tasGPUFlavor *kueue.ResourceFlavor
+			tasCPUFlavor *kueue.ResourceFlavor
+			topology     *kueuealpha.Topology
+			localQueue   *kueue.LocalQueue
+			clusterQueue *kueue.ClusterQueue
+		)
+
+		ginkgo.When("Nodes are created before test", func() {
+			const (
+				gpuResName = "example.com/gpu"
+			)
+			var (
+				nodes []corev1.Node
+			)
+
+			ginkgo.BeforeEach(func() {
+				nodes = []corev1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "cpu-node",
+							Labels: map[string]string{
+								"node.kubernetes.io/instance-type": "cpu-node",
+								tasRackLabel:                       "cpu-rack",
+							},
+						},
+						Status: corev1.NodeStatus{
+							Allocatable: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("5"),
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "gpu-node",
+							Labels: map[string]string{
+								"node.kubernetes.io/instance-type": "gpu-node",
+								tasRackLabel:                       "gpu-rack",
+							},
+						},
+						Status: corev1.NodeStatus{
+							Allocatable: corev1.ResourceList{
+								gpuResName: resource.MustParse("4"),
+							},
+						},
+					},
+				}
+				for _, node := range nodes {
+					gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
+					gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
+				}
+
+				topology = testing.MakeTopology("default").Levels([]string{
+					tasRackLabel,
+				}).Obj()
+				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
+
+				tasGPUFlavor = testing.MakeResourceFlavor("tas-gpu-flavor").
+					NodeLabel("node.kubernetes.io/instance-type", "gpu-node").
+					TopologyName("default").
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, tasGPUFlavor)).Should(gomega.Succeed())
+
+				tasCPUFlavor = testing.MakeResourceFlavor("tas-cpu-flavor").
+					NodeLabel("node.kubernetes.io/instance-type", "cpu-node").
+					TopologyName("default").
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, tasCPUFlavor)).Should(gomega.Succeed())
+
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas(tasGPUFlavor.Name).Resource(corev1.ResourceCPU, "1").Resource(gpuResName, "5").Obj(),
+						*testing.MakeFlavorQuotas(tasCPUFlavor.Name).Resource(corev1.ResourceCPU, "5").Resource(gpuResName, "0").Obj(),
+					).Obj()
+				gomega.Expect(k8sClient.Create(ctx, clusterQueue)).Should(gomega.Succeed())
+
+				localQueue = testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+				gomega.Expect(k8sClient.Create(ctx, localQueue)).Should(gomega.Succeed())
+			})
+
+			ginkgo.AfterEach(func() {
+				gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteObject(ctx, k8sClient, topology)).Should(gomega.Succeed())
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, tasCPUFlavor, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, tasGPUFlavor, true)
+				for _, node := range nodes {
+					gomega.Expect(util.DeleteObject(ctx, k8sClient, &node)).Should(gomega.Succeed())
+				}
+			})
+
+			ginkgo.It("should admit workload which fits in a required topology domain", func() {
+				var wl1 *kueue.Workload
+				ginkgo.By("creating a workload which requires block and can fit", func() {
+					wl1 = testing.MakeWorkload("wl1", ns.Name).
+						Queue(localQueue.Name).Obj()
+					ps1 := *testing.MakePodSet("manager", 1).NodeSelector(
+						map[string]string{"node.kubernetes.io/instance-type": "cpu-node"},
+					).Request(corev1.ResourceCPU, "5").Obj()
+					ps1.TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					}
+					ps2 := *testing.MakePodSet("worker", 2).NodeSelector(
+						map[string]string{"node.kubernetes.io/instance-type": "gpu-node"},
+					).Request(gpuResName, "2").Obj()
+					ps2.TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasRackLabel),
+					}
+					wl1.Spec.PodSets = []kueue.PodSet{ps1, ps2}
+					gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify the workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+				})
+
+				ginkgo.By("verify admission for the workload1", func() {
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+					gomega.Expect(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						&kueue.TopologyAssignment{
+							Levels: []string{
+								tasRackLabel,
+							},
+							Domains: []kueue.TopologyDomainAssignment{
+								{
+									Count: 1,
+									Values: []string{
+										"cpu-rack",
+									},
+								},
+							},
+						},
+					))
+					gomega.Expect(wl1.Status.Admission.PodSetAssignments[1].TopologyAssignment).Should(gomega.BeComparableTo(
+						&kueue.TopologyAssignment{
+							Levels: []string{
+								tasRackLabel,
+							},
+							Domains: []kueue.TopologyDomainAssignment{
+								{
+									Count: 2,
+									Values: []string{
+										"gpu-rack",
+									},
+								},
+							},
+						},
+					))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes-sigs/kueue/issues/2724

#### Special notes for your reviewer:

This is an e2e prototype of the feature. I used it to evaluate if there are no gaps in the KEP. There are no bigger gaps, but doing the prototype I identified a couple of issues that could be improved in the design. I will submit a KEP update PR.

Comments are welcome, but the actual code to merge will be in separate smaller PRs.

Things which are still missing in the PR:
- validation (hard and soft)
- sending events from the TASResourceFlavorController or TASTopologyUngater
- skipping Failed pods in TASTopologyUngater (DONE)
- use the expectations mechanism in TASTopologyUngater  (DONE)
- add higher-level test (integration / e2e) for JobSet
- tracking usage from DaemonSet pods

#### Does this PR introduce a user-facing change?

```release-note
NONE
```