### PR TITLE
Deactivate ClusterQueue if there is no Topology

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -34,6 +34,7 @@ const (
 	ClusterQueueActiveReasonMultipleMultiKueueAdmissionChecks               = "MultipleMultiKueueAdmissionChecks"
 	ClusterQueueActiveReasonMultiKueueAdmissionCheckAppliedPerFlavor        = "MultiKueueAdmissionCheckAppliedPerFlavor"
 	ClusterQueueActiveReasonNotSupportedWithTopologyAwareScheduling         = "NotSupportedWithTopologyAwareScheduling"
+	ClusterQueueActiveReasonTopologyNotFound                                = "TopologyNotFound"
 	ClusterQueueActiveReasonUnknown                                         = "Unknown"
 	ClusterQueueActiveReasonReady                                           = "Ready"
 )

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -256,6 +257,22 @@ func (c *Cache) DeleteResourceFlavor(rf *kueue.ResourceFlavor) sets.Set[string] 
 	c.Lock()
 	defer c.Unlock()
 	delete(c.resourceFlavors, kueue.ResourceFlavorReference(rf.Name))
+	return c.updateClusterQueues()
+}
+
+func (c *Cache) AddOrUpdateTopologyForFlavor(topology *kueuealpha.Topology, flv *kueue.ResourceFlavor) sets.Set[string] {
+	c.Lock()
+	defer c.Unlock()
+	levels := utiltas.Levels(topology)
+	tasInfo := c.tasCache.NewTASFlavorCache(kueue.TopologyReference(topology.Name), levels, flv.Spec.NodeLabels, flv.Spec.Tolerations)
+	c.tasCache.Set(kueue.ResourceFlavorReference(flv.Name), tasInfo)
+	return c.updateClusterQueues()
+}
+
+func (c *Cache) DeleteTopologyForFlavor(flv kueue.ResourceFlavorReference) sets.Set[string] {
+	c.Lock()
+	defer c.Unlock()
+	c.tasCache.Delete(flv)
 	return c.updateClusterQueues()
 }
 
@@ -824,6 +841,21 @@ func (c *Cache) ClusterQueuesUsingFlavor(flavor kueue.ResourceFlavorReference) [
 	for _, cq := range c.hm.ClusterQueues {
 		if cq.flavorInUse(flavor) {
 			cqs = append(cqs, cq.Name)
+		}
+	}
+	return cqs
+}
+
+func (c *Cache) ClusterQueuesUsingTopology(tName kueue.TopologyReference) []string {
+	c.RLock()
+	defer c.RUnlock()
+	var cqs []string
+
+	for _, cq := range c.hm.ClusterQueues {
+		for _, tRef := range cq.tasFlavors {
+			if tRef == tName {
+				cqs = append(cqs, cq.Name)
+			}
 		}
 	}
 	return cqs

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -1070,7 +1070,7 @@ func TestClusterQueueReadinessWithTAS(t *testing.T) {
 			wantMessage: "Can't admit new workloads: TAS is not supported with ProvisioningRequest admission check.",
 		},
 		{
-			name:         "TAS do not support ProvisioningRequest AdmissionCheck",
+			name:         "Referenced TAS flavor without topology",
 			skipTopology: true,
 			cq: utiltesting.MakeClusterQueue("cq").
 				ResourceGroup(

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta1"
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/constants"
@@ -70,6 +71,7 @@ type ClusterQueueReconciler struct {
 	rfUpdateCh                           chan event.GenericEvent
 	acUpdateCh                           chan event.GenericEvent
 	snapUpdateCh                         chan event.GenericEvent
+	topologyUpdateCh                     chan event.GenericEvent
 	watchers                             []ClusterQueueUpdateWatcher
 	reportResourceMetrics                bool
 	fairSharingEnabled                   bool
@@ -155,6 +157,7 @@ func NewClusterQueueReconciler(
 		rfUpdateCh:                           make(chan event.GenericEvent, updateChBuffer),
 		acUpdateCh:                           make(chan event.GenericEvent, updateChBuffer),
 		snapUpdateCh:                         make(chan event.GenericEvent, updateChBuffer),
+		topologyUpdateCh:                     make(chan event.GenericEvent, updateChBuffer),
 		watchers:                             options.Watchers,
 		reportResourceMetrics:                options.ReportResourceMetrics,
 		fairSharingEnabled:                   options.FairSharingEnabled,
@@ -213,6 +216,22 @@ func (r *ClusterQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	return ctrl.Result{}, nil
+}
+
+// Only topology Creation or Delete can impact the CQ active state, so we
+// ignore other updates
+func (r *ClusterQueueReconciler) NotifyTopologyUpdate(oldTopology, newTopology *kueuealpha.Topology) {
+	// if oldTopology is nil, it's a create event.
+	if oldTopology == nil {
+		r.topologyUpdateCh <- event.GenericEvent{Object: newTopology}
+		return
+	}
+
+	// if newTopology is nil, it's a delete event.
+	if newTopology == nil {
+		r.topologyUpdateCh <- event.GenericEvent{Object: oldTopology}
+		return
+	}
 }
 
 func (r *ClusterQueueReconciler) NotifyWorkloadUpdate(oldWl, newWl *kueue.Workload) {
@@ -594,6 +613,34 @@ func (h *cqAdmissionCheckHandler) Generic(_ context.Context, e event.GenericEven
 	}
 }
 
+type cqTopologyHandler struct {
+	cache *cache.Cache
+}
+
+func (h *cqTopologyHandler) Create(context.Context, event.CreateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *cqTopologyHandler) Update(context.Context, event.UpdateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *cqTopologyHandler) Delete(context.Context, event.DeleteEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *cqTopologyHandler) Generic(_ context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	topology, isTopology := e.Object.(*kueuealpha.Topology)
+	if !isTopology {
+		return
+	}
+	cqs := h.cache.ClusterQueuesUsingTopology(kueue.TopologyReference(topology.Name))
+	for _, cq := range cqs {
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name: cq,
+			}}
+		q.AddAfter(req, time.Second)
+	}
+}
+
 func (h *cqSnapshotHandler) Create(context.Context, event.CreateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 }
 
@@ -636,6 +683,9 @@ func (r *ClusterQueueReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.
 	acHandler := cqAdmissionCheckHandler{
 		cache: r.cache,
 	}
+	topologyHandler := cqTopologyHandler{
+		cache: r.cache,
+	}
 	snapHandler := cqSnapshotHandler{
 		queueVisibilityUpdateInterval: r.queueVisibilityUpdateInterval,
 	}
@@ -646,6 +696,7 @@ func (r *ClusterQueueReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.
 		WatchesRawSource(source.Channel(r.wlUpdateCh, &wHandler)).
 		WatchesRawSource(source.Channel(r.rfUpdateCh, &rfHandler)).
 		WatchesRawSource(source.Channel(r.acUpdateCh, &acHandler)).
+		WatchesRawSource(source.Channel(r.topologyUpdateCh, &topologyHandler)).
 		WatchesRawSource(source.Channel(r.snapUpdateCh, &snapHandler)).
 		WithEventFilter(r).
 		Complete(WithLeadingManager(mgr, r, &kueue.ClusterQueue{}, cfg))

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -637,7 +637,7 @@ func (h *cqTopologyHandler) Generic(_ context.Context, e event.GenericEvent, q w
 			NamespacedName: types.NamespacedName{
 				Name: cq,
 			}}
-		q.AddAfter(req, time.Second)
+		q.Add(req)
 	}
 }
 

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -83,6 +83,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *queue.Manager, cc *cache.Cache
 	).SetupWithManager(mgr, cfg); err != nil {
 		return "Workload", err
 	}
+	qManager.AddTopologyUpdateWatcher(cqRec)
 	return "", nil
 }
 

--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -41,7 +41,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/queue"
-	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
 const (
@@ -54,6 +53,7 @@ type rfReconciler struct {
 	tasCache *cache.TASCache
 	client   client.Client
 	recorder record.EventRecorder
+	tHandler *topologyHandler
 }
 
 var _ reconcile.Reconciler = (*rfReconciler)(nil)
@@ -70,6 +70,7 @@ func newRfReconciler(c client.Client, queues *queue.Manager, cache *cache.Cache,
 		cache:    cache,
 		tasCache: cache.TASCache(),
 		recorder: recorder,
+		tHandler: &topologyHandler{client: c, cache: cache, tasCache: cache.TASCache(), queues: queues},
 	}
 }
 
@@ -81,7 +82,7 @@ func (r *rfReconciler) setupWithManager(mgr ctrl.Manager, cache *cache.Cache, cf
 		Named(TASResourceFlavorController).
 		For(&kueue.ResourceFlavor{}).
 		Watches(&corev1.Node{}, &nodeHandler).
-		Watches(&kueuealpha.Topology{}, &topologyHandler{client: r.client, tasCache: r.tasCache}).
+		Watches(&kueuealpha.Topology{}, r.tHandler).
 		WithOptions(controller.Options{NeedLeaderElection: ptr.To(false)}).
 		WithEventFilter(r).
 		Complete(core.WithLeadingManager(mgr, r, &kueue.ResourceFlavor{}, cfg))
@@ -142,6 +143,8 @@ var _ handler.EventHandler = (*topologyHandler)(nil)
 // topologyHandler handles node update events.
 type topologyHandler struct {
 	client   client.Client
+	queues   *queue.Manager
+	cache    *cache.Cache
 	tasCache *cache.TASCache
 }
 
@@ -158,13 +161,16 @@ func (h *topologyHandler) Create(ctx context.Context, e event.CreateEvent, q wor
 		return
 	}
 
+	defer h.notifyTopologyWatchers(nil, topology)
+
 	// trigger reconcile for TAS flavors affected by the node being created or updated
-	for _, flavor := range flavors.Items {
-		if flavor.Spec.TopologyName == nil {
+	for _, flv := range flavors.Items {
+		if flv.Spec.TopologyName == nil {
 			continue
 		}
-		if *flavor.Spec.TopologyName == kueue.TopologyReference(topology.Name) {
-			q.AddAfter(reconcile.Request{NamespacedName: types.NamespacedName{Name: flavor.Name}}, nodeBatchPeriod)
+		if *flv.Spec.TopologyName == kueue.TopologyReference(topology.Name) {
+			h.cache.AddOrUpdateTopologyForFlavor(topology, &flv)
+			q.AddAfter(reconcile.Request{NamespacedName: types.NamespacedName{Name: flv.Name}}, nodeBatchPeriod)
 		}
 	}
 }
@@ -177,9 +183,10 @@ func (h *topologyHandler) Delete(_ context.Context, e event.DeleteEvent, _ workq
 	if !isTopology || topology == nil {
 		return
 	}
+	defer h.notifyTopologyWatchers(topology, nil)
 	for name, flavor := range h.tasCache.Clone() {
 		if flavor.TopologyName == kueue.TopologyReference(topology.Name) {
-			h.tasCache.Delete(name)
+			h.cache.DeleteTopologyForFlavor(name)
 		}
 	}
 }
@@ -205,11 +212,8 @@ func (r *rfReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 			if err := r.client.Get(ctx, types.NamespacedName{Name: string(*flv.Spec.TopologyName)}, &topology); err != nil {
 				return reconcile.Result{}, client.IgnoreNotFound(err)
 			}
-			levels := utiltas.Levels(&topology)
-			tasInfo := r.tasCache.NewTASFlavorCache(kueue.TopologyReference(topology.Name), levels, flv.Spec.NodeLabels, flv.Spec.Tolerations)
-			r.tasCache.Set(flavorReference, tasInfo)
+			r.cache.AddOrUpdateTopologyForFlavor(&topology, flv)
 		}
-
 		// requeue inadmissible workloads as a change to the resource flavor
 		// or the set of nodes can allow admitting a workload which was
 		// previously inadmissible.
@@ -218,6 +222,10 @@ func (r *rfReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		}
 	}
 	return reconcile.Result{}, nil
+}
+
+func (t *topologyHandler) notifyTopologyWatchers(oldTopology, newTopology *kueuealpha.Topology) {
+	t.queues.NotifyTopologyUpdateWatchers(oldTopology, newTopology)
 }
 
 func (r *rfReconciler) Create(event event.CreateEvent) bool {

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -534,11 +534,9 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				var wl *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {
 					wl = testing.MakeWorkload("wl", ns.Name).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
-					wl.Spec.PodSets[0].Count = 2
-					wl.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(testing.DefaultBlockTopologyLevel),
-					}
+						Queue(localQueue.Name).PodSets(*testing.MakePodSet("worker", 2).
+						RequiredTopologyRequest(testing.DefaultBlockTopologyLevel).
+						Obj()).Request(corev1.ResourceCPU, "1").Obj()
 					gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
 				})
 
@@ -603,11 +601,9 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				var wl *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {
 					wl = testing.MakeWorkload("wl", ns.Name).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
-					wl.Spec.PodSets[0].Count = 2
-					wl.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(testing.DefaultBlockTopologyLevel),
-					}
+						Queue(localQueue.Name).PodSets(*testing.MakePodSet("worker", 2).
+						RequiredTopologyRequest(testing.DefaultBlockTopologyLevel).
+						Obj()).Request(corev1.ResourceCPU, "1").Obj()
 					gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
 				})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3645 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: The CQ referencing a Topology is deactivated if the topology does not exist.
```