### PR TITLE
test cleanup: replace equality.DeepEqual by gomega.BeComparableTo

### DIFF
--- a/test/integration/scheduler/workload_controller_test.go
+++ b/test/integration/scheduler/workload_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -362,7 +361,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			ginkgo.By("Check podSets spec", func() {
 				wlRead := kueue.Workload{}
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &wlRead)).To(gomega.Succeed())
-				gomega.Expect(equality.Semantic.DeepEqual(wl.Spec.PodSets, wlRead.Spec.PodSets)).To(gomega.BeTrue())
+				gomega.Expect(wl.Spec.PodSets).Should(gomega.BeComparableTo(wlRead.Spec.PodSets))
 			})
 		})
 		ginkgo.It("Should not use the range defined requests, if provided by the workload", func() {
@@ -404,7 +403,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			ginkgo.By("Check podSets spec", func() {
 				wlRead := kueue.Workload{}
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &wlRead)).To(gomega.Succeed())
-				gomega.Expect(equality.Semantic.DeepEqual(wl.Spec.PodSets, wlRead.Spec.PodSets)).To(gomega.BeTrue())
+				gomega.Expect(wl.Spec.PodSets).Should(gomega.BeComparableTo(wlRead.Spec.PodSets))
 			})
 		})
 	})
@@ -465,7 +464,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			ginkgo.By("Check podSets spec", func() {
 				wlRead := kueue.Workload{}
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &wlRead)).To(gomega.Succeed())
-				gomega.Expect(equality.Semantic.DeepEqual(wl.Spec.PodSets, wlRead.Spec.PodSets)).To(gomega.BeTrue())
+				gomega.Expect(wl.Spec.PodSets).Should(gomega.BeComparableTo(wlRead.Spec.PodSets))
 			})
 		})
 	})
@@ -521,7 +520,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			ginkgo.By("Check podSets spec", func() {
 				wlRead := kueue.Workload{}
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &wlRead)).To(gomega.Succeed())
-				gomega.Expect(equality.Semantic.DeepEqual(wl.Spec.PodSets, wlRead.Spec.PodSets)).To(gomega.BeTrue())
+				gomega.Expect(wl.Spec.PodSets).Should(gomega.BeComparableTo(wlRead.Spec.PodSets))
 			})
 
 			ginkgo.By("Create a pending workload and validate its resourceRequests", func() {
@@ -534,10 +533,10 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
 				wl2Read := kueue.Workload{}
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &wl2Read)).To(gomega.Succeed())
-				gomega.Expect(equality.Semantic.DeepEqual(wl2Read.Status.ResourceRequests, []kueue.PodSetRequest{{
+				gomega.Expect(wl2Read.Status.ResourceRequests).Should(gomega.BeComparableTo([]kueue.PodSetRequest{{
 					Name:      "main",
 					Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")}},
-				})).To(gomega.BeTrue())
+				}))
 			})
 
 			ginkgo.By("Finishing the first workload causes the second one to be admitted", func() {
@@ -622,7 +621,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			ginkgo.By("Check podSets spec", func() {
 				wlRead := kueue.Workload{}
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &wlRead)).To(gomega.Succeed())
-				gomega.Expect(equality.Semantic.DeepEqual(wl.Spec.PodSets, wlRead.Spec.PodSets)).To(gomega.BeTrue())
+				gomega.Expect(wl.Spec.PodSets).Should(gomega.BeComparableTo(wlRead.Spec.PodSets))
 			})
 
 			ginkgo.By("Create a pending workload and validate resourceRequests is not created", func() {
@@ -661,10 +660,10 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
 				read := kueue.Workload{}
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).To(gomega.Succeed())
-				gomega.Expect(equality.Semantic.DeepEqual(read.Status.ResourceRequests, []kueue.PodSetRequest{{
+				gomega.Expect(read.Status.ResourceRequests).Should(gomega.BeComparableTo([]kueue.PodSetRequest{{
 					Name:      "main",
-					Resources: corev1.ResourceList{pseudoCPU: resource.MustParse("1")}},
-				})).To(gomega.BeTrue())
+					Resources: corev1.ResourceList{pseudoCPU: resource.MustParse("1")},
+				}}))
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
#### What this PR does / why we need it:

Cleanup tests introduced in #3026 as [requested](https://github.com/kubernetes-sigs/kueue/pull/3026#discussion_r1805521518) 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

NONE
```