### PR TITLE
[kjobctl] Add validation for priority required field.

### DIFF
--- a/cmd/experimental/kjobctl/pkg/builder/builder.go
+++ b/cmd/experimental/kjobctl/pkg/builder/builder.go
@@ -69,6 +69,7 @@ var (
 	noNTasksSpecifiedErr                   = errors.New("no ntasks specified")
 	noOutputSpecifiedErr                   = errors.New("no output specified")
 	noPartitionSpecifiedErr                = errors.New("no partition specified")
+	noPrioritySpecifiedErr                 = errors.New("no priority specified")
 	noTimeSpecifiedErr                     = errors.New("no time specified")
 )
 
@@ -459,6 +460,10 @@ func (b *Builder) validateFlags() error {
 
 	if slices.Contains(b.mode.RequiredFlags, v1alpha1.PartitionFlag) && b.partition == "" {
 		return noPartitionSpecifiedErr
+	}
+
+	if slices.Contains(b.mode.RequiredFlags, v1alpha1.PriorityFlag) && b.priority == "" {
+		return noPrioritySpecifiedErr
 	}
 
 	if slices.Contains(b.mode.RequiredFlags, v1alpha1.TimeFlag) && b.timeLimit == "" {

--- a/cmd/experimental/kjobctl/pkg/builder/builder_test.go
+++ b/cmd/experimental/kjobctl/pkg/builder/builder_test.go
@@ -399,6 +399,20 @@ func TestBuilder(t *testing.T) {
 			},
 			wantErr: noPartitionSpecifiedErr,
 		},
+		"shouldn't build job because priority not specified with required flags": {
+			namespace: metav1.NamespaceDefault,
+			profile:   "profile",
+			mode:      v1alpha1.SlurmMode,
+			kjobctlObjs: []runtime.Object{
+				wrappers.MakeApplicationProfile("profile", metav1.NamespaceDefault).
+					WithSupportedMode(v1alpha1.SupportedMode{
+						Name:          v1alpha1.SlurmMode,
+						RequiredFlags: []v1alpha1.Flag{v1alpha1.PriorityFlag},
+					}).
+					Obj(),
+			},
+			wantErr: noPrioritySpecifiedErr,
+		},
 		"should build job": {
 			namespace: metav1.NamespaceDefault,
 			profile:   "profile",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add validation for priority required field in kjobctl slurm mode.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```