### PR TITLE
[MultiKueue] Document  MPI Operator managedBy field

### DIFF
--- a/site/content/en/docs/tasks/run/multikueue/kubeflow.md
+++ b/site/content/en/docs/tasks/run/multikueue/kubeflow.md
@@ -31,3 +31,10 @@ See [Training Operator Installation](https://www.kubeflow.org/docs/components/tr
 ## MultiKueue integration
 
 Once the setup is complete you can test it by running one of the Kubeflow Jobs e.g. PyTorchJob [`sample-pytorchjob.yaml`](/docs/tasks/run/kubeflow/pytorchjobs/#sample-pytorchjob). 
+
+
+## Working alongside MPI Operator
+In order for MPI-operator and Training-operator to work on the same cluster it is required that:
+1. `kubeflow.org_mpijobs.yaml` entry is removed from `base/crds/kustomization.yaml` - https://github.com/kubeflow/training-operator/issues/1930
+2. Training Operator deployment is modified to enable all kubeflow jobs except for MPI -  https://github.com/kubeflow/training-operator/issues/1777
+  

--- a/site/content/en/docs/tasks/run/multikueue/mpijob.md
+++ b/site/content/en/docs/tasks/run/multikueue/mpijob.md
@@ -1,6 +1,6 @@
 ---
 title: "Run MPI Jobs in Multi-Cluster"
-linkTitle: "MPI"
+linkTitle: "MPIJob"
 weight: 3
 date: 2024-10-25
 description: >
@@ -26,12 +26,11 @@ See [MPI Operator Installation](https://www.kubeflow.org/docs/components/trainin
 
 Once the setup is complete you can test it by running a MPI Job [`sample-mpijob.yaml`](/docs/tasks/run/kubeflow/mpijobs/#sample-mpijob). 
 
+{{% alert title="Note" color="primary" %}}
+Note: Kueue defaults the `spec.runPolicy.managedBy` field to `kueue.x-k8s.io/multikueue` on the management cluster for MPIJob. 
 
-### ManagedBy
+This allows the MPI Operator to ignore the Jobs managed by MultiKueue on the management cluster, and in particular skip Pod creation. 
 
-The feature allows you to disable the MPI Operator and delegate reconciliation of that job to the Kueue controller.
-In order to change the controller that reconciles the job to the Kueue you need to set a value of that field to `kueue.x-k8s.io/multikueue`. 
-
-However the `spec.runPolicy.managedBy` field is defaulted to `kueue.x-k8s.io/multikueue` automatically if following conditions are met.
-
-The `kueue.x-k8s.io/queue-name` annotation of the mpijob job points to a Local Queue, whose corresponding Cluster Queue uses the Multi Kueue admission check.
+The pods are created and the actual computation will happen on the mirror copy of the Job on the selected worker cluster. 
+The mirror copy of the Job does not have the field set.
+{{% /alert %}}

--- a/site/content/en/docs/tasks/run/multikueue/mpijob.md
+++ b/site/content/en/docs/tasks/run/multikueue/mpijob.md
@@ -1,0 +1,27 @@
+---
+title: "Run MPI Jobs in Multi-Cluster"
+linkTitle: "MPI"
+weight: 3
+date: 2024-10-25
+description: >
+  Run a MultiKueue scheduled MPI Jobs.
+---
+
+## Before you begin
+
+Check the [MultiKueue installation guide](/docs/tasks/manage/setup_multikueue) on how to properly setup MultiKueue clusters.
+
+For the proper setup and use it is required using at least Kueue v0.9.0 and for MPI Operator at least v0.6.0.
+
+### Installation on the Clusters
+
+{{% alert title="Note" color="primary" %}}
+Note: While both MPI Operator and Training Operator must be running on the same cluster, there are special steps that has to be applied to Training Operator deployment.
+See [Working alongside MPI Operator](/docs/tasks/run/multikueue/kubeflow#working-alongside-mpi-operator) for more details.
+{{% /alert %}}
+
+See [MPI Operator Installation](https://www.kubeflow.org/docs/components/training/user-guides/mpi/#installation) for installation and configuration details of MPI Operator.
+
+## MultiKueue integration
+
+Once the setup is complete you can test it by running a MPI Job [`sample-mpijob.yaml`](/docs/tasks/run/kubeflow/mpijobs/#sample-mpijob). 

--- a/site/content/en/docs/tasks/run/multikueue/mpijob.md
+++ b/site/content/en/docs/tasks/run/multikueue/mpijob.md
@@ -25,3 +25,13 @@ See [MPI Operator Installation](https://www.kubeflow.org/docs/components/trainin
 ## MultiKueue integration
 
 Once the setup is complete you can test it by running a MPI Job [`sample-mpijob.yaml`](/docs/tasks/run/kubeflow/mpijobs/#sample-mpijob). 
+
+
+### ManagedBy
+
+The feature allows you to disable the MPI Operator and delegate reconciliation of that job to the Kueue controller.
+In order to change the controller that reconciles the job to the Kueue you need to set a value of that field to `kueue.x-k8s.io/multikueue`. 
+
+However the `spec.runPolicy.managedBy` field is defaulted to `kueue.x-k8s.io/multikueue` automatically if following conditions are met.
+
+The `kueue.x-k8s.io/queue-name` annotation of the mpijob job points to a Local Queue, whose corresponding Cluster Queue uses the Multi Kueue admission check.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Document how to use managedBy provided by the mpi-operator.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3313 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```