### PR TITLE
Automated cherry pick of #3573: Update latest version to v0.9.1

### DIFF
--- a/CHANGELOG/CHANGELOG-0.9.md
+++ b/CHANGELOG/CHANGELOG-0.9.md
@@ -1,3 +1,26 @@
+## v0.9.1
+
+Changes since `v0.9.0`:
+
+## Changes by Kind
+
+### Bug or Regression
+
+- Change, and in some scenarios fix, the status message displayed to user when a workload doesn't fit in available capacity. (#3549, @gabesaba)
+- Determine borrowing more accurately, allowing preempting workloads which fit in nominal quota to schedule faster (#3550, @gabesaba)
+- Fix accounting for usage coming from TAS workloads using multiple resources. The usage was multiplied
+  by the number of resources requested by a workload, which could result in under-utilization of the cluster.
+  It also manifested itself in the message in the workload status which could contain negative numbers. (#3513, @mimowo)
+- Fix computing the topology assignment for workloads using multiple PodSets requesting the same
+  topology. In particular, it was possible for the set of topology domains in the assignment to be empty,
+  and as a consequence the pods would remain gated forever as the TopologyUngater would not have
+  topology assignment information. (#3524, @mimowo)
+- Fix running Job when parallelism < completions, before the fix the replacement pods for the successfully
+  completed Pods were not ungated. (#3561, @mimowo)
+- Fix the flow of deactivation for workloads due to rejected AdmissionChecks.
+  Now, all AdmissionChecks are reset back to the Pending state on eviction (and deactivation in particular),
+  and so an admin can easily re-activate such a workload manually without tweaking the checks. (#3518, @KPostOffice)
+
 ## v0.9.0
 
 Changes since `v0.8.0`:

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ LD_FLAGS += -X '$(version_pkg).GitCommit=$(shell git rev-parse HEAD)'
 
 # Update these variables when preparing a new release or a release branch.
 # Then run `make prepare-release-branch`
-RELEASE_VERSION=v0.9.0
+RELEASE_VERSION=v0.9.1
 RELEASE_BRANCH=main
 
 .PHONY: all

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) to learn more.
 To install the latest release of Kueue in your cluster, run the following command:
 
 ```shell
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.0/manifests.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.1/manifests.yaml
 ```
 
 The controller runs in the `kueue-system` namespace.

--- a/SECURITY-INSIGHTS.yaml
+++ b/SECURITY-INSIGHTS.yaml
@@ -1,11 +1,11 @@
 header:
   schema-version: 1.0.0
   expiration-date: '2024-09-28T01:00:00.000Z'
-  last-updated: '2024-11-05'
-  last-reviewed: '2024-11-05'
-  commit-hash: d3b8af0ffd6f5b8c440b20f9454c2244f59ce5cb
+  last-updated: '2024-11-18'
+  last-reviewed: '2024-11-18'
+  commit-hash: c6c50ba5f479bf666624069c2d74a0960afc6d44
   project-url: 'https://github.com/kubernetes-sigs/kueue'
-  project-release: 0.9.0
+  project-release: 0.9.1
   changelog: 'https://github.com/kubernetes-sigs/kueue/tree/main/CHANGELOG'
   license: 'https://github.com/kubernetes-sigs/kueue/blob/main/LICENSE'
 project-lifecycle:
@@ -28,7 +28,7 @@ documentation:
   - 'https://kueue.sigs.k8s.io/docs/'
 distribution-points:
   - >-
-    https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.0/manifests.yaml
+    https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.1/manifests.yaml
 security-artifacts:
   threat-model:
     threat-model-created: false
@@ -62,5 +62,5 @@ dependencies:
   dependencies-lists:
     - 'https://github.com/kubernetes-sigs/kueue/blob/main/go.mod'
   sbom:
-    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.0/kueue-v0.9.0.spdx.json
+    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.1/kueue-v0.9.1.spdx.json
       sbom-format: SPDX

--- a/charts/kueue/Chart.yaml
+++ b/charts/kueue/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.9.0"
+appVersion: "v0.9.1"

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -90,7 +90,7 @@ ignoreFiles = []
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
   # version number for this doc set.
-  version = "v0.9.0"
+  version = "v0.9.1"
 
   # Flag used in the "version-banner" partial to decide whether to display a
   # banner on every page indicating that this is an archived version of the docs.


### PR DESCRIPTION
Cherry pick of #3573 on website.

#3573: Update latest version to v0.9.1

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```