### PR TITLE
KEP 3589: Uniformly filter manageJobsWithoutQueueNames by namespace

### DIFF
--- a/keps/3589-manage-jobs-selectively/README.md
+++ b/keps/3589-manage-jobs-selectively/README.md
@@ -184,9 +184,10 @@ However, while exploring this idea further a complication arose. The ValidatingA
 must be able to distinguish between top-level resources without queue names (which should be denied)
 and child resources that are owned by Kueue-managed parents (which must be admitted even if they do not have a queue name).
 In other words, the VAP must implement the same functionality as `jobframework.IsOwnerManagedByKueue`
-and cross check controller-references against managed kinds.  This approach may be challenging to scale
-as the number of Kueue managed kinds increases and ancestor trees become deeper.
-For example in the not so distant future we might see: AppWrapper->PyTorchJob->JobSet->Job->Pod.
+and cross check controller-references against managed Kinds.  This approach may be challenging to scale
+as the number of Kueue managed Kinds increases and especially as the possible pairs of parent/child
+relationships grows. We expect JobSets to be adopted as an implementation mechanism by multiple Kueue
+managed Kinds. AppWrappers can be the parent for any Kueue managed Kind.
 
 As a concrete example, here is the simplest possible VAP
 (taken from [MLBatch](https://github.com/project-codeflare/mlbatch/blob/main/setup.k8s-v1.30/admission-policy.yaml))

--- a/keps/3589-manage-jobs-selectively/README.md
+++ b/keps/3589-manage-jobs-selectively/README.md
@@ -187,7 +187,7 @@ In other words, the VAP must implement the same functionality as `jobframework.I
 and cross check controller-references against managed Kinds.  This approach may be challenging to scale
 as the number of Kueue managed Kinds increases and especially as the possible pairs of parent/child
 relationships grows. We expect JobSets to be adopted as an implementation mechanism by multiple Kueue
-managed Kinds. AppWrappers can be the parent for any Kueue managed Kind.
+managed Kinds. AppWrappers can be the parent for any Kueue managed Kind. RayJobs create child Jobs.
 
 As a concrete example, here is the VAP to enforce user quotas
 used in [MLBatch](https://github.com/project-codeflare/mlbatch/blob/main/setup.k8s-v1.30/admission-policy.yaml)).
@@ -202,9 +202,6 @@ spec:
   failurePolicy: Fail
   matchConstraints:
     resourceRules:
-    - apiGroups:   ["batch"]
-      apiVersions: ["v1"]
-      resources:   ["jobs"]
       operations:  ["CREATE", "UPDATE"]
     - apiGroups:   ["kubeflow.org"]
       apiVersions: ["v1"]

--- a/keps/3589-manage-jobs-selectively/README.md
+++ b/keps/3589-manage-jobs-selectively/README.md
@@ -189,9 +189,10 @@ as the number of Kueue managed Kinds increases and especially as the possible pa
 relationships grows. We expect JobSets to be adopted as an implementation mechanism by multiple Kueue
 managed Kinds. AppWrappers can be the parent for any Kueue managed Kind.
 
-As a concrete example, here is the simplest possible VAP
-(taken from [MLBatch](https://github.com/project-codeflare/mlbatch/blob/main/setup.k8s-v1.30/admission-policy.yaml))
-that only considers `AppWrapper` as a possible Kueue-managed parent Kind.
+As a concrete example, here is the VAP to enforce user quotas
+used in [MLBatch](https://github.com/project-codeflare/mlbatch/blob/main/setup.k8s-v1.30/admission-policy.yaml)).
+It only has to cover the subset of Kueue integrations that MLBatch users are permitted to created (gated by other RBAC rules)
+and therefore only has to consider `AppWrapper` as a possible Kueue-managed parent Kind.
 ```yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy

--- a/keps/3589-manage-jobs-selectively/README.md
+++ b/keps/3589-manage-jobs-selectively/README.md
@@ -90,7 +90,7 @@ Ideally we remove it from the `Configuration` struct as part of going to the `v1
 Cluster admins will be able to use the combination of `managedJobsNamespaceSelector` and
 `manageJobsWithoutQueueName` to configure Kueue to enable quota enforcement on a per namespace basis.
 
-One sapproach would be to exempt selected namespaces from management:
+One approach would be to exempt selected namespaces from management:
 ```yaml
 managedJobsNamespaceSelector:
   matchExpressions:
@@ -109,7 +109,7 @@ managedJobsNamespaceSelector:
 
 ### API
 
-The `Configuration` struct is extended to add ManageAllJobsNamespaceSelector
+The `Configuration` struct is extended to add ManagedJobsNamespaceSelector
 ```go
 type Configuration struct {
 
@@ -124,7 +124,7 @@ type Configuration struct {
 	// unsuspended, they will start immediately.
 	ManageJobsWithoutQueueName bool `json:"manageJobsWithoutQueueName"`
 
-  // ManageAllJobsNamespaceSelector can be used to omit some namespaces from ManageJobsWithoutQueueName
+  // ManagedJobsNamespaceSelector can be used to omit some namespaces from ManagedJobsWithoutQueueName
 	ManagedJobsNamespaceSelector *metav1.LabelSelector `json:"managedJobsNamespaceSelector,omitempty"`
 
   ...

--- a/keps/3589-manage-jobs-selectively/README.md
+++ b/keps/3589-manage-jobs-selectively/README.md
@@ -1,4 +1,4 @@
-# KEP-3589: Uniform namespace-based controls for all integrations
+# KEP-3589: Uniformly filter manageJobsWithoutQueueNames by namespace
 
 <!-- toc -->
 - [Summary](#summary)

--- a/keps/3589-manage-jobs-selectively/README.md
+++ b/keps/3589-manage-jobs-selectively/README.md
@@ -1,0 +1,149 @@
+# KEP-3589: Uniformly filter manageJobsWithoutQueueName by namespace
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories (Optional)](#user-stories-optional)
+    - [Story 1](#story-1)
+- [Design Details](#design-details)
+  - [API](#api)
+  - [Implementation](#implementation)
+  - [Test Plan](#test-plan)
+    - [Unit Tests](#unit-tests)
+    - [Integration tests](#integration-tests)
+  - [Graduation Criteria](#graduation-criteria)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Summary
+
+This KEP adds an optional field to the Kueue `Configuration` struct that enables
+the effect of `manageJobsWithoutQueueName` to be controlled on a per-namespace
+basis for all Kueue integrations.
+
+-->
+
+## Motivation
+
+Kueue already allows per-namespace control of `manageJobsWithoutQueueName`
+for the Pod integration via `integrations.podOptions.namespaceSelector`.
+The effect of `manageJobsWithoutQueueName` on the `Deployment` and `StatefulSet`
+integrations in Kueue 0.9 are also indirectly controlled by the same `namespaceSelector`
+because these integrations are built on top of the `Pod` integration.  Just like the
+`Pod` integration, Kueue requires some mechanism for modulating `manageJobsWithoutQueueName`
+for these fundamental types for system namespaces to avoid interrupting normal cluster operations.
+
+No other integrations beyond these three consider the `namespaceSelector` when deciding whether or not to
+suspend jobs that do not have a queue name.  This results in an irregular API and makes it
+harder to configure Kueue such that quotas will be enforced (cannot be bypassed by users).
+The irregularity between `batchv1/Job` and `Deployment` is likely to be especially confusing
+to users and cluster admins who would view both of these types as "built-in" to Kubernetes and
+would expect them to be configured in the same way.
+
+### Goals
+
+Provide a simple and uniform API to enable cluster admins to configure Kueue
+such that quotas will be enforced for specific namespaces.
+
+### Non-Goals
+
+Consider any scope for filtering `manageJobsWithoutQueueName` that is not based on namespaces.
+
+## Proposal
+
+We add a `manageAllJobsNamespaceSelector` of type `*metav1.LabelSelector`
+to the top level of the Kueue `Configuration` struct (same level as `manageJobsWithoutQueueName`).
+(The name of `manageJobsWithoutQueueNameNamespaceSelector` reads poorly, so I propose something else)
+
+We use this new configuration for all integrations in the same way that the current
+`namespaceSelector` is used by the Pod integration.
+
+We migrate away from using `podOptions.namespaceSelector` over the course of several releases.
+Ideally we remove it from the `Configuration` struct as part of going to the `v1` API level.
+
+### User Stories (Optional)
+
+#### Story 1
+
+Cluster admins will be able to use `manageAllJobsNamespaceSelector` to easily configure Kueue
+to enable quota enforcement on a per namespace basis.
+
+## Design Details
+
+### API
+
+The `Configuration` struct is extended to add ManageAllJobsNamespaceSelector
+```go
+type Configuration struct {
+
+  ...
+
+	// ManageJobsWithoutQueueName controls whether or not Kueue reconciles
+	// jobs that don't set the label kueue.x-k8s.io/queue-name.
+	// If set to true, then those jobs will be suspended and never started unless
+	// they are assigned a queue and eventually admitted. This also applies to
+	// jobs created before starting the kueue controller.
+	// Defaults to false; therefore, those jobs are not managed and if they are created
+	// unsuspended, they will start immediately.
+	ManageJobsWithoutQueueName bool `json:"manageJobsWithoutQueueName"`
+
+  // ManageAllJobsNamespaceSelector can be used to omit some namespaces from ManageJobsWithoutQueueName
+	ManageAllJobsNamespaceSelector *metav1.LabelSelector `json:"manageAllJobsNamespaceSelector,omitempty"`
+
+  ...
+}
+```
+
+### Implementation
+
+The configuration of all Job webhooks are extended to propagate the label selector and it is
+used to filter manageJobsWithoutQueueNames as is currently done in the Pod integration.
+
+Configuration parsing during startup is extended to give a deprecation notice if `podOptions.namespaceSelector` is set.
+Setting both `podOptions.namespaceSelector` and `manageAllJobsNamespaceSelector` will be flagged as a configuration error.
+
+### Test Plan
+
+[ X ] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+#### Unit Tests
+
+Unit tests for configuration parsing will be added.
+
+All unit tests for the current Pod integration namespaceSelector will be extended across all integrations.
+
+#### Integration tests
+
+All integration tests for the current Pod integration namespaceSelector will be extended across all integrations.
+
+### Graduation Criteria
+
+The feature is implemented as described for all Job integrations.
+
+## Implementation History
+
+## Drawbacks
+
+<!--
+Why should this KEP _not_ be implemented?
+-->
+
+## Alternatives
+
+We could do nothing and simply document that despite its historical placement in
+a subfield of the `Configuration` struct, `podOptions.namespaceSelector` also applies
+to the `StatefulSet` and `Deployment` integrations.
+
+We could phase out `manageJobsWithoutQueueNames` and instead recommend the
+use of ValidatingAdmissionPolicies to ensure that Jobs created in "user" namespaces
+all have a queue name label (and thus will be managed by Kueue). However, for this to
+work the VAP must be able to correctly identify child Jobs that are owned directly
+or indirectly by Kueue-managed Jobs and are thus exempt from the policy.  Since there
+can be multiple levels of such parent-child links, the VAP becomes complex.

--- a/keps/3589-manage-jobs-selectively/kep.yaml
+++ b/keps/3589-manage-jobs-selectively/kep.yaml
@@ -1,0 +1,24 @@
+title: Uniformly filter manageJobsWithoutQueueName by namespace
+kep-number: 3589
+authors:
+  - "@dgrove-oss"
+status: provisional
+creation-date: 2024-11-19
+reviewers:
+  - "@mimowo"
+  - "@tenzen-y"
+approvers:
+  - "@mimowo"
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: beta
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v0.10"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  beta: "v0.10"
+

--- a/keps/3589-manage-jobs-selectively/kep.yaml
+++ b/keps/3589-manage-jobs-selectively/kep.yaml
@@ -1,4 +1,4 @@
-title: Uniformly filter manageJobsWithoutQueueName by namespace
+title: Uniform namespace-based controls for all integrations
 kep-number: 3589
 authors:
   - "@dgrove-oss"
@@ -16,9 +16,12 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.10"
+latest-milestone: "v0.11"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  beta: "v0.10"
+  beta: "v0.11"
 
+feature-gates:
+  - name: ManagedJobsNamespaceSelector
+disable-supported: true

--- a/keps/3589-manage-jobs-selectively/kep.yaml
+++ b/keps/3589-manage-jobs-selectively/kep.yaml
@@ -1,4 +1,4 @@
-title: Uniform namespace-based controls for all integrations
+title: Uniformly filter manageJobsWithoutQueueNames by namespace
 kep-number: 3589
 authors:
   - "@dgrove-oss"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

KEP to propose a design for #3589 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```