### PR TITLE
Replace bytes.NewReader with strings.NewReader

### DIFF
--- a/cmd/experimental/kjobctl/pkg/cmd/describe/describe_test.go
+++ b/cmd/experimental/kjobctl/pkg/cmd/describe/describe_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package describe
 
 import (
-	"bytes"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -716,7 +716,7 @@ Worker Groups:
 					NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 					Resp: &http.Response{
 						StatusCode: http.StatusOK,
-						Body:       io.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(codec, tc.objs[0])))),
+						Body:       io.NopCloser(strings.NewReader(runtime.EncodeOrDie(codec, tc.objs[0]))),
 					},
 				})
 			}

--- a/cmd/experimental/kjobctl/pkg/parser/slurm.go
+++ b/cmd/experimental/kjobctl/pkg/parser/slurm.go
@@ -18,7 +18,6 @@ package parser
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"fmt"
 	"regexp"
@@ -57,7 +56,7 @@ type ParsedSlurmFlags struct {
 func SlurmFlags(script string, ignoreUnknown bool) (ParsedSlurmFlags, error) {
 	var flags ParsedSlurmFlags
 
-	scanner := bufio.NewScanner(bytes.NewReader([]byte(script)))
+	scanner := bufio.NewScanner(strings.NewReader(script))
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())

--- a/cmd/kueuectl/app/list/list_pods_test.go
+++ b/cmd/kueuectl/app/list/list_pods_test.go
@@ -833,7 +833,7 @@ func mockRESTClient(codec runtime.Codec, tc podTestCase) (*restfake.RESTClient, 
 				return &http.Response{
 					StatusCode: http.StatusOK,
 					Header:     getDefaultHeader(),
-					Body:       io.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(codec, tc.job)))),
+					Body:       io.NopCloser(strings.NewReader(runtime.EncodeOrDie(codec, tc.job))),
 				}, nil
 			case fmt.Sprintf("%s/pods", reqPathPrefix):
 				return &http.Response{
@@ -900,5 +900,5 @@ func emptyTableObjBody(codec runtime.Codec) io.ReadCloser {
 	table := &metav1.Table{
 		ColumnDefinitions: podColumns,
 	}
-	return io.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(codec, table))))
+	return io.NopCloser(strings.NewReader(runtime.EncodeOrDie(codec, table)))
 }

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package list
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -911,7 +911,7 @@ wl2               j2         lq2          cq2            PENDING   22           
 					NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
 					Resp: &http.Response{
 						StatusCode: http.StatusOK,
-						Body:       io.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(codec, tc.job[0])))),
+						Body:       io.NopCloser(strings.NewReader(runtime.EncodeOrDie(codec, tc.job[0]))),
 					},
 				})
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR refactors code by replacing `bytes.NewReader([]byte(str))` with `strings.NewReader(str)` to avoid extra allocation and shorten statements.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```