### PR TITLE
TAS: fix scenario when parallelism < completions

### DIFF
--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -262,9 +262,9 @@ func (r *topologyUngater) podsForPodSet(ctx context.Context, ns, wlName, psName 
 	}
 	result := make([]*corev1.Pod, 0, len(pods.Items))
 	for i := range pods.Items {
-		if pods.Items[i].Status.Phase == corev1.PodFailed {
-			// ignore failed pods as they need to be replaced, and so we don't
-			// want to count them as already ungated Pods.
+		if phase := pods.Items[i].Status.Phase; phase == corev1.PodFailed || phase == corev1.PodSucceeded {
+			// ignore failed or succeeded pods as they need to be replaced, and
+			// so we don't want to count them as already ungated Pods.
 			continue
 		}
 		result = append(result, &pods.Items[i])

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -87,7 +87,7 @@ func TestReconcile(t *testing.T) {
 			if utilpod.HasGate(&pod, kueuealpha.TopologySchedulingGate) {
 				continue
 			}
-			if pod.Status.Phase == corev1.PodFailed {
+			if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
 				continue
 			}
 			key := mapToJSON(t, pod.Spec.NodeSelector)
@@ -744,7 +744,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
-		"expect single pod; one ungated pod succeeded - don't ungate second pod": {
+		"expect single pod; one ungated pod succeeded - ungate second pod": {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
@@ -794,7 +794,6 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
-					TopologySchedulingGate().
 					Obj(),
 			},
 			wantCounts: []counts{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Part of #3450 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix running Job when parallelism < completions, before the fix the replacement pods for the successfully
completed Pods were not ungated.
```