### PR TITLE
Use ResourceFlavorReference for ResourceFlavor names

### DIFF
--- a/cmd/importer/pod/check.go
+++ b/cmd/importer/pod/check.go
@@ -54,8 +54,8 @@ func Check(ctx context.Context, c client.Client, cache *util.ImportCache, jobs u
 			return false, fmt.Errorf("%q has no resource groups flavors: %w", cq.Name, util.ErrCQInvalid)
 		}
 
-		rfName := string(cq.Spec.ResourceGroups[0].Flavors[0].Name)
-		rf, rfFound := cache.ResourceFalvors[rfName]
+		rfName := cq.Spec.ResourceGroups[0].Flavors[0].Name
+		rf, rfFound := cache.ResourceFlavors[rfName]
 		if !rfFound {
 			return false, fmt.Errorf("%q flavor %q: %w", cq.Name, rfName, util.ErrCQInvalid)
 		}

--- a/cmd/importer/util/util.go
+++ b/cmd/importer/util/util.go
@@ -62,7 +62,7 @@ type ImportCache struct {
 	MappingRules    MappingRules
 	LocalQueues     map[string]map[string]*kueue.LocalQueue
 	ClusterQueues   map[string]*kueue.ClusterQueue
-	ResourceFalvors map[string]*kueue.ResourceFlavor
+	ResourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor
 	PriorityClasses map[string]*schedulingv1.PriorityClass
 	AddLabels       map[string]string
 }
@@ -158,7 +158,9 @@ func LoadImportCache(ctx context.Context, c client.Client, namespaces []string, 
 	if err := c.List(ctx, rfList); err != nil {
 		return nil, fmt.Errorf("loading resource flavors: %w", err)
 	}
-	ret.ResourceFalvors = utilslices.ToRefMap(rfList.Items, func(rf *kueue.ResourceFlavor) string { return rf.Name })
+	ret.ResourceFlavors = utilslices.ToRefMap(rfList.Items, func(rf *kueue.ResourceFlavor) kueue.ResourceFlavorReference {
+		return kueue.ResourceFlavorReference(rf.Name)
+	})
 
 	// PriorityClasses
 	pcList := &schedulingv1.PriorityClassList{}

--- a/cmd/kueuectl/app/create/create_clusterqueue.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue.go
@@ -409,10 +409,10 @@ func parseKeyValue(str, sep string) (string, string) {
 func mergeResourcesByFlavor(resourceGroups []v1beta1.ResourceGroup) ([]v1beta1.ResourceGroup, error) {
 	var mergedResources []v1beta1.ResourceGroup
 
-	indexByFlavor := make(map[string]int)
+	indexByFlavor := make(map[v1beta1.ResourceFlavorReference]int)
 	var index int
 	for _, rg := range resourceGroups {
-		flavorName := string(rg.Flavors[0].Name)
+		flavorName := rg.Flavors[0].Name
 		idx, found := indexByFlavor[flavorName]
 		if !found {
 			mergedResources = append(mergedResources, rg)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -811,7 +811,7 @@ func (c *Cache) clusterQueueForWorkload(w *kueue.Workload) *clusterQueue {
 	return nil
 }
 
-func (c *Cache) ClusterQueuesUsingFlavor(flavor string) []string {
+func (c *Cache) ClusterQueuesUsingFlavor(flavor kueue.ResourceFlavorReference) []string {
 	c.RLock()
 	defer c.RUnlock()
 	var cqs []string

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -602,10 +602,10 @@ func (c *clusterQueue) deleteLocalQueue(q *kueue.LocalQueue) {
 	delete(c.localQueues, qKey)
 }
 
-func (c *clusterQueue) flavorInUse(flavor string) bool {
+func (c *clusterQueue) flavorInUse(flavor kueue.ResourceFlavorReference) bool {
 	for _, rg := range c.ResourceGroups {
 		for _, fName := range rg.Flavors {
-			if kueue.ResourceFlavorReference(flavor) == fName {
+			if flavor == fName {
 				return true
 			}
 		}

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -120,7 +120,7 @@ func (c *Cache) Snapshot(ctx context.Context) (*Snapshot, error) {
 		}
 		if features.Enabled(features.TopologyAwareScheduling) {
 			for tasFlv, s := range tasSnapshots {
-				if cq.flavorInUse(string(tasFlv)) {
+				if cq.flavorInUse(tasFlv) {
 					cqSnapshot.TASFlavors[tasFlv] = s
 				}
 			}

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -535,7 +535,7 @@ func (h *cqResourceFlavorHandler) Generic(_ context.Context, e event.GenericEven
 		return
 	}
 
-	if cqs := h.cache.ClusterQueuesUsingFlavor(rf.Name); len(cqs) != 0 {
+	if cqs := h.cache.ClusterQueuesUsingFlavor(kueue.ResourceFlavorReference(rf.Name)); len(cqs) != 0 {
 		for _, cq := range cqs {
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{

--- a/pkg/controller/core/resourceflavor_controller.go
+++ b/pkg/controller/core/resourceflavor_controller.go
@@ -91,7 +91,7 @@ func (r *ResourceFlavorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	} else {
 		if controllerutil.ContainsFinalizer(&flavor, kueue.ResourceInUseFinalizerName) {
-			if cqs := r.cache.ClusterQueuesUsingFlavor(flavor.Name); len(cqs) != 0 {
+			if cqs := r.cache.ClusterQueuesUsingFlavor(kueue.ResourceFlavorReference(flavor.Name)); len(cqs) != 0 {
 				log.V(3).Info("resourceFlavor is still in use", "ClusterQueues", cqs)
 				// We avoid to return error here to prevent backoff requeue, which is passive and wasteful.
 				// Instead, we drive the removal of finalizer by ClusterQueue Update/Delete events
@@ -239,7 +239,7 @@ func (h *cqHandler) Generic(_ context.Context, e event.GenericEvent, q workqueue
 
 	for _, rg := range cq.Spec.ResourceGroups {
 		for _, flavor := range rg.Flavors {
-			if cqs := h.cache.ClusterQueuesUsingFlavor(string(flavor.Name)); len(cqs) == 0 {
+			if cqs := h.cache.ClusterQueuesUsingFlavor(flavor.Name); len(cqs) == 0 {
 				req := reconcile.Request{
 					NamespacedName: types.NamespacedName{
 						Name: string(flavor.Name),

--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -146,14 +146,15 @@ func (r *rfReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		r.tasCache.Delete(kueue.ResourceFlavorReference(req.NamespacedName.Name))
 	}
 	if flv.Spec.TopologyName != nil {
-		if r.tasCache.Get(kueue.ResourceFlavorReference(flv.Name)) == nil {
+		flavorReference := kueue.ResourceFlavorReference(flv.Name)
+		if r.tasCache.Get(flavorReference) == nil {
 			topology := kueuealpha.Topology{}
 			if err := r.client.Get(ctx, types.NamespacedName{Name: string(*flv.Spec.TopologyName)}, &topology); err != nil {
 				return reconcile.Result{}, err
 			}
 			levels := utiltas.Levels(&topology)
 			tasInfo := r.tasCache.NewTASFlavorCache(kueue.TopologyReference(topology.Name), levels, flv.Spec.NodeLabels)
-			r.tasCache.Set(kueue.ResourceFlavorReference(flv.Name), tasInfo)
+			r.tasCache.Set(flavorReference, tasInfo)
 		}
 
 		// requeue inadmissible workloads as a change to the resource flavor


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
A ResourceFlavor name is referenced in different ways through the code, either as a `ResourceFlavorReference` or as a `string`.  This PR ensures that only `ResourceFlavorReference` is used unless a cast to string is absolutely necessary.

#### Which issue(s) this PR fixes:
Fixes #3491

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```