### PR TITLE
[KubeRay] Support NumOfHosts when calculating PodSet assignments

### DIFF
--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -113,14 +113,17 @@ func (j *RayCluster) PodSets() []kueue.PodSet {
 	// workers
 	for index := range j.Spec.WorkerGroupSpecs {
 		wgs := &j.Spec.WorkerGroupSpecs[index]
-		replicas := int32(1)
+		count := int32(1)
 		if wgs.Replicas != nil {
-			replicas = *wgs.Replicas
+			count = *wgs.Replicas
+		}
+		if wgs.NumOfHosts > 1 {
+			count *= wgs.NumOfHosts
 		}
 		podSets[index+1] = kueue.PodSet{
 			Name:            strings.ToLower(wgs.GroupName),
 			Template:        *wgs.Template.DeepCopy(),
-			Count:           replicas,
+			Count:           count,
 			TopologyRequest: jobframework.PodSetTopologyRequest(&wgs.Template.ObjectMeta),
 		}
 	}

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -524,6 +524,142 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 			},
 		},
+		"RayCluster with NumOfHosts > 1": {
+			initObjects: []client.Object{
+				utiltesting.MakeResourceFlavor("unit-test-flavor").NodeLabel("kubernetes.io/arch", "arm64").Obj(),
+			},
+			job: *baseJobWrapper.Clone().
+				WithNumOfHosts("workers-group-0", 2).
+				Obj(),
+			wantJob: *baseJobWrapper.Clone().
+				Suspend(false).
+				NodeSelectorHeadGroup("kubernetes.io/arch", "arm64").
+				WithNumOfHosts("workers-group-0", 2).
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("test", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						kueue.PodSet{
+							Name:  "head",
+							Count: int32(1),
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+
+									RestartPolicy: corev1.RestartPolicyNever,
+									Containers: []corev1.Container{
+										{
+											Name: "head-container",
+											Resources: corev1.ResourceRequirements{
+												Requests: make(corev1.ResourceList),
+											},
+										},
+									},
+								},
+							},
+						},
+						kueue.PodSet{
+							Name:  "workers-group-0",
+							Count: int32(2),
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									RestartPolicy: corev1.RestartPolicyNever,
+
+									Containers: []corev1.Container{
+										{
+											Name: "worker-container",
+											Resources: corev1.ResourceRequirements{
+												Requests: corev1.ResourceList{
+													corev1.ResourceCPU: resource.MustParse("10"),
+												},
+											},
+										},
+									},
+								},
+							},
+						}).
+					Request(corev1.ResourceCPU, "10").
+					ReserveQuota(
+						utiltesting.MakeAdmission("cq", "head", "workers-group-0").
+							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
+							AssignmentPodCount(2).
+							Obj(),
+					).
+					Admitted(true).
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:  "check",
+						State: kueue.CheckStateReady,
+						PodSetUpdates: []kueue.PodSetUpdate{
+							{
+								Name: "head",
+							},
+							{
+								Name: "workers-group-0",
+							},
+						},
+					}).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("a", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						kueue.PodSet{
+							Name:  "head",
+							Count: int32(1),
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									RestartPolicy: corev1.RestartPolicyNever,
+									Containers: []corev1.Container{
+										{
+											Name: "head-container",
+											Resources: corev1.ResourceRequirements{
+												Requests: make(corev1.ResourceList),
+											},
+										},
+									},
+								},
+							},
+						},
+						kueue.PodSet{
+							Name:  "workers-group-0",
+							Count: int32(2),
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									RestartPolicy: corev1.RestartPolicyNever,
+									Containers: []corev1.Container{
+										{
+											Name: "worker-container",
+											Resources: corev1.ResourceRequirements{
+												Requests: make(corev1.ResourceList),
+											},
+										},
+									},
+								},
+							},
+						}).
+					ReserveQuota(
+						utiltesting.MakeAdmission("cq", "head", "workers-group-0").
+							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
+							AssignmentPodCount(2).
+							Obj(),
+					).
+					Admitted(true).
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:  "check",
+						State: kueue.CheckStateReady,
+						PodSetUpdates: []kueue.PodSetUpdate{
+							{
+								Name: "head",
+							},
+							{
+								Name: "workers-group-0",
+							},
+						},
+					}).
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -117,14 +117,17 @@ func (j *RayJob) PodSets() []kueue.PodSet {
 	// workers
 	for index := range j.Spec.RayClusterSpec.WorkerGroupSpecs {
 		wgs := &j.Spec.RayClusterSpec.WorkerGroupSpecs[index]
-		replicas := int32(1)
+		count := int32(1)
 		if wgs.Replicas != nil {
-			replicas = *wgs.Replicas
+			count = *wgs.Replicas
+		}
+		if wgs.NumOfHosts > 1 {
+			count *= wgs.NumOfHosts
 		}
 		podSets[index+1] = kueue.PodSet{
 			Name:            strings.ToLower(wgs.GroupName),
 			Template:        *wgs.Template.DeepCopy(),
-			Count:           replicas,
+			Count:           count,
 			TopologyRequest: jobframework.PodSetTopologyRequest(&wgs.Template.ObjectMeta),
 		}
 	}

--- a/pkg/util/testingjobs/raycluster/wrappers.go
+++ b/pkg/util/testingjobs/raycluster/wrappers.go
@@ -150,6 +150,15 @@ func (j *ClusterWrapper) WithWorkerPriorityClassName(value string) *ClusterWrapp
 	return j
 }
 
+func (j *ClusterWrapper) WithNumOfHosts(groupName string, value int32) *ClusterWrapper {
+	for index, group := range j.Spec.WorkerGroupSpecs {
+		if group.GroupName == groupName {
+			j.Spec.WorkerGroupSpecs[index].NumOfHosts = value
+		}
+	}
+	return j
+}
+
 // WorkloadPriorityClass updates job workloadpriorityclass.
 func (j *ClusterWrapper) WorkloadPriorityClass(wpc string) *ClusterWrapper {
 	if j.Labels == nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

NumOfHosts is a new field we added to KubeRay RayCluster to support multi-host training / inference with accelerators like TPUs. Kueue needs to be updated to check NumOfHosts and appropriately adjust podset assignments if NumOfHosts is greater than 1 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Account for NumOfHosts when calculating PodSet assignments for KubeRay jobs
```