### PR TITLE
Use gomega Matcher in the visibility E2E testings

### DIFF
--- a/test/e2e/singlecluster/visibility_test.go
+++ b/test/e2e/singlecluster/visibility_test.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -503,9 +502,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			ginkgo.By("Wait for ResourceNotFound error instead of Forbidden to make sure the role bindings work", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					_, err := impersonatedVisibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
-					statusErr, ok := err.(*errors.StatusError)
-					g.Expect(ok).To(gomega.BeTrue())
-					g.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonNotFound))
+					g.Expect(err).Should(testing.BeNotFoundError())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
@@ -517,15 +514,11 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 		ginkgo.It("Should return an appropriate error", func() {
 			ginkgo.By("Returning a ResourceNotFound error for a nonexistent ClusterQueue", func() {
 				_, err := impersonatedVisibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
-				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.BeTrue())
-				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonNotFound))
+				gomega.Expect(err).Should(testing.BeNotFoundError())
 			})
 			ginkgo.By("Returning a ResourceNotFound error for a nonexistent LocalQueue", func() {
 				_, err := impersonatedVisibilityClient.LocalQueues(nsA.Name).GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
-				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.BeTrue())
-				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonNotFound))
+				gomega.Expect(err).Should(testing.BeNotFoundError())
 			})
 		})
 	})
@@ -545,9 +538,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 			ginkgo.By("Wait for ResourceNotFound error instead of Forbidden to make sure the role bindings work", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					_, err := impersonatedVisibilityClient.LocalQueues(nsA.Name).GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
-					statusErr, ok := err.(*errors.StatusError)
-					g.Expect(ok).To(gomega.BeTrue())
-					g.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonNotFound))
+					g.Expect(err).Should(testing.BeNotFoundError())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
@@ -559,21 +550,15 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 		ginkgo.It("Should return an appropriate error", func() {
 			ginkgo.By("Returning a Forbidden error due to insufficient permissions for the ClusterQueue request", func() {
 				_, err := impersonatedVisibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
-				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.BeTrue())
-				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonForbidden))
+				gomega.Expect(err).Should(testing.BeForbiddenError())
 			})
 			ginkgo.By("Returning a ResourceNotFound error for a nonexistent LocalQueue", func() {
 				_, err := impersonatedVisibilityClient.LocalQueues(nsA.Name).GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
-				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.BeTrue())
-				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonNotFound))
+				gomega.Expect(err).Should(testing.BeNotFoundError())
 			})
 			ginkgo.By("Returning a Forbidden error due to insufficient permissions for the LocalQueue request in different namespace", func() {
 				_, err := impersonatedVisibilityClient.LocalQueues("default").GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
-				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.BeTrue())
-				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonForbidden))
+				gomega.Expect(err).Should(testing.BeForbiddenError())
 			})
 		})
 	})
@@ -582,15 +567,11 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 		ginkgo.It("Should return an appropriate error", func() {
 			ginkgo.By("Returning a Forbidden error due to insufficient permissions for the ClusterQueue request", func() {
 				_, err := impersonatedVisibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
-				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.BeTrue())
-				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonForbidden))
+				gomega.Expect(err).Should(testing.BeForbiddenError())
 			})
 			ginkgo.By("Returning a Forbidden error due to insufficient permissions for the LocalQueue request", func() {
 				_, err := impersonatedVisibilityClient.LocalQueues(nsA.Name).GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
-				statusErr, ok := err.(*errors.StatusError)
-				gomega.Expect(ok).To(gomega.BeTrue())
-				gomega.Expect(statusErr.ErrStatus.Reason).To(gomega.Equal(metav1.StatusReasonForbidden))
+				gomega.Expect(err).Should(testing.BeForbiddenError())
 			})
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
It would be better to use the Gomega matcher instead of directly comparing reasons.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I confirmed that e2e testings failed if we specify the incorrect error reason.

```shell
Kueue visibility server when A subject is bound to kueue-batch-user-role, but not to kueue-batch-admin-role Should return an appropriate error
/Users/tenzen/go/src/sigs.k8s.io/kueue/test/e2e/singlecluster/visibility_test.go:555
  STEP: Wait for ResourceNotFound error instead of Forbidden to make sure the role bindings work @ 11/26/24 15:58:06.764
  STEP: Returning a Forbidden error due to insufficient permissions for the ClusterQueue request @ 11/26/24 15:58:06.768
  [FAILED] in [It] - /Users/tenzen/go/src/sigs.k8s.io/kueue/test/e2e/singlecluster/visibility_test.go:559 @ 11/26/24 15:58:06.769
• [FAILED] [0.212 seconds]
Kueue visibility server when A subject is bound to kueue-batch-user-role, but not to kueue-batch-admin-role [It] Should return an appropriate error
/Users/tenzen/go/src/sigs.k8s.io/kueue/test/e2e/singlecluster/visibility_test.go:555

  [FAILED] Expected NotFoundError, but got:
      <*errors.StatusError | 0x14000614140>: 
      clusterqueues.visibility.kueue.x-k8s.io "non-existent" is forbidden: User "system:serviceaccount:kueue-system:default" cannot get resource "clusterqueues/pendingworkloads" in API group "visibility.kueue.x-k8s.io" at the cluster scope
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "clusterqueues.visibility.kueue.x-k8s.io \"non-existent\" is forbidden: User \"system:serviceaccount:kueue-system:default\" cannot get resource \"clusterqueues/pendingworkloads\" in API group \"visibility.kueue.x-k8s.io\" at the cluster scope",
              Reason: "Forbidden",
              Details: {
                  Name: "non-existent",
                  Group: "visibility.kueue.x-k8s.io",
                  Kind: "clusterqueues",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 403,
          },
      }
  In [It] at: /Users/tenzen/go/src/sigs.k8s.io/kueue/test/e2e/singlecluster/visibility_test.go:559 @ 11/26/24 15:58:06.769
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```