### PR TITLE
Add missed defer cancel().

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -2844,6 +2844,7 @@ func TestMatchingClusterQueues(t *testing.T) {
 func TestWaitForPodsReadyCancelled(t *testing.T) {
 	cache := New(utiltesting.NewFakeClient(), WithPodsReadyTracking(true))
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	log := ctrl.LoggerFrom(ctx)
 
 	go cache.CleanUpOnContext(ctx)

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -271,6 +271,7 @@ func TestClusterQueueToActive(t *testing.T) {
 	wgCounterEnd.Add(1)
 	condRec := make(chan struct{})
 	counterCtx, counterCancel := context.WithCancel(ctx)
+	defer counterCancel()
 	go func() {
 		manager.cond.L.Lock()
 		defer manager.cond.L.Unlock()

--- a/pkg/util/wait/backoff_test.go
+++ b/pkg/util/wait/backoff_test.go
@@ -89,6 +89,7 @@ func TestUntilWithBackoff(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			timer := makeSpyTimer()
 			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			i := 0
 			f := func(ctx context.Context) SpeedSignal {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add missed defer cancel() on unit tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #3382

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```