### PR TITLE
Use variadic function to set levels in TopologyWrapper

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3773,7 +3773,7 @@ func TestSnapshotError(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 
 	topology := *utiltesting.MakeTopology("default").
-		Levels([]string{corev1.LabelHostname}).
+		Levels(corev1.LabelHostname).
 		Obj()
 	flavor := *utiltesting.MakeResourceFlavor("tas-default").
 		TopologyName("default").

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -1076,7 +1076,7 @@ func TestClusterQueueReadinessWithTAS(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			cqCache := New(utiltesting.NewFakeClient())
 
-			topology := utiltesting.MakeTopology("example-topology").Levels([]string{"tas-level-0"}).Obj()
+			topology := utiltesting.MakeTopology("example-topology").Levels("tas-level-0").Obj()
 
 			rf := utiltesting.MakeResourceFlavor("tas-flavor").TopologyName(topology.Name).Obj()
 			cqCache.AddOrUpdateResourceFlavor(rf)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -3816,10 +3816,10 @@ func TestScheduleForTAS(t *testing.T) {
 			Obj(),
 	}
 	defaultSingleLevelTopology := *utiltesting.MakeTopology("tas-single-level").
-		Levels([]string{corev1.LabelHostname}).
+		Levels(corev1.LabelHostname).
 		Obj()
 	defaultTwoLevelTopology := *utiltesting.MakeTopology("tas-two-level").
-		Levels([]string{tasRackLabel, corev1.LabelHostname}).
+		Levels(tasRackLabel, corev1.LabelHostname).
 		Obj()
 	defaultFlavor := *utiltesting.MakeResourceFlavor("default").Obj()
 	defaultTASFlavor := *utiltesting.MakeResourceFlavor("tas-default").
@@ -4119,7 +4119,7 @@ func TestScheduleForTAS(t *testing.T) {
 			},
 			topologies: []kueuealpha.Topology{defaultSingleLevelTopology,
 				*utiltesting.MakeTopology("tas-custom-topology").
-					Levels([]string{"cloud.com/custom-level"}).
+					Levels("cloud.com/custom-level").
 					Obj(),
 			},
 			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor,

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -974,7 +974,7 @@ func MakeTopology(name string) *TopologyWrapper {
 }
 
 // Levels sets the levels for a Topology.
-func (t *TopologyWrapper) Levels(levels []string) *TopologyWrapper {
+func (t *TopologyWrapper) Levels(levels ...string) *TopologyWrapper {
 	t.Spec.Levels = make([]kueuealpha.TopologyLevel, len(levels))
 	for i, level := range levels {
 		t.Spec.Levels[i] = kueuealpha.TopologyLevel{

--- a/test/e2e/singlecluster/tas_test.go
+++ b/test/e2e/singlecluster/tas_test.go
@@ -63,9 +63,9 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			clusterQueue *kueue.ClusterQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("hostname").Levels([]string{
+			topology = testing.MakeTopology("hostname").Levels(
 				corev1.LabelHostname,
-			}).Obj()
+			).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			onDemandRF = testing.MakeResourceFlavor("on-demand").
@@ -157,7 +157,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			localQueue   *kueue.LocalQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("hostname").Levels([]string{corev1.LabelHostname}).Obj()
+			topology = testing.MakeTopology("hostname").Levels(corev1.LabelHostname).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			onDemandRF = testing.MakeResourceFlavor("on-demand").
@@ -292,7 +292,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			localQueue   *kueue.LocalQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("hostname").Levels([]string{corev1.LabelHostname}).Obj()
+			topology = testing.MakeTopology("hostname").Levels(corev1.LabelHostname).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			onDemandRF = testing.MakeResourceFlavor("on-demand").

--- a/test/e2e/tas/job_test.go
+++ b/test/e2e/tas/job_test.go
@@ -68,11 +68,11 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 			clusterQueue *kueue.ClusterQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("datacenter").Levels([]string{
+			topology = testing.MakeTopology("datacenter").Levels(
 				topologyLevelBlock,
 				topologyLevelRack,
 				corev1.LabelHostname,
-			}).Obj()
+			).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/e2e/tas/jobset_test.go
+++ b/test/e2e/tas/jobset_test.go
@@ -58,11 +58,11 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", func() {
 			clusterQueue *kueue.ClusterQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("datacenter").Levels([]string{
+			topology = testing.MakeTopology("datacenter").Levels(
 				topologyLevelBlock,
 				topologyLevelRack,
 				corev1.LabelHostname,
-			}).Obj()
+			).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/e2e/tas/mpijob_test.go
+++ b/test/e2e/tas/mpijob_test.go
@@ -54,7 +54,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for MPIJob", func() {
 		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
 		topology = testing.MakeTopology("datacenter").
-			Levels([]string{topologyLevelBlock, topologyLevelRack, corev1.LabelHostname}).
+			Levels(topologyLevelBlock, topologyLevelRack, corev1.LabelHostname).
 			Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 

--- a/test/e2e/tas/pod_group_test.go
+++ b/test/e2e/tas/pod_group_test.go
@@ -53,11 +53,11 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Pod group", func() {
 			clusterQueue *kueue.ClusterQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("datacenter").Levels([]string{
+			topology = testing.MakeTopology("datacenter").Levels(
 				topologyLevelBlock,
 				topologyLevelRack,
 				corev1.LabelHostname,
-			}).Obj()
+			).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/e2e/tas/pytorch_test.go
+++ b/test/e2e/tas/pytorch_test.go
@@ -53,7 +53,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", func() {
 		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
 		topology = testing.MakeTopology("datacenter").
-			Levels([]string{topologyLevelBlock, topologyLevelRack, corev1.LabelHostname}).
+			Levels(topologyLevelBlock, topologyLevelRack, corev1.LabelHostname).
 			Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 

--- a/test/integration/controller/jobs/job/job_controller_test.go
+++ b/test/integration/controller/jobs/job/job_controller_test.go
@@ -2245,9 +2245,7 @@ var _ = ginkgo.Describe("Job controller when TopologyAwareScheduling enabled", g
 		}
 		util.CreateNodes(ctx, k8sClient, nodes)
 
-		topology = testing.MakeTopology("default").Levels([]string{
-			tasBlockLabel,
-		}).Obj()
+		topology = testing.MakeTopology("default").Levels(tasBlockLabel).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/controller/jobs/jobset/jobset_controller_test.go
@@ -1201,9 +1201,9 @@ var _ = ginkgo.Describe("JobSet controller when TopologyAwareScheduling enabled"
 		}
 		util.CreateNodes(ctx, k8sClient, nodes)
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
@@ -974,9 +974,9 @@ var _ = ginkgo.Describe("MPIJob controller when TopologyAwareScheduling enabled"
 		}
 		util.CreateNodes(ctx, k8sClient, nodes)
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/mxjob/mxjob_controller_test.go
+++ b/test/integration/controller/jobs/mxjob/mxjob_controller_test.go
@@ -367,9 +367,9 @@ var _ = ginkgo.Describe("MXJob controller when TopologyAwareScheduling enabled",
 		}
 		util.CreateNodes(ctx, k8sClient, nodes)
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/paddlejob/paddlejob_controller_test.go
+++ b/test/integration/controller/jobs/paddlejob/paddlejob_controller_test.go
@@ -356,9 +356,9 @@ var _ = ginkgo.Describe("PaddleJob controller when TopologyAwareScheduling enabl
 		}
 		util.CreateNodes(ctx, k8sClient, nodes)
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -2031,9 +2031,7 @@ var _ = ginkgo.Describe("Pod controller when TopologyAwareScheduling enabled", g
 		}
 		util.CreateNodes(ctx, k8sClient, nodes)
 
-		topology = testing.MakeTopology("default").Levels([]string{
-			tasBlockLabel,
-		}).Obj()
+		topology = testing.MakeTopology("default").Levels(tasBlockLabel).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/test/integration/controller/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -659,9 +659,9 @@ var _ = ginkgo.Describe("PyTorchJob controller when TopologyAwareScheduling enab
 		}
 		util.CreateNodes(ctx, k8sClient, nodes)
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/tfjob/tfjob_controller_test.go
+++ b/test/integration/controller/jobs/tfjob/tfjob_controller_test.go
@@ -370,9 +370,9 @@ var _ = ginkgo.Describe("TFJob controller when TopologyAwareScheduling enabled",
 		}
 		util.CreateNodes(ctx, k8sClient, nodes)
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/test/integration/controller/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -353,9 +353,9 @@ var _ = ginkgo.Describe("XGBoostJob controller when TopologyAwareScheduling enab
 		}
 		util.CreateNodes(ctx, k8sClient, nodes)
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -147,10 +147,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 		)
 
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("default").Levels([]string{
+			topology = testing.MakeTopology("default").Levels(
 				tasBlockLabel,
 				tasRackLabel,
-			}).Obj()
+			).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -319,10 +319,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				}
 				util.CreateNodes(ctx, k8sClient, nodes)
 
-				topology = testing.MakeTopology("default").Levels([]string{
+				topology = testing.MakeTopology("default").Levels(
 					tasBlockLabel,
 					tasRackLabel,
-				}).Obj()
+				).Obj()
 				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 				tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -550,7 +550,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
 				})
 
-				topology = testing.MakeTopology("default").Levels([]string{tasBlockLabel, tasRackLabel}).Obj()
+				topology = testing.MakeTopology("default").Levels(tasBlockLabel, tasRackLabel).Obj()
 				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 				ginkgo.By("verify the workload is admitted", func() {
@@ -626,11 +626,11 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				}
 				util.CreateNodes(ctx, k8sClient, nodes)
 
-				topology = testing.MakeTopology("default").Levels([]string{
+				topology = testing.MakeTopology("default").Levels(
 					tasBlockLabel,
 					tasRackLabel,
 					corev1.LabelHostname,
-				}).Obj()
+				).Obj()
 				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 				tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -720,10 +720,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				}
 				gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
-				topology = testing.MakeTopology("default").Levels([]string{
+				topology = testing.MakeTopology("default").Levels(
 					tasBlockLabel,
 					tasRackLabel,
-				}).Obj()
+				).Obj()
 				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 				tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -808,11 +808,11 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				}
 				gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
-				topology = testing.MakeTopology("default").Levels([]string{
+				topology = testing.MakeTopology("default").Levels(
 					tasBlockLabel,
 					tasRackLabel,
 					corev1.LabelHostname,
-				}).Obj()
+				).Obj()
 				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 				tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -936,9 +936,9 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				}
 				util.CreateNodes(ctx, k8sClient, nodes)
 
-				topology = testing.MakeTopology("default").Levels([]string{
+				topology = testing.MakeTopology("default").Levels(
 					tasRackLabel,
-				}).Obj()
+				).Obj()
 				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 				tasGPUFlavor = testing.MakeResourceFlavor("tas-gpu-flavor").
@@ -1053,22 +1053,22 @@ var _ = ginkgo.Describe("Topology validations", func() {
 			gomega.Expect(err).Should(matcher)
 		},
 			ginkgo.Entry("valid Topology",
-				testing.MakeTopology("valid").Levels([]string{corev1.LabelHostname}).Obj(),
+				testing.MakeTopology("valid").Levels(corev1.LabelHostname).Obj(),
 				gomega.Succeed()),
 			ginkgo.Entry("invalid levels",
-				testing.MakeTopology("invalid-level").Levels([]string{"@invalid"}).Obj(),
+				testing.MakeTopology("invalid-level").Levels("@invalid").Obj(),
 				testing.BeInvalidError()),
 			ginkgo.Entry("non-unique levels",
-				testing.MakeTopology("default").Levels([]string{tasBlockLabel, tasBlockLabel}).Obj(),
+				testing.MakeTopology("default").Levels(tasBlockLabel, tasBlockLabel).Obj(),
 				testing.BeInvalidError()),
 			ginkgo.Entry("kubernetes.io/hostname first",
-				testing.MakeTopology("default").Levels([]string{corev1.LabelHostname, tasBlockLabel, tasRackLabel}).Obj(),
+				testing.MakeTopology("default").Levels(corev1.LabelHostname, tasBlockLabel, tasRackLabel).Obj(),
 				testing.BeInvalidError()),
 			ginkgo.Entry("kubernetes.io/hostname middle",
-				testing.MakeTopology("default").Levels([]string{tasBlockLabel, corev1.LabelHostname, tasRackLabel}).Obj(),
+				testing.MakeTopology("default").Levels(tasBlockLabel, corev1.LabelHostname, tasRackLabel).Obj(),
 				testing.BeInvalidError()),
 			ginkgo.Entry("kubernetes.io/hostname last",
-				testing.MakeTopology("default").Levels([]string{tasBlockLabel, tasRackLabel, corev1.LabelHostname}).Obj(),
+				testing.MakeTopology("default").Levels(tasBlockLabel, tasRackLabel, corev1.LabelHostname).Obj(),
 				gomega.Succeed()),
 		)
 	})
@@ -1087,7 +1087,7 @@ var _ = ginkgo.Describe("Topology validations", func() {
 			gomega.Expect(k8sClient.Update(ctx, topology)).Should(matcher)
 		},
 			ginkgo.Entry("succeed to update topology",
-				testing.MakeTopology("valid").Levels([]string{corev1.LabelHostname}).Obj(),
+				testing.MakeTopology("valid").Levels(corev1.LabelHostname).Obj(),
 				func(topology *kueuealpha.Topology) {
 					topology.ObjectMeta.Labels = map[string]string{
 						"alpha": "beta",
@@ -1095,7 +1095,7 @@ var _ = ginkgo.Describe("Topology validations", func() {
 				},
 				gomega.Succeed()),
 			ginkgo.Entry("updating levels is prohibited",
-				testing.MakeTopology("valid").Levels([]string{corev1.LabelHostname}).Obj(),
+				testing.MakeTopology("valid").Levels(corev1.LabelHostname).Obj(),
 				func(topology *kueuealpha.Topology) {
 					topology.Spec.Levels = append(topology.Spec.Levels, kueuealpha.TopologyLevel{
 						NodeLabel: "added",
@@ -1103,7 +1103,7 @@ var _ = ginkgo.Describe("Topology validations", func() {
 				},
 				testing.BeInvalidError()),
 			ginkgo.Entry("updating levels order is prohibited",
-				testing.MakeTopology("default").Levels([]string{tasRackLabel, tasBlockLabel, corev1.LabelHostname}).Obj(),
+				testing.MakeTopology("default").Levels(tasRackLabel, tasBlockLabel, corev1.LabelHostname).Obj(),
 				func(topology *kueuealpha.Topology) {
 					topology.Spec.Levels[0], topology.Spec.Levels[1] = topology.Spec.Levels[1], topology.Spec.Levels[0]
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Change Levels method of TopologyWrapper to the variadic function to ease the declaration process.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #3662 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```