### PR TITLE
[kjobctl] Skip removing ConfigMap on delete Slurm.

### DIFF
--- a/cmd/experimental/kjobctl/pkg/cmd/delete/delete_slurm_test.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/delete/delete_slurm_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
@@ -37,147 +36,104 @@ import (
 
 func TestSlurmCmd(t *testing.T) {
 	testCases := map[string]struct {
-		ns             string
-		args           []string
-		objs           []runtime.Object
-		wantJobs       []batchv1.Job
-		wantConfigMaps []corev1.ConfigMap
-		wantOut        string
-		wantOutErr     string
-		wantErr        string
+		ns         string
+		args       []string
+		objs       []runtime.Object
+		wantJobs   []batchv1.Job
+		wantOut    string
+		wantOutErr string
+		wantErr    string
 	}{
 		"shouldn't delete slurm job because it is not found": {
 			args: []string{"j"},
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
-				wrappers.MakeConfigMap("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
 				wrappers.MakeJob("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
-				wrappers.MakeConfigMap("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
 			},
 			wantJobs: []batchv1.Job{
 				*wrappers.MakeJob("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
 				*wrappers.MakeJob("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
 			},
-			wantConfigMaps: []corev1.ConfigMap{
-				*wrappers.MakeConfigMap("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
-				*wrappers.MakeConfigMap("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
-			},
-			wantOutErr: "jobs.batch \"j\" not found\nconfigmaps \"j\" not found\n",
+			wantOutErr: "jobs.batch \"j\" not found\n",
 		},
-		"shouldn't delete job because it is not created via kjob": {
+		"shouldn't delete slurm job because it is not created via kjob": {
 			args: []string{"j1"},
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", metav1.NamespaceDefault).Obj(),
-				wrappers.MakeConfigMap("j1", metav1.NamespaceDefault).Obj(),
 			},
 			wantJobs: []batchv1.Job{
 				*wrappers.MakeJob("j1", metav1.NamespaceDefault).Obj(),
 			},
-			wantConfigMaps: []corev1.ConfigMap{
-				*wrappers.MakeConfigMap("j1", metav1.NamespaceDefault).Obj(),
-			},
-			wantOutErr: "jobs.batch \"j1\" not created via kjob\nconfigmaps \"j1\" not created via kjob\n",
+			wantOutErr: "jobs.batch \"j1\" not created via kjob\n",
 		},
 		"shouldn't delete slurm job because it is not used for Job mode": {
 			args: []string{"j1", "j2"},
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", metav1.NamespaceDefault).Profile("p1").Obj(),
-				wrappers.MakeConfigMap("j1", metav1.NamespaceDefault).Profile("p1").Obj(),
 				wrappers.MakeJob("j2", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.JobMode).Obj(),
-				wrappers.MakeConfigMap("j2", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.JobMode).Obj(),
 			},
 			wantJobs: []batchv1.Job{
 				*wrappers.MakeJob("j1", metav1.NamespaceDefault).Profile("p1").Obj(),
 				*wrappers.MakeJob("j2", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.JobMode).Obj(),
 			},
-			wantConfigMaps: []corev1.ConfigMap{
-				*wrappers.MakeConfigMap("j1", metav1.NamespaceDefault).Profile("p1").Obj(),
-				*wrappers.MakeConfigMap("j2", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.JobMode).Obj(),
-			},
 			wantOutErr: `jobs.batch "j1" created in "" mode. Switch to the correct mode to delete it
-configmaps "j1" created in "" mode. Switch to the correct mode to delete it
 jobs.batch "j2" created in "Job" mode. Switch to the correct mode to delete it
-configmaps "j2" created in "Job" mode. Switch to the correct mode to delete it
 `,
 		},
 		"should delete slurm job": {
 			args: []string{"j1"},
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
-				wrappers.MakeConfigMap("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
 				wrappers.MakeJob("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
-				wrappers.MakeConfigMap("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
 			},
 			wantJobs: []batchv1.Job{
 				*wrappers.MakeJob("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
 			},
-			wantConfigMaps: []corev1.ConfigMap{
-				*wrappers.MakeConfigMap("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
-			},
-			wantOut: "job.batch/j1 deleted\nconfigmap/j1 deleted\n",
+			wantOut: "job.batch/j1 deleted\n",
 		},
 		"should delete slurm jobs": {
 			args: []string{"j1", "j2"},
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
-				wrappers.MakeConfigMap("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
 				wrappers.MakeJob("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
-				wrappers.MakeConfigMap("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
 			},
-			wantOut: "job.batch/j1 deleted\nconfigmap/j1 deleted\njob.batch/j2 deleted\nconfigmap/j2 deleted\n",
+			wantOut: "job.batch/j1 deleted\njob.batch/j2 deleted\n",
 		},
 		"should delete only one slurm job": {
 			args: []string{"j1", "j"},
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
-				wrappers.MakeConfigMap("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
 				wrappers.MakeJob("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
-				wrappers.MakeConfigMap("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
 			},
 			wantJobs: []batchv1.Job{
 				*wrappers.MakeJob("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
 			},
-			wantConfigMaps: []corev1.ConfigMap{
-				*wrappers.MakeConfigMap("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
-			},
-			wantOut:    "job.batch/j1 deleted\nconfigmap/j1 deleted\n",
-			wantOutErr: "jobs.batch \"j\" not found\nconfigmaps \"j\" not found\n",
+			wantOut:    "job.batch/j1 deleted\n",
+			wantOutErr: "jobs.batch \"j\" not found\n",
 		},
 		"shouldn't delete slurm job with client dry run": {
 			args: []string{"j1", "--dry-run", "client"},
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
-				wrappers.MakeConfigMap("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
 				wrappers.MakeJob("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
-				wrappers.MakeConfigMap("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
 			},
 			wantJobs: []batchv1.Job{
 				*wrappers.MakeJob("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
 				*wrappers.MakeJob("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
 			},
-			wantConfigMaps: []corev1.ConfigMap{
-				*wrappers.MakeConfigMap("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
-				*wrappers.MakeConfigMap("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
-			},
-			wantOut: "job.batch/j1 deleted (client dry run)\nconfigmap/j1 deleted (client dry run)\n",
+			wantOut: "job.batch/j1 deleted (client dry run)\n",
 		},
 		"shouldn't delete slurm job with server dry run": {
 			args: []string{"j1", "--dry-run", "server"},
 			objs: []runtime.Object{
 				wrappers.MakeJob("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
-				wrappers.MakeConfigMap("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
 				wrappers.MakeJob("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
-				wrappers.MakeConfigMap("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
 			},
 			wantJobs: []batchv1.Job{
 				*wrappers.MakeJob("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
 				*wrappers.MakeJob("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
 			},
-			wantConfigMaps: []corev1.ConfigMap{
-				*wrappers.MakeConfigMap("j1", metav1.NamespaceDefault).Profile("p1").Mode(v1alpha1.SlurmMode).Obj(),
-				*wrappers.MakeConfigMap("j2", metav1.NamespaceDefault).Profile("p2").Mode(v1alpha1.SlurmMode).Obj(),
-			},
-			wantOut: "job.batch/j1 deleted (server dry run)\nconfigmap/j1 deleted (server dry run)\n",
+			wantOut: "job.batch/j1 deleted (server dry run)\n",
 		},
 		"no args": {
 			args:    []string{},
@@ -195,12 +151,6 @@ configmaps "j2" created in "Job" mode. Switch to the correct mode to delete it
 
 			clientset := k8sfake.NewSimpleClientset(tc.objs...)
 			clientset.PrependReactor("delete", "jobs", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
-				if slices.Contains(action.(kubetesting.DeleteAction).GetDeleteOptions().DryRun, metav1.DryRunAll) {
-					handled = true
-				}
-				return handled, ret, err
-			})
-			clientset.PrependReactor("delete", "configmaps", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 				if slices.Contains(action.(kubetesting.DeleteAction).GetDeleteOptions().DryRun, metav1.DryRunAll) {
 					handled = true
 				}
@@ -241,25 +191,13 @@ configmaps "j2" created in "Job" mode. Switch to the correct mode to delete it
 				t.Errorf("Unexpected error output (-want/+got)\n%s", diff)
 			}
 
-			ctx := context.Background()
-
-			gotJobList, err := clientset.BatchV1().Jobs(tc.ns).List(ctx, metav1.ListOptions{})
+			gotJobList, err := clientset.BatchV1().Jobs(tc.ns).List(context.Background(), metav1.ListOptions{})
 			if err != nil {
 				t.Error(err)
 				return
 			}
 
 			if diff := cmp.Diff(tc.wantJobs, gotJobList.Items); diff != "" {
-				t.Errorf("Unexpected jobs (-want/+got)\n%s", diff)
-			}
-
-			gotConfigMapList, err := clientset.CoreV1().ConfigMaps(tc.ns).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				t.Error(err)
-				return
-			}
-
-			if diff := cmp.Diff(tc.wantConfigMaps, gotConfigMapList.Items); diff != "" {
 				t.Errorf("Unexpected jobs (-want/+got)\n%s", diff)
 			}
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We added `ownerReference` for additional Slurm objects in https://github.com/kubernetes-sigs/kueue/pull/3129, so it's no longer necessary to manually remove the ConfigMaps.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```