### PR TITLE
Use -ldflags=-linkmode=internal to fix malformed LC_DYSYMTAB issue.

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -16,7 +16,7 @@ PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 ARTIFACTS ?= $(PROJECT_DIR)/bin
 
 ifeq ($(shell uname),Darwin)
-    GOFLAGS ?= -ldflags=-extldflags=-Wl,-ld_classic
+    GOFLAGS ?= -ldflags=-linkmode=internal
 endif
 
 ifeq (,$(shell go env GOBIN))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

`-ldflags=-linkmode=internal` using to fix `malformed LC_DYSYMTAB` issue. But it's deprecated and now we have errors:

```
=== Errors
ld: warning: -ld_classic is deprecated and will be removed in a future release
ld: warning: -ld_classic is deprecated and will be removed in a future release
ld: warning: -ld_classic is deprecated and will be removed in a future release
ld: warning: -ld_classic is deprecated and will be removed in a future release
ld: warning: -ld_classic is deprecated and will be removed in a future release
```

To fix it we can force using Go linker to do the whole linking instead of old Apple linker. For more details https://github.com/golang/go/issues/61229#issuecomment-1988965927.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```