### PR TITLE
Automated cherry pick of #3835: Fix memory leak due to workload entries left in MultiKueue cache

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -160,7 +160,24 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 	}
 
 	if mkAc == nil || mkAc.State == kueue.CheckStateRejected {
-		log.V(2).Info("Skip Workload")
+		log.V(2).Info("Skip Workload", "isDeleted", isDeleted)
+		if isDeleted {
+			// Delete the workload from the cache considering the following cases:
+			// 1. the workload is not admitted by MultiKueue and so there are
+			//    no workloads on worker clusters created, we can safely drop it
+			//    from the cache.
+			//    TODO(#3840): Ideally, we would not add it to the cache in the
+			//    first place.
+			// 2. the AdmissionCheck was rejected then, ideally, we trigger
+			//    deletion of the workloads on the worker clusters, rather than
+			//    deleting from cache. However,
+			//    - this is not a regression as the case was not handled anyway.
+			//    - we have the MultiKueue GarbageCollector which will take care
+			//      of the orphaned workloads with a delay.
+			//    TODO(#3841): Ideally, we would delete workloads on the worker
+			//    clusters synchronously.
+			w.deletedWlCache.Delete(req.String())
+		}
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -51,6 +51,7 @@ var (
 )
 
 func TestWlReconcile(t *testing.T) {
+	now := time.Now()
 	objCheckOpts := []cmp.Option{
 		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
 		cmpopts.EquateEmpty(),
@@ -91,6 +92,41 @@ func TestWlReconcile(t *testing.T) {
 		wantWorker2Workloads []kueue.Workload
 		wantWorker2Jobs      []batchv1.Job
 	}{
+		"deleted regular workload is removed from the cache": {
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobBuilder.Clone().Obj()},
+			managersDeletedWorkloads: []*kueue.Workload{
+				baseWorkloadBuilder.Clone().
+					DeletionTimestamp(now).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{*baseJobBuilder.Clone().Obj()},
+		},
+		"deleted MultiKueue workload is deleted from cache - the worker will be deleted by GC": {
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.Clone().Obj()},
+			managersDeletedWorkloads: []*kueue.Workload{
+				baseWorkloadBuilder.Clone().
+					DeletionTimestamp(now).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStateRejected}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					Obj(),
+			},
+			worker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.Clone().Obj()},
+			wantWorker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+		},
 		"missing workload": {
 			reconcileFor: "missing workload",
 		},


### PR DESCRIPTION
Cherry pick of #3835 on release-0.9.

#3835: Fix memory leak due to workload entries left in MultiKueue cache

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix memory leak due to workload entries left in MultiKueue cache. The leak affects the 0.9.0 and 0.9.1 
releases which enable MultiKueue by default, even if MultiKueue is not explicitly used on the cluster.
```