### PR TITLE
TAS: Move sorting domains lexicographically from TopologyUngater to TAS Snapshot

### DIFF
--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"context"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -30,6 +31,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/resources"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 )
@@ -1351,6 +1353,11 @@ func TestFindTopologyAssignment(t *testing.T) {
 				t.Fatalf("failed to build the snapshot: %v", err)
 			}
 			gotAssignment, reason := snapshot.FindTopologyAssignment(&tc.request, tc.requests, tc.count)
+			if gotAssignment != nil {
+				sort.Slice(tc.wantAssignment.Domains, func(i, j int) bool {
+					return utiltas.DomainID(tc.wantAssignment.Domains[i].Values) < utiltas.DomainID(tc.wantAssignment.Domains[j].Values)
+				})
+			}
 			if diff := cmp.Diff(tc.wantAssignment, gotAssignment); diff != "" {
 				t.Errorf("unexpected topology assignment (-want,+got): %s", diff)
 			}

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -300,6 +300,10 @@ func (s *TASFlavorSnapshot) buildAssignment(domains []*domain) *kueue.TopologyAs
 		Levels:  s.levelKeys,
 		Domains: make([]kueue.TopologyDomainAssignment, 0),
 	}
+	// lex sort domains
+	slices.SortFunc(domains, func(a, b *domain) int {
+		return cmp.Compare(a.id, b.id)
+	})
 	for _, domain := range domains {
 		assignment.Domains = append(assignment.Domains, kueue.TopologyDomainAssignment{
 			Values: domain.levelValues,

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -893,17 +893,17 @@ func TestReconcile(t *testing.T) {
 										},
 									},
 									{
-										Count: 2,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-									{
 										Count: 1,
 										Values: []string{
 											"b1",
 											"r2",
+										},
+									},
+									{
+										Count: 2,
+										Values: []string{
+											"b2",
+											"r1",
 										},
 									},
 								},
@@ -1028,17 +1028,17 @@ func TestReconcile(t *testing.T) {
 										},
 									},
 									{
-										Count: 2,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-									{
 										Count: 1,
 										Values: []string{
 											"b1",
 											"r2",
+										},
+									},
+									{
+										Count: 2,
+										Values: []string{
+											"b2",
+											"r1",
 										},
 									},
 								},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Reduce the amount of sorting as in TAS Snapshot it's done only once . Account for future changes regarding #3671 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #3671 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```