### PR TITLE
Prioritize Workload which fits in its CQ's Nominal Capacity

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -372,6 +372,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
+				Borrowing: true,
 				Usage: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}:    3_000,
 					{Flavor: "two", Resource: corev1.ResourceMemory}: 10 * utiltesting.Mi,
@@ -885,6 +886,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
+				Borrowing: true,
 				Usage: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
 				},
@@ -966,6 +968,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
+				Borrowing: true,
 				Usage: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
 				},
@@ -1816,6 +1819,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
+				Borrowing: true,
 				Usage: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}:  9_000,
 					{Flavor: "one", Resource: corev1.ResourcePods}: 1,

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -1801,9 +1801,10 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				g.Expect(k8sClient.Update(ctx, &cq)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			// pendingWl exceed nominal+borrowing quota and cannot preempt due to low priority.
+			// pendingWl exceed nominal+borrowing quota and cannot preempt as priority based
+			// premption within CQ is disabled.
 			pendingWl := testing.MakeWorkload("pending-wl", matchingNS.Name).Queue(strictFIFOLocalQueue.
-				Name).Request(corev1.ResourceCPU, "3").Priority(9).Obj()
+				Name).Request(corev1.ResourceCPU, "3").Priority(99).Obj()
 			gomega.Expect(k8sClient.Create(ctx, pendingWl)).Should(gomega.Succeed())
 
 			// borrowingWL can borrow shared resources, so it should be scheduled even if workloads


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We fix the calculation of borrowing in FlavorAssignment for `Preemption` fit mode. Now, it matches how we calculate borrowing for `Fit` mode. This ensures that a workload which fits within its CQ's nominal capacity is sorted before an earlier created workload which pushes its CQ over nominal capacity. This sorting is important as this borrowing workload may invalidate the non-borrowing workload's preemption calculations

#### Which issue(s) this PR fixes:
Fixes #3405

#### Special notes for your reviewer:
We tweak an integ test which relied on details of FlavorAssigner's borrowing calculations for ordering. By updating the priority of `pendingWl`, we ensure that it reservers resources and prevents  `blockedWl` from scheduling.

#### Does this PR introduce a user-facing change?
```release-note
Determine borrowing more accurately, allowing preempting workloads which fit in nominal quota to schedule faster
```