### PR TITLE
[kjobctl] refactor to use utilmaps.SortedKeys

### DIFF
--- a/cmd/experimental/kjobctl/pkg/cmd/describe/describe_printer.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/describe/describe_printer.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 	describehelper "k8s.io/kubectl/pkg/describe"
 	"k8s.io/utils/ptr"
+	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 )
 
 // ResourceDescriber generates output for the named resource or an error
@@ -316,16 +317,14 @@ func describeConfigMap(configMap *corev1.ConfigMap) (string, error) {
 		printLabelsMultiline(w, "Labels", configMap.Labels)
 
 		w.Write(IndentLevelZero, "\nData\n====\n")
-		sortedKeys := sortMapKeys(configMap.Data)
-		for _, k := range sortedKeys {
+		for _, k := range utilmaps.SortedKeys(configMap.Data) {
 			w.Write(IndentLevelZero, "%s:\n----\n", k)
 			w.Write(IndentLevelZero, "%s\n", configMap.Data[k])
 			w.Write(IndentLevelZero, "\n")
 		}
 
 		w.Write(IndentLevelZero, "\nBinaryData\n====\n")
-		sortedKeys = sortMapKeys(configMap.BinaryData)
-		for _, k := range sortedKeys {
+		for _, k := range utilmaps.SortedKeys(configMap.BinaryData) {
 			w.Write(IndentLevelZero, "%s: %s bytes\n", k, strconv.Itoa(len(configMap.BinaryData[k])))
 		}
 		w.Write(IndentLevelZero, "\n")

--- a/cmd/experimental/kjobctl/pkg/cmd/describe/helpers.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/describe/helpers.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -97,17 +96,6 @@ func gvkFor(mapper meta.RESTMapper, resource string) (schema.GroupVersionKind, e
 	}
 
 	return gvk, err
-}
-
-func sortMapKeys[T any](m map[string]T) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-
-	slices.Sort(keys)
-
-	return keys
 }
 
 // below functions copied from https://github.com/kubernetes/kubectl/blob/master/pkg/describe/describe.go


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR simplifies implementation of `describeConfigMap` by using `utilmaps.SortedKeys` and removing the `sortMapKeys` function.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```