### PR TITLE
Propagate gomega.Gomega.

### DIFF
--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -127,7 +127,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(p), &pCopy)).To(testing.BeNotFoundError())
 					}
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				util.ExpectWorkloadsFinalized(ctx, k8sClient, gKey)
+				util.ExpectWorkloadsFinalizedOrGone(ctx, k8sClient, gKey)
 			})
 		})
 
@@ -250,7 +250,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rep), &p)).To(gomega.Succeed())
 					g.Expect(p.Spec.SchedulingGates).To(gomega.BeEmpty())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				util.ExpectPodsFinalized(ctx, k8sClient, client.ObjectKeyFromObject(group[0]))
+				util.ExpectPodsFinalizedOrGone(ctx, k8sClient, client.ObjectKeyFromObject(group[0]))
 			})
 
 			ginkgo.By("Excess pod is deleted", func() {
@@ -404,7 +404,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 						var pCopy corev1.Pod
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(p), &pCopy)).To(testing.BeNotFoundError())
 					}
-					util.ExpectWorkloadsFinalized(ctx, k8sClient, gKey)
+					util.ExpectWorkloadsFinalizedOrGone(ctx, k8sClient, gKey)
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -404,8 +404,8 @@ var _ = ginkgo.Describe("Pod groups", func() {
 						var pCopy corev1.Pod
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(p), &pCopy)).To(testing.BeNotFoundError())
 					}
-					util.ExpectWorkloadsFinalizedOrGone(ctx, k8sClient, gKey)
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectWorkloadsFinalizedOrGone(ctx, k8sClient, gKey)
 			})
 		})
 

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -404,7 +404,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 						var pCopy corev1.Pod
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(p), &pCopy)).To(testing.BeNotFoundError())
 					}
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 				util.ExpectWorkloadsFinalizedOrGone(ctx, k8sClient, gKey)
 			})
 		})

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -209,7 +209,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					g.Expect(createdWorkload.Status.Conditions).To(testing.HaveConditionStatusTrue(kueue.WorkloadFinished))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-				util.ExpectPodsFinalizedOrGone(ctx, k8sClient, lookupKey)
+				util.ExpectPodsJustFinalized(ctx, k8sClient, lookupKey)
 			})
 
 			ginkgo.It("Should remove finalizers from Pods that are actively deleted after being admitted", func() {
@@ -590,7 +590,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						g.Expect(createdWorkload.Status.Conditions).Should(testing.HaveConditionStatusTrue(kueue.WorkloadFinished))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, pod1LookupKey, pod2LookupKey)
+					util.ExpectPodsJustFinalized(ctx, k8sClient, pod1LookupKey, pod2LookupKey)
 				})
 			})
 
@@ -660,7 +660,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						g.Expect(createdWorkload.Status.Conditions).Should(testing.HaveConditionStatusTrue(kueue.WorkloadFinished))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, pod1LookupKey, pod2LookupKey)
+					util.ExpectPodsJustFinalized(ctx, k8sClient, pod1LookupKey, pod2LookupKey)
 				})
 			})
 
@@ -914,7 +914,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				})
 
 				ginkgo.By("Failing the replacement", func() {
-					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, podLookupKey)
+					util.ExpectPodsJustFinalized(ctx, k8sClient, podLookupKey)
 					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, replacementPodLookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
 					util.SetPodsPhase(ctx, k8sClient, corev1.PodFailed, replacementPod)
 				})
@@ -958,7 +958,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, replacementPod2LookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
 				util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, replacementPod2)
-				util.ExpectPodsFinalizedOrGone(ctx, k8sClient, replacementPodLookupKey, replacementPod2LookupKey)
+				util.ExpectPodsJustFinalized(ctx, k8sClient, replacementPodLookupKey, replacementPod2LookupKey)
 
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
@@ -1065,7 +1065,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				})
 
 				ginkgo.By("checking that the replaced pod is finalized", func() {
-					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, pod1LookupKey)
+					util.ExpectPodsJustFinalized(ctx, k8sClient, pod1LookupKey)
 				})
 
 				ginkgo.By("checking that pod group is finalized when unretriable pod has failed", func() {
@@ -1076,7 +1076,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						g.Expect(createdWorkload.Status.Conditions).Should(testing.HaveConditionStatusTrue(kueue.WorkloadFinished))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, pod2LookupKey, replacementPod2LookupKey)
+					util.ExpectPodsJustFinalized(ctx, k8sClient, pod2LookupKey, replacementPod2LookupKey)
 				})
 			})
 
@@ -1574,7 +1574,7 @@ var _ = ginkgo.Describe("Pod controller interacting with scheduler", ginkgo.Orde
 
 		ginkgo.By("checking pods are finalized", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				util.ExpectPodsFinalizedOrGone(ctx, k8sClient,
+				util.ExpectPodsJustFinalized(ctx, k8sClient,
 					client.ObjectKeyFromObject(role1Pod1),
 					client.ObjectKeyFromObject(role1Pod2),
 					client.ObjectKeyFromObject(role2Pod1),

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -209,7 +209,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					g.Expect(createdWorkload.Status.Conditions).To(testing.HaveConditionStatusTrue(kueue.WorkloadFinished))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-				util.ExpectPodsFinalized(ctx, k8sClient, lookupKey)
+				util.ExpectPodsFinalizedOrGone(ctx, k8sClient, lookupKey)
 			})
 
 			ginkgo.It("Should remove finalizers from Pods that are actively deleted after being admitted", func() {
@@ -590,7 +590,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						g.Expect(createdWorkload.Status.Conditions).Should(testing.HaveConditionStatusTrue(kueue.WorkloadFinished))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-					util.ExpectPodsFinalized(ctx, k8sClient, pod1LookupKey, pod2LookupKey)
+					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, pod1LookupKey, pod2LookupKey)
 				})
 			})
 
@@ -660,8 +660,8 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						g.Expect(createdWorkload.Status.Conditions).Should(testing.HaveConditionStatusTrue(kueue.WorkloadFinished))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-					util.ExpectPodsFinalized(ctx, k8sClient, pod1LookupKey)
-					util.ExpectPodsFinalized(ctx, k8sClient, pod2LookupKey)
+					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, pod1LookupKey)
+					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, pod2LookupKey)
 				})
 			})
 
@@ -915,7 +915,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				})
 
 				ginkgo.By("Failing the replacement", func() {
-					util.ExpectPodsFinalized(ctx, k8sClient, podLookupKey)
+					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, podLookupKey)
 					util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, replacementPodLookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
 					util.SetPodsPhase(ctx, k8sClient, corev1.PodFailed, replacementPod)
 				})
@@ -959,7 +959,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				util.ExpectPodUnsuspendedWithNodeSelectors(ctx, k8sClient, replacementPod2LookupKey, map[string]string{"kubernetes.io/arch": "arm64"})
 				util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, replacementPod2)
-				util.ExpectPodsFinalized(ctx, k8sClient, replacementPodLookupKey, replacementPod2LookupKey)
+				util.ExpectPodsFinalizedOrGone(ctx, k8sClient, replacementPodLookupKey, replacementPod2LookupKey)
 
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
@@ -1066,7 +1066,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				})
 
 				ginkgo.By("checking that the replaced pod is finalized", func() {
-					util.ExpectPodsFinalized(ctx, k8sClient, pod1LookupKey)
+					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, pod1LookupKey)
 				})
 
 				ginkgo.By("checking that pod group is finalized when unretriable pod has failed", func() {
@@ -1077,7 +1077,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						g.Expect(createdWorkload.Status.Conditions).Should(testing.HaveConditionStatusTrue(kueue.WorkloadFinished))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-					util.ExpectPodsFinalized(ctx, k8sClient, pod2LookupKey, replacementPod2LookupKey)
+					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, pod2LookupKey, replacementPod2LookupKey)
 				})
 			})
 
@@ -1575,7 +1575,7 @@ var _ = ginkgo.Describe("Pod controller interacting with scheduler", ginkgo.Orde
 
 		ginkgo.By("checking pods are finalized", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				util.ExpectPodsFinalized(ctx, k8sClient,
+				util.ExpectPodsFinalizedOrGone(ctx, k8sClient,
 					client.ObjectKeyFromObject(role1Pod1),
 					client.ObjectKeyFromObject(role1Pod2),
 					client.ObjectKeyFromObject(role2Pod1),

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -660,8 +660,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						g.Expect(createdWorkload.Status.Conditions).Should(testing.HaveConditionStatusTrue(kueue.WorkloadFinished))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, pod1LookupKey)
-					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, pod2LookupKey)
+					util.ExpectPodsFinalizedOrGone(ctx, k8sClient, pod1LookupKey, pod2LookupKey)
 				})
 			})
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -657,6 +657,16 @@ func ExpectPodUnsuspendedWithNodeSelectors(ctx context.Context, k8sClient client
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
+func ExpectPodsJustFinalized(ctx context.Context, k8sClient client.Client, keys ...types.NamespacedName) {
+	for _, key := range keys {
+		createdPod := &corev1.Pod{}
+		gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, key, createdPod)).To(gomega.Succeed())
+			g.Expect(createdPod.Finalizers).Should(gomega.BeEmpty(), "Expected pod to be finalized")
+		}, Timeout, Interval).Should(gomega.Succeed())
+	}
+}
+
 func ExpectPodsFinalizedOrGone(ctx context.Context, k8sClient client.Client, keys ...types.NamespacedName) {
 	for _, key := range keys {
 		createdPod := &corev1.Pod{}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -136,28 +136,19 @@ func DeleteAllJobsetsInNamespace(ctx context.Context, c client.Client, ns *corev
 }
 
 func DeleteAllPodsInNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace) error {
-	err := c.DeleteAllOf(ctx, &corev1.Pod{}, client.InNamespace(ns.Name))
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err := client.IgnoreNotFound(c.DeleteAllOf(ctx, &corev1.Pod{}, client.InNamespace(ns.Name))); err != nil {
 		return fmt.Errorf("deleting all Pods in namespace %q: %w", ns.Name, err)
 	}
 
-	gomega.Eventually(func() error {
+	gomega.Eventually(func(g gomega.Gomega) {
 		lst := corev1.PodList{}
-		err := c.List(ctx, &lst, client.InNamespace(ns.Name))
-		if err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("listing Pods with a finalizer in namespace %q: %w", ns.Name, err)
-		}
-
+		g.Expect(client.IgnoreNotFound(c.List(ctx, &lst, client.InNamespace(ns.Name)))).
+			Should(gomega.Succeed(), "listing Pods with a finalizer in namespace %q", ns.Name)
 		for _, p := range lst.Items {
 			if controllerutil.RemoveFinalizer(&p, pod.PodFinalizer) {
-				err = c.Update(ctx, &p)
-				if err != nil && !apierrors.IsNotFound(err) {
-					return fmt.Errorf("removing finalizer: %w", err)
-				}
+				g.Expect(client.IgnoreNotFound(c.Update(ctx, &p))).Should(gomega.Succeed(), "removing finalizer")
 			}
 		}
-
-		return nil
 	}, LongTimeout, Interval).Should(gomega.Succeed())
 
 	return nil
@@ -168,23 +159,14 @@ func DeleteWorkloadsInNamespace(ctx context.Context, c client.Client, ns *corev1
 		return err
 	}
 
-	gomega.Eventually(func() error {
+	gomega.Eventually(func(g gomega.Gomega) {
 		lst := kueue.WorkloadList{}
-		err := c.List(ctx, &lst, client.InNamespace(ns.Name))
-		if err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("listing Workloads with a finalizer in namespace %q: %w", ns.Name, err)
-		}
-
+		g.Expect(c.List(ctx, &lst, client.InNamespace(ns.Name))).Should(gomega.Succeed())
 		for _, wl := range lst.Items {
 			if controllerutil.RemoveFinalizer(&wl, kueue.ResourceInUseFinalizerName) {
-				err = c.Update(ctx, &wl)
-				if err != nil && !apierrors.IsNotFound(err) {
-					return fmt.Errorf("removing finalizer: %w", err)
-				}
+				g.Expect(client.IgnoreNotFound(c.Update(ctx, &wl))).Should(gomega.Succeed())
 			}
 		}
-
-		return nil
 	}, LongTimeout, Interval).Should(gomega.Succeed())
 
 	return nil
@@ -679,8 +661,18 @@ func ExpectPodsFinalized(ctx context.Context, k8sClient client.Client, keys ...t
 	for _, key := range keys {
 		createdPod := &corev1.Pod{}
 		gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, key, createdPod)).To(gomega.Succeed())
+			g.Expect(client.IgnoreNotFound(k8sClient.Get(ctx, key, createdPod))).To(gomega.Succeed())
 			g.Expect(createdPod.Finalizers).Should(gomega.BeEmpty(), "Expected pod to be finalized")
+		}, Timeout, Interval).Should(gomega.Succeed())
+	}
+}
+
+func ExpectWorkloadsFinalized(ctx context.Context, k8sClient client.Client, keys ...types.NamespacedName) {
+	for _, key := range keys {
+		createdWorkload := &kueue.Workload{}
+		gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+			g.Expect(client.IgnoreNotFound(k8sClient.Get(ctx, key, createdWorkload))).To(gomega.Succeed())
+			g.Expect(createdWorkload.Finalizers).Should(gomega.BeEmpty(), "Expected workload to be finalized")
 		}, Timeout, Interval).Should(gomega.Succeed())
 	}
 }

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -657,7 +657,7 @@ func ExpectPodUnsuspendedWithNodeSelectors(ctx context.Context, k8sClient client
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
-func ExpectPodsFinalized(ctx context.Context, k8sClient client.Client, keys ...types.NamespacedName) {
+func ExpectPodsFinalizedOrGone(ctx context.Context, k8sClient client.Client, keys ...types.NamespacedName) {
 	for _, key := range keys {
 		createdPod := &corev1.Pod{}
 		gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
@@ -667,7 +667,7 @@ func ExpectPodsFinalized(ctx context.Context, k8sClient client.Client, keys ...t
 	}
 }
 
-func ExpectWorkloadsFinalized(ctx context.Context, k8sClient client.Client, keys ...types.NamespacedName) {
+func ExpectWorkloadsFinalizedOrGone(ctx context.Context, k8sClient client.Client, keys ...types.NamespacedName) {
 	for _, key := range keys {
 		createdWorkload := &kueue.Workload{}
 		gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Propagate gomega.Gomega.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3300

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```