### PR TITLE
Reuse the core API hostname node label

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3769,9 +3769,6 @@ func TestCohortCycles(t *testing.T) {
 // TestSnapshotError tests the negative scenario when an error is returned while
 // using TopologyAwareScheduling
 func TestSnapshotError(t *testing.T) {
-	const (
-		tasHostLabel = "kubernetes.io/hostname"
-	)
 	var (
 		connectionRefusedErr = errors.New("connection refused")
 	)
@@ -3782,7 +3779,7 @@ func TestSnapshotError(t *testing.T) {
 		Spec: kueuealpha.TopologySpec{
 			Levels: []kueuealpha.TopologyLevel{
 				{
-					NodeLabel: tasHostLabel,
+					NodeLabel: corev1.LabelHostname,
 				},
 			},
 		},
@@ -3819,7 +3816,7 @@ func TestSnapshotError(t *testing.T) {
 	cache := New(client)
 	cache.AddOrUpdateResourceFlavor(&flavor)
 	if flavor.Spec.TopologyName != nil {
-		tasFlavorCache := cache.tasCache.NewTASFlavorCache(*flavor.Spec.TopologyName, []string{tasHostLabel}, flavor.Spec.NodeLabels)
+		tasFlavorCache := cache.tasCache.NewTASFlavorCache(*flavor.Spec.TopologyName, []string{corev1.LabelHostname}, flavor.Spec.NodeLabels)
 		cache.tasCache.Set(kueue.ResourceFlavorReference(flavor.Name), tasFlavorCache)
 	}
 	if err := cache.AddClusterQueue(ctx, &clusterQueue); err != nil {

--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -38,7 +38,6 @@ func TestFindTopologyAssignment(t *testing.T) {
 	const (
 		tasBlockLabel = "cloud.com/topology-block"
 		tasRackLabel  = "cloud.com/topology-rack"
-		tasHostLabel  = "kubernetes.io/hostname"
 	)
 
 	//      b1                   b2
@@ -51,9 +50,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b1-r1-x1",
 				Labels: map[string]string{
-					tasBlockLabel: "b1",
-					tasRackLabel:  "r1",
-					tasHostLabel:  "x1",
+					tasBlockLabel:        "b1",
+					tasRackLabel:         "r1",
+					corev1.LabelHostname: "x1",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -73,9 +72,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b1-r2-x2",
 				Labels: map[string]string{
-					tasBlockLabel: "b1",
-					tasRackLabel:  "r2",
-					tasHostLabel:  "x2",
+					tasBlockLabel:        "b1",
+					tasRackLabel:         "r2",
+					corev1.LabelHostname: "x2",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -95,9 +94,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b1-r2-x3",
 				Labels: map[string]string{
-					tasBlockLabel: "b1",
-					tasRackLabel:  "r2",
-					tasHostLabel:  "x3",
+					tasBlockLabel:        "b1",
+					tasRackLabel:         "r2",
+					corev1.LabelHostname: "x3",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -117,9 +116,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b1-r2-x4",
 				Labels: map[string]string{
-					tasBlockLabel: "b1",
-					tasRackLabel:  "r2",
-					tasHostLabel:  "x4",
+					tasBlockLabel:        "b1",
+					tasRackLabel:         "r2",
+					corev1.LabelHostname: "x4",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -139,9 +138,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b2-r1-x5",
 				Labels: map[string]string{
-					tasBlockLabel: "b2",
-					tasRackLabel:  "r1",
-					tasHostLabel:  "x5",
+					tasBlockLabel:        "b2",
+					tasRackLabel:         "r1",
+					corev1.LabelHostname: "x5",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -161,9 +160,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b2-r2-x6",
 				Labels: map[string]string{
-					tasBlockLabel: "b2",
-					tasRackLabel:  "r2",
-					tasHostLabel:  "x6",
+					tasBlockLabel:        "b2",
+					tasRackLabel:         "r2",
+					corev1.LabelHostname: "x6",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -181,7 +180,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 		},
 	}
 	defaultOneLevel := []string{
-		tasHostLabel,
+		corev1.LabelHostname,
 	}
 	defaultTwoLevels := []string{
 		tasBlockLabel,
@@ -190,7 +189,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 	defaultThreeLevels := []string{
 		tasBlockLabel,
 		tasRackLabel,
-		tasHostLabel,
+		corev1.LabelHostname,
 	}
 
 	//           b1                    b2
@@ -203,9 +202,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b1-r1-x1",
 				Labels: map[string]string{
-					tasBlockLabel: "b1",
-					tasRackLabel:  "r1",
-					tasHostLabel:  "x1",
+					tasBlockLabel:        "b1",
+					tasRackLabel:         "r1",
+					corev1.LabelHostname: "x1",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -225,9 +224,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b1-r1-x2",
 				Labels: map[string]string{
-					tasBlockLabel: "b1",
-					tasRackLabel:  "r1",
-					tasHostLabel:  "x2",
+					tasBlockLabel:        "b1",
+					tasRackLabel:         "r1",
+					corev1.LabelHostname: "x2",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -247,9 +246,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b1-r2-x3",
 				Labels: map[string]string{
-					tasBlockLabel: "b1",
-					tasRackLabel:  "r2",
-					tasHostLabel:  "x3",
+					tasBlockLabel:        "b1",
+					tasRackLabel:         "r2",
+					corev1.LabelHostname: "x3",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -269,9 +268,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b1-r2-x4",
 				Labels: map[string]string{
-					tasBlockLabel: "b1",
-					tasRackLabel:  "r2",
-					tasHostLabel:  "x4",
+					tasBlockLabel:        "b1",
+					tasRackLabel:         "r2",
+					corev1.LabelHostname: "x4",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -291,9 +290,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b2-r1-x5",
 				Labels: map[string]string{
-					tasBlockLabel: "b2",
-					tasRackLabel:  "r1",
-					tasHostLabel:  "x5",
+					tasBlockLabel:        "b2",
+					tasRackLabel:         "r1",
+					corev1.LabelHostname: "x5",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -313,9 +312,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b2-r1-x6",
 				Labels: map[string]string{
-					tasBlockLabel: "b2",
-					tasRackLabel:  "r1",
-					tasHostLabel:  "x6",
+					tasBlockLabel:        "b2",
+					tasRackLabel:         "r1",
+					corev1.LabelHostname: "x6",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -335,9 +334,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b2-r2-x7",
 				Labels: map[string]string{
-					tasBlockLabel: "b2",
-					tasRackLabel:  "r2",
-					tasHostLabel:  "x7",
+					tasBlockLabel:        "b2",
+					tasRackLabel:         "r2",
+					corev1.LabelHostname: "x7",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -357,9 +356,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "b2-r2-x8",
 				Labels: map[string]string{
-					tasBlockLabel: "b2",
-					tasRackLabel:  "r2",
-					tasHostLabel:  "x8",
+					tasBlockLabel:        "b2",
+					tasRackLabel:         "r2",
+					corev1.LabelHostname: "x8",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -403,9 +402,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "b1-r1-x1",
 						Labels: map[string]string{
-							tasBlockLabel: "b1",
-							tasRackLabel:  "r1",
-							tasHostLabel:  "x1",
+							tasBlockLabel:        "b1",
+							tasRackLabel:         "r1",
+							corev1.LabelHostname: "x1",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -424,9 +423,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "b1-r2-x2",
 						Labels: map[string]string{
-							tasBlockLabel: "b1",
-							tasRackLabel:  "r2",
-							tasHostLabel:  "x2",
+							tasBlockLabel:        "b1",
+							tasRackLabel:         "r2",
+							corev1.LabelHostname: "x2",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -445,9 +444,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "b1-r3-x3",
 						Labels: map[string]string{
-							tasBlockLabel: "b1",
-							tasRackLabel:  "r3",
-							tasHostLabel:  "x3",
+							tasBlockLabel:        "b1",
+							tasRackLabel:         "r3",
+							corev1.LabelHostname: "x3",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -466,9 +465,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "b1-r3-x4",
 						Labels: map[string]string{
-							tasBlockLabel: "b1",
-							tasRackLabel:  "r3",
-							tasHostLabel:  "x4",
+							tasBlockLabel:        "b1",
+							tasRackLabel:         "r3",
+							corev1.LabelHostname: "x4",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -487,9 +486,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "b1-r3-x5",
 						Labels: map[string]string{
-							tasBlockLabel: "b1",
-							tasRackLabel:  "r3",
-							tasHostLabel:  "x5",
+							tasBlockLabel:        "b1",
+							tasRackLabel:         "r3",
+							corev1.LabelHostname: "x5",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -508,9 +507,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "b1-r3-x6",
 						Labels: map[string]string{
-							tasBlockLabel: "b1",
-							tasRackLabel:  "r3",
-							tasHostLabel:  "x6",
+							tasBlockLabel:        "b1",
+							tasRackLabel:         "r3",
+							corev1.LabelHostname: "x6",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -623,7 +622,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 		"host required; single Pod fits in the host": {
 			nodes: defaultNodes,
 			request: kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasHostLabel),
+				Required: ptr.To(corev1.LabelHostname),
 			},
 			levels: defaultThreeLevels,
 			requests: resources.Requests{
@@ -927,8 +926,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "b1-r1-x1",
 						Labels: map[string]string{
-							"zone":       "zone-a",
-							tasHostLabel: "x1",
+							"zone":               "zone-a",
+							corev1.LabelHostname: "x1",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -940,7 +939,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 				},
 			},
 			request: kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasHostLabel),
+				Required: ptr.To(corev1.LabelHostname),
 			},
 			nodeLabels: map[string]string{
 				"zone": "zone-b",
@@ -958,8 +957,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "b1-r1-x1",
 						Labels: map[string]string{
-							"zone":       "zone-a",
-							tasHostLabel: "x1",
+							"zone":               "zone-a",
+							corev1.LabelHostname: "x1",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -977,7 +976,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 				},
 			},
 			request: kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasHostLabel),
+				Required: ptr.To(corev1.LabelHostname),
 			},
 			nodeLabels: map[string]string{
 				"zone": "zone-a",
@@ -1007,7 +1006,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 						Labels: map[string]string{
 							tasBlockLabel: "b1",
 							tasRackLabel:  "r1",
-							// the node doesn't have the tasHostLabel required by topology
+							// the node doesn't have the 'kubernetes.io/hostname' required by topology
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -1041,7 +1040,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "x1",
 						Labels: map[string]string{
-							tasHostLabel: "x1",
+							corev1.LabelHostname: "x1",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -1064,7 +1063,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					Obj(),
 			},
 			request: kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasHostLabel),
+				Required: ptr.To(corev1.LabelHostname),
 			},
 			levels: defaultOneLevel,
 			requests: resources.Requests{
@@ -1089,7 +1088,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "x1",
 						Labels: map[string]string{
-							tasHostLabel: "x1",
+							corev1.LabelHostname: "x1",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -1117,7 +1116,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					Obj(),
 			},
 			request: kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasHostLabel),
+				Required: ptr.To(corev1.LabelHostname),
 			},
 			levels: defaultOneLevel,
 			requests: resources.Requests{
@@ -1143,7 +1142,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "x1",
 						Labels: map[string]string{
-							tasHostLabel: "x1",
+							corev1.LabelHostname: "x1",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -1167,7 +1166,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					Obj(),
 			},
 			request: kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasHostLabel),
+				Required: ptr.To(corev1.LabelHostname),
 			},
 			levels: defaultOneLevel,
 			requests: resources.Requests{
@@ -1183,7 +1182,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "x1",
 						Labels: map[string]string{
-							tasHostLabel: "x1",
+							corev1.LabelHostname: "x1",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -1207,7 +1206,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					Obj(),
 			},
 			request: kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasHostLabel),
+				Required: ptr.To(corev1.LabelHostname),
 			},
 			levels: defaultOneLevel,
 			requests: resources.Requests{
@@ -1224,7 +1223,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "x1",
 						Labels: map[string]string{
-							tasHostLabel: "x1",
+							corev1.LabelHostname: "x1",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -1244,7 +1243,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "x2",
 						Labels: map[string]string{
-							tasHostLabel: "x2",
+							corev1.LabelHostname: "x2",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -1267,7 +1266,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					Obj(),
 			},
 			request: kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasHostLabel),
+				Required: ptr.To(corev1.LabelHostname),
 			},
 			levels: defaultOneLevel,
 			requests: resources.Requests{
@@ -1292,8 +1291,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "b1-r1-x1",
 						Labels: map[string]string{
-							"zone":       "zone-a",
-							tasHostLabel: "x1",
+							"zone":               "zone-a",
+							corev1.LabelHostname: "x1",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -1315,7 +1314,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 				},
 			},
 			request: kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasHostLabel),
+				Required: ptr.To(corev1.LabelHostname),
 			},
 			nodeLabels: map[string]string{
 				"zone": "zone-a",

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -3984,15 +3984,14 @@ func TestResourcesToReserve(t *testing.T) {
 func TestScheduleForTAS(t *testing.T) {
 	const (
 		tasRackLabel = "cloud.provider.com/rack"
-		tasHostLabel = "kubernetes.io/hostname"
 	)
 	defaultSingleNode := []corev1.Node{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "x1",
 				Labels: map[string]string{
-					"tas-node":   "true",
-					tasHostLabel: "x1",
+					"tas-node":           "true",
+					corev1.LabelHostname: "x1",
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -4016,7 +4015,7 @@ func TestScheduleForTAS(t *testing.T) {
 		Spec: kueuealpha.TopologySpec{
 			Levels: []kueuealpha.TopologyLevel{
 				{
-					NodeLabel: tasHostLabel,
+					NodeLabel: corev1.LabelHostname,
 				},
 			},
 		},
@@ -4031,7 +4030,7 @@ func TestScheduleForTAS(t *testing.T) {
 					NodeLabel: tasRackLabel,
 				},
 				{
-					NodeLabel: tasHostLabel,
+					NodeLabel: corev1.LabelHostname,
 				},
 			},
 		},
@@ -4117,7 +4116,7 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("foo", "default").
 					Queue("tas-main").
 					PodSets(*utiltesting.MakePodSet("one", 1).
-						RequiredTopologyRequest(tasHostLabel).
+						RequiredTopologyRequest(corev1.LabelHostname).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Obj(),
@@ -4214,7 +4213,7 @@ func TestScheduleForTAS(t *testing.T) {
 							Request(corev1.ResourceCPU, "500m").
 							Obj(),
 						*utiltesting.MakePodSet("worker", 1).
-							RequiredTopologyRequest(tasHostLabel).
+							RequiredTopologyRequest(corev1.LabelHostname).
 							Request(corev1.ResourceCPU, "500m").
 							Obj()).
 					Obj(),
@@ -4279,7 +4278,7 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("foo", "default").
 					Queue("tas-main").
 					PodSets(*utiltesting.MakePodSet("one", 1).
-						RequiredTopologyRequest(tasHostLabel).
+						RequiredTopologyRequest(corev1.LabelHostname).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Obj(),
@@ -4447,7 +4446,7 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("foo", "default").
 					Queue("tas-main").
 					PodSets(*utiltesting.MakePodSet("one", 2).
-						RequiredTopologyRequest(tasHostLabel).
+						RequiredTopologyRequest(corev1.LabelHostname).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Obj(),
@@ -4473,7 +4472,7 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("foo", "default").
 					Queue("tas-main").
 					PodSets(*utiltesting.MakePodSet("one", 1).
-						RequiredTopologyRequest(tasHostLabel).
+						RequiredTopologyRequest(corev1.LabelHostname).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Obj(),
@@ -4497,7 +4496,7 @@ func TestScheduleForTAS(t *testing.T) {
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
-						RequiredTopologyRequest(tasHostLabel).
+						RequiredTopologyRequest(corev1.LabelHostname).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Obj(),
@@ -4529,7 +4528,7 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("foo", "default").
 					Queue("tas-main").
 					PodSets(*utiltesting.MakePodSet("one", 1).
-						RequiredTopologyRequest(tasHostLabel).
+						RequiredTopologyRequest(corev1.LabelHostname).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Obj(),
@@ -4552,7 +4551,7 @@ func TestScheduleForTAS(t *testing.T) {
 				*testingpod.MakePod("test-running", "test-ns").NodeName("x1").
 					StatusPhase(corev1.PodRunning).
 					Request(corev1.ResourceCPU, "400m").
-					NodeSelector(tasHostLabel, "x1").
+					NodeSelector(corev1.LabelHostname, "x1").
 					Label(kueuealpha.TASLabel, "true").
 					Obj(),
 			},
@@ -4563,7 +4562,7 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("foo", "default").
 					Queue("tas-main").
 					PodSets(*utiltesting.MakePodSet("one", 1).
-						RequiredTopologyRequest(tasHostLabel).
+						RequiredTopologyRequest(corev1.LabelHostname).
 						Request(corev1.ResourceCPU, "500m").
 						Obj()).
 					Obj(),
@@ -4587,7 +4586,7 @@ func TestScheduleForTAS(t *testing.T) {
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
-						RequiredTopologyRequest(tasHostLabel).
+						RequiredTopologyRequest(corev1.LabelHostname).
 						Request(corev1.ResourceCPU, "400m").
 						Obj()).
 					Obj(),
@@ -4631,7 +4630,7 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("foo", "default").
 					Queue("tas-main").
 					PodSets(*utiltesting.MakePodSet("one", 1).
-						RequiredTopologyRequest(tasHostLabel).
+						RequiredTopologyRequest(corev1.LabelHostname).
 						Request(corev1.ResourceCPU, "500m").
 						Request(corev1.ResourceMemory, "500Mi").
 						Obj()).
@@ -4657,7 +4656,7 @@ func TestScheduleForTAS(t *testing.T) {
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
-						RequiredTopologyRequest(tasHostLabel).
+						RequiredTopologyRequest(corev1.LabelHostname).
 						Request(corev1.ResourceCPU, "500m").
 						Request(corev1.ResourceMemory, "500Mi").
 						Obj()).
@@ -4700,9 +4699,9 @@ func TestScheduleForTAS(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "x1",
 						Labels: map[string]string{
-							"tas-node":   "true",
-							tasRackLabel: "r1",
-							tasHostLabel: "x1",
+							"tas-node":           "true",
+							tasRackLabel:         "r1",
+							corev1.LabelHostname: "x1",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -4721,9 +4720,9 @@ func TestScheduleForTAS(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "y1",
 						Labels: map[string]string{
-							"tas-node":   "true",
-							tasRackLabel: "r1",
-							tasHostLabel: "y1",
+							"tas-node":           "true",
+							tasRackLabel:         "r1",
+							corev1.LabelHostname: "y1",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -4753,11 +4752,11 @@ func TestScheduleForTAS(t *testing.T) {
 					Queue("tas-main").
 					PodSets(
 						*utiltesting.MakePodSet("launcher", 1).
-							PreferredTopologyRequest(tasHostLabel).
+							PreferredTopologyRequest(corev1.LabelHostname).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 						*utiltesting.MakePodSet("worker", 1).
-							PreferredTopologyRequest(tasHostLabel).
+							PreferredTopologyRequest(corev1.LabelHostname).
 							Request(corev1.ResourceCPU, "7").
 							Obj()).
 					Obj(),

--- a/test/e2e/singlecluster/tas_test.go
+++ b/test/e2e/singlecluster/tas_test.go
@@ -40,10 +40,6 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-const (
-	topologyLevel = "kubernetes.io/hostname"
-)
-
 var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 	var ns *corev1.Namespace
 
@@ -68,7 +64,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 		)
 		ginkgo.BeforeEach(func() {
 			topology = testing.MakeTopology("hostname").Levels([]string{
-				topologyLevel,
+				corev1.LabelHostname,
 			}).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
@@ -107,7 +103,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 				Obj()
 			jobKey := client.ObjectKeyFromObject(sampleJob)
 			sampleJob = (&testingjob.JobWrapper{Job: *sampleJob}).
-				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, topologyLevel).
+				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
 				Image(util.E2eTestSleepImage, []string{"1ms"}).
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, sampleJob)).Should(gomega.Succeed())
@@ -129,7 +125,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
 						Levels: []string{
-							topologyLevel,
+							corev1.LabelHostname,
 						},
 						Domains: []kueue.TopologyDomainAssignment{
 							{
@@ -161,7 +157,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			localQueue   *kueue.LocalQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("hostname").Levels([]string{topologyLevel}).Obj()
+			topology = testing.MakeTopology("hostname").Levels([]string{corev1.LabelHostname}).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			onDemandRF = testing.MakeResourceFlavor("on-demand").
@@ -205,7 +201,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 						Parallelism: 1,
 						Completions: 1,
 						PodAnnotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation: topologyLevel,
+							kueuealpha.PodSetRequiredTopologyAnnotation: corev1.LabelHostname,
 						},
 						Image: util.E2eTestSleepImage,
 						Args:  []string{"1ms"},
@@ -216,7 +212,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 						Parallelism: 1,
 						Completions: 1,
 						PodAnnotations: map[string]string{
-							kueuealpha.PodSetRequiredTopologyAnnotation: topologyLevel,
+							kueuealpha.PodSetRequiredTopologyAnnotation: corev1.LabelHostname,
 						},
 						Image: util.E2eTestSleepImage,
 						Args:  []string{"1ms"},
@@ -260,7 +256,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(2))
 				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels: []string{topologyLevel},
+						Levels: []string{corev1.LabelHostname},
 						Domains: []kueue.TopologyDomainAssignment{{
 							Count:  1,
 							Values: []string{"kind-worker"},
@@ -269,7 +265,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 				))
 				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments[1].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels: []string{topologyLevel},
+						Levels: []string{corev1.LabelHostname},
 						Domains: []kueue.TopologyDomainAssignment{{
 							Count:  1,
 							Values: []string{"kind-worker"},
@@ -296,7 +292,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			localQueue   *kueue.LocalQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("hostname").Levels([]string{topologyLevel}).Obj()
+			topology = testing.MakeTopology("hostname").Levels([]string{corev1.LabelHostname}).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			onDemandRF = testing.MakeResourceFlavor("on-demand").
@@ -334,7 +330,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			p := testingpod.MakePod("test-pod", ns.Name).
 				Queue(localQueue.Name).
 				Image(util.E2eTestSleepImage, []string{"1ms"}).
-				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, topologyLevel).
+				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
 				Request("cpu", "100m").
 				Request("memory", "100Mi").
 				Obj()
@@ -353,8 +349,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, jobSetKey, p)).To(gomega.Succeed())
 					g.Expect(p.Spec.NodeSelector).To(gomega.Equal(map[string]string{
-						"instance-type": "on-demand",
-						topologyLevel:   "kind-worker",
+						"instance-type":      "on-demand",
+						corev1.LabelHostname: "kind-worker",
 					}))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -371,7 +367,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
 				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels: []string{topologyLevel},
+						Levels: []string{corev1.LabelHostname},
 						Domains: []kueue.TopologyDomainAssignment{{
 							Count:  1,
 							Values: []string{"kind-worker"},
@@ -393,7 +389,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			group := testingpod.MakePod("group", ns.Name).
 				Queue(localQueue.Name).
 				Image(util.E2eTestSleepImage, []string{"1ms"}).
-				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, topologyLevel).
+				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
 				Request("cpu", "100m").
 				Request("memory", "100Mi").
 				MakeGroup(2)
@@ -417,8 +413,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(origPod), &p)).To(gomega.Succeed())
 						g.Expect(p.Spec.SchedulingGates).To(gomega.BeEmpty())
 						g.Expect(p.Spec.NodeSelector).To(gomega.Equal(map[string]string{
-							"instance-type": "on-demand",
-							topologyLevel:   "kind-worker",
+							"instance-type":      "on-demand",
+							corev1.LabelHostname: "kind-worker",
 						}))
 					}
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -436,7 +432,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
 				gomega.Expect(createdWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels: []string{topologyLevel},
+						Levels: []string{corev1.LabelHostname},
 						Domains: []kueue.TopologyDomainAssignment{{
 							Count:  2,
 							Values: []string{"kind-worker"},

--- a/test/e2e/tas/job_test.go
+++ b/test/e2e/tas/job_test.go
@@ -39,12 +39,11 @@ import (
 )
 
 const (
-	instanceType          = "tas-group"
-	tasNodeGroupLabel     = "cloud.provider.com/node-group"
-	topologyLevelRack     = "cloud.provider.com/topology-rack"
-	topologyLevelBlock    = "cloud.provider.com/topology-block"
-	topologyLevelHostname = "kubernetes.io/hostname"
-	extraResource         = "example.com/gpu"
+	instanceType       = "tas-group"
+	tasNodeGroupLabel  = "cloud.provider.com/node-group"
+	topologyLevelRack  = "cloud.provider.com/topology-rack"
+	topologyLevelBlock = "cloud.provider.com/topology-block"
+	extraResource      = "example.com/gpu"
 )
 
 var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
@@ -72,7 +71,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 			topology = testing.MakeTopology("datacenter").Levels([]string{
 				topologyLevelBlock,
 				topologyLevelRack,
-				topologyLevelHostname,
+				corev1.LabelHostname,
 			}).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
@@ -152,7 +151,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 					[]string{
 						topologyLevelBlock,
 						topologyLevelRack,
-						topologyLevelHostname,
+						corev1.LabelHostname,
 					},
 				))
 				podCountPerBlock := map[string]int32{}
@@ -201,7 +200,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 					[]string{
 						topologyLevelBlock,
 						topologyLevelRack,
-						topologyLevelHostname,
+						corev1.LabelHostname,
 					},
 				))
 				podCountPerBlock := map[string]int32{}

--- a/test/e2e/tas/jobset_test.go
+++ b/test/e2e/tas/jobset_test.go
@@ -61,7 +61,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", func() {
 			topology = testing.MakeTopology("datacenter").Levels([]string{
 				topologyLevelBlock,
 				topologyLevelRack,
-				topologyLevelHostname,
+				corev1.LabelHostname,
 			}).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 

--- a/test/e2e/tas/mpijob_test.go
+++ b/test/e2e/tas/mpijob_test.go
@@ -54,7 +54,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for MPIJob", func() {
 		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
 		topology = testing.MakeTopology("datacenter").
-			Levels([]string{topologyLevelBlock, topologyLevelRack, topologyLevelHostname}).
+			Levels([]string{topologyLevelBlock, topologyLevelRack, corev1.LabelHostname}).
 			Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 

--- a/test/e2e/tas/pytorch_test.go
+++ b/test/e2e/tas/pytorch_test.go
@@ -53,7 +53,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", func() {
 		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
 		topology = testing.MakeTopology("datacenter").
-			Levels([]string{topologyLevelBlock, topologyLevelRack, topologyLevelHostname}).
+			Levels([]string{topologyLevelBlock, topologyLevelRack, corev1.LabelHostname}).
 			Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Instead of self-defined "kubernetes.io/hostname", we use the core API hostname label.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```