### PR TITLE
TAS: fix dropping of reconcile events for non-leading replica

### DIFF
--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -81,7 +81,7 @@ func (r *rfReconciler) setupWithManager(mgr ctrl.Manager, cache *cache.Cache, cf
 		Watches(&corev1.Node{}, &nodeHandler).
 		WithOptions(controller.Options{NeedLeaderElection: ptr.To(false)}).
 		WithEventFilter(r).
-		Complete(core.WithLeadingManager(mgr, r, &kueue.ClusterQueue{}, cfg))
+		Complete(core.WithLeadingManager(mgr, r, &kueue.ResourceFlavor{}, cfg))
 }
 
 var _ handler.EventHandler = (*nodeHandler)(nil)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

To fix the bug where Kueue drops reconcile events for the non-leading replica, due to the handling [here](https://github.com/kubernetes-sigs/kueue/blob/4bbddce73eb368caa54a6f570fed683f46fa78b6/pkg/controller/core/leader_aware_reconciler.go#L73-L89).
The reconciled type for the object was passed wrong (ClusterQueue instead of ResourceFlavor), and thus this was returning NotFound, and thus be ignored [here](https://github.com/kubernetes-sigs/kueue/blob/4bbddce73eb368caa54a6f570fed683f46fa78b6/pkg/controller/core/leader_aware_reconciler.go#L79C55-L82).

As a consequence, after a rolling restart, the previously non-leading replica would not perform Reconcile when becoming the leading replica (and the events where lost). Users could observe this as workloads stuck with the following message: `couldn''t assign flavors to pod set main: Flavor "tas-flavor" information
        missing in TAS cache, Workload requires Topology, but there is no TAS cache
        information`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix dropping of reconcile events for non-leading replica, which was resulting in workloads
getting stuck pending after the rolling restart of Kueue.
```