### PR TITLE
Sync KEP and actual APIs for Hierarchical Cohort

### DIFF
--- a/keps/79-hierarchical-cohorts/README.md
+++ b/keps/79-hierarchical-cohorts/README.md
@@ -128,14 +128,13 @@ type Cohort struct {
     metav1.ObjectMeta `json:"metadata,omitempty"`
 
     Spec   CohortSpec   `json:"spec,omitempty"`
-    Status CohortStatus `json:"status,omitempty"`
 }
 
 type CohortSpec struct {
     // Cohort parent name. The parent Cohort object doesn't have to exist.
     // In such case, it is assumed that parent simply doesn't have any
     // quota and limits and doesn't have any other custom settings.
-    Parent *string `json:"parent,omitempty"`
+    Parent string `json:"parent,omitempty"`
 
     // resourceGroups describes groups of resources that the Cohort can
     // share with ClusterQueues within the same group of Cohorts/ClusterQueues.
@@ -156,28 +155,6 @@ type CohortSpec struct {
     // +listType=atomic
     // +kubebuilder:validation:MaxItems=16
     ResourceGroups []ResourceGroup `json:"resourceGroups,omitempty"`
-}
-
-const (
-    // Condition indicating that a Cohort is correctly configured (for example, there is no cycle).
-    CohortActive = "CohortActive"
-)
-
-// Status of the Cohort. May be empty if Cohort support is not enabled in alpha.
-// Status and stats may not cover the entire subtree, as the number of needed updates
-// per workload admission may be to high.
-type CohortStatus struct {
-    // conditions hold the latest available observations of the Conditions
-    // current state.
-    // +optional
-    // +listType=map
-    // +listMapKey=type
-    // +patchStrategy=merge
-    // +patchMergeKey=type
-    Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
-
-    // Additional stats may be added in the future, like the number 
-    // of admitted workloads, their usage etc, based on the user feedback.
 }
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
I refined the Hierarchical Cohort KEP to align with actual APIs in the following:

- Make `.spec.parent` non pointer
- Remove Status

For the status, we should reconsider and clarify the status implementation and how we can expose those stats when we decide to implement it in the future.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```