### PR TITLE
[MultiKueue] Fix a typo in cluster queue type constant

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -32,7 +32,7 @@ const (
 	ClusterQueueActiveReasonMultipleSingleInstanceControllerAdmissionChecks = "MultipleSingleInstanceControllerAdmissionChecks"
 	ClusterQueueActiveReasonFlavorIndependentAdmissionCheckAppliedPerFlavor = "FlavorIndependentAdmissionCheckAppliedPerFlavor"
 	ClusterQueueActiveReasonMultipleMultiKueueAdmissionChecks               = "MultipleMultiKueueAdmissionChecks"
-	ClusterQueueActiveReasonMutliKueueAdmissionCheckAppliedPerFlavor        = "MutliKueueAdmissionCheckAppliedPerFlavor"
+	ClusterQueueActiveReasonMultiKueueAdmissionCheckAppliedPerFlavor        = "MultiKueueAdmissionCheckAppliedPerFlavor"
 	ClusterQueueActiveReasonUnknown                                         = "Unknown"
 	ClusterQueueActiveReasonReady                                           = "Ready"
 )

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -280,7 +280,7 @@ func (c *clusterQueue) inactiveReason() (string, string) {
 		}
 
 		if len(c.perFlavorMultiKueueAdmissionChecks) > 0 {
-			reasons = append(reasons, kueue.ClusterQueueActiveReasonMutliKueueAdmissionCheckAppliedPerFlavor)
+			reasons = append(reasons, kueue.ClusterQueueActiveReasonMultiKueueAdmissionCheckAppliedPerFlavor)
 			messages = append(messages, fmt.Sprintf("Cannot specify MultiKueue AdmissionCheck per flavor, found: %s", strings.Join(c.perFlavorMultiKueueAdmissionChecks, ",")))
 		}
 

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -872,7 +872,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 				},
 			},
 			wantStatus:  pending,
-			wantReason:  "MutliKueueAdmissionCheckAppliedPerFlavor",
+			wantReason:  "MultiKueueAdmissionCheckAppliedPerFlavor",
 			wantMessage: `Can't admit new workloads: Cannot specify MultiKueue AdmissionCheck per flavor, found: check1.`,
 		},
 	}

--- a/test/integration/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/controller/core/clusterqueue_controller_test.go
@@ -816,7 +816,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 				{
 					Type:    kueue.ClusterQueueActive,
 					Status:  metav1.ConditionFalse,
-					Reason:  "MutliKueueAdmissionCheckAppliedPerFlavor",
+					Reason:  "MultiKueueAdmissionCheckAppliedPerFlavor",
 					Message: `Can't admit new workloads: Cannot specify MultiKueue AdmissionCheck per flavor, found: check1.`,
 				},
 			}, util.IgnoreConditionTimestampsAndObservedGeneration))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The PR corrects a typo in the constant `ClusterQueueActiveReasonMultiKueueAdmissionCheckAppliedPerFlavor`. Should be `Multi`, not `Mutli`.

#### Special notes for your reviewer:

This constant was introduced yesterday in PR #3254. I believe we can fix it.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```