### PR TITLE
[kjobctl] Fix crash issue in Slurm mode when ntasks > 1

### DIFF
--- a/cmd/experimental/kjobctl/pkg/builder/slurm_builder.go
+++ b/cmd/experimental/kjobctl/pkg/builder/slurm_builder.go
@@ -412,7 +412,7 @@ func (b *slurmBuilder) build(ctx context.Context) (runtime.Object, []runtime.Obj
 			}
 		}
 
-		for i, j := 0, 0; i <= int(nTasks); i++ {
+		for i, j := 0, 0; i <= len(job.Spec.Template.Spec.Containers) && j < int(nTasks); i++ {
 			if job.Spec.Template.Spec.Containers[i].Name != replicatedContainer.Name {
 				continue
 			}

--- a/cmd/experimental/kjobctl/pkg/cmd/create/create_test.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/create/create_test.go
@@ -1235,6 +1235,69 @@ cd /mydir
 			},
 			wantOutPattern: `job\.batch\/.+ created\\nconfigmap\/.+ created`,
 		},
+		"should create slurm with --ntasks flag": {
+			beforeTest: beforeSlurmTest,
+			afterTest:  afterSlurmTest,
+			args: func(tc *createCmdTestCase) []string {
+				return []string{
+					"slurm",
+					"--profile", "profile",
+					"--",
+					"--ntasks", "3",
+					tc.tempFile,
+				}
+			},
+			kjobctlObjs: []runtime.Object{
+				wrappers.MakeJobTemplate("slurm-job-template", metav1.NamespaceDefault).
+					WithContainer(*wrappers.MakeContainer("c1", "bash:4.4").Obj()).
+					Obj(),
+				wrappers.MakeApplicationProfile("profile", metav1.NamespaceDefault).
+					WithSupportedMode(*wrappers.MakeSupportedMode(v1alpha1.SlurmMode, "slurm-job-template").Obj()).
+					Obj(),
+			},
+			gvks: []schema.GroupVersionKind{
+				{Group: "batch", Version: "v1", Kind: "Job"},
+				{Group: "", Version: "v1", Kind: "ConfigMap"},
+				{Group: "", Version: "v1", Kind: "Service"},
+			},
+			wantLists: []runtime.Object{
+				&batchv1.JobList{
+					TypeMeta: metav1.TypeMeta{Kind: "JobList", APIVersion: "batch/v1"},
+					Items: []batchv1.Job{
+						*wrappers.MakeJob("", metav1.NamespaceDefault).
+							Completions(1).
+							CompletionMode(batchv1.IndexedCompletion).
+							Profile("profile").
+							Mode(v1alpha1.SlurmMode).
+							Subdomain("profile-slurm").
+							WithContainer(*wrappers.MakeContainer("c1-0", "bash:4.4").
+								Command("bash", "/slurm/scripts/entrypoint.sh").
+								Obj()).
+							WithContainer(*wrappers.MakeContainer("c1-1", "bash:4.4").
+								Command("bash", "/slurm/scripts/entrypoint.sh").
+								Obj()).
+							WithContainer(*wrappers.MakeContainer("c1-2", "bash:4.4").
+								Command("bash", "/slurm/scripts/entrypoint.sh").
+								Obj()).
+							Obj(),
+					},
+				},
+				&corev1.ConfigMapList{},
+				&corev1.ServiceList{},
+			},
+			cmpopts: []cmp.Option{
+				cmpopts.IgnoreFields(corev1.LocalObjectReference{}, "Name"),
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "Name"),
+				cmpopts.IgnoreFields(metav1.OwnerReference{}, "Name"),
+				cmpopts.IgnoreFields(corev1.PodSpec{}, "InitContainers", "Subdomain"),
+				cmpopts.IgnoreTypes([]corev1.EnvVar{}),
+				cmpopts.IgnoreTypes([]corev1.Volume{}),
+				cmpopts.IgnoreTypes([]corev1.VolumeMount{}),
+				cmpopts.IgnoreTypes(corev1.ConfigMapList{}),
+				cmpopts.IgnoreTypes(corev1.ServiceList{}),
+			},
+			wantOutPattern: `job\.batch\/.+ created\\nconfigmap\/.+ created`,
+		},
 		"should divide --mem exactly across containers": {
 			beforeTest: beforeSlurmTest,
 			afterTest:  afterSlurmTest,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

It fixes a crash issue when the Slurm template has one container and --ntasks is greater than 1.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```