### PR TITLE
Optimize and extend deployment integration tests.

### DIFF
--- a/test/integration/webhook/jobs/deployment_webhook_test.go
+++ b/test/integration/webhook/jobs/deployment_webhook_test.go
@@ -22,111 +22,124 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	"sigs.k8s.io/kueue/pkg/controller/jobs/deployment"
+	deploymentcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/deployment"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
+	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingdeployment "sigs.k8s.io/kueue/pkg/util/testingjobs/deployment"
 	"sigs.k8s.io/kueue/test/util"
 )
 
 var _ = ginkgo.Describe("Deployment Webhook", func() {
-	var ns *corev1.Namespace
-	ginkgo.When("with pod integration enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-		ginkgo.BeforeAll(func() {
-			discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			serverVersionFetcher = kubeversion.NewServerVersionFetcher(discoveryClient)
-			err = serverVersionFetcher.FetchServerVersion()
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	var (
+		ns         *corev1.Namespace
+		deployment *appsv1.Deployment
+	)
 
-			fwk.StartManager(ctx, cfg, managerSetup(
-				deployment.SetupWebhook,
-				jobframework.WithManageJobsWithoutQueueName(false),
-				jobframework.WithKubeServerVersion(serverVersionFetcher),
-			))
-		})
+	ginkgo.BeforeEach(func() {
+		discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		serverVersionFetcher = kubeversion.NewServerVersionFetcher(discoveryClient)
+		err = serverVersionFetcher.FetchServerVersion()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		fwk.StartManager(ctx, cfg, managerSetup(
+			deploymentcontroller.SetupWebhook,
+			jobframework.WithKubeServerVersion(serverVersionFetcher),
+		))
+
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "deployment-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+	})
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.When("the queue-name label is set", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 		ginkgo.BeforeEach(func() {
-			ns = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "deployment-",
-				},
-			}
-			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
-		})
-
-		ginkgo.AfterEach(func() {
-			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-		})
-		ginkgo.AfterAll(func() {
-			fwk.StopManager(ctx)
-		})
-
-		ginkgo.When("The queue-name label is set", func() {
-			var (
-				deployment *appsv1.Deployment
-				lookupKey  types.NamespacedName
-			)
-
-			ginkgo.BeforeEach(func() {
-				deployment = testingdeployment.MakeDeployment("deployment-with-queue-name", ns.Name).
+			ginkgo.By("Create deployment", func() {
+				deployment = testingdeployment.MakeDeployment("deployment", ns.Name).
 					Queue("user-queue").
 					Obj()
-				lookupKey = client.ObjectKeyFromObject(deployment)
-			})
-
-			ginkgo.It("Should inject queue name to pod template labels", func() {
 				gomega.Expect(k8sClient.Create(ctx, deployment)).Should(gomega.Succeed())
-
-				gomega.Eventually(func(g gomega.Gomega) {
-					createdDeployment := &appsv1.Deployment{}
-					g.Expect(k8sClient.Get(ctx, lookupKey, createdDeployment)).Should(gomega.Succeed())
-					g.Expect(createdDeployment.Spec.Template.Labels[constants.QueueLabel]).
-						To(
-							gomega.Equal("user-queue"),
-							"Queue name should be injected to pod template labels",
-						)
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-				ginkgo.By("Updating the deployment should not allow to change the queue name", func() {
-					deploymentToUpdate := &appsv1.Deployment{}
-					gomega.Expect(k8sClient.Get(ctx, lookupKey, deploymentToUpdate)).Should(gomega.Succeed())
-					deploymentWrapper := &testingdeployment.DeploymentWrapper{
-						Deployment: *deploymentToUpdate,
-					}
-					updatedDeployment := deploymentWrapper.Queue("another-queue").Obj()
-					gomega.Expect(k8sClient.Update(ctx, updatedDeployment)).To(gomega.HaveOccurred())
-				})
 			})
 		})
 
-		ginkgo.When("The queue-name label is not set", func() {
-			var (
-				deployment *appsv1.Deployment
-				lookupKey  types.NamespacedName
-			)
+		ginkgo.It("should inject queue name to pod template labels", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdDeployment := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+				g.Expect(createdDeployment.Spec.Template.Labels[constants.QueueLabel]).
+					To(
+						gomega.Equal("user-queue"),
+						"Queue name should be injected to pod template labels",
+					)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
 
-			ginkgo.BeforeEach(func() {
-				deployment = testingdeployment.MakeDeployment("deployment-without-queue-name", ns.Name).
-					Obj()
-				lookupKey = client.ObjectKeyFromObject(deployment)
-			})
+		ginkgo.It("should allow to change the queue", func() {
+			createdDeployment := &appsv1.Deployment{}
 
-			ginkgo.It("Should not inject queue name to pod template labels", func() {
-				gomega.Expect(k8sClient.Create(ctx, deployment)).Should(gomega.Succeed())
-
+			ginkgo.By("Change queue name", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
-					createdDeployment := &appsv1.Deployment{}
-					g.Expect(k8sClient.Get(ctx, lookupKey, createdDeployment)).Should(gomega.Succeed())
-					g.Expect(createdDeployment.Spec.Template.Labels[constants.QueueLabel]).
-						To(
-							gomega.BeEmpty(),
-							"Queue name should not be injected to pod template labels",
-						)
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+					deploymentWrapper := &testingdeployment.DeploymentWrapper{Deployment: *createdDeployment}
+					updatedDeployment := deploymentWrapper.Queue("another-queue").Obj()
+					g.Expect(k8sClient.Update(ctx, updatedDeployment)).To(testing.BeForbiddenError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should not allow to remove the queue label", func() {
+			createdDeployment := &appsv1.Deployment{}
+
+			ginkgo.By("Remove queue label", func() {
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+				delete(createdDeployment.Labels, constants.QueueLabel)
+				gomega.Expect(k8sClient.Update(ctx, createdDeployment)).To(testing.BeForbiddenError())
+			})
+		})
+	})
+
+	ginkgo.When("the queue-name label is not set", func() {
+		ginkgo.BeforeEach(func() {
+			ginkgo.By("Create deployment", func() {
+				deployment = testingdeployment.MakeDeployment("deployment", ns.Name).Obj()
+				gomega.Expect(k8sClient.Create(ctx, deployment)).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should not inject queue name to pod template labels", func() {
+			createdDeployment := &appsv1.Deployment{}
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+				g.Expect(createdDeployment.Spec.Template.Labels[constants.QueueLabel]).
+					To(
+						gomega.BeEmpty(),
+						"Queue name should not be injected to pod template labels",
+					)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("should not allow to change the queue name", func() {
+			createdDeployment := &appsv1.Deployment{}
+
+			ginkgo.By("Change queue name", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+					deploymentWrapper := &testingdeployment.DeploymentWrapper{Deployment: *createdDeployment}
+					updatedDeployment := deploymentWrapper.Queue("user-queue").Obj()
+					g.Expect(k8sClient.Update(ctx, updatedDeployment)).To(testing.BeForbiddenError())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})

--- a/test/integration/webhook/jobs/deployment_webhook_test.go
+++ b/test/integration/webhook/jobs/deployment_webhook_test.go
@@ -131,7 +131,7 @@ var _ = ginkgo.Describe("Deployment Webhook", func() {
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("should not allow to change the queue name", func() {
+		ginkgo.It("should not allow to introduce the queue name, as it was not existent", func() {
 			createdDeployment := &appsv1.Deployment{}
 
 			ginkgo.By("Change queue name", func() {


### PR DESCRIPTION
Fix manageJobsWithoutQueueName on Deployment.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Optimize and extend deployment integration tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Prepare for #3528

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```