### PR TITLE
[Fix] Remove the requirement for VAP

### DIFF
--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -80,15 +80,6 @@ rules:
       - update
       - watch
   - apiGroups:
-      - admissionregistration.k8s.io
-    resources:
-      - validatingadmissionpolicies
-      - validatingadmissionpolicybindings
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - apps
     resources:
       - replicasets

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -79,15 +79,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - validatingadmissionpolicies
-  - validatingadmissionpolicybindings
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - apps
   resources:
   - replicasets

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -38,8 +38,6 @@ const (
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=get;list;watch;update
-// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingadmissionpolicies,verbs=get;list;watch
-// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingadmissionpolicybindings,verbs=get;list;watch
 
 // ManageCerts creates all certs for webhooks. This function is called from main.go.
 func ManageCerts(mgr ctrl.Manager, cfg config.Configuration, setupFinished chan struct{}) error {

--- a/pkg/visibility/server.go
+++ b/pkg/visibility/server.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 
+	validatingadmissionpolicy "k8s.io/apiserver/pkg/admission/plugin/policy/validating"
 	openapinamer "k8s.io/apiserver/pkg/endpoints/openapi"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
@@ -77,7 +78,7 @@ func applyVisibilityServerOptions(config *genericapiserver.RecommendedConfig) er
 	o.SecureServing.BindPort = 8082
 	// The directory where TLS certs will be created
 	o.SecureServing.ServerCert.CertDirectory = "/tmp"
-
+	o.Admission.DisablePlugins = []string{validatingadmissionpolicy.PluginName}
 	if err := o.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		return fmt.Errorf("error creating self-signed certificates: %v", err)
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
VAP is a default admission plugin enabled while starting an API server for visibility ([ref](https://github.com/kubernetes-sigs/kueue/blob/95bc3b28da49862186f5e38924e1507ce4b7c703/pkg/visibility/server.go#L75)). The Kueue
controller has additional permissions to watch those GVKs even though it is not required. Disabling the plugin from api server helps in keeping it minimal and maintaining compatibility with previous versions of K8s.

For details:
By default, the admission server enables the default set of admission plugins while starting an API server in K8s: https://github.com/kubernetes/kubernetes/blob/e85c72d4177fba224cb1baa1b5abfb5980e6d867/pkg/kubeapiserver/options/admission.go#L59. However, all the plugins are not necessary, as the visibility server is publishing metrics though read-only APIs, rather than modifying/validating the request. 


