### PR TITLE
Revert "Add section about Workload's requeueState field to KEP#349"

### DIFF
--- a/keps/349-all-or-nothing/README.md
+++ b/keps/349-all-or-nothing/README.md
@@ -28,7 +28,6 @@ tags, and then generate with `hack/update-toc.sh`.
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [Kueue Configuration API](#kueue-configuration-api)
-  - [Workload API changes](#workload-api-changes)
   - [PodsReady workload condition](#podsready-workload-condition)
   - [Waiting for PodsReady condition](#waiting-for-podsready-condition)
   - [Timeout on reaching the PodsReady condition](#timeout-on-reaching-the-podsready-condition)
@@ -278,37 +277,6 @@ const (
 	EvictionTimestamp RequeuingTimestamp = "Eviction"
 )
 
-```
-
-### Workload API changes
-We are also adding a `RequeueState` field to the WorkloadStatus API to track how many
-times a Workload has been requeued and when the Workload should be requeued.
-```go
-type WorkloadStatus struct {
-	...
-	// requeueState holds the re-queue state
-	// when a workload meets Eviction with PodsReadyTimeout reason.
-	//
-	// +optional
-	RequeueState *RequeueState `json:"requeueState,omitempty"`
-}
-
-type RequeueState struct {
-	// count records the number of times a workload has been re-queued
-	// When a deactivated (`.spec.activate`=`false`) workload is reactivated (`.spec.activate`=`true`),
-	// this count would be reset to null.
-	//
-	// +optional
-	// +kubebuilder:validation:Minimum=0
-	Count *int32 `json:"count,omitempty"`
-
-	// requeueAt records the time when a workload will be re-queued.
-	// When a deactivated (`.spec.activate`=`false`) workload is reactivated (`.spec.activate`=`true`),
-	// this time would be reset to null.
-	//
-	// +optional
-	RequeueAt *metav1.Time `json:"requeueAt,omitempty"`
-}
 ```
 
 ### PodsReady workload condition


### PR DESCRIPTION
Reverts kubernetes-sigs/kueue#3882

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The API change was accidentally added in the https://github.com/kubernetes-sigs/kueue/pull/3882 to the KEP.

The `Requeue` state API was added by the KEP-1282: Pods Ready Requeue Strategy https://github.com/kubernetes-sigs/kueue/tree/main/keps/1282-pods-ready-requeue-strategy#workload

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
