### PR TITLE
Replace `time.Now()` with `clock.Clock.Now()` in pkg/pod

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -120,7 +120,7 @@ type Reconciler struct {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.ReconcileGenericJob(ctx, req, &Pod{excessPodExpectations: r.expectationsStore, clock: realClock})
+	return r.ReconcileGenericJob(ctx, req, NewPod(WithExcessPodExpectations(r.expectationsStore), WithClock(realClock)))
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -209,6 +209,13 @@ func (p *Pod) isUnretriableGroup() bool {
 	return false
 }
 
+func (p *Pod) Clock() clock.Clock {
+	if p.clock != nil {
+		return p.clock
+	}
+	return realClock
+}
+
 // IsSuspended returns whether the job is suspended or not.
 func (p *Pod) IsSuspended() bool {
 	if !p.isGroup {

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -455,7 +455,7 @@ func (p *Pod) Stop(ctx context.Context, c client.Client, _ []podset.PodSetInfo, 
 						Type:   ConditionTypeTerminationTarget,
 						Status: corev1.ConditionTrue,
 						LastTransitionTime: metav1.Time{
-							Time: p.clock.Now(),
+							Time: p.getClock().Now(),
 						},
 						Reason:  string(stopReason),
 						Message: eventMsg,

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -1335,7 +1335,7 @@ func (p *Pod) waitingForReplacementPodsCondition(wl *kueue.Workload) (*metav1.Co
 
 	if updated {
 		replCond.ObservedGeneration = wl.Generation
-		replCond.LastTransitionTime = metav1.Now()
+		replCond.LastTransitionTime = metav1.NewTime(p.getClock().Now())
 	}
 
 	return replCond, updated

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -137,7 +137,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func NewJob() jobframework.GenericJob {
-	return NewPod(WithClock(realClock))
+	return NewPod()
 }
 
 func NewReconciler(c client.Client, record record.EventRecorder, opts ...jobframework.Option) jobframework.JobReconcilerInterface {

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -209,7 +209,7 @@ func (p *Pod) isUnretriableGroup() bool {
 	return false
 }
 
-func (p *Pod) Clock() clock.Clock {
+func (p *Pod) getClock() clock.Clock {
 	if p.clock != nil {
 		return p.clock
 	}

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -5194,8 +5194,8 @@ func TestReconciler(t *testing.T) {
 
 func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
-	now := time.Now()
-	fakeClock := testingclock.NewFakeClock(now)
+	// now := time.Now()
+	// fakeClock := testingclock.NewFakeClock(now)
 
 	clientBuilder := utiltesting.NewClientBuilder()
 	if err := SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder)); err != nil {
@@ -5256,7 +5256,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 	}
 	recorder := record.NewBroadcaster().NewRecorder(kClient.Scheme(), corev1.EventSource{Component: "test"})
 
-	reconciler := NewReconciler(kClient, recorder, jobframework.WithClock(t, fakeClock))
+	reconciler := NewReconciler(kClient, recorder)
 
 	podKey := client.ObjectKeyFromObject(&pod)
 	_, err := reconciler.Reconcile(ctx, reconcile.Request{

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -5194,8 +5194,6 @@ func TestReconciler(t *testing.T) {
 
 func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
-	// now := time.Now()
-	// fakeClock := testingclock.NewFakeClock(now)
 
 	clientBuilder := utiltesting.NewClientBuilder()
 	if err := SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder)); err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Replaces `time.Now()` to use the Now() function present inside `clock` package.

#### Which issue(s) this PR fixes:
Fixes #3380

#### Special notes for your reviewer:

```release-note
NONE
```