### PR TITLE
PodSet label and Workload annotation for PodTemplates

### DIFF
--- a/apis/kueue/v1alpha1/tas_types.go
+++ b/apis/kueue/v1alpha1/tas_types.go
@@ -1,0 +1,29 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+const (
+	// WorkloadAnnotation is an annotation set on the Job's PodTemplate to
+	// indicate the name of the admitted Workload corresponding to the Job. The
+	// annotation is set when starting the Job, and removed on stopping the Job.
+	WorkloadAnnotation = "kueue.x-k8s.io/workload"
+
+	// PodSetLabel is a label set on the Job's PodTemplate to indicate the name
+	// of the PodSet of the admitted Workload corresponding to the PodTemplate.
+	// The label is set when starting the Job, and removed on stopping the Job.
+	PodSetLabel = "kueue.x-k8s.io/podset"
+)

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/constants"
@@ -973,7 +974,10 @@ func getPodSetsInfoFromStatus(ctx context.Context, c client.Client, w *kueue.Wor
 		if err != nil {
 			return nil, err
 		}
-
+		if features.Enabled(features.TopologyAwareScheduling) {
+			info.Labels[kueuealpha.PodSetLabel] = podSetFlavor.Name
+			info.Annotations[kueuealpha.WorkloadAnnotation] = w.Name
+		}
 		for _, admissionCheck := range w.Status.AdmissionChecks {
 			for _, podSetUpdate := range admissionCheck.PodSetUpdates {
 				if podSetUpdate.Name == info.Name {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -102,6 +102,13 @@ const (
 	// Enable more than one workload sharing flavors to preempt within a Cohort,
 	// as long as the preemption targets don't overlap.
 	MultiplePreemptions featuregate.Feature = "MultiplePreemptions"
+
+	// owner: @mimowo
+	// alpha: v0.9
+	//
+	// Enable Topology Aware Scheduling allowing to optimize placement of Pods
+	// to put them on closely located nodes (e.g. within the same rack or block).
+	TopologyAwareScheduling featuregate.Feature = "TopologyAwareScheduling"
 )
 
 func init() {
@@ -125,6 +132,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	LendingLimit:                    {Default: true, PreRelease: featuregate.Beta},
 	MultiKueueBatchJobWithManagedBy: {Default: false, PreRelease: featuregate.Alpha},
 	MultiplePreemptions:             {Default: true, PreRelease: featuregate.Beta},
+	TopologyAwareScheduling:         {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) {

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -252,6 +252,7 @@ The currently supported features are:
 | `LendingLimit`                    | `true`  | Beta       | 0.9   |       |
 | `MultiplePreemptions`             | `false` | Alpha      | 0.8   | 0.8   |
 | `MultiplePreemptions`             | `true`  | Beta       | 0.9   |       |
+| `TopologyAwareScheduling`         | `false` | Alpha      | 0.9   |       |
 
 ## What's next
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #2724

#### Special notes for your reviewer:

The annotation and label are used only for TAS now, but the names are generic since they can be used in other contexts too. For TAS they are used by TopologyUngater to lookup The admitted Workload from a Pod.

#### Does this PR introduce a user-facing change?

```release-note
Introduce the new PodTemplate annotation kueue.x-k8s.io/workload, and label kueue.x-k8s.io/podset.
```