### PR TITLE
[KEP] Extend `WaitForPodsReady` config by `.waitForAdmissionChecks` field

### DIFF
--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -127,6 +127,7 @@ which prevents starvation of new workloads.
 Additionally, we introduce a second mechanism to timeout Kueue's AdmissionChecks.
 AdmissionChecks (especially ProvisioningRequest), face the same risk of getting stuck for 
 an extended period of time, for example, in case of quota fragmentation as described above.
+an extended period of time, for example, in case of quota fragmentation as described above.
 
 Both behaviors can be opted-in at the level of
 the Kueue configuration.

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -125,7 +125,8 @@ unsuspended job is scheduled. We also specify the timeout for the Workload to sc
 which prevents starvation of new workloads.
 
 Additionally, we introduce a second mechanism to timeout Kueue's AdmissionChecks.
-AdmissionChecks (especially ProvisioningRequest), face the same risk of fragmentation as described above.
+AdmissionChecks (especially ProvisioningRequest), face the same risk of getting stuck for 
+an extended period of time, for example, in case of quota fragmentation as described above.
 
 Both behaviors can be opted-in at the level of
 the Kueue configuration.

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -251,7 +251,7 @@ type WaitForPodsReady struct {
 	// which is used to ensure that specific AdmissionCheck is ready within the specified time.
 	// If there is no specified configuration for an AdmissionCheck, there is no timeout for it.
 	// +listType=map
-	WaitForAdmissionChecks *WaitForAdmissionChecks
+	WaitForAdmissionChecks []WaitForAdmissionChecks
 }
 
 type WaitForAdmissionChecks struct {

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -164,8 +164,7 @@ configuration.
 #### Story 2
 
 As a Kueue administrator I want to ensure that a Job doesn't allocate resources
-infinitely if there is capacity in Kueue, but there's no capacity on the cloud
-provider side.
+infinitely for Workloads awaiting for AdmissionChecks.
 
 ### Notes/Constraints/Caveats (Optional)
 

--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -78,9 +78,12 @@ large jobs may deadlock if there are issues with resource provisioning to
 match the configured cluster quota. The same pair of jobs could run to
 completion if their pods were scheduled sequentially.
 
-Another reason a pods could not schedule, even if Kueue had a free quota would be resource
-fragmentation. We would like to prevent allocating quota for an extended period of time
-if it cannot be consumed.
+Another reason pods could not schedule is that there are some AdmissionChecks configured which are
+not satisfied for a long time for a Workload which already reserves the quota.
+
+For example, some users may use AdmissionCheck [atomic-scale-up ProvisioningRequest](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/proposals/provisioning-request.md#atomic-scale-upkubernetesio-class)
+to gate admission of Workload. If there is a stock out on the cloud provider side, the Workload may stay waiting for admission for
+an extended period of time, and we would like to help users to avoid that situation.
 
 <!--
 This section is for explicitly listing the motivation, goals, and non-goals of
@@ -259,8 +262,8 @@ type WaitForAdmissionChecks struct {
 	// Name of the AdmissionCheck the configuration refers to
 	AdmissionCheck string
 
-	// Timeout defines the time for workload with reserved quota to reach the
-	// Admitted=true condition. When the timeout is exceeded, the workload
+	// Timeout defines the time for an AdmissionCheck to change its state from
+	// Pending to Ready. When the timeout is exceeded, the workload is
 	// evicted and requeued in the same cluster queue.
 	// Defaults to 10min.
 	// +optional


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Describes API extension for `WaitForPodsReady` which expands it's functionality to AdmissionChecks, to prevent wasteful allocation of resources and starvation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #3231 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```