### PR TITLE
Allow mutating queue name in Deployment Webhook.

### DIFF
--- a/charts/kueue/templates/webhook/webhook.yaml
+++ b/charts/kueue/templates/webhook/webhook.yaml
@@ -38,6 +38,7 @@ webhooks:
           - v1
         operations:
           - CREATE
+          - UPDATE
         resources:
           - deployments
     sideEffects: None

--- a/config/components/webhook/manifests.yaml
+++ b/config/components/webhook/manifests.yaml
@@ -20,6 +20,7 @@ webhooks:
     - v1
     operations:
     - CREATE
+    - UPDATE
     resources:
     - deployments
   sideEffects: None

--- a/pkg/controller/jobs/deployment/deployment_webhook.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook.go
@@ -101,8 +101,9 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Ob
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, jobframework.ValidateQueueName(newDeployment.Object())...)
 
-	// Prevents updating the queue-name if at least one Pod is not suspended.
-	if oldDeployment.Status.ReadyReplicas > 0 {
+	// Prevents updating the queue-name if at least one Pod is not suspended
+	// or if the queue-name has been deleted.
+	if oldDeployment.Status.ReadyReplicas > 0 || newQueueName == "" {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldQueueName, newQueueName, queueNameLabelPath)...)
 	}
 

--- a/pkg/controller/jobs/deployment/deployment_webhook.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook.go
@@ -48,7 +48,7 @@ func SetupWebhook(mgr ctrl.Manager, _ ...jobframework.Option) error {
 		Complete()
 }
 
-// +kubebuilder:webhook:path=/mutate-apps-v1-deployment,mutating=true,failurePolicy=fail,sideEffects=None,groups="apps",resources=deployments,verbs=create,versions=v1,name=mdeployment.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-apps-v1-deployment,mutating=true,failurePolicy=fail,sideEffects=None,groups="apps",resources=deployments,verbs=create;update,versions=v1,name=mdeployment.kb.io,admissionReviewVersions=v1
 
 var _ admission.CustomDefaulter = &Webhook{}
 
@@ -84,10 +84,8 @@ func (wh *Webhook) ValidateCreate(ctx context.Context, obj runtime.Object) (warn
 }
 
 var (
-	labelsPath                = field.NewPath("metadata", "labels")
-	queueNameLabelPath        = labelsPath.Key(constants.QueueLabel)
-	podSpecLabelPath          = field.NewPath("spec", "template", "metadata", "labels")
-	podSpecQueueNameLabelPath = podSpecLabelPath.Key(constants.QueueLabel)
+	labelsPath         = field.NewPath("metadata", "labels")
+	queueNameLabelPath = labelsPath.Key(constants.QueueLabel)
 )
 
 func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
@@ -100,12 +98,13 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Ob
 	oldQueueName := jobframework.QueueNameForObject(oldDeployment.Object())
 	newQueueName := jobframework.QueueNameForObject(newDeployment.Object())
 
-	allErrs := apivalidation.ValidateImmutableField(oldQueueName, newQueueName, queueNameLabelPath)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(
-		newDeployment.Spec.Template.GetLabels()[constants.QueueLabel],
-		oldDeployment.Spec.Template.GetLabels()[constants.QueueLabel],
-		podSpecQueueNameLabelPath,
-	)...)
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, jobframework.ValidateQueueName(newDeployment.Object())...)
+
+	// Prevents updating the queue-name if at least one Pod is not suspended.
+	if oldDeployment.Status.ReadyReplicas > 0 {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(oldQueueName, newQueueName, queueNameLabelPath)...)
+	}
 
 	return warnings, allErrs.ToAggregate()
 }

--- a/pkg/controller/jobs/deployment/deployment_webhook_test.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook_test.go
@@ -147,8 +147,16 @@ func TestValidateUpdate(t *testing.T) {
 			newDeployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),
 		},
 		"without queue": {
-			oldDeployment: testingdeployment.MakeDeployment("test-pod", "test-queue").Obj(),
+			oldDeployment: testingdeployment.MakeDeployment("test-pod", "").
+				Queue("test-queue").
+				Obj(),
 			newDeployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.labels[kueue.x-k8s.io/queue-name]",
+				},
+			}.ToAggregate(),
 		},
 		"with queue (no changes)": {
 			oldDeployment: testingdeployment.MakeDeployment("test-pod", "").

--- a/pkg/controller/jobs/deployment/deployment_webhook_test.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook_test.go
@@ -48,6 +48,20 @@ func TestDefault(t *testing.T) {
 				PodTemplateSpecQueue("test-queue").
 				Obj(),
 		},
+		"deployment with queue and pod template spec queue": {
+			deployment: testingdeployment.MakeDeployment("test-pod", "").
+				Queue("new-test-queue").
+				PodTemplateSpecQueue("test-queue").
+				Obj(),
+			want: testingdeployment.MakeDeployment("test-pod", "").
+				Queue("new-test-queue").
+				PodTemplateSpecQueue("new-test-queue").
+				Obj(),
+		},
+		"deployment without queue with pod template spec queue": {
+			deployment: testingdeployment.MakeDeployment("test-pod", "").PodTemplateSpecQueue("test-queue").Obj(),
+			want:       testingdeployment.MakeDeployment("test-pod", "").PodTemplateSpecQueue("test-queue").Obj(),
+		},
 	}
 
 	for name, tc := range testCases {
@@ -128,8 +142,12 @@ func TestValidateUpdate(t *testing.T) {
 		wantErr       error
 		wantWarns     admission.Warnings
 	}{
-		"without queue": {
+		"without queue (no changes)": {
 			oldDeployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),
+			newDeployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),
+		},
+		"without queue": {
+			oldDeployment: testingdeployment.MakeDeployment("test-pod", "test-queue").Obj(),
 			newDeployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),
 		},
 		"with queue (no changes)": {
@@ -144,6 +162,30 @@ func TestValidateUpdate(t *testing.T) {
 			oldDeployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),
 			newDeployment: testingdeployment.MakeDeployment("test-pod", "").
 				Queue("test-queue").
+				Obj(),
+		},
+		"with queue (invalid)": {
+			oldDeployment: testingdeployment.MakeDeployment("test-pod", "").
+				Queue("test/queue").
+				Obj(),
+			newDeployment: testingdeployment.MakeDeployment("test-pod", "").
+				Queue("test/queue").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.labels[kueue.x-k8s.io/queue-name]",
+				},
+			}.ToAggregate(),
+		},
+		"with queue (ready replicas)": {
+			oldDeployment: testingdeployment.MakeDeployment("test-pod", "").
+				Queue("test-queue").
+				ReadyReplicas(1).
+				Obj(),
+			newDeployment: testingdeployment.MakeDeployment("test-pod", "").
+				Queue("test-queue-new").
+				ReadyReplicas(1).
 				Obj(),
 			wantErr: field.ErrorList{
 				&field.Error{

--- a/pkg/util/testingjobs/deployment/wrappers.go
+++ b/pkg/util/testingjobs/deployment/wrappers.go
@@ -113,6 +113,12 @@ func (d *DeploymentWrapper) Replicas(replicas int32) *DeploymentWrapper {
 	return d
 }
 
+// ReadyReplicas updated the readyReplicas of the Deployment
+func (d *DeploymentWrapper) ReadyReplicas(readyReplicas int32) *DeploymentWrapper {
+	d.Status.ReadyReplicas = readyReplicas
+	return d
+}
+
 // PodTemplateSpecLabel sets the label of the pod template spec of the Deployment
 func (d *DeploymentWrapper) PodTemplateSpecLabel(k, v string) *DeploymentWrapper {
 	if d.Spec.Template.Labels == nil {

--- a/test/integration/webhook/jobs/deployment_webhook_test.go
+++ b/test/integration/webhook/jobs/deployment_webhook_test.go
@@ -34,13 +34,13 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-var _ = ginkgo.Describe("Deployment Webhook", func() {
+var _ = ginkgo.Describe("Deployment Webhook", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns         *corev1.Namespace
 		deployment *appsv1.Deployment
 	)
 
-	ginkgo.BeforeEach(func() {
+	ginkgo.BeforeAll(func() {
 		discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		serverVersionFetcher = kubeversion.NewServerVersionFetcher(discoveryClient)
@@ -51,7 +51,12 @@ var _ = ginkgo.Describe("Deployment Webhook", func() {
 			deploymentcontroller.SetupWebhook,
 			jobframework.WithKubeServerVersion(serverVersionFetcher),
 		))
+	})
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
 
+	ginkgo.BeforeEach(func() {
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "deployment-",
@@ -61,10 +66,9 @@ var _ = ginkgo.Describe("Deployment Webhook", func() {
 	})
 	ginkgo.AfterEach(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-		fwk.StopManager(ctx)
 	})
 
-	ginkgo.When("the queue-name label is set", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	ginkgo.When("the queue-name label is set", func() {
 		ginkgo.BeforeEach(func() {
 			ginkgo.By("Create deployment", func() {
 				deployment = testingdeployment.MakeDeployment("deployment", ns.Name).
@@ -113,10 +117,10 @@ var _ = ginkgo.Describe("Deployment Webhook", func() {
 		ginkgo.It("shouldn't allow to remove the queue label", func() {
 			createdDeployment := &appsv1.Deployment{}
 
-			ginkgo.By("Remove queue label", func() {
+			ginkgo.By("Try to remove queue label", func() {
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
 				delete(createdDeployment.Labels, constants.QueueLabel)
-				gomega.Expect(k8sClient.Update(ctx, createdDeployment)).To(gomega.Succeed())
+				gomega.Expect(k8sClient.Update(ctx, createdDeployment)).To(testing.BeForbiddenError())
 			})
 
 			ginkgo.By("Check that queue label not deleted from pod template spec", func() {

--- a/test/integration/webhook/jobs/deployment_webhook_test.go
+++ b/test/integration/webhook/jobs/deployment_webhook_test.go
@@ -86,7 +86,7 @@ var _ = ginkgo.Describe("Deployment Webhook", func() {
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("should allow to change the queue", func() {
+		ginkgo.It("should allow to change the queue name (ReadyReplicas = 0)", func() {
 			createdDeployment := &appsv1.Deployment{}
 
 			ginkgo.By("Change queue name", func() {
@@ -94,18 +94,69 @@ var _ = ginkgo.Describe("Deployment Webhook", func() {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
 					deploymentWrapper := &testingdeployment.DeploymentWrapper{Deployment: *createdDeployment}
 					updatedDeployment := deploymentWrapper.Queue("another-queue").Obj()
-					g.Expect(k8sClient.Update(ctx, updatedDeployment)).To(testing.BeForbiddenError())
+					g.Expect(k8sClient.Update(ctx, updatedDeployment)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Check queue name is injected to pod template label", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+					g.Expect(createdDeployment.Spec.Template.Labels[constants.QueueLabel]).
+						To(
+							gomega.Equal("another-queue"),
+							"Queue name should be injected to pod template labels",
+						)
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 
-		ginkgo.It("should not allow to remove the queue label", func() {
+		ginkgo.It("shouldn't allow to remove the queue label", func() {
 			createdDeployment := &appsv1.Deployment{}
 
 			ginkgo.By("Remove queue label", func() {
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
 				delete(createdDeployment.Labels, constants.QueueLabel)
-				gomega.Expect(k8sClient.Update(ctx, createdDeployment)).To(testing.BeForbiddenError())
+				gomega.Expect(k8sClient.Update(ctx, createdDeployment)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("Check that queue label not deleted from pod template spec", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+					g.Expect(createdDeployment.Spec.Template.Labels).Should(gomega.HaveKey(constants.QueueLabel))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("shouldn't allow to change the queue name (ReadyReplicas > 0)", func() {
+			createdDeployment := &appsv1.Deployment{}
+
+			ginkgo.By("Update deployment status", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+					createdDeployment.Status.Replicas = 1
+					createdDeployment.Status.ReadyReplicas = 1
+					g.Expect(k8sClient.Status().Update(ctx, createdDeployment)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Try to update", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+					deploymentWrapper := &testingdeployment.DeploymentWrapper{Deployment: *createdDeployment}
+					updatedDeployment := deploymentWrapper.Queue("another-queue").Obj()
+					g.Expect(k8sClient.Update(ctx, updatedDeployment)).To(testing.BeForbiddenError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Check queue name is injected to pod template label", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+					g.Expect(createdDeployment.Spec.Template.Labels[constants.QueueLabel]).
+						To(
+							gomega.Equal("user-queue"),
+							"Queue name should be injected to pod template labels",
+						)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 	})
@@ -131,7 +182,7 @@ var _ = ginkgo.Describe("Deployment Webhook", func() {
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("should not allow to introduce the queue name, as it was not existent", func() {
+		ginkgo.It("should allow to change the queue name", func() {
 			createdDeployment := &appsv1.Deployment{}
 
 			ginkgo.By("Change queue name", func() {
@@ -139,7 +190,18 @@ var _ = ginkgo.Describe("Deployment Webhook", func() {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
 					deploymentWrapper := &testingdeployment.DeploymentWrapper{Deployment: *createdDeployment}
 					updatedDeployment := deploymentWrapper.Queue("user-queue").Obj()
-					g.Expect(k8sClient.Update(ctx, updatedDeployment)).To(testing.BeForbiddenError())
+					g.Expect(k8sClient.Update(ctx, updatedDeployment)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Check queue name is injected to pod template label", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+					g.Expect(createdDeployment.Spec.Template.Labels[constants.QueueLabel]).
+						To(
+							gomega.Equal("user-queue"),
+							"Queue name should be injected to pod template labels",
+						)
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Allow mutating queue name in Deployment Webhook.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3552

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Allow mutating the queue-name label for non-running Deployments.
```