### PR TITLE
Add RemoveFinalizersWithStrictPatch feature gate

### DIFF
--- a/keps/3899-remove-finalizers-with-strict-patch/kep.yaml
+++ b/keps/3899-remove-finalizers-with-strict-patch/kep.yaml
@@ -17,10 +17,10 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.11"
+latest-milestone: "v0.14"
 
 milestone:
-    beta: "v0.11"
+    beta: "v0.14"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -529,7 +529,7 @@ func (p *Pod) Finalize(ctx context.Context, c client.Client) error {
 
 	return parallelize.Until(ctx, len(podsInGroup.Items), func(i int) error {
 		pod := &podsInGroup.Items[i]
-		return clientutil.Patch(ctx, c, pod, false, func() (bool, error) {
+		return clientutil.Patch(ctx, c, pod, features.Enabled(features.RemoveFinalizersWithStrictPatch), func() (bool, error) {
 			return controllerutil.RemoveFinalizer(pod, podconstants.PodFinalizer), nil
 		})
 	})
@@ -885,7 +885,8 @@ func (p *Pod) removeExcessPods(ctx context.Context, c client.Client, r record.Ev
 	// Finalize and delete the active pods created last
 	err := parallelize.Until(ctx, len(extraPods), func(i int) error {
 		pod := extraPods[i]
-		if err := clientutil.Patch(ctx, c, &pod, false, func() (bool, error) {
+
+		if err := clientutil.Patch(ctx, c, &pod, features.Enabled(features.RemoveFinalizersWithStrictPatch), func() (bool, error) {
 			removed := controllerutil.RemoveFinalizer(&pod, podconstants.PodFinalizer)
 			log.V(3).Info("Finalizing excess pod in group", "excessPod", klog.KObj(&pod))
 			return removed, nil
@@ -925,7 +926,8 @@ func (p *Pod) finalizePods(ctx context.Context, c client.Client, extraPods []cor
 	err := parallelize.Until(ctx, len(extraPods), func(i int) error {
 		pod := extraPods[i]
 		var removed bool
-		if err := clientutil.Patch(ctx, c, &pod, false, func() (bool, error) {
+
+		if err := clientutil.Patch(ctx, c, &pod, features.Enabled(features.RemoveFinalizersWithStrictPatch), func() (bool, error) {
 			removed = controllerutil.RemoveFinalizer(&pod, podconstants.PodFinalizer)
 			log.V(3).Info("Finalizing pod in group", "Pod", klog.KObj(&pod))
 			return removed, nil

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -187,6 +187,12 @@ const (
 	// In flavor fungibility, the preference whether to preempt or borrow is inferred from flavor fungibility policy
 	// This feature gate is going to be replaced by an API before graduation or deprecation.
 	FlavorFungibilityImplicitPreferenceDefault featuregate.Feature = "FlavorFungibilityImplicitPreferenceDefault"
+
+	// owner: @mykysha
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/3899-remove-finalizers-with-strict-patch
+	//
+	// Finalizers are removed using a strict patch not to cause race conditions.
+	RemoveFinalizersWithStrictPatch featuregate.Feature = "RemoveFinalizersWithStrictPatch"
 )
 
 func init() {
@@ -289,6 +295,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	FlavorFungibilityImplicitPreferenceDefault: {
 		{Version: version.MustParse("0.13"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	RemoveFinalizersWithStrictPatch: {
+		{Version: version.MustParse("0.14"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -291,6 +291,7 @@ spec:
 | `ElasticJobsViaWorkloadSlices`                | `false` | Alpha | 0.13  |       |
 | `ManagedJobsNamespaceSelectorAlwaysRespected` | `false` | Alpha | 0.13  |       |
 | `FlavorFungibilityImplicitPreferenceDefault`  | `false` | Alpha | 0.13  |       |
+| `RemoveFinalizersWithStrictPatch`             | `true`  | Beta  | 0.14  |       |
 
 ### Feature gates for graduated or deprecated features
 

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -291,6 +291,7 @@ spec:
 | `ElasticJobsViaWorkloadSlices`                | `false` | Alpha | 0.13 |      |
 | `ManagedJobsNamespaceSelectorAlwaysRespected` | `false` | Alpha | 0.13 |      |
 | `FlavorFungibilityImplicitPreferenceDefault`  | `false` | Alpha | 0.13 |      |
+| `RemoveFinalizersWithStrictPatch`             | `true`  | Beta  | 0.14  |       |
 
 ### 已毕业或已弃用特性的特性门控 {#feature-gates-for-graduated-or-deprecated-features}
 

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -259,6 +259,70 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
+			ginkgo.It("Should preserve custom finalizers when using RemoveFinalizersWithStrictPatch featuregate", func() {
+				pod := testingpod.MakePod(podName, ns.Name).Queue("test-queue").Obj()
+				gomega.Expect(k8sClient.Create(ctx, pod)).Should(gomega.Succeed())
+
+				createdPod := &corev1.Pod{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Expect(createdPod.Finalizers).
+					To(gomega.ContainElement(constants.ManagedByKueueLabelKey), "Pod should have finalizer")
+
+				ginkgo.By("checking that workload is created for pod with the queue name")
+				createdWorkload := &kueue.Workload{}
+				wlLookupKey := types.NamespacedName{
+					Name:      podcontroller.GetWorkloadNameForPod(pod.Name, pod.UID),
+					Namespace: ns.Name,
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("checking the pod is unsuspended when workload is assigned")
+				clusterQueue := testing.MakeClusterQueue("cluster-queue").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
+					).Obj()
+				admission := testing.MakeAdmission(clusterQueue.Name).
+					Assignment(corev1.ResourceCPU, "default", "1").
+					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					Obj()
+				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).
+					Should(gomega.Succeed())
+				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).Should(gomega.Succeed())
+					g.Expect(createdPod.Spec.SchedulingGates).Should(gomega.BeEmpty())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("adding custom finalizer to the pod and setting the pod as succeeded")
+				customFinalizer := "my.custom/finalizer"
+
+				updatedPod := pod.DeepCopy()
+
+				updatedPod.Finalizers = append(updatedPod.Finalizers, customFinalizer)
+
+				util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, pod)
+				gomega.Expect(k8sClient.Patch(ctx, updatedPod, client.MergeFrom(pod))).Should(gomega.Succeed())
+
+				ginkgo.By("waiting for the workload to finish")
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+					g.Expect(createdWorkload.Status.Conditions).Should(testing.HaveConditionStatusTrue(kueue.WorkloadFinished))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("checking that the custom finalizer is preserved")
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).Should(gomega.Succeed())
+					g.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabelKey))
+					g.Expect(createdPod.Finalizers).To(gomega.ContainElement(customFinalizer))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
 			ginkgo.When("A workload is evicted", func() {
 				const finalizerName = "kueue.x-k8s.io/integration-test"
 				var pod *corev1.Pod


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add a RemoveFinalizersWithStrictMode feature gate to ensure that the finalizer deletion does not result in a race condition removing simultaneous finalizer updates.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3899

#### Special notes for your reviewer:
Manual performance testing on a scale of 10000 pods was conducted using https://gist.github.com/mykysha/bd8ed4ae3609e67a1542557628f1b0c1
Results are the following:
Feature-gate disabled:
Total pod test runtime - 1h27m16s
Reconciliation time - 2h31m26s
Number of "lost" finalizer removals - 7297/10000

Feature-gate enabled:
Total pod test runtime - 1h27m6s
Reconciliation time - 3h8m38s

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add RemoveFinalizersWithStrictMode feature gate
```