### PR TITLE
Fix: kueue-manager-role can not update topologies

### DIFF
--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -236,7 +236,7 @@ rules:
       - clusterqueues/finalizers
       - localqueues/finalizers
       - resourceflavors/finalizers
-      - topology/finalizers
+      - topologies/finalizers
       - workloads/finalizers
     verbs:
       - update
@@ -258,7 +258,6 @@ rules:
       - multikueueclusters
       - multikueueconfigs
       - provisioningrequestconfigs
-      - topologies
       - workloadpriorityclasses
     verbs:
       - get
@@ -277,7 +276,7 @@ rules:
   - apiGroups:
       - kueue.x-k8s.io
     resources:
-      - topology
+      - topologies
     verbs:
       - get
       - list

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -235,7 +235,7 @@ rules:
   - clusterqueues/finalizers
   - localqueues/finalizers
   - resourceflavors/finalizers
-  - topology/finalizers
+  - topologies/finalizers
   - workloads/finalizers
   verbs:
   - update
@@ -257,7 +257,6 @@ rules:
   - multikueueclusters
   - multikueueconfigs
   - provisioningrequestconfigs
-  - topologies
   - workloadpriorityclasses
   verbs:
   - get
@@ -276,7 +275,7 @@ rules:
 - apiGroups:
   - kueue.x-k8s.io
   resources:
-  - topology
+  - topologies
   verbs:
   - get
   - list

--- a/pkg/controller/tas/topology_controller.go
+++ b/pkg/controller/tas/topology_controller.go
@@ -78,8 +78,8 @@ func (r *topologyReconciler) setupWithManager(mgr ctrl.Manager, cfg *configapi.C
 		Complete(core.WithLeadingManager(mgr, r, &kueuealpha.Topology{}, cfg))
 }
 
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=topology,verbs=get;list;watch;update
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=topology/finalizers,verbs=update
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=topologies,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=topologies/finalizers,verbs=update
 
 func (r topologyReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	topology := &kueuealpha.Topology{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

Report errors like this:
```
{"level":"error","ts":"2024-12-26T05:32:34.012480568Z","caller":"controller/controller.go:316","msg":"Reconciler error","controller":"tas-topology-controller","controllerGroup":"kueue.x-k8s.io","controllerKind":"Topology","Topology":{"name":"default"},"namespace":"","name":"default","reconcileID":"276f685c-1d43-4d07-bf1a-2a062eee43bf","error":"topologies.kueue.x-k8s.io \"default\" is forbidden: User \"system:serviceaccount:kueue-system:kueue-controller-manager\" cannot update resource \"topologies\" in API group \"kueue.x-k8s.io\" at the cluster scope","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:224"}
```

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```