### PR TITLE
Use previously created context instead of the background

### DIFF
--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -379,7 +379,7 @@ func TestFitInCohort(t *testing.T) {
 			cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("f2").Obj())
 
 			for _, cq := range tc.clusterQueue {
-				_ = cache.AddClusterQueue(context.Background(), cq)
+				_ = cache.AddClusterQueue(ctx, cq)
 			}
 
 			snapshot, err := cache.Snapshot(ctx)
@@ -1194,11 +1194,11 @@ func TestDominantResourceShare(t *testing.T) {
 			cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("on-demand").Obj())
 			cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("spot").Obj())
 
-			_ = cache.AddClusterQueue(context.Background(), tc.clusterQueue)
+			_ = cache.AddClusterQueue(ctx, tc.clusterQueue)
 
 			if tc.lendingClusterQueue != nil {
 				// we create a second cluster queue to add lendable capacity to the cohort.
-				_ = cache.AddClusterQueue(context.Background(), tc.lendingClusterQueue)
+				_ = cache.AddClusterQueue(ctx, tc.lendingClusterQueue)
 			}
 
 			snapshot, err := cache.Snapshot(ctx)

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -886,7 +886,7 @@ func TestSnapshot(t *testing.T) {
 			for _, cq := range tc.cqs {
 				// Purposely do not make a copy of clusterQueues. Clones of necessary fields are
 				// done in AddClusterQueue.
-				if err := cache.AddClusterQueue(context.Background(), cq); err != nil {
+				if err := cache.AddClusterQueue(ctx, cq); err != nil {
 					t.Fatalf("Failed adding ClusterQueue: %v", err)
 				}
 			}

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -128,10 +128,10 @@ func TestLocalQueueReconcile(t *testing.T) {
 
 			cqCache := cache.New(cl)
 			qManager := queue.NewManager(cl, cqCache)
-			_ = qManager.AddLocalQueue(context.TODO(), tc.localQueue)
+			ctxWithLogger, _ := utiltesting.ContextWithLog(t)
+			_ = qManager.AddLocalQueue(ctxWithLogger, tc.localQueue)
 			reconciler := NewLocalQueueReconciler(cl, qManager, cqCache)
 
-			ctxWithLogger, _ := utiltesting.ContextWithLog(t)
 			ctx, ctxCancel := context.WithCancel(ctxWithLogger)
 			defer ctxCancel()
 

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package flavorassigner
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -1941,7 +1940,7 @@ func TestAssignFlavors(t *testing.T) {
 			})
 
 			cache := cache.New(utiltesting.NewFakeClient())
-			if err := cache.AddClusterQueue(context.Background(), &tc.clusterQueue); err != nil {
+			if err := cache.AddClusterQueue(ctx, &tc.clusterQueue); err != nil {
 				t.Fatalf("Failed to add CQ to cache")
 			}
 			for _, rf := range resourceFlavors {
@@ -2099,10 +2098,10 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 			}
 
 			cache := cache.New(utiltesting.NewFakeClient())
-			if err := cache.AddClusterQueue(context.Background(), &testCq); err != nil {
+			if err := cache.AddClusterQueue(ctx, &testCq); err != nil {
 				t.Fatalf("Failed to add CQ to cache")
 			}
-			if err := cache.AddClusterQueue(context.Background(), &otherCq); err != nil {
+			if err := cache.AddClusterQueue(ctx, &otherCq); err != nil {
 				t.Fatalf("Failed to add CQ to cache")
 			}
 			for _, rf := range resourceFlavors {
@@ -2223,7 +2222,7 @@ func TestDeletedFlavors(t *testing.T) {
 			})
 
 			cache := cache.New(utiltesting.NewFakeClient())
-			if err := cache.AddClusterQueue(context.Background(), &tc.clusterQueue); err != nil {
+			if err := cache.AddClusterQueue(ctx, &tc.clusterQueue); err != nil {
 				t.Fatalf("Failed to add CQ to cache")
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Provide consistent style of using contexts, use previously created contexts instead of using the background context in consecutive calls.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3343

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```