### PR TITLE
Automated cherry pick of #3770: Deactivate ClusterQueue if there is no Topology

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -34,6 +34,7 @@ const (
 	ClusterQueueActiveReasonMultipleMultiKueueAdmissionChecks               = "MultipleMultiKueueAdmissionChecks"
 	ClusterQueueActiveReasonMultiKueueAdmissionCheckAppliedPerFlavor        = "MultiKueueAdmissionCheckAppliedPerFlavor"
 	ClusterQueueActiveReasonNotSupportedWithTopologyAwareScheduling         = "NotSupportedWithTopologyAwareScheduling"
+	ClusterQueueActiveReasonTopologyNotFound                                = "TopologyNotFound"
 	ClusterQueueActiveReasonUnknown                                         = "Unknown"
 	ClusterQueueActiveReasonReady                                           = "Ready"
 )

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -81,7 +81,7 @@ type clusterQueue struct {
 	multiKueueAdmissionChecks                       []string
 	provisioningAdmissionChecks                     []string
 	perFlavorMultiKueueAdmissionChecks              []string
-	tasFlavors                                      []kueue.ResourceFlavorReference
+	tasFlavors                                      map[kueue.ResourceFlavorReference]kueue.TopologyReference
 	admittedWorkloadsCount                          int
 	isStopped                                       bool
 	workloadInfoOptions                             []workload.InfoOption
@@ -317,6 +317,12 @@ func (c *clusterQueue) inactiveReason() (string, string) {
 				reasons = append(reasons, kueue.ClusterQueueActiveReasonNotSupportedWithTopologyAwareScheduling)
 				messages = append(messages, "TAS is not supported with ProvisioningRequest admission check")
 			}
+			for tasFlavor, topology := range c.tasFlavors {
+				if c.tasCache.Get(tasFlavor) == nil {
+					reasons = append(reasons, kueue.ClusterQueueActiveReasonTopologyNotFound)
+					messages = append(messages, fmt.Sprintf("there is no Topology %q for TAS flavor %q", topology, tasFlavor))
+				}
+			}
 		}
 
 		if len(reasons) == 0 {
@@ -331,6 +337,11 @@ func (c *clusterQueue) inactiveReason() (string, string) {
 func (c *clusterQueue) isTASViolated() bool {
 	if !features.Enabled(features.TopologyAwareScheduling) || len(c.tasFlavors) == 0 {
 		return false
+	}
+	for tasFlavor := range c.tasFlavors {
+		if c.tasCache.Get(tasFlavor) == nil {
+			return true
+		}
 	}
 	return c.HasParent() ||
 		c.Preemption.WithinClusterQueue != kueue.PreemptionPolicyNever ||
@@ -361,7 +372,10 @@ func (c *clusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference
 					keys.Insert(k)
 				}
 				if flv.Spec.TopologyName != nil {
-					c.tasFlavors = append(c.tasFlavors, fName)
+					if c.tasFlavors == nil {
+						c.tasFlavors = make(map[kueue.ResourceFlavorReference]kueue.TopologyReference, 1)
+					}
+					c.tasFlavors[fName] = *flv.Spec.TopologyName
 				}
 			} else {
 				c.missingFlavors = append(c.missingFlavors, fName)

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -1373,7 +1373,7 @@ func TestClusterQueueReadinessWithTAS(t *testing.T) {
 			wantMessage: "Can't admit new workloads: TAS is not supported with ProvisioningRequest admission check.",
 		},
 		{
-			name:         "TAS do not support ProvisioningRequest AdmissionCheck",
+			name:         "Referenced TAS flavor without topology",
 			skipTopology: true,
 			cq: utiltesting.MakeClusterQueue("cq").
 				ResourceGroup(

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -623,7 +623,7 @@ func (h *cqTopologyHandler) Generic(_ context.Context, e event.GenericEvent, q w
 			NamespacedName: types.NamespacedName{
 				Name: cq,
 			}}
-		q.AddAfter(req, time.Second)
+		q.Add(req)
 	}
 }
 

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -83,6 +83,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *queue.Manager, cc *cache.Cache
 	).SetupWithManager(mgr, cfg); err != nil {
 		return "Workload", err
 	}
+	qManager.AddTopologyUpdateWatcher(cqRec)
 	return "", nil
 }
 

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -78,6 +78,10 @@ func WithResourceTransformations(transforms []config.ResourceTransformation) Opt
 	}
 }
 
+type TopologyUpdateWatcher interface {
+	NotifyTopologyUpdate(oldTopology, newTopology *kueuealpha.Topology)
+}
+
 type Manager struct {
 	sync.RWMutex
 	cond sync.Cond
@@ -94,6 +98,8 @@ type Manager struct {
 	workloadInfoOptions []workload.InfoOption
 
 	hm hierarchy.Manager[*ClusterQueue, *cohort]
+
+	topologyUpdateWatchers []TopologyUpdateWatcher
 }
 
 func NewManager(client client.Client, checker StatusChecker, opts ...Option) *Manager {
@@ -112,9 +118,21 @@ func NewManager(client client.Client, checker StatusChecker, opts ...Option) *Ma
 		},
 		workloadInfoOptions: options.workloadInfoOptions,
 		hm:                  hierarchy.NewManager[*ClusterQueue, *cohort](newCohort),
+
+		topologyUpdateWatchers: make([]TopologyUpdateWatcher, 0),
 	}
 	m.cond.L = &m.RWMutex
 	return m
+}
+
+func (m *Manager) AddTopologyUpdateWatcher(watcher TopologyUpdateWatcher) {
+	m.topologyUpdateWatchers = append(m.topologyUpdateWatchers, watcher)
+}
+
+func (m *Manager) NotifyTopologyUpdateWatchers(oldTopology, newTopology *kueuealpha.Topology) {
+	for _, watcher := range m.topologyUpdateWatchers {
+		watcher.NotifyTopologyUpdate(oldTopology, newTopology)
+	}
 }
 
 func (m *Manager) AddOrUpdateCohort(ctx context.Context, cohort *kueuealpha.Cohort) {

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package core
 
 import (
-	"time"
-
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -511,11 +509,20 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
 				})
 
-				// TODO(#3645): replace the sleep with waiting for CQ deactivation.
-				// The sleep is a temporary solution to minimize the chance for the test flaking in case
-				// the workload is created and admitted before the event is handled and the topology
-				// is removed from the cache.
-				time.Sleep(time.Second)
+				ginkgo.By("await for the CQ to become inactive", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						var updatedCq kueue.ClusterQueue
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCq)).To(gomega.Succeed())
+						g.Expect(updatedCq.Status.Conditions).Should(gomega.BeComparableTo([]metav1.Condition{
+							{
+								Type:    kueue.ClusterQueueActive,
+								Status:  metav1.ConditionFalse,
+								Reason:  "TopologyNotFound",
+								Message: `Can't admit new workloads: there is no Topology "default" for TAS flavor "tas-flavor".`,
+							},
+						}, util.IgnoreConditionTimestampsAndObservedGeneration))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
 
 				var wl *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {
@@ -532,8 +539,82 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
 				})
 
-				topology = testing.MakeDefaultTwoLevelTopology("default")
-				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
+				ginkgo.By("recreate the Topology and wait for the queue to become active", func() {
+					topology = testing.MakeDefaultTwoLevelTopology("default")
+					gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
+					util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+				})
+
+				ginkgo.By("verify the workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+				})
+
+				ginkgo.By("verify admission for the workload", func() {
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+					gomega.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						&kueue.TopologyAssignment{
+							Levels: []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
+							Domains: []kueue.TopologyDomainAssignment{
+								{Count: 1, Values: []string{"b1", "r1"}},
+								{Count: 1, Values: []string{"b1", "r2"}},
+							},
+						},
+					))
+				})
+			})
+
+			ginkgo.It("should not admit the workload after the TAS RF is deleted and admit it after the RF is re-created", func() {
+				ginkgo.By("remove TAS RF finalizers to allow deletion", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						var updatedFlavor kueue.ResourceFlavor
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), &updatedFlavor)).To(gomega.Succeed())
+						updatedFlavor.Finalizers = nil
+						g.Expect(k8sClient.Update(ctx, &updatedFlavor)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("delete TAS RF", func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+				})
+
+				ginkgo.By("await for the CQ to become inactive", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						var updatedCq kueue.ClusterQueue
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCq)).To(gomega.Succeed())
+						g.Expect(updatedCq.Status.Conditions).Should(gomega.BeComparableTo([]metav1.Condition{
+							{
+								Type:    kueue.ClusterQueueActive,
+								Status:  metav1.ConditionFalse,
+								Reason:  "FlavorNotFound",
+								Message: `Can't admit new workloads: references missing ResourceFlavor(s): [tas-flavor].`,
+							},
+						}, util.IgnoreConditionTimestampsAndObservedGeneration))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				var wl *kueue.Workload
+				ginkgo.By("creating a workload which requires block and can fit", func() {
+					wl = testing.MakeWorkload("wl", ns.Name).
+						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+					wl.Spec.PodSets[0].Count = 2
+					wl.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(testing.DefaultBlockTopologyLevel),
+					}
+					gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify the workload is inadmissible", func() {
+					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+				})
+
+				ginkgo.By("recreate the ResourceFlavor and wait for the queue to become active", func() {
+					tasFlavor = testing.MakeResourceFlavor("tas-flavor").
+						NodeLabel("node-group", "tas").
+						TopologyName("default").Obj()
+					gomega.Expect(k8sClient.Create(ctx, tasFlavor)).Should(gomega.Succeed())
+					util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+				})
 
 				ginkgo.By("verify the workload is admitted", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -527,11 +527,9 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				var wl *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {
 					wl = testing.MakeWorkload("wl", ns.Name).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
-					wl.Spec.PodSets[0].Count = 2
-					wl.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(testing.DefaultBlockTopologyLevel),
-					}
+						Queue(localQueue.Name).PodSets(*testing.MakePodSet("worker", 2).
+						RequiredTopologyRequest(testing.DefaultBlockTopologyLevel).
+						Obj()).Request(corev1.ResourceCPU, "1").Obj()
 					gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
 				})
 
@@ -596,11 +594,9 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				var wl *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {
 					wl = testing.MakeWorkload("wl", ns.Name).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
-					wl.Spec.PodSets[0].Count = 2
-					wl.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(testing.DefaultBlockTopologyLevel),
-					}
+						Queue(localQueue.Name).PodSets(*testing.MakePodSet("worker", 2).
+						RequiredTopologyRequest(testing.DefaultBlockTopologyLevel).
+						Obj()).Request(corev1.ResourceCPU, "1").Obj()
 					gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
 				})
 


### PR DESCRIPTION
Cherry pick of #3770 on release-0.9.

#3770: Deactivate ClusterQueue if there is no Topology

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
TAS: The CQ referencing a Topology is deactivated if the topology does not exist.
```