### PR TITLE
Automated cherry pick of #3514: TAS: fix computing assignment when multiple PodSets

### DIFF
--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -338,13 +338,17 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain) []*domain {
 }
 
 func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests) {
+	// cleanup the state in case some remaining values are present from computing
+	// assignments for previous PodSets.
+	for domainID := range s.state {
+		s.state[domainID] = 0
+	}
 	for domainID, capacity := range s.freeCapacityPerLeafDomain {
 		s.state[domainID] = requests.CountIn(capacity)
 	}
 	lastLevelIdx := len(s.domainsPerLevel) - 1
 	for levelIdx := lastLevelIdx - 1; levelIdx >= 0; levelIdx-- {
 		for _, info := range s.domainsPerLevel[levelIdx] {
-			s.state[info.id] = 0
 			for _, childDomainID := range info.childIDs {
 				s.state[info.id] += s.state[childDomainID]
 			}

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -344,6 +344,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests) {
 	lastLevelIdx := len(s.domainsPerLevel) - 1
 	for levelIdx := lastLevelIdx - 1; levelIdx >= 0; levelIdx-- {
 		for _, info := range s.domainsPerLevel[levelIdx] {
+			s.state[info.id] = 0
 			for _, childDomainID := range info.childIDs {
 				s.state[info.id] += s.state[childDomainID]
 			}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -3944,7 +3944,7 @@ func TestScheduleForTAS(t *testing.T) {
 			NodeLabels: map[string]string{
 				"tas-node": "true",
 			},
-			TopologyName: ptr.To[kueue.TopologyReference]("tas-two-level"),
+			TopologyName: ptr.To("tas-two-level"),
 		},
 	}
 	defaultClusterQueue := *utiltesting.MakeClusterQueue("tas-main").

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -3866,6 +3866,7 @@ func TestResourcesToReserve(t *testing.T) {
 
 func TestScheduleForTAS(t *testing.T) {
 	const (
+		tasRackLabel = "cloud.provider.com/rack"
 		tasHostLabel = "kubernetes.io/hostname"
 	)
 	defaultSingleNode := []corev1.Node{
@@ -3903,6 +3904,21 @@ func TestScheduleForTAS(t *testing.T) {
 			},
 		},
 	}
+	defaultTwoLevelTopology := kueuealpha.Topology{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tas-two-level",
+		},
+		Spec: kueuealpha.TopologySpec{
+			Levels: []kueuealpha.TopologyLevel{
+				{
+					NodeLabel: tasRackLabel,
+				},
+				{
+					NodeLabel: tasHostLabel,
+				},
+			},
+		},
+	}
 	defaultFlavor := kueue.ResourceFlavor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "default",
@@ -3918,6 +3934,17 @@ func TestScheduleForTAS(t *testing.T) {
 				"tas-node": "true",
 			},
 			TopologyName: ptr.To("tas-single-level"),
+		},
+	}
+	defaultTASTwoLevelFlavor := kueue.ResourceFlavor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tas-default",
+		},
+		Spec: kueue.ResourceFlavorSpec{
+			NodeLabels: map[string]string{
+				"tas-node": "true",
+			},
+			TopologyName: ptr.To[kueue.TopologyReference]("tas-two-level"),
 		},
 	}
 	defaultClusterQueue := *utiltesting.MakeClusterQueue("tas-main").
@@ -4547,6 +4574,86 @@ func TestScheduleForTAS(t *testing.T) {
 					Key:       types.NamespacedName{Namespace: "default", Name: "foo"},
 					Reason:    "Admitted",
 					EventType: corev1.EventTypeNormal,
+				},
+			},
+		},
+		"workload with multiple PodSets requesting the same TAS flavor; multiple levels": {
+			nodes: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "x1",
+						Labels: map[string]string{
+							"tas-node":   "true",
+							tasRackLabel: "r1",
+							tasHostLabel: "x1",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("3"),
+						},
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "y1",
+						Labels: map[string]string{
+							"tas-node":   "true",
+							tasRackLabel: "r1",
+							tasHostLabel: "y1",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Allocatable: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("3"),
+						},
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			topologies:      []kueuealpha.Topology{defaultTwoLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASTwoLevelFlavor},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("tas-main").
+					ResourceGroup(
+						*utiltesting.MakeFlavorQuotas("tas-default").
+							Resource(corev1.ResourceCPU, "50").Obj()).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("foo", "default").
+					Queue("tas-main").
+					PodSets(
+						*utiltesting.MakePodSet("launcher", 1).
+							PreferredTopologyRequest(tasHostLabel).
+							Request(corev1.ResourceCPU, "1").
+							Obj(),
+						*utiltesting.MakePodSet("worker", 1).
+							PreferredTopologyRequest(tasHostLabel).
+							Request(corev1.ResourceCPU, "7").
+							Obj()).
+					Obj(),
+			},
+			wantInadmissibleLeft: map[string][]string{
+				"tas-main": {"default/foo"},
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Namespace: "default", Name: "foo"},
+					EventType: "Warning",
+					Reason:    "Pending",
+					Message:   `couldn't assign flavors to pod set worker: topology "tas-two-level" doesn't allow to fit any of 1 pod(s)`,
 				},
 			},
 		},


### PR DESCRIPTION
Cherry pick of #3514 on release-0.9.

#3514: TAS: fix computing assignment when multiple PodSets

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix computing the topology assignment for workloads using multiple PodSets requesting the same
topology. In particular, it was possible for the set of topology domains in the assignment to be empty,
and as a consequence the pods would remain gated forever as the TopologyUngater would not have
topology assignment information.
```