### PR TITLE
Fix "Should requeue a workload which exceeded the timeout to reach PodsReady=True" test.

### DIFF
--- a/test/integration/scheduler/podsready/scheduler_test.go
+++ b/test/integration/scheduler/podsready/scheduler_test.go
@@ -223,7 +223,6 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodWl1), prodWl1)).Should(gomega.Succeed())
 				g.Expect(workload.HasQuotaReservation(prodWl1)).Should(gomega.BeTrue())
-				g.Expect(prodWl1.Status.Conditions).ShouldNot(testing.HaveConditionStatusTrue(kueue.WorkloadEvicted))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("wait for the 'prod1' workload to be evicted")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix "Scheduler with WaitForPodsReady Suite: [It] SchedulerWithWaitForPodsReady Short PodsReady timeout Should requeue a workload which exceeded the timeout to reach PodsReady=True" integration test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3366

#### Special notes for your reviewer:
Sometimes, `prodWl1` is already evicted on 
https://github.com/kubernetes-sigs/kueue/blob/236a1e4bfe7d291676918231c313ddf37d3550a8/test/integration/scheduler/podsready/scheduler_test.go#L223-L226

It happens because we are waiting for `prodWl2` to be waiting.
https://github.com/kubernetes-sigs/kueue/blob/236a1e4bfe7d291676918231c313ddf37d3550a8/test/integration/scheduler/podsready/scheduler_test.go#L218

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```