### PR TITLE
extend GenericJob.GetPodSets() to return error

### DIFF
--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -76,7 +76,7 @@ func (t *testGenericJob) Finished() (string, bool, bool) {
 	panic("not implemented")
 }
 
-func (t *testGenericJob) PodSets() []kueue.PodSet {
+func (t *testGenericJob) PodSets() ([]kueue.PodSet, error) {
 	panic("not implemented")
 }
 

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -53,7 +53,7 @@ type GenericJob interface {
 	// Observed generation of the workload is set by the jobframework.
 	Finished() (message string, success, finished bool)
 	// PodSets will build workload podSets corresponding to the job.
-	PodSets() []kueue.PodSet
+	PodSets() ([]kueue.PodSet, error)
 	// IsActive returns true if there are any running pods.
 	IsActive() bool
 	// PodsReady instructs whether job derived pods are all ready now.

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller.go
@@ -114,15 +114,13 @@ func (aw *AppWrapper) GVK() schema.GroupVersionKind {
 	return gvk
 }
 
-func (aw *AppWrapper) PodSets() []kueue.PodSet {
+func (aw *AppWrapper) PodSets() ([]kueue.PodSet, error) {
 	podSets, err := awutils.GetPodSets((*awv1beta2.AppWrapper)(aw))
 	if err != nil {
-		// TODO: https://github.com/kubernetes-sigs/kueue/issues/3969
-		// Kueue will raise an error on zero length PodSet; the Kueue GenericJob API prevents propagating the actual error.
 		ctrl.Log.Error(err, "Error returned from awutils.GetPodSets", "appwrapper", aw)
-		return []kueue.PodSet{}
+		return nil, err
 	}
-	return podSets
+	return podSets, nil
 }
 
 func (aw *AppWrapper) RunWithPodSetsInfo(podSetsInfo []podset.PodSetInfo) error {

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller_test.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller_test.go
@@ -85,7 +85,10 @@ func TestPodSets(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotPodSets := fromObject(tc.job).PodSets()
+			gotPodSets, err := fromObject(tc.job).PodSets()
+			if err != nil {
+				t.Fatalf("failed to get pod sets: %v", err)
+			}
 			if diff := cmp.Diff(tc.wantPodSets, gotPodSets, podSetCmpOpts...); diff != "" {
 				t.Errorf("pod sets mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -246,7 +246,7 @@ func cleanManagedLabels(pt *corev1.PodTemplateSpec) *corev1.PodTemplateSpec {
 	return pt
 }
 
-func (j *Job) PodSets() []kueue.PodSet {
+func (j *Job) PodSets() ([]kueue.PodSet, error) {
 	return []kueue.PodSet{
 		{
 			Name:     kueue.DefaultPodSetName,
@@ -256,7 +256,7 @@ func (j *Job) PodSets() []kueue.PodSet {
 			TopologyRequest: jobframework.PodSetTopologyRequest(&j.Spec.Template.ObjectMeta,
 				ptr.To(batchv1.JobCompletionIndexAnnotation), nil, nil),
 		},
-	}
+	}, nil
 }
 
 func (j *Job) RunWithPodSetsInfo(podSetsInfo []podset.PodSetInfo) error {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -397,7 +397,10 @@ func TestPodSets(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			gotPodSets := tc.job.PodSets()
+			gotPodSets, err := tc.job.PodSets()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if diff := cmp.Diff(tc.wantPodSets, gotPodSets); diff != "" {
 				t.Errorf("pod sets mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -115,7 +115,7 @@ func (j *JobSet) PodLabelSelector() string {
 	return fmt.Sprintf("%s=%s", jobsetapi.JobSetNameKey, j.Name)
 }
 
-func (j *JobSet) PodSets() []kueue.PodSet {
+func (j *JobSet) PodSets() ([]kueue.PodSet, error) {
 	podSets := make([]kueue.PodSet, len(j.Spec.ReplicatedJobs))
 	for index, replicatedJob := range j.Spec.ReplicatedJobs {
 		podSets[index] = kueue.PodSet{
@@ -127,7 +127,7 @@ func (j *JobSet) PodSets() []kueue.PodSet {
 				ptr.To(replicatedJob.Replicas)),
 		}
 	}
-	return podSets
+	return podSets, nil
 }
 
 func (j *JobSet) RunWithPodSetsInfo(podSetsInfo []podset.PodSetInfo) error {

--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -302,7 +302,10 @@ func TestPodSets(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotPodSets := tc.jobSet.PodSets()
+			gotPodSets, err := tc.jobSet.PodSets()
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
 			if diff := cmp.Diff(tc.wantPodSets(tc.jobSet), gotPodSets); diff != "" {
 				t.Errorf("pod sets mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/controller/jobs/kubeflow/jobs/mxjob/mxjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/mxjob/mxjob_controller_test.go
@@ -359,7 +359,10 @@ func TestPodSets(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotPodSets := fromObject(tc.job).PodSets()
+			gotPodSets, err := fromObject(tc.job).PodSets()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if diff := cmp.Diff(tc.wantPodSets(tc.job), gotPodSets); diff != "" {
 				t.Errorf("pod sets mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
@@ -306,7 +306,10 @@ func TestPodSets(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotPodSets := fromObject(tc.job).PodSets()
+			gotPodSets, err := fromObject(tc.job).PodSets()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if diff := cmp.Diff(tc.wantPodSets(tc.job), gotPodSets); diff != "" {
 				t.Errorf("pod sets mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -297,7 +297,10 @@ func TestPodSets(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotPodSets := fromObject(tc.job).PodSets()
+			gotPodSets, err := fromObject(tc.job).PodSets()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if diff := cmp.Diff(tc.wantPodSets(tc.job), gotPodSets); diff != "" {
 				t.Errorf("pod sets mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller_test.go
@@ -318,7 +318,10 @@ func TestPodSets(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotPodSets := fromObject(tc.job).PodSets()
+			gotPodSets, err := fromObject(tc.job).PodSets()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if diff := cmp.Diff(tc.wantPodSets(tc.job), gotPodSets); diff != "" {
 				t.Errorf("pod sets mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -304,7 +304,10 @@ func TestPodSets(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotPodSets := fromObject(tc.job).PodSets()
+			gotPodSets, err := fromObject(tc.job).PodSets()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if diff := cmp.Diff(tc.wantPodSets(tc.job), gotPodSets); diff != "" {
 				t.Errorf("pod sets mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
@@ -97,7 +97,7 @@ func (j *KubeflowJob) Finished() (message string, success, finished bool) {
 	return "", true, false
 }
 
-func (j *KubeflowJob) PodSets() []kueue.PodSet {
+func (j *KubeflowJob) PodSets() ([]kueue.PodSet, error) {
 	replicaTypes := j.OrderedReplicaTypes()
 	podSets := make([]kueue.PodSet, len(replicaTypes))
 	for index, replicaType := range replicaTypes {
@@ -109,7 +109,7 @@ func (j *KubeflowJob) PodSets() []kueue.PodSet {
 				ptr.To(kftraining.ReplicaIndexLabel), nil, nil),
 		}
 	}
-	return podSets
+	return podSets, nil
 }
 
 func (j *KubeflowJob) IsActive() bool {

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -114,7 +114,7 @@ func (j *MPIJob) PodLabelSelector() string {
 	return fmt.Sprintf("%s=%s,%s=%s", kfmpi.JobNameLabel, j.Name, kfmpi.OperatorNameLabel, kfmpi.OperatorName)
 }
 
-func (j *MPIJob) PodSets() []kueue.PodSet {
+func (j *MPIJob) PodSets() ([]kueue.PodSet, error) {
 	replicaTypes := orderedReplicaTypes(&j.Spec)
 	podSets := make([]kueue.PodSet, len(replicaTypes))
 	for index, mpiReplicaType := range replicaTypes {
@@ -125,7 +125,7 @@ func (j *MPIJob) PodSets() []kueue.PodSet {
 			TopologyRequest: jobframework.PodSetTopologyRequest(&j.Spec.MPIReplicaSpecs[mpiReplicaType].Template.ObjectMeta, ptr.To(kfmpi.ReplicaIndexLabel), nil, nil),
 		}
 	}
-	return podSets
+	return podSets, nil
 }
 
 func (j *MPIJob) RunWithPodSetsInfo(podSetsInfo []podset.PodSetInfo) error {

--- a/pkg/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller_test.go
@@ -332,7 +332,11 @@ func TestPodSets(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if diff := cmp.Diff(tc.wantPodSets, tc.job.PodSets()); diff != "" {
+			gotPodSets, err := tc.job.PodSets()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantPodSets, gotPodSets); diff != "" {
 				t.Errorf("pod sets mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -356,7 +356,7 @@ func (p *Pod) Finished() (message string, success, finished bool) {
 }
 
 // PodSets will build workload podSets corresponding to the job.
-func (p *Pod) PodSets() []kueue.PodSet {
+func (p *Pod) PodSets() ([]kueue.PodSet, error) {
 	return []kueue.PodSet{
 		{
 			Name:  kueue.DefaultPodSetName,
@@ -366,7 +366,7 @@ func (p *Pod) PodSets() []kueue.PodSet {
 			},
 			TopologyRequest: jobframework.PodSetTopologyRequest(&p.pod.ObjectMeta, ptr.To(kueuealpha.PodGroupPodIndexLabel), nil, nil),
 		},
-	}
+	}, nil
 }
 
 // IsActive returns true if there are any running pods.
@@ -629,7 +629,7 @@ func constructGroupPodSetsFast(p *Pod, groupTotalCount int) ([]kueue.PodSet, err
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate pod role hash: %w", err)
 		}
-		podSets := FromObject(&podInGroup).PodSets()
+		podSets, _ := FromObject(&podInGroup).PodSets()
 		podSets[0].Name = roleHash
 		podSets[0].Count = int32(groupTotalCount)
 		return podSets, nil
@@ -660,7 +660,7 @@ func constructGroupPodSets(pods []corev1.Pod) ([]kueue.PodSet, error) {
 		}
 
 		if !podRoleFound {
-			podSet := FromObject(&podInGroup).PodSets()
+			podSet, _ := FromObject(&podInGroup).PodSets()
 			podSet[0].Name = roleHash
 
 			resultPodSets = append(resultPodSets, podSet[0])
@@ -950,7 +950,7 @@ func (p *Pod) ConstructComposableWorkload(ctx context.Context, c client.Client, 
 
 	// Construct workload for a single pod
 	if !p.isGroup {
-		wl.Spec.PodSets = p.PodSets()
+		wl.Spec.PodSets, _ = p.PodSets()
 
 		wl.Name = jobframework.GetWorkloadNameForOwnerWithGVK(p.pod.GetName(), p.pod.GetUID(), p.GVK())
 		jobUID := string(object.GetUID())

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -182,7 +182,11 @@ func TestPodSets(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if diff := cmp.Diff(tc.wantPodSets(tc.pod), tc.pod.PodSets()); diff != "" {
+			gotPodSets, err := tc.pod.PodSets()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantPodSets(tc.pod), gotPodSets); diff != "" {
 				t.Errorf("pod sets mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -98,7 +98,7 @@ func (j *RayCluster) PodLabelSelector() string {
 	return fmt.Sprintf("%s=%s", rayutils.RayClusterLabelKey, j.Name)
 }
 
-func (j *RayCluster) PodSets() []kueue.PodSet {
+func (j *RayCluster) PodSets() ([]kueue.PodSet, error) {
 	// len = workerGroups + head
 	podSets := make([]kueue.PodSet, len(j.Spec.WorkerGroupSpecs)+1)
 
@@ -127,7 +127,7 @@ func (j *RayCluster) PodSets() []kueue.PodSet {
 			TopologyRequest: jobframework.PodSetTopologyRequest(&wgs.Template.ObjectMeta, nil, nil, nil),
 		}
 	}
-	return podSets
+	return podSets, nil
 }
 
 func (j *RayCluster) RunWithPodSetsInfo(podSetsInfo []podset.PodSetInfo) error {

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -223,7 +223,11 @@ func TestPodSets(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if diff := cmp.Diff(tc.wantPodSets(tc.rayCluster), tc.rayCluster.PodSets()); diff != "" {
+			gotPodSets, err := tc.rayCluster.PodSets()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantPodSets(tc.rayCluster), gotPodSets); diff != "" {
 				t.Errorf("pod sets mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -112,7 +112,7 @@ func (j *RayJob) PodLabelSelector() string {
 	return ""
 }
 
-func (j *RayJob) PodSets() []kueue.PodSet {
+func (j *RayJob) PodSets() ([]kueue.PodSet, error) {
 	podSets := make([]kueue.PodSet, 0)
 
 	// head
@@ -152,7 +152,7 @@ func (j *RayJob) PodSets() []kueue.PodSet {
 		podSets = append(podSets, submitterJobPodSet)
 	}
 
-	return podSets
+	return podSets, nil
 }
 
 func (j *RayJob) RunWithPodSetsInfo(podSetsInfo []podset.PodSetInfo) error {

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -380,7 +380,11 @@ func TestPodSets(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if diff := cmp.Diff(tc.wantPodSets(tc.rayJob), tc.rayJob.PodSets()); diff != "" {
+			gotPodSets, err := tc.rayJob.PodSets()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantPodSets(tc.rayJob), gotPodSets); diff != "" {
 				t.Errorf("pod sets mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/vendor/github.com/project-codeflare/appwrapper/pkg/utils/utils.go
+++ b/vendor/github.com/project-codeflare/appwrapper/pkg/utils/utils.go
@@ -355,6 +355,10 @@ func GetPodSets(aw *workloadv1beta2.AppWrapper) ([]kueue.PodSet, error) {
 			}
 		}
 	}
+
+	if len(podSets) == 0 {
+		return nil, fmt.Errorf("no PodSets found for AppWrapper %s", aw.Name)
+	}
 	return podSets, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
extend  GenericJob.GetPodSets() interface to return error

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/kubernetes-sigs/kueue/issues/3969#event-15979527705

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```