### PR TITLE
TAS: Make ResourceFlavorSpec that defines `topologyName` immutable

### DIFF
--- a/apis/kueue/v1beta1/resourceflavor_types.go
+++ b/apis/kueue/v1beta1/resourceflavor_types.go
@@ -42,6 +42,8 @@ type TopologyReference string
 
 // ResourceFlavorSpec defines the desired state of the ResourceFlavor
 // +kubebuilder:validation:XValidation:rule="!has(self.topologyName) || self.nodeLabels.size() >= 1", message="at least one nodeLabel is required when topology is set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (self.tolerations.all(x, oldSelf.tolerations.indexOf(x) != -1) && oldSelf.tolerations.all(y, self.tolerations.indexOf(y) != -1))", message="tolerations are immutable when topologyName is set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (self.nodeTaints.all(x, oldSelf.nodeTaints.indexOf(x) != -1) && oldSelf.nodeTaints.all(y, self.nodeTaints.indexOf(y) != -1))", message="nodeTaints are immutable when topologyName is set"
 type ResourceFlavorSpec struct {
 	// nodeLabels are labels that associate the ResourceFlavor with Nodes that
 	// have the same labels.
@@ -56,6 +58,7 @@ type ResourceFlavorSpec struct {
 	// +optional
 	// +mapType=atomic
 	// +kubebuilder:validation:MaxProperties=8
+	// +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || self == oldSelf", message="nodeLabels are immutable when topologyName is set"
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
 
 	// nodeTaints are taints that the nodes associated with this ResourceFlavor
@@ -97,6 +100,7 @@ type ResourceFlavorSpec struct {
 	// nodes matching to the Resource Flavor node labels.
 	//
 	// +optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="topologyName is immutable"
 	TopologyName *TopologyReference `json:"topologyName,omitempty"`
 }
 

--- a/apis/kueue/v1beta1/resourceflavor_types.go
+++ b/apis/kueue/v1beta1/resourceflavor_types.go
@@ -42,8 +42,7 @@ type TopologyReference string
 
 // ResourceFlavorSpec defines the desired state of the ResourceFlavor
 // +kubebuilder:validation:XValidation:rule="!has(self.topologyName) || self.nodeLabels.size() >= 1", message="at least one nodeLabel is required when topology is set"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (self.tolerations.all(x, oldSelf.tolerations.indexOf(x) != -1) && oldSelf.tolerations.all(y, self.tolerations.indexOf(y) != -1))", message="tolerations are immutable when topologyName is set"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (self.nodeTaints.all(x, oldSelf.nodeTaints.indexOf(x) != -1) && oldSelf.nodeTaints.all(y, self.nodeTaints.indexOf(y) != -1))", message="nodeTaints are immutable when topologyName is set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || self == oldSelf", message="resourceFlavorSpec are immutable when topologyName is set"
 type ResourceFlavorSpec struct {
 	// nodeLabels are labels that associate the ResourceFlavor with Nodes that
 	// have the same labels.
@@ -58,7 +57,6 @@ type ResourceFlavorSpec struct {
 	// +optional
 	// +mapType=atomic
 	// +kubebuilder:validation:MaxProperties=8
-	// +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || self == oldSelf", message="nodeLabels are immutable when topologyName is set"
 	NodeLabels map[string]string `json:"nodeLabels,omitempty"`
 
 	// nodeTaints are taints that the nodes associated with this ResourceFlavor
@@ -100,7 +98,6 @@ type ResourceFlavorSpec struct {
 	// nodes matching to the Resource Flavor node labels.
 	//
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="topologyName is immutable"
 	TopologyName *TopologyReference `json:"topologyName,omitempty"`
 }
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
@@ -198,6 +198,8 @@ spec:
             x-kubernetes-validations:
             - message: at least one nodeLabel is required when topology is set
               rule: '!has(self.topologyName) || self.nodeLabels.size() >= 1'
+            - message: resourceFlavorSpec are immutable when topologyName is set
+              rule: '!has(oldSelf.topologyName) || self == oldSelf'
         type: object
     served: true
     storage: true

--- a/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
@@ -60,9 +60,6 @@ spec:
                 maxProperties: 8
                 type: object
                 x-kubernetes-map-type: atomic
-                x-kubernetes-validations:
-                - message: nodeLabels are immutable when topologyName is set
-                  rule: '!has(oldSelf.topologyName) || self == oldSelf'
               nodeTaints:
                 description: |-
                   nodeTaints are taints that the nodes associated with this ResourceFlavor
@@ -182,21 +179,12 @@ spec:
                 maxLength: 253
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
-                x-kubernetes-validations:
-                - message: topologyName is immutable
-                  rule: self == oldSelf
             type: object
             x-kubernetes-validations:
             - message: at least one nodeLabel is required when topology is set
               rule: '!has(self.topologyName) || self.nodeLabels.size() >= 1'
-            - message: tolerations are immutable when topologyName is set
-              rule: '!has(oldSelf.topologyName) || (self.tolerations.all(x, oldSelf.tolerations.indexOf(x)
-                != -1) && oldSelf.tolerations.all(y, self.tolerations.indexOf(y) !=
-                -1))'
-            - message: nodeTaints are immutable when topologyName is set
-              rule: '!has(oldSelf.topologyName) || (self.nodeTaints.all(x, oldSelf.nodeTaints.indexOf(x)
-                != -1) && oldSelf.nodeTaints.all(y, self.nodeTaints.indexOf(y) !=
-                -1))'
+            - message: resourceFlavorSpec are immutable when topologyName is set
+              rule: '!has(oldSelf.topologyName) || self == oldSelf'
         type: object
     served: true
     storage: true

--- a/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
@@ -60,6 +60,9 @@ spec:
                 maxProperties: 8
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: nodeLabels are immutable when topologyName is set
+                  rule: '!has(oldSelf.topologyName) || self == oldSelf'
               nodeTaints:
                 description: |-
                   nodeTaints are taints that the nodes associated with this ResourceFlavor
@@ -179,10 +182,21 @@ spec:
                 maxLength: 253
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string
+                x-kubernetes-validations:
+                - message: topologyName is immutable
+                  rule: self == oldSelf
             type: object
             x-kubernetes-validations:
             - message: at least one nodeLabel is required when topology is set
               rule: '!has(self.topologyName) || self.nodeLabels.size() >= 1'
+            - message: tolerations are immutable when topologyName is set
+              rule: '!has(oldSelf.topologyName) || (self.tolerations.all(x, oldSelf.tolerations.indexOf(x)
+                != -1) && oldSelf.tolerations.all(y, self.tolerations.indexOf(y) !=
+                -1))'
+            - message: nodeTaints are immutable when topologyName is set
+              rule: '!has(oldSelf.topologyName) || (self.nodeTaints.all(x, oldSelf.nodeTaints.indexOf(x)
+                != -1) && oldSelf.nodeTaints.all(y, self.nodeTaints.indexOf(y) !=
+                -1))'
         type: object
     served: true
     storage: true

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			gomega.Expect(k8sClient.Create(ctx, tasFlavor)).Should(gomega.HaveOccurred())
 		})
 
-		ginkgo.FIt("should not allow to update ResourceFlavorSpec", func() {
+		ginkgo.It("should not allow to update ResourceFlavorSpec", func() {
 			tasFlavor := testing.MakeResourceFlavor("tas-flavor").
 				TopologyName("default").
 				NodeLabel("node-group", "tas").

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -80,57 +80,61 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			tasFlavor := testing.MakeResourceFlavor("tas-flavor").TopologyName("default").Obj()
 			gomega.Expect(k8sClient.Create(ctx, tasFlavor)).Should(gomega.HaveOccurred())
 		})
+	})
 
-		ginkgo.It("should not allow to update ResourceFlavorSpec", func() {
-			tasFlavor := testing.MakeResourceFlavor("tas-flavor").
+	ginkgo.When("Updating ResourceFlavorSpec that defines TopologyName", func() {
+		var tasFlavor *kueue.ResourceFlavor
+
+		ginkgo.BeforeEach(func() {
+			tasFlavor = testing.MakeResourceFlavor("tas-flavor").
 				TopologyName("default").
 				NodeLabel("node-group", "tas").
 				NodeLabel("foo", "bar").
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, tasFlavor)).Should(gomega.Succeed())
+		})
 
-			ginkgo.By("Updating topologyName", func() {
-				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
-				tasFlavor.Spec.TopologyName = ptr.To(kueue.TopologyReference("invalid"))
-				gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
-			})
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+		})
 
-			ginkgo.By("Updating nodeTaints", func() {
-				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
-				tasFlavor.Spec.NodeTaints = []corev1.Taint{{
-					Key:    "foo",
-					Value:  "bar",
-					Effect: "Invalid",
-				}}
-				gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
-			})
+		ginkgo.It("should not allow to update topologyName", func() {
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
+			tasFlavor.Spec.TopologyName = ptr.To(kueue.TopologyReference("invalid"))
+			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
+		})
 
-			ginkgo.By("Updating tolerations", func() {
-				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
-				tasFlavor.Spec.Tolerations = []corev1.Toleration{
-					{Key: "key1", Value: "value", Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpEqual}}
-				gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
-			})
+		ginkgo.It("should not allow to update nodeTaints", func() {
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
+			tasFlavor.Spec.NodeTaints = []corev1.Taint{{
+				Key:    "foo",
+				Value:  "bar",
+				Effect: "Invalid",
+			}}
+			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
+		})
 
-			ginkgo.By("Updating nodeLabels", func() {
-				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
-				tasFlavor.Spec.NodeLabels = map[string]string{
-					"tas-node": "true",
-				}
-				gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
-			})
+		ginkgo.It("should not allow to update tolerations", func() {
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
+			tasFlavor.Spec.Tolerations = []corev1.Toleration{
+				{Key: "key1", Value: "value", Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpEqual}}
+			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
+		})
 
-			ginkgo.By("Deleting one of the nodeLabels", func() {
-				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
-				tasFlavor.Spec.NodeLabels = map[string]string{
-					"foo": "bar",
-				}
-				gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
-			})
+		ginkgo.It("should not allow to update nodeLabels", func() {
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
+			tasFlavor.Spec.NodeLabels = map[string]string{
+				"tas-node": "true",
+			}
+			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
+		})
 
-			ginkgo.By("Cleaning up RF", func() {
-				util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
-			})
+		ginkgo.It("should not allow to delete one of the nodeLabels", func() {
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
+			tasFlavor.Spec.NodeLabels = map[string]string{
+				"foo": "bar",
+			}
+			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
 		})
 	})
 

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -127,6 +127,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				}
 				gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
 			})
+
+			ginkgo.By("Cleaning up RF", func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+			})
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
TAS: Make ResourceFlavorSpec that defines `topologyName` immutable

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #3733 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ResourceFlavorSpec that defines topologyName is not immutable
```