### PR TITLE
Automated cherry pick of #3991: [StatefulSet] Allow to change replicas without queue-name.

### DIFF
--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -22,6 +22,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -130,7 +131,7 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Ob
 		statefulsetGroupNameLabelPath,
 	)...)
 
-	if jobframework.QueueNameForObject(newStatefulSet.Object()) != "" {
+	if isManagedByKueue(newStatefulSet.Object()) {
 		// TODO(#3279): support resizes later
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(
 			newStatefulSet.Spec.Replicas,
@@ -149,4 +150,14 @@ func (wh *Webhook) ValidateDelete(context.Context, runtime.Object) (warnings adm
 func GetWorkloadName(statefulSetName string) string {
 	// Passing empty UID as it is not available before object creation
 	return jobframework.GetWorkloadNameForOwnerWithGVK(statefulSetName, "", gvk)
+}
+
+func isManagedByKueue(obj client.Object) bool {
+	objectOwner := metav1.GetControllerOf(obj)
+	if objectOwner != nil && jobframework.IsOwnerManagedByKueue(objectOwner) {
+		return false
+	} else if jobframework.QueueNameForObject(obj) != "" {
+		return true
+	}
+	return false
 }

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -130,12 +130,14 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Ob
 		statefulsetGroupNameLabelPath,
 	)...)
 
-	// TODO(#3279): support resizes later
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(
-		newStatefulSet.Spec.Replicas,
-		oldStatefulSet.Spec.Replicas,
-		statefulsetReplicasPath,
-	)...)
+	if jobframework.QueueNameForObject(newStatefulSet.Object()) != "" {
+		// TODO(#3279): support resizes later
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(
+			newStatefulSet.Spec.Replicas,
+			oldStatefulSet.Spec.Replicas,
+			statefulsetReplicasPath,
+		)...)
+	}
 
 	return warnings, allErrs.ToAggregate()
 }

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -261,16 +261,22 @@ func TestValidateUpdate(t *testing.T) {
 			}.ToAggregate(),
 		},
 		"change in replicas": {
-			oldObj: &appsv1.StatefulSet{
-				Spec: appsv1.StatefulSetSpec{
-					Replicas: ptr.To(int32(3)),
-				},
-			},
-			newObj: &appsv1.StatefulSet{
-				Spec: appsv1.StatefulSetSpec{
-					Replicas: ptr.To(int32(4)),
-				},
-			},
+			oldObj: testingstatefulset.MakeStatefulSet("test-name", "test-ns").
+				Replicas(3).
+				Obj(),
+			newObj: testingstatefulset.MakeStatefulSet("test-name", "test-ns").
+				Replicas(4).
+				Obj(),
+		},
+		"change in replicas with queue-name": {
+			oldObj: testingstatefulset.MakeStatefulSet("test-name", "test-ns").
+				Queue("test-queue").
+				Replicas(3).
+				Obj(),
+			newObj: testingstatefulset.MakeStatefulSet("test-name", "test-ns").
+				Queue("test-queue").
+				Replicas(4).
+				Obj(),
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,

--- a/pkg/util/testingjobs/statefulset/wrappers.go
+++ b/pkg/util/testingjobs/statefulset/wrappers.go
@@ -124,6 +124,11 @@ func (ss *StatefulSetWrapper) Replicas(r int32) *StatefulSetWrapper {
 	return ss
 }
 
+func (ss *StatefulSetWrapper) StatusReplicas(r int32) *StatefulSetWrapper {
+	ss.Status.Replicas = r
+	return ss
+}
+
 func (ss *StatefulSetWrapper) PodTemplateSpecPodGroupNameLabel(
 	ownerName string, ownerUID types.UID, ownerGVK schema.GroupVersionKind,
 ) *StatefulSetWrapper {

--- a/pkg/util/testingjobs/statefulset/wrappers.go
+++ b/pkg/util/testingjobs/statefulset/wrappers.go
@@ -96,6 +96,11 @@ func (ss *StatefulSetWrapper) Name(n string) *StatefulSetWrapper {
 	return ss
 }
 
+func (ss *StatefulSetWrapper) WithOwnerReference(ownerReference metav1.OwnerReference) *StatefulSetWrapper {
+	ss.OwnerReferences = append(ss.OwnerReferences, ownerReference)
+	return ss
+}
+
 // PodTemplateSpecLabel sets the label of the pod template spec of the StatefulSet
 func (ss *StatefulSetWrapper) PodTemplateSpecLabel(k, v string) *StatefulSetWrapper {
 	if ss.Spec.Template.Labels == nil {


### PR DESCRIPTION
Cherry pick of #3991 on release-0.9.

#3991: [StatefulSet] Allow to change replicas without queue-name.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix the bug that prevented scaling StatefulSets which aren't managed by Kueue when the "statefulset" integration is enabled.
```