### PR TITLE
Helm: sanitize resource name lengths

### DIFF
--- a/charts/kueue/templates/certmanager/certificate.yaml
+++ b/charts/kueue/templates/certmanager/certificate.yaml
@@ -2,7 +2,7 @@
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: {{ include "kueue.fullname" . }}-selfsigned-issuer
+  name: {{ printf "%s-selfsigned-issuer" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
@@ -12,16 +12,16 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "kueue.fullname" . }}-serving-cert
+  name: {{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
 spec:
   dnsNames:
-  - '{{ include "kueue.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc'
-  - '{{ include "kueue.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesClusterDomain }}'
+  - '{{ printf "%s-webhook-service.%s.svc" (include "kueue.fullname" .) .Release.Namespace | trunc 63 | trimSuffix "-" }}'
+  - '{{ printf "%s-webhook-service.%s.svc.%s" (include "kueue.fullname" .) .Release.Namespace .Values.kubernetesClusterDomain | trunc 63 | trimSuffix "-" }}'
   issuerRef:
     kind: Issuer
-    name: {{ include "kueue.fullname" . }}-selfsigned-issuer
-  secretName: {{ include "kueue.fullname" . }}-webhook-server-cert
+    name: {{ printf "%s-selfsigned-issuer" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
+  secretName: {{ printf "%s-webhook-server-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_admissionchecks.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.4
   name: admissionchecks.kueue.x-k8s.io
@@ -16,7 +16,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: {{ include "kueue.fullname" . }}-webhook-service
+          name: {{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.4
   name: clusterqueues.kueue.x-k8s.io
@@ -16,7 +16,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: {{ include "kueue.fullname" . }}-webhook-service
+          name: {{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.4
   name: cohorts.kueue.x-k8s.io
@@ -16,7 +16,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: {{ include "kueue.fullname" . }}-webhook-service
+          name: {{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_localqueues.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.4
   name: localqueues.kueue.x-k8s.io
@@ -16,7 +16,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: {{ include "kueue.fullname" . }}-webhook-service
+          name: {{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueclusters.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.4
   name: multikueueclusters.kueue.x-k8s.io
@@ -16,7 +16,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: {{ include "kueue.fullname" . }}-webhook-service
+          name: {{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.4
   name: multikueueconfigs.kueue.x-k8s.io
@@ -16,7 +16,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: {{ include "kueue.fullname" . }}-webhook-service
+          name: {{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_provisioningrequestconfigs.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.4
   name: provisioningrequestconfigs.kueue.x-k8s.io
@@ -16,7 +16,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: {{ include "kueue.fullname" . }}-webhook-service
+          name: {{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.4
   name: resourceflavors.kueue.x-k8s.io
@@ -16,7 +16,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: {{ include "kueue.fullname" . }}-webhook-service
+          name: {{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.4
   name: topologies.kueue.x-k8s.io
@@ -16,7 +16,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: {{ include "kueue.fullname" . }}-webhook-service
+          name: {{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloadpriorityclasses.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.4
   name: workloadpriorityclasses.kueue.x-k8s.io
@@ -16,7 +16,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: {{ include "kueue.fullname" . }}-webhook-service
+          name: {{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- include "kueue.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.enableCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
     {{- end }}
     controller-gen.kubebuilder.io/version: v0.16.4
   name: workloads.kueue.x-k8s.io
@@ -16,7 +16,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: {{ include "kueue.fullname" . }}-webhook-service
+          name: {{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/charts/kueue/templates/internalcert/secret.yaml
+++ b/charts/kueue/templates/internalcert/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "kueue.fullname" . }}-webhook-server-cert
+  name: {{ printf "%s-webhook-server-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}

--- a/charts/kueue/templates/manager/auth_proxy_service.yaml
+++ b/charts/kueue/templates/manager/auth_proxy_service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kueue.fullname" . }}-controller-manager-metrics-service
+  name: {{ printf "%s-controller-manager-metrics-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}

--- a/charts/kueue/templates/manager/manager-config.yaml
+++ b/charts/kueue/templates/manager/manager-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "kueue.fullname" . }}-manager-config
+  name: {{ printf "%s-manager-config" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}

--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kueue.fullname" . }}-controller-manager
+  name: {{ printf "%s-controller-manager" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
@@ -82,7 +82,7 @@ spec:
         resources: {}
       securityContext:
         {{- toYaml .Values.controllerManager.manager.podSecurityContext | nindent 8 }}
-      serviceAccountName: {{ include "kueue.fullname" . }}-controller-manager
+      serviceAccountName: {{ printf "%s-controller-manager" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
       {{- with .Values.controllerManager.imagePullSecrets  }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -92,7 +92,7 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: {{ include "kueue.fullname" . }}-webhook-server-cert
+          secretName: {{ printf "%s-webhook-server-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
       - configMap:
-          name: {{ include "kueue.fullname" . }}-manager-config
+          name: {{ printf "%s-manager-config" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
         name: manager-config

--- a/charts/kueue/templates/prometheus/monitor.yaml
+++ b/charts/kueue/templates/prometheus/monitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "kueue.fullname" . }}-controller-manager-metrics-monitor
+  name: {{ printf "%s-controller-manager-metrics-monitor" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
   namespace: '{{ .Release.Namespace }}'

--- a/charts/kueue/templates/prometheus/role.yaml
+++ b/charts/kueue/templates/prometheus/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "kueue.fullname" . }}-prometheus-k8s
+  name: {{ printf "%s-prometheus-k8s" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
@@ -37,14 +37,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "kueue.fullname" . }}-prometheus-k8s
+  name: {{ printf "%s-prometheus-k8s" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: '{{ .Release.Namespace }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: '{{ include "kueue.fullname" . }}-prometheus-k8s'
+  name: '{{ printf "%s-prometheus-k8s" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s

--- a/charts/kueue/templates/rbac/auth_proxy_client_clusterrole.yaml
+++ b/charts/kueue/templates/rbac/auth_proxy_client_clusterrole.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-metrics-reader'
+  name: '{{ printf "%s-metrics-reader" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
 rules:
   - nonResourceURLs:
       - "/metrics"

--- a/charts/kueue/templates/rbac/auth_proxy_role.yaml
+++ b/charts/kueue/templates/rbac/auth_proxy_role.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-proxy-role'
+  name: '{{ printf "%s-proxy-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
 rules:
   - apiGroups:
       - authentication.k8s.io

--- a/charts/kueue/templates/rbac/auth_proxy_role_binding.yaml
+++ b/charts/kueue/templates/rbac/auth_proxy_role_binding.yaml
@@ -3,12 +3,12 @@ kind: ClusterRoleBinding
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-proxy-rolebinding'
+  name: '{{ printf "%s-proxy-rolebinding" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: '{{ include "kueue.fullname" . }}-proxy-role'
+  name: '{{ printf "%s-proxy-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
 subjects:
   - kind: ServiceAccount
-    name: '{{ include "kueue.fullname" . }}-controller-manager'
+    name: '{{ printf "%s-controller-manager" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
     namespace: '{{ .Release.Namespace }}'

--- a/charts/kueue/templates/rbac/batch_admin_role.yaml
+++ b/charts/kueue/templates/rbac/batch_admin_role.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-batch-admin-role'
+  name: '{{ printf "%s-batch-admin-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:

--- a/charts/kueue/templates/rbac/batch_user_role.yaml
+++ b/charts/kueue/templates/rbac/batch_user_role.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-batch-user-role'
+  name: '{{ printf "%s-batch-user-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels:

--- a/charts/kueue/templates/rbac/clusterqueue_editor_role.yaml
+++ b/charts/kueue/templates/rbac/clusterqueue_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-clusterqueue-editor-role'
+  name: '{{ printf "%s-clusterqueue-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/clusterqueue_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/clusterqueue_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-clusterqueue-viewer-role'
+  name: '{{ printf "%s-clusterqueue-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/job_editor_role.yaml
+++ b/charts/kueue/templates/rbac/job_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-job-editor-role'
+  name: '{{ printf "%s-job-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/job_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/job_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-job-viewer-role'
+  name: '{{ printf "%s-job-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/jobset_editor_role.yaml
+++ b/charts/kueue/templates/rbac/jobset_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-jobset-editor-role'
+  name: '{{ printf "%s-jobset-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/jobset_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/jobset_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-jobset-viewer-role'
+  name: '{{ printf "%s-jobset-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/leader_election_role.yaml
+++ b/charts/kueue/templates/rbac/leader_election_role.yaml
@@ -4,7 +4,7 @@ kind: Role
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-leader-election-role'
+  name: '{{ printf "%s-leader-election-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
 rules:
   - apiGroups:
       - ""

--- a/charts/kueue/templates/rbac/leader_election_role_binding.yaml
+++ b/charts/kueue/templates/rbac/leader_election_role_binding.yaml
@@ -3,12 +3,12 @@ kind: RoleBinding
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-leader-election-rolebinding'
+  name: '{{ printf "%s-leader-election-rolebinding" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: '{{ include "kueue.fullname" . }}-leader-election-role'
+  name: '{{ printf "%s-leader-election-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
 subjects:
   - kind: ServiceAccount
-    name: '{{ include "kueue.fullname" . }}-controller-manager'
+    name: '{{ printf "%s-controller-manager" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
     namespace: '{{ .Release.Namespace }}'

--- a/charts/kueue/templates/rbac/localqueue_editor_role.yaml
+++ b/charts/kueue/templates/rbac/localqueue_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-localqueue-editor-role'
+  name: '{{ printf "%s-localqueue-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/localqueue_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/localqueue_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-localqueue-viewer-role'
+  name: '{{ printf "%s-localqueue-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/mpijob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/mpijob_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-mpijob-editor-role'
+  name: '{{ printf "%s-mpijob-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/mpijob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/mpijob_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-mpijob-viewer-role'
+  name: '{{ printf "%s-mpijob-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/mxjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/mxjob_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-mxjob-editor-role'
+  name: '{{ printf "%s-mxjob-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/mxjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/mxjob_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-mxjob-viewer-role'
+  name: '{{ printf "%s-mxjob-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/paddlejob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/paddlejob_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-paddlejob-editor-role'
+  name: '{{ printf "%s-paddlejob-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/paddlejob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/paddlejob_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-paddlejob-viewer-role'
+  name: '{{ printf "%s-paddlejob-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/pending_workloads_cq_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/pending_workloads_cq_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-pending-workloads-cq-viewer-role'
+  name: '{{ printf "%s-pending-workloads-cq-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/pending_workloads_lq_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/pending_workloads_lq_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-pending-workloads-lq-viewer-role'
+  name: '{{ printf "%s-pending-workloads-lq-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/pytorchjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/pytorchjob_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-pytorchjob-editor-role'
+  name: '{{ printf "%s-pytorchjob-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/pytorchjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/pytorchjob_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-pytorchjob-viewer-role'
+  name: '{{ printf "%s-pytorchjob-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/raycluster_editor_role.yaml
+++ b/charts/kueue/templates/rbac/raycluster_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-raycluster-editor-role'
+  name: '{{ printf "%s-raycluster-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/raycluster_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/raycluster_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-raycluster-viewer-role'
+  name: '{{ printf "%s-raycluster-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/rayjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/rayjob_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-rayjob-editor-role'
+  name: '{{ printf "%s-rayjob-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/rayjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/rayjob_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-rayjob-viewer-role'
+  name: '{{ printf "%s-rayjob-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/resourceflavor_editor_role.yaml
+++ b/charts/kueue/templates/rbac/resourceflavor_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-resourceflavor-editor-role'
+  name: '{{ printf "%s-resourceflavor-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/resourceflavor_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/resourceflavor_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-resourceflavor-viewer-role'
+  name: '{{ printf "%s-resourceflavor-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-manager-role'
+  name: '{{ printf "%s-manager-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
 rules:
   - apiGroups:
       - ""

--- a/charts/kueue/templates/rbac/role_binding.yaml
+++ b/charts/kueue/templates/rbac/role_binding.yaml
@@ -3,12 +3,12 @@ kind: ClusterRoleBinding
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-manager-rolebinding'
+  name: '{{ printf "%s-manager-rolebinding" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: '{{ include "kueue.fullname" . }}-manager-role'
+  name: '{{ printf "%s-manager-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
 subjects:
   - kind: ServiceAccount
-    name: '{{ include "kueue.fullname" . }}-controller-manager'
+    name: '{{ printf "%s-controller-manager" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
     namespace: '{{ .Release.Namespace }}'

--- a/charts/kueue/templates/rbac/service_account.yaml
+++ b/charts/kueue/templates/rbac/service_account.yaml
@@ -3,5 +3,5 @@ kind: ServiceAccount
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-controller-manager'
+  name: '{{ printf "%s-controller-manager" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   namespace: '{{ .Release.Namespace }}'

--- a/charts/kueue/templates/rbac/tfjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/tfjob_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-tfjob-editor-role'
+  name: '{{ printf "%s-tfjob-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/tfjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/tfjob_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-tfjob-viewer-role'
+  name: '{{ printf "%s-tfjob-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/workload_editor_role.yaml
+++ b/charts/kueue/templates/rbac/workload_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-workload-editor-role'
+  name: '{{ printf "%s-workload-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/workload_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/workload_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-workload-viewer-role'
+  name: '{{ printf "%s-workload-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/xgboostjob_editor_role.yaml
+++ b/charts/kueue/templates/rbac/xgboostjob_editor_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-xgboostjob-editor-role'
+  name: '{{ printf "%s-xgboostjob-editor-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/rbac/xgboostjob_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/xgboostjob_viewer_role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "kueue.fullname" . }}-xgboostjob-viewer-role'
+  name: '{{ printf "%s-xgboostjob-viewer-role" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
     rbac.kueue.x-k8s.io/batch-admin: "true"

--- a/charts/kueue/templates/visibility-apf/flowschema.yaml
+++ b/charts/kueue/templates/visibility-apf/flowschema.yaml
@@ -4,7 +4,7 @@ kind: FlowSchema
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-visibility'
+  name: '{{ printf "%s-visibility" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   namespace: '{{ .Release.Namespace }}'
 spec:
   distinguisherMethod:

--- a/charts/kueue/templates/visibility-apf/prioritylevelconfigurations.yaml
+++ b/charts/kueue/templates/visibility-apf/prioritylevelconfigurations.yaml
@@ -4,7 +4,7 @@ kind: PriorityLevelConfiguration
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-visibility'
+  name: '{{ printf "%s-visibility" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   namespace: '{{ .Release.Namespace }}'
 spec:
   limited:

--- a/charts/kueue/templates/visibility/apiservice_v1alpha1.yaml
+++ b/charts/kueue/templates/visibility/apiservice_v1alpha1.yaml
@@ -9,7 +9,7 @@ spec:
   groupPriorityMinimum: 100
   insecureSkipTLSVerify: true
   service:
-    name: '{{ include "kueue.fullname" . }}-visibility-server'
+    name: '{{ printf "%s-visibility-server" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
     namespace: '{{ .Release.Namespace }}'
   version: v1alpha1
   versionPriority: 100

--- a/charts/kueue/templates/visibility/apiservice_v1beta1.yaml
+++ b/charts/kueue/templates/visibility/apiservice_v1beta1.yaml
@@ -9,7 +9,7 @@ spec:
   groupPriorityMinimum: 100
   insecureSkipTLSVerify: true
   service:
-    name: '{{ include "kueue.fullname" . }}-visibility-server'
+    name: '{{ printf "%s-visibility-server" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
     namespace: '{{ .Release.Namespace }}'
   version: v1beta1
   versionPriority: 100

--- a/charts/kueue/templates/visibility/role_binding.yaml
+++ b/charts/kueue/templates/visibility/role_binding.yaml
@@ -3,7 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-visibility-server-auth-reader'
+  name: '{{ printf "%s-visibility-server-auth-reader" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/kueue/templates/visibility/service.yaml
+++ b/charts/kueue/templates/visibility/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-visibility-server'
+  name: '{{ printf "%s-visibility-server" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   namespace: '{{ .Release.Namespace }}'
 spec:
   ports:

--- a/charts/kueue/templates/webhook/service.yaml
+++ b/charts/kueue/templates/webhook/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-webhook-service'
+  name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   namespace: '{{ .Release.Namespace }}'
 spec:
   {{- if .Values.webhookService.ipDualStack.enabled }}

--- a/charts/kueue/templates/webhook/webhook.yaml
+++ b/charts/kueue/templates/webhook/webhook.yaml
@@ -4,10 +4,10 @@ kind: MutatingWebhookConfiguration
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-mutating-webhook-configuration'
+  name: '{{ printf "%s-mutating-webhook-configuration" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   {{- if .Values.enableCertManager }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
   {{- end }}
   namespace: '{{ .Release.Namespace }}'
 webhooks:
@@ -15,7 +15,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-apps-v1-deployment
     {{- if has "deployment" $integrationsConfig.frameworks }}
@@ -45,7 +45,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-batch-v1-job
     failurePolicy: Fail
@@ -64,7 +64,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-jobset-x-k8s-io-v1alpha2-jobset
     failurePolicy: Fail
@@ -83,7 +83,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-kubeflow-org-v1-mxjob
     failurePolicy: Fail
@@ -102,7 +102,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-kubeflow-org-v1-paddlejob
     failurePolicy: Fail
@@ -121,7 +121,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-kubeflow-org-v1-pytorchjob
     failurePolicy: Fail
@@ -140,7 +140,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-kubeflow-org-v1-tfjob
     failurePolicy: Fail
@@ -159,7 +159,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-kubeflow-org-v1-xgboostjob
     failurePolicy: Fail
@@ -178,7 +178,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-kubeflow-org-v2beta1-mpijob
     failurePolicy: Fail
@@ -197,7 +197,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate--v1-pod
     {{- if has "pod" $integrationsConfig.frameworks }}
@@ -231,7 +231,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-ray-io-v1-raycluster
     failurePolicy: Fail
@@ -250,7 +250,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-ray-io-v1-rayjob
     failurePolicy: Fail
@@ -269,7 +269,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-kueue-x-k8s-io-v1beta1-clusterqueue
     failurePolicy: Fail
@@ -288,7 +288,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-kueue-x-k8s-io-v1beta1-resourceflavor
     failurePolicy: Fail
@@ -307,7 +307,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-kueue-x-k8s-io-v1beta1-workload
     failurePolicy: Fail
@@ -328,10 +328,10 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
   {{- include "kueue.labels" . | nindent 4 }}
-  name: '{{ include "kueue.fullname" . }}-validating-webhook-configuration'
+  name: '{{ printf "%s-validating-webhook-configuration" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
   {{- if .Values.enableCertManager }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
   {{- end }}
   namespace: '{{ .Release.Namespace }}'
 webhooks:
@@ -339,7 +339,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-apps-v1-deployment
     {{- if has "deployment" $integrationsConfig.frameworks }}
@@ -370,7 +370,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-batch-v1-job
     failurePolicy: Fail
@@ -390,7 +390,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-jobset-x-k8s-io-v1alpha2-jobset
     failurePolicy: Fail
@@ -410,7 +410,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-kubeflow-org-v1-mxjob
     failurePolicy: Fail
@@ -430,7 +430,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-kubeflow-org-v1-paddlejob
     failurePolicy: Fail
@@ -450,7 +450,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-kubeflow-org-v1-pytorchjob
     failurePolicy: Fail
@@ -470,7 +470,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-kubeflow-org-v1-tfjob
     failurePolicy: Fail
@@ -490,7 +490,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-kubeflow-org-v1-xgboostjob
     failurePolicy: Fail
@@ -510,7 +510,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-kubeflow-org-v2beta1-mpijob
     failurePolicy: Fail
@@ -530,7 +530,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate--v1-pod
     {{- if has "pod" $integrationsConfig.frameworks }}
@@ -565,7 +565,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-ray-io-v1-raycluster
     failurePolicy: Fail
@@ -585,7 +585,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-ray-io-v1-rayjob
     failurePolicy: Fail
@@ -605,7 +605,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-kueue-x-k8s-io-v1beta1-clusterqueue
     failurePolicy: Fail
@@ -625,7 +625,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-kueue-x-k8s-io-v1alpha1-cohort
     failurePolicy: Fail
@@ -645,7 +645,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-kueue-x-k8s-io-v1beta1-resourceflavor
     failurePolicy: Fail
@@ -665,7 +665,7 @@ webhooks:
       - v1
     clientConfig:
       service:
-        name: '{{ include "kueue.fullname" . }}-webhook-service'
+        name: '{{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-kueue-x-k8s-io-v1beta1-workload
     failurePolicy: Fail

--- a/hack/update-helm.sh
+++ b/hack/update-helm.sh
@@ -63,7 +63,7 @@ search_cert_line="  annotations:"
 replace_cert_line=$(
   cat <<'EOF'
     {{- if .Values.enableCertManager }}
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
     {{- end }}
 EOF
 )
@@ -76,7 +76,7 @@ replace_webhook_line=$(
     webhook:
       clientConfig:
         service:
-          name: {{ include "kueue.fullname" . }}-webhook-service
+          name: {{ printf "%s-webhook-service" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:
@@ -103,8 +103,8 @@ search_webhook_pod_mutate="        path: /mutate--v1-pod"
 search_webhook_pod_validate="        path: /validate--v1-pod"
 search_webhook_deployment_mutate="        path: /mutate-apps-v1-deployment"
 search_webhook_deployment_validate="        path: /validate-apps-v1-deployment"
-search_mutate_webhook_annotations='  name: '\''{{ include "kueue.fullname" . }}-mutating-webhook-configuration'\'''
-search_validate_webhook_annotations='  name: '\''{{ include "kueue.fullname" . }}-validating-webhook-configuration'\'''
+search_mutate_webhook_annotations='  name: '\''{{ printf "%s-mutating-webhook-configuration" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'\'''
+search_validate_webhook_annotations='  name: '\''{{ printf "%s-validating-webhook-configuration" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}'\'''
 add_webhook_line=$(
   cat <<'EOF'
 {{- $integrationsConfig := (fromYaml .Values.managerConfig.controllerManagerConfigYaml).integrations }}
@@ -114,7 +114,7 @@ add_annotations_line=$(
   cat <<'EOF'
   {{- if .Values.enableCertManager }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "kueue.fullname" . }}-serving-cert
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ printf "%s-serving-cert" (include "kueue.fullname" .) | trunc 63 | trimSuffix "-" }}
   {{- end }}
   namespace: '{{ .Release.Namespace }}'
 EOF


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR addresses a but in the Helm chart. Some of the resources generated by the Helm chart are very long. Combined with the release name, they can easily get too long.

### Example

Let's look at the resource `{{ include "kueue.fullname" . }}-controller-manager-metrics-service` of `kind: Service`. When generated for a somewhat long release name like `project-foo-cluster-bar-kueue`, the resulting resource name is `project-foo-cluster-bar-kueue-controller-manager-metrics-service` which is 65 characters long and we get the following error when trying to apply/install:

```
Service "project-foo-cluster-bar-kueue-controller-manager-metrics-service" is invalid: metadata.name: Invalid value: "project-foo-cluster-bar-kueue-controller-manager-metrics-service": must be no more than 63 characters
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE (it only affects names for resources that would have been too long and therefore failed anyway. Existing resources remain unchanged)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Helm: Sanitize resource names by truncating them to a maximum length of 63 characters
```