### PR TITLE
TAS: skip flavor checks which don't have requested level

### DIFF
--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -209,6 +209,11 @@ func (s *TASFlavorSnapshot) FindTopologyAssignment(
 	return s.buildAssignment(currFitDomain)
 }
 
+func (s *TASFlavorSnapshot) HasLevel(r *kueue.PodSetTopologyRequest) bool {
+	_, found := s.resolveLevelIdx(r)
+	return found
+}
+
 func (s *TASFlavorSnapshot) resolveLevelIdx(
 	topologyRequest *kueue.PodSetTopologyRequest) (int, bool) {
 	var levelKey string

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -443,7 +443,7 @@ func (a *FlavorAssigner) findFlavorForPodSetResource(
 			continue
 		}
 		if features.Enabled(features.TopologyAwareScheduling) {
-			if message := checkPodSetAndFlavorMatchForTAS(ps, flavor); message != nil {
+			if message := checkPodSetAndFlavorMatchForTAS(a.cq, ps, flavor); message != nil {
 				log.Error(nil, *message)
 				status.append(*message)
 				continue


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This is a small improvement to skip from consideration TAS flavors which don't match by the requested topology level.

#### Which issue(s) this PR fixes:

Part of #2724 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```