### PR TITLE
Use testGenericJob on BaseWebhook tests.

### DIFF
--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -21,39 +21,115 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	kfmpi "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	"sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
-	testingutil "sigs.k8s.io/kueue/pkg/util/testingjobs/mpijob"
+	"sigs.k8s.io/kueue/pkg/podset"
 )
 
-func toMPIJob(o runtime.Object) jobframework.GenericJob {
-	return (*mpijob.MPIJob)(o.(*kfmpi.MPIJob))
+type testGenericJob batchv1.Job
+
+var _ jobframework.GenericJob = (*testGenericJob)(nil)
+
+func (t *testGenericJob) Object() client.Object {
+	return (*batchv1.Job)(t)
+}
+
+func (t *testGenericJob) IsSuspended() bool {
+	return ptr.Deref(t.Spec.Suspend, false)
+}
+
+func (t *testGenericJob) Suspend() {
+	t.Spec.Suspend = ptr.To(true)
+}
+
+func (t *testGenericJob) RunWithPodSetsInfo([]podset.PodSetInfo) error {
+	panic("not implemented")
+}
+
+func (t *testGenericJob) RestorePodSetsInfo([]podset.PodSetInfo) bool {
+	panic("not implemented")
+}
+
+func (t *testGenericJob) Finished() (string, bool, bool) {
+	panic("not implemented")
+}
+
+func (t *testGenericJob) PodSets() []kueue.PodSet {
+	panic("not implemented")
+}
+
+func (t *testGenericJob) IsActive() bool {
+	panic("not implemented")
+}
+
+func (t *testGenericJob) PodsReady() bool {
+	panic("not implemented")
+}
+
+func (t *testGenericJob) GVK() schema.GroupVersionKind {
+	panic("not implemented")
+}
+
+func fromObject(o runtime.Object) jobframework.GenericJob {
+	return (*testGenericJob)(o.(*batchv1.Job))
 }
 
 func TestBaseWebhookDefault(t *testing.T) {
 	testcases := map[string]struct {
-		job                        *kfmpi.MPIJob
 		manageJobsWithoutQueueName bool
-		want                       *kfmpi.MPIJob
+
+		job  *batchv1.Job
+		want *batchv1.Job
 	}{
 		"update the suspend field with 'manageJobsWithoutQueueName=false'": {
-			job:  testingutil.MakeMPIJob("job", "default").Queue("queue").Suspend(false).Obj(),
-			want: testingutil.MakeMPIJob("job", "default").Queue("queue").Obj(),
+			job: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job",
+					Namespace: "default",
+					Labels:    map[string]string{constants.QueueLabel: "queue"},
+				},
+			},
+			want: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job",
+					Namespace: "default",
+					Labels:    map[string]string{constants.QueueLabel: "queue"},
+				},
+				Spec: batchv1.JobSpec{Suspend: ptr.To(true)},
+			},
 		},
 		"update the suspend field 'manageJobsWithoutQueueName=true'": {
-			job:                        testingutil.MakeMPIJob("job", "default").Suspend(false).Obj(),
 			manageJobsWithoutQueueName: true,
-			want:                       testingutil.MakeMPIJob("job", "default").Obj(),
+			job: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job",
+					Namespace: "default",
+					Labels:    map[string]string{constants.QueueLabel: "queue"},
+				},
+			},
+			want: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job",
+					Namespace: "default",
+					Labels:    map[string]string{constants.QueueLabel: "queue"},
+				},
+				Spec: batchv1.JobSpec{Suspend: ptr.To(true)},
+			},
 		},
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			w := &jobframework.BaseWebhook{
 				ManageJobsWithoutQueueName: tc.manageJobsWithoutQueueName,
-				FromObject:                 toMPIJob,
+				FromObject:                 fromObject,
 			}
 			if err := w.Default(context.Background(), tc.job); err != nil {
 				t.Errorf("set defaults to a kubeflow/mpijob by a Defaulter")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Use testGenericJob on testing BaseWebhook.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #3372

#### Special notes for your reviewer:
This is prepare PR for #3414.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```