### PR TITLE
Automated cherry pick of #3509: Use TopologyReference instead of string.
#3615: TAS: Update cache on delete Topology.

### DIFF
--- a/apis/kueue/v1beta1/resourceflavor_types.go
+++ b/apis/kueue/v1beta1/resourceflavor_types.go
@@ -35,6 +35,11 @@ type ResourceFlavor struct {
 	Spec ResourceFlavorSpec `json:"spec,omitempty"`
 }
 
+// TopologyReference is the name of the Topology.
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+type TopologyReference string
+
 // ResourceFlavorSpec defines the desired state of the ResourceFlavor
 // +kubebuilder:validation:XValidation:rule="!has(self.topologyName) || self.nodeLabels.size() >= 1", message="at least one nodeLabel is required when topology is set"
 type ResourceFlavorSpec struct {
@@ -92,9 +97,7 @@ type ResourceFlavorSpec struct {
 	// nodes matching to the Resource Flavor node labels.
 	//
 	// +optional
-	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-	TopologyName *string `json:"topologyName,omitempty"`
+	TopologyName *TopologyReference `json:"topologyName,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/kueue/v1beta1/zz_generated.deepcopy.go
+++ b/apis/kueue/v1beta1/zz_generated.deepcopy.go
@@ -1348,7 +1348,7 @@ func (in *ResourceFlavorSpec) DeepCopyInto(out *ResourceFlavorSpec) {
 	}
 	if in.TopologyName != nil {
 		in, out := &in.TopologyName, &out.TopologyName
-		*out = new(string)
+		*out = new(TopologyReference)
 		**out = **in
 	}
 }

--- a/client-go/applyconfiguration/kueue/v1beta1/resourceflavorspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/resourceflavorspec.go
@@ -19,15 +19,16 @@ package v1beta1
 
 import (
 	v1 "k8s.io/api/core/v1"
+	v1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 // ResourceFlavorSpecApplyConfiguration represents a declarative configuration of the ResourceFlavorSpec type for use
 // with apply.
 type ResourceFlavorSpecApplyConfiguration struct {
-	NodeLabels   map[string]string `json:"nodeLabels,omitempty"`
-	NodeTaints   []v1.Taint        `json:"nodeTaints,omitempty"`
-	Tolerations  []v1.Toleration   `json:"tolerations,omitempty"`
-	TopologyName *string           `json:"topologyName,omitempty"`
+	NodeLabels   map[string]string          `json:"nodeLabels,omitempty"`
+	NodeTaints   []v1.Taint                 `json:"nodeTaints,omitempty"`
+	Tolerations  []v1.Toleration            `json:"tolerations,omitempty"`
+	TopologyName *v1beta1.TopologyReference `json:"topologyName,omitempty"`
 }
 
 // ResourceFlavorSpecApplyConfiguration constructs a declarative configuration of the ResourceFlavorSpec type for use with
@@ -73,7 +74,7 @@ func (b *ResourceFlavorSpecApplyConfiguration) WithTolerations(values ...v1.Tole
 // WithTopologyName sets the TopologyName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the TopologyName field is set to the value of the last call.
-func (b *ResourceFlavorSpecApplyConfiguration) WithTopologyName(value string) *ResourceFlavorSpecApplyConfiguration {
+func (b *ResourceFlavorSpecApplyConfiguration) WithTopologyName(value v1beta1.TopologyReference) *ResourceFlavorSpecApplyConfiguration {
 	b.TopologyName = &value
 	return b
 }

--- a/pkg/cache/tas_flavor.go
+++ b/pkg/cache/tas_flavor.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/limitrange"
@@ -55,7 +56,7 @@ type TASFlavorCache struct {
 
 	// topologyName indicates the name of the topology specified in the
 	// ResourceFlavor spec.topologyName field.
-	topologyName string
+	topologyName kueue.TopologyReference
 	// nodeLabels is a map of nodeLabels defined in the ResourceFlavor object.
 	NodeLabels map[string]string
 	// levels is a list of levels defined in the Topology object referenced
@@ -66,7 +67,7 @@ type TASFlavorCache struct {
 	usage map[utiltas.TopologyDomainID]resources.Requests
 }
 
-func (t *TASCache) NewTASFlavorCache(topologyName string, labels []string, nodeLabels map[string]string) *TASFlavorCache {
+func (t *TASCache) NewTASFlavorCache(topologyName kueue.TopologyReference, labels []string, nodeLabels map[string]string) *TASFlavorCache {
 	return &TASFlavorCache{
 		client:       t.client,
 		topologyName: topologyName,

--- a/pkg/cache/tas_flavor.go
+++ b/pkg/cache/tas_flavor.go
@@ -54,9 +54,9 @@ type TASFlavorCache struct {
 
 	client client.Client
 
-	// topologyName indicates the name of the topology specified in the
+	// TopologyName indicates the name of the topology specified in the
 	// ResourceFlavor spec.topologyName field.
-	topologyName kueue.TopologyReference
+	TopologyName kueue.TopologyReference
 	// nodeLabels is a map of nodeLabels defined in the ResourceFlavor object.
 	NodeLabels map[string]string
 	// levels is a list of levels defined in the Topology object referenced
@@ -67,11 +67,11 @@ type TASFlavorCache struct {
 	usage map[utiltas.TopologyDomainID]resources.Requests
 }
 
-func (t *TASCache) NewTASFlavorCache(topologyName kueue.TopologyReference, labels []string, nodeLabels map[string]string) *TASFlavorCache {
+func (t *TASCache) NewTASFlavorCache(topologyName kueue.TopologyReference, levels []string, nodeLabels map[string]string) *TASFlavorCache {
 	return &TASFlavorCache{
 		client:       t.client,
-		topologyName: topologyName,
-		Levels:       slices.Clone(labels),
+		TopologyName: topologyName,
+		Levels:       slices.Clone(levels),
 		NodeLabels:   maps.Clone(nodeLabels),
 		usage:        make(map[utiltas.TopologyDomainID]resources.Requests),
 	}
@@ -111,7 +111,7 @@ func (c *TASFlavorCache) snapshotForNodes(log logr.Logger, nodes []corev1.Node, 
 
 	log.V(3).Info("Constructing TAS snapshot", "nodeLabels", c.NodeLabels,
 		"levels", c.Levels, "nodeCount", len(nodes), "podCount", len(pods))
-	snapshot := newTASFlavorSnapshot(log, c.topologyName, c.Levels)
+	snapshot := newTASFlavorSnapshot(log, c.TopologyName, c.Levels)
 	nodeToDomain := make(map[string]utiltas.TopologyDomainID)
 	for _, node := range nodes {
 		levelValues := utiltas.LevelValues(c.Levels, node.Labels)

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -61,7 +61,7 @@ type TASFlavorSnapshot struct {
 
 	// topologyName indicates the name of the topology specified in the
 	// ResourceFlavor spec.topologyName field.
-	topologyName string
+	topologyName kueue.TopologyReference
 
 	// levelKeys denotes the ordered list of topology keys set as label keys
 	// on the Topology object
@@ -91,7 +91,7 @@ type TASFlavorSnapshot struct {
 	state statePerDomain
 }
 
-func newTASFlavorSnapshot(log logr.Logger, topologyName string, levels []string) *TASFlavorSnapshot {
+func newTASFlavorSnapshot(log logr.Logger, topologyName kueue.TopologyReference, levels []string) *TASFlavorSnapshot {
 	snapshot := &TASFlavorSnapshot{
 		log:                       log,
 		topologyName:              topologyName,

--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -148,13 +148,11 @@ func (r *rfReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 	if flv.Spec.TopologyName != nil {
 		if r.tasCache.Get(kueue.ResourceFlavorReference(flv.Name)) == nil {
 			topology := kueuealpha.Topology{}
-			if err := r.client.Get(ctx, types.NamespacedName{
-				Name: *flv.Spec.TopologyName,
-			}, &topology); err != nil {
+			if err := r.client.Get(ctx, types.NamespacedName{Name: string(*flv.Spec.TopologyName)}, &topology); err != nil {
 				return reconcile.Result{}, err
 			}
 			levels := utiltas.Levels(&topology)
-			tasInfo := r.tasCache.NewTASFlavorCache(topology.Name, levels, flv.Spec.NodeLabels)
+			tasInfo := r.tasCache.NewTASFlavorCache(kueue.TopologyReference(topology.Name), levels, flv.Spec.NodeLabels)
 			r.tasCache.Set(kueue.ResourceFlavorReference(flv.Name), tasInfo)
 		}
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4056,7 +4056,7 @@ func TestScheduleForTAS(t *testing.T) {
 			NodeLabels: map[string]string{
 				"tas-node": "true",
 			},
-			TopologyName: ptr.To("tas-two-level"),
+			TopologyName: ptr.To[kueue.TopologyReference]("tas-two-level"),
 		},
 	}
 	defaultClusterQueue := *utiltesting.MakeClusterQueue("tas-main").

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4045,7 +4045,7 @@ func TestScheduleForTAS(t *testing.T) {
 			NodeLabels: map[string]string{
 				"tas-node": "true",
 			},
-			TopologyName: ptr.To("tas-single-level"),
+			TopologyName: ptr.To[kueue.TopologyReference]("tas-single-level"),
 		},
 	}
 	defaultTASTwoLevelFlavor := kueue.ResourceFlavor{
@@ -4381,7 +4381,7 @@ func TestScheduleForTAS(t *testing.T) {
 						NodeLabels: map[string]string{
 							"tas-node": "true",
 						},
-						TopologyName: ptr.To("tas-custom-topology"),
+						TopologyName: ptr.To[kueue.TopologyReference]("tas-custom-topology"),
 					},
 				},
 			},
@@ -4790,8 +4790,8 @@ func TestScheduleForTAS(t *testing.T) {
 			recorder := &utiltesting.EventRecorder{}
 			cqCache := cache.New(cl)
 			qManager := queue.NewManager(cl, cqCache)
-			topologyByName := slices.ToMap(tc.topologies, func(i int) (string, kueuealpha.Topology) {
-				return tc.topologies[i].Name, tc.topologies[i]
+			topologyByName := slices.ToMap(tc.topologies, func(i int) (kueue.TopologyReference, kueuealpha.Topology) {
+				return kueue.TopologyReference(tc.topologies[i].Name), tc.topologies[i]
 			})
 			for _, flavor := range tc.resourceFlavors {
 				cqCache.AddOrUpdateResourceFlavor(&flavor)

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -842,36 +842,36 @@ func (f *FlavorQuotasWrapper) Resource(name corev1.ResourceName, qs ...string) *
 }
 
 // ResourceQuotaWrapper allows creation the creation of a Resource in a type-safe manner.
-func (f *FlavorQuotasWrapper) ResourceQuotaWrapper(name corev1.ResourceName) *resourceQuotaWrapper {
+func (f *FlavorQuotasWrapper) ResourceQuotaWrapper(name corev1.ResourceName) *ResourceQuotaWrapper {
 	rq := kueue.ResourceQuota{
 		Name: name,
 	}
-	return &resourceQuotaWrapper{parent: f, ResourceQuota: rq}
+	return &ResourceQuotaWrapper{parent: f, ResourceQuota: rq}
 }
 
-// resourceQuotaWrapper wraps a ResourceQuota object.
-type resourceQuotaWrapper struct {
+// ResourceQuotaWrapper wraps a ResourceQuota object.
+type ResourceQuotaWrapper struct {
 	parent *FlavorQuotasWrapper
 	kueue.ResourceQuota
 }
 
-func (rq *resourceQuotaWrapper) NominalQuota(quantity string) *resourceQuotaWrapper {
+func (rq *ResourceQuotaWrapper) NominalQuota(quantity string) *ResourceQuotaWrapper {
 	rq.ResourceQuota.NominalQuota = resource.MustParse(quantity)
 	return rq
 }
 
-func (rq *resourceQuotaWrapper) BorrowingLimit(quantity string) *resourceQuotaWrapper {
+func (rq *ResourceQuotaWrapper) BorrowingLimit(quantity string) *ResourceQuotaWrapper {
 	rq.ResourceQuota.BorrowingLimit = ptr.To(resource.MustParse(quantity))
 	return rq
 }
 
-func (rq *resourceQuotaWrapper) LendingLimit(quantity string) *resourceQuotaWrapper {
+func (rq *ResourceQuotaWrapper) LendingLimit(quantity string) *ResourceQuotaWrapper {
 	rq.ResourceQuota.LendingLimit = ptr.To(resource.MustParse(quantity))
 	return rq
 }
 
 // Append appends the ResourceQuotaWrapper to its parent
-func (rq *resourceQuotaWrapper) Append() *FlavorQuotasWrapper {
+func (rq *ResourceQuotaWrapper) Append() *FlavorQuotasWrapper {
 	rq.parent.Resources = append(rq.parent.Resources, rq.ResourceQuota)
 	return rq.parent
 }
@@ -896,9 +896,9 @@ func (rf *ResourceFlavorWrapper) Obj() *kueue.ResourceFlavor {
 	return &rf.ResourceFlavor
 }
 
-// TopologyLevels sets the topology name
+// TopologyName sets the topology name
 func (rf *ResourceFlavorWrapper) TopologyName(name string) *ResourceFlavorWrapper {
-	rf.ResourceFlavor.Spec.TopologyName = ptr.To(name)
+	rf.ResourceFlavor.Spec.TopologyName = ptr.To(kueue.TopologyReference(name))
 	return rf
 }
 

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -2100,7 +2100,7 @@ cloud.provider.com/preemptible=&quot;true&quot;:NoSchedule</p>
 </td>
 </tr>
 <tr><td><code>topologyName</code><br/>
-<code>string</code>
+<a href="#kueue-x-k8s-io-v1beta1-TopologyReference"><code>TopologyReference</code></a>
 </td>
 <td>
    <p>topologyName indicates topology for the TAS ResourceFlavor.
@@ -2343,6 +2343,20 @@ domain indicated by the values field.</p>
 </tr>
 </tbody>
 </table>
+
+## `TopologyReference`     {#kueue-x-k8s-io-v1beta1-TopologyReference}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [ResourceFlavorSpec](#kueue-x-k8s-io-v1beta1-ResourceFlavorSpec)
+
+
+<p>TopologyReference is the name of the Topology.</p>
+
+
+
 
 ## `WorkloadSpec`     {#kueue-x-k8s-io-v1beta1-WorkloadSpec}
     

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package core
 
 import (
+	"time"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -519,6 +521,12 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				ginkgo.By("delete topology", func() {
 					util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
 				})
+
+				// TODO(#3645): replace the sleep with waiting for CQ deactivation.
+				// The sleep is a temporary solution to minimize the chance for the test flaking in case
+				// the workload is created and admitted before the event is handled and the topology
+				// is removed from the cache.
+				time.Sleep(time.Second)
 
 				var wl *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -514,6 +514,48 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					))
 				})
 			})
+
+			ginkgo.It("should not admit the workload after the topology is deleted but should admit it after the topology is created", func() {
+				ginkgo.By("delete topology", func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+				})
+
+				var wl *kueue.Workload
+				ginkgo.By("creating a workload which requires block and can fit", func() {
+					wl = testing.MakeWorkload("wl", ns.Name).
+						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+					wl.Spec.PodSets[0].Count = 2
+					wl.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(tasBlockLabel),
+					}
+					gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify the workload is inadmissible", func() {
+					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+				})
+
+				topology = testing.MakeTopology("default").Levels([]string{tasBlockLabel, tasRackLabel}).Obj()
+				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
+
+				ginkgo.By("verify the workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+				})
+
+				ginkgo.By("verify admission for the workload", func() {
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+					gomega.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						&kueue.TopologyAssignment{
+							Levels: []string{tasBlockLabel, tasRackLabel},
+							Domains: []kueue.TopologyDomainAssignment{
+								{Count: 1, Values: []string{"b1", "r1"}},
+								{Count: 1, Values: []string{"b1", "r2"}},
+							},
+						},
+					))
+				})
+			})
 		})
 
 		ginkgo.When("Node structure is mutated during test cases", func() {


### PR DESCRIPTION
Cherry pick of #3509 #3615 on release-0.9.

#3509: Use TopologyReference instead of string.
#3615: TAS: Update cache on delete Topology.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
TAS: Fixed bug that doesn't allow to update cache on delete Topology.
```