### PR TITLE
Remove redundant inflight object informations from webhook loggings

### DIFF
--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -54,7 +53,7 @@ var _ admission.CustomDefaulter = &BaseWebhook{}
 func (w *BaseWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	job := w.FromObject(obj)
 	log := ctrl.LoggerFrom(ctx)
-	log.V(5).Info("Applying defaults", "job", klog.KObj(job.Object()))
+	log.V(5).Info("Applying defaults")
 	ApplyDefaultForSuspend(job, w.ManageJobsWithoutQueueName)
 	return nil
 }
@@ -65,7 +64,7 @@ var _ admission.CustomValidator = &BaseWebhook{}
 func (w *BaseWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	job := w.FromObject(obj)
 	log := ctrl.LoggerFrom(ctx)
-	log.V(5).Info("Validating create", "job", klog.KObj(job.Object()))
+	log.V(5).Info("Validating create")
 	allErrs := ValidateJobOnCreate(job)
 	if jobWithValidation, ok := job.(JobWithCustomValidation); ok {
 		allErrs = append(allErrs, jobWithValidation.ValidateOnCreate()...)
@@ -78,7 +77,7 @@ func (w *BaseWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime
 	oldJob := w.FromObject(oldObj)
 	newJob := w.FromObject(newObj)
 	log := ctrl.LoggerFrom(ctx)
-	log.Info("Validating update", "job", klog.KObj(newJob.Object()))
+	log.Info("Validating update")
 	allErrs := ValidateJobOnUpdate(oldJob, newJob)
 	if jobWithValidation, ok := newJob.(JobWithCustomValidation); ok {
 		allErrs = append(allErrs, jobWithValidation.ValidateOnUpdate(oldJob)...)

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -25,7 +25,6 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -75,7 +74,7 @@ var _ admission.CustomDefaulter = &JobWebhook{}
 func (w *JobWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	job := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")
-	log.V(5).Info("Applying defaults", "job", klog.KObj(job))
+	log.V(5).Info("Applying defaults")
 
 	jobframework.ApplyDefaultForSuspend(job, w.manageJobsWithoutQueueName)
 
@@ -86,12 +85,12 @@ func (w *JobWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		}
 		clusterQueueName, ok := w.queues.ClusterQueueFromLocalQueue(queue.QueueKey(job.ObjectMeta.Namespace, localQueueName))
 		if !ok {
-			log.V(5).Info("Cluster queue for local queue not found", "job", klog.KObj(job), "localQueueName", localQueueName)
+			log.V(5).Info("Cluster queue for local queue not found", "localQueueName", localQueueName)
 			return nil
 		}
 		for _, admissionCheck := range w.cache.AdmissionChecksForClusterQueue(clusterQueueName) {
 			if admissionCheck.Controller == kueue.MultiKueueControllerName {
-				log.V(5).Info("Defaulting ManagedBy", "job", klog.KObj(job), "oldManagedBy", job.Spec.ManagedBy, "managedBy", kueue.MultiKueueControllerName)
+				log.V(5).Info("Defaulting ManagedBy", "oldManagedBy", job.Spec.ManagedBy, "managedBy", kueue.MultiKueueControllerName)
 				job.Spec.ManagedBy = ptr.To(kueue.MultiKueueControllerName)
 				return nil
 			}
@@ -114,7 +113,7 @@ var _ admission.CustomValidator = &JobWebhook{}
 func (w *JobWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	job := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")
-	log.V(5).Info("Validating create", "job", klog.KObj(job))
+	log.V(5).Info("Validating create")
 	return nil, w.validateCreate(job).ToAggregate()
 }
 
@@ -164,7 +163,7 @@ func (w *JobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.
 	oldJob := fromObject(oldObj)
 	newJob := fromObject(newObj)
 	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")
-	log.V(5).Info("Validating update", "job", klog.KObj(newJob))
+	log.V(5).Info("Validating update")
 	return nil, w.validateUpdate(oldJob, newJob).ToAggregate()
 }
 

--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -70,7 +69,7 @@ var _ admission.CustomDefaulter = &JobSetWebhook{}
 func (w *JobSetWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	jobSet := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("jobset-webhook")
-	log.V(5).Info("Applying defaults", "jobset", klog.KObj(jobSet))
+	log.V(5).Info("Applying defaults")
 
 	jobframework.ApplyDefaultForSuspend(jobSet, w.manageJobsWithoutQueueName)
 
@@ -81,12 +80,12 @@ func (w *JobSetWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		}
 		clusterQueueName, ok := w.queues.ClusterQueueFromLocalQueue(queue.QueueKey(jobSet.ObjectMeta.Namespace, localQueueName))
 		if !ok {
-			log.V(5).Info("Cluster queue for local queue not found", "jobset", klog.KObj(jobSet), "localQueue", localQueueName)
+			log.V(5).Info("Cluster queue for local queue not found", "localQueue", localQueueName)
 			return nil
 		}
 		for _, admissionCheck := range w.cache.AdmissionChecksForClusterQueue(clusterQueueName) {
 			if admissionCheck.Controller == kueue.MultiKueueControllerName {
-				log.V(5).Info("Defaulting ManagedBy", "jobset", klog.KObj(jobSet), "oldManagedBy", jobSet.Spec.ManagedBy, "managedBy", kueue.MultiKueueControllerName)
+				log.V(5).Info("Defaulting ManagedBy", "oldManagedBy", jobSet.Spec.ManagedBy, "managedBy", kueue.MultiKueueControllerName)
 				jobSet.Spec.ManagedBy = ptr.To(kueue.MultiKueueControllerName)
 				return nil
 			}
@@ -109,7 +108,7 @@ var _ admission.CustomValidator = &JobSetWebhook{}
 func (w *JobSetWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	jobSet := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("jobset-webhook")
-	log.Info("Validating create", "jobset", klog.KObj(jobSet))
+	log.Info("Validating create")
 	return nil, w.validateCreate(jobSet).ToAggregate()
 }
 
@@ -118,7 +117,7 @@ func (w *JobSetWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runti
 	oldJobSet := fromObject(oldObj)
 	newJobSet := fromObject(newObj)
 	log := ctrl.LoggerFrom(ctx).WithName("jobset-webhook")
-	log.Info("Validating update", "jobset", klog.KObj(newJobSet))
+	log.Info("Validating update")
 	return nil, w.validateUpdate(oldJobSet, newJobSet).ToAggregate()
 }
 

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -23,7 +23,6 @@ import (
 	"github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -74,7 +73,7 @@ var _ admission.CustomDefaulter = &MpiJobWebhook{}
 func (w *MpiJobWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	mpiJob := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("mpijob-webhook")
-	log.V(5).Info("Applying defaults", "mpijob", klog.KObj(mpiJob))
+	log.V(5).Info("Applying defaults")
 
 	jobframework.ApplyDefaultForSuspend(mpiJob, w.manageJobsWithoutQueueName)
 
@@ -85,12 +84,12 @@ func (w *MpiJobWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		}
 		clusterQueueName, ok := w.queues.ClusterQueueFromLocalQueue(queue.QueueKey(mpiJob.ObjectMeta.Namespace, localQueueName))
 		if !ok {
-			log.V(5).Info("Cluster queue for local queue not found", "mpijob", klog.KObj(mpiJob), "localQueue", localQueueName)
+			log.V(5).Info("Cluster queue for local queue not found", "localQueue", localQueueName)
 			return nil
 		}
 		for _, admissionCheck := range w.cache.AdmissionChecksForClusterQueue(clusterQueueName) {
 			if admissionCheck.Controller == kueue.MultiKueueControllerName {
-				log.V(5).Info("Defaulting ManagedBy", "mpijob", klog.KObj(mpiJob), "oldManagedBy", mpiJob.Spec.RunPolicy.ManagedBy, "managedBy", kueue.MultiKueueControllerName)
+				log.V(5).Info("Defaulting ManagedBy", "oldManagedBy", mpiJob.Spec.RunPolicy.ManagedBy, "managedBy", kueue.MultiKueueControllerName)
 				mpiJob.Spec.RunPolicy.ManagedBy = ptr.To(kueue.MultiKueueControllerName)
 				return nil
 			}
@@ -113,7 +112,7 @@ var _ admission.CustomValidator = &MpiJobWebhook{}
 func (w *MpiJobWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	mpiJob := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("mpijob-webhook")
-	log.Info("Validating create", "mpijob", klog.KObj(mpiJob))
+	log.Info("Validating create")
 	return nil, w.validateCommon(mpiJob).ToAggregate()
 }
 
@@ -122,7 +121,7 @@ func (w *MpiJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runti
 	oldMpiJob := fromObject(oldObj)
 	newMpiJob := fromObject(newObj)
 	log := ctrl.LoggerFrom(ctx).WithName("mpijob-webhook")
-	log.Info("Validating update", "mpijob", klog.KObj(newMpiJob))
+	log.Info("Validating update")
 	allErrs := jobframework.ValidateJobOnUpdate(oldMpiJob, newMpiJob)
 	allErrs = append(allErrs, w.validateCommon(newMpiJob)...)
 	return nil, allErrs.ToAggregate()

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -140,7 +139,7 @@ func (p *Pod) addRoleHash() error {
 
 func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	pod := FromObject(obj)
-	log := ctrl.LoggerFrom(ctx).WithName("pod-webhook").WithValues("pod", klog.KObj(&pod.pod))
+	log := ctrl.LoggerFrom(ctx).WithName("pod-webhook")
 	log.V(5).Info("Applying defaults")
 
 	if IsPodOwnerManagedByKueue(pod) {
@@ -210,7 +209,7 @@ func (w *PodWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (ad
 	var warnings admission.Warnings
 
 	pod := FromObject(obj)
-	log := ctrl.LoggerFrom(ctx).WithName("pod-webhook").WithValues("pod", klog.KObj(&pod.pod))
+	log := ctrl.LoggerFrom(ctx).WithName("pod-webhook")
 	log.V(5).Info("Validating create")
 
 	allErrs := jobframework.ValidateJobOnCreate(pod)
@@ -228,7 +227,7 @@ func (w *PodWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.
 
 	oldPod := FromObject(oldObj)
 	newPod := FromObject(newObj)
-	log := ctrl.LoggerFrom(ctx).WithName("pod-webhook").WithValues("pod", klog.KObj(&newPod.pod))
+	log := ctrl.LoggerFrom(ctx).WithName("pod-webhook")
 	log.V(5).Info("Validating update")
 
 	allErrs := jobframework.ValidateJobOnUpdate(oldPod, newPod)

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -20,7 +20,6 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -64,7 +63,7 @@ var _ admission.CustomDefaulter = &RayClusterWebhook{}
 func (w *RayClusterWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	job := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("raycluster-webhook")
-	log.V(10).Info("Applying defaults", "job", klog.KObj(job))
+	log.V(10).Info("Applying defaults")
 	jobframework.ApplyDefaultForSuspend(job, w.manageJobsWithoutQueueName)
 	return nil
 }
@@ -77,7 +76,7 @@ var _ admission.CustomValidator = &RayClusterWebhook{}
 func (w *RayClusterWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	job := obj.(*rayv1.RayCluster)
 	log := ctrl.LoggerFrom(ctx).WithName("raycluster-webhook")
-	log.V(10).Info("Validating create", "job", klog.KObj(job))
+	log.V(10).Info("Validating create")
 	return nil, w.validateCreate(job).ToAggregate()
 }
 
@@ -130,7 +129,7 @@ func (w *RayClusterWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj r
 	newJob := newObj.(*rayv1.RayCluster)
 	log := ctrl.LoggerFrom(ctx).WithName("raycluster-webhook")
 	if w.manageJobsWithoutQueueName || jobframework.QueueName((*RayCluster)(newJob)) != "" {
-		log.Info("Validating update", "job", klog.KObj(newJob))
+		log.Info("Validating update")
 		allErrors := jobframework.ValidateJobOnUpdate((*RayCluster)(oldJob), (*RayCluster)(newJob))
 		allErrors = append(allErrors, w.validateCreate(newJob)...)
 		return nil, allErrors.ToAggregate()

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -23,7 +23,6 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -64,7 +63,7 @@ var _ admission.CustomDefaulter = &RayJobWebhook{}
 func (w *RayJobWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	job := obj.(*rayv1.RayJob)
 	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
-	log.V(5).Info("Applying defaults", "job", klog.KObj(job))
+	log.V(5).Info("Applying defaults")
 	jobframework.ApplyDefaultForSuspend((*RayJob)(job), w.manageJobsWithoutQueueName)
 	return nil
 }
@@ -77,7 +76,7 @@ var _ admission.CustomValidator = &RayJobWebhook{}
 func (w *RayJobWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	job := obj.(*rayv1.RayJob)
 	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
-	log.Info("Validating create", "job", klog.KObj(job))
+	log.Info("Validating create")
 	return nil, w.validateCreate(job).ToAggregate()
 }
 
@@ -145,7 +144,7 @@ func (w *RayJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runti
 	newJob := newObj.(*rayv1.RayJob)
 	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
 	if w.manageJobsWithoutQueueName || jobframework.QueueName((*RayJob)(newJob)) != "" {
-		log.Info("Validating update", "job", klog.KObj(newJob))
+		log.Info("Validating update")
 		allErrors := jobframework.ValidateJobOnUpdate((*RayJob)(oldJob), (*RayJob)(newJob))
 		allErrors = append(allErrors, w.validateCreate(newJob)...)
 		return nil, allErrors.ToAggregate()

--- a/pkg/webhooks/clusterqueue_webhook.go
+++ b/pkg/webhooks/clusterqueue_webhook.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -59,7 +58,7 @@ var _ webhook.CustomDefaulter = &ClusterQueueWebhook{}
 func (w *ClusterQueueWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	cq := obj.(*kueue.ClusterQueue)
 	log := ctrl.LoggerFrom(ctx).WithName("clusterqueue-webhook")
-	log.V(5).Info("Applying defaults", "clusterQueue", klog.KObj(cq))
+	log.V(5).Info("Applying defaults")
 	if !controllerutil.ContainsFinalizer(cq, kueue.ResourceInUseFinalizerName) {
 		controllerutil.AddFinalizer(cq, kueue.ResourceInUseFinalizerName)
 	}
@@ -74,7 +73,7 @@ var _ webhook.CustomValidator = &ClusterQueueWebhook{}
 func (w *ClusterQueueWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	cq := obj.(*kueue.ClusterQueue)
 	log := ctrl.LoggerFrom(ctx).WithName("clusterqueue-webhook")
-	log.V(5).Info("Validating create", "clusterQueue", klog.KObj(cq))
+	log.V(5).Info("Validating create")
 	allErrs := ValidateClusterQueue(cq)
 	return nil, allErrs.ToAggregate()
 }
@@ -84,7 +83,7 @@ func (w *ClusterQueueWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj
 	newCQ := newObj.(*kueue.ClusterQueue)
 
 	log := ctrl.LoggerFrom(ctx).WithName("clusterqueue-webhook")
-	log.V(5).Info("Validating update", "clusterQueue", klog.KObj(newCQ))
+	log.V(5).Info("Validating update")
 	allErrs := ValidateClusterQueueUpdate(newCQ)
 	return nil, allErrs.ToAggregate()
 }

--- a/pkg/webhooks/cohort_webhook.go
+++ b/pkg/webhooks/cohort_webhook.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -50,7 +49,7 @@ var _ webhook.CustomValidator = &CohortWebhook{}
 func (w *CohortWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	cohort := obj.(*kueuealpha.Cohort)
 	log := ctrl.LoggerFrom(ctx).WithName("cohort-webhook")
-	log.V(5).Info("Validating Cohort create", "cohort", klog.KObj(cohort))
+	log.V(5).Info("Validating Cohort create")
 	return nil, validateCohort(cohort).ToAggregate()
 }
 
@@ -58,7 +57,7 @@ func (w *CohortWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) 
 func (w *CohortWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	cohort := newObj.(*kueuealpha.Cohort)
 	log := ctrl.LoggerFrom(ctx).WithName("cohort-webhook")
-	log.V(5).Info("Validating Cohort update", "cohort", klog.KObj(cohort))
+	log.V(5).Info("Validating Cohort update")
 	return nil, validateCohort(cohort).ToAggregate()
 }
 

--- a/pkg/webhooks/resourceflavor_webhook.go
+++ b/pkg/webhooks/resourceflavor_webhook.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -53,7 +52,7 @@ var _ webhook.CustomDefaulter = &ResourceFlavorWebhook{}
 func (w *ResourceFlavorWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	rf := obj.(*kueue.ResourceFlavor)
 	log := ctrl.LoggerFrom(ctx).WithName("resourceflavor-webhook")
-	log.V(5).Info("Applying defaults", "resourceFlavor", klog.KObj(rf))
+	log.V(5).Info("Applying defaults")
 
 	if !controllerutil.ContainsFinalizer(rf, kueue.ResourceInUseFinalizerName) {
 		controllerutil.AddFinalizer(rf, kueue.ResourceInUseFinalizerName)
@@ -69,7 +68,7 @@ var _ webhook.CustomValidator = &ResourceFlavorWebhook{}
 func (w *ResourceFlavorWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	rf := obj.(*kueue.ResourceFlavor)
 	log := ctrl.LoggerFrom(ctx).WithName("resourceflavor-webhook")
-	log.V(5).Info("Validating create", "resourceFlavor", klog.KObj(rf))
+	log.V(5).Info("Validating create")
 	return nil, ValidateResourceFlavor(rf).ToAggregate()
 }
 
@@ -77,7 +76,7 @@ func (w *ResourceFlavorWebhook) ValidateCreate(ctx context.Context, obj runtime.
 func (w *ResourceFlavorWebhook) ValidateUpdate(ctx context.Context, _, newObj runtime.Object) (admission.Warnings, error) {
 	newRF := newObj.(*kueue.ResourceFlavor)
 	log := ctrl.LoggerFrom(ctx).WithName("resourceflavor-webhook")
-	log.V(5).Info("Validating update", "resourceFlavor", klog.KObj(newRF))
+	log.V(5).Info("Validating update")
 	return nil, ValidateResourceFlavor(newRF).ToAggregate()
 }
 

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -57,7 +56,7 @@ var _ webhook.CustomDefaulter = &WorkloadWebhook{}
 func (w *WorkloadWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	wl := obj.(*kueue.Workload)
 	log := ctrl.LoggerFrom(ctx).WithName("workload-webhook")
-	log.V(5).Info("Applying defaults", "workload", klog.KObj(wl))
+	log.V(5).Info("Applying defaults")
 
 	// drop minCounts if PartialAdmission is not enabled
 	if !features.Enabled(features.PartialAdmission) {
@@ -77,7 +76,7 @@ var _ webhook.CustomValidator = &WorkloadWebhook{}
 func (w *WorkloadWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	wl := obj.(*kueue.Workload)
 	log := ctrl.LoggerFrom(ctx).WithName("workload-webhook")
-	log.V(5).Info("Validating create", "workload", klog.KObj(wl))
+	log.V(5).Info("Validating create")
 	return nil, ValidateWorkload(wl).ToAggregate()
 }
 
@@ -86,7 +85,7 @@ func (w *WorkloadWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj run
 	newWL := newObj.(*kueue.Workload)
 	oldWL := oldObj.(*kueue.Workload)
 	log := ctrl.LoggerFrom(ctx).WithName("workload-webhook")
-	log.V(5).Info("Validating update", "workload", klog.KObj(newWL))
+	log.V(5).Info("Validating update")
 	return nil, ValidateWorkloadUpdate(newWL, oldWL).ToAggregate()
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
I removed the redundant logging information in the webhooks.
The controller runtime has already added the inflight object information into loggers.

This is similar to https://github.com/kubernetes-sigs/kueue/pull/3576.
Actually, we can observe the redundant loggings in the followings:

```
Validating create	{
  "webhookGroup": "ray.io",
  "webhookKind": "RayJob",
  "RayJob": {
    "name": "parent-job",
    "namespace": "raycluster-xg8h7"
  },
  "namespace": "raycluster-xg8h7",
  "name": "parent-job",
  "resource": {
    "group": "ray.io",
    "version": "v1",
    "resource": "rayjobs"
  },
  "user": "admin",
  "requestID": "ca808e9c-0102-401c-804c-ce7f217a927e",
  "job": {
    "name": "parent-job",
    "namespace": "raycluster-xg8h7"
  }
}
```

```
Validating update	{
  "webhookGroup": "kubeflow.org",
  "webhookKind": "PyTorchJob",
  "PyTorchJob": {
    "name": "pytorchjob1",
    "namespace": "multikueue-j52tc"
  },
  "namespace": "multikueue-j52tc",
  "name": "pytorchjob1",
  "resource": {
    "group": "kubeflow.org",
    "version": "v1",
    "resource": "pytorchjobs"
  },
  "user": "admin",
  "requestID": "38e31ecc-1ea7-4f9c-9053-9df4fb38e22c",
  "job": {
    "name": "pytorchjob1",
    "namespace": "multikueue-j52tc"
  }
}
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```