### PR TITLE
Remove node.kubernetes.io/not-ready taint if status active after creation.

### DIFF
--- a/pkg/controller/tas/indexer/indexer.go
+++ b/pkg/controller/tas/indexer/indexer.go
@@ -52,7 +52,7 @@ func indexReadyNode(o client.Object) []string {
 		return nil
 	}
 
-	if !utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady, corev1.ConditionTrue) {
+	if !utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady) {
 		return nil
 	}
 

--- a/pkg/util/slices/slices.go
+++ b/pkg/util/slices/slices.go
@@ -116,3 +116,33 @@ func Pick[E any, S ~[]E](s S, keep func(*E) bool) S {
 	}
 	return ret
 }
+
+// IndexFunc returns the first index i satisfying f(s[i]),
+// or -1 if none do.
+func IndexFunc[S ~[]E, E any](s S, f func(E) bool) int {
+	for i := range s {
+		if f(s[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+// DeleteFunc removes any elements from s for which del returns true,
+// returning the modified slice.
+// DeleteFunc zeroes the elements between the new length and the original length.
+func DeleteFunc[S ~[]E, E any](s S, del func(E) bool) S {
+	i := IndexFunc(s, del)
+	if i == -1 {
+		return s
+	}
+	// Don't start copying elements until we find one to delete.
+	for j := i + 1; j < len(s); j++ {
+		if v := s[j]; !del(v) {
+			s[i] = v
+			i++
+		}
+	}
+	clear(s[i:]) // zero/nil out the obsolete elements, for GC
+	return s[:i]
+}

--- a/pkg/util/tas/tas.go
+++ b/pkg/util/tas/tas.go
@@ -54,10 +54,10 @@ func Levels(topology *kueuealpha.Topology) []string {
 	return result
 }
 
-func IsNodeStatusConditionTrue(conditions []corev1.NodeCondition, conditionType corev1.NodeConditionType, conditionStatus corev1.ConditionStatus) bool {
+func IsNodeStatusConditionTrue(conditions []corev1.NodeCondition, conditionType corev1.NodeConditionType) bool {
 	for _, cond := range conditions {
 		if cond.Type == conditionType {
-			return cond.Status == conditionStatus
+			return cond.Status == corev1.ConditionTrue
 		}
 	}
 	return false

--- a/pkg/util/testingjobs/node/wrappers.go
+++ b/pkg/util/testingjobs/node/wrappers.go
@@ -68,7 +68,7 @@ func (n *NodeWrapper) StatusAllocatable(resourceList corev1.ResourceList) *NodeW
 	return n
 }
 
-// StatusConditions appends the given taints to the Node.
+// Taints appends the given taints to the Node.
 func (n *NodeWrapper) Taints(taints ...corev1.Taint) *NodeWrapper {
 	n.Spec.Taints = append(n.Spec.Taints, taints...)
 	return n
@@ -83,7 +83,7 @@ func (n *NodeWrapper) Ready() *NodeWrapper {
 	return n
 }
 
-// Ready sets the Node to a not ready status condition
+// NotReady sets the Node to a not ready status condition
 func (n *NodeWrapper) NotReady() *NodeWrapper {
 	n.StatusConditions(corev1.NodeCondition{
 		Type:   corev1.NodeReady,

--- a/test/integration/controller/jobs/job/job_controller_test.go
+++ b/test/integration/controller/jobs/job/job_controller_test.go
@@ -2204,10 +2204,7 @@ var _ = ginkgo.Describe("Job controller when TopologyAwareScheduling enabled", g
 				Ready().
 				Obj(),
 		}
-		for _, node := range nodes {
-			gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-		}
+		util.CreateNodes(ctx, k8sClient, nodes)
 
 		topology = testing.MakeTopology("default").Levels([]string{
 			tasBlockLabel,

--- a/test/integration/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/controller/jobs/jobset/jobset_controller_test.go
@@ -1163,10 +1163,7 @@ var _ = ginkgo.Describe("JobSet controller when TopologyAwareScheduling enabled"
 				Ready().
 				Obj(),
 		}
-		for _, node := range nodes {
-			gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-		}
+		util.CreateNodes(ctx, k8sClient, nodes)
 
 		topology = testing.MakeTopology("default").Levels([]string{
 			tasBlockLabel, tasRackLabel,

--- a/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
@@ -946,10 +946,7 @@ var _ = ginkgo.Describe("MPIJob controller when TopologyAwareScheduling enabled"
 				Ready().
 				Obj(),
 		}
-		for _, node := range nodes {
-			gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-		}
+		util.CreateNodes(ctx, k8sClient, nodes)
 
 		topology = testing.MakeTopology("default").Levels([]string{
 			tasBlockLabel, tasRackLabel,

--- a/test/integration/controller/jobs/mxjob/mxjob_controller_test.go
+++ b/test/integration/controller/jobs/mxjob/mxjob_controller_test.go
@@ -351,10 +351,7 @@ var _ = ginkgo.Describe("MXJob controller when TopologyAwareScheduling enabled",
 				Ready().
 				Obj(),
 		}
-		for _, node := range nodes {
-			gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-		}
+		util.CreateNodes(ctx, k8sClient, nodes)
 
 		topology = testing.MakeTopology("default").Levels([]string{
 			tasBlockLabel, tasRackLabel,

--- a/test/integration/controller/jobs/paddlejob/paddlejob_controller_test.go
+++ b/test/integration/controller/jobs/paddlejob/paddlejob_controller_test.go
@@ -340,10 +340,7 @@ var _ = ginkgo.Describe("PaddleJob controller when TopologyAwareScheduling enabl
 				Ready().
 				Obj(),
 		}
-		for _, node := range nodes {
-			gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-		}
+		util.CreateNodes(ctx, k8sClient, nodes)
 
 		topology = testing.MakeTopology("default").Levels([]string{
 			tasBlockLabel, tasRackLabel,

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -1913,10 +1913,7 @@ var _ = ginkgo.Describe("Pod controller when TopologyAwareScheduling enabled", g
 				Ready().
 				Obj(),
 		}
-		for _, node := range nodes {
-			gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-		}
+		util.CreateNodes(ctx, k8sClient, nodes)
 
 		topology = testing.MakeTopology("default").Levels([]string{
 			tasBlockLabel,

--- a/test/integration/controller/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/test/integration/controller/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -643,10 +643,7 @@ var _ = ginkgo.Describe("PyTorchJob controller when TopologyAwareScheduling enab
 				Ready().
 				Obj(),
 		}
-		for _, node := range nodes {
-			gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-		}
+		util.CreateNodes(ctx, k8sClient, nodes)
 
 		topology = testing.MakeTopology("default").Levels([]string{
 			tasBlockLabel, tasRackLabel,

--- a/test/integration/controller/jobs/tfjob/tfjob_controller_test.go
+++ b/test/integration/controller/jobs/tfjob/tfjob_controller_test.go
@@ -354,10 +354,7 @@ var _ = ginkgo.Describe("TFJob controller when TopologyAwareScheduling enabled",
 				Ready().
 				Obj(),
 		}
-		for _, node := range nodes {
-			gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-		}
+		util.CreateNodes(ctx, k8sClient, nodes)
 
 		topology = testing.MakeTopology("default").Levels([]string{
 			tasBlockLabel, tasRackLabel,

--- a/test/integration/controller/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/test/integration/controller/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -337,10 +337,7 @@ var _ = ginkgo.Describe("XGBoostJob controller when TopologyAwareScheduling enab
 				Ready().
 				Obj(),
 		}
-		for _, node := range nodes {
-			gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-		}
+		util.CreateNodes(ctx, k8sClient, nodes)
 
 		topology = testing.MakeTopology("default").Levels([]string{
 			tasBlockLabel, tasRackLabel,

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -261,10 +261,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						Ready().
 						Obj(),
 				}
-				for _, node := range nodes {
-					gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-					gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-				}
+				util.CreateNodes(ctx, k8sClient, nodes)
 
 				topology = testing.MakeTopology("default").Levels([]string{
 					tasBlockLabel,
@@ -571,11 +568,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						Ready().
 						Obj(),
 				}
-				for _, node := range nodes {
-					gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-					gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&node), &node)).Should(gomega.Succeed())
-				}
+				util.CreateNodes(ctx, k8sClient, nodes)
 
 				topology = testing.MakeTopology("default").Levels([]string{
 					tasBlockLabel,
@@ -632,10 +625,6 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					wl1 = testing.MakeWorkload("wl1", ns.Name).
 						PodSets(*testing.MakePodSet("worker", 1).
 							PreferredTopologyRequest(tasBlockLabel).
-							Toleration(corev1.Toleration{
-								Key:      "node.kubernetes.io/not-ready",
-								Operator: corev1.TolerationOpExists,
-							}).
 							Obj()).
 						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
 					gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
@@ -650,10 +639,6 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					wl2 = testing.MakeWorkload("wl2", ns.Name).
 						PodSets(*testing.MakePodSet("worker-2", 4).
 							PreferredTopologyRequest(tasBlockLabel).
-							Toleration(corev1.Toleration{
-								Key:      "node.kubernetes.io/not-ready",
-								Operator: corev1.TolerationOpExists,
-							}).
 							Obj()).
 						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
 					gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
@@ -743,10 +728,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 							Ready().
 							Obj(),
 					}
-					for _, node := range nodes {
-						gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-						gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-					}
+					util.CreateNodes(ctx, k8sClient, nodes)
 				})
 
 				ginkgo.By("verify the workload is admitted", func() {
@@ -828,11 +810,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 							Ready().
 							Obj(),
 					}
-					for _, node := range nodes {
-						gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-						gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-						gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(&node), &node)).Should(gomega.Succeed())
-					}
+					util.CreateNodes(ctx, k8sClient, nodes)
 				})
 
 				ginkgo.By("creating a workload which does not tolerate the taint", func() {
@@ -900,10 +878,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						Ready().
 						Obj(),
 				}
-				for _, node := range nodes {
-					gomega.Expect(k8sClient.Create(ctx, &node)).Should(gomega.Succeed())
-					gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
-				}
+				util.CreateNodes(ctx, k8sClient, nodes)
 
 				topology = testing.MakeTopology("default").Levels([]string{
 					tasRackLabel,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Remove node.kubernetes.io/not-ready taint if status active after creation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3709

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```