### PR TITLE
[MultiKueue] Document batch/Job managedBy field usage

### DIFF
--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -60,7 +60,7 @@ Known Limitations:
 
 #### MultiKueueBatchJobWithManagedBy enabled
 
-When you want to submit Job to a ClusterQueue with a MultiKueue admission check, you should set the `spec.managedBy` field to `kueue.x-k8s.io/multikueue`, otherwise the admission check controller will `Reject` the workload causing it to be marked as `Finished` with an error indicating the cause.
+When you want to submit Job to a ClusterQueue with a MultiKueue admission check, you should set the `spec.managedBy` field to `kueue.x-k8s.io/multikueue`, otherwise the admission check controller will `Reject` the workload.
 
 The `managedBy` field is available as an Alpha feature staring Kubernetes 1.30.0, check the [Delegation of managing a Job object to external controller](https://kubernetes.io/docs/concepts/workloads/controllers/job/#delegation-of-managing-a-job-object-to-external-controller) for details.
 

--- a/site/content/en/docs/tasks/run/multikueue/job.md
+++ b/site/content/en/docs/tasks/run/multikueue/job.md
@@ -23,7 +23,7 @@ The `JobManagedBy` feature gate is disabled in 1.30 and 1.31 by default, and wil
 
 When `JobManagedBy` is enabled in your cluster we recommend configuring Kueue to enable the `MultiKueueBatchJobWithManagedBy` feature gate. 
 
-When `MultiKueueBatchJobWithManagedBy` is enabled the current status of a Job being executed by MultiKueue on a worker cluster is live-updated on the management cluster.
+When `MultiKueueBatchJobWithManagedBy` is enabled, the current status of a Job being executed by MultiKueue on a worker cluster is live-updated on the management cluster.
 
 This gives the users and automation tools the ability to track the progress of Job status (.status) without lookup to the
 worker cluster, making MultiKueue transparent from that perspective.

--- a/site/content/en/docs/tasks/run/multikueue/job.md
+++ b/site/content/en/docs/tasks/run/multikueue/job.md
@@ -23,11 +23,10 @@ The `JobManagedBy` feature gate is disabled in 1.30 and 1.31 by default, and wil
 
 When `JobManagedBy` is enabled in your cluster we recommend configuring Kueue to enable the `MultiKueueBatchJobWithManagedBy` feature gate. 
 
-When `MultiKueueBatchJobWithManagedBy` is enabled the Job is processed by MultiKueue, which effectively reflects the job state in the management cluster.
+When `MultiKueueBatchJobWithManagedBy` is enabled the current status of a Job being executed by MultiKueue on a worker cluster is live-updated on the management cluster.
 
-So regardless of the number of clusters, all states of all jobs are available in the management cluster.
-
-This in turn allows you to track the progress of a job as it occurs.
+This gives the users and automation tools the ability to track the progress of Job status (.status) without lookup to the
+worker cluster, making MultiKueue transparent from that perspective.
 
 ### Cluster with JobManagedBy disabled
 
@@ -41,7 +40,7 @@ You can identify the worker cluster running the job by checking the AC status me
 
 Also, the job is suspended from the perspective of the management cluster until it is `Finished`.
 
-## Run Kubernetes Job example
+## Example
 
 Once the setup is complete you can test it by running the example below:
 

--- a/site/content/en/docs/tasks/run/multikueue/job.md
+++ b/site/content/en/docs/tasks/run/multikueue/job.md
@@ -1,0 +1,35 @@
+---
+title: "Run Kubernetes Job in Multi-Cluster"
+linkTitle: "Kubernetes Job"
+weight: 2
+date: 2024-11-05
+description: >
+  Run a MultiKueue scheduled Kubernetes Job.
+---
+
+## Before you begin
+
+Check the [MultiKueue installation guide](/docs/tasks/manage/setup_multikueue) on how to properly setup MultiKueue clusters.
+
+For the ease of setup and use we recommend using at least Kueue v0.8.1.
+
+## Run Kubernetes Job example
+
+Once the setup is complete you can test it by running the [`job-sample.yaml`](/docs/tasks/run/jobs/#1-define-the-job) Job. 
+
+
+## ManagedBy
+
+The batch/Job can work in two different ways depending on the state of `MultiKueueBatchJobWithManagedBy` feature gate.
+
+When `MultiKueueBatchJobWithManagedBy` is disabled, the management cluster keeps the status of the Job `Pending` during the remote job execution.
+The sync happens only when the remote workload is marked as `Finished`.
+
+When `MultiKueueBatchJobWithManagedBy` is enabled, Kueue defaults the `spec.managedBy` field to `kueue.x-k8s.io/multikueue`.
+This allows the Jobs Controller to ignore the Jobs managed by MultiKueue on the management cluster, while 
+the status of the Job is synchronized during the remote job execution.
+
+{{% alert title="Note" color="primary" %}}
+Note: The MultiKueue admission check controller will `Reject` the workload that does not have the `spec.managedBy` field set to `kueue.x-k8s.io/multikueue`, causing it to be marked as `Finished` with an error indicating the cause.
+
+{{% /alert %}}

--- a/site/content/en/docs/tasks/run/multikueue/job.md
+++ b/site/content/en/docs/tasks/run/multikueue/job.md
@@ -11,30 +11,38 @@ description: >
 
 Check the [MultiKueue installation guide](/docs/tasks/manage/setup_multikueue) on how to properly setup MultiKueue clusters.
 
-For the ease of setup and use we recommend using at least Kueue v0.8.1 and Kubernetes v1.30.0.
-
-## Run Kubernetes Job example
-
-Once the setup is complete you can test it by running the [`job-sample.yaml`](/docs/tasks/run/jobs/#1-define-the-job) Job. 
+For the ease of setup and use we recommend using at least Kueue v0.8.1.
 
 The recommended way of running MultiKueue depends on the configuration of the `JobManagedBy` feature gate in your cluster. 
 
-NOTE: The `JobManagedBy` feature gate is disabled in 1.30 and 1.31 by default, and will be enabled in 1.32 by default.
+{{% alert title="Note" color="primary" %}}
+The `JobManagedBy` feature gate is disabled in 1.30 and 1.31 by default, and will be enabled in 1.32 by default.
+{{% /alert %}}
 
-## Cluster with JobManagedBy enabled
+### Cluster with JobManagedBy enabled
 
 When `JobManagedBy` is enabled in your cluster we recommend configuring Kueue to enable the `MultiKueueBatchJobWithManagedBy` feature gate. 
 
-When `MultiKueueBatchJobWithManagedBy` is enabled Kueue defaults the `spec.managedBy` field to `kueue.x-k8s.io/multikueue`. This allows to disable processing of the Job by the built-in controller, and allows MultiKueue
-to send live updates reflecting the status of the mirror Job on the worker.
+When `MultiKueueBatchJobWithManagedBy` is enabled the Job is processed by MultiKueue, which effectively reflects the job state in the management cluster.
 
-## Cluster with JobManagedBy disabled
+So regardless of the number of clusters, all states of all jobs are available in the management cluster.
 
-When `JobManagedBy` is disabled in your cluster you should make sure `MultiKueueBatchJobWithManagedBy` 
-is also disabled in Kueue. 
+This in turn allows you to track the progress of a job as it occurs.
 
-This is important so that MultiKueue does not conflict with the build-in Job controller
-on the management cluster. 
+### Cluster with JobManagedBy disabled
 
-Note that Kueue will not perform live updates of the mirror Job from a worker 
-cluster.
+When `JobManagedBy` is disabled in your cluster you should make sure `MultiKueueBatchJobWithManagedBy` is also disabled in Kueue. 
+
+This is important so that MultiKueue does not conflict with the build-in Job controller on the management cluster. 
+
+As a limitation of this deployment mode, to get the actual status of the job, you need to access the worker cluster.
+
+You can identify the worker cluster running the job by checking the AC status message of the workload object in the management cluster.
+
+Also, the job is suspended from the perspective of the management cluster until it is `Finished`.
+
+## Run Kubernetes Job example
+
+Once the setup is complete you can test it by running the example below:
+
+{{< include "examples/jobs/sample-job.yaml" "yaml" >}}

--- a/site/content/en/docs/tasks/run/multikueue/job.md
+++ b/site/content/en/docs/tasks/run/multikueue/job.md
@@ -11,25 +11,30 @@ description: >
 
 Check the [MultiKueue installation guide](/docs/tasks/manage/setup_multikueue) on how to properly setup MultiKueue clusters.
 
-For the ease of setup and use we recommend using at least Kueue v0.8.1.
+For the ease of setup and use we recommend using at least Kueue v0.8.1 and Kubernetes v1.30.0.
 
 ## Run Kubernetes Job example
 
 Once the setup is complete you can test it by running the [`job-sample.yaml`](/docs/tasks/run/jobs/#1-define-the-job) Job. 
 
+The recommended way of running MultiKueue depends on the configuration of the `JobManagedBy` feature gate in your cluster. 
 
-## ManagedBy
+NOTE: The `JobManagedBy` feature gate is disabled in 1.30 and 1.31 by default, and will be enabled in 1.32 by default.
 
-The batch/Job can work in two different ways depending on the state of `MultiKueueBatchJobWithManagedBy` feature gate.
+## Cluster with JobManagedBy enabled
 
-When `MultiKueueBatchJobWithManagedBy` is disabled, the management cluster keeps the status of the Job `Pending` during the remote job execution.
-The sync happens only when the remote workload is marked as `Finished`.
+When `JobManagedBy` is enabled in your cluster we recommend configuring Kueue to enable the `MultiKueueBatchJobWithManagedBy` feature gate. 
 
-When `MultiKueueBatchJobWithManagedBy` is enabled, Kueue defaults the `spec.managedBy` field to `kueue.x-k8s.io/multikueue`.
-This allows the Jobs Controller to ignore the Jobs managed by MultiKueue on the management cluster, while 
-the status of the Job is synchronized during the remote job execution.
+When `MultiKueueBatchJobWithManagedBy` is enabled Kueue defaults the `spec.managedBy` field to `kueue.x-k8s.io/multikueue`. This allows to disable processing of the Job by the built-in controller, and allows MultiKueue
+to send live updates reflecting the status of the mirror Job on the worker.
 
-{{% alert title="Note" color="primary" %}}
-Note: The MultiKueue admission check controller will `Reject` the workload that does not have the `spec.managedBy` field set to `kueue.x-k8s.io/multikueue`, causing it to be marked as `Finished` with an error indicating the cause.
+## Cluster with JobManagedBy disabled
 
-{{% /alert %}}
+When `JobManagedBy` is disabled in your cluster you should make sure `MultiKueueBatchJobWithManagedBy` 
+is also disabled in Kueue. 
+
+This is important so that MultiKueue does not conflict with the build-in Job controller
+on the management cluster. 
+
+Note that Kueue will not perform live updates of the mirror Job from a worker 
+cluster.

--- a/site/content/en/docs/tasks/run/multikueue/jobsets.md
+++ b/site/content/en/docs/tasks/run/multikueue/jobsets.md
@@ -1,7 +1,7 @@
 ---
 title: "Run Jobsets in Multi-Cluster"
 linkTitle: "Jobsets"
-weight: 2
+weight: 3
 date: 2024-09-25
 description: >
   Run a MultiKueue scheduled JobSet.

--- a/site/content/en/docs/tasks/run/multikueue/kubeflow.md
+++ b/site/content/en/docs/tasks/run/multikueue/kubeflow.md
@@ -1,7 +1,7 @@
 ---
 title: "Run Kubeflow Jobs in Multi-Cluster"
 linkTitle: "Kubeflow"
-weight: 2
+weight: 4
 date: 2024-09-25
 description: >
   Run a MultiKueue scheduled Kubeflow Jobs.

--- a/site/content/en/docs/tasks/run/multikueue/mpijob.md
+++ b/site/content/en/docs/tasks/run/multikueue/mpijob.md
@@ -1,7 +1,7 @@
 ---
 title: "Run MPIJobs in Multi-Cluster"
 linkTitle: "MPIJob"
-weight: 3
+weight: 5
 date: 2024-10-25
 description: >
   Run a MultiKueue scheduled MPIJobs.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Document how to use managedBy provided by the Job Controller.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3357 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```