### PR TITLE
[KEP] Add retry strategy to the ProvisionigRequestConfig API

### DIFF
--- a/keps/1136-provisioning-request-support/README.md
+++ b/keps/1136-provisioning-request-support/README.md
@@ -135,8 +135,9 @@ Workload gets requeued in a similar way to [WaitForPodsReady](https://github.com
 When AdmissionCheck is in `Retry` state, the workload controller evicts the Workload with `WorkloadRequeued=False` condition with `AdmissionCheck` as a reason.
 After the backoff period, the Workload is requeued, enters the queue again, and begins a new admission cycle.
 
-Additionally, we introduce the feature gate `KeepQuotaForProvReqRetry`. If the feature gate is enabled the Workload with failed ProvisioningRequest
-will keep the allocated quota and won't be requeued. Instead it will be in the AdmissionCheck phase of admission, and will recreate ProvisioningRequest after backoff time
+Additionally, to enable the previous behavior of keeping the quota, in 0.9.0 we introduce the feature gate `KeepQuotaForProvReqRetry`. If the feature gate is enabled the Workload with failed ProvisioningRequest
+will keep the allocated quota and won't be requeued. Instead it will be in the AdmissionCheck phase of admission, and will recreate ProvisioningRequest after backoff time.
+The feature gate is deprecated and will be removed in 0.10 unless we get feedback from users indicating that the old behavior is needed.
 
 The definition of `ProvisioningRequestConfig` is relatively simple and is based on
 what can be set in `ProvisioningRequest`.

--- a/keps/1136-provisioning-request-support/README.md
+++ b/keps/1136-provisioning-request-support/README.md
@@ -174,9 +174,7 @@ type ProvisioningRequestConfigSpec struct {
 	ManagedResources []corev1.ResourceName `json:"managedResources,omitempty"`
 
 	// retryStrategy defines strategy for retrying ProvisioningRequest
-	//
-	// +optional
-	RetryStrategy *ProvisioningRequestRetryStrategy `json:retryStrategy, omitempty`
+	RetryStrategy *ProvisioningRequestRetryStrategy `json:"retryStrategy, omitempty"`
 }
 
 type ProvisioningRequestRetryStrategy struct {
@@ -186,7 +184,6 @@ type ProvisioningRequestRetryStrategy struct {
 	// - `Eviction` (default) indicates from Workload `Evicted` condition with `PodsReadyTimeout` reason.
 	// - `Creation` indicates from Workload .metadata.creationTimestamp.
 	//
-	// +optional
 	Timestamp *RequeuingTimestamp `json:"timestamp,omitempty"`
 
 	// BackoffLimitCount defines the maximum number of re-queuing retries.

--- a/keps/1136-provisioning-request-support/README.md
+++ b/keps/1136-provisioning-request-support/README.md
@@ -133,7 +133,7 @@ from 1min (1, 2, 4 min),
 
 Workload gets requeued in a similar way to [WaitForPodsReady](https://github.com/kubernetes-sigs/kueue/tree/main/keps/349-all-or-nothing) mechanism.
 When AdmissionCheck is in `Retry` state, the workload controller evicts the Workload with `WorkloadRequeued=False` condition with `AdmissionCheck` as a reason.
-After the backoff period, the Workload is requeued, enters the queue again, and begins a new admission cycle.
+After the backoff period, the Workload is requeued, enters the queue again, and begins a new admission cycle, and `.status.requeueState.requeueAt` field is reset.
 
 Additionally, to enable the previous behavior of keeping the quota, in 0.9.0 we introduce the feature gate `KeepQuotaForProvReqRetry`. If the feature gate is enabled the Workload with failed ProvisioningRequest
 will keep the allocated quota and won't be requeued. Instead it will be in the AdmissionCheck phase of admission, and will recreate ProvisioningRequest after backoff time.

--- a/keps/1136-provisioning-request-support/kep.yaml
+++ b/keps/1136-provisioning-request-support/kep.yaml
@@ -22,6 +22,9 @@ latest-milestone: "v0.5"
 milestone:
   beta: "v0.5"
 
+feature-gates:
+  - KeepQuotaForProvReqRetry
+
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 disable-supported: false

--- a/keps/1136-provisioning-request-support/kep.yaml
+++ b/keps/1136-provisioning-request-support/kep.yaml
@@ -2,6 +2,7 @@ title: ProvisioningRequest support
 kep-number: 1136
 authors:
   - "@mwielgus"
+  - "@pbundyra"
 status: draft
 creation-date: 2023-09-20
 reviewers:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Introduces configurable retry strategy for ProvisioningRequests

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #1353 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```