### PR TITLE
TAS: validate that kubernetes.io/hostname can only be at the lowest level

### DIFF
--- a/apis/kueue/v1alpha1/tas_types.go
+++ b/apis/kueue/v1alpha1/tas_types.go
@@ -73,7 +73,9 @@ type TopologySpec struct {
 	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=8
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="the levels field is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"
+	// +kubebuilder:validation:XValidation:rule="size(self.filter(i, size(self.filter(j, j == i)) > 1)) == 0",message="must be unique"
+	// +kubebuilder:validation:XValidation:rule="size(self.filter(i, i.nodeLabel == 'kubernetes.io/hostname')) == 0 || self[size(self) - 1].nodeLabel == 'kubernetes.io/hostname'",message="the kubernetes.io/hostname label can only be used at the lowest level of topology"
 	Levels []TopologyLevel `json:"levels,omitempty"`
 }
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
@@ -79,8 +79,15 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
-                - message: the levels field is immutable
+                - message: field is immutable
                   rule: self == oldSelf
+                - message: must be unique
+                  rule: size(self.filter(i, size(self.filter(j, j == i)) > 1)) ==
+                    0
+                - message: the kubernetes.io/hostname label can only be used at the
+                    lowest level of topology
+                  rule: size(self.filter(i, i.nodeLabel == 'kubernetes.io/hostname'))
+                    == 0 || self[size(self) - 1].nodeLabel == 'kubernetes.io/hostname'
             required:
             - levels
             type: object

--- a/config/components/crd/bases/kueue.x-k8s.io_topologies.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_topologies.yaml
@@ -64,8 +64,15 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
-                - message: the levels field is immutable
+                - message: field is immutable
                   rule: self == oldSelf
+                - message: must be unique
+                  rule: size(self.filter(i, size(self.filter(j, j == i)) > 1)) ==
+                    0
+                - message: the kubernetes.io/hostname label can only be used at the
+                    lowest level of topology
+                  rule: size(self.filter(i, i.nodeLabel == 'kubernetes.io/hostname'))
+                    == 0 || self[size(self) - 1].nodeLabel == 'kubernetes.io/hostname'
             required:
             - levels
             type: object

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -979,6 +979,18 @@ var _ = ginkgo.Describe("Topology validations", func() {
 			ginkgo.Entry("invalid levels",
 				testing.MakeTopology("invalid-level").Levels([]string{"@invalid"}).Obj(),
 				testing.BeInvalidError()),
+			ginkgo.Entry("non-unique levels",
+				testing.MakeTopology("default").Levels([]string{tasBlockLabel, tasBlockLabel}).Obj(),
+				testing.BeInvalidError()),
+			ginkgo.Entry("kubernetes.io/hostname first",
+				testing.MakeTopology("default").Levels([]string{corev1.LabelHostname, tasBlockLabel, tasRackLabel}).Obj(),
+				testing.BeInvalidError()),
+			ginkgo.Entry("kubernetes.io/hostname middle",
+				testing.MakeTopology("default").Levels([]string{tasBlockLabel, corev1.LabelHostname, tasRackLabel}).Obj(),
+				testing.BeInvalidError()),
+			ginkgo.Entry("kubernetes.io/hostname last",
+				testing.MakeTopology("default").Levels([]string{tasBlockLabel, tasRackLabel, corev1.LabelHostname}).Obj(),
+				gomega.Succeed()),
 		)
 	})
 
@@ -1009,6 +1021,12 @@ var _ = ginkgo.Describe("Topology validations", func() {
 					topology.Spec.Levels = append(topology.Spec.Levels, kueuealpha.TopologyLevel{
 						NodeLabel: "added",
 					})
+				},
+				testing.BeInvalidError()),
+			ginkgo.Entry("updating levels order is prohibited",
+				testing.MakeTopology("default").Levels([]string{tasRackLabel, tasBlockLabel, corev1.LabelHostname}).Obj(),
+				func(topology *kueuealpha.Topology) {
+					topology.Spec.Levels[0], topology.Spec.Levels[1] = topology.Spec.Levels[1], topology.Spec.Levels[0]
 				},
 				testing.BeInvalidError()),
 		)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Validate that kubernetes.io/hostname can only be at the lowest level in Topology.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3688

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: validate that kubernetes.io/hostname can only be at the lowest level
```