### PR TITLE
Make error matcher more verbosity.

### DIFF
--- a/test/integration/webhook/core/admissioncheck_test.go
+++ b/test/integration/webhook/core/admissioncheck_test.go
@@ -55,7 +55,7 @@ var _ = ginkgo.Describe("AdmissionCheck Webhook", func() {
 
 			if errorType == isInvalid {
 				gomega.Expect(err).Should(gomega.HaveOccurred())
-				gomega.Expect(err).Should(testing.BeAPIError(testing.InvalidError), "error: %v", err)
+				gomega.Expect(err).Should(testing.BeInvalidError())
 			} else {
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			}

--- a/test/integration/webhook/core/clusterqueue_test.go
+++ b/test/integration/webhook/core/clusterqueue_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -216,10 +215,10 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 			switch errorType {
 			case isForbidden:
 				gomega.Expect(err).Should(gomega.HaveOccurred())
-				gomega.Expect(errors.IsForbidden(err)).Should(gomega.BeTrue(), "error: %v", err)
+				gomega.Expect(err).Should(testing.BeForbiddenError())
 			case isInvalid:
 				gomega.Expect(err).Should(gomega.HaveOccurred())
-				gomega.Expect(err).Should(testing.BeAPIError(testing.InvalidError), "error: %v", err)
+				gomega.Expect(err).Should(testing.BeInvalidError())
 			default:
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				// Validating that defaults are set.

--- a/test/integration/webhook/core/cohort_test.go
+++ b/test/integration/webhook/core/cohort_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
@@ -38,10 +37,10 @@ var _ = ginkgo.Describe("Cohort Webhook", func() {
 			switch errorType {
 			case isForbidden:
 				gomega.Expect(err).Should(gomega.HaveOccurred())
-				gomega.Expect(errors.IsForbidden(err)).Should(gomega.BeTrue(), "error: %v", err)
+				gomega.Expect(err).Should(testing.BeForbiddenError())
 			case isInvalid:
 				gomega.Expect(err).Should(gomega.HaveOccurred())
-				gomega.Expect(err).Should(testing.BeAPIError(testing.InvalidError), "error: %v", err)
+				gomega.Expect(err).Should(testing.BeInvalidError())
 			default:
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			}

--- a/test/integration/webhook/core/localqueue_test.go
+++ b/test/integration/webhook/core/localqueue_test.go
@@ -30,7 +30,7 @@ var _ = ginkgo.Describe("Queue validating webhook", func() {
 		ginkgo.It("Should reject bad value for spec.clusterQueue", func() {
 			ginkgo.By("Creating a new Queue")
 			obj := testing.MakeLocalQueue(queueName, ns.Name).ClusterQueue("invalid_name").Obj()
-			gomega.Expect(k8sClient.Create(ctx, obj)).Should(testing.BeAPIError(testing.InvalidError))
+			gomega.Expect(k8sClient.Create(ctx, obj)).Should(testing.BeInvalidError())
 		})
 		ginkgo.It("Should reject the change of spec.clusterQueue", func() {
 			ginkgo.By("Creating a new Queue")

--- a/test/integration/webhook/core/resourceflavor_test.go
+++ b/test/integration/webhook/core/resourceflavor_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -100,7 +99,7 @@ var _ = ginkgo.Describe("ResourceFlavor Webhook", func() {
 		err := k8sClient.Create(ctx, resourceFlavor)
 		if isInvalid {
 			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(errors.IsInvalid(err)).To(gomega.BeTrue(), "error: %v", err)
+			gomega.Expect(err).Should(testing.BeInvalidError())
 		} else {
 			gomega.Expect(err).To(gomega.Succeed())
 			defer func() {
@@ -141,7 +140,7 @@ var _ = ginkgo.Describe("ResourceFlavor Webhook", func() {
 			ginkgo.By("Updating the resourceFlavor with invalid labels")
 			err := k8sClient.Update(ctx, &created)
 			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err).Should(testing.BeAPIError(testing.InvalidError))
+			gomega.Expect(err).Should(testing.BeInvalidError())
 		})
 	})
 
@@ -155,10 +154,10 @@ var _ = ginkgo.Describe("ResourceFlavor Webhook", func() {
 		switch errorType {
 		case isForbidden:
 			gomega.Expect(err).Should(gomega.HaveOccurred())
-			gomega.Expect(err).Should(testing.BeAPIError(testing.ForbiddenError), "error: %v", err)
+			gomega.Expect(err).Should(testing.BeForbiddenError())
 		case isInvalid:
 			gomega.Expect(err).Should(gomega.HaveOccurred())
-			gomega.Expect(err).Should(testing.BeAPIError(testing.InvalidError), "error: %v", err)
+			gomega.Expect(err).Should(testing.BeInvalidError())
 		default:
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		}

--- a/test/integration/webhook/core/workload_test.go
+++ b/test/integration/webhook/core/workload_test.go
@@ -111,7 +111,7 @@ var _ = ginkgo.Describe("Workload defaulting webhook", func() {
 					},
 				},
 			}
-			gomega.Expect(k8sClient.Create(ctx, &workload)).Should(testing.BeAPIError(testing.InvalidError))
+			gomega.Expect(k8sClient.Create(ctx, &workload)).Should(testing.BeInvalidError())
 		})
 	})
 })
@@ -126,7 +126,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 			workload := testing.MakeWorkload(workloadName, ns.Name).PodSets(podSets...).Obj()
 			err := k8sClient.Create(ctx, workload)
 			if isInvalid {
-				gomega.Expect(err).Should(testing.BeAPIError(testing.InvalidError), "error: %v", err)
+				gomega.Expect(err).Should(testing.BeInvalidError())
 			} else {
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			}
@@ -140,7 +140,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 		ginkgo.DescribeTable("Should have valid values when creating", func(w func() *kueue.Workload, errorType gomega.OmegaMatcher) {
 			err := k8sClient.Create(ctx, w())
 			if errorType != nil {
-				gomega.Expect(err).Should(errorType, "error: %v", err)
+				gomega.Expect(err).Should(errorType)
 			} else {
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			}
@@ -159,7 +159,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						*testing.MakePodSet("@driver", 1).Obj(),
 					).Obj()
 				},
-				testing.BeAPIError(testing.InvalidError)),
+				testing.BeInvalidError()),
 			ginkgo.Entry("invalid priorityClassName",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
@@ -167,7 +167,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						Priority(0).
 						Obj()
 				},
-				testing.BeAPIError(testing.InvalidError)),
+				testing.BeInvalidError()),
 			ginkgo.Entry("empty priorityClassName is valid",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
@@ -180,14 +180,14 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						PriorityClass("priority").
 						Obj()
 				},
-				testing.BeAPIError(testing.InvalidError)),
+				testing.BeInvalidError()),
 			ginkgo.Entry("invalid queueName",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
 						Queue("@invalid").
 						Obj()
 				},
-				testing.BeAPIError(testing.InvalidError)),
+				testing.BeInvalidError()),
 			ginkgo.Entry("should not request num-pods resource",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
@@ -219,7 +219,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						}).
 						Obj()
 				},
-				testing.BeAPIError(testing.ForbiddenError)),
+				testing.BeForbiddenError()),
 			ginkgo.Entry("empty podSetUpdates should be valid since it is optional",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
@@ -281,7 +281,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						).
 						Obj()
 				},
-				testing.BeAPIError(testing.InvalidError)),
+				testing.BeInvalidError()),
 			ginkgo.Entry("invalid podSet minCount (too big)",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
@@ -290,7 +290,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						).
 						Obj()
 				},
-				testing.BeAPIError(testing.InvalidError)),
+				testing.BeInvalidError()),
 			ginkgo.Entry("too many variable count podSets",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
@@ -300,14 +300,14 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						).
 						Obj()
 				},
-				testing.BeAPIError(testing.ForbiddenError)),
+				testing.BeForbiddenError()),
 			ginkgo.Entry("invalid maximumExexcutionTimeSeconds",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
 						MaximumExecutionTimeSeconds(0).
 						Obj()
 				},
-				testing.BeAPIError(testing.InvalidError)),
+				testing.BeInvalidError()),
 			ginkgo.Entry("valid maximumExexcutionTimeSeconds",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
@@ -323,7 +323,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 
 			err := util.SetQuotaReservation(ctx, k8sClient, workload, a)
 			if errorType != nil {
-				gomega.Expect(err).Should(errorType, "error: %v", err)
+				gomega.Expect(err).Should(errorType)
 			} else {
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			}
@@ -334,14 +334,14 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						Obj()
 				},
 				testing.MakeAdmission("@invalid").Obj(),
-				testing.BeAPIError(testing.InvalidError)),
+				testing.BeInvalidError()),
 			ginkgo.Entry("invalid podSet name in status assignment",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
 						Obj()
 				},
 				testing.MakeAdmission("cluster-queue", "@invalid").Obj(),
-				testing.BeAPIError(testing.InvalidError)),
+				testing.BeInvalidError()),
 			ginkgo.Entry("mismatched names in admission with names in podSets",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
@@ -352,7 +352,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						Obj()
 				},
 				testing.MakeAdmission("cluster-queue", "main1", "main2", "main3").Obj(),
-				testing.BeAPIError(testing.InvalidError)),
+				testing.BeInvalidError()),
 			ginkgo.Entry("assignment usage should be divisible by count",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
@@ -367,7 +367,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 					Assignment(corev1.ResourceCPU, "flv", "1").
 					AssignmentPodCount(3).
 					Obj(),
-				testing.BeAPIError(testing.ForbiddenError)),
+				testing.BeForbiddenError()),
 		)
 
 		ginkgo.DescribeTable("Should have valid values when setting AdmissionCheckState", func(w func() *kueue.Workload, acs kueue.AdmissionCheckState) {
@@ -439,7 +439,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				{Name: "ps1", Count: 4},
 				{Name: "ps2", Count: 1},
 			})
-			gomega.Expect(err).Should(testing.BeAPIError(testing.ForbiddenError), "error: %v", err)
+			gomega.Expect(err).Should(testing.BeForbiddenError())
 		})
 	})
 
@@ -487,7 +487,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				func(newWL *kueue.Workload) {
 					newWL.Spec.PodSets = []kueue.PodSet{*testing.MakePodSet("main", 2).Obj()}
 				},
-				testing.BeAPIError(testing.ForbiddenError),
+				testing.BeForbiddenError(),
 			),
 			ginkgo.Entry("podSets should not be updated: podSpec",
 				func() *kueue.Workload {
@@ -512,7 +512,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						},
 					}}
 				},
-				testing.BeAPIError(testing.ForbiddenError),
+				testing.BeForbiddenError(),
 			),
 			ginkgo.Entry("queueName can be updated when not admitted",
 				func() *kueue.Workload {
@@ -542,7 +542,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				func(newWL *kueue.Workload) {
 					newWL.Spec.QueueName = "q2"
 				},
-				testing.BeAPIError(testing.InvalidError),
+				testing.BeInvalidError(),
 			),
 			ginkgo.Entry("queueName can be updated when admission is reset",
 				func() *kueue.Workload {
@@ -599,7 +599,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				func(newWL *kueue.Workload) {
 					newWL.Spec.PriorityClassSource = constants.WorkloadPriorityClassSource
 				},
-				testing.BeAPIError(testing.InvalidError),
+				testing.BeInvalidError(),
 			),
 			ginkgo.Entry("priorityClassName should not be updated",
 				func() *kueue.Workload {
@@ -613,7 +613,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				func(newWL *kueue.Workload) {
 					newWL.Spec.PriorityClassName = "test-class-2"
 				},
-				testing.BeAPIError(testing.InvalidError),
+				testing.BeInvalidError(),
 			),
 			ginkgo.Entry("should change other fields of admissionchecks when podSetUpdates is immutable",
 				func() *kueue.Workload {
@@ -714,7 +714,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				func(newWL *kueue.Workload) {
 					newWL.Spec.PodSets[0].Count = 10
 				},
-				testing.BeAPIError(testing.ForbiddenError),
+				testing.BeForbiddenError(),
 			),
 			ginkgo.Entry("reclaimable pod count can go to 0 if the job is suspended",
 				func() *kueue.Workload {
@@ -779,7 +779,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				func(newWL *kueue.Workload) {
 					newWL.Spec.MaximumExecutionTimeSeconds = ptr.To[int32](1)
 				},
-				testing.BeAPIError(testing.InvalidError),
+				testing.BeInvalidError(),
 			),
 			ginkgo.Entry("cannot update maximum execution time when admitted",
 				func() *kueue.Workload {
@@ -791,7 +791,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				func(newWL *kueue.Workload) {
 					*newWL.Spec.MaximumExecutionTimeSeconds = 2
 				},
-				testing.BeAPIError(testing.InvalidError),
+				testing.BeInvalidError(),
 			),
 		)
 
@@ -839,7 +839,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 			ginkgo.By("Creating a new Workload")
 			workload := testing.MakeWorkload(workloadName, ns.Name).PriorityClass("priority").Obj()
 			err := k8sClient.Create(ctx, workload)
-			gomega.Expect(err).Should(testing.BeAPIError(testing.InvalidError), "error: %v", err)
+			gomega.Expect(err).Should(testing.BeInvalidError())
 		})
 
 		ginkgo.It("workload's priority should be mutable when referencing WorkloadPriorityClass", func() {
@@ -954,7 +954,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 			err := workload.UpdateReclaimablePods(ctx, k8sClient, wl, []kueue.ReclaimablePod{
 				{Name: "ps1", Count: 1},
 			})
-			gomega.Expect(err).Should(testing.BeAPIError(testing.ForbiddenError))
+			gomega.Expect(err).Should(testing.BeForbiddenError())
 		})
 
 		ginkgo.It("podSetUpdates should be immutable when state is ready", func() {

--- a/test/integration/webhook/jobs/job_webhook_test.go
+++ b/test/integration/webhook/jobs/job_webhook_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
@@ -31,6 +30,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
+	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe("Job Webhook With manageJobsWithoutQueueName enabled", g
 		job := testingjob.MakeJob("job-with-queue-name", ns.Name).Queue("foo").SetAnnotation(job.JobMinParallelismAnnotation, "a").Obj()
 		err := k8sClient.Create(ctx, job)
 		gomega.Expect(err).Should(gomega.HaveOccurred())
-		gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.BeTrue(), "error: %v", err)
+		gomega.Expect(err).Should(testing.BeForbiddenError())
 	})
 
 	ginkgo.It("Should suspend a Job even no queue name specified", func() {
@@ -108,7 +108,7 @@ var _ = ginkgo.Describe("Job Webhook With manageJobsWithoutQueueName enabled", g
 			SetAnnotation(job.JobCompletionsEqualParallelismAnnotation, "true").
 			Indexed(true).
 			Obj()
-		gomega.Expect(apierrors.IsForbidden(k8sClient.Create(ctx, j))).Should(gomega.BeTrue())
+		gomega.Expect(k8sClient.Create(ctx, j)).Should(testing.BeForbiddenError())
 	})
 })
 

--- a/test/integration/webhook/jobs/jobset_webhook_test.go
+++ b/test/integration/webhook/jobs/jobset_webhook_test.go
@@ -20,10 +20,10 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
+	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/jobset"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -54,7 +54,7 @@ var _ = ginkgo.Describe("JobSet Webhook", func() {
 			job := testingjob.MakeJobSet("jobset", ns.Name).Queue("indexed_job").Obj()
 			err := k8sClient.Create(ctx, job)
 			gomega.Expect(err).Should(gomega.HaveOccurred())
-			gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.BeTrue(), "error: %v", err)
+			gomega.Expect(err).Should(testing.BeForbiddenError())
 		})
 	})
 })

--- a/test/integration/webhook/jobs/mpijob_webhook_test.go
+++ b/test/integration/webhook/jobs/mpijob_webhook_test.go
@@ -20,10 +20,10 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
+	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/mpijob"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -55,7 +55,7 @@ var _ = ginkgo.Describe("MPIJob Webhook", ginkgo.Ordered, func() {
 			job := testingjob.MakeMPIJob("job", ns.Name).Queue("indexed_job").Obj()
 			err := k8sClient.Create(ctx, job)
 			gomega.Expect(err).Should(gomega.HaveOccurred())
-			gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.BeTrue(), "error: %v", err)
+			gomega.Expect(err).Should(testing.BeForbiddenError())
 		})
 	})
 })

--- a/test/integration/webhook/jobs/raycluster_webhook_test.go
+++ b/test/integration/webhook/jobs/raycluster_webhook_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/onsi/gomega"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -65,7 +64,7 @@ var _ = ginkgo.Describe("RayCluster Webhook", func() {
 			job := testingraycluster.MakeCluster("raycluster", ns.Name).Queue("indexed_job").Obj()
 			err := k8sClient.Create(ctx, job)
 			gomega.Expect(err).Should(gomega.HaveOccurred())
-			gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.BeTrue(), "error: %v", err)
+			gomega.Expect(err).Should(testing.BeForbiddenError())
 		})
 	})
 

--- a/test/integration/webhook/jobs/rayjob_webhook_test.go
+++ b/test/integration/webhook/jobs/rayjob_webhook_test.go
@@ -20,10 +20,10 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
+	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -55,7 +55,7 @@ var _ = ginkgo.Describe("RayJob Webhook", func() {
 			job := testingjob.MakeJob("rayjob", ns.Name).Queue("indexed_job").Obj()
 			err := k8sClient.Create(ctx, job)
 			gomega.Expect(err).Should(gomega.HaveOccurred())
-			gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.BeTrue(), "error: %v", err)
+			gomega.Expect(err).Should(testing.BeForbiddenError())
 		})
 
 		ginkgo.It("invalid configuration shutdown after job finishes", func() {
@@ -65,7 +65,7 @@ var _ = ginkgo.Describe("RayJob Webhook", func() {
 				Obj()
 			err := k8sClient.Create(ctx, job)
 			gomega.Expect(err).Should(gomega.HaveOccurred())
-			gomega.Expect(apierrors.IsForbidden(err)).Should(gomega.BeTrue(), "error: %v", err)
+			gomega.Expect(err).Should(testing.BeForbiddenError())
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Make error matcher more verbosity.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
The error matcher doesn't show actual error. This is an example https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/3445/pull-kueue-test-multikueue-e2e-main/1853747452654391296.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```