### PR TITLE
Publish the debug:main image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,9 @@ update-security-insights: yq
 # Developers don't need to build this image, as it will be available as us-central1-docker.pkg.dev/k8s-staging-images/kueue/debug
 .PHONY: debug-image-push
 debug-image-push: ## Build and push the debug image to the registry
-	$(IMAGE_BUILD_CMD) -t $(IMAGE_REGISTRY)/debug:$(GIT_TAG) \
+	$(IMAGE_BUILD_CMD) \
+		-t $(IMAGE_REGISTRY)/debug:$(GIT_TAG) \
+		-t $(IMAGE_REGISTRY)/debug:$(RELEASE_BRANCH) \
 		--platform=$(PLATFORMS) \
 		--push ./hack/debugpod
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

At push time, the `debug` image is not tagged with `main`. This causes the `dump_cache.sh` script to fail because it [references the `main` tag by default](https://github.com/kubernetes-sigs/kueue/blob/4c2a0cddc35b80995653c24a9fe85cb57743179f/hack/dump_cache.sh#L25)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3873

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```