### PR TITLE
Simplify functions by removing strings.Compare

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,7 @@ linters-settings:
   gocritic:
     enabled-checks:
       - dupImport
+      - stringsCompare
     disabled-checks:
       - appendAssign
       - exitAfterDefer

--- a/cmd/experimental/kjobctl/cmd/kjobctl-docs/generators/doc.go
+++ b/cmd/experimental/kjobctl/cmd/kjobctl-docs/generators/doc.go
@@ -265,7 +265,7 @@ func getDefaultVal(flag *pflag.Flag) string {
 				defaultVal = strings.ReplaceAll(defaultVal, ",", ",<br />")
 			}
 			// clean up kjobctl cache-dir flag value
-			if strings.Compare(flag.Name, "cache-dir") == 0 {
+			if flag.Name == "cache-dir" {
 				myUser, err := user.Current()
 				if err == nil {
 					noprefix := strings.TrimPrefix(defaultVal, myUser.HomeDir)

--- a/cmd/kueuectl-docs/generators/doc.go
+++ b/cmd/kueuectl-docs/generators/doc.go
@@ -263,7 +263,7 @@ func getDefaultVal(flag *pflag.Flag) string {
 				defaultVal = strings.ReplaceAll(defaultVal, ",", ",<br />")
 			}
 			// clean up kueuectl cache-dir flag value
-			if strings.Compare(flag.Name, "cache-dir") == 0 {
+			if flag.Name == "cache-dir" {
 				myUser, err := user.Current()
 				if err == nil {
 					noprefix := strings.TrimPrefix(defaultVal, myUser.HomeDir)

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -17,10 +17,10 @@ limitations under the License.
 package cache
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/go-logr/logr"
 
@@ -323,7 +323,7 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain) []*domain {
 	slices.SortFunc(result, func(a, b *domain) int {
 		switch {
 		case a.state == b.state:
-			return strings.Compare(string(a.id), string(b.id))
+			return cmp.Compare(a.id, b.id)
 		case a.state > b.state:
 			return -1
 		default:

--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -17,12 +17,12 @@ limitations under the License.
 package tas
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -353,7 +353,7 @@ func sortDomains(psa *kueue.PodSetAssignment) []domainWithCount {
 		}
 	}
 	slices.SortFunc(sortableDomains, func(a, b domainWithCount) int {
-		return strings.Compare(string(a.domainID), string(b.domainID))
+		return cmp.Compare(a.domainID, b.domainID)
 	})
 	return sortableDomains
 }

--- a/pkg/util/testing/client.go
+++ b/pkg/util/testing/client.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -89,17 +88,17 @@ type EventRecorder struct {
 var _ record.EventRecorder = (*EventRecorder)(nil)
 
 func SortEvents(ei, ej EventRecord) bool {
-	if cmp := strings.Compare(ei.Key.String(), ej.Key.String()); cmp != 0 {
-		return cmp < 0
+	if ei.Key.String() != ej.Key.String() {
+		return ei.Key.String() < ej.Key.String()
 	}
-	if cmp := strings.Compare(ei.EventType, ej.EventType); cmp != 0 {
-		return cmp < 0
+	if ei.EventType != ej.EventType {
+		return ei.EventType < ej.EventType
 	}
-	if cmp := strings.Compare(ei.Reason, ej.Reason); cmp != 0 {
-		return cmp < 0
+	if ei.Reason != ej.Reason {
+		return ei.Reason < ej.Reason
 	}
-	if cmp := strings.Compare(ei.Message, ej.Message); cmp != 0 {
-		return cmp < 0
+	if ei.Message != ej.Message {
+		return ei.Message < ej.Message
 	}
 	return false
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Simplify code by replacing `strings.Compare` with `cmp.Compare` or string comparison operators.

#### Special notes for your reviewer:

https://pkg.go.dev/cmp#Compare

The PR enables `gocritic.stringsCompare` to automatically search for unnecessary `strings.Compare`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```