### PR TITLE
Support MPIJob managedBy feature for the MultiKueue

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -33,7 +33,6 @@ export KUBEFLOW_IMAGE=kubeflow/training-operator:${KUBEFLOW_IMAGE_VERSION}
 
 export KUBEFLOW_MPI_MANIFEST="https://raw.githubusercontent.com/kubeflow/mpi-operator/${KUBEFLOW_MPI_VERSION}/deploy/v2beta1/mpi-operator.yaml"
 export KUBEFLOW_MPI_IMAGE=mpioperator/mpi-operator:${KUBEFLOW_MPI_VERSION/#v}
-export KUBEFLOW_MPI_CRD=${ROOT_DIR}/dep-crds/mpi-operator/kubeflow.org_mpijobs.yaml
 
 # sleep image to use for testing.
 export E2E_TEST_IMAGE=gcr.io/k8s-staging-perf-tests/sleep:v0.1.0@sha256:8d91ddf9f145b66475efda1a1b52269be542292891b5de2a7fad944052bab6ea

--- a/hack/multikueue-e2e-test.sh
+++ b/hack/multikueue-e2e-test.sh
@@ -95,14 +95,16 @@ function kind_load {
     # have Kubeflow Jobs admitted without execution in the manager cluster.
     kubectl config use-context "kind-${MANAGER_KIND_CLUSTER_NAME}"
     kubectl apply -k "${KUBEFLOW_MANIFEST_MANAGER}"
-    ## MPI
-    kubectl apply --server-side -f "${KUBEFLOW_MPI_CRD}"
 
     # WORKERS
     docker pull "${KUBEFLOW_IMAGE}"
-    docker pull "${KUBEFLOW_MPI_IMAGE}"
+    
     install_kubeflow "$WORKER1_KIND_CLUSTER_NAME"
     install_kubeflow "$WORKER2_KIND_CLUSTER_NAME"
+    
+     ## MPI
+    docker pull "${KUBEFLOW_MPI_IMAGE}"
+    install_mpi "$MANAGER_KIND_CLUSTER_NAME"
     install_mpi "$WORKER1_KIND_CLUSTER_NAME"
     install_mpi "$WORKER2_KIND_CLUSTER_NAME"
     

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -40,12 +40,7 @@ var (
 	gvk = kfmpi.SchemeGroupVersionKind
 
 	FrameworkName = "kubeflow.org/mpijob"
-
-	SetupMPIJobWebhook = jobframework.BaseWebhookFactory(NewJob(), fromObject)
 )
-
-// +kubebuilder:webhook:path=/mutate-kubeflow-org-v2beta1-mpijob,mutating=true,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=mpijobs,verbs=create,versions=v2beta1,name=mmpijob.kb.io,admissionReviewVersions=v1
-// +kubebuilder:webhook:path=/validate-kubeflow-org-v2beta1-mpijob,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=mpijobs,verbs=create;update,versions=v2beta1,name=vmpijob.kb.io,admissionReviewVersions=v1
 
 func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
@@ -90,7 +85,7 @@ func (j *MPIJob) Object() client.Object {
 	return (*kfmpi.MPIJob)(j)
 }
 
-func fromObject(o runtime.Object) jobframework.GenericJob {
+func fromObject(o runtime.Object) *MPIJob {
 	return (*MPIJob)(o.(*kfmpi.MPIJob))
 }
 

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
@@ -90,9 +90,9 @@ func (b *multikueueAdapter) KeepAdmissionCheckPending() bool {
 	return false
 }
 
-func (b *multikueueAdapter) IsJobManagedByKueue(ctx context.Context, remoteClient client.Client, key types.NamespacedName) (bool, string, error) {
+func (b *multikueueAdapter) IsJobManagedByKueue(ctx context.Context, c client.Client, key types.NamespacedName) (bool, string, error) {
 	job := kfmpi.MPIJob{}
-	err := remoteClient.Get(ctx, key, &job)
+	err := c.Get(ctx, key, &job)
 	if err != nil {
 		return false, "", err
 	}

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter_test.go
@@ -153,6 +153,14 @@ func TestMultikueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
+		"missing job is not considered managed": {
+			operation: func(ctx context.Context, adapter *multikueueAdapter, managerClient, workerClient client.Client) error {
+				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}); isManged {
+					return errors.New("expecting false")
+				}
+				return nil
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter_test.go
@@ -18,6 +18,7 @@ package mpijob
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -49,28 +50,27 @@ func TestMultikueueAdapter(t *testing.T) {
 	mpiJobBuilder := utiltestingmpijob.MakeMPIJob("mpijob1", TestNamespace)
 
 	cases := map[string]struct {
-		managersJobSets []kfmpi.MPIJob
-		workerJobSets   []kfmpi.MPIJob
+		managersMpiJobs []kfmpi.MPIJob
+		workerMpiJobs   []kfmpi.MPIJob
 
 		operation func(ctx context.Context, adapter *multikueueAdapter, managerClient, workerClient client.Client) error
 
 		wantError           error
-		wantManagersJobSets []kfmpi.MPIJob
-		wantWorkerJobSets   []kfmpi.MPIJob
+		wantManagersMpiJobs []kfmpi.MPIJob
+		wantWorkerMpiJobs   []kfmpi.MPIJob
 	}{
-
 		"sync creates missing remote mpijob": {
-			managersJobSets: []kfmpi.MPIJob{
+			managersMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.DeepCopy(),
 			},
 			operation: func(ctx context.Context, adapter *multikueueAdapter, managerClient, workerClient client.Client) error {
 				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}, "wl1", "origin1")
 			},
 
-			wantManagersJobSets: []kfmpi.MPIJob{
+			wantManagersMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.DeepCopy(),
 			},
-			wantWorkerJobSets: []kfmpi.MPIJob{
+			wantWorkerMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
 					Label(constants.PrebuiltWorkloadLabel, "wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
@@ -78,10 +78,10 @@ func TestMultikueueAdapter(t *testing.T) {
 			},
 		},
 		"sync status from remote mpijob": {
-			managersJobSets: []kfmpi.MPIJob{
+			managersMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.DeepCopy(),
 			},
-			workerJobSets: []kfmpi.MPIJob{
+			workerMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
 					Label(constants.PrebuiltWorkloadLabel, "wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
@@ -92,12 +92,12 @@ func TestMultikueueAdapter(t *testing.T) {
 				return adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}, "wl1", "origin1")
 			},
 
-			wantManagersJobSets: []kfmpi.MPIJob{
+			wantManagersMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
 					StatusConditions(kfmpi.JobCondition{Type: kfmpi.JobSucceeded, Status: corev1.ConditionTrue}).
 					Obj(),
 			},
-			wantWorkerJobSets: []kfmpi.MPIJob{
+			wantWorkerMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
 					Label(constants.PrebuiltWorkloadLabel, "wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
@@ -106,7 +106,7 @@ func TestMultikueueAdapter(t *testing.T) {
 			},
 		},
 		"remote mpijob is deleted": {
-			workerJobSets: []kfmpi.MPIJob{
+			workerMpiJobs: []kfmpi.MPIJob{
 				*mpiJobBuilder.Clone().
 					Label(constants.PrebuiltWorkloadLabel, "wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
@@ -116,16 +116,53 @@ func TestMultikueueAdapter(t *testing.T) {
 				return adapter.DeleteRemoteObject(ctx, workerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace})
 			},
 		},
+		"job with wrong managedBy is not considered managed": {
+			managersMpiJobs: []kfmpi.MPIJob{
+				*mpiJobBuilder.Clone().
+					ManagedBy("some-other-controller").
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multikueueAdapter, managerClient, workerClient client.Client) error {
+				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}); isManged {
+					return errors.New("expecting false")
+				}
+				return nil
+			},
+			wantManagersMpiJobs: []kfmpi.MPIJob{
+				*mpiJobBuilder.Clone().
+					ManagedBy("some-other-controller").
+					Obj(),
+			},
+		},
+
+		"job managedBy multikueue": {
+			managersMpiJobs: []kfmpi.MPIJob{
+				*mpiJobBuilder.Clone().
+					ManagedBy(kueue.MultiKueueControllerName).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter *multikueueAdapter, managerClient, workerClient client.Client) error {
+				if isManged, _, _ := adapter.IsJobManagedByKueue(ctx, managerClient, types.NamespacedName{Name: "mpijob1", Namespace: TestNamespace}); !isManged {
+					return errors.New("expecting true")
+				}
+				return nil
+			},
+			wantManagersMpiJobs: []kfmpi.MPIJob{
+				*mpiJobBuilder.Clone().
+					ManagedBy(kueue.MultiKueueControllerName).
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			managerBuilder := utiltesting.NewClientBuilder(kfmpi.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
-			managerBuilder = managerBuilder.WithLists(&kfmpi.MPIJobList{Items: tc.managersJobSets})
-			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersJobSets, func(w *kfmpi.MPIJob) client.Object { return w })...)
+			managerBuilder = managerBuilder.WithLists(&kfmpi.MPIJobList{Items: tc.managersMpiJobs})
+			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersMpiJobs, func(w *kfmpi.MPIJob) client.Object { return w })...)
 			managerClient := managerBuilder.Build()
 
 			workerBuilder := utiltesting.NewClientBuilder(kfmpi.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
-			workerBuilder = workerBuilder.WithLists(&kfmpi.MPIJobList{Items: tc.workerJobSets})
+			workerBuilder = workerBuilder.WithLists(&kfmpi.MPIJobList{Items: tc.workerMpiJobs})
 			workerClient := workerBuilder.Build()
 
 			ctx, _ := utiltesting.ContextWithLog(t)
@@ -138,20 +175,20 @@ func TestMultikueueAdapter(t *testing.T) {
 				t.Errorf("unexpected error (-want/+got):\n%s", diff)
 			}
 
-			gotManagersJobSets := &kfmpi.MPIJobList{}
-			if err := managerClient.List(ctx, gotManagersJobSets); err != nil {
+			gotManagersMpiJobs := &kfmpi.MPIJobList{}
+			if err := managerClient.List(ctx, gotManagersMpiJobs); err != nil {
 				t.Errorf("unexpected list manager's mpijobs error %s", err)
 			} else {
-				if diff := cmp.Diff(tc.wantManagersJobSets, gotManagersJobSets.Items, objCheckOpts...); diff != "" {
+				if diff := cmp.Diff(tc.wantManagersMpiJobs, gotManagersMpiJobs.Items, objCheckOpts...); diff != "" {
 					t.Errorf("unexpected manager's mpijobs (-want/+got):\n%s", diff)
 				}
 			}
 
-			gotWorkerJobSets := &kfmpi.MPIJobList{}
-			if err := workerClient.List(ctx, gotWorkerJobSets); err != nil {
+			gotWorkerMpiJobs := &kfmpi.MPIJobList{}
+			if err := workerClient.List(ctx, gotWorkerMpiJobs); err != nil {
 				t.Errorf("unexpected list worker's mpijobs error %s", err)
 			} else {
-				if diff := cmp.Diff(tc.wantWorkerJobSets, gotWorkerJobSets.Items, objCheckOpts...); diff != "" {
+				if diff := cmp.Diff(tc.wantWorkerMpiJobs, gotWorkerMpiJobs.Items, objCheckOpts...); diff != "" {
 					t.Errorf("unexpected worker's mpijobs (-want/+got):\n%s", diff)
 				}
 			}

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mpijob
+
+import (
+	"context"
+
+	"github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework/webhook"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/queue"
+	"sigs.k8s.io/kueue/pkg/util/kubeversion"
+)
+
+type MpiJobWebhook struct {
+	manageJobsWithoutQueueName bool
+	kubeServerVersion          *kubeversion.ServerVersionFetcher
+	queues                     *queue.Manager
+	cache                      *cache.Cache
+}
+
+// SetupMPIJobWebhook configures the webhook for MPIJob.
+func SetupMPIJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
+	options := jobframework.ProcessOptions(opts...)
+	wh := &MpiJobWebhook{
+		manageJobsWithoutQueueName: options.ManageJobsWithoutQueueName,
+		kubeServerVersion:          options.KubeServerVersion,
+		queues:                     options.Queues,
+		cache:                      options.Cache,
+	}
+	obj := &v2beta1.MPIJob{}
+	return webhook.WebhookManagedBy(mgr).
+		For(obj).
+		WithMutationHandler(webhook.WithLosslessDefaulter(mgr.GetScheme(), obj, wh)).
+		WithValidator(wh).
+		Complete()
+}
+
+// +kubebuilder:webhook:path=/mutate-kubeflow-org-v2beta1-mpijob,mutating=true,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=mpijobs,verbs=create,versions=v2beta1,name=mmpijob.kb.io,admissionReviewVersions=v1
+
+var _ admission.CustomDefaulter = &MpiJobWebhook{}
+
+// Default implements webhook.CustomDefaulter so a webhook will be registered for the type
+func (w *MpiJobWebhook) Default(ctx context.Context, obj runtime.Object) error {
+	mpiJob := fromObject(obj)
+	log := ctrl.LoggerFrom(ctx).WithName("mpijob-webhook")
+	log.V(5).Info("Applying defaults", "mpijob", klog.KObj(mpiJob))
+
+	jobframework.ApplyDefaultForSuspend(mpiJob, w.manageJobsWithoutQueueName)
+
+	if canDefaultManagedBy(mpiJob.Spec.RunPolicy.ManagedBy) {
+		localQueueName, found := mpiJob.Labels[constants.QueueLabel]
+		if !found {
+			return nil
+		}
+		clusterQueueName, ok := w.queues.ClusterQueueFromLocalQueue(queue.QueueKey(mpiJob.ObjectMeta.Namespace, localQueueName))
+		if !ok {
+			log.V(5).Info("Cluster queue for local queue not found", "mpijob", klog.KObj(mpiJob), "localQueue", localQueueName)
+			return nil
+		}
+		for _, admissionCheck := range w.cache.AdmissionChecksForClusterQueue(clusterQueueName) {
+			if admissionCheck.Controller == kueue.MultiKueueControllerName {
+				log.V(5).Info("Defaulting ManagedBy", "mpijob", klog.KObj(mpiJob), "oldManagedBy", mpiJob.Spec.RunPolicy.ManagedBy, "managedBy", kueue.MultiKueueControllerName)
+				mpiJob.Spec.RunPolicy.ManagedBy = ptr.To(kueue.MultiKueueControllerName)
+				return nil
+			}
+		}
+	}
+
+	return nil
+}
+
+func canDefaultManagedBy(mpiJobSpecManagedBy *string) bool {
+	return features.Enabled(features.MultiKueue) &&
+		(mpiJobSpecManagedBy == nil || *mpiJobSpecManagedBy == v2beta1.KubeflowJobController)
+}
+
+// +kubebuilder:webhook:path=/validate-kubeflow-org-v2beta1-mpijob,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=mpijobs,verbs=create;update,versions=v2beta1,name=vmpijob.kb.io,admissionReviewVersions=v1
+
+var _ admission.CustomValidator = &MpiJobWebhook{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
+func (w *MpiJobWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	mpiJob := fromObject(obj)
+	log := ctrl.LoggerFrom(ctx).WithName("mpijob-webhook")
+	log.Info("Validating create", "mpijob", klog.KObj(mpiJob))
+	return nil, jobframework.ValidateJobOnCreate(mpiJob).ToAggregate()
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
+func (w *MpiJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	oldMpiJob := fromObject(oldObj)
+	newMpiJob := fromObject(newObj)
+	log := ctrl.LoggerFrom(ctx).WithName("mpijob-webhook")
+	log.Info("Validating update", "mpijob", klog.KObj(newMpiJob))
+	allErrs := jobframework.ValidateJobOnUpdate(oldMpiJob, newMpiJob)
+	allErrs = append(allErrs, jobframework.ValidateJobOnCreate(newMpiJob)...)
+	return nil, allErrs.ToAggregate()
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
+func (w *MpiJobWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -123,6 +123,6 @@ func (w *MpiJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runti
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type
-func (w *MpiJobWebhook) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+func (w *MpiJobWebhook) ValidateDelete(context.Context, runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mpijob
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/queue"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingutil "sigs.k8s.io/kueue/pkg/util/testingjobs/mpijob"
+)
+
+const (
+	invalidRFC1123Message = `a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`
+)
+
+var (
+	labelsPath         = field.NewPath("metadata", "labels")
+	queueNameLabelPath = labelsPath.Key(constants.QueueLabel)
+)
+
+func TestValidateCreate(t *testing.T) {
+	testcases := []struct {
+		name    string
+		job     *v2beta1.MPIJob
+		wantErr error
+	}{
+		{
+			name:    "simple",
+			job:     testingutil.MakeMPIJob("job", "default").Queue("queue").Obj(),
+			wantErr: nil,
+		},
+		{
+			name:    "invalid queue-name label",
+			job:     testingutil.MakeMPIJob("job", "default").Queue("queue_name").Obj(),
+			wantErr: field.ErrorList{field.Invalid(queueNameLabelPath, "queue_name", invalidRFC1123Message)}.ToAggregate(),
+		},
+		{
+			name:    "with prebuilt workload",
+			job:     testingutil.MakeMPIJob("job", "default").Queue("queue").Label(constants.PrebuiltWorkloadLabel, "prebuilt-workload").Obj(),
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			jsw := &MpiJobWebhook{}
+			_, gotErr := jsw.ValidateCreate(context.Background(), tc.job)
+
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+				t.Errorf("validateCreate() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDefault(t *testing.T) {
+	testCases := []struct {
+		name              string
+		mpiJob            *v2beta1.MPIJob
+		queues            []kueue.LocalQueue
+		clusterQueues     []kueue.ClusterQueue
+		admissionCheck    *kueue.AdmissionCheck
+		multiKueueEnabled bool
+		wantManagedBy     *string
+		wantErr           error
+	}{
+		{
+			name: "TestDefault_MPIJobManagedBy_mpijobapi.MPIJobControllerName",
+			mpiJob: &v2beta1.MPIJob{
+				Spec: v2beta1.MPIJobSpec{
+					RunPolicy: v2beta1.RunPolicy{
+						ManagedBy: ptr.To(v2beta1.KubeflowJobController),
+					},
+				},
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels: map[string]string{
+						constants.QueueLabel: "local-queue",
+					},
+					Namespace: "default",
+				},
+			},
+			queues: []kueue.LocalQueue{
+				*utiltesting.MakeLocalQueue("local-queue", "default").
+					ClusterQueue("cluster-queue").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("cluster-queue").
+					AdmissionChecks("admission-check").
+					Obj(),
+			},
+			admissionCheck: utiltesting.MakeAdmissionCheck("admission-check").
+				ControllerName(kueue.MultiKueueControllerName).
+				Active(metav1.ConditionTrue).
+				Obj(),
+			multiKueueEnabled: true,
+			wantManagedBy:     ptr.To(kueue.MultiKueueControllerName),
+		},
+		{
+			name: "TestDefault_WithQueueLabel",
+			mpiJob: &v2beta1.MPIJob{
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels: map[string]string{
+						constants.QueueLabel: "local-queue",
+					},
+					Namespace: "default",
+				},
+			},
+			queues: []kueue.LocalQueue{
+				*utiltesting.MakeLocalQueue("local-queue", "default").
+					ClusterQueue("cluster-queue").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("cluster-queue").
+					AdmissionChecks("admission-check").
+					Obj(),
+			},
+			admissionCheck: utiltesting.MakeAdmissionCheck("admission-check").
+				ControllerName(kueue.MultiKueueControllerName).
+				Active(metav1.ConditionTrue).
+				Obj(),
+			multiKueueEnabled: true,
+			wantManagedBy:     ptr.To(kueue.MultiKueueControllerName),
+		},
+		{
+			name: "TestDefault_WithoutQueueLabel",
+			mpiJob: &v2beta1.MPIJob{
+				ObjectMeta: ctrl.ObjectMeta{Namespace: "default"},
+			},
+			multiKueueEnabled: true,
+			wantManagedBy:     nil,
+		},
+		{
+			name: "TestDefault_InvalidQueueName",
+			mpiJob: &v2beta1.MPIJob{
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels:    map[string]string{constants.QueueLabel: "invalid-queue"},
+					Namespace: "default",
+				},
+			},
+			multiKueueEnabled: true,
+		},
+		{
+			name: "TestDefault_QueueNotFound",
+			mpiJob: &v2beta1.MPIJob{
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels: map[string]string{
+						constants.QueueLabel: "non-existent-queue",
+					},
+					Namespace: "default",
+				},
+			},
+			multiKueueEnabled: true,
+		},
+		{
+			name: "TestDefault_AdmissionCheckNotFound",
+			mpiJob: &v2beta1.MPIJob{
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels: map[string]string{
+						constants.QueueLabel: "local-queue",
+					},
+					Namespace: "default",
+				},
+			},
+			queues: []kueue.LocalQueue{
+				*utiltesting.MakeLocalQueue("local-queue", "default").
+					ClusterQueue("cluster-queue").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("cluster-queue").
+					AdmissionChecks("non-existent-admission-check").
+					Obj(),
+			},
+			multiKueueEnabled: true,
+			wantManagedBy:     nil,
+		},
+		{
+			name: "TestDefault_MultiKueueFeatureDisabled",
+			mpiJob: &v2beta1.MPIJob{
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels: map[string]string{
+						constants.QueueLabel: "local-queue",
+					},
+					Namespace: "default",
+				},
+			},
+			queues: []kueue.LocalQueue{
+				*utiltesting.MakeLocalQueue("local-queue", "default").
+					ClusterQueue("cluster-queue").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("cluster-queue").
+					AdmissionChecks("admission-check").
+					Obj(),
+			},
+			admissionCheck: utiltesting.MakeAdmissionCheck("admission-check").
+				ControllerName(kueue.MultiKueueControllerName).
+				Active(metav1.ConditionTrue).
+				Obj(),
+			multiKueueEnabled: false,
+			wantManagedBy:     nil,
+		},
+		{
+			name: "TestDefault_UserSpecifiedManagedBy",
+			mpiJob: &v2beta1.MPIJob{
+				Spec: v2beta1.MPIJobSpec{
+					RunPolicy: v2beta1.RunPolicy{
+						ManagedBy: ptr.To("example.com/foo"),
+					},
+				},
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels: map[string]string{
+						constants.QueueLabel: "local-queue",
+					},
+					Namespace: "default",
+				},
+			},
+			queues: []kueue.LocalQueue{
+				*utiltesting.MakeLocalQueue("local-queue", "default").
+					ClusterQueue("cluster-queue").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("cluster-queue").
+					AdmissionChecks("admission-check").
+					Obj(),
+			},
+			admissionCheck: utiltesting.MakeAdmissionCheck("admission-check").
+				ControllerName(kueue.MultiKueueControllerName).
+				Active(metav1.ConditionTrue).
+				Obj(),
+			multiKueueEnabled: true,
+			wantManagedBy:     ptr.To("example.com/foo"),
+		},
+		{
+			name: "TestDefault_ClusterQueueWithoutAdmissionCheck",
+			mpiJob: &v2beta1.MPIJob{
+				ObjectMeta: ctrl.ObjectMeta{
+					Labels: map[string]string{
+						constants.QueueLabel: "local-queue",
+					},
+					Namespace: "default",
+				},
+			},
+			queues: []kueue.LocalQueue{
+				*utiltesting.MakeLocalQueue("local-queue", "default").
+					ClusterQueue("cluster-queue").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("cluster-queue").
+					Obj(),
+			},
+			multiKueueEnabled: true,
+			wantManagedBy:     nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+
+			clientBuilder := utiltesting.NewClientBuilder().
+				WithObjects(
+					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+				)
+			cl := clientBuilder.Build()
+			cqCache := cache.New(cl)
+			queueManager := queue.NewManager(cl, cqCache)
+
+			for _, q := range tc.queues {
+				if err := queueManager.AddLocalQueue(ctx, &q); err != nil {
+					t.Fatalf("Inserting queue %s/%s in manager: %v", q.Namespace, q.Name, err)
+				}
+			}
+			for _, cq := range tc.clusterQueues {
+				if err := cqCache.AddClusterQueue(ctx, &cq); err != nil {
+					t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
+				}
+				if tc.admissionCheck != nil {
+					cqCache.AddOrUpdateAdmissionCheck(tc.admissionCheck)
+					if err := queueManager.AddClusterQueue(ctx, &cq); err != nil {
+						t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
+					}
+				}
+			}
+			webhook := &MpiJobWebhook{
+				manageJobsWithoutQueueName: false,
+				queues:                     queueManager,
+				cache:                      cqCache,
+			}
+
+			gotErr := webhook.Default(ctx, tc.mpiJob)
+			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Default() error mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantManagedBy, tc.mpiJob.Spec.RunPolicy.ManagedBy); diff != "" {
+				t.Errorf("Default() mpijob.Spec.RunPolicy.ManagedBy mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
+++ b/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
@@ -214,3 +214,9 @@ func (j *MPIJobWrapper) Image(replicaType kfmpi.MPIReplicaType, image string, ar
 	j.Spec.MPIReplicaSpecs[replicaType].Template.Spec.Containers[0].Args = args
 	return j
 }
+
+// ManagedBy adds a managedby.
+func (j *MPIJobWrapper) ManagedBy(c string) *MPIJobWrapper {
+	j.Spec.RunPolicy.ManagedBy = &c
+	return j
+}

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -436,6 +436,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			// Since it requires 1.5 CPU, this job can only be admitted in worker 1.
 			mpijob := testingmpijob.MakeMPIJob("mpijob1", managerNs.Name).
 				Queue(managerLq.Name).
+				ManagedBy(kueue.MultiKueueControllerName).
 				MPIJobReplicaSpecs(
 					testingmpijob.MPIJobReplicaSpecRequirement{
 						ReplicaType:   kfmpi.MPIReplicaTypeLauncher,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Support MPIJob managedBy feature for the MultiKueue.
Allow for installing `mpi-operator` in management cluster instead of only crds. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3257 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Add support for  MPIJob  `spec.runPolicy.managedBy` field
```