### PR TITLE
Use IsNegativeErrorMsg in the apimachnery lib instead of self deined one

### DIFF
--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -23,19 +23,19 @@ import (
 	"unsafe"
 
 	corev1 "k8s.io/api/core/v1"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-	apimachineryvalidation "k8s.io/apimachinery/pkg/util/validation"
+	apimachineryutilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
-	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	podworkload "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 )
@@ -78,12 +78,12 @@ func validateInternalCertManagement(c *configapi.Configuration) field.ErrorList 
 		return allErrs
 	}
 	if svcName := c.InternalCertManagement.WebhookServiceName; svcName != nil {
-		if errs := apimachineryvalidation.IsDNS1035Label(*svcName); len(errs) != 0 {
+		if errs := apimachineryutilvalidation.IsDNS1035Label(*svcName); len(errs) != 0 {
 			allErrs = append(allErrs, field.Invalid(internalCertManagementPath.Child("webhookServiceName"), svcName, strings.Join(errs, ",")))
 		}
 	}
 	if secName := c.InternalCertManagement.WebhookSecretName; secName != nil {
-		if errs := apimachineryvalidation.IsDNS1123Subdomain(*secName); len(errs) != 0 {
+		if errs := apimachineryutilvalidation.IsDNS1123Subdomain(*secName); len(errs) != 0 {
 			allErrs = append(allErrs, field.Invalid(internalCertManagementPath.Child("webhookSecretName"), secName, strings.Join(errs, ",")))
 		}
 	}
@@ -95,14 +95,14 @@ func validateMultiKueue(c *configapi.Configuration) field.ErrorList {
 	if c.MultiKueue != nil {
 		if c.MultiKueue.GCInterval != nil && c.MultiKueue.GCInterval.Duration < 0 {
 			allErrs = append(allErrs, field.Invalid(multiKueuePath.Child("gcInterval"),
-				c.MultiKueue.GCInterval.Duration, constants.IsNegativeErrorMsg))
+				c.MultiKueue.GCInterval.Duration, apimachineryvalidation.IsNegativeErrorMsg))
 		}
 		if c.MultiKueue.WorkerLostTimeout != nil && c.MultiKueue.WorkerLostTimeout.Duration < 0 {
 			allErrs = append(allErrs, field.Invalid(multiKueuePath.Child("workerLostTimeout"),
-				c.MultiKueue.WorkerLostTimeout.Duration, constants.IsNegativeErrorMsg))
+				c.MultiKueue.WorkerLostTimeout.Duration, apimachineryvalidation.IsNegativeErrorMsg))
 		}
 		if c.MultiKueue.Origin != nil {
-			if errs := apimachineryvalidation.IsValidLabelValue(*c.MultiKueue.Origin); len(errs) != 0 {
+			if errs := apimachineryutilvalidation.IsValidLabelValue(*c.MultiKueue.Origin); len(errs) != 0 {
 				allErrs = append(allErrs, field.Invalid(multiKueuePath.Child("origin"), *c.MultiKueue.Origin, strings.Join(errs, ",")))
 			}
 		}
@@ -117,7 +117,7 @@ func validateWaitForPodsReady(c *configapi.Configuration) field.ErrorList {
 	}
 	if c.WaitForPodsReady.Timeout != nil && c.WaitForPodsReady.Timeout.Duration < 0 {
 		allErrs = append(allErrs, field.Invalid(waitForPodsReadyPath.Child("timeout"),
-			c.WaitForPodsReady.Timeout, constants.IsNegativeErrorMsg))
+			c.WaitForPodsReady.Timeout, apimachineryvalidation.IsNegativeErrorMsg))
 	}
 	if strategy := c.WaitForPodsReady.RequeuingStrategy; strategy != nil {
 		if strategy.Timestamp != nil &&
@@ -127,15 +127,15 @@ func validateWaitForPodsReady(c *configapi.Configuration) field.ErrorList {
 		}
 		if strategy.BackoffLimitCount != nil && *strategy.BackoffLimitCount < 0 {
 			allErrs = append(allErrs, field.Invalid(requeuingStrategyPath.Child("backoffLimitCount"),
-				*strategy.BackoffLimitCount, constants.IsNegativeErrorMsg))
+				*strategy.BackoffLimitCount, apimachineryvalidation.IsNegativeErrorMsg))
 		}
 		if strategy.BackoffBaseSeconds != nil && *strategy.BackoffBaseSeconds < 0 {
 			allErrs = append(allErrs, field.Invalid(requeuingStrategyPath.Child("backoffBaseSeconds"),
-				*strategy.BackoffBaseSeconds, constants.IsNegativeErrorMsg))
+				*strategy.BackoffBaseSeconds, apimachineryvalidation.IsNegativeErrorMsg))
 		}
 		if ptr.Deref(strategy.BackoffMaxSeconds, 0) < 0 {
 			allErrs = append(allErrs, field.Invalid(requeuingStrategyPath.Child("backoffMaxSeconds"),
-				*strategy.BackoffMaxSeconds, constants.IsNegativeErrorMsg))
+				*strategy.BackoffMaxSeconds, apimachineryvalidation.IsNegativeErrorMsg))
 		}
 	}
 	return allErrs
@@ -147,7 +147,7 @@ func validateQueueVisibility(cfg *configapi.Configuration) field.ErrorList {
 		if cfg.QueueVisibility.ClusterQueues != nil {
 			maxCountPath := queueVisibilityPath.Child("clusterQueues").Child("maxCount")
 			if cfg.QueueVisibility.ClusterQueues.MaxCount < 0 {
-				allErrs = append(allErrs, field.Invalid(maxCountPath, cfg.QueueVisibility.ClusterQueues.MaxCount, constants.IsNegativeErrorMsg))
+				allErrs = append(allErrs, field.Invalid(maxCountPath, cfg.QueueVisibility.ClusterQueues.MaxCount, apimachineryvalidation.IsNegativeErrorMsg))
 			}
 			if cfg.QueueVisibility.ClusterQueues.MaxCount > queueVisibilityClusterQueuesMaxValue {
 				allErrs = append(allErrs, field.Invalid(maxCountPath, cfg.QueueVisibility.ClusterQueues.MaxCount, fmt.Sprintf("must be less than %d", queueVisibilityClusterQueuesMaxValue)))

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -41,8 +41,6 @@ const (
 
 	DefaultPendingWorkloadsLimit = 1000
 
-	IsNegativeErrorMsg string = `must be greater than or equal to 0`
-
 	// Label that signalize that an object is managed by Kueue
 	ManagedByKueueLabel = "kueue.x-k8s.io/managed"
 )

--- a/pkg/webhooks/clusterqueue_webhook.go
+++ b/pkg/webhooks/clusterqueue_webhook.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -32,7 +33,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
-	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 )
 
@@ -198,7 +198,7 @@ func validateFlavorQuotas(flavorQuotas kueue.FlavorQuotas, coveredResources []co
 func validateResourceQuantity(value resource.Quantity, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if value.Cmp(resource.Quantity{}) < 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath, value.String(), constants.IsNegativeErrorMsg))
+		allErrs = append(allErrs, field.Invalid(fldPath, value.String(), apimachineryvalidation.IsNegativeErrorMsg))
 	}
 	return allErrs
 }
@@ -227,7 +227,7 @@ func validateFairSharing(fs *kueue.FairSharing, fldPath *field.Path) field.Error
 	}
 	var allErrs field.ErrorList
 	if fs.Weight != nil && fs.Weight.Cmp(resource.Quantity{}) < 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath, fs.Weight.String(), constants.IsNegativeErrorMsg))
+		allErrs = append(allErrs, field.Invalid(fldPath, fs.Weight.String(), apimachineryvalidation.IsNegativeErrorMsg))
 	}
 	return allErrs
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
It would be better to hold self-defined constants.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```