### PR TITLE
Automated cherry pick of #3132: Drop remove operations from webhook patches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/ray-project/kuberay/ray-operator v1.2.1
 	github.com/spf13/cobra v1.8.1
 	go.uber.org/zap v1.27.0
+	gomodules.xyz/jsonpatch/v2 v2.4.0
 	k8s.io/api v0.30.2
 	k8s.io/apimachinery v0.30.2
 	k8s.io/apiserver v0.29.6
@@ -121,7 +122,6 @@ require (
 	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.22.0 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20240528184218-531527333157 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240528184218-531527333157 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240528184218-531527333157 // indirect

--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -43,7 +43,7 @@ func DefaultWebhookFactory(job GenericJob, fromObject func(runtime.Object) Gener
 		}
 		return webhook.WebhookManagedBy(mgr).
 			For(job.Object()).
-			WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), job.Object(), wh)).
+			WithMutationHandler(webhook.WithLosslessDefaulter(mgr.GetScheme(), job.Object(), wh)).
 			WithValidator(wh).
 			Complete()
 	}

--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -41,7 +41,7 @@ func DefaultWebhookFactory(job GenericJob, fromObject func(runtime.Object) Gener
 			ManageJobsWithoutQueueName: options.ManageJobsWithoutQueueName,
 			FromObject:                 fromObject,
 		}
-		return webhook.ManagedBy(mgr).
+		return webhook.WebhookManagedBy(mgr).
 			For(job.Object()).
 			WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), job.Object(), wh)).
 			WithValidator(wh).

--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/kueue/pkg/controller/jobframework/webhook"
 )
 
 // BaseWebhook applies basic defaulting and validation for jobs.
@@ -39,9 +41,9 @@ func DefaultWebhookFactory(job GenericJob, fromObject func(runtime.Object) Gener
 			ManageJobsWithoutQueueName: options.ManageJobsWithoutQueueName,
 			FromObject:                 fromObject,
 		}
-		return ctrl.NewWebhookManagedBy(mgr).
+		return webhook.ManagedBy(mgr).
 			For(job.Object()).
-			WithDefaulter(wh).
+			WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), job.Object(), wh)).
 			WithValidator(wh).
 			Complete()
 	}

--- a/pkg/controller/jobframework/webhook/builder.go
+++ b/pkg/controller/jobframework/webhook/builder.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+)
+
+// This code is copied from https://github.com/kubernetes-sigs/controller-runtime
+// with some modifications to get full control of the construction of patches.
+
+// Builder builds a Webhook.
+type Builder struct {
+	apiType         runtime.Object
+	mutationHandler admission.Handler
+	customValidator admission.CustomValidator
+	gvk             schema.GroupVersionKind
+	mgr             manager.Manager
+	config          *rest.Config
+	recoverPanic    bool
+	logConstructor  func(base logr.Logger, req *admission.Request) logr.Logger
+}
+
+// ManagedBy returns a new webhook builder.
+func ManagedBy(m manager.Manager) *Builder {
+	return &Builder{mgr: m}
+}
+
+// For takes a runtime.Object which should be a CR.
+func (blder *Builder) For(apiType runtime.Object) *Builder {
+	blder.apiType = apiType
+	return blder
+}
+
+// WithMutationHandler takes an admission.Handler inteface, a MutationgWebhook will be wired for this type.
+func (blder *Builder) WithMutationHandler(handler admission.Handler) *Builder {
+	blder.mutationHandler = handler
+	return blder
+}
+
+// WithValidator takes a admission.CustomValidator interface, a ValidatingWebhook will be wired for this type.
+func (blder *Builder) WithValidator(validator admission.CustomValidator) *Builder {
+	blder.customValidator = validator
+	return blder
+}
+
+// WithLogConstructor overrides the webhook's LogConstructor.
+func (blder *Builder) WithLogConstructor(logConstructor func(base logr.Logger, req *admission.Request) logr.Logger) *Builder {
+	blder.logConstructor = logConstructor
+	return blder
+}
+
+// RecoverPanic indicates whether panics caused by the webhook should be recovered.
+func (blder *Builder) RecoverPanic() *Builder {
+	blder.recoverPanic = true
+	return blder
+}
+
+// Complete builds the webhook.
+func (blder *Builder) Complete() error {
+	// Set the Config
+	blder.loadRestConfig()
+
+	// Configure the default LogConstructor
+	blder.setLogConstructor()
+
+	// Set the Webhook if needed
+	return blder.registerWebhooks()
+}
+
+func (blder *Builder) loadRestConfig() {
+	if blder.config == nil {
+		blder.config = blder.mgr.GetConfig()
+	}
+}
+
+func (blder *Builder) setLogConstructor() {
+	if blder.logConstructor == nil {
+		blder.logConstructor = func(base logr.Logger, req *admission.Request) logr.Logger {
+			log := base.WithValues(
+				"webhookGroup", blder.gvk.Group,
+				"webhookKind", blder.gvk.Kind,
+			)
+			if req != nil {
+				return log.WithValues(
+					blder.gvk.Kind, klog.KRef(req.Namespace, req.Name),
+					"namespace", req.Namespace, "name", req.Name,
+					"resource", req.Resource, "user", req.UserInfo.Username,
+					"requestID", req.UID,
+				)
+			}
+			return log
+		}
+	}
+}
+
+func (blder *Builder) registerWebhooks() error {
+	typ, err := blder.getType()
+	if err != nil {
+		return err
+	}
+
+	blder.gvk, err = apiutil.GVKForObject(typ, blder.mgr.GetScheme())
+	if err != nil {
+		return err
+	}
+
+	// Register webhook(s) for type
+	blder.registerDefaultingWebhook()
+	blder.registerValidatingWebhook()
+
+	err = blder.registerConversionWebhook()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// registerDefaultingWebhook registers a defaulting webhook if necessary.
+func (blder *Builder) registerDefaultingWebhook() {
+	mwh := blder.getDefaultingWebhook()
+	if mwh != nil {
+		mwh.LogConstructor = blder.logConstructor
+		path := generateMutatePath(blder.gvk)
+
+		// Checking if the path is already registered.
+		// If so, just skip it.
+		if !blder.isAlreadyHandled(path) {
+			blder.mgr.GetLogger().Info("Registering a mutating webhook",
+				"GVK", blder.gvk,
+				"path", path)
+			blder.mgr.GetWebhookServer().Register(path, mwh)
+		}
+	}
+}
+
+func (blder *Builder) getDefaultingWebhook() *admission.Webhook {
+	if handler := blder.mutationHandler; handler != nil {
+		return (&admission.Webhook{Handler: handler}).WithRecoverPanic(blder.recoverPanic)
+	}
+	blder.mgr.GetLogger().Info(
+		"skip registering a mutating webhook, WithMutationHandler wasn't called",
+		"GVK", blder.gvk)
+	return nil
+}
+
+// registerValidatingWebhook registers a validating webhook if necessary.
+func (blder *Builder) registerValidatingWebhook() {
+	vwh := blder.getValidatingWebhook()
+	if vwh != nil {
+		vwh.LogConstructor = blder.logConstructor
+		path := generateValidatePath(blder.gvk)
+
+		// Checking if the path is already registered.
+		// If so, just skip it.
+		if !blder.isAlreadyHandled(path) {
+			blder.mgr.GetLogger().Info("Registering a validating webhook",
+				"GVK", blder.gvk,
+				"path", path)
+			blder.mgr.GetWebhookServer().Register(path, vwh)
+		}
+	}
+}
+
+func (blder *Builder) getValidatingWebhook() *admission.Webhook {
+	if validator := blder.customValidator; validator != nil {
+		return admission.WithCustomValidator(blder.mgr.GetScheme(), blder.apiType, validator).WithRecoverPanic(blder.recoverPanic)
+	}
+	blder.mgr.GetLogger().Info(
+		"skip registering a validating webhook, WithValidator wasn't called",
+		"GVK", blder.gvk)
+	return nil
+}
+
+func (blder *Builder) registerConversionWebhook() error {
+	log := blder.mgr.GetLogger()
+	ok, err := conversion.IsConvertible(blder.mgr.GetScheme(), blder.apiType)
+	if err != nil {
+		log.Error(err, "conversion check failed", "GVK", blder.gvk)
+		return err
+	}
+	if ok {
+		if !blder.isAlreadyHandled("/convert") {
+			blder.mgr.GetWebhookServer().Register("/convert", conversion.NewWebhookHandler(blder.mgr.GetScheme()))
+		}
+		log.Info("Conversion webhook enabled", "GVK", blder.gvk)
+	}
+
+	return nil
+}
+
+func (blder *Builder) getType() (runtime.Object, error) {
+	if blder.apiType != nil {
+		return blder.apiType, nil
+	}
+	return nil, errors.New("For() must be called with a valid object")
+}
+
+func (blder *Builder) isAlreadyHandled(path string) bool {
+	if blder.mgr.GetWebhookServer().WebhookMux() == nil {
+		return false
+	}
+	h, p := blder.mgr.GetWebhookServer().WebhookMux().Handler(&http.Request{URL: &url.URL{Path: path}})
+	if p == path && h != nil {
+		return true
+	}
+	return false
+}
+
+func generateMutatePath(gvk schema.GroupVersionKind) string {
+	return "/mutate-" + strings.ReplaceAll(gvk.Group, ".", "-") + "-" +
+		gvk.Version + "-" + strings.ToLower(gvk.Kind)
+}
+
+func generateValidatePath(gvk schema.GroupVersionKind) string {
+	return "/validate-" + strings.ReplaceAll(gvk.Group, ".", "-") + "-" +
+		gvk.Version + "-" + strings.ToLower(gvk.Kind)
+}

--- a/pkg/controller/jobframework/webhook/defaulter.go
+++ b/pkg/controller/jobframework/webhook/defaulter.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// WithDefaulter creates a new Handler for a CustomDefaulter interface that drops remove operations.
+// WithDefaulter creates a new Handler for a CustomDefaulter interface that **drops** remove operations.
 func WithDefaulter(scheme *runtime.Scheme, obj runtime.Object, defaulter admission.CustomDefaulter) admission.Handler {
 	return &defaulterForType{
 		Handler: admission.WithCustomDefaulter(scheme, obj, defaulter).Handler,
@@ -36,7 +36,7 @@ type defaulterForType struct {
 	admission.Handler
 }
 
-// Handle handles admission requests, dropping remove operations from patches produced by controller-runtime.
+// Handle handles admission requests, **dropping** remove operations from patches produced by controller-runtime.
 // The controller-runtime handler works by creating a jsondiff from the raw object and the marshalled
 // version of the object modified by the defaulter. This generates "remove" operations for fields
 // that are not present in the go types, which can occur when Kueue libraries are behind the latest

--- a/pkg/controller/jobframework/webhook/defaulter.go
+++ b/pkg/controller/jobframework/webhook/defaulter.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// WithDefaulter creates a new Handler for a CustomDefaulter interface that drops remove operations.
+func WithDefaulter(scheme *runtime.Scheme, obj runtime.Object, defaulter admission.CustomDefaulter) admission.Handler {
+	return &defaulterForType{
+		Handler: admission.WithCustomDefaulter(scheme, obj, defaulter).Handler,
+	}
+}
+
+type defaulterForType struct {
+	admission.Handler
+}
+
+// Handle handles admission requests, dropping remove operations from patches produced by controller-runtime.
+// The controller-runtime handler works by creating a jsondiff from the raw object and the marshalled
+// version of the object modified by the defaulter. This generates "remove" operations for fields
+// that are not present in the go types, which can occur when Kueue libraries are behind the latest
+// released CRDs.
+// Dropping the "remove" operations is safe because Kueue's job mutators never remove fields.
+func (h *defaulterForType) Handle(ctx context.Context, req admission.Request) admission.Response {
+	response := h.Handler.Handle(ctx, req)
+	if response.Allowed {
+		var patches []jsonpatch.Operation
+		for _, p := range response.Patches {
+			if p.Operation != "remove" {
+				patches = append(patches, p)
+			}
+		}
+		if len(patches) == 0 {
+			response.PatchType = nil
+		}
+		response.Patches = patches
+	}
+	return response
+}

--- a/pkg/controller/jobframework/webhook/defaulter_test.go
+++ b/pkg/controller/jobframework/webhook/defaulter_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var (
+	testResourceKind = "TestResource"
+	testResourceGVK  = schema.GroupVersionKind{Group: "foo.test.org", Version: "v1", Kind: testResourceKind}
+)
+
+type TestResource struct {
+	Foo string `json:"foo,omitempty"`
+}
+
+func (d *TestResource) GetObjectKind() schema.ObjectKind { return d }
+func (d *TestResource) DeepCopyObject() runtime.Object {
+	return &TestResource{
+		Foo: d.Foo,
+	}
+}
+
+func (d *TestResource) GroupVersionKind() schema.GroupVersionKind {
+	return testResourceGVK
+}
+
+func (d *TestResource) SetGroupVersionKind(gvk schema.GroupVersionKind) {}
+
+type TestCustomDefaulter struct{}
+
+func (*TestCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	d := obj.(*TestResource)
+	if d.Foo == "" {
+		d.Foo = "bar"
+	}
+	return nil
+}
+
+func TestDefaulter(t *testing.T) {
+	sch := runtime.NewScheme()
+	builder := scheme.Builder{GroupVersion: testResourceGVK.GroupVersion()}
+	builder.Register(&TestResource{})
+	if err := builder.AddToScheme(sch); err != nil {
+		t.Fatalf("Couldn't add types to scheme: %v", err)
+	}
+
+	handler := WithDefaulter(sch, &TestResource{}, &TestCustomDefaulter{})
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Kind: metav1.GroupVersionKind(testResourceGVK),
+			Object: runtime.RawExtension{
+				Raw: []byte(`{"baz": "qux"}`),
+			},
+		},
+	}
+	resp := handler.Handle(context.Background(), req)
+	if !resp.Allowed {
+		t.Errorf("Response not allowed")
+	}
+	wantPatches := []jsonpatch.Operation{
+		{
+			Operation: "add",
+			Path:      "/foo",
+			Value:     "bar",
+		},
+	}
+	if diff := cmp.Diff(wantPatches, resp.Patches); diff != "" {
+		t.Errorf("Unexpected patches (-want, +got): %s", diff)
+	}
+}

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -62,7 +62,7 @@ func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		cache:                      options.Cache,
 	}
 	obj := &batchv1.Job{}
-	return webhook.ManagedBy(mgr).
+	return webhook.WebhookManagedBy(mgr).
 		For(obj).
 		WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -64,7 +64,7 @@ func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	obj := &batchv1.Job{}
 	return webhook.WebhookManagedBy(mgr).
 		For(obj).
-		WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), obj, wh)).
+		WithMutationHandler(webhook.WithLosslessDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
 		Complete()
 }

--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -50,7 +50,7 @@ func SetupJobSetWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		cache:                      options.Cache,
 	}
 	obj := &jobsetapi.JobSet{}
-	return webhook.ManagedBy(mgr).
+	return webhook.WebhookManagedBy(mgr).
 		For(obj).
 		WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).

--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -52,7 +52,7 @@ func SetupJobSetWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	obj := &jobsetapi.JobSet{}
 	return webhook.WebhookManagedBy(mgr).
 		For(obj).
-		WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), obj, wh)).
+		WithMutationHandler(webhook.WithLosslessDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
 		Complete()
 }

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -81,7 +81,7 @@ func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		podSelector:                podOpts.PodSelector,
 	}
 	obj := &corev1.Pod{}
-	return webhook.ManagedBy(mgr).
+	return webhook.WebhookManagedBy(mgr).
 		For(obj).
 		WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -83,7 +83,7 @@ func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	obj := &corev1.Pod{}
 	return webhook.WebhookManagedBy(mgr).
 		For(obj).
-		WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), obj, wh)).
+		WithMutationHandler(webhook.WithLosslessDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
 		Complete()
 }

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -31,11 +31,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework/webhook"
 )
 
 const (
@@ -80,9 +80,10 @@ func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		namespaceSelector:          podOpts.NamespaceSelector,
 		podSelector:                podOpts.PodSelector,
 	}
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(&corev1.Pod{}).
-		WithDefaulter(wh).
+	obj := &corev1.Pod{}
+	return webhook.ManagedBy(mgr).
+		For(obj).
+		WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
 		Complete()
 }
@@ -102,7 +103,7 @@ func getPodOptions(integrationOpts map[string]any) (configapi.PodIntegrationOpti
 // +kubebuilder:webhook:path=/mutate--v1-pod,mutating=true,failurePolicy=fail,sideEffects=None,groups="",resources=pods,verbs=create,versions=v1,name=mpod.kb.io,admissionReviewVersions=v1
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 
-var _ webhook.CustomDefaulter = &PodWebhook{}
+var _ admission.CustomDefaulter = &PodWebhook{}
 
 func containersShape(containers []corev1.Container) (result []map[string]interface{}) {
 	for _, c := range containers {
@@ -196,7 +197,7 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 
 // +kubebuilder:webhook:path=/validate--v1-pod,mutating=false,failurePolicy=fail,sideEffects=None,groups="",resources=pods,verbs=create;update,versions=v1,name=vpod.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomValidator = &PodWebhook{}
+var _ admission.CustomValidator = &PodWebhook{}
 
 func (w *PodWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	var warnings admission.Warnings

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -44,7 +44,7 @@ func SetupRayClusterWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error
 		manageJobsWithoutQueueName: options.ManageJobsWithoutQueueName,
 	}
 	obj := &rayv1.RayCluster{}
-	return webhook.ManagedBy(mgr).
+	return webhook.WebhookManagedBy(mgr).
 		For(obj).
 		WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -46,7 +46,7 @@ func SetupRayClusterWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error
 	obj := &rayv1.RayCluster{}
 	return webhook.WebhookManagedBy(mgr).
 		For(obj).
-		WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), obj, wh)).
+		WithMutationHandler(webhook.WithLosslessDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
 		Complete()
 }

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -24,10 +24,10 @@ import (
 	"k8s.io/utils/ptr"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework/webhook"
 )
 
 type RayClusterWebhook struct {
@@ -43,16 +43,17 @@ func SetupRayClusterWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error
 	wh := &RayClusterWebhook{
 		manageJobsWithoutQueueName: options.ManageJobsWithoutQueueName,
 	}
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(&rayv1.RayCluster{}).
-		WithDefaulter(wh).
+	obj := &rayv1.RayCluster{}
+	return webhook.ManagedBy(mgr).
+		For(obj).
+		WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
 		Complete()
 }
 
 // +kubebuilder:webhook:path=/mutate-ray-io-v1-raycluster,mutating=true,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayclusters,verbs=create,versions=v1,name=mraycluster.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomDefaulter = &RayClusterWebhook{}
+var _ admission.CustomDefaulter = &RayClusterWebhook{}
 
 // Default implements webhook.CustomDefaulter so a webhook will be registered for the type
 func (w *RayClusterWebhook) Default(ctx context.Context, obj runtime.Object) error {
@@ -65,7 +66,7 @@ func (w *RayClusterWebhook) Default(ctx context.Context, obj runtime.Object) err
 
 // +kubebuilder:webhook:path=/validate-ray-io-v1-raycluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayclusters,verbs=create;update,versions=v1,name=vraycluster.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomValidator = &RayClusterWebhook{}
+var _ admission.CustomValidator = &RayClusterWebhook{}
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
 func (w *RayClusterWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -27,10 +27,10 @@ import (
 	"k8s.io/utils/ptr"
 
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework/webhook"
 )
 
 type RayJobWebhook struct {
@@ -43,16 +43,17 @@ func SetupRayJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	wh := &RayJobWebhook{
 		manageJobsWithoutQueueName: options.ManageJobsWithoutQueueName,
 	}
-	return ctrl.NewWebhookManagedBy(mgr).
-		For(&rayv1.RayJob{}).
-		WithDefaulter(wh).
+	obj := &rayv1.RayJob{}
+	return webhook.ManagedBy(mgr).
+		For(obj).
+		WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
 		Complete()
 }
 
 // +kubebuilder:webhook:path=/mutate-ray-io-v1-rayjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayjobs,verbs=create,versions=v1,name=mrayjob.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomDefaulter = &RayJobWebhook{}
+var _ admission.CustomDefaulter = &RayJobWebhook{}
 
 // Default implements webhook.CustomDefaulter so a webhook will be registered for the type
 func (w *RayJobWebhook) Default(ctx context.Context, obj runtime.Object) error {
@@ -65,7 +66,7 @@ func (w *RayJobWebhook) Default(ctx context.Context, obj runtime.Object) error {
 
 // +kubebuilder:webhook:path=/validate-ray-io-v1-rayjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayjobs,verbs=create;update,versions=v1,name=vrayjob.kb.io,admissionReviewVersions=v1
 
-var _ webhook.CustomValidator = &RayJobWebhook{}
+var _ admission.CustomValidator = &RayJobWebhook{}
 
 // ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type
 func (w *RayJobWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -46,7 +46,7 @@ func SetupRayJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	obj := &rayv1.RayJob{}
 	return webhook.WebhookManagedBy(mgr).
 		For(obj).
-		WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), obj, wh)).
+		WithMutationHandler(webhook.WithLosslessDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).
 		Complete()
 }

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -44,7 +44,7 @@ func SetupRayJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 		manageJobsWithoutQueueName: options.ManageJobsWithoutQueueName,
 	}
 	obj := &rayv1.RayJob{}
-	return webhook.ManagedBy(mgr).
+	return webhook.WebhookManagedBy(mgr).
 		For(obj).
 		WithMutationHandler(webhook.WithDefaulter(mgr.GetScheme(), obj, wh)).
 		WithValidator(wh).


### PR DESCRIPTION
Cherry pick of #3132 on release-0.8.

#3132: Drop remove operations from webhook patches

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

Created manually due to https://github.com/kubernetes-sigs/kueue/pull/3132#issuecomment-2443986857.

Summary:
- Fixed go.mod conflicts.
- Skip `noop_webhook.go`.
- Skip `deployment_webhook.go`.

Fixes #3349

```release-note
Prevent job webhooks from dropping fields for newer API fields when Kueue libraries are behind the latest released CRDs.
```