### PR TITLE
TAS: fix computing assignment when multiple PodSets

### DIFF
--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -338,13 +338,17 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain) []*domain {
 }
 
 func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests) {
+	// cleanup the state in case some remaining values are present from computing
+	// assignments for previous PodSets.
+	for domainID := range s.state {
+		s.state[domainID] = 0
+	}
 	for domainID, capacity := range s.freeCapacityPerLeafDomain {
 		s.state[domainID] = requests.CountIn(capacity)
 	}
 	lastLevelIdx := len(s.domainsPerLevel) - 1
 	for levelIdx := lastLevelIdx - 1; levelIdx >= 0; levelIdx-- {
 		for _, info := range s.domainsPerLevel[levelIdx] {
-			s.state[info.id] = 0
 			for _, childDomainID := range info.childIDs {
 				s.state[info.id] += s.state[childDomainID]
 			}

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -344,6 +344,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests) {
 	lastLevelIdx := len(s.domainsPerLevel) - 1
 	for levelIdx := lastLevelIdx - 1; levelIdx >= 0; levelIdx-- {
 		for _, info := range s.domainsPerLevel[levelIdx] {
+			s.state[info.id] = 0
 			for _, childDomainID := range info.childIDs {
 				s.state[info.id] += s.state[childDomainID]
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3494

#### Special notes for your reviewer:

I reproduced the same issue for JobSet, so this is not specific to MPIJob. Any Job is affected with multiple PodSets requesting the same RF using the same topology.

The issue was the capacity for non-leaf nodes was counted twice. The newly added test fails on the main branch, the workload gets admitted by with empty assignment.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix computing the topology assignment for workloads using multiple PodSets requesting the same
topology. In particular, it was possible for the set of topology domains in the assignment to be empty,
and as a consequence the pods would remain gated forever as the TopologyUngater would not have
topology assignment information.
```