### PR TITLE
Add Deployment e2e test.

### DIFF
--- a/pkg/util/testingjobs/deployment/wrappers.go
+++ b/pkg/util/testingjobs/deployment/wrappers.go
@@ -21,6 +21,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
@@ -87,6 +88,28 @@ func (d *DeploymentWrapper) Queue(q string) *DeploymentWrapper {
 // Name updated the name of the Deployment
 func (d *DeploymentWrapper) Name(n string) *DeploymentWrapper {
 	d.ObjectMeta.Name = n
+	return d
+}
+
+// Image sets an image to the default container.
+func (d *DeploymentWrapper) Image(image string, args []string) *DeploymentWrapper {
+	d.Spec.Template.Spec.Containers[0].Image = image
+	d.Spec.Template.Spec.Containers[0].Args = args
+	return d
+}
+
+// Request adds a resource request to the default container.
+func (d *DeploymentWrapper) Request(r corev1.ResourceName, v string) *DeploymentWrapper {
+	if d.Spec.Template.Spec.Containers[0].Resources.Requests == nil {
+		d.Spec.Template.Spec.Containers[0].Resources.Requests = corev1.ResourceList{}
+	}
+	d.Spec.Template.Spec.Containers[0].Resources.Requests[r] = resource.MustParse(v)
+	return d
+}
+
+// Replicas updated the replicas of the Deployment
+func (d *DeploymentWrapper) Replicas(replicas int32) *DeploymentWrapper {
+	d.Spec.Replicas = &replicas
 	return d
 }
 

--- a/test/e2e/config/common/controller_manager_config.yaml
+++ b/test/e2e/config/common/controller_manager_config.yaml
@@ -27,4 +27,5 @@ integrations:
   - "kubeflow.org/tfjob"
   - "kubeflow.org/xgboostjob"
   - "pod"
+  - "deployment"
   - "statefulset"

--- a/test/e2e/singlecluster/deployment_test.go
+++ b/test/e2e/singlecluster/deployment_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
+	"sigs.k8s.io/kueue/pkg/util/testing"
+	deploymenttesting "sigs.k8s.io/kueue/pkg/util/testingjobs/deployment"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("Deployment", func() {
+	const (
+		resourceFlavorName = "deployment-rf"
+		clusterQueueName   = "deployment-cq"
+		localQueueName     = "deployment-lq"
+	)
+
+	var (
+		ns *corev1.Namespace
+		rf *kueue.ResourceFlavor
+		cq *kueue.ClusterQueue
+		lq *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "deployment-e2e-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+		rf = testing.MakeResourceFlavor(resourceFlavorName).
+			NodeLabel("instance-type", "on-demand").
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, rf)).To(gomega.Succeed())
+
+		cq = testing.MakeClusterQueue(clusterQueueName).
+			ResourceGroup(
+				*testing.MakeFlavorQuotas(resourceFlavorName).
+					Resource(corev1.ResourceCPU, "5").
+					Obj(),
+			).
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+			}).
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, cq)).To(gomega.Succeed())
+
+		lq = testing.MakeLocalQueue(localQueueName, ns.Name).ClusterQueue(cq.Name).Obj()
+		gomega.Expect(k8sClient.Create(ctx, lq)).To(gomega.Succeed())
+	})
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, rf, true)
+	})
+
+	ginkgo.It("should admit workloads that fits", func() {
+		deployment := deploymenttesting.MakeDeployment("deployment", ns.Name).
+			Image(util.E2eTestSleepImage, []string{"10m"}).
+			Request(corev1.ResourceCPU, "100m").
+			Replicas(3).
+			Queue(lq.Name).
+			Obj()
+
+		ginkgo.By("Create a deployment", func() {
+			gomega.Expect(k8sClient.Create(ctx, deployment)).To(gomega.Succeed())
+		})
+
+		ginkgo.By("Wait for replicas ready", func() {
+			createdDeployment := &appsv1.Deployment{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).To(gomega.Succeed())
+				g.Expect(createdDeployment.Status.ReadyReplicas).To(gomega.Equal(int32(3)))
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		pods := &corev1.PodList{}
+		gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Namespace),
+			client.MatchingLabels(deployment.Spec.Selector.MatchLabels))).To(gomega.Succeed())
+
+		createdWorkloads := make([]*kueue.Workload, 0, len(pods.Items))
+		ginkgo.By("Check that workloads are created and admitted", func() {
+			for _, p := range pods.Items {
+				createdWorkload := &kueue.Workload{}
+				wlLookupKey := types.NamespacedName{
+					Name:      pod.GetWorkloadNameForPod(p.Name, p.UID),
+					Namespace: p.Namespace,
+				}
+				gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				gomega.Expect(createdWorkload.Status.Conditions).To(testing.HaveConditionStatusTrue(kueue.WorkloadAdmitted))
+				createdWorkloads = append(createdWorkloads, createdWorkload)
+			}
+		})
+
+		ginkgo.By("Delete the deployment", func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, deployment, true)
+		})
+
+		ginkgo.By("Check that workloads are deleted", func() {
+			for _, wl := range createdWorkloads {
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, wl, false, util.LongTimeout)
+			}
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add Deployment e2e test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Prepare for #3528

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```