### PR TITLE
Propagate gomega.Gomega on integration/scheduler tests.

### DIFF
--- a/test/integration/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/scheduler/fairsharing/fair_sharing_test.go
@@ -312,7 +312,7 @@ func finishRunningWorkloadsInCQ(cq *kueue.ClusterQueue, n int) {
 
 func finishEvictionOfWorkloadsInCQ(cq *kueue.ClusterQueue, n int) {
 	finished := sets.New[types.UID]()
-	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) int {
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
 		var wList kueue.WorkloadList
 		g.Expect(k8sClient.List(ctx, &wList)).To(gomega.Succeed())
 		for i := 0; i < len(wList.Items) && finished.Len() < n; i++ {
@@ -328,6 +328,6 @@ func finishEvictionOfWorkloadsInCQ(cq *kueue.ClusterQueue, n int) {
 				finished.Insert(wl.UID)
 			}
 		}
-		return finished.Len()
-	}, util.Timeout, util.Interval).Should(gomega.Equal(n), "Not enough workloads evicted")
+		g.Expect(finished.Len()).Should(gomega.Equal(n), "Not enough workloads evicted")
+	}, util.Timeout, util.Interval).Should(gomega.Succeed())
 }

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -424,19 +424,19 @@ var _ = ginkgo.Describe("Preemption", func() {
 			gomega.Expect(k8sClient.Create(ctx, gammaWl)).To(gomega.Succeed())
 
 			var evictedWorkloads []*kueue.Workload
-			gomega.Eventually(func() int {
+			gomega.Eventually(func(g gomega.Gomega) {
 				evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
-				return len(evictedWorkloads)
-			}, util.Timeout, util.Interval).Should(gomega.Equal(1), "Number of evicted workloads")
+				g.Expect(evictedWorkloads).Should(gomega.HaveLen(1), "Number of evicted workloads")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Finishing eviction for first set of preempted workloads")
 			util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
 			util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, alphaWl, gammaWl)
 
-			gomega.Eventually(func() int {
+			gomega.Eventually(func(g gomega.Gomega) {
 				evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
-				return len(evictedWorkloads)
-			}, util.Timeout, util.Interval).Should(gomega.Equal(2), "Number of evicted workloads")
+				g.Expect(evictedWorkloads).Should(gomega.HaveLen(2), "Number of evicted workloads")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Finishing eviction for second set of preempted workloads")
 			util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)

--- a/test/integration/scheduler/workload_controller_test.go
+++ b/test/integration/scheduler/workload_controller_test.go
@@ -219,30 +219,28 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-				gomega.Eventually(func() bool {
+				gomega.Eventually(func(g gomega.Gomega) {
 					read := kueue.Workload{}
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read); err != nil {
-						return false
-					}
-					return workload.HasQuotaReservation(&read)
-				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Check queue resource consumption", func() {
-				gomega.Eventually(func() kueue.ClusterQueueStatus {
-					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
-					return updatedCQ.Status
-				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
-					PendingWorkloads:   0,
-					ReservingWorkloads: 1,
-					FlavorsReservation: []kueue.FlavorUsage{{
-						Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
-						Resources: []kueue.ResourceUsage{{
-							Name:  corev1.ResourceCPU,
-							Total: resource.MustParse("2"),
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 1,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("2"),
+							}},
 						}},
-					}},
-				}, ignoreCqCondition, ignoreInClusterQueueStatus))
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 	})
@@ -275,30 +273,28 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-				gomega.Eventually(func() bool {
+				gomega.Eventually(func(g gomega.Gomega) {
 					read := kueue.Workload{}
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read); err != nil {
-						return false
-					}
-					return workload.HasQuotaReservation(&read)
-				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Check queue resource consumption", func() {
-				gomega.Eventually(func() kueue.ClusterQueueStatus {
-					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
-					return updatedCQ.Status
-				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
-					PendingWorkloads:   0,
-					ReservingWorkloads: 1,
-					FlavorsReservation: []kueue.FlavorUsage{{
-						Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
-						Resources: []kueue.ResourceUsage{{
-							Name:  corev1.ResourceCPU,
-							Total: resource.MustParse("1"),
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 1,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("1"),
+							}},
 						}},
-					}},
-				}, ignoreCqCondition, ignoreInClusterQueueStatus))
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 	})
@@ -330,32 +326,30 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-				gomega.Eventually(func() bool {
+				gomega.Eventually(func(g gomega.Gomega) {
 					read := kueue.Workload{}
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read); err != nil {
-						return false
-					}
-					return workload.HasQuotaReservation(&read)
-				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Check queue resource consumption", func() {
-				gomega.Eventually(func() kueue.ClusterQueueStatus {
-					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
-					return updatedCQ.Status
-				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
-					PendingWorkloads:   0,
-					ReservingWorkloads: 1,
-					FlavorsReservation: []kueue.FlavorUsage{{
-						Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
-						Resources: []kueue.ResourceUsage{
-							{
-								Name:  corev1.ResourceCPU,
-								Total: resource.MustParse("3"),
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 1,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{
+								{
+									Name:  corev1.ResourceCPU,
+									Total: resource.MustParse("3"),
+								},
 							},
-						},
-					}},
-				}, ignoreCqCondition, ignoreInClusterQueueStatus))
+						}},
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Check podSets spec", func() {
@@ -372,32 +366,30 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-				gomega.Eventually(func() bool {
+				gomega.Eventually(func(g gomega.Gomega) {
 					read := kueue.Workload{}
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read); err != nil {
-						return false
-					}
-					return workload.HasQuotaReservation(&read)
-				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Check queue resource consumption", func() {
-				gomega.Eventually(func() kueue.ClusterQueueStatus {
-					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
-					return updatedCQ.Status
-				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
-					PendingWorkloads:   0,
-					ReservingWorkloads: 1,
-					FlavorsReservation: []kueue.FlavorUsage{{
-						Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
-						Resources: []kueue.ResourceUsage{
-							{
-								Name:  corev1.ResourceCPU,
-								Total: resource.MustParse("1"),
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 1,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{
+								{
+									Name:  corev1.ResourceCPU,
+									Total: resource.MustParse("1"),
+								},
 							},
-						},
-					}},
-				}, ignoreCqCondition, ignoreInClusterQueueStatus))
+						}},
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Check podSets spec", func() {
@@ -435,30 +427,28 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 
 				gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
 
-				gomega.Eventually(func() bool {
+				gomega.Eventually(func(g gomega.Gomega) {
 					read := kueue.Workload{}
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read); err != nil {
-						return false
-					}
-					return workload.HasQuotaReservation(&read)
-				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Check queue resource consumption", func() {
-				gomega.Eventually(func() kueue.ClusterQueueStatus {
-					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
-					return updatedCQ.Status
-				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
-					PendingWorkloads:   0,
-					ReservingWorkloads: 1,
-					FlavorsReservation: []kueue.FlavorUsage{{
-						Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
-						Resources: []kueue.ResourceUsage{{
-							Name:  corev1.ResourceCPU,
-							Total: resource.MustParse("1"),
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 1,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("1"),
+							}},
 						}},
-					}},
-				}, ignoreCqCondition, ignoreInClusterQueueStatus))
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Check podSets spec", func() {
@@ -501,20 +491,20 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			})
 
 			ginkgo.By("Check queue resource consumption", func() {
-				gomega.Eventually(func(g gomega.Gomega) kueue.ClusterQueueStatus {
+				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
-					return updatedCQ.Status
-				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
-					PendingWorkloads:   0,
-					ReservingWorkloads: 1,
-					FlavorsReservation: []kueue.FlavorUsage{{
-						Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
-						Resources: []kueue.ResourceUsage{{
-							Name:  corev1.ResourceCPU,
-							Total: resource.MustParse("2"), // conversionBaseFactor is 2
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 1,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("2"), // conversionBaseFactor is 2
+							}},
 						}},
-					}},
-				}, ignoreCqCondition, ignoreInClusterQueueStatus))
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Check podSets spec", func() {
@@ -551,38 +541,38 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			})
 
 			ginkgo.By("Check queue resource consumption", func() {
-				gomega.Eventually(func(g gomega.Gomega) kueue.ClusterQueueStatus {
+				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
-					return updatedCQ.Status
-				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
-					PendingWorkloads:   0,
-					ReservingWorkloads: 1,
-					FlavorsReservation: []kueue.FlavorUsage{{
-						Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
-						Resources: []kueue.ResourceUsage{{
-							Name:  corev1.ResourceCPU,
-							Total: resource.MustParse("4"), // conversionBaseFactor is 2
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 1,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("4"), // conversionBaseFactor is 2
+							}},
 						}},
-					}},
-				}, ignoreCqCondition, ignoreInClusterQueueStatus))
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("After all workloads are finished cluster queue state is clean", func() {
 				util.FinishWorkloads(ctx, k8sClient, wl2)
-				gomega.Eventually(func(g gomega.Gomega) kueue.ClusterQueueStatus {
+				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
-					return updatedCQ.Status
-				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
-					PendingWorkloads:   0,
-					ReservingWorkloads: 0,
-					FlavorsReservation: []kueue.FlavorUsage{{
-						Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
-						Resources: []kueue.ResourceUsage{{
-							Name:  corev1.ResourceCPU,
-							Total: resource.MustParse("0"),
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 0,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("0"),
+							}},
 						}},
-					}},
-				}, ignoreCqCondition, ignoreInClusterQueueStatus))
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 
@@ -602,20 +592,20 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			})
 
 			ginkgo.By("Check queue resource consumption", func() {
-				gomega.Eventually(func(g gomega.Gomega) kueue.ClusterQueueStatus {
+				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
-					return updatedCQ.Status
-				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
-					PendingWorkloads:   0,
-					ReservingWorkloads: 1,
-					FlavorsReservation: []kueue.FlavorUsage{{
-						Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
-						Resources: []kueue.ResourceUsage{{
-							Name:  corev1.ResourceCPU,
-							Total: resource.MustParse("2"), // conversionBaseFactor is 2
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 1,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("2"), // conversionBaseFactor is 2
+							}},
 						}},
-					}},
-				}, ignoreCqCondition, ignoreInClusterQueueStatus))
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Check podSets spec", func() {
@@ -700,13 +690,11 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-				gomega.Eventually(func() bool {
+				gomega.Eventually(func(g gomega.Gomega) {
 					read := kueue.Workload{}
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read); err != nil {
-						return false
-					}
-					return workload.HasQuotaReservation(&read)
-				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			var wl2 *kueue.Workload
@@ -735,33 +723,31 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			})
 
 			ginkgo.By("The second workload now fits and is admitted", func() {
-				gomega.Eventually(func() bool {
+				gomega.Eventually(func(g gomega.Gomega) {
 					read := kueue.Workload{}
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &read); err != nil {
-						return false
-					}
-					return workload.HasQuotaReservation(&read)
-				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Check queue resource consumption", func() {
 				// the total CPU usage in the queue should be 5
 				// for the first workload: 3 = 1 (podSet provided) + 2 (initial class overhead, at the time of it's admission)
 				// for the second workload: 2 = 1 (podSet provided) + 1 (updated class overhead, at the time of it's admission)
-				gomega.Eventually(func() kueue.ClusterQueueStatus {
-					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
-					return updatedCQ.Status
-				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
-					PendingWorkloads:   0,
-					ReservingWorkloads: 2,
-					FlavorsReservation: []kueue.FlavorUsage{{
-						Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
-						Resources: []kueue.ResourceUsage{{
-							Name:  corev1.ResourceCPU,
-							Total: resource.MustParse("5"),
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 2,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("5"),
+							}},
 						}},
-					}},
-				}, ignoreCqCondition, ignoreInClusterQueueStatus))
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 	})
@@ -793,13 +779,11 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-				gomega.Eventually(func() bool {
+				gomega.Eventually(func(g gomega.Gomega) {
 					read := kueue.Workload{}
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read); err != nil {
-						return false
-					}
-					return workload.HasQuotaReservation(&read)
-				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			var wl2 *kueue.Workload
@@ -826,33 +810,31 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			})
 
 			ginkgo.By("The second workload now fits and is admitted", func() {
-				gomega.Eventually(func() bool {
+				gomega.Eventually(func(g gomega.Gomega) {
 					read := kueue.Workload{}
-					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &read); err != nil {
-						return false
-					}
-					return workload.HasQuotaReservation(&read)
-				}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Check queue resource consumption", func() {
 				// the total CPU usage in the queue should be 5
 				// for the first workload: 3 initial limitRange default, at the time of it's admission
 				// for the second workload: 2 updated limitRange default, at the time of it's admission
-				gomega.Eventually(func() kueue.ClusterQueueStatus {
-					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
-					return updatedCQ.Status
-				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
-					PendingWorkloads:   0,
-					ReservingWorkloads: 2,
-					FlavorsReservation: []kueue.FlavorUsage{{
-						Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
-						Resources: []kueue.ResourceUsage{{
-							Name:  corev1.ResourceCPU,
-							Total: resource.MustParse("5"),
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 2,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("5"),
+							}},
 						}},
-					}},
-				}, ignoreCqCondition, ignoreInClusterQueueStatus))
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 	})
@@ -874,20 +856,20 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 		})
 		ginkgo.AfterEach(func() {
 			ginkgo.By("Resource consumption should be 0", func() {
-				gomega.Eventually(func() kueue.ClusterQueueStatus {
-					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
-					return updatedCQ.Status
-				}, util.Timeout, util.Interval).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
-					PendingWorkloads:   0,
-					ReservingWorkloads: 0,
-					FlavorsReservation: []kueue.FlavorUsage{{
-						Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
-						Resources: []kueue.ResourceUsage{{
-							Name:  corev1.ResourceCPU,
-							Total: resource.MustParse("0"),
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 0,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("0"),
+							}},
 						}},
-					}},
-				}, ignoreCqCondition, ignoreInClusterQueueStatus))
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Propagate gomega.Gomega on integration/scheduler tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #3300

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```