### PR TITLE
[LeaderWorkerSet] Support LeaderReadyStartupPolicy

### DIFF
--- a/pkg/controller/jobframework/integrationmanager.go
+++ b/pkg/controller/jobframework/integrationmanager.go
@@ -61,6 +61,9 @@ type IntegrationCallbacks struct {
 	GVK schema.GroupVersionKind
 	// NewReconciler creates a new reconciler
 	NewReconciler ReconcilerFactory
+	// NewAdditionalReconcilers creates additional reconcilers
+	// (this callback is optional)
+	NewAdditionalReconcilers []ReconcilerFactory
 	// SetupWebhook sets up the framework's webhook with the controllers manager
 	SetupWebhook func(mgr ctrl.Manager, opts ...Option) error
 	// JobType holds an object of the type managed by the integration's webhook

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -713,8 +713,7 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 	}
 
 	if toUpdate != nil {
-		wl, err := r.updateWorkloadToMatchJob(ctx, job, object, toUpdate)
-		return wl, err
+		return r.updateWorkloadToMatchJob(ctx, job, object, toUpdate)
 	}
 
 	return match, nil

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -40,7 +40,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
@@ -619,10 +618,6 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 				"workload", klog.KObj(wl),
 				"controlledBy", controlledBy,
 			)
-			return nil, nil
-		}
-
-		if controllerutil.HasControllerReference(wl) && !metav1.IsControlledBy(wl, object) {
 			return nil, nil
 		}
 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -53,7 +53,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/podset"
 	"sigs.k8s.io/kueue/pkg/queue"
-	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 	"sigs.k8s.io/kueue/pkg/util/equality"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
@@ -862,7 +861,7 @@ func EquivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, 
 }
 
 func (r *JobReconciler) updateWorkloadToMatchJob(ctx context.Context, job GenericJob, object client.Object, wl *kueue.Workload) (*kueue.Workload, error) {
-	newWl, err := r.constructWorkload(ctx, job, object)
+	newWl, err := r.constructWorkload(ctx, job)
 	if err != nil {
 		return nil, fmt.Errorf("can't construct workload for update: %w", err)
 	}
@@ -962,9 +961,7 @@ func (r *JobReconciler) finalizeJob(ctx context.Context, job GenericJob) error {
 }
 
 // constructWorkload will derive a workload from the corresponding job.
-func (r *JobReconciler) constructWorkload(ctx context.Context, job GenericJob, object client.Object) (*kueue.Workload, error) {
-	log := ctrl.LoggerFrom(ctx)
-
+func (r *JobReconciler) constructWorkload(ctx context.Context, job GenericJob) (*kueue.Workload, error) {
 	if cj, implements := job.(ComposableJob); implements {
 		wl, err := cj.ConstructComposableWorkload(ctx, r.client, r.record, r.labelKeysToCopy)
 		if err != nil {
@@ -972,26 +969,20 @@ func (r *JobReconciler) constructWorkload(ctx context.Context, job GenericJob, o
 		}
 		return wl, nil
 	}
+	return ConstructWorkload(ctx, r.client, job, r.labelKeysToCopy)
+}
+
+func ConstructWorkload(ctx context.Context, c client.Client, job GenericJob, labelKeysToCopy []string) (*kueue.Workload, error) {
+	log := ctrl.LoggerFrom(ctx)
+	object := job.Object()
 
 	podSets, err := job.PodSets()
 	if err != nil {
 		return nil, err
 	}
 
-	wl := &kueue.Workload{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        GetWorkloadNameForOwnerWithGVK(object.GetName(), object.GetUID(), job.GVK()),
-			Namespace:   object.GetNamespace(),
-			Labels:      maps.FilterKeys(job.Object().GetLabels(), r.labelKeysToCopy),
-			Finalizers:  []string{kueue.ResourceInUseFinalizerName},
-			Annotations: admissioncheck.FilterProvReqAnnotations(job.Object().GetAnnotations()),
-		},
-		Spec: kueue.WorkloadSpec{
-			PodSets:                     podSets,
-			QueueName:                   QueueName(job),
-			MaximumExecutionTimeSeconds: MaximumExecutionTimeSeconds(job),
-		},
-	}
+	wl := NewWorkload(GetWorkloadNameForOwnerWithGVK(object.GetName(), object.GetUID(), job.GVK()), object, podSets, labelKeysToCopy)
+
 	if wl.Labels == nil {
 		wl.Labels = make(map[string]string)
 	}
@@ -1006,7 +997,7 @@ func (r *JobReconciler) constructWorkload(ctx context.Context, job GenericJob, o
 		)
 	}
 
-	if err := ctrl.SetControllerReference(object, wl, r.client.Scheme()); err != nil {
+	if err := ctrl.SetControllerReference(object, wl, c.Scheme()); err != nil {
 		return nil, err
 	}
 	return wl, nil
@@ -1104,7 +1095,7 @@ func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job Generic
 	}
 
 	// Create the corresponding workload.
-	wl, err := r.constructWorkload(ctx, job, object)
+	wl, err := r.constructWorkload(ctx, job)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -113,6 +113,15 @@ func (m *integrationManager) setupControllerAndWebhook(mgr ctrl.Manager, name st
 	).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("%s: %w", fwkNamePrefix, err)
 	}
+	for _, rec := range cb.NewAdditionalReconcilers {
+		if err := rec(
+			mgr.GetClient(),
+			mgr.GetEventRecorderFor(fmt.Sprintf("%s-%s-controller", name, options.ManagerName)),
+			opts...,
+		).SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("%s: %w", fwkNamePrefix, err)
+		}
+	}
 	if err := cb.SetupWebhook(mgr, opts...); err != nil {
 		return fmt.Errorf("%s: unable to create webhook: %w", fwkNamePrefix, err)
 	}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_controller.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_controller.go
@@ -40,14 +40,15 @@ const (
 
 func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
-		SetupIndexes:           SetupIndexes,
-		NewReconciler:          NewPodReconciler,
-		SetupWebhook:           SetupWebhook,
-		JobType:                &leaderworkersetv1.LeaderWorkerSet{},
-		AddToScheme:            leaderworkersetv1.AddToScheme,
-		DependencyList:         []string{"pod"},
-		IsManagingObjectsOwner: isLeaderWorkerSet,
-		GVK:                    gvk,
+		SetupIndexes:             SetupIndexes,
+		NewReconciler:            NewReconciler,
+		NewAdditionalReconcilers: []jobframework.ReconcilerFactory{NewPodReconciler},
+		SetupWebhook:             SetupWebhook,
+		JobType:                  &leaderworkersetv1.LeaderWorkerSet{},
+		AddToScheme:              leaderworkersetv1.AddToScheme,
+		DependencyList:           []string{"pod"},
+		IsManagingObjectsOwner:   isLeaderWorkerSet,
+		GVK:                      gvk,
 	}))
 }
 

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
-	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
@@ -142,7 +141,7 @@ func (r *Reconciler) podSets(lws *leaderworkersetv1.LeaderWorkerSet) []kueue.Pod
 			},
 			TopologyRequest: jobframework.PodSetTopologyRequest(
 				&lws.Spec.LeaderWorkerTemplate.LeaderTemplate.ObjectMeta,
-				ptr.To(kueuealpha.PodGroupPodIndexLabel),
+				nil,
 				nil,
 				nil,
 			),
@@ -167,7 +166,7 @@ func (r *Reconciler) podSets(lws *leaderworkersetv1.LeaderWorkerSet) []kueue.Pod
 		},
 		TopologyRequest: jobframework.PodSetTopologyRequest(
 			&lws.Spec.LeaderWorkerTemplate.WorkerTemplate.ObjectMeta,
-			ptr.To(kueuealpha.PodGroupPodIndexLabel),
+			nil,
 			nil,
 			nil,
 		),

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderworkerset
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
+	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+const (
+	leaderPodSetName = "leader"
+	workerPodSetName = "worker"
+)
+
+type Reconciler struct {
+	client          client.Client
+	record          record.EventRecorder
+	labelKeysToCopy []string
+}
+
+func NewReconciler(client client.Client, eventRecorder record.EventRecorder, opts ...jobframework.Option) jobframework.JobReconcilerInterface {
+	options := jobframework.ProcessOptions(opts...)
+
+	return &Reconciler{
+		client:          client,
+		record:          eventRecorder,
+		labelKeysToCopy: options.LabelKeysToCopy,
+	}
+}
+
+var _ jobframework.JobReconcilerInterface = (*Reconciler)(nil)
+
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	ctrl.Log.V(3).Info("Setting up LeaderWorkerSet reconciler")
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&leaderworkersetv1.LeaderWorkerSet{}).
+		Named("leaderworkerset").
+		WithEventFilter(r).
+		Complete(r)
+}
+
+// +kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets,verbs=get;list;watch
+
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	lws := &leaderworkersetv1.LeaderWorkerSet{}
+	err := r.client.Get(ctx, req.NamespacedName, lws)
+	if err != nil {
+		// we'll ignore not-found errors, since there is nothing to do.
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	log := ctrl.LoggerFrom(ctx).WithValues("leaderworkerset", klog.KObj(lws))
+	ctx = ctrl.LoggerInto(ctx, log)
+	log.V(2).Info("Reconciling LeaderWorkerSet")
+
+	err = r.createPrebuildWorkloadsIfNotExist(ctx, lws)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) createPrebuildWorkloadsIfNotExist(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet) error {
+	replicas := ptr.Deref(lws.Spec.Replicas, 1)
+	for i := int32(0); i < replicas; i++ {
+		if err := r.createPrebuildWorkloadIfNotExist(ctx, lws, i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) createPrebuildWorkloadIfNotExist(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, index int32) error {
+	wl := &kueue.Workload{}
+	err := r.client.Get(ctx, client.ObjectKey{Name: GetWorkloadName(lws.UID, lws.Name, fmt.Sprint(index)), Namespace: lws.Namespace}, wl)
+	// Ignore if the Workload already exists or an error occurs.
+	if err == nil || client.IgnoreNotFound(err) != nil {
+		return err
+	}
+	return r.createPrebuildWorkload(ctx, lws, index)
+}
+
+func (r *Reconciler) createPrebuildWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, index int32) error {
+	createdWorkload := r.constructWorkload(lws, index)
+	err := r.client.Create(ctx, createdWorkload)
+	if err != nil {
+		return err
+	}
+	r.record.Eventf(
+		lws, corev1.EventTypeNormal, jobframework.ReasonCreatedWorkload,
+		"Created Workload: %v", workload.Key(createdWorkload),
+	)
+	return nil
+}
+
+func (r *Reconciler) constructWorkload(lws *leaderworkersetv1.LeaderWorkerSet, index int32) *kueue.Workload {
+	wl := &kueue.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        GetWorkloadName(lws.UID, lws.Name, fmt.Sprint(index)),
+			Namespace:   lws.Namespace,
+			Finalizers:  []string{kueue.ResourceInUseFinalizerName},
+			Annotations: admissioncheck.FilterProvReqAnnotations(lws.GetAnnotations()),
+		},
+		Spec: kueue.WorkloadSpec{
+			QueueName:                   jobframework.QueueNameForObject(lws),
+			PodSets:                     r.podSets(lws),
+			MaximumExecutionTimeSeconds: jobframework.MaximumExecutionTimeSecondsForObject(lws),
+		},
+	}
+
+	wl.Annotations[podcontroller.IsGroupWorkloadAnnotationKey] = podcontroller.IsGroupWorkloadAnnotationValue
+
+	return wl
+}
+
+func (r *Reconciler) podSets(lws *leaderworkersetv1.LeaderWorkerSet) []kueue.PodSet {
+	podSets := make([]kueue.PodSet, 0, 2)
+
+	if lws.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
+		podSets = append(podSets, kueue.PodSet{
+			Name:  leaderPodSetName,
+			Count: 1,
+			Template: corev1.PodTemplateSpec{
+				Spec: *lws.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec.DeepCopy(),
+			},
+			TopologyRequest: jobframework.PodSetTopologyRequest(
+				&lws.Spec.LeaderWorkerTemplate.LeaderTemplate.ObjectMeta,
+				ptr.To(kueuealpha.PodGroupPodIndexLabel),
+				nil,
+				nil,
+			),
+		})
+	}
+
+	defaultPodSetName := kueue.DefaultPodSetName
+	if len(podSets) > 0 {
+		defaultPodSetName = workerPodSetName
+	}
+
+	defaultPodSetCount := ptr.Deref(lws.Spec.LeaderWorkerTemplate.Size, 1)
+	if len(podSets) > 0 {
+		defaultPodSetCount--
+	}
+
+	podSets = append(podSets, kueue.PodSet{
+		Name:  defaultPodSetName,
+		Count: defaultPodSetCount,
+		Template: corev1.PodTemplateSpec{
+			Spec: *lws.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec.DeepCopy(),
+		},
+		TopologyRequest: jobframework.PodSetTopologyRequest(
+			&lws.Spec.LeaderWorkerTemplate.WorkerTemplate.ObjectMeta,
+			ptr.To(kueuealpha.PodGroupPodIndexLabel),
+			nil,
+			nil,
+		),
+	})
+
+	return podSets
+}
+
+var _ predicate.Predicate = (*Reconciler)(nil)
+
+func (r *Reconciler) Generic(event.GenericEvent) bool {
+	return false
+}
+
+func (r *Reconciler) Create(e event.CreateEvent) bool {
+	return r.handle(e.Object)
+}
+
+func (r *Reconciler) Update(e event.UpdateEvent) bool {
+	return r.handle(e.ObjectNew)
+}
+
+func (r *Reconciler) Delete(event.DeleteEvent) bool {
+	return false
+}
+
+func (r *Reconciler) handle(obj client.Object) bool {
+	lws, isLws := obj.(*leaderworkersetv1.LeaderWorkerSet)
+	if !isLws {
+		return false
+	}
+	// Handle only leaderworkerset managed by kueue.
+	return jobframework.IsManagedByKueue(lws)
+}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -1,0 +1,326 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderworkerset
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/pkg/util/testingjobs/leaderworkerset"
+)
+
+var (
+	baseCmpOpts = []cmp.Option{
+		cmpopts.EquateEmpty(),
+		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+	}
+)
+
+var (
+	testNS  = "test-ns"
+	testLWS = "test-lws"
+	testUID = "test-uid"
+)
+
+func TestReconciler(t *testing.T) {
+	cases := map[string]struct {
+		labelKeysToCopy     []string
+		leaderWorkerSet     *leaderworkersetv1.LeaderWorkerSet
+		workloads           []kueue.Workload
+		wantLeaderWorkerSet *leaderworkersetv1.LeaderWorkerSet
+		wantWorkloads       []kueue.Workload
+		wantEvents          []utiltesting.EventRecord
+		wantErr             error
+	}{
+		"should create prebuild workload": {
+			leaderWorkerSet:     leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testUID).Obj(),
+			wantLeaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testUID).Obj(),
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload(GetWorkloadName(types.UID(testUID), testLWS, "0"), testNS).
+					Annotation(podcontroller.IsGroupWorkloadAnnotationKey, podcontroller.IsGroupWorkloadAnnotationValue).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						kueue.PodSet{
+							Name: kueue.DefaultPodSetName,
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{Name: "c", Image: "pause"},
+									},
+								},
+							},
+							Count:           1,
+							TopologyRequest: nil,
+						}).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: testLWS, Namespace: testNS},
+					EventType: corev1.EventTypeNormal,
+					Reason:    jobframework.ReasonCreatedWorkload,
+					Message: fmt.Sprintf(
+						"Created Workload: %s/%s",
+						testNS,
+						GetWorkloadName(types.UID(testUID), testLWS, "0"),
+					),
+				},
+			},
+		},
+		"should create prebuild workload with leader template": {
+			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+				UID(testUID).
+				Size(3).
+				LeaderTemplate(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "c", Image: "pause"},
+						},
+					},
+				}).
+				Obj(),
+			wantLeaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+				UID(testUID).
+				Size(3).
+				LeaderTemplate(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "c", Image: "pause"},
+						},
+					},
+				}).
+				Obj(),
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload(GetWorkloadName(types.UID(testUID), testLWS, "0"), testNS).
+					Annotation(podcontroller.IsGroupWorkloadAnnotationKey, podcontroller.IsGroupWorkloadAnnotationValue).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						kueue.PodSet{
+							Name: leaderPodSetName,
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{Name: "c", Image: "pause"},
+									},
+								},
+							},
+							Count:           1,
+							TopologyRequest: nil,
+						},
+						kueue.PodSet{
+							Name: workerPodSetName,
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{Name: "c", Image: "pause"},
+									},
+								},
+							},
+							Count:           2,
+							TopologyRequest: nil,
+						},
+					).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: testLWS, Namespace: testNS},
+					EventType: corev1.EventTypeNormal,
+					Reason:    jobframework.ReasonCreatedWorkload,
+					Message: fmt.Sprintf(
+						"Created Workload: %s/%s",
+						testNS,
+						GetWorkloadName(types.UID(testUID), testLWS, "0"),
+					),
+				},
+			},
+		},
+		"should create prebuild workloads with leader template": {
+			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+				UID(testUID).
+				Replicas(2).
+				Size(3).
+				LeaderTemplate(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "c", Image: "pause"},
+						},
+					},
+				}).
+				Obj(),
+			wantLeaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+				UID(testUID).
+				Replicas(2).
+				Size(3).
+				LeaderTemplate(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: "c", Image: "pause"},
+						},
+					},
+				}).
+				Obj(),
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload(GetWorkloadName(types.UID(testUID), testLWS, "0"), testNS).
+					Annotation(podcontroller.IsGroupWorkloadAnnotationKey, podcontroller.IsGroupWorkloadAnnotationValue).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						kueue.PodSet{
+							Name: leaderPodSetName,
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{Name: "c", Image: "pause"},
+									},
+								},
+							},
+							Count:           1,
+							TopologyRequest: nil,
+						},
+						kueue.PodSet{
+							Name: workerPodSetName,
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{Name: "c", Image: "pause"},
+									},
+								},
+							},
+							Count:           2,
+							TopologyRequest: nil,
+						},
+					).
+					Obj(),
+				*utiltesting.MakeWorkload(GetWorkloadName(types.UID(testUID), testLWS, "1"), testNS).
+					Annotation(podcontroller.IsGroupWorkloadAnnotationKey, podcontroller.IsGroupWorkloadAnnotationValue).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						kueue.PodSet{
+							Name: leaderPodSetName,
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{Name: "c", Image: "pause"},
+									},
+								},
+							},
+							Count:           1,
+							TopologyRequest: nil,
+						},
+						kueue.PodSet{
+							Name: workerPodSetName,
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{Name: "c", Image: "pause"},
+									},
+								},
+							},
+							Count:           2,
+							TopologyRequest: nil,
+						},
+					).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: testLWS, Namespace: testNS},
+					EventType: corev1.EventTypeNormal,
+					Reason:    jobframework.ReasonCreatedWorkload,
+					Message: fmt.Sprintf(
+						"Created Workload: %s/%s",
+						testNS,
+						GetWorkloadName(types.UID(testUID), testLWS, "0"),
+					),
+				},
+				{
+					Key:       types.NamespacedName{Name: testLWS, Namespace: testNS},
+					EventType: corev1.EventTypeNormal,
+					Reason:    jobframework.ReasonCreatedWorkload,
+					Message: fmt.Sprintf(
+						"Created Workload: %s/%s",
+						testNS,
+						GetWorkloadName(types.UID(testUID), testLWS, "1"),
+					),
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			clientBuilder := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme)
+
+			objs := make([]client.Object, 0, len(tc.workloads)+1)
+			objs = append(objs, tc.leaderWorkerSet)
+			for _, wl := range tc.workloads {
+				objs = append(objs, &wl)
+			}
+
+			kClient := clientBuilder.WithObjects(objs...).Build()
+			recorder := &utiltesting.EventRecorder{}
+
+			reconciler := NewReconciler(kClient, recorder, jobframework.WithLabelKeysToCopy(tc.labelKeysToCopy))
+
+			lwsKey := client.ObjectKeyFromObject(tc.leaderWorkerSet)
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: lwsKey})
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Reconcile returned error (-want,+got):\n%s", diff)
+			}
+
+			gotLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+			if err := kClient.Get(ctx, lwsKey, gotLeaderWorkerSet); err != nil {
+				if !errors.IsNotFound(err) {
+					t.Fatalf("Could not get LeaderWorkerSet after reconcile: %v", err)
+				}
+				gotLeaderWorkerSet = nil
+			}
+
+			if diff := cmp.Diff(tc.wantLeaderWorkerSet, gotLeaderWorkerSet, baseCmpOpts...); diff != "" {
+				t.Errorf("LeaderWorkerSet after reconcile (-want,+got):\n%s", diff)
+			}
+
+			gotWorkloads := kueue.WorkloadList{}
+			err = kClient.List(ctx, &gotWorkloads, client.InNamespace(tc.leaderWorkerSet.Namespace))
+			if err != nil {
+				t.Fatalf("Could not get Workloads after reconcile: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.wantWorkloads, gotWorkloads.Items, baseCmpOpts...); diff != "" {
+				t.Errorf("Workloads after reconcile (-want,+got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents, cmpopts.SortSlices(utiltesting.SortEvents)); diff != "" {
+				t.Errorf("Unexpected events (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -22,19 +22,15 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	awv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	"sigs.k8s.io/kueue/pkg/controller/jobs/appwrapper"
 	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/queue"
@@ -157,34 +153,6 @@ func TestValidateCreate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
-		"leader ready startup policy": {
-			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
-				LeaderTemplate(corev1.PodTemplateSpec{}).
-				StartupPolicy(leaderworkersetv1.LeaderReadyStartupPolicy).
-				Obj(),
-		},
-		"leader ready startup policy with queue-name": {
-			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
-				LeaderTemplate(corev1.PodTemplateSpec{}).
-				Queue("test-queue").
-				StartupPolicy(leaderworkersetv1.LeaderReadyStartupPolicy).
-				Obj(),
-			wantErr: field.ErrorList{
-				&field.Error{Type: field.ErrorTypeInvalid, Field: "spec.startupPolicy"},
-			}.ToAggregate(),
-		},
-		"leader ready startup policy with owner reference": {
-			integrations: []string{appwrapper.FrameworkName},
-			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
-				WithOwnerReference(metav1.OwnerReference{
-					APIVersion: awv1beta2.GroupVersion.String(),
-					Kind:       "AppWrapper",
-					Controller: ptr.To(true),
-				}).
-				LeaderTemplate(corev1.PodTemplateSpec{}).
-				StartupPolicy(leaderworkersetv1.LeaderReadyStartupPolicy).
-				Obj(),
-		},
 	}
 
 	for name, tc := range testCases {
@@ -262,46 +230,6 @@ func TestValidateUpdate(t *testing.T) {
 					Field: priorityClassNamePath.String(),
 				},
 			}.ToAggregate(),
-		},
-		"change startup policy without queue-name": {
-			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
-				StartupPolicy(leaderworkersetv1.LeaderCreatedStartupPolicy).
-				Obj(),
-			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
-				StartupPolicy(leaderworkersetv1.LeaderReadyStartupPolicy).
-				Obj(),
-		},
-		"change startup policy with queue-name": {
-			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
-				StartupPolicy(leaderworkersetv1.LeaderCreatedStartupPolicy).
-				Queue("test-queue").
-				Obj(),
-			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
-				StartupPolicy(leaderworkersetv1.LeaderReadyStartupPolicy).
-				Queue("test-queue").
-				Obj(),
-			wantErr: field.ErrorList{
-				&field.Error{
-					Type:  field.ErrorTypeInvalid,
-					Field: startupPolicyPath.String(),
-				},
-			}.ToAggregate(),
-		},
-		"change startup policy with owner reference": {
-			integrations: []string{appwrapper.FrameworkName},
-			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
-				StartupPolicy(leaderworkersetv1.LeaderCreatedStartupPolicy).
-				Queue("test-queue").
-				Obj(),
-			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
-				WithOwnerReference(metav1.OwnerReference{
-					APIVersion: awv1beta2.GroupVersion.String(),
-					Kind:       "AppWrapper",
-					Controller: ptr.To(true),
-				}).
-				Queue("test-queue").
-				StartupPolicy(leaderworkersetv1.LeaderReadyStartupPolicy).
-				Obj(),
 		},
 		"change image": {
 			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -284,6 +284,14 @@ func (w *WorkloadWrapper) Label(k, v string) *WorkloadWrapper {
 	return w
 }
 
+func (w *WorkloadWrapper) Annotation(k, v string) *WorkloadWrapper {
+	if w.ObjectMeta.Annotations == nil {
+		w.ObjectMeta.Annotations = make(map[string]string)
+	}
+	w.ObjectMeta.Annotations[k] = v
+	return w
+}
+
 func (w *WorkloadWrapper) AdmissionChecks(checks ...kueue.AdmissionCheckState) *WorkloadWrapper {
 	w.Status.AdmissionChecks = checks
 	return w
@@ -386,6 +394,11 @@ func MakePodSet(name string, count int) *PodSetWrapper {
 			},
 		},
 	}
+}
+
+func (p *PodSetWrapper) PodSpec(ps corev1.PodSpec) *PodSetWrapper {
+	p.Template.Spec = ps
+	return p
 }
 
 func (p *PodSetWrapper) PriorityClass(pc string) *PodSetWrapper {

--- a/pkg/util/testingjobs/leaderworkerset/wrappers.go
+++ b/pkg/util/testingjobs/leaderworkerset/wrappers.go
@@ -92,6 +92,12 @@ func (w *LeaderWorkerSetWrapper) Name(n string) *LeaderWorkerSetWrapper {
 	return w
 }
 
+// UID updated the uid of the LeaderWorkerSet
+func (w *LeaderWorkerSetWrapper) UID(uid string) *LeaderWorkerSetWrapper {
+	w.ObjectMeta.UID = types.UID(uid)
+	return w
+}
+
 func (w *LeaderWorkerSetWrapper) WithOwnerReference(ownerReference metav1.OwnerReference) *LeaderWorkerSetWrapper {
 	w.OwnerReferences = append(w.OwnerReferences, ownerReference)
 	return w

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -101,6 +101,10 @@ func (p *PodWrapper) Queue(q string) *PodWrapper {
 	return p.Label(controllerconsts.QueueLabel, q)
 }
 
+func (p *PodWrapper) PrebuildWorkload(name string) *PodWrapper {
+	return p.Label(controllerconsts.PrebuiltWorkloadLabel, name)
+}
+
 // PriorityClass updates the priority class name of the Pod
 func (p *PodWrapper) PriorityClass(pc string) *PodWrapper {
 	p.Spec.PriorityClassName = pc

--- a/test/e2e/singlecluster/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/leaderworkerset_test.go
@@ -113,7 +113,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 			})
 
 			wlLookupKey := types.NamespacedName{
-				Name:      leaderworkerset.GetWorkloadName(lws, "0"),
+				Name:      leaderworkerset.GetWorkloadName(lws.UID, lws.Name, "0"),
 				Namespace: ns.Name,
 			}
 			createdWorkload := &kueue.Workload{}
@@ -170,7 +170,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 			})
 
 			createdWorkload := &kueue.Workload{}
-			wlLookupKey := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws, "0"), Namespace: ns.Name}
+			wlLookupKey := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws.UID, lws.Name, "0"), Namespace: ns.Name}
 			ginkgo.By("Check workload is created", func() {
 				gomega.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 			})
@@ -225,13 +225,13 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 			})
 
 			createdWorkload1 := &kueue.Workload{}
-			wlLookupKey1 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws, "0"), Namespace: ns.Name}
+			wlLookupKey1 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws.UID, lws.Name, "0"), Namespace: ns.Name}
 			ginkgo.By("Check workload for group 1 is created", func() {
 				gomega.Expect(k8sClient.Get(ctx, wlLookupKey1, createdWorkload1)).To(gomega.Succeed())
 			})
 
 			createdWorkload2 := &kueue.Workload{}
-			wlLookupKey2 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws, "1"), Namespace: ns.Name}
+			wlLookupKey2 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws.UID, lws.Name, "1"), Namespace: ns.Name}
 			ginkgo.By("Check workload for group 2 is created", func() {
 				gomega.Expect(k8sClient.Get(ctx, wlLookupKey2, createdWorkload2)).To(gomega.Succeed())
 			})
@@ -287,7 +287,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 			})
 
 			createdWorkload1 := &kueue.Workload{}
-			wlLookupKey1 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws, "0"), Namespace: ns.Name}
+			wlLookupKey1 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws.UID, lws.Name, "0"), Namespace: ns.Name}
 			ginkgo.By("Check workload is created", func() {
 				gomega.Expect(k8sClient.Get(ctx, wlLookupKey1, createdWorkload1)).To(gomega.Succeed())
 			})
@@ -320,7 +320,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 			})
 
 			createdWorkload2 := &kueue.Workload{}
-			wlLookupKey2 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws, "1"), Namespace: ns.Name}
+			wlLookupKey2 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws.UID, lws.Name, "1"), Namespace: ns.Name}
 			ginkgo.By("Check workload for group 2 is created", func() {
 				gomega.Expect(k8sClient.Get(ctx, wlLookupKey2, createdWorkload2)).To(gomega.Succeed())
 			})
@@ -376,13 +376,13 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 			})
 
 			createdWorkload1 := &kueue.Workload{}
-			wlLookupKey1 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws, "0"), Namespace: ns.Name}
+			wlLookupKey1 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws.UID, lws.Name, "0"), Namespace: ns.Name}
 			ginkgo.By("Check workload for group 1 is created", func() {
 				gomega.Expect(k8sClient.Get(ctx, wlLookupKey1, createdWorkload1)).To(gomega.Succeed())
 			})
 
 			createdWorkload2 := &kueue.Workload{}
-			wlLookupKey2 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws, "1"), Namespace: ns.Name}
+			wlLookupKey2 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws.UID, lws.Name, "1"), Namespace: ns.Name}
 			ginkgo.By("Check workload for group 2 is created", func() {
 				gomega.Expect(k8sClient.Get(ctx, wlLookupKey2, createdWorkload2)).To(gomega.Succeed())
 			})
@@ -437,7 +437,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 			})
 		})
 
-		ginkgo.It("should admit group with multiple leaders and workers that fits and have different resource needs", func() {
+		ginkgo.It("should admit group with multiple leaders and workers that fits and have different resource needs (LeaderCreatedStartupPolicy)", func() {
 			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
 				Image(util.E2eTestSleepImage, []string{"10m"}).
 				Size(3).
@@ -485,13 +485,93 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 			})
 
 			createdWorkload1 := &kueue.Workload{}
-			wlLookupKey1 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws, "0"), Namespace: ns.Name}
+			wlLookupKey1 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws.UID, lws.Name, "0"), Namespace: ns.Name}
 			ginkgo.By("Check workload for group 1 is created", func() {
 				gomega.Expect(k8sClient.Get(ctx, wlLookupKey1, createdWorkload1)).To(gomega.Succeed())
 			})
 
 			createdWorkload2 := &kueue.Workload{}
-			wlLookupKey2 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws, "0"), Namespace: ns.Name}
+			wlLookupKey2 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws.UID, lws.Name, "0"), Namespace: ns.Name}
+			ginkgo.By("Check workload for group 2 is created", func() {
+				gomega.Expect(k8sClient.Get(ctx, wlLookupKey2, createdWorkload2)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("Delete the LeaderWorkerSet", func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, lws, true)
+			})
+
+			ginkgo.By("Check pods are deleted", func() {
+				pods := &corev1.PodList{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
+						leaderworkersetv1.SetNameLabelKey: lws.Name,
+					}, client.InNamespace(lws.Namespace))).Should(gomega.Succeed())
+					g.Expect(pods.Items).To(gomega.BeEmpty())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Check workloads are deleted", func() {
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, createdWorkload1, false, util.LongTimeout)
+				util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, createdWorkload2, false, util.LongTimeout)
+			})
+		})
+
+		ginkgo.It("should admit group with multiple leaders and workers that fits and have different resource needs (LeaderReadyStartupPolicy)", func() {
+			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
+				Image(util.E2eTestSleepImage, []string{"10m"}).
+				Size(3).
+				Replicas(2).
+				Request(corev1.ResourceCPU, "100m").
+				StartupPolicy(leaderworkersetv1.LeaderReadyStartupPolicy).
+				Queue(lq.Name).
+				LeaderTemplate(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "c",
+								Args:  []string{"10m"},
+								Image: util.E2eTestSleepImage,
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU: resource.MustParse("150m"),
+									},
+								},
+							},
+						},
+						NodeSelector: map[string]string{},
+					},
+				}).
+				Obj()
+
+			ginkgo.By("Create a LeaderWorkerSet", func() {
+				gomega.Expect(k8sClient.Create(ctx, lws)).To(gomega.Succeed())
+			})
+
+			createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+
+			ginkgo.By("Waiting for replicas is ready", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(2)))
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
+						gomega.BeComparableTo(metav1.Condition{
+							Type:    "Available",
+							Status:  metav1.ConditionTrue,
+							Reason:  "AllGroupsReady",
+							Message: "All replicas are ready",
+						}, util.IgnoreConditionTimestampsAndObservedGeneration)),
+					)
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			createdWorkload1 := &kueue.Workload{}
+			wlLookupKey1 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws.UID, lws.Name, "0"), Namespace: ns.Name}
+			ginkgo.By("Check workload for group 1 is created", func() {
+				gomega.Expect(k8sClient.Get(ctx, wlLookupKey1, createdWorkload1)).To(gomega.Succeed())
+			})
+
+			createdWorkload2 := &kueue.Workload{}
+			wlLookupKey2 := types.NamespacedName{Name: leaderworkerset.GetWorkloadName(lws.UID, lws.Name, "0"), Namespace: ns.Name}
 			ginkgo.By("Check workload for group 2 is created", func() {
 				gomega.Expect(k8sClient.Get(ctx, wlLookupKey2, createdWorkload2)).To(gomega.Succeed())
 			})
@@ -605,7 +685,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 
 			createdWorkload1 := &kueue.Workload{}
 			wlLookupKey1 := types.NamespacedName{
-				Name:      leaderworkerset.GetWorkloadName(createdLeaderWorkerSet, "0"),
+				Name:      leaderworkerset.GetWorkloadName(createdLeaderWorkerSet.UID, createdLeaderWorkerSet.Name, "0"),
 				Namespace: ns.Name,
 			}
 			ginkgo.By("Check workload for group 1 is created", func() {
@@ -614,7 +694,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 
 			createdWorkload2 := &kueue.Workload{}
 			wlLookupKey2 := types.NamespacedName{
-				Name:      leaderworkerset.GetWorkloadName(createdLeaderWorkerSet, "0"),
+				Name:      leaderworkerset.GetWorkloadName(createdLeaderWorkerSet.UID, createdLeaderWorkerSet.Name, "0"),
 				Namespace: ns.Name,
 			}
 			ginkgo.By("Check workload for group 2 is created", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Support LeaderReadyStartupPolicy on LeaderWorkerSet.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3232

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```