### PR TITLE
Reduce number of API requests in the Provisioning Controller

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -122,56 +122,69 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, nil
 	}
 
+	list := &autoscaling.ProvisioningRequestList{}
+	if err := c.client.List(ctx, list, client.InNamespace(wl.Namespace), client.MatchingFields{RequestsOwnedByWorkloadKey: wl.Name}); client.IgnoreNotFound(err) != nil {
+		return reconcile.Result{}, err
+	}
+
 	// get the lists of relevant checks
 	relevantChecks, err := admissioncheck.FilterForController(ctx, c.client, wl.Status.AdmissionChecks, kueue.ProvisioningRequestControllerName)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	list := &autoscaling.ProvisioningRequestList{}
-	if err := c.client.List(ctx, list, client.InNamespace(wl.Namespace), client.MatchingFields{RequestsOwnedByWorkloadKey: wl.Name}); client.IgnoreNotFound(err) != nil {
-		return reconcile.Result{}, err
+	checkConfig := make(map[string]*kueue.ProvisioningRequestConfig, len(relevantChecks))
+	for _, checkName := range relevantChecks {
+		prc, err := c.helper.ConfigForAdmissionCheck(ctx, checkName)
+		if client.IgnoreNotFound(err) != nil {
+			return reconcile.Result{}, err
+		}
+		checkConfig[checkName] = prc
 	}
-	ownedPrs := list.Items
-	activeOrLastPRForChecks := c.activeOrLastPRForChecks(ctx, wl, relevantChecks, ownedPrs)
+
+	activeOrLastPRForChecks := c.activeOrLastPRForChecks(ctx, wl, checkConfig, list.Items)
 
 	wlInfo := workloadInfo{
 		checkStates: make([]kueue.AdmissionCheckState, 0),
 	}
-	err = c.syncCheckStates(ctx, wl, &wlInfo, relevantChecks, activeOrLastPRForChecks)
+	err = c.syncCheckStates(ctx, wl, &wlInfo, checkConfig, activeOrLastPRForChecks)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	err = c.deleteUnusedProvisioningRequests(ctx, ownedPrs, activeOrLastPRForChecks)
+	err = c.deleteUnusedProvisioningRequests(ctx, list.Items, activeOrLastPRForChecks)
 	if err != nil {
 		log.V(2).Error(err, "syncOwnedProvisionRequest failed to delete unused provisioning requests")
 		return reconcile.Result{}, err
 	}
 
-	requeAfter, err := c.syncOwnedProvisionRequest(ctx, wl, &wlInfo, relevantChecks, activeOrLastPRForChecks)
+	requeueAfter, err := c.syncOwnedProvisionRequest(ctx, wl, &wlInfo, checkConfig, activeOrLastPRForChecks)
 	if err != nil {
 		// this can also delete unneeded checks
 		log.V(2).Error(err, "syncOwnedProvisionRequest failed")
 		return reconcile.Result{}, err
 	}
 
-	if requeAfter != nil {
-		return reconcile.Result{RequeueAfter: *requeAfter}, nil
+	if requeueAfter != nil {
+		return reconcile.Result{RequeueAfter: *requeueAfter}, nil
 	}
 	return reconcile.Result{}, nil
 }
 
-func (c *Controller) activeOrLastPRForChecks(ctx context.Context, wl *kueue.Workload, relevantChecks []string, ownedPrs []autoscaling.ProvisioningRequest) map[string]*autoscaling.ProvisioningRequest {
+func (c *Controller) activeOrLastPRForChecks(
+	ctx context.Context,
+	wl *kueue.Workload,
+	checkConfig map[string]*kueue.ProvisioningRequestConfig,
+	ownedPrs []autoscaling.ProvisioningRequest,
+) map[string]*autoscaling.ProvisioningRequest {
 	activeOrLastPRForChecks := make(map[string]*autoscaling.ProvisioningRequest)
 	log := ctrl.LoggerFrom(ctx)
-	for _, checkName := range relevantChecks {
+	for checkName, prc := range checkConfig {
 		for i := range ownedPrs {
 			req := &ownedPrs[i]
 			// PRs relevant for the admission check
 			if matchesWorkloadAndCheck(req, wl.Name, checkName) {
-				prc, err := c.helper.ConfigForAdmissionCheck(ctx, checkName)
-				if err == nil && c.reqIsNeeded(wl, prc) && provReqSyncedWithConfig(req, prc) {
+				if prc != nil && c.reqIsNeeded(wl, prc) && provReqSyncedWithConfig(req, prc) {
 					if currPr, exists := activeOrLastPRForChecks[checkName]; !exists || getAttempt(log, currPr, wl.Name, checkName) < getAttempt(log, req, wl.Name, checkName) {
 						activeOrLastPRForChecks[checkName] = req
 					}
@@ -200,14 +213,17 @@ func (c *Controller) deleteUnusedProvisioningRequests(ctx context.Context, owned
 	return nil
 }
 
-func (c *Controller) syncOwnedProvisionRequest(ctx context.Context, wl *kueue.Workload, wlInfo *workloadInfo,
-	relevantChecks []string, activeOrLastPRForChecks map[string]*autoscaling.ProvisioningRequest) (*time.Duration, error) {
+func (c *Controller) syncOwnedProvisionRequest(
+	ctx context.Context,
+	wl *kueue.Workload,
+	wlInfo *workloadInfo,
+	checkConfig map[string]*kueue.ProvisioningRequestConfig,
+	activeOrLastPRForChecks map[string]*autoscaling.ProvisioningRequest,
+) (*time.Duration, error) {
 	log := ctrl.LoggerFrom(ctx)
 	var requeAfter *time.Duration
-	for _, checkName := range relevantChecks {
-		// get the config
-		prc, err := c.helper.ConfigForAdmissionCheck(ctx, checkName)
-		if err != nil {
+	for checkName, prc := range checkConfig {
+		if prc == nil {
 			// the check is not active
 			continue
 		}
@@ -476,16 +492,22 @@ func (wlInfo *workloadInfo) update(wl *kueue.Workload) {
 	wlInfo.requeueState = wl.Status.RequeueState
 }
 
-func (c *Controller) syncCheckStates(ctx context.Context, wl *kueue.Workload, wlInfo *workloadInfo, checks []string, activeOrLastPRForChecks map[string]*autoscaling.ProvisioningRequest) error {
+func (c *Controller) syncCheckStates(
+	ctx context.Context, wl *kueue.Workload,
+	wlInfo *workloadInfo,
+	checkConfig map[string]*kueue.ProvisioningRequestConfig,
+	activeOrLastPRForChecks map[string]*autoscaling.ProvisioningRequest,
+) error {
 	log := ctrl.LoggerFrom(ctx)
 	wlInfo.update(wl)
 	checksMap := slices.ToRefMap(wl.Status.AdmissionChecks, func(c *kueue.AdmissionCheckState) string { return c.Name })
 	wlPatch := workload.BaseSSAWorkload(wl)
-	recorderMessages := make([]string, 0, len(checks))
+	recorderMessages := make([]string, 0, len(checkConfig))
 	updated := false
-	for _, check := range checks {
+	for check, prc := range checkConfig {
 		checkState := *checksMap[check]
-		if prc, err := c.helper.ConfigForAdmissionCheck(ctx, check); err != nil {
+		//nolint:gocritic
+		if prc == nil {
 			// the check is not active
 			updated = updateCheckState(&checkState, kueue.CheckStatePending) || updated
 			updated = updateCheckMessage(&checkState, CheckInactiveMessage) || updated

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -1416,9 +1416,10 @@ func TestActiveOrLastPRForChecks(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			workload := baseWorkload.DeepCopy()
-			relevantChecks := []string{"check"}
 			checks := []kueue.AdmissionCheck{*baseCheck.DeepCopy()}
-			configs := []kueue.ProvisioningRequestConfig{*baseConfig.DeepCopy()}
+			checkConfig := map[string]*kueue.ProvisioningRequestConfig{
+				baseCheck.Name: baseConfig.DeepCopy(),
+			}
 
 			builder, ctx := getClientBuilder()
 
@@ -1427,7 +1428,6 @@ func TestActiveOrLastPRForChecks(t *testing.T) {
 
 			builder = builder.WithLists(
 				&autoscaling.ProvisioningRequestList{Items: tc.requests},
-				&kueue.ProvisioningRequestConfigList{Items: configs},
 				&kueue.AdmissionCheckList{Items: checks},
 			)
 
@@ -1438,7 +1438,7 @@ func TestActiveOrLastPRForChecks(t *testing.T) {
 				t.Fatalf("Setting up the provisioning request controller: %v", err)
 			}
 
-			gotResult := controller.activeOrLastPRForChecks(ctx, workload, relevantChecks, tc.requests)
+			gotResult := controller.activeOrLastPRForChecks(ctx, workload, checkConfig, tc.requests)
 			if diff := cmp.Diff(tc.wantResult, gotResult, reqCmpOptions...); diff != "" {
 				t.Errorf("unexpected request %q (-want/+got):\n%s", name, diff)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Reduce number of API requests in the Provisioning Controller

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3471

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```