### PR TITLE
Wait for the prebuild workload.

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -387,10 +386,6 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 			if apierrors.IsAlreadyExists(err) {
 				log.V(3).Info("Handling job with no workload found an existing workload")
 				return ctrl.Result{Requeue: true}, nil
-			}
-			if errors.Is(err, ErrPrebuildWorkloadNotFound) {
-				log.V(2).Info("Prebuilt workload not found. Requeue in 1 second.")
-				return ctrl.Result{RequeueAfter: time.Second}, nil
 			}
 			if IsUnretryableError(err) {
 				log.V(3).Info("Handling job with no workload", "unretryableError", err)

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -63,10 +64,11 @@ const (
 )
 
 var (
-	ErrUnknownWorkloadOwner  = errors.New("workload owner is unknown")
-	ErrWorkloadOwnerNotFound = errors.New("workload owner not found")
-	ErrNoMatchingWorkloads   = errors.New("no matching workloads")
-	ErrExtraWorkloads        = errors.New("extra workloads")
+	ErrUnknownWorkloadOwner     = errors.New("workload owner is unknown")
+	ErrWorkloadOwnerNotFound    = errors.New("workload owner not found")
+	ErrNoMatchingWorkloads      = errors.New("no matching workloads")
+	ErrExtraWorkloads           = errors.New("extra workloads")
+	ErrPrebuildWorkloadNotFound = errors.New("prebuild workload not found")
 )
 
 // JobReconciler reconciles a GenericJob object
@@ -385,6 +387,10 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 			if apierrors.IsAlreadyExists(err) {
 				log.V(3).Info("Handling job with no workload found an existing workload")
 				return ctrl.Result{Requeue: true}, nil
+			}
+			if errors.Is(err, ErrPrebuildWorkloadNotFound) {
+				log.V(2).Info("Prebuilt workload not found. Requeue in 1 second.")
+				return ctrl.Result{RequeueAfter: time.Second}, nil
 			}
 			if IsUnretryableError(err) {
 				log.V(3).Info("Handling job with no workload", "unretryableError", err)
@@ -1011,8 +1017,7 @@ func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job Generic
 	}
 
 	if usePrebuiltWorkload {
-		log.V(2).Info("Skip workload creation for job with prebuilt workload")
-		return nil
+		return ErrPrebuildWorkloadNotFound
 	}
 
 	// Create the corresponding workload.

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -2286,7 +2286,7 @@ func TestReconciler(t *testing.T) {
 				Obj(),
 			wantWorkloads: []kueue.Workload{},
 		},
-		"when the prebuilt workload is missing, no new one is created and the job is suspended": {
+		"when the prebuilt workload is missing, no new one is created, the job is suspended and prebuild workload not found error is returned": {
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -2306,6 +2306,7 @@ func TestReconciler(t *testing.T) {
 					Message:   "missing workload",
 				},
 			},
+			wantErr: jobframework.ErrPrebuildWorkloadNotFound,
 		},
 		"when the prebuilt workload exists its owner info is updated": {
 			job: *baseJobWrapper.
@@ -2394,6 +2395,7 @@ func TestReconciler(t *testing.T) {
 					Message:   "missing workload",
 				},
 			},
+			wantErr: jobframework.ErrPrebuildWorkloadNotFound,
 		},
 		"when the prebuilt workload is not equivalent to the job": {
 			job: *baseJobWrapper.
@@ -2445,6 +2447,7 @@ func TestReconciler(t *testing.T) {
 					Message:   "missing workload",
 				},
 			},
+			wantErr: jobframework.ErrPrebuildWorkloadNotFound,
 		},
 		"the workload is not admitted, tolerations and node selector change": {
 			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{

--- a/site/content/en/docs/reference/labels-and-annotations.md
+++ b/site/content/en/docs/reference/labels-and-annotations.md
@@ -115,6 +115,8 @@ Example: `kueue.x-k8s.io/prebuilt -workload-name: "my-prebuild-workload-name"`
 Used on: Kueue-managed Jobs.
 
 The label key of the job holds the name of the pre-built workload to be used.
+The intended use of prebuilt workload is to create the Job once the workload 
+is created. In other scenarios the behavior is undefined.
 
 
 ### kueue.x-k8s.io/priority-class


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Wait for the prebuilt Workload if a Job is running before it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3051

#### Special notes for your reviewer:
Follow up for https://github.com/kubernetes-sigs/kueue/pull/3131#issuecomment-2413187780.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Best effort support for scenarios when the Job is created at the same time as prebuilt workload or momentarily before the workload. In that case an error is logged to indicate that creating a Job before prebuilt-workload is outside of the intended use.
```