### PR TITLE
Propagate gomega.Gomega on integration/webhook tests.

### DIFF
--- a/pkg/util/testing/error_matchers.go
+++ b/pkg/util/testing/error_matchers.go
@@ -32,6 +32,10 @@ func BeForbiddenError() types.GomegaMatcher {
 	return BeAPIError(ForbiddenError)
 }
 
+func BeInvalidError() types.GomegaMatcher {
+	return BeAPIError(InvalidError)
+}
+
 type errorMatcher int
 
 const (

--- a/test/integration/webhook/core/admissioncheck_test.go
+++ b/test/integration/webhook/core/admissioncheck_test.go
@@ -189,13 +189,13 @@ var _ = ginkgo.Describe("AdmissionCheck Webhook", func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, ac, true)
 		}()
 
-		gomega.Eventually(func() error {
+		gomega.Eventually(func(g gomega.Gomega) {
 			var updateAC kueue.AdmissionCheck
-			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ac), &updateAC)).Should(gomega.Succeed())
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ac), &updateAC)).Should(gomega.Succeed())
 			updateAC.Spec.Parameters.APIGroup = "ref.api.group2"
 			updateAC.Spec.Parameters.Kind = "RefKind2"
 			updateAC.Spec.Parameters.Name = "ref-name2"
-			return k8sClient.Update(ctx, &updateAC)
+			g.Expect(k8sClient.Update(ctx, &updateAC)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
@@ -211,11 +211,11 @@ var _ = ginkgo.Describe("AdmissionCheck Webhook", func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, ac, true)
 		}()
 
-		gomega.Eventually(func() error {
+		gomega.Eventually(func(g gomega.Gomega) {
 			var updateAC kueue.AdmissionCheck
-			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ac), &updateAC)).Should(gomega.Succeed())
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ac), &updateAC)).Should(gomega.Succeed())
 			updateAC.Spec.Parameters = nil
-			return k8sClient.Update(ctx, &updateAC)
+			g.Expect(k8sClient.Update(ctx, &updateAC)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
@@ -231,12 +231,12 @@ var _ = ginkgo.Describe("AdmissionCheck Webhook", func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, ac, true)
 		}()
 
-		gomega.Eventually(func() error {
+		gomega.Eventually(func(g gomega.Gomega) {
 			var updateAC kueue.AdmissionCheck
-			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ac), &updateAC)).Should(gomega.Succeed())
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ac), &updateAC)).Should(gomega.Succeed())
 			updateAC.Spec.Parameters.Name = ""
-			return k8sClient.Update(ctx, &updateAC)
-		}, util.Timeout, util.Interval).Should(testing.BeAPIError(testing.InvalidError))
+			g.Expect(k8sClient.Update(ctx, &updateAC)).Should(testing.BeInvalidError())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
 	ginkgo.It("Should fail to update AdmissionCheck when breaking parameters", func() {
@@ -251,11 +251,11 @@ var _ = ginkgo.Describe("AdmissionCheck Webhook", func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, ac, true)
 		}()
 
-		gomega.Eventually(func() error {
+		gomega.Eventually(func(g gomega.Gomega) {
 			var updateAC kueue.AdmissionCheck
-			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ac), &updateAC)).Should(gomega.Succeed())
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(ac), &updateAC)).Should(gomega.Succeed())
 			updateAC.Spec.ControllerName = "controller-name2"
-			return k8sClient.Update(ctx, &updateAC)
-		}, util.Timeout, util.Interval).Should(testing.BeAPIError(testing.InvalidError))
+			g.Expect(k8sClient.Update(ctx, &updateAC)).Should(testing.BeInvalidError())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 })

--- a/test/integration/webhook/core/clusterqueue_test.go
+++ b/test/integration/webhook/core/clusterqueue_test.go
@@ -178,12 +178,12 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
 			}()
 
-			gomega.Eventually(func() error {
+			gomega.Eventually(func(g gomega.Gomega) {
 				var updateCQ kueue.ClusterQueue
-				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &updateCQ)).Should(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &updateCQ)).Should(gomega.Succeed())
 				updateCQ.Spec.ResourceGroups[0].Flavors[0].Name = "@x86"
-				return k8sClient.Update(ctx, &updateCQ)
-			}, util.Timeout, util.Interval).Should(testing.BeAPIError(testing.InvalidError))
+				g.Expect(k8sClient.Update(ctx, &updateCQ)).Should(testing.BeInvalidError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("Should allow to update queueingStrategy with different value", func() {
@@ -198,11 +198,11 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
 			}()
 
-			gomega.Eventually(func() error {
+			gomega.Eventually(func(g gomega.Gomega) {
 				var updateCQ kueue.ClusterQueue
-				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &updateCQ)).Should(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &updateCQ)).Should(gomega.Succeed())
 				updateCQ.Spec.QueueingStrategy = kueue.BestEffortFIFO
-				return k8sClient.Update(ctx, &updateCQ)
+				g.Expect(k8sClient.Update(ctx, &updateCQ)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 

--- a/test/integration/webhook/core/localqueue_test.go
+++ b/test/integration/webhook/core/localqueue_test.go
@@ -38,12 +38,12 @@ var _ = ginkgo.Describe("Queue validating webhook", func() {
 			gomega.Expect(k8sClient.Create(ctx, obj)).Should(gomega.Succeed())
 
 			ginkgo.By("Updating the Queue")
-			gomega.Eventually(func() error {
+			gomega.Eventually(func(g gomega.Gomega) {
 				var updatedQ kueue.LocalQueue
-				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), &updatedQ)).Should(gomega.Succeed())
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(obj), &updatedQ)).Should(gomega.Succeed())
 				updatedQ.Spec.ClusterQueue = "bar"
-				return k8sClient.Update(ctx, &updatedQ)
-			}, util.Timeout, util.Interval).Should(testing.BeAPIError(testing.InvalidError))
+				g.Expect(k8sClient.Update(ctx, &updatedQ)).Should(testing.BeInvalidError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 })

--- a/test/integration/webhook/jobs/job_webhook_test.go
+++ b/test/integration/webhook/jobs/job_webhook_test.go
@@ -79,12 +79,10 @@ var _ = ginkgo.Describe("Job Webhook With manageJobsWithoutQueueName enabled", g
 
 		lookupKey := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
 		createdJob := &batchv1.Job{}
-		gomega.Eventually(func() bool {
-			if err := k8sClient.Get(ctx, lookupKey, createdJob); err != nil {
-				return false
-			}
-			return createdJob.Spec.Suspend != nil && *createdJob.Spec.Suspend
-		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+			g.Expect(createdJob.Spec.Suspend).Should(gomega.Equal(ptr.To(true)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
 	ginkgo.It("Should not update unsuspend Job successfully when adding queue name", func() {
@@ -140,12 +138,10 @@ var _ = ginkgo.Describe("Job Webhook with manageJobsWithoutQueueName disabled", 
 
 		lookupKey := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
 		createdJob := &batchv1.Job{}
-		gomega.Eventually(func() bool {
-			if err := k8sClient.Get(ctx, lookupKey, createdJob); err != nil {
-				return false
-			}
-			return createdJob.Spec.Suspend != nil && *createdJob.Spec.Suspend
-		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+			g.Expect(createdJob.Spec.Suspend).Should(gomega.Equal(ptr.To(true)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
 	ginkgo.It("should not suspend a Job when no queue name specified", func() {
@@ -154,12 +150,10 @@ var _ = ginkgo.Describe("Job Webhook with manageJobsWithoutQueueName disabled", 
 
 		lookupKey := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
 		createdJob := &batchv1.Job{}
-		gomega.Eventually(func() bool {
-			if err := k8sClient.Get(ctx, lookupKey, createdJob); err != nil {
-				return false
-			}
-			return createdJob.Spec.Suspend != nil && !(*createdJob.Spec.Suspend)
-		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+			g.Expect(createdJob.Spec.Suspend).Should(gomega.Equal(ptr.To(false)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
 	ginkgo.It("should not update unsuspend Job successfully when changing queue name", func() {

--- a/test/integration/webhook/jobs/pod_webhook_test.go
+++ b/test/integration/webhook/jobs/pod_webhook_test.go
@@ -93,8 +93,8 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
 
 				createdPod := &corev1.Pod{}
-				gomega.Eventually(func() error {
-					return k8sClient.Get(ctx, lookupKey, createdPod)
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				gomega.Expect(createdPod.Spec.SchedulingGates).To(
@@ -117,8 +117,8 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 
 				lookupKey := types.NamespacedName{Name: pod.Name, Namespace: "kube-system"}
 				createdPod := &corev1.Pod{}
-				gomega.Eventually(func() error {
-					return k8sClient.Get(ctx, lookupKey, createdPod)
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				gomega.Expect(createdPod.Spec.SchedulingGates).NotTo(
@@ -151,8 +151,8 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
 
 				createdPod := &corev1.Pod{}
-				gomega.Eventually(func() error {
-					return k8sClient.Get(ctx, lookupKey, createdPod)
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				gomega.Expect(createdPod.Spec.SchedulingGates).NotTo(
@@ -225,8 +225,8 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 
 				lookupKey := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
 				createdPod := &corev1.Pod{}
-				gomega.Eventually(func() error {
-					return k8sClient.Get(ctx, lookupKey, createdPod)
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				gomega.Expect(createdPod.Spec.SchedulingGates).To(
@@ -249,8 +249,8 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 
 				lookupKey := types.NamespacedName{Name: pod.Name, Namespace: "kube-system"}
 				createdPod := &corev1.Pod{}
-				gomega.Eventually(func() error {
-					return k8sClient.Get(ctx, lookupKey, createdPod)
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 				gomega.Expect(createdPod.Spec.SchedulingGates).NotTo(

--- a/test/integration/webhook/jobs/raycluster_webhook_test.go
+++ b/test/integration/webhook/jobs/raycluster_webhook_test.go
@@ -137,8 +137,8 @@ var _ = ginkgo.Describe("RayCluster Webhook", func() {
 			ginkgo.By("Fetching the workload created for the job")
 			createdWorkload := &kueue.Workload{}
 			wlLookupKey := types.NamespacedName{Name: workloadrayjob.GetWorkloadNameForRayJob(parentJob.Name, parentJob.UID), Namespace: ns.Name}
-			gomega.Eventually(func() error {
-				return k8sClient.Get(ctx, wlLookupKey, createdWorkload)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Admitting the workload created for the job")
@@ -169,8 +169,8 @@ var _ = ginkgo.Describe("RayCluster Webhook", func() {
 			ginkgo.By("Checking that the child cluster is not suspended")
 			childClusterKey := client.ObjectKeyFromObject(childCluster)
 			gomega.Eventually(func(g gomega.Gomega) {
-				gomega.Expect(k8sClient.Get(ctx, childClusterKey, childCluster)).To(gomega.Succeed())
-				gomega.Expect(childCluster.Spec.Suspend).To(gomega.Equal(ptr.To(false)))
+				g.Expect(k8sClient.Get(ctx, childClusterKey, childCluster)).To(gomega.Succeed())
+				g.Expect(childCluster.Spec.Suspend).To(gomega.Equal(ptr.To(false)))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Propagate gomega.Gomega on integration/webhook tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #3300

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```