### PR TITLE
Remove kubernetes 1.27 from supported versions

### DIFF
--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -199,7 +199,6 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(maxExecTimeLabelPath, "NaN", `strconv.Atoi: parsing "NaN": invalid syntax`),
 			},
-			serverVersion: "1.31.0",
 		},
 		{
 			name: "zero maximum execution time",
@@ -212,7 +211,6 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(maxExecTimeLabelPath, 0, "should be greater than 0"),
 			},
-			serverVersion: "1.31.0",
 		},
 		{
 			name: "negative maximum execution time",
@@ -225,7 +223,6 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(maxExecTimeLabelPath, -10, "should be greater than 0"),
 			},
-			serverVersion: "1.31.0",
 		},
 		{
 			name: "valid maximum execution time",
@@ -235,7 +232,6 @@ func TestValidateCreate(t *testing.T) {
 				Label(constants.MaxExecTimeSecondsLabel, "10").
 				Indexed(true).
 				Obj(),
-			serverVersion: "1.31.0",
 		},
 		{
 			name: "valid topology request",

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -27,9 +27,6 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/apimachinery/pkg/version"
-	fakediscovery "k8s.io/client-go/discovery/fake"
-	fakeclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
@@ -38,7 +35,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/queue"
-	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingutil "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 
@@ -63,10 +59,9 @@ var (
 
 func TestValidateCreate(t *testing.T) {
 	testcases := []struct {
-		name          string
-		job           *batchv1.Job
-		wantErr       field.ErrorList
-		serverVersion string
+		name    string
+		job     *batchv1.Job
+		wantErr field.ErrorList
 	}{
 		{
 			name:    "simple",
@@ -137,7 +132,6 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "completions"), ptr.To[int32](6), fmt.Sprintf("should be equal to parallelism when %s is annotation is true", JobCompletionsEqualParallelismAnnotation)),
 			},
-			serverVersion: "1.27.0",
 		},
 		{
 			name: "valid sync completions annotation, wrong job completions type (default)",
@@ -149,7 +143,6 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(syncCompletionAnnotationsPath, "true", "should not be enabled for NonIndexed jobs"),
 			},
-			serverVersion: "1.27.0",
 		},
 		{
 			name: "valid sync completions annotation, wrong job completions type",
@@ -162,32 +155,6 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(syncCompletionAnnotationsPath, "true", "should not be enabled for NonIndexed jobs"),
 			},
-			serverVersion: "1.27.0",
-		},
-		{
-			name: "valid sync completions annotation, server version less then 1.27",
-			job: testingutil.MakeJob("job", "default").
-				Parallelism(4).
-				Completions(4).
-				SetAnnotation(JobCompletionsEqualParallelismAnnotation, "true").
-				Indexed(true).
-				Obj(),
-			wantErr: field.ErrorList{
-				field.Invalid(syncCompletionAnnotationsPath, "true", "only supported in Kubernetes 1.27 or newer"),
-			},
-			serverVersion: "1.26.3",
-		},
-		{
-			name: "valid sync completions annotation, server version wasn't specified",
-			job: testingutil.MakeJob("job", "default").
-				Parallelism(4).
-				Completions(4).
-				SetAnnotation(JobCompletionsEqualParallelismAnnotation, "true").
-				Indexed(true).
-				Obj(),
-			wantErr: field.ErrorList{
-				field.Invalid(syncCompletionAnnotationsPath, "true", "only supported in Kubernetes 1.27 or newer"),
-			},
 		},
 		{
 			name: "valid sync completions annotation",
@@ -197,8 +164,7 @@ func TestValidateCreate(t *testing.T) {
 				SetAnnotation(JobCompletionsEqualParallelismAnnotation, "true").
 				Indexed(true).
 				Obj(),
-			wantErr:       nil,
-			serverVersion: "1.27.0",
+			wantErr: nil,
 		},
 		{
 			name: "invalid prebuilt workload",
@@ -211,7 +177,6 @@ func TestValidateCreate(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(prebuiltWlNameLabelPath, "workload name", invalidRFC1123Message),
 			},
-			serverVersion: "1.27.0",
 		},
 		{
 			name: "valid prebuilt workload",
@@ -221,8 +186,7 @@ func TestValidateCreate(t *testing.T) {
 				Label(constants.PrebuiltWorkloadLabel, "workload-name").
 				Indexed(true).
 				Obj(),
-			wantErr:       nil,
-			serverVersion: "1.27.0",
+			wantErr: nil,
 		},
 		{
 			name: "invalid maximum execution time",
@@ -316,12 +280,6 @@ func TestValidateCreate(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			jw := &JobWebhook{}
-			fakeDiscoveryClient, _ := fakeclient.NewSimpleClientset().Discovery().(*fakediscovery.FakeDiscovery)
-			fakeDiscoveryClient.FakedServerVersion = &version.Info{GitVersion: tc.serverVersion}
-			jw.kubeServerVersion = kubeversion.NewServerVersionFetcher(fakeDiscoveryClient)
-			if err := jw.kubeServerVersion.FetchServerVersion(); err != nil && tc.serverVersion != "" {
-				t.Fatalf("Failed fetching server version: %v", err)
-			}
 
 			gotErr := jw.validateCreate((*Job)(tc.job))
 

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -54,7 +54,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 	"sigs.k8s.io/kueue/pkg/util/expectations"
-	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	"sigs.k8s.io/kueue/pkg/util/maps"
 	"sigs.k8s.io/kueue/pkg/util/parallelize"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
@@ -89,7 +88,6 @@ var (
 	gvk                          = corev1.SchemeGroupVersion.WithKind("Pod")
 	errIncorrectReconcileRequest = errors.New("event handler error: got a single pod reconcile request for a pod group")
 	errPendingOps                = jobframework.UnretryableError("waiting to observe previous operations on pods")
-	errPodNoSupportKubeVersion   = errors.New("pod integration only supported in Kubernetes 1.27 or newer")
 	errPodGroupLabelsMismatch    = errors.New("constructing workload: pods have different label values")
 )
 
@@ -497,13 +495,7 @@ func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {
 	return nil
 }
 
-func CanSupportIntegration(opts ...jobframework.Option) (bool, error) {
-	options := jobframework.ProcessOptions(opts...)
-
-	v := options.KubeServerVersion.GetServerVersion()
-	if v.String() == "" || v.LessThan(kubeversion.KubeVersion1_27) {
-		return false, fmt.Errorf("kubernetesVersion %q: %w", v.String(), errPodNoSupportKubeVersion)
-	}
+func CanSupportIntegration(_ ...jobframework.Option) (bool, error) {
 	return true, nil
 }
 

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -93,12 +93,11 @@ var (
 
 func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
-		SetupIndexes:          SetupIndexes,
-		NewJob:                NewJob,
-		NewReconciler:         NewReconciler,
-		SetupWebhook:          SetupWebhook,
-		JobType:               &corev1.Pod{},
-		CanSupportIntegration: CanSupportIntegration,
+		SetupIndexes:  SetupIndexes,
+		NewJob:        NewJob,
+		NewReconciler: NewReconciler,
+		SetupWebhook:  SetupWebhook,
+		JobType:       &corev1.Pod{},
 	}))
 }
 
@@ -493,10 +492,6 @@ func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {
 		return err
 	}
 	return nil
-}
-
-func CanSupportIntegration(_ ...jobframework.Option) (bool, error) {
-	return true, nil
 }
 
 func (p *Pod) Finalize(ctx context.Context, c client.Client) error {

--- a/pkg/util/kubeversion/kubeversion.go
+++ b/pkg/util/kubeversion/kubeversion.go
@@ -28,10 +28,6 @@ import (
 
 const fetchServerVersionInterval = time.Minute * 10
 
-var (
-	KubeVersion1_27 = versionutil.MustParseSemantic("1.27.0")
-)
-
 type ServerVersionFetcher struct {
 	dc            discovery.DiscoveryInterface
 	ticker        *time.Ticker

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -25,14 +25,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/version"
-	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
-	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	podtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	"sigs.k8s.io/kueue/test/util"
@@ -47,9 +43,6 @@ var _ = ginkgo.Describe("Pod groups", func() {
 	)
 
 	ginkgo.BeforeEach(func() {
-		if kubeVersion().LessThan(kubeversion.KubeVersion1_27) {
-			ginkgo.Skip("Unsupported in versions older than 1.27")
-		}
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "pod-e2e-",
@@ -556,13 +549,3 @@ var _ = ginkgo.Describe("Pod groups", func() {
 		})
 	})
 })
-
-func kubeVersion() *version.Version {
-	cfg, err := config.GetConfigWithContext("")
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	v, err := kubeversion.FetchServerVersion(discoveryClient)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	return v
-}

--- a/test/integration/webhook/jobs/job_webhook_test.go
+++ b/test/integration/webhook/jobs/job_webhook_test.go
@@ -97,19 +97,6 @@ var _ = ginkgo.Describe("Job Webhook With manageJobsWithoutQueueName enabled", g
 		createdJob.Spec.Suspend = ptr.To(false)
 		gomega.Expect(k8sClient.Update(ctx, createdJob)).ShouldNot(gomega.Succeed())
 	})
-
-	ginkgo.It("Should not succeed Job when kubernetes less than 1.27 and sync completions annotation is enabled for indexed jobs", func() {
-		if v := serverVersionFetcher.GetServerVersion(); v.AtLeast(kubeversion.KubeVersion1_27) {
-			ginkgo.Skip("Kubernetes version is not less then 1.27. Skip test...")
-		}
-		j := testingjob.MakeJob("job-without-queue-name", ns.Name).
-			Parallelism(5).
-			Completions(5).
-			SetAnnotation(job.JobCompletionsEqualParallelismAnnotation, "true").
-			Indexed(true).
-			Obj()
-		gomega.Expect(k8sClient.Create(ctx, j)).Should(testing.BeForbiddenError())
-	})
 })
 
 var _ = ginkgo.Describe("Job Webhook with manageJobsWithoutQueueName disabled", ginkgo.Ordered, func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Removes skip of tests which are not supported on k8s with version less then 1.27, since we are running tests on 1.28+

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Done per discussion here: https://github.com/kubernetes-sigs/kueue/pull/3001#discussion_r1800671498

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Kubernetes 1.27 is removed from supported Kubernetes versions
```