### PR TITLE
TAS: Respect node taints if the lowest level is node

### DIFF
--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -66,7 +66,7 @@ func assignTopology(log logr.Logger,
 		}
 		var reason string
 		psAssignment.TopologyAssignment, reason = snapshot.FindTopologyAssignment(podSet.TopologyRequest,
-			singlePodRequests, podCount)
+			singlePodRequests, podCount, podSet.Template.Spec.Tolerations)
 		if psAssignment.TopologyAssignment == nil {
 			if psAssignment.Status == nil {
 				psAssignment.Status = &Status{}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Part of #3658 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Respect node taints in Topology-Aware Scheduling when the lowest topology level is kubernetes.io/hostname.
```