### PR TITLE
Automated cherry pick of #3719: Use TopologyWrapper and ResourceFlavorWrapper in tests
#3744: Use variadic function to set levels in TopologyWrapper
#3769: Add default topologies for tests

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3775,9 +3775,7 @@ func TestSnapshotError(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, true)
 	ctx, _ := utiltesting.ContextWithLog(t)
 
-	topology := *utiltesting.MakeTopology("default").
-		Levels(corev1.LabelHostname).
-		Obj()
+	topology := *utiltesting.MakeDefaultOneLevelTopology("default")
 	flavor := *utiltesting.MakeResourceFlavor("tas-default").
 		TopologyName("default").
 		Obj()

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3776,7 +3776,7 @@ func TestSnapshotError(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 
 	topology := *utiltesting.MakeTopology("default").
-		Levels([]string{corev1.LabelHostname}).
+		Levels(corev1.LabelHostname).
 		Obj()
 	flavor := *utiltesting.MakeResourceFlavor("tas-default").
 		TopologyName("default").

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -35,7 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
-	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
@@ -610,9 +609,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				cache.AddOrUpdateResourceFlavor(&kueue.ResourceFlavor{
-					ObjectMeta: metav1.ObjectMeta{Name: "nonexistent-flavor"},
-				})
+				cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("nonexistent-flavor").Obj())
 				return nil
 			},
 			wantClusterQueues: map[string]*clusterQueue{
@@ -3778,15 +3775,9 @@ func TestSnapshotError(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, true)
 	ctx, _ := utiltesting.ContextWithLog(t)
 
-	topology := kueuealpha.Topology{
-		Spec: kueuealpha.TopologySpec{
-			Levels: []kueuealpha.TopologyLevel{
-				{
-					NodeLabel: tasHostLabel,
-				},
-			},
-		},
-	}
+	topology := *utiltesting.MakeTopology("default").
+		Levels([]string{corev1.LabelHostname}).
+		Obj()
 	flavor := *utiltesting.MakeResourceFlavor("tas-default").
 		TopologyName("default").
 		Obj()

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -399,8 +399,8 @@ func TestFitInCohort(t *testing.T) {
 
 func TestClusterQueueUpdate(t *testing.T) {
 	resourceFlavors := []*kueue.ResourceFlavor{
-		{ObjectMeta: metav1.ObjectMeta{Name: "on-demand"}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "spot"}},
+		utiltesting.MakeResourceFlavor("on-demand").Obj(),
+		utiltesting.MakeResourceFlavor("spot").Obj(),
 	}
 	clusterQueue :=
 		*utiltesting.MakeClusterQueue("eng-alpha").

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
@@ -43,13 +42,11 @@ func (f *testOracle) IsReclaimPossible(log logr.Logger, cq *cache.ClusterQueueSn
 
 func TestAssignFlavors(t *testing.T) {
 	resourceFlavors := map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
-		"default": {
-			ObjectMeta: metav1.ObjectMeta{Name: "default"},
-		},
-		"one":   utiltesting.MakeResourceFlavor("one").NodeLabel("type", "one").Obj(),
-		"two":   utiltesting.MakeResourceFlavor("two").NodeLabel("type", "two").Obj(),
-		"b_one": utiltesting.MakeResourceFlavor("b_one").NodeLabel("b_type", "one").Obj(),
-		"b_two": utiltesting.MakeResourceFlavor("b_two").NodeLabel("b_type", "two").Obj(),
+		"default": utiltesting.MakeResourceFlavor("default").Obj(),
+		"one":     utiltesting.MakeResourceFlavor("one").NodeLabel("type", "one").Obj(),
+		"two":     utiltesting.MakeResourceFlavor("two").NodeLabel("type", "two").Obj(),
+		"b_one":   utiltesting.MakeResourceFlavor("b_one").NodeLabel("b_type", "one").Obj(),
+		"b_two":   utiltesting.MakeResourceFlavor("b_two").NodeLabel("b_type", "two").Obj(),
 		"tainted": utiltesting.MakeResourceFlavor("tainted").
 			Taint(corev1.Taint{
 				Key:    "instance",

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4004,9 +4004,7 @@ func TestScheduleForTAS(t *testing.T) {
 			},
 		},
 	}
-	defaultSingleLevelTopology := *utiltesting.MakeTopology("tas-single-level").
-		Levels(corev1.LabelHostname).
-		Obj()
+	defaultSingleLevelTopology := *utiltesting.MakeDefaultOneLevelTopology("tas-single-level")
 	defaultTwoLevelTopology := *utiltesting.MakeTopology("tas-two-level").
 		Levels(tasRackLabel, corev1.LabelHostname).
 		Obj()

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4005,10 +4005,10 @@ func TestScheduleForTAS(t *testing.T) {
 		},
 	}
 	defaultSingleLevelTopology := *utiltesting.MakeTopology("tas-single-level").
-		Levels([]string{corev1.LabelHostname}).
+		Levels(corev1.LabelHostname).
 		Obj()
 	defaultTwoLevelTopology := *utiltesting.MakeTopology("tas-two-level").
-		Levels([]string{tasRackLabel, corev1.LabelHostname}).
+		Levels(tasRackLabel, corev1.LabelHostname).
 		Obj()
 	defaultFlavor := *utiltesting.MakeResourceFlavor("default").Obj()
 	defaultTASFlavor := *utiltesting.MakeResourceFlavor("tas-default").
@@ -4320,7 +4320,7 @@ func TestScheduleForTAS(t *testing.T) {
 			},
 			topologies: []kueuealpha.Topology{defaultSingleLevelTopology,
 				*utiltesting.MakeTopology("tas-custom-topology").
-					Levels([]string{"cloud.com/custom-level"}).
+					Levels("cloud.com/custom-level").
 					Obj(),
 			},
 			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor,

--- a/pkg/util/testing/defaults.go
+++ b/pkg/util/testing/defaults.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+)
+
+const (
+	DefaultRackTopologyLevel  = "cloud.provider.com/topology-rack"
+	DefaultBlockTopologyLevel = "cloud.provider.com/topology-block"
+)
+
+// MakeDefaultOneLevelTopology creates a default topology with hostname level.
+func MakeDefaultOneLevelTopology(name string) *kueuealpha.Topology {
+	return MakeTopology(name).
+		Levels(corev1.LabelHostname).
+		Obj()
+}
+
+// MakeDefaultTwoLevelTopology creates a default topology with block and rack levels.
+func MakeDefaultTwoLevelTopology(name string) *kueuealpha.Topology {
+	return MakeTopology(name).
+		Levels(DefaultBlockTopologyLevel, DefaultRackTopologyLevel).
+		Obj()
+}
+
+// MakeDefaultThreeLevelTopology creates a default topology with block, rack and hostname levels.
+func MakeDefaultThreeLevelTopology(name string) *kueuealpha.Topology {
+	return MakeTopology(name).
+		Levels(DefaultBlockTopologyLevel, DefaultRackTopologyLevel, corev1.LabelHostname).
+		Obj()
+}

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -948,7 +948,7 @@ func MakeTopology(name string) *TopologyWrapper {
 }
 
 // Levels sets the levels for a Topology.
-func (t *TopologyWrapper) Levels(levels []string) *TopologyWrapper {
+func (t *TopologyWrapper) Levels(levels ...string) *TopologyWrapper {
 	t.Spec.Levels = make([]kueuealpha.TopologyLevel, len(levels))
 	for i, level := range levels {
 		t.Spec.Levels[i] = kueuealpha.TopologyLevel{

--- a/test/e2e/singlecluster/tas_test.go
+++ b/test/e2e/singlecluster/tas_test.go
@@ -67,9 +67,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			clusterQueue *kueue.ClusterQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("hostname").Levels(
-				corev1.LabelHostname,
-			).Obj()
+			topology = testing.MakeDefaultOneLevelTopology("hostname")
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			onDemandRF = testing.MakeResourceFlavor("on-demand").
@@ -161,7 +159,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			localQueue   *kueue.LocalQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("hostname").Levels(corev1.LabelHostname).Obj()
+			topology = testing.MakeDefaultOneLevelTopology("hostname")
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			onDemandRF = testing.MakeResourceFlavor("on-demand").
@@ -296,7 +294,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			localQueue   *kueue.LocalQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("hostname").Levels(corev1.LabelHostname).Obj()
+			topology = testing.MakeDefaultOneLevelTopology("hostname")
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			onDemandRF = testing.MakeResourceFlavor("on-demand").

--- a/test/e2e/singlecluster/tas_test.go
+++ b/test/e2e/singlecluster/tas_test.go
@@ -67,9 +67,9 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			clusterQueue *kueue.ClusterQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("hostname").Levels([]string{
-				topologyLevel,
-			}).Obj()
+			topology = testing.MakeTopology("hostname").Levels(
+				corev1.LabelHostname,
+			).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			onDemandRF = testing.MakeResourceFlavor("on-demand").
@@ -161,7 +161,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			localQueue   *kueue.LocalQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("hostname").Levels([]string{topologyLevel}).Obj()
+			topology = testing.MakeTopology("hostname").Levels(corev1.LabelHostname).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			onDemandRF = testing.MakeResourceFlavor("on-demand").
@@ -296,7 +296,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 			localQueue   *kueue.LocalQueue
 		)
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("hostname").Levels([]string{topologyLevel}).Obj()
+			topology = testing.MakeTopology("hostname").Levels(corev1.LabelHostname).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			onDemandRF = testing.MakeResourceFlavor("on-demand").

--- a/test/integration/controller/jobs/job/job_controller_test.go
+++ b/test/integration/controller/jobs/job/job_controller_test.go
@@ -2222,9 +2222,7 @@ var _ = ginkgo.Describe("Job controller when TopologyAwareScheduling enabled", g
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels([]string{
-			tasBlockLabel,
-		}).Obj()
+		topology = testing.MakeTopology("default").Levels(tasBlockLabel).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/controller/jobs/jobset/jobset_controller_test.go
@@ -1118,8 +1118,6 @@ var _ = ginkgo.Describe("JobSet controller interacting with scheduler", ginkgo.O
 var _ = ginkgo.Describe("JobSet controller when TopologyAwareScheduling enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	const (
 		nodeGroupLabel = "node-group"
-		tasBlockLabel  = "cloud.com/topology-block"
-		tasRackLabel   = "cloud.com/topology-rack"
 	)
 
 	var (
@@ -1154,9 +1152,9 @@ var _ = ginkgo.Describe("JobSet controller when TopologyAwareScheduling enabled"
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "b1r1",
 					Labels: map[string]string{
-						nodeGroupLabel: "tas",
-						tasBlockLabel:  "b1",
-						tasRackLabel:   "r1",
+						nodeGroupLabel:                    "tas",
+						testing.DefaultBlockTopologyLevel: "b1",
+						testing.DefaultRackTopologyLevel:  "r1",
 					},
 				},
 				Status: corev1.NodeStatus{
@@ -1178,9 +1176,7 @@ var _ = ginkgo.Describe("JobSet controller when TopologyAwareScheduling enabled"
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels(
-			tasBlockLabel, tasRackLabel,
-		).Obj()
+		topology = testing.MakeDefaultTwoLevelTopology("default")
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -1218,7 +1214,7 @@ var _ = ginkgo.Describe("JobSet controller when TopologyAwareScheduling enabled"
 					Parallelism: 1,
 					Completions: 1,
 					PodAnnotations: map[string]string{
-						kueuealpha.PodSetRequiredTopologyAnnotation: tasBlockLabel,
+						kueuealpha.PodSetRequiredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
 					},
 					Image: util.E2eTestSleepImage,
 					Args:  []string{"1ms"},
@@ -1229,7 +1225,7 @@ var _ = ginkgo.Describe("JobSet controller when TopologyAwareScheduling enabled"
 					Parallelism: 1,
 					Completions: 1,
 					PodAnnotations: map[string]string{
-						kueuealpha.PodSetPreferredTopologyAnnotation: tasRackLabel,
+						kueuealpha.PodSetPreferredTopologyAnnotation: testing.DefaultRackTopologyLevel,
 					},
 					Image: util.E2eTestSleepImage,
 					Args:  []string{"1ms"},
@@ -1256,14 +1252,14 @@ var _ = ginkgo.Describe("JobSet controller when TopologyAwareScheduling enabled"
 						Name:  "rj1",
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required: ptr.To(tasBlockLabel),
+							Required: ptr.To(testing.DefaultBlockTopologyLevel),
 						},
 					},
 					{
 						Name:  "rj2",
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred: ptr.To(tasRackLabel),
+							Preferred: ptr.To(testing.DefaultRackTopologyLevel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
@@ -1282,13 +1278,13 @@ var _ = ginkgo.Describe("JobSet controller when TopologyAwareScheduling enabled"
 				g.Expect(wl.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(2))
 				g.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))
 				g.Expect(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))

--- a/test/integration/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/controller/jobs/jobset/jobset_controller_test.go
@@ -1178,9 +1178,9 @@ var _ = ginkgo.Describe("JobSet controller when TopologyAwareScheduling enabled"
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/controller/jobs/mpijob/mpijob_controller_test.go
@@ -964,9 +964,9 @@ var _ = ginkgo.Describe("MPIJob controller when TopologyAwareScheduling enabled"
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/mxjob/mxjob_controller_test.go
+++ b/test/integration/controller/jobs/mxjob/mxjob_controller_test.go
@@ -369,9 +369,9 @@ var _ = ginkgo.Describe("MXJob controller when TopologyAwareScheduling enabled",
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/mxjob/mxjob_controller_test.go
+++ b/test/integration/controller/jobs/mxjob/mxjob_controller_test.go
@@ -309,8 +309,6 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", framework.R
 var _ = ginkgo.Describe("MXJob controller when TopologyAwareScheduling enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	const (
 		nodeGroupLabel = "node-group"
-		tasBlockLabel  = "cloud.com/topology-block"
-		tasRackLabel   = "cloud.com/topology-rack"
 	)
 
 	var (
@@ -345,9 +343,9 @@ var _ = ginkgo.Describe("MXJob controller when TopologyAwareScheduling enabled",
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "b1r1",
 					Labels: map[string]string{
-						nodeGroupLabel: "tas",
-						tasBlockLabel:  "b1",
-						tasRackLabel:   "r1",
+						nodeGroupLabel:                    "tas",
+						testing.DefaultBlockTopologyLevel: "b1",
+						testing.DefaultRackTopologyLevel:  "r1",
 					},
 				},
 				Status: corev1.NodeStatus{
@@ -369,9 +367,7 @@ var _ = ginkgo.Describe("MXJob controller when TopologyAwareScheduling enabled",
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels(
-			tasBlockLabel, tasRackLabel,
-		).Obj()
+		topology = testing.MakeDefaultTwoLevelTopology("default")
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -405,9 +401,9 @@ var _ = ginkgo.Describe("MXJob controller when TopologyAwareScheduling enabled",
 			Request(kftraining.MXJobReplicaTypeScheduler, corev1.ResourceCPU, "100m").
 			Request(kftraining.MXJobReplicaTypeServer, corev1.ResourceCPU, "100m").
 			Request(kftraining.MXJobReplicaTypeWorker, corev1.ResourceCPU, "100m").
-			PodAnnotation(kftraining.MXJobReplicaTypeScheduler, kueuealpha.PodSetRequiredTopologyAnnotation, tasBlockLabel).
-			PodAnnotation(kftraining.MXJobReplicaTypeServer, kueuealpha.PodSetRequiredTopologyAnnotation, tasBlockLabel).
-			PodAnnotation(kftraining.MXJobReplicaTypeWorker, kueuealpha.PodSetPreferredTopologyAnnotation, tasRackLabel).
+			PodAnnotation(kftraining.MXJobReplicaTypeScheduler, kueuealpha.PodSetRequiredTopologyAnnotation, testing.DefaultBlockTopologyLevel).
+			PodAnnotation(kftraining.MXJobReplicaTypeServer, kueuealpha.PodSetRequiredTopologyAnnotation, testing.DefaultBlockTopologyLevel).
+			PodAnnotation(kftraining.MXJobReplicaTypeWorker, kueuealpha.PodSetPreferredTopologyAnnotation, testing.DefaultRackTopologyLevel).
 			Obj()
 		ginkgo.By("creating a MXJob", func() {
 			gomega.Expect(k8sClient.Create(ctx, mxJob)).Should(gomega.Succeed())
@@ -424,21 +420,21 @@ var _ = ginkgo.Describe("MXJob controller when TopologyAwareScheduling enabled",
 						Name:  strings.ToLower(string(kftraining.MXJobReplicaTypeScheduler)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required: ptr.To(tasBlockLabel),
+							Required: ptr.To(testing.DefaultBlockTopologyLevel),
 						},
 					},
 					{
 						Name:  strings.ToLower(string(kftraining.MXJobReplicaTypeServer)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required: ptr.To(tasBlockLabel),
+							Required: ptr.To(testing.DefaultBlockTopologyLevel),
 						},
 					},
 					{
 						Name:  strings.ToLower(string(kftraining.MXJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred: ptr.To(tasRackLabel),
+							Preferred: ptr.To(testing.DefaultRackTopologyLevel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
@@ -457,19 +453,19 @@ var _ = ginkgo.Describe("MXJob controller when TopologyAwareScheduling enabled",
 				g.Expect(wl.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(3))
 				g.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))
 				g.Expect(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))
 				g.Expect(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))

--- a/test/integration/controller/jobs/paddlejob/paddlejob_controller_test.go
+++ b/test/integration/controller/jobs/paddlejob/paddlejob_controller_test.go
@@ -298,8 +298,6 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", framework.R
 var _ = ginkgo.Describe("PaddleJob controller when TopologyAwareScheduling enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	const (
 		nodeGroupLabel = "node-group"
-		tasBlockLabel  = "cloud.com/topology-block"
-		tasRackLabel   = "cloud.com/topology-rack"
 	)
 
 	var (
@@ -334,9 +332,9 @@ var _ = ginkgo.Describe("PaddleJob controller when TopologyAwareScheduling enabl
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "b1r1",
 					Labels: map[string]string{
-						nodeGroupLabel: "tas",
-						tasBlockLabel:  "b1",
-						tasRackLabel:   "r1",
+						nodeGroupLabel:                    "tas",
+						testing.DefaultBlockTopologyLevel: "b1",
+						testing.DefaultRackTopologyLevel:  "r1",
 					},
 				},
 				Status: corev1.NodeStatus{
@@ -358,9 +356,7 @@ var _ = ginkgo.Describe("PaddleJob controller when TopologyAwareScheduling enabl
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels(
-			tasBlockLabel, tasRackLabel,
-		).Obj()
+		topology = testing.MakeDefaultTwoLevelTopology("default")
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -395,14 +391,14 @@ var _ = ginkgo.Describe("PaddleJob controller when TopologyAwareScheduling enabl
 					ReplicaType:  kftraining.PaddleJobReplicaTypeMaster,
 					ReplicaCount: 1,
 					Annotations: map[string]string{
-						kueuealpha.PodSetRequiredTopologyAnnotation: tasRackLabel,
+						kueuealpha.PodSetRequiredTopologyAnnotation: testing.DefaultRackTopologyLevel,
 					},
 				},
 				testingpaddlejob.PaddleReplicaSpecRequirement{
 					ReplicaType:  kftraining.PaddleJobReplicaTypeWorker,
 					ReplicaCount: 1,
 					Annotations: map[string]string{
-						kueuealpha.PodSetPreferredTopologyAnnotation: tasBlockLabel,
+						kueuealpha.PodSetPreferredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
 					},
 				},
 			).
@@ -425,14 +421,14 @@ var _ = ginkgo.Describe("PaddleJob controller when TopologyAwareScheduling enabl
 						Name:  strings.ToLower(string(kftraining.PaddleJobReplicaTypeMaster)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required: ptr.To(tasRackLabel),
+							Required: ptr.To(testing.DefaultRackTopologyLevel),
 						},
 					},
 					{
 						Name:  strings.ToLower(string(kftraining.PaddleJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred: ptr.To(tasBlockLabel),
+							Preferred: ptr.To(testing.DefaultBlockTopologyLevel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
@@ -451,13 +447,13 @@ var _ = ginkgo.Describe("PaddleJob controller when TopologyAwareScheduling enabl
 				g.Expect(wl.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(2))
 				g.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))
 				g.Expect(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))

--- a/test/integration/controller/jobs/paddlejob/paddlejob_controller_test.go
+++ b/test/integration/controller/jobs/paddlejob/paddlejob_controller_test.go
@@ -358,9 +358,9 @@ var _ = ginkgo.Describe("PaddleJob controller when TopologyAwareScheduling enabl
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/controller/jobs/pod/pod_controller_test.go
@@ -1929,9 +1929,7 @@ var _ = ginkgo.Describe("Pod controller when TopologyAwareScheduling enabled", g
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels([]string{
-			tasBlockLabel,
-		}).Obj()
+		topology = testing.MakeTopology("default").Levels(tasBlockLabel).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/test/integration/controller/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -601,8 +601,6 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", ginkgo.Orde
 var _ = ginkgo.Describe("PyTorchJob controller when TopologyAwareScheduling enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	const (
 		nodeGroupLabel = "node-group"
-		tasBlockLabel  = "cloud.com/topology-block"
-		tasRackLabel   = "cloud.com/topology-rack"
 	)
 
 	var (
@@ -637,9 +635,9 @@ var _ = ginkgo.Describe("PyTorchJob controller when TopologyAwareScheduling enab
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "b1r1",
 					Labels: map[string]string{
-						nodeGroupLabel: "tas",
-						tasBlockLabel:  "b1",
-						tasRackLabel:   "r1",
+						nodeGroupLabel:                    "tas",
+						testing.DefaultBlockTopologyLevel: "b1",
+						testing.DefaultRackTopologyLevel:  "r1",
 					},
 				},
 				Status: corev1.NodeStatus{
@@ -661,9 +659,7 @@ var _ = ginkgo.Describe("PyTorchJob controller when TopologyAwareScheduling enab
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels(
-			tasBlockLabel, tasRackLabel,
-		).Obj()
+		topology = testing.MakeDefaultTwoLevelTopology("default")
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -698,14 +694,14 @@ var _ = ginkgo.Describe("PyTorchJob controller when TopologyAwareScheduling enab
 					ReplicaType:  kftraining.PyTorchJobReplicaTypeMaster,
 					ReplicaCount: 1,
 					Annotations: map[string]string{
-						kueuealpha.PodSetRequiredTopologyAnnotation: tasRackLabel,
+						kueuealpha.PodSetRequiredTopologyAnnotation: testing.DefaultRackTopologyLevel,
 					},
 				},
 				testingpytorchjob.PyTorchReplicaSpecRequirement{
 					ReplicaType:  kftraining.PyTorchJobReplicaTypeWorker,
 					ReplicaCount: 1,
 					Annotations: map[string]string{
-						kueuealpha.PodSetPreferredTopologyAnnotation: tasBlockLabel,
+						kueuealpha.PodSetPreferredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
 					},
 				},
 			).
@@ -728,14 +724,14 @@ var _ = ginkgo.Describe("PyTorchJob controller when TopologyAwareScheduling enab
 						Name:  strings.ToLower(string(kftraining.PyTorchJobReplicaTypeMaster)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required: ptr.To(tasRackLabel),
+							Required: ptr.To(testing.DefaultRackTopologyLevel),
 						},
 					},
 					{
 						Name:  strings.ToLower(string(kftraining.PyTorchJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred: ptr.To(tasBlockLabel),
+							Preferred: ptr.To(testing.DefaultBlockTopologyLevel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
@@ -754,13 +750,13 @@ var _ = ginkgo.Describe("PyTorchJob controller when TopologyAwareScheduling enab
 				g.Expect(wl.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(2))
 				g.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))
 				g.Expect(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))

--- a/test/integration/controller/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/test/integration/controller/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -661,9 +661,9 @@ var _ = ginkgo.Describe("PyTorchJob controller when TopologyAwareScheduling enab
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/tfjob/tfjob_controller_test.go
+++ b/test/integration/controller/jobs/tfjob/tfjob_controller_test.go
@@ -372,9 +372,9 @@ var _ = ginkgo.Describe("TFJob controller when TopologyAwareScheduling enabled",
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/controller/jobs/tfjob/tfjob_controller_test.go
+++ b/test/integration/controller/jobs/tfjob/tfjob_controller_test.go
@@ -312,8 +312,6 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", framework.R
 var _ = ginkgo.Describe("TFJob controller when TopologyAwareScheduling enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	const (
 		nodeGroupLabel = "node-group"
-		tasBlockLabel  = "cloud.com/topology-block"
-		tasRackLabel   = "cloud.com/topology-rack"
 	)
 
 	var (
@@ -348,9 +346,9 @@ var _ = ginkgo.Describe("TFJob controller when TopologyAwareScheduling enabled",
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "b1r1",
 					Labels: map[string]string{
-						nodeGroupLabel: "tas",
-						tasBlockLabel:  "b1",
-						tasRackLabel:   "r1",
+						nodeGroupLabel:                    "tas",
+						testing.DefaultBlockTopologyLevel: "b1",
+						testing.DefaultRackTopologyLevel:  "r1",
 					},
 				},
 				Status: corev1.NodeStatus{
@@ -372,9 +370,7 @@ var _ = ginkgo.Describe("TFJob controller when TopologyAwareScheduling enabled",
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels(
-			tasBlockLabel, tasRackLabel,
-		).Obj()
+		topology = testing.MakeDefaultTwoLevelTopology("default")
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -409,21 +405,21 @@ var _ = ginkgo.Describe("TFJob controller when TopologyAwareScheduling enabled",
 					ReplicaType:  kftraining.TFJobReplicaTypeChief,
 					ReplicaCount: 1,
 					Annotations: map[string]string{
-						kueuealpha.PodSetRequiredTopologyAnnotation: tasRackLabel,
+						kueuealpha.PodSetRequiredTopologyAnnotation: testing.DefaultRackTopologyLevel,
 					},
 				},
 				testingtfjob.TFReplicaSpecRequirement{
 					ReplicaType:  kftraining.TFJobReplicaTypePS,
 					ReplicaCount: 1,
 					Annotations: map[string]string{
-						kueuealpha.PodSetRequiredTopologyAnnotation: tasRackLabel,
+						kueuealpha.PodSetRequiredTopologyAnnotation: testing.DefaultRackTopologyLevel,
 					},
 				},
 				testingtfjob.TFReplicaSpecRequirement{
 					ReplicaType:  kftraining.TFJobReplicaTypeWorker,
 					ReplicaCount: 1,
 					Annotations: map[string]string{
-						kueuealpha.PodSetPreferredTopologyAnnotation: tasBlockLabel,
+						kueuealpha.PodSetPreferredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
 					},
 				},
 			).
@@ -447,21 +443,21 @@ var _ = ginkgo.Describe("TFJob controller when TopologyAwareScheduling enabled",
 						Name:  strings.ToLower(string(kftraining.TFJobReplicaTypeChief)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required: ptr.To(tasRackLabel),
+							Required: ptr.To(testing.DefaultRackTopologyLevel),
 						},
 					},
 					{
 						Name:  strings.ToLower(string(kftraining.TFJobReplicaTypePS)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required: ptr.To(tasRackLabel),
+							Required: ptr.To(testing.DefaultRackTopologyLevel),
 						},
 					},
 					{
 						Name:  strings.ToLower(string(kftraining.TFJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred: ptr.To(tasBlockLabel),
+							Preferred: ptr.To(testing.DefaultBlockTopologyLevel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
@@ -480,19 +476,19 @@ var _ = ginkgo.Describe("TFJob controller when TopologyAwareScheduling enabled",
 				g.Expect(wl.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(3))
 				g.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))
 				g.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))
 				g.Expect(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))

--- a/test/integration/controller/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/test/integration/controller/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -295,8 +295,6 @@ var _ = ginkgo.Describe("Job controller interacting with scheduler", framework.R
 var _ = ginkgo.Describe("XGBoostJob controller when TopologyAwareScheduling enabled", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	const (
 		nodeGroupLabel = "node-group"
-		tasBlockLabel  = "cloud.com/topology-block"
-		tasRackLabel   = "cloud.com/topology-rack"
 	)
 
 	var (
@@ -331,9 +329,9 @@ var _ = ginkgo.Describe("XGBoostJob controller when TopologyAwareScheduling enab
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "b1r1",
 					Labels: map[string]string{
-						nodeGroupLabel: "tas",
-						tasBlockLabel:  "b1",
-						tasRackLabel:   "r1",
+						nodeGroupLabel:                    "tas",
+						testing.DefaultBlockTopologyLevel: "b1",
+						testing.DefaultRackTopologyLevel:  "r1",
 					},
 				},
 				Status: corev1.NodeStatus{
@@ -355,9 +353,7 @@ var _ = ginkgo.Describe("XGBoostJob controller when TopologyAwareScheduling enab
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels(
-			tasBlockLabel, tasRackLabel,
-		).Obj()
+		topology = testing.MakeDefaultTwoLevelTopology("default")
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -392,14 +388,14 @@ var _ = ginkgo.Describe("XGBoostJob controller when TopologyAwareScheduling enab
 					ReplicaType:  kftraining.XGBoostJobReplicaTypeMaster,
 					ReplicaCount: 1,
 					Annotations: map[string]string{
-						kueuealpha.PodSetRequiredTopologyAnnotation: tasRackLabel,
+						kueuealpha.PodSetRequiredTopologyAnnotation: testing.DefaultRackTopologyLevel,
 					},
 				},
 				testingxgboostjob.XGBReplicaSpecRequirement{
 					ReplicaType:  kftraining.XGBoostJobReplicaTypeWorker,
 					ReplicaCount: 1,
 					Annotations: map[string]string{
-						kueuealpha.PodSetPreferredTopologyAnnotation: tasBlockLabel,
+						kueuealpha.PodSetPreferredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
 					},
 				},
 			).
@@ -422,14 +418,14 @@ var _ = ginkgo.Describe("XGBoostJob controller when TopologyAwareScheduling enab
 						Name:  strings.ToLower(string(kftraining.XGBoostJobReplicaTypeMaster)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required: ptr.To(tasRackLabel),
+							Required: ptr.To(testing.DefaultRackTopologyLevel),
 						},
 					},
 					{
 						Name:  strings.ToLower(string(kftraining.XGBoostJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred: ptr.To(tasBlockLabel),
+							Preferred: ptr.To(testing.DefaultBlockTopologyLevel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
@@ -448,13 +444,13 @@ var _ = ginkgo.Describe("XGBoostJob controller when TopologyAwareScheduling enab
 				g.Expect(wl.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(2))
 				g.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))
 				g.Expect(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment).Should(gomega.BeComparableTo(
 					&kueue.TopologyAssignment{
-						Levels:  []string{tasBlockLabel, tasRackLabel},
+						Levels:  []string{testing.DefaultBlockTopologyLevel, testing.DefaultRackTopologyLevel},
 						Domains: []kueue.TopologyDomainAssignment{{Count: 1, Values: []string{"b1", "r1"}}},
 					},
 				))

--- a/test/integration/controller/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/test/integration/controller/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -355,9 +355,9 @@ var _ = ginkgo.Describe("XGBoostJob controller when TopologyAwareScheduling enab
 			gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 		}
 
-		topology = testing.MakeTopology("default").Levels([]string{
+		topology = testing.MakeTopology("default").Levels(
 			tasBlockLabel, tasRackLabel,
-		}).Obj()
+		).Obj()
 		gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 		tasFlavor = testing.MakeResourceFlavor("tas-flavor").

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -89,10 +89,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 		)
 
 		ginkgo.BeforeEach(func() {
-			topology = testing.MakeTopology("default").Levels([]string{
+			topology = testing.MakeTopology("default").Levels(
 				tasBlockLabel,
 				tasRackLabel,
-			}).Obj()
+			).Obj()
 			gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 			tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -312,10 +312,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 				}
 
-				topology = testing.MakeTopology("default").Levels([]string{
+				topology = testing.MakeTopology("default").Levels(
 					tasBlockLabel,
 					tasRackLabel,
-				}).Obj()
+				).Obj()
 				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 				tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -543,7 +543,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
 				})
 
-				topology = testing.MakeTopology("default").Levels([]string{tasBlockLabel, tasRackLabel}).Obj()
+				topology = testing.MakeTopology("default").Levels(tasBlockLabel, tasRackLabel).Obj()
 				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 				ginkgo.By("verify the workload is admitted", func() {
@@ -579,10 +579,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				}
 				gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
-				topology = testing.MakeTopology("default").Levels([]string{
+				topology = testing.MakeTopology("default").Levels(
 					tasBlockLabel,
 					tasRackLabel,
-				}).Obj()
+				).Obj()
 				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 				tasFlavor = testing.MakeResourceFlavor("tas-flavor").
@@ -735,9 +735,9 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					gomega.Expect(k8sClient.Status().Update(ctx, &node)).Should(gomega.Succeed())
 				}
 
-				topology = testing.MakeTopology("default").Levels([]string{
+				topology = testing.MakeTopology("default").Levels(
 					tasRackLabel,
-				}).Obj()
+				).Obj()
 				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
 
 				tasGPUFlavor = testing.MakeResourceFlavor("tas-gpu-flavor").


### PR DESCRIPTION
Cherry pick of #3719 #3744 #3769 on release-0.9.

#3719: Use TopologyWrapper and ResourceFlavorWrapper in tests
#3744: Use variadic function to set levels in TopologyWrapper
#3769: Add default topologies for tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```