### PR TITLE
managedJobsNamespaceSelector for Deployment, StatefulSets, and Pods

### DIFF
--- a/pkg/controller/jobframework/defaults_test.go
+++ b/pkg/controller/jobframework/defaults_test.go
@@ -16,32 +16,112 @@ limitations under the License.
 
 package jobframework
 
-/*
-
 import (
 	"testing"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 )
 
 func TestWorkloadShouldBeSuspended(t *testing.T) {
+	managedNamespace := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "managed-ns",
+			Labels: map[string]string{"kubernetes.io/metadata.name": "managed-ns"},
+		},
+	}
 
+	unmanagedNamespace := &corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "unmanaged-ns",
+			Labels: map[string]string{"kubernetes.io/metadata.name": "unmanaged-ns"},
+		},
+	}
 
+	ls := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "kubernetes.io/metadata.name",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{unmanagedNamespace.Name},
+			},
+		},
+	}
+	namespaceSelector, _ := metav1.LabelSelectorAsSelector(ls)
 
 	cases := map[string]struct {
 		obj                        client.Object
 		manageJobsWithoutQueueName bool
+		featureGateEnabled         bool
 		wantSuspend                bool
 	}{
-		""
-		obj: v1.Object{},
-
-
-
-
+		"job with queue name ": {
+			obj:                        utiltestingjob.MakeJob("test-job", managedNamespace.Name).Queue("default").Obj(),
+			manageJobsWithoutQueueName: false,
+			featureGateEnabled:         true,
+			wantSuspend:                true,
+		},
+		"job with queue name manageJobs": {
+			obj:                        utiltestingjob.MakeJob("test-job", managedNamespace.Name).Queue("default").Obj(),
+			manageJobsWithoutQueueName: true,
+			featureGateEnabled:         true,
+			wantSuspend:                true,
+		},
+		"job without queue name": {
+			obj:                        utiltestingjob.MakeJob("test-job", managedNamespace.Name).Obj(),
+			manageJobsWithoutQueueName: false,
+			featureGateEnabled:         true,
+			wantSuspend:                false,
+		},
+		"job without queue name with manageJobs": {
+			obj:                        utiltestingjob.MakeJob("test-job", managedNamespace.Name).Obj(),
+			manageJobsWithoutQueueName: true,
+			featureGateEnabled:         true,
+			wantSuspend:                true,
+		},
+		"job without queue name with manageJobs with feature disabled": {
+			obj:                        utiltestingjob.MakeJob("test-job", managedNamespace.Name).Obj(),
+			manageJobsWithoutQueueName: true,
+			featureGateEnabled:         false,
+			wantSuspend:                true,
+		},
+		"job without queue name with manageJobs in unmanaged ns": {
+			obj:                        utiltestingjob.MakeJob("test-job", unmanagedNamespace.Name).Obj(),
+			manageJobsWithoutQueueName: true,
+			featureGateEnabled:         true,
+			wantSuspend:                false,
+		},
+		"job without queue name with manageJobs in unmanaged ns with feature disabled": {
+			obj:                        utiltestingjob.MakeJob("test-job", unmanagedNamespace.Name).Obj(),
+			manageJobsWithoutQueueName: true,
+			featureGateEnabled:         false,
+			wantSuspend:                true,
+		},
 	}
 
-}
+	for tcName, tc := range cases {
+		t.Run(tcName, func(t *testing.T) {
+			builder := utiltesting.NewClientBuilder()
+			builder.WithObjects(managedNamespace, unmanagedNamespace, tc.obj)
+			client := builder.Build()
+			ctx, _ := utiltesting.ContextWithLog(t)
 
-*/
+			features.SetFeatureGateDuringTest(t, features.ManagedJobsNamespaceSelector, tc.featureGateEnabled)
+			suspend, err := WorkloadShouldBeSuspended(ctx, tc.obj, client, tc.manageJobsWithoutQueueName, namespaceSelector)
+			if err != nil {
+				t.Errorf("Got error: %v", err)
+			}
+			if suspend != tc.wantSuspend {
+				t.Errorf("Unexpected result: got %v wanted %v", suspend, tc.wantSuspend)
+			}
+		})
+	}
+}

--- a/pkg/controller/jobframework/defaults_test.go
+++ b/pkg/controller/jobframework/defaults_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+/*
+
+import (
+	"testing"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestWorkloadShouldBeSuspended(t *testing.T) {
+
+
+
+	cases := map[string]struct {
+		obj                        client.Object
+		manageJobsWithoutQueueName bool
+		wantSuspend                bool
+	}{
+		""
+		obj: v1.Object{},
+
+
+
+
+	}
+
+}
+
+*/

--- a/pkg/controller/jobframework/defaults_test.go
+++ b/pkg/controller/jobframework/defaults_test.go
@@ -21,7 +21,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/kueue/pkg/features"

--- a/pkg/controller/jobs/deployment/deployment_webhook.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook.go
@@ -18,9 +18,12 @@ package deployment
 
 import (
 	"context"
+	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -30,15 +33,21 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework/webhook"
+	"sigs.k8s.io/kueue/pkg/features"
 )
 
 type Webhook struct {
-	client client.Client
+	client                       client.Client
+	manageJobsWithoutQueueName   bool
+	managedJobsNamespaceSelector labels.Selector
 }
 
-func SetupWebhook(mgr ctrl.Manager, _ ...jobframework.Option) error {
+func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
+	options := jobframework.ProcessOptions(opts...)
 	wh := &Webhook{
-		client: mgr.GetClient(),
+		client:                       mgr.GetClient(),
+		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
+		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
 	}
 	obj := &appsv1.Deployment{}
 	return webhook.WebhookManagedBy(mgr).
@@ -58,7 +67,21 @@ func (wh *Webhook) Default(ctx context.Context, obj runtime.Object) error {
 	log := ctrl.LoggerFrom(ctx).WithName("deployment-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if queueName := jobframework.QueueNameForObject(deployment.Object()); queueName != "" {
+	queueName := jobframework.QueueNameForObject(deployment.Object())
+
+	// Do not manage a deployment without a queue name unless the namespace selector also matches
+	if features.Enabled(features.ManagedJobsNamespaceSelector) && wh.manageJobsWithoutQueueName && queueName == "" {
+		ns := corev1.Namespace{}
+		err := wh.client.Get(ctx, client.ObjectKey{Name: deployment.Namespace}, &ns)
+		if err != nil {
+			return fmt.Errorf("failed to get namespace: %w", err)
+		}
+		if !wh.managedJobsNamespaceSelector.Matches(labels.Set(ns.GetLabels())) {
+			return nil
+		}
+	}
+
+	if queueName != "" || wh.manageJobsWithoutQueueName {
 		if deployment.Spec.Template.Labels == nil {
 			deployment.Spec.Template.Labels = make(map[string]string, 1)
 		}

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -151,9 +151,9 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		return err
 	}
 
-	// Backwards compatability until podOptions.podSelector and podOptions.namespaceSelector are deprecated.
-	// When the shared logic determines the Pod should be suspended, run the legacy checks as well
-	// and if either of them fires then abort the suspension.
+	// Backwards compatibility support until podOptions.podSelector and podOptions.namespaceSelector are deprecated.
+	// When WorkloadShouldBeSuspend determines that suspend is true, also run the podOptions based checks
+	// and if either of them exempts the Pod from suspension, we return early.
 	if suspend {
 		// podOptions.podSelector
 		podSelector, err := metav1.LabelSelectorAsSelector(w.podSelector)

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -170,7 +170,7 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		)
 	}
 	log.V(5).Info("Found pod namespace", "Namespace.Name", ns.GetName())
-	if features.Enabled(features.ManagedJobsNamespaceSelector) {
+	if features.Enabled(features.ManagedJobsNamespaceSelector) && w.manageJobsWithoutQueueName && jobframework.QueueName(pod) == "" {
 		if !w.managedJobsNamespaceSelector.Matches(labels.Set(ns.GetLabels())) {
 			return nil
 		}
@@ -212,7 +212,6 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		// copy back changes to the object
 		pod.pod.DeepCopyInto(obj.(*corev1.Pod))
 	}
-
 	return nil
 }
 

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -146,44 +146,44 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 	log := ctrl.LoggerFrom(ctx).WithName("pod-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if IsPodOwnerManagedByKueue(pod) {
-		log.V(5).Info("Pod owner is managed by kueue, skipping")
-		return nil
+	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, pod.Object(), w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector)
+	if err != nil {
+		return err
 	}
 
-	// Check for pod label selector match
-	podSelector, err := metav1.LabelSelectorAsSelector(w.podSelector)
-	if err != nil {
-		return fmt.Errorf("failed to parse pod selector: %w", err)
-	}
-	if !podSelector.Matches(labels.Set(pod.pod.GetLabels())) {
-		return nil
-	}
+	// Backwards compatability until podOptions.podSelector and podOptions.namespaceSelector are deprecated.
+	// When the shared logic determines the Pod should be suspended, run the legacy checks as well
+	// and if either of them fires then abort the suspension.
+	if suspend {
+		// podOptions.podSelector
+		podSelector, err := metav1.LabelSelectorAsSelector(w.podSelector)
+		if err != nil {
+			return fmt.Errorf("failed to parse pod selector: %w", err)
+		}
+		if !podSelector.Matches(labels.Set(pod.pod.GetLabels())) {
+			return nil
+		}
 
-	// Get pod namespace and check for namespace label selector match
-	ns := corev1.Namespace{}
-	err = w.client.Get(ctx, client.ObjectKey{Name: pod.pod.GetNamespace()}, &ns)
-	if err != nil {
-		return fmt.Errorf("failed to run mutating webhook on pod %s, error while getting namespace: %w",
-			pod.pod.GetName(),
-			err,
-		)
-	}
-	log.V(5).Info("Found pod namespace", "Namespace.Name", ns.GetName())
-	if features.Enabled(features.ManagedJobsNamespaceSelector) && w.manageJobsWithoutQueueName && jobframework.QueueName(pod) == "" {
-		if !w.managedJobsNamespaceSelector.Matches(labels.Set(ns.GetLabels())) {
+		// podOptions.namespaceSelector
+		ns := corev1.Namespace{}
+		err = w.client.Get(ctx, client.ObjectKey{Name: pod.pod.GetNamespace()}, &ns)
+		if err != nil {
+			return fmt.Errorf("failed to run mutating webhook on pod %s, error while getting namespace: %w",
+				pod.pod.GetName(),
+				err,
+			)
+		}
+		log.V(5).Info("Found pod namespace", "Namespace.Name", ns.GetName())
+		nsSelector, err := metav1.LabelSelectorAsSelector(w.namespaceSelector)
+		if err != nil {
+			return fmt.Errorf("failed to parse namespace selector: %w", err)
+		}
+		if !nsSelector.Matches(labels.Set(ns.GetLabels())) {
 			return nil
 		}
 	}
-	nsSelector, err := metav1.LabelSelectorAsSelector(w.namespaceSelector)
-	if err != nil {
-		return fmt.Errorf("failed to parse namespace selector: %w", err)
-	}
-	if !nsSelector.Matches(labels.Set(ns.GetLabels())) {
-		return nil
-	}
 
-	if jobframework.QueueName(pod) != "" || w.manageJobsWithoutQueueName {
+	if suspend {
 		controllerutil.AddFinalizer(pod.Object(), PodFinalizer)
 
 		if pod.pod.Labels == nil {
@@ -212,6 +212,7 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		// copy back changes to the object
 		pod.pod.DeepCopyInto(obj.(*corev1.Pod))
 	}
+
 	return nil
 }
 

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -38,10 +38,9 @@ import (
 
 func TestDefault(t *testing.T) {
 	testCases := map[string]struct {
-		statefulset                *appsv1.StatefulSet
-		manageJobsWithoutQueueName bool
-		enableIntegrations         []string
-		want                       *appsv1.StatefulSet
+		statefulset        *appsv1.StatefulSet
+		enableIntegrations []string
+		want               *appsv1.StatefulSet
 	}{
 		"statefulset with queue": {
 			enableIntegrations: []string{"pod"},
@@ -84,8 +83,7 @@ func TestDefault(t *testing.T) {
 			cli := builder.Build()
 
 			w := &Webhook{
-				client:                     cli,
-				manageJobsWithoutQueueName: tc.manageJobsWithoutQueueName,
+				client: cli,
 			}
 
 			ctx, _ := utiltesting.ContextWithLog(t)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Normalizes handling of manageJobsWithoutQueueName and managedJobsNamespaceSelector for the Pods, Deployment, and StatefulSet integrations.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Part of #3589 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```