### PR TITLE
Distinguish errors for non-existing LocalQueue and ClusterQueue in the workload-controller

### DIFF
--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -39,9 +39,9 @@ import (
 )
 
 var (
-	ErrQueueDoesNotExist         = errors.New("queue doesn't exist")
-	ErrClusterQueueDoesNotExist  = errors.New("clusterQueue doesn't exist")
-	errClusterQueueAlreadyExists = errors.New("clusterQueue already exists")
+	ErrLocalQueueDoesNotExistOrInactive = errors.New("localQueue doesn't exist or inactive")
+	ErrClusterQueueDoesNotExist         = errors.New("clusterQueue doesn't exist")
+	errClusterQueueAlreadyExists        = errors.New("clusterQueue already exists")
 )
 
 type options struct {
@@ -286,7 +286,7 @@ func (m *Manager) UpdateLocalQueue(q *kueue.LocalQueue) error {
 	defer m.Unlock()
 	qImpl, ok := m.localQueues[Key(q)]
 	if !ok {
-		return ErrQueueDoesNotExist
+		return ErrLocalQueueDoesNotExistOrInactive
 	}
 	if qImpl.ClusterQueue != string(q.Spec.ClusterQueue) {
 		oldCQ := m.hm.ClusterQueues[qImpl.ClusterQueue]
@@ -326,7 +326,7 @@ func (m *Manager) PendingWorkloads(q *kueue.LocalQueue) (int32, error) {
 
 	qImpl, ok := m.localQueues[Key(q)]
 	if !ok {
-		return 0, ErrQueueDoesNotExist
+		return 0, ErrLocalQueueDoesNotExistOrInactive
 	}
 
 	return int32(len(qImpl.items)), nil
@@ -377,7 +377,7 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(w *kueue.Workload) error {
 	qKey := workload.QueueKey(w)
 	q := m.localQueues[qKey]
 	if q == nil {
-		return ErrQueueDoesNotExist
+		return ErrLocalQueueDoesNotExistOrInactive
 	}
 	wInfo := workload.NewInfo(w, m.workloadInfoOptions...)
 	q.AddOrUpdate(wInfo)

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -420,7 +420,7 @@ func TestAddWorkload(t *testing.T) {
 	}
 	cases := []struct {
 		workload *kueue.Workload
-		wantErr  string
+		wantErr  error
 	}{
 		{
 			workload: &kueue.Workload{
@@ -430,7 +430,6 @@ func TestAddWorkload(t *testing.T) {
 				},
 				Spec: kueue.WorkloadSpec{QueueName: "foo"},
 			},
-			wantErr: "",
 		},
 		{
 			workload: &kueue.Workload{
@@ -440,7 +439,7 @@ func TestAddWorkload(t *testing.T) {
 				},
 				Spec: kueue.WorkloadSpec{QueueName: "baz"},
 			},
-			wantErr: ErrQueueDoesNotExist.Error(),
+			wantErr: ErrLocalQueueDoesNotExistOrInactive,
 		},
 		{
 			workload: &kueue.Workload{
@@ -450,7 +449,7 @@ func TestAddWorkload(t *testing.T) {
 				},
 				Spec: kueue.WorkloadSpec{QueueName: "bar"},
 			},
-			wantErr: ErrClusterQueueDoesNotExist.Error(),
+			wantErr: ErrClusterQueueDoesNotExist,
 		},
 		{
 			workload: &kueue.Workload{
@@ -460,14 +459,14 @@ func TestAddWorkload(t *testing.T) {
 				},
 				Spec: kueue.WorkloadSpec{QueueName: "foo"},
 			},
-			wantErr: ErrQueueDoesNotExist.Error(),
+			wantErr: ErrLocalQueueDoesNotExistOrInactive,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.workload.Name, func(t *testing.T) {
 			err := manager.AddOrUpdateWorkload(tc.workload)
-			if err != nil && err.Error() != tc.wantErr {
-				t.Fatalf("AddWorkload returned %v, want %v", err, tc.wantErr)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); len(diff) != 0 {
+				t.Errorf("Unexpected AddWorkload returned error (-want,+got):\n%s", diff)
 			}
 		})
 	}
@@ -558,7 +557,7 @@ func TestStatus(t *testing.T) {
 		"fake": {
 			queue:      &kueue.LocalQueue{ObjectMeta: metav1.ObjectMeta{Name: "fake"}},
 			wantStatus: 0,
-			wantErr:    ErrQueueDoesNotExist,
+			wantErr:    ErrLocalQueueDoesNotExistOrInactive,
 		},
 	}
 	for name, tc := range cases {
@@ -772,7 +771,7 @@ func TestUpdateWorkload(t *testing.T) {
 			wantQueueMembers: map[string]sets.Set[string]{
 				"/foo": nil,
 			},
-			wantErr: ErrQueueDoesNotExist,
+			wantErr: ErrLocalQueueDoesNotExistOrInactive,
 		},
 		"from non existing queue": {
 			clusterQueues: []*kueue.ClusterQueue{
@@ -816,8 +815,8 @@ func TestUpdateWorkload(t *testing.T) {
 			wl := tc.workloads[0].DeepCopy()
 			tc.update(wl)
 			err := manager.UpdateWorkload(tc.workloads[0], wl)
-			if (err != nil) != (tc.wantErr != nil) {
-				t.Errorf("UpdatedWorkload returned %t, want %t", err, tc.wantErr)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); len(diff) != 0 {
+				t.Errorf("Unexpected UpdatedWorkload returned error (-want,+got):\n%s", diff)
 			}
 			q := manager.localQueues[workload.QueueKey(wl)]
 			if q != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
In the https://github.com/kubernetes-sigs/kueue/pull/3605, we dropped the inactive LocalQueue and ClusterQueue reason.
But we still face errors in situations where those are inactive.

Additionally, we should not omit errors verifications in testing.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```