### PR TITLE
Allow to delete queue-name on deployment.

### DIFF
--- a/pkg/controller/jobs/deployment/deployment_webhook_test.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook_test.go
@@ -71,7 +71,7 @@ func TestDefault(t *testing.T) {
 		},
 		"deployment without queue with pod template spec queue": {
 			deployment: testingdeployment.MakeDeployment("test-pod", "").PodTemplateSpecQueue("test-queue").Obj(),
-			want:       testingdeployment.MakeDeployment("test-pod", "").PodTemplateSpecQueue("test-queue").Obj(),
+			want:       testingdeployment.MakeDeployment("test-pod", "").Obj(),
 		},
 		"LocalQueueDefaulting enabled, default lq is created, job doesn't have queue label": {
 			localQueueDefaulting: true,
@@ -138,7 +138,6 @@ func TestDefault(t *testing.T) {
 				PodTemplateSpecLabel(constants.WorkloadPriorityClassLabel, "test").
 				Obj(),
 			want: testingdeployment.MakeDeployment("test-pod", "").
-				PodTemplateSpecQueue("test-queue").
 				PodTemplateSpecLabel(constants.WorkloadPriorityClassLabel, "test").
 				Obj(),
 		},
@@ -168,7 +167,7 @@ func TestDefault(t *testing.T) {
 			if err := w.Default(ctx, tc.deployment); err != nil {
 				t.Errorf("failed to set defaults for v1/deployment: %s", err)
 			}
-			if diff := cmp.Diff(tc.want, tc.deployment); len(diff) != 0 {
+			if diff := cmp.Diff(tc.want, tc.deployment, cmpopts.EquateEmpty()); len(diff) != 0 {
 				t.Errorf("Default() mismatch (-want,+got):\n%s", diff)
 			}
 		})
@@ -235,8 +234,15 @@ func TestValidateUpdate(t *testing.T) {
 			oldDeployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),
 			newDeployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),
 		},
-		"without queue": {
+		"without queue (ReadyReplicas = 0)": {
 			oldDeployment: testingdeployment.MakeDeployment("test-pod", "").
+				Queue("test-queue").
+				Obj(),
+			newDeployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),
+		},
+		"without queue (ReadyReplicas > 0)": {
+			oldDeployment: testingdeployment.MakeDeployment("test-pod", "").
+				ReadyReplicas(1).
 				Queue("test-queue").
 				Obj(),
 			newDeployment: testingdeployment.MakeDeployment("test-pod", "").Obj(),

--- a/test/e2e/singlecluster/deployment_test.go
+++ b/test/e2e/singlecluster/deployment_test.go
@@ -126,7 +126,7 @@ var _ = ginkgo.Describe("Deployment", func() {
 		})
 	})
 
-	ginkgo.It("should admit workloads after change queue-name if AvailableReplicas = 0", func() {
+	ginkgo.It("should admit workloads after change queue-name if ReadyReplicas = 0", func() {
 		deployment := deploymenttesting.MakeDeployment("deployment", ns.Name).
 			Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 			RequestAndLimit(corev1.ResourceCPU, "200m").
@@ -145,7 +145,7 @@ var _ = ginkgo.Describe("Deployment", func() {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).To(gomega.Succeed())
 				g.Expect(createdDeployment.Status.Replicas).To(gomega.Equal(int32(3)))
 				g.Expect(createdDeployment.Status.UnavailableReplicas).To(gomega.Equal(int32(3)))
-				g.Expect(createdDeployment.Status.AvailableReplicas).To(gomega.Equal(int32(0)))
+				g.Expect(createdDeployment.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 

--- a/test/integration/singlecluster/webhook/jobs/deployment_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/deployment_webhook_test.go
@@ -108,8 +108,17 @@ var _ = ginkgo.Describe("Deployment Webhook", ginkgo.Ordered, ginkgo.ContinueOnF
 			})
 		})
 
-		ginkgo.It("shouldn't allow to remove the queue label", func() {
+		ginkgo.It("shouldn't allow to remove the queue label (ReadyReplicas > 0)", func() {
 			createdDeployment := &appsv1.Deployment{}
+
+			ginkgo.By("Update status ReadyReplicas = 1", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+					createdDeployment.Status.Replicas = 1
+					createdDeployment.Status.ReadyReplicas = 1
+					gomega.Expect(k8sClient.Status().Update(ctx, createdDeployment)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
 
 			ginkgo.By("Try to remove queue label", func() {
 				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
@@ -121,6 +130,23 @@ var _ = ginkgo.Describe("Deployment Webhook", ginkgo.Ordered, ginkgo.ContinueOnF
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
 					g.Expect(createdDeployment.Spec.Template.Labels).Should(gomega.HaveKey(constants.QueueLabel))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should allow to remove the queue label (ReadyReplicas = 0)", func() {
+			createdDeployment := &appsv1.Deployment{}
+
+			ginkgo.By("Try to remove queue label", func() {
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+				delete(createdDeployment.Labels, constants.QueueLabel)
+				gomega.Expect(k8sClient.Update(ctx, createdDeployment)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("Check that queue-name label deleted from pod template spec", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).Should(gomega.Succeed())
+					g.Expect(createdDeployment.Spec.Template.Labels).ShouldNot(gomega.HaveKey(constants.QueueLabel))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Allow to delete queue-name on deployment.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```