### PR TITLE
TAS: add validation for ResourceFlavor

### DIFF
--- a/apis/kueue/v1beta1/resourceflavor_types.go
+++ b/apis/kueue/v1beta1/resourceflavor_types.go
@@ -36,6 +36,7 @@ type ResourceFlavor struct {
 }
 
 // ResourceFlavorSpec defines the desired state of the ResourceFlavor
+// +kubebuilder:validation:XValidation:rule="!has(self.topologyName) || self.nodeLabels.size() >= 1", message="at least one nodeLabel is required when topology is set"
 type ResourceFlavorSpec struct {
 	// nodeLabels are labels that associate the ResourceFlavor with Nodes that
 	// have the same labels.
@@ -91,6 +92,8 @@ type ResourceFlavorSpec struct {
 	// nodes matching to the Resource Flavor node labels.
 	//
 	// +optional
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 	TopologyName *string `json:"topologyName,omitempty"`
 }
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
@@ -191,8 +191,13 @@ spec:
                   topologyName indicates topology for the TAS ResourceFlavor.
                   When specified, it enables scraping of the topology information from the
                   nodes matching to the Resource Flavor node labels.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: at least one nodeLabel is required when topology is set
+              rule: '!has(self.topologyName) || self.nodeLabels.size() >= 1'
         type: object
     served: true
     storage: true

--- a/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
@@ -176,8 +176,13 @@ spec:
                   topologyName indicates topology for the TAS ResourceFlavor.
                   When specified, it enables scraping of the topology information from the
                   nodes matching to the Resource Flavor node labels.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: at least one nodeLabel is required when topology is set
+              rule: '!has(self.topologyName) || self.nodeLabels.size() >= 1'
         type: object
     served: true
     storage: true

--- a/test/integration/tas/tas_job_test.go
+++ b/test/integration/tas/tas_job_test.go
@@ -85,6 +85,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "b1-r1",
 							Labels: map[string]string{
+								"node-group":  "tas",
 								tasBlockLabel: "b1",
 								tasRackLabel:  "r1",
 							},
@@ -100,6 +101,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "b1-r2",
 							Labels: map[string]string{
+								"node-group":  "tas",
 								tasBlockLabel: "b1",
 								tasRackLabel:  "r2",
 							},
@@ -115,6 +117,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "b2-r1",
 							Labels: map[string]string{
+								"node-group":  "tas",
 								tasBlockLabel: "b2",
 								tasRackLabel:  "r1",
 							},
@@ -130,6 +133,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "b2-r2",
 							Labels: map[string]string{
+								"node-group":  "tas",
 								tasBlockLabel: "b2",
 								tasRackLabel:  "r2",
 							},
@@ -153,7 +157,9 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				}).Obj()
 				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
-				tasFlavor = testing.MakeResourceFlavor("tas-flavor").TopologyName("default").Obj()
+				tasFlavor = testing.MakeResourceFlavor("tas-flavor").
+					NodeLabel("node-group", "tas").
+					TopologyName("default").Obj()
 				gomega.Expect(k8sClient.Create(ctx, tasFlavor)).Should(gomega.Succeed())
 
 				clusterQueue = testing.MakeClusterQueue("cluster-queue").
@@ -369,7 +375,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				}).Obj()
 				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
-				tasFlavor = testing.MakeResourceFlavor("tas-flavor").TopologyName("default").Obj()
+				tasFlavor = testing.MakeResourceFlavor("tas-flavor").
+					NodeLabel("node-group", "tas").
+					TopologyName("default").
+					Obj()
 				gomega.Expect(k8sClient.Create(ctx, tasFlavor)).Should(gomega.Succeed())
 
 				clusterQueue = testing.MakeClusterQueue("cluster-queue").
@@ -417,6 +426,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "b1-r1",
 								Labels: map[string]string{
+									"node-group":  "tas",
 									tasBlockLabel: "b1",
 									tasRackLabel:  "r1",
 								},

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
+	var (
+		ns *corev1.Namespace
+	)
+
+	ginkgo.BeforeAll(func() {
+		fwk.StartManager(ctx, cfg, managerSetup)
+	})
+
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		_ = features.SetEnable(features.TopologyAwareScheduling, true)
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "tas-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		_ = features.SetEnable(features.TopologyAwareScheduling, false)
+	})
+
+	ginkgo.When("Negative scenarios for ResourceFlavor configuration", func() {
+		ginkgo.It("should not allow to create ResourceFlavor with invalid topology name", func() {
+			tasFlavor := testing.MakeResourceFlavor("tas-flavor").
+				NodeLabel("node-group", "tas").
+				TopologyName("invalid topology name").Obj()
+			gomega.Expect(k8sClient.Create(ctx, tasFlavor)).Should(gomega.HaveOccurred())
+		})
+
+		ginkgo.It("should not allow to create ResourceFlavor without any node labels", func() {
+			tasFlavor := testing.MakeResourceFlavor("tas-flavor").TopologyName("default").Obj()
+			gomega.Expect(k8sClient.Create(ctx, tasFlavor)).Should(gomega.HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

To add validation as proposed [here](https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-schedling#validation) in the KEP.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #2724 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```