### PR TITLE
Fix "Stateful set integration when Single CQ should admit group that fits" test.

### DIFF
--- a/test/e2e/singlecluster/statefulset_test.go
+++ b/test/e2e/singlecluster/statefulset_test.go
@@ -126,11 +126,11 @@ var _ = ginkgo.Describe("Stateful set integration", func() {
 				conflictingWorkload := &kueue.Workload{}
 				gomega.Expect(k8sClient.Get(ctx, conflictingWlLookupKey, conflictingWorkload)).To(gomega.Succeed())
 				gomega.Expect(createdWorkload.Name).ToNot(gomega.Equal(conflictingWorkload.Name))
-				util.ExpectObjectToBeDeleted(ctx, k8sClient, conflictingStatefulSet, true)
+				gomega.Expect(k8sClient.Delete(ctx, conflictingStatefulSet)).To(gomega.Succeed())
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, conflictingWorkload, false)
 			})
 
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, statefulSet, true)
+			gomega.Expect(k8sClient.Delete(ctx, statefulSet)).To(gomega.Succeed())
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, createdWorkload, false)
 		})
 	})

--- a/test/e2e/singlecluster/statefulset_test.go
+++ b/test/e2e/singlecluster/statefulset_test.go
@@ -126,11 +126,11 @@ var _ = ginkgo.Describe("Stateful set integration", func() {
 				conflictingWorkload := &kueue.Workload{}
 				gomega.Expect(k8sClient.Get(ctx, conflictingWlLookupKey, conflictingWorkload)).To(gomega.Succeed())
 				gomega.Expect(createdWorkload.Name).ToNot(gomega.Equal(conflictingWorkload.Name))
-				gomega.Expect(k8sClient.Delete(ctx, conflictingStatefulSet)).To(gomega.Succeed())
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, conflictingStatefulSet, true, util.LongTimeout)
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, conflictingWorkload, false)
 			})
 
-			gomega.Expect(k8sClient.Delete(ctx, statefulSet)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, statefulSet, true, util.LongTimeout)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, createdWorkload, false)
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix "Stateful set integration when Single CQ should admit group that fits" test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3299

#### Special notes for your reviewer:
Removing a StatefulSet sometimes takes more than 5 seconds. However, we don't need to wait for the StatefulSet to be completely removed; instead, we just need to ensure that the workload is removed.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```