### PR TITLE
Fix memory leak due to workload entries left in MultiKueue cache

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -95,6 +95,41 @@ func TestWlReconcile(t *testing.T) {
 		wantWorker2Workloads []kueue.Workload
 		wantWorker2Jobs      []batchv1.Job
 	}{
+		"deleted regular workload is removed from the cache": {
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobBuilder.Clone().Obj()},
+			managersDeletedWorkloads: []*kueue.Workload{
+				baseWorkloadBuilder.Clone().
+					DeletionTimestamp(now).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{*baseJobBuilder.Clone().Obj()},
+		},
+		"deleted MultiKueue workload is deleted from cache - the worker will be deleted by GC": {
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.Clone().Obj()},
+			managersDeletedWorkloads: []*kueue.Workload{
+				baseWorkloadBuilder.Clone().
+					DeletionTimestamp(now).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStateRejected}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					Obj(),
+			},
+			worker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.Clone().Obj()},
+			wantWorker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+		},
 		"missing workload": {
 			reconcileFor: "missing workload",
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3818 

#### Special notes for your reviewer:

I have unit tests added and they fail without the change:
```
--- FAIL: TestWlReconcile (0.22s)
    --- FAIL: TestWlReconcile/deleted_MultiKueue_workload_is_deleted_from_cache_-_the_worker_will_be_deleted_by_GC (0.01s)
        /usr/local/google/home/michalwozniak/go/src/sigs.k8s.io/kueue/pkg/controller/admissionchecks/multikueue/workload_test.go:1166: unexpected deletedWlCache len 1 expecting 0
    --- FAIL: TestWlReconcile/deleted_regular_workload_is_removed_from_the_cache (0.01s)
        /usr/local/google/home/michalwozniak/go/src/sigs.k8s.io/kueue/pkg/controller/admissionchecks/multikueue/workload_test.go:1166: unexpected deletedWlCache len 1 expecting 0
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix memory leak due to workload entries left in MultiKueue cache. The leak affects the 0.9.0 and 0.9.1 
releases which enable MultiKueue by default, even if MultiKueue is not explicitly used on the cluster.
```