### PR TITLE
TAS: Clean up TAS flavor snapshot

### DIFF
--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -193,6 +193,190 @@ func TestFindTopologyAssignment(t *testing.T) {
 		tasHostLabel,
 	}
 
+	//           b1                    b2
+	//       /        \             /      \
+	//      r1         r2          r1       r2
+	//     /  \      /   \        /   \    /   \
+	//    x1   x2   x3    x4     x5   x6  x7    x6
+	binaryTreesNodes := []corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b1-r1-x1",
+				Labels: map[string]string{
+					tasBlockLabel: "b1",
+					tasRackLabel:  "r1",
+					tasHostLabel:  "x1",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b1-r1-x2",
+				Labels: map[string]string{
+					tasBlockLabel: "b1",
+					tasRackLabel:  "r1",
+					tasHostLabel:  "x2",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b1-r2-x3",
+				Labels: map[string]string{
+					tasBlockLabel: "b1",
+					tasRackLabel:  "r2",
+					tasHostLabel:  "x3",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b1-r2-x4",
+				Labels: map[string]string{
+					tasBlockLabel: "b1",
+					tasRackLabel:  "r2",
+					tasHostLabel:  "x4",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b2-r1-x5",
+				Labels: map[string]string{
+					tasBlockLabel: "b2",
+					tasRackLabel:  "r1",
+					tasHostLabel:  "x5",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b2-r1-x6",
+				Labels: map[string]string{
+					tasBlockLabel: "b2",
+					tasRackLabel:  "r1",
+					tasHostLabel:  "x6",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b2-r2-x7",
+				Labels: map[string]string{
+					tasBlockLabel: "b2",
+					tasRackLabel:  "r2",
+					tasHostLabel:  "x7",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "b2-r2-x8",
+				Labels: map[string]string{
+					tasBlockLabel: "b2",
+					tasRackLabel:  "r2",
+					tasHostLabel:  "x8",
+				},
+			},
+			Status: corev1.NodeStatus{
+				Allocatable: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+	}
+
 	cases := map[string]struct {
 		request        kueue.PodSetTopologyRequest
 		levels         []string
@@ -383,6 +567,54 @@ func TestFindTopologyAssignment(t *testing.T) {
 							"b1",
 							"r3",
 							"x6",
+						},
+					},
+				},
+			},
+		},
+		"binaryTrees" : {
+			nodes: binaryTreesNodes,
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasBlockLabel),
+			},
+			levels: defaultThreeLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 4,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultThreeLevels,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r1",
+							"x1",
+						},
+					},
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r1",
+							"x2",
+						},
+					},
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r2",
+							"x3",
+						},
+					},
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r2",
+							"x4",
 						},
 					},
 				},
@@ -1097,6 +1329,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 		},
 	}
 	for name, tc := range cases {
+		if name != "binaryTrees" {
+			continue
+		}
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 

--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -41,6 +41,11 @@ func TestFindTopologyAssignment(t *testing.T) {
 		tasHostLabel  = "kubernetes.io/hostname"
 	)
 
+	//      b1                   b2
+	//   /      \             /      \
+	//  r1       r2          r1       r2
+	//  |      /  |  \       |         |
+	//  x1    x2  x3  x4     x5       x6
 	defaultNodes := []corev1.Node{
 		{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -572,7 +572,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 				},
 			},
 		},
-		"binaryTrees" : {
+		"block required; 4 pods fit into one host each": {
 			nodes: binaryTreesNodes,
 			request: kueue.PodSetTopologyRequest{
 				Required: ptr.To(tasBlockLabel),
@@ -1329,9 +1329,6 @@ func TestFindTopologyAssignment(t *testing.T) {
 		},
 	}
 	for name, tc := range cases {
-		if name != "binaryTrees" {
-			continue
-		}
 		t.Run(name, func(t *testing.T) {
 			ctx := context.Background()
 

--- a/pkg/cache/tas_flavor.go
+++ b/pkg/cache/tas_flavor.go
@@ -117,8 +117,7 @@ func (c *TASFlavorCache) snapshotForNodes(log logr.Logger, nodes []corev1.Node, 
 		levelValues := utiltas.LevelValues(c.Levels, node.Labels)
 		capacity := resources.NewRequests(node.Status.Allocatable)
 		domainID := utiltas.DomainID(levelValues)
-		snapshot.levelValuesPerDomain[domainID] = levelValues
-		snapshot.addCapacity(domainID, capacity)
+		snapshot.addNode(levelValues, capacity, domainID)
 		nodeToDomain[node.Name] = domainID
 	}
 	snapshot.initialize()

--- a/pkg/cache/tas_flavor.go
+++ b/pkg/cache/tas_flavor.go
@@ -117,7 +117,7 @@ func (c *TASFlavorCache) snapshotForNodes(log logr.Logger, nodes []corev1.Node, 
 		levelValues := utiltas.LevelValues(c.Levels, node.Labels)
 		capacity := resources.NewRequests(node.Status.Allocatable)
 		domainID := utiltas.DomainID(levelValues)
-		snapshot.addNode(levelValues, capacity, domainID)
+		snapshot.addLeafDomain(levelValues, capacity, domainID)
 		nodeToDomain[node.Name] = domainID
 	}
 	snapshot.initialize()

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -156,7 +156,9 @@ func (s *TASFlavorSnapshot) initializeHelper(dom *domain) {
 	// connect parent and child
 	dom.parent = parent
 	parent.children = append(parent.children, dom)
-	s.initializeHelper(parent)
+	if !parentFound {
+		s.initializeHelper(parent)
+	}
 }
 
 func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.Requests) {

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -111,7 +111,7 @@ func newTASFlavorSnapshot(log logr.Logger, topologyName kueue.TopologyReference,
 	return snapshot
 }
 
-func (s *TASFlavorSnapshot) addNode(levelValues []string, capacity resources.Requests, domainID utiltas.TopologyDomainID) {
+func (s *TASFlavorSnapshot) addLeafDomain(levelValues []string, capacity resources.Requests, domainID utiltas.TopologyDomainID) {
 	domain := domain{
 		id:          domainID,
 		levelValues: levelValues,
@@ -152,13 +152,11 @@ func (s *TASFlavorSnapshot) initializeHelper(dom *domain) {
 		}
 		s.domainsPerLevel[len(parentValues)-1][parentID] = parent
 		s.domains[parentID] = parent
+		s.initializeHelper(parent)
 	}
 	// connect parent and child
 	dom.parent = parent
 	parent.children = append(parent.children, dom)
-	if !parentFound {
-		s.initializeHelper(parent)
-	}
 }
 
 func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.Requests) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Optimizes memory used by `TASFlavorSnapshot` by deleting fields: sortName, childIDs, parentIDs
- Improves code clarity by moving fields which where previously 'perDomain' to the actual domain object


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3522 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```