### PR TITLE
Added Log output for LocalQueue and ClusterQueue

### DIFF
--- a/pkg/controller/core/clusterqueue_controller_test.go
+++ b/pkg/controller/core/clusterqueue_controller_test.go
@@ -229,7 +229,9 @@ func TestUpdateCqStatusIfChanged(t *testing.T) {
 				qManager: qManager,
 			}
 			if tc.newWl != nil {
-				r.qManager.AddOrUpdateWorkload(tc.newWl)
+				if err := r.qManager.AddOrUpdateWorkload(tc.newWl); err != nil {
+					t.Fatalf("Failed to add or update workload : %v", err)
+				}
 			}
 			gotError := r.updateCqStatusIfChanged(ctx, cq, tc.newConditionStatus, tc.newReason, tc.newMessage)
 			if diff := cmp.Diff(tc.wantError, gotError, cmpopts.EquateErrors()); len(diff) != 0 {

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -601,7 +601,7 @@ func (r *WorkloadReconciler) Create(e event.CreateEvent) bool {
 	if !workload.HasQuotaReservation(wl) {
 		err := r.queues.AddOrUpdateWorkload(wlCopy)
 		if err != nil {
-			log.V(2).Info(err.Error())
+			log.V(2).Info(fmt.Sprintf("%s; ignored for now", err))
 		}
 		return true
 	}
@@ -706,7 +706,7 @@ func (r *WorkloadReconciler) Update(e event.UpdateEvent) bool {
 	case prevStatus == workload.StatusPending && status == workload.StatusPending:
 		err := r.queues.UpdateWorkload(oldWl, wlCopy)
 		if err != nil {
-			log.V(2).Info(err.Error())
+			log.V(2).Info(fmt.Sprintf("%s; ignored for now", err))
 		}
 	case prevStatus == workload.StatusPending && (status == workload.StatusQuotaReserved || status == workload.StatusAdmitted):
 		r.queues.DeleteWorkload(oldWl)
@@ -732,7 +732,7 @@ func (r *WorkloadReconciler) Update(e event.UpdateEvent) bool {
 			if immediate {
 				err := r.queues.AddOrUpdateWorkloadWithoutLock(wlCopy)
 				if err != nil {
-					log.V(2).Info(err.Error())
+					log.V(2).Info(fmt.Sprintf("%s; ignored for now", err))
 				}
 			}
 		})
@@ -745,7 +745,7 @@ func (r *WorkloadReconciler) Update(e event.UpdateEvent) bool {
 				if err == nil && workload.Status(&updatedWl) == workload.StatusPending {
 					err := r.queues.AddOrUpdateWorkload(wlCopy)
 					if err != nil {
-						log.V(2).Info(err.Error())
+						log.V(2).Info(fmt.Sprintf("%s; ignored for now", err))
 					} else {
 						log.V(3).Info("Workload requeued after backoff")
 					}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -730,7 +730,6 @@ func (r *WorkloadReconciler) Update(e event.UpdateEvent) bool {
 			// function.
 			if immediate {
 				if !r.queues.AddOrUpdateWorkloadWithoutLock(wlCopy) {
-					log.V(2).Info("LocalQueue for workload didn't exist or not active; ignored for now")
 				}
 			}
 		})

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -730,6 +730,7 @@ func (r *WorkloadReconciler) Update(e event.UpdateEvent) bool {
 			// function.
 			if immediate {
 				if !r.queues.AddOrUpdateWorkloadWithoutLock(wlCopy) {
+					log.V(2).Info("Workload could not be added or updated; ignoring for now", "workload", wlCopy.Name)
 				}
 			}
 		})

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -330,14 +329,14 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(w *kueue.Workload) bool {
 	qKey := workload.QueueKey(w)
 	q := m.localQueues[qKey]
 	if q == nil {
-		log.Printf("LocalQueue for workload not found; queueKey: %s, workload: %s", qKey, w.Name)
+		fmt.Println("LocalQueue for workload not found")
 		return false
 	}
 	wInfo := workload.NewInfo(w, m.workloadInfoOptions...)
 	q.AddOrUpdate(wInfo)
 	cq := m.hm.ClusterQueues[q.ClusterQueue]
 	if cq == nil {
-		log.Printf("ClusterQueue for workload not found; clusterQueue: %s, workload: %s", q.ClusterQueue, w.Name)
+		fmt.Print("ClusterQueue for workload not found")
 		return false
 	}
 	cq.PushOrUpdate(wInfo)

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -329,12 +330,14 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(w *kueue.Workload) bool {
 	qKey := workload.QueueKey(w)
 	q := m.localQueues[qKey]
 	if q == nil {
+		log.Printf("LocalQueue for workload not found; queueKey: %s, workload: %s", qKey, w.Name)
 		return false
 	}
 	wInfo := workload.NewInfo(w, m.workloadInfoOptions...)
 	q.AddOrUpdate(wInfo)
 	cq := m.hm.ClusterQueues[q.ClusterQueue]
 	if cq == nil {
+		log.Printf("ClusterQueue for workload not found; clusterQueue: %s, workload: %s", q.ClusterQueue, w.Name)
 		return false
 	}
 	cq.PushOrUpdate(wInfo)

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -336,7 +336,7 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(w *kueue.Workload) bool {
 	q.AddOrUpdate(wInfo)
 	cq := m.hm.ClusterQueues[q.ClusterQueue]
 	if cq == nil {
-		fmt.Print("ClusterQueue for workload not found")
+		fmt.Println("ClusterQueue for workload not found")
 		return false
 	}
 	cq.PushOrUpdate(wInfo)

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -335,7 +335,7 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(w *kueue.Workload) error {
 	q.AddOrUpdate(wInfo)
 	cq := m.hm.ClusterQueues[q.ClusterQueue]
 	if cq == nil {
-		return errClusterQueueAlreadyExists
+		return ErrClusterQueueDoesNotExist
 	}
 	cq.PushOrUpdate(wInfo)
 	m.reportPendingWorkloads(q.ClusterQueue, cq)

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -346,7 +346,10 @@ func TestUpdateLocalQueue(t *testing.T) {
 		}
 	}
 	for _, w := range workloads {
-		manager.AddOrUpdateWorkload(w)
+		//manager.AddOrUpdateWorkload(w)
+		if err := manager.AddOrUpdateWorkload(w); err != nil {
+			t.Errorf("Failed to add or update workload: %v", err)
+		}
 	}
 
 	// Update cluster queue of first queue.
@@ -531,7 +534,7 @@ func TestStatus(t *testing.T) {
 		}
 	}
 	for _, wl := range workloads {
-		manager.AddOrUpdateWorkload(&wl)
+		_ = manager.AddOrUpdateWorkload(&wl)
 	}
 
 	cases := map[string]struct {
@@ -805,7 +808,7 @@ func TestUpdateWorkload(t *testing.T) {
 				}
 			}
 			for _, w := range tc.workloads {
-				manager.AddOrUpdateWorkload(w)
+				_ = manager.AddOrUpdateWorkload(w)
 			}
 			wl := tc.workloads[0].DeepCopy()
 			tc.update(wl)
@@ -923,7 +926,9 @@ func TestHeads(t *testing.T) {
 
 			go manager.CleanUpOnContext(ctx)
 			for _, wl := range tc.workloads {
-				manager.AddOrUpdateWorkload(wl)
+				if err := manager.AddOrUpdateWorkload(wl); err != nil {
+					t.Errorf("Failed to add or update workload: %v", err)
+				}
 			}
 
 			wlNames := sets.New[string]()
@@ -978,13 +983,15 @@ func TestHeadsAsync(t *testing.T) {
 		"AddClusterQueue": {
 			initialObjs: []client.Object{&wl, &queues[0]},
 			op: func(ctx context.Context, mgr *Manager) {
+				if err := mgr.AddClusterQueue(ctx, clusterQueues[0]); err != nil {
+					t.Errorf("Failed adding clusterQueue: %v", err)
+				}
 				if err := mgr.AddLocalQueue(ctx, &queues[0]); err != nil {
 					t.Errorf("Failed adding queue: %s", err)
 				}
-				mgr.AddOrUpdateWorkload(&wl)
 				go func() {
-					if err := mgr.AddClusterQueue(ctx, clusterQueues[0]); err != nil {
-						t.Errorf("Failed adding clusterQueue: %v", err)
+					if err := mgr.AddOrUpdateWorkload(&wl); err != nil {
+						t.Errorf("Failed to add or update workload: %v", err)
 					}
 				}()
 			},
@@ -1023,7 +1030,9 @@ func TestHeadsAsync(t *testing.T) {
 					t.Errorf("Failed adding queue: %s", err)
 				}
 				go func() {
-					mgr.AddOrUpdateWorkload(&wl)
+					if err := mgr.AddOrUpdateWorkload(&wl); err != nil {
+						t.Errorf("Failed to add or update workload: %v", err)
+					}
 				}()
 			},
 			wantHeads: []workload.Info{
@@ -1044,7 +1053,9 @@ func TestHeadsAsync(t *testing.T) {
 				go func() {
 					wlCopy := wl.DeepCopy()
 					wlCopy.ResourceVersion = "old"
-					mgr.UpdateWorkload(wlCopy, &wl)
+					if err := mgr.UpdateWorkload(wlCopy, &wl); err != nil {
+						t.Errorf("Failed to add or update workload: %v", err)
+					}
 				}()
 			},
 			wantHeads: []workload.Info{
@@ -1224,7 +1235,9 @@ func TestGetPendingWorkloadsInfo(t *testing.T) {
 		}
 	}
 	for _, w := range workloads {
-		manager.AddOrUpdateWorkload(w)
+		if err := manager.AddOrUpdateWorkload(w); err != nil {
+			t.Errorf("Failed to add or update workload: %v", err)
+		}
 	}
 
 	cases := map[string]struct {

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -465,7 +465,7 @@ func TestAddWorkload(t *testing.T) {
 		t.Run(tc.workload.Name, func(t *testing.T) {
 			err := manager.AddOrUpdateWorkload(tc.workload)
 			if err != nil && err.Error() != tc.wantErr {
-				t.Fatalf("AddWorkload = %v, wantErr = %v", err, tc.wantErr)
+				t.Fatalf("AddWorkload returned %v, want %v", err, tc.wantErr)
 			}
 		})
 	}

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -346,7 +346,6 @@ func TestUpdateLocalQueue(t *testing.T) {
 		}
 	}
 	for _, w := range workloads {
-		//manager.AddOrUpdateWorkload(w)
 		if err := manager.AddOrUpdateWorkload(w); err != nil {
 			t.Errorf("Failed to add or update workload: %v", err)
 		}

--- a/pkg/visibility/api/v1beta1/pending_workloads_cq_test.go
+++ b/pkg/visibility/api/v1beta1/pending_workloads_cq_test.go
@@ -338,7 +338,9 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 				}
 			}
 			for _, w := range tc.workloads {
-				manager.AddOrUpdateWorkload(w)
+				if err := manager.AddOrUpdateWorkload(w); err != nil {
+					t.Fatalf("Failed to add or update workload %q: %v", w.Name, err)
+				}
 			}
 
 			info, err := pendingWorkloadsInCqRest.Get(ctx, tc.req.queueName, tc.req.queryParams)

--- a/pkg/visibility/api/v1beta1/pending_workloads_lq_test.go
+++ b/pkg/visibility/api/v1beta1/pending_workloads_lq_test.go
@@ -454,7 +454,9 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 				}
 			}
 			for _, w := range tc.workloads {
-				manager.AddOrUpdateWorkload(w)
+				if err := manager.AddOrUpdateWorkload(w); err != nil {
+					t.Fatalf("Failed to add or update workload :%v", err)
+				}
 			}
 
 			ctx = request.WithNamespace(ctx, tc.req.nsName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
### This PR added  Log output for LocalQueue and ClusterQueue
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3527 

#### Special notes for your reviewer:
It added some log output for better debugging without breaking the function..
#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix misleading log messages from workload_controller indicating not existing LocalQueue or
Cluster Queue. For example "LocalQueue for workload didn't exist or not active; ignored for now"
could also be logged the ClusterQueue does not exist.
```