### PR TITLE
Use lock when accessing IsIntegrationEnabled

### DIFF
--- a/pkg/controller/jobframework/integrationmanager.go
+++ b/pkg/controller/jobframework/integrationmanager.go
@@ -264,6 +264,8 @@ func GetIntegration(name string) (IntegrationCallbacks, bool) {
 }
 
 func IsIntegrationEnabled(name string) bool {
+	manager.mu.RLock()
+	defer manager.mu.RUnlock()
 	return manager.enabledIntegrations.Has(name)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

To address https://github.com/kubernetes-sigs/kueue/pull/3803/files#r1879511754 which could be sometimes an issue when installing a new integration

#### Special notes for your reviewer:

No need for release note because it was not released yet.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```