### PR TITLE
Use ReadUIntFromLabelWithMax to get and validate pod index.

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -86,12 +86,10 @@ const (
 )
 
 var (
-	gvk                           = corev1.SchemeGroupVersion.WithKind("Pod")
-	errIncorrectReconcileRequest  = errors.New("event handler error: got a single pod reconcile request for a pod group")
-	errPendingOps                 = jobframework.UnretryableError("waiting to observe previous operations on pods")
-	errPodGroupLabelsMismatch     = errors.New("constructing workload: pods have different label values")
-	errIndexGreaterThanGroupCount = errors.New("incorrect label value: group pod index should be less than group total count")
-	errGroupIndexLessThanZero     = errors.New("incorrect label value: group pod index should be greater than zero")
+	gvk                          = corev1.SchemeGroupVersion.WithKind("Pod")
+	errIncorrectReconcileRequest = errors.New("event handler error: got a single pod reconcile request for a pod group")
+	errPendingOps                = jobframework.UnretryableError("waiting to observe previous operations on pods")
+	errPodGroupLabelsMismatch    = errors.New("constructing workload: pods have different label values")
 )
 
 func init() {
@@ -559,25 +557,6 @@ func (p *Pod) groupTotalCount() (int, error) {
 	return gtc, nil
 }
 
-// podGroupIndex returns the value of GroupIndexLabel for the pod being reconciled at the moment.
-func (p *Pod) podGroupIndex(podGroupTotalCount int) (*int, error) {
-	podIndex, ok := p.Object().GetLabels()[kueuealpha.PodGroupPodIndexLabel]
-	if !ok {
-		return nil, nil
-	}
-	groupIndexValue, err := strconv.Atoi(podIndex)
-	if err != nil {
-		return nil, err
-	}
-	if groupIndexValue >= podGroupTotalCount {
-		return nil, errIndexGreaterThanGroupCount
-	}
-	if groupIndexValue < 0 {
-		return nil, errGroupIndexLessThanZero
-	}
-	return &groupIndexValue, nil
-}
-
 // getRoleHash will filter all the fields of the pod that are relevant to admission (pod role) and return a sha256
 // checksum of those fields. This is used to group the pods of the same roles when interacting with the workload.
 func getRoleHash(p corev1.Pod) (string, error) {
@@ -725,9 +704,12 @@ func (p *Pod) validatePodGroupMetadata(r record.EventRecorder, activePods []core
 	if err != nil {
 		return err
 	}
-	if _, err = p.podGroupIndex(groupTotalCount); err != nil {
+
+	_, err = utilpod.ReadUIntFromLabelBelowBound(p.Object(), kueuealpha.PodGroupPodIndexLabel, groupTotalCount-1)
+	if utilpod.IgnoreLabelNotFoundError(err) != nil {
 		return err
 	}
+
 	originalQueue := jobframework.QueueName(p)
 	_, useFastAdmission := p.pod.GetAnnotations()[GroupFastAdmissionAnnotation]
 

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -705,7 +705,7 @@ func (p *Pod) validatePodGroupMetadata(r record.EventRecorder, activePods []core
 		return err
 	}
 
-	_, err = utilpod.ReadUIntFromLabelBelowBound(p.Object(), kueuealpha.PodGroupPodIndexLabel, groupTotalCount-1)
+	_, err = utilpod.ReadUIntFromLabelBelowBound(p.Object(), kueuealpha.PodGroupPodIndexLabel, groupTotalCount)
 	if utilpod.IgnoreLabelNotFoundError(err) != nil {
 		return err
 	}

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -44,6 +44,7 @@ import (
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/podset"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 
@@ -4048,7 +4049,7 @@ func TestReconciler(t *testing.T) {
 				GroupTotalCount("1").
 				Obj(),
 			},
-			wantErr: errIndexGreaterThanGroupCount,
+			wantErr: utilpod.ErrValidation,
 		},
 		"reconciler returns error in case pod group pod index is less than 0": {
 			pods: []corev1.Pod{*basePodWrapper.
@@ -4061,7 +4062,7 @@ func TestReconciler(t *testing.T) {
 				GroupTotalCount("1").
 				Obj(),
 			},
-			wantErr: errGroupIndexLessThanZero,
+			wantErr: utilpod.ErrInvalidUInt,
 		},
 		"reconciler returns error in case of label mismatch in pod group": {
 			pods: []corev1.Pod{

--- a/pkg/util/pod/pod.go
+++ b/pkg/util/pod/pod.go
@@ -99,7 +99,7 @@ func readUIntFromStringBelowBound(value string, bound int) (*int, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidUInt, err.Error())
 	}
-	if uintValue > uint64(bound) {
+	if uintValue >= uint64(bound) {
 		return nil, fmt.Errorf("%w: value should be less than %d", ErrValidation, bound)
 	}
 	return ptr.To(int(uintValue)), nil

--- a/pkg/util/pod/pod_test.go
+++ b/pkg/util/pod/pod_test.go
@@ -220,7 +220,7 @@ func TestReadUIntFromLabel(t *testing.T) {
 			},
 			label:   "label",
 			max:     math.MaxInt,
-			wantErr: errLabelNotFound,
+			wantErr: ErrLabelNotFound,
 		},
 		"valid label value": {
 			obj: &corev1.Pod{
@@ -245,7 +245,7 @@ func TestReadUIntFromLabel(t *testing.T) {
 				},
 			},
 			label:   "label",
-			wantErr: errInvalidUInt,
+			wantErr: ErrInvalidUInt,
 		},
 		"less than zero": {
 			obj: &corev1.Pod{
@@ -257,7 +257,7 @@ func TestReadUIntFromLabel(t *testing.T) {
 				},
 			},
 			label:   "label",
-			wantErr: errInvalidUInt,
+			wantErr: ErrInvalidUInt,
 		},
 		"greater than max": {
 			obj: &corev1.Pod{
@@ -270,7 +270,7 @@ func TestReadUIntFromLabel(t *testing.T) {
 			},
 			label:   "label",
 			max:     1000,
-			wantErr: errValidation,
+			wantErr: ErrValidation,
 		},
 	}
 

--- a/pkg/util/pod/pod_test.go
+++ b/pkg/util/pod/pod_test.go
@@ -259,7 +259,7 @@ func TestReadUIntFromLabel(t *testing.T) {
 			label:   "label",
 			wantErr: ErrInvalidUInt,
 		},
-		"greater than max": {
+		"equal to bound": {
 			obj: &corev1.Pod{
 				TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: ""},
 				ObjectMeta: metav1.ObjectMeta{
@@ -269,7 +269,7 @@ func TestReadUIntFromLabel(t *testing.T) {
 				},
 			},
 			label:   "label",
-			max:     1000,
+			max:     1001,
 			wantErr: ErrValidation,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Use ReadUIntFromLabelWithMax to get and validate pod index.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3651

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```