### PR TITLE
[MultiKueue] Introduce Admission Check Validation feature gate

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -31,6 +31,8 @@ const (
 	ClusterQueueActiveReasonAdmissionCheckInactive                          = "AdmissionCheckInactive"
 	ClusterQueueActiveReasonMultipleSingleInstanceControllerAdmissionChecks = "MultipleSingleInstanceControllerAdmissionChecks"
 	ClusterQueueActiveReasonFlavorIndependentAdmissionCheckAppliedPerFlavor = "FlavorIndependentAdmissionCheckAppliedPerFlavor"
+	ClusterQueueActiveReasonMultipleMultiKueueAdmissionChecks               = "MultipleMultiKueueAdmissionChecks"
+	ClusterQueueActiveReasonMutliKueueAdmissionCheckAppliedPerFlavor        = "MutliKueueAdmissionCheckAppliedPerFlavor"
 	ClusterQueueActiveReasonUnknown                                         = "Unknown"
 	ClusterQueueActiveReasonReady                                           = "Ready"
 )

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -242,11 +242,19 @@ func (c *Cache) DeleteResourceFlavor(rf *kueue.ResourceFlavor) sets.Set[string] 
 func (c *Cache) AddOrUpdateAdmissionCheck(ac *kueue.AdmissionCheck) sets.Set[string] {
 	c.Lock()
 	defer c.Unlock()
+
+	// TBD: This might not be needed, but we could keep it for readability
+	// because SingleInstanceInClusterQueue and FlavorIndependent will be false if AdmissionCheckValidationRules is off
+	singleInstanceInClusterQueue, flavorIndependent := false, false
+	if features.Enabled(features.AdmissionCheckValidationRules) {
+		singleInstanceInClusterQueue = apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionChecksSingleInstanceInClusterQueue)
+		flavorIndependent = apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.FlavorIndependentAdmissionCheck)
+	}
 	c.admissionChecks[ac.Name] = AdmissionCheck{
 		Active:                       apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionCheckActive),
 		Controller:                   ac.Spec.ControllerName,
-		SingleInstanceInClusterQueue: apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionChecksSingleInstanceInClusterQueue),
-		FlavorIndependent:            apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.FlavorIndependentAdmissionCheck),
+		SingleInstanceInClusterQueue: singleInstanceInClusterQueue,
+		FlavorIndependent:            flavorIndependent,
 	}
 
 	return c.updateClusterQueues()

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -274,12 +274,12 @@ func (c *clusterQueue) inactiveReason() (string, string) {
 
 		if len(c.multipleMultiKueueAdmissionChecks) > 1 {
 			reasons = append(reasons, kueue.ClusterQueueActiveReasonMultipleMultiKueueAdmissionChecks)
-			messages = append(messages, "Cannot use multiple MultiKueue AdmissionChecks on the same ClusterQueue")
+			messages = append(messages, fmt.Sprintf("Cannot use multiple MultiKueue AdmissionChecks on the same ClusterQueue, found: %v", strings.Join(c.multipleMultiKueueAdmissionChecks, ",")))
 		}
 
 		if len(c.perFlavorMultiKueueAdmissionChecks) > 0 {
 			reasons = append(reasons, kueue.ClusterQueueActiveReasonMutliKueueAdmissionCheckAppliedPerFlavor)
-			messages = append(messages, "MultiKueue AdmissionCheck cannot be specified per flavor")
+			messages = append(messages, fmt.Sprintf("Cannot specify MultiKueue AdmissionCheck per flavor, found: %s", strings.Join(c.perFlavorMultiKueueAdmissionChecks, ",")))
 		}
 
 		// This doesn't need to be gated behind, because it is empty when the gate is disabled
@@ -361,9 +361,9 @@ func (c *clusterQueue) updateWithAdmissionChecks(checks map[string]AdmissionChec
 			}
 
 			if ac.Controller == kueue.MultiKueueControllerName {
-				// MultiKueue Admission Checks have extra constraints
-				// disallow to use multiple MultiKueue AdmissionChecks on the same ClusterQueue
-				// MultiKueue AdmissionCheck cannot be specified per flavor
+				// MultiKueue Admission Checks has extra constraints:
+				// - cannot use multiple MultiKueue AdmissionChecks on the same ClusterQueue
+				// - cannot use specify MultiKueue AdmissionCheck per flavor
 				multipleMultiKueueControllers.Insert(acName)
 				if flavors.Len() != 0 {
 					perFlavorMultiKueueChecks = append(perFlavorMultiKueueChecks, acName)

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -722,10 +722,10 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  kueue.ClusterQueueActiveReasonMultipleMultiKueueAdmissionChecks,
-			wantMessage: `Can't admit new workloads: Cannot use multiple MultiKueue AdmissionChecks on the same ClusterQueue.`,
+			wantMessage: `Can't admit new workloads: Cannot use multiple MultiKueue AdmissionChecks on the same ClusterQueue, found: check1,check3.`,
 		},
 		{
-			name:     "Active clusterQueue with a FlavorIndependent AC applied per ResourceFlavor - AdmissionCheckValidationRules enabled",
+			name:     "Pending clusterQueue with a FlavorIndependent AC applied per ResourceFlavor",
 			cq:       cqWithACPerFlavor,
 			cqStatus: pending,
 			admissionChecks: map[string]AdmissionCheck{
@@ -735,10 +735,9 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 					FlavorIndependent: true,
 				},
 			},
-			wantStatus:               pending,
-			wantReason:               "FlavorIndependentAdmissionCheckAppliedPerFlavor",
-			wantMessage:              "Can't admit new workloads: AdmissionCheck(s): [check1] cannot be set at flavor level.",
-			acValidationRulesEnabled: true,
+			wantStatus:  active,
+			wantReason:  "Ready",
+			wantMessage: "Can admit new workloads",
 		},
 		{
 			name:     "Terminating clusterQueue updated with valid AC list",
@@ -873,7 +872,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "MutliKueueAdmissionCheckAppliedPerFlavor",
-			wantMessage: `Can't admit new workloads: MultiKueue AdmissionCheck cannot be specified per flavor.`,
+			wantMessage: `Can't admit new workloads: Cannot specify MultiKueue AdmissionCheck per flavor, found: check1.`,
 		},
 	}
 

--- a/pkg/controller/admissionchecks/multikueue/admissioncheck.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 )
 
@@ -126,28 +127,30 @@ func (a *ACReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		apimeta.SetStatusCondition(&ac.Status.Conditions, newCondition)
 		needsUpdate = true
 	}
-	if !apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionChecksSingleInstanceInClusterQueue) {
-		apimeta.SetStatusCondition(&ac.Status.Conditions, metav1.Condition{
-			Type:               kueue.AdmissionChecksSingleInstanceInClusterQueue,
-			Status:             metav1.ConditionTrue,
-			Reason:             SingleInstanceReason,
-			Message:            SingleInstanceMessage,
-			ObservedGeneration: ac.Generation,
-		})
-		needsUpdate = true
-	}
 
-	if !apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.FlavorIndependentAdmissionCheck) {
-		apimeta.SetStatusCondition(&ac.Status.Conditions, metav1.Condition{
-			Type:               kueue.FlavorIndependentAdmissionCheck,
-			Status:             metav1.ConditionTrue,
-			Reason:             FlavorIndependentCheckReason,
-			Message:            FlavorIndependentCheckMessage,
-			ObservedGeneration: ac.Generation,
-		})
-		needsUpdate = true
-	}
+	if features.Enabled(features.AdmissionCheckValidationRules) {
+		if !apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionChecksSingleInstanceInClusterQueue) {
+			apimeta.SetStatusCondition(&ac.Status.Conditions, metav1.Condition{
+				Type:               kueue.AdmissionChecksSingleInstanceInClusterQueue,
+				Status:             metav1.ConditionTrue,
+				Reason:             SingleInstanceReason,
+				Message:            SingleInstanceMessage,
+				ObservedGeneration: ac.Generation,
+			})
+			needsUpdate = true
+		}
 
+		if !apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.FlavorIndependentAdmissionCheck) {
+			apimeta.SetStatusCondition(&ac.Status.Conditions, metav1.Condition{
+				Type:               kueue.FlavorIndependentAdmissionCheck,
+				Status:             metav1.ConditionTrue,
+				Reason:             FlavorIndependentCheckReason,
+				Message:            FlavorIndependentCheckMessage,
+				ObservedGeneration: ac.Generation,
+			})
+			needsUpdate = true
+		}
+	}
 	if needsUpdate {
 		err := a.client.Status().Update(ctx, ac)
 		if err != nil {

--- a/pkg/controller/admissionchecks/multikueue/admissioncheck_test.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck_test.go
@@ -57,8 +57,6 @@ func TestReconcile(t *testing.T) {
 				*utiltesting.MakeAdmissionCheck("ac1").
 					ControllerName(kueue.MultiKueueControllerName).
 					Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", "config1").
-					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
-					ApplyToAllFlavors(true, FlavorIndependentCheckReason, FlavorIndependentCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionFalse,
@@ -68,7 +66,6 @@ func TestReconcile(t *testing.T) {
 					}).
 					Obj(),
 			},
-			acValidationRulesEnabled: true,
 		},
 		"unmanaged": {
 			reconcileFor: "ac1",
@@ -99,8 +96,6 @@ func TestReconcile(t *testing.T) {
 				*utiltesting.MakeAdmissionCheck("ac1").
 					ControllerName(kueue.MultiKueueControllerName).
 					Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", "config1").
-					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
-					ApplyToAllFlavors(true, FlavorIndependentCheckReason, FlavorIndependentCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionFalse,
@@ -110,7 +105,6 @@ func TestReconcile(t *testing.T) {
 					}).
 					Obj(),
 			},
-			acValidationRulesEnabled: true,
 		},
 		"inactive cluster": {
 			reconcileFor: "ac1",
@@ -133,8 +127,6 @@ func TestReconcile(t *testing.T) {
 				*utiltesting.MakeAdmissionCheck("ac1").
 					ControllerName(kueue.MultiKueueControllerName).
 					Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", "config1").
-					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
-					ApplyToAllFlavors(true, FlavorIndependentCheckReason, FlavorIndependentCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionFalse,
@@ -144,7 +136,6 @@ func TestReconcile(t *testing.T) {
 					}).
 					Obj(),
 			},
-			acValidationRulesEnabled: true,
 		},
 		"all clusters missing or inactive": {
 			reconcileFor: "ac1",
@@ -170,8 +161,6 @@ func TestReconcile(t *testing.T) {
 				*utiltesting.MakeAdmissionCheck("ac1").
 					ControllerName(kueue.MultiKueueControllerName).
 					Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", "config1").
-					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
-					ApplyToAllFlavors(true, FlavorIndependentCheckReason, FlavorIndependentCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionFalse,
@@ -181,7 +170,6 @@ func TestReconcile(t *testing.T) {
 					}).
 					Obj(),
 			},
-			acValidationRulesEnabled: true,
 		},
 		"partially active": {
 			reconcileFor: "ac1",
@@ -207,8 +195,6 @@ func TestReconcile(t *testing.T) {
 				*utiltesting.MakeAdmissionCheck("ac1").
 					ControllerName(kueue.MultiKueueControllerName).
 					Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", "config1").
-					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
-					ApplyToAllFlavors(true, FlavorIndependentCheckReason, FlavorIndependentCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionTrue,
@@ -218,7 +204,6 @@ func TestReconcile(t *testing.T) {
 					}).
 					Obj(),
 			},
-			acValidationRulesEnabled: true,
 		},
 		"active": {
 			reconcileFor: "ac1",
@@ -254,7 +239,7 @@ func TestReconcile(t *testing.T) {
 			},
 			acValidationRulesEnabled: true,
 		},
-		"active AdmissionCheckValidationRules disabled": {
+		"extra status conditions of SingleInstance and FlavorIndependent when AdmissionCheckValidationRules is enabled": {
 			reconcileFor: "ac1",
 			checks: []kueue.AdmissionCheck{
 				*utiltesting.MakeAdmissionCheck("ac1").
@@ -275,6 +260,8 @@ func TestReconcile(t *testing.T) {
 				*utiltesting.MakeAdmissionCheck("ac1").
 					ControllerName(kueue.MultiKueueControllerName).
 					Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", "config1").
+					SingleInstanceInClusterQueue(true, SingleInstanceReason, SingleInstanceMessage, 1).
+					ApplyToAllFlavors(true, FlavorIndependentCheckReason, FlavorIndependentCheckMessage, 1).
 					Condition(metav1.Condition{
 						Type:               kueue.AdmissionCheckActive,
 						Status:             metav1.ConditionTrue,
@@ -284,6 +271,7 @@ func TestReconcile(t *testing.T) {
 					}).
 					Obj(),
 			},
+			acValidationRulesEnabled: true,
 		},
 	}
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -132,6 +132,13 @@ const (
 	// Enable the Flavors status field in the LocalQueue, allowing users to view
 	// all currently available ResourceFlavors for the LocalQueue.
 	ExposeFlavorsInLocalQueue featuregate.Feature = "ExposeFlavorsInLocalQueue"
+
+	// owner: @mszadkow
+	// alpha: v0.9
+	// Deprecated: v0.9
+	//
+	// Enable additional AdmissionCheck validation rules that will appear in status conditions.
+	AdmissionCheckValidationRules featuregate.Feature = "AdmissionCheckValidationRules"
 )
 
 func init() {
@@ -159,6 +166,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ConfigurableResourceTransformations: {Default: false, PreRelease: featuregate.Alpha},
 	WorkloadResourceRequestsSummary:     {Default: false, PreRelease: featuregate.Alpha},
 	ExposeFlavorsInLocalQueue:           {Default: true, PreRelease: featuregate.Beta},
+	AdmissionCheckValidationRules:       {Default: false, PreRelease: featuregate.Alpha},
 }
 
 func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -166,7 +166,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ConfigurableResourceTransformations: {Default: false, PreRelease: featuregate.Alpha},
 	WorkloadResourceRequestsSummary:     {Default: false, PreRelease: featuregate.Alpha},
 	ExposeFlavorsInLocalQueue:           {Default: true, PreRelease: featuregate.Beta},
-	AdmissionCheckValidationRules:       {Default: false, PreRelease: featuregate.Alpha},
+	AdmissionCheckValidationRules:       {Default: false, PreRelease: featuregate.Deprecated},
 }
 
 func SetFeatureGateDuringTest(tb testing.TB, f featuregate.Feature, value bool) {

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -256,6 +256,7 @@ The currently supported features are:
 | `ConfigurableResourceTransformations` | `false` | Alpha      | 0.9   |       |
 | `WorkloadResourceRequestsSummary`     | `false` | Alpha      | 0.9   |       |
 | `ExposeFlavorsInLocalQueue`           | `true`  | Beta       | 0.9   |       |
+| `AdmissionCheckValidationRules`       | `false` | Alpha      | 0.9   | 0.9   |
 
 ## What's next
 

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -255,8 +255,7 @@ The currently supported features are:
 | `TopologyAwareScheduling`             | `false` | Alpha      | 0.9   |       |
 | `ConfigurableResourceTransformations` | `false` | Alpha      | 0.9   |       |
 | `WorkloadResourceRequestsSummary`     | `false` | Alpha      | 0.9   |       |
-| `ExposeFlavorsInLocalQueue`           | `true`  | Beta       | 0.9   |       |
-| `AdmissionCheckValidationRules`       | `false` | Alpha      | 0.9   | 0.9   |
+| `AdmissionCheckValidationRules`       | `false` | Deprecated | 0.9   | 0.9   |
 
 ## What's next
 

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -788,7 +788,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
 					Reason:  "MultipleMultiKueueAdmissionChecks",
-					Message: `Can't admit new workloads: Cannot use multiple MultiKueue AdmissionChecks on the same ClusterQueue.`,
+					Message: `Can't admit new workloads: Cannot use multiple MultiKueue AdmissionChecks on the same ClusterQueue, found: check1,check2.`,
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 
@@ -817,7 +817,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
 					Reason:  "MutliKueueAdmissionCheckAppliedPerFlavor",
-					Message: `Can't admit new workloads: MultiKueue AdmissionCheck cannot be specified per flavor.`,
+					Message: `Can't admit new workloads: Cannot specify MultiKueue AdmissionCheck per flavor, found: check1.`,
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -787,8 +787,8 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 				{
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
-					Reason:  "MultipleSingleInstanceControllerAdmissionChecks",
-					Message: `Can't admit new workloads: only one AdmissionCheck of [check1 check2] can be referenced for controller "kueue.x-k8s.io/multikueue", Cannot use multiple MultiKueue AdmissionChecks on the same ClusterQueue.`,
+					Reason:  "MultipleMultiKueueAdmissionChecks",
+					Message: `Can't admit new workloads: Cannot use multiple MultiKueue AdmissionChecks on the same ClusterQueue.`,
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 
@@ -816,8 +816,8 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 				{
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
-					Reason:  "FlavorIndependentAdmissionCheckAppliedPerFlavor",
-					Message: `Can't admit new workloads: AdmissionCheck(s): [check1] cannot be set at flavor level, MultiKueue AdmissionCheck cannot be specified per flavor.`,
+					Reason:  "MutliKueueAdmissionCheckAppliedPerFlavor",
+					Message: `Can't admit new workloads: MultiKueue AdmissionCheck cannot be specified per flavor.`,
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))
 

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -187,10 +187,6 @@ var _ = ginkgo.Describe("Multikueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 		gomega.Expect(worker2TestCluster.client.Create(worker2TestCluster.ctx, worker2Cq)).Should(gomega.Succeed())
 		worker2Lq = utiltesting.MakeLocalQueue(worker2Cq.Name, worker2Ns.Name).ClusterQueue(worker2Cq.Name).Obj()
 		gomega.Expect(worker2TestCluster.client.Create(worker2TestCluster.ctx, worker2Lq)).Should(gomega.Succeed())
-
-		ginkgo.By("Disabling AdmissionCheckValidationRules feature", func() {
-			gomega.Expect(features.SetEnable(features.AdmissionCheckValidationRules, false)).To(gomega.Succeed())
-		})
 	})
 
 	ginkgo.AfterEach(func() {
@@ -341,7 +337,7 @@ var _ = ginkgo.Describe("Multikueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 
 	ginkgo.It("Should properly manage the active condition of AdmissionChecks and MultiKueueClusters, kubeconfig provided by file", func() {
 		ginkgo.By("Enabling AdmissionCheckValidationRules feature", func() {
-			gomega.Expect(features.SetEnable(features.AdmissionCheckValidationRules, true)).To(gomega.Succeed())
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.AdmissionCheckValidationRules, true)
 		})
 		ac := utiltesting.MakeAdmissionCheck("testing-ac").
 			ControllerName(kueue.MultiKueueControllerName).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`SingleInstanceInClusterQueue` and `FlavorIndependent` are confusing to the multi-cluster users.
We need to wrap them with feature gate, but preserve the logic for MultiKueue Admission Checks constraints without those status conditions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3094 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Deprecated SingleInstanceInClusterQueue and FlavorIndependent status conditions.

ACTION REQUIRED: the Admission check status conditions “FlavorIndependent” and “SingleInstanceInClusterQueue” are no longer supported by default.
If you were using any of these conditions for your external AdmissionCheck you need to enable the `AdmissionCheckValidationRules` feature gate. 
For the future releases you will need to provide validation by an external controller.
```