### PR TITLE
Fix link to examples directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Read the [installation guide](https://kueue.sigs.k8s.io/docs/installation/) to l
 A minimal configuration can be set by running the [examples](site/static/examples):
 
 ```shell
-kubectl apply -f site/static/examples/admin/single-clusterqueue-setup.yaml
+kubectl apply -f examples/admin/single-clusterqueue-setup.yaml
 ```
 
 Then you can run a job with:
 
 ```shell
-kubectl create -f site/static/examples/jobs/sample-job.yaml
+kubectl create -f examples/jobs/sample-job.yaml
 ```
 
 Learn more about:

--- a/README.md
+++ b/README.md
@@ -67,16 +67,16 @@ Read the [installation guide](https://kueue.sigs.k8s.io/docs/installation/) to l
 
 ## Usage
 
-A minimal configuration can be set by running the [examples](examples):
+A minimal configuration can be set by running the [examples](site/static/examples):
 
 ```shell
-kubectl apply -f examples/admin/single-clusterqueue-setup.yaml
+kubectl apply -f site/static/examples/admin/single-clusterqueue-setup.yaml
 ```
 
 Then you can run a job with:
 
 ```shell
-kubectl create -f examples/jobs/sample-job.yaml
+kubectl create -f site/static/examples/jobs/sample-job.yaml
 ```
 
 Learn more about:


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
This pull request fixes the link to the `examples` directory in the README.

#### Which issue(s) this PR fixes:

Fixes #3976 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```