### PR TITLE
Fix integration tests fail after upgrade to 1.32.

### DIFF
--- a/test/integration/controller/jobs/job/job_controller_test.go
+++ b/test/integration/controller/jobs/job/job_controller_test.go
@@ -265,13 +265,22 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 		}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("checking the workload is finished when job is completed")
+		createdJob.Status.StartTime = ptr.To(metav1.Now())
+		createdJob.Status.CompletionTime = ptr.To(metav1.Now())
 		createdJob.Status.Conditions = append(createdJob.Status.Conditions,
+			batchv1.JobCondition{
+				Type:               batchv1.JobSuccessCriteriaMet,
+				Status:             corev1.ConditionTrue,
+				LastProbeTime:      metav1.Now(),
+				LastTransitionTime: metav1.Now(),
+			},
 			batchv1.JobCondition{
 				Type:               batchv1.JobComplete,
 				Status:             corev1.ConditionTrue,
 				LastProbeTime:      metav1.Now(),
 				LastTransitionTime: metav1.Now(),
-			})
+			},
+		)
 		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
@@ -1310,13 +1319,22 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 		util.ExpectReservingActiveWorkloadsMetric(devClusterQ, 1)
 
 		ginkgo.By("checking the second prod job starts when the first finishes")
+		createdProdJob1.Status.StartTime = ptr.To(metav1.Now())
+		createdProdJob1.Status.CompletionTime = ptr.To(metav1.Now())
 		createdProdJob1.Status.Conditions = append(createdProdJob1.Status.Conditions,
+			batchv1.JobCondition{
+				Type:               batchv1.JobSuccessCriteriaMet,
+				Status:             corev1.ConditionTrue,
+				LastProbeTime:      metav1.Now(),
+				LastTransitionTime: metav1.Now(),
+			},
 			batchv1.JobCondition{
 				Type:               batchv1.JobComplete,
 				Status:             corev1.ConditionTrue,
 				LastProbeTime:      metav1.Now(),
 				LastTransitionTime: metav1.Now(),
-			})
+			},
+		)
 		gomega.Expect(k8sClient.Status().Update(ctx, createdProdJob1)).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, lookupKey2, createdProdJob2)).Should(gomega.Succeed())

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -529,25 +529,26 @@ var _ = ginkgo.Describe("Multikueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 			gomega.Eventually(func(g gomega.Gomega) {
 				createdJob := batchv1.Job{}
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+				now := metav1.Now()
 				createdJob.Status.Conditions = append(createdJob.Status.Conditions,
 					batchv1.JobCondition{
 						Type:               batchv1.JobSuccessCriteriaMet,
 						Status:             corev1.ConditionTrue,
-						LastProbeTime:      metav1.Now(),
-						LastTransitionTime: metav1.Now(),
+						LastProbeTime:      now,
+						LastTransitionTime: now,
 						Message:            reachedPodsReason,
 					},
 					batchv1.JobCondition{
 						Type:               batchv1.JobComplete,
 						Status:             corev1.ConditionTrue,
-						LastProbeTime:      metav1.Now(),
-						LastTransitionTime: metav1.Now(),
+						LastProbeTime:      now,
+						LastTransitionTime: now,
 						Message:            finishJobReason,
 					},
 				)
 				createdJob.Status.Succeeded = 1
-				createdJob.Status.StartTime = ptr.To(metav1.Now())
-				createdJob.Status.CompletionTime = ptr.To(metav1.Now())
+				createdJob.Status.StartTime = ptr.To(now)
+				createdJob.Status.CompletionTime = ptr.To(now)
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -634,26 +635,27 @@ var _ = ginkgo.Describe("Multikueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 			gomega.Eventually(func(g gomega.Gomega) {
 				createdJob := batchv1.Job{}
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+				now := metav1.Now()
 				createdJob.Status.Conditions = append(createdJob.Status.Conditions,
 					batchv1.JobCondition{
 						Type:               batchv1.JobSuccessCriteriaMet,
 						Status:             corev1.ConditionTrue,
-						LastProbeTime:      metav1.Now(),
-						LastTransitionTime: metav1.Now(),
+						LastProbeTime:      now,
+						LastTransitionTime: now,
 						Message:            reachedPodsReason,
 					},
 					batchv1.JobCondition{
 						Type:               batchv1.JobComplete,
 						Status:             corev1.ConditionTrue,
-						LastProbeTime:      metav1.Now(),
-						LastTransitionTime: metav1.Now(),
+						LastProbeTime:      now,
+						LastTransitionTime: now,
 						Message:            finishJobReason,
 					},
 				)
 				createdJob.Status.Active = 0
 				createdJob.Status.Ready = ptr.To[int32](0)
 				createdJob.Status.Succeeded = 1
-				createdJob.Status.CompletionTime = ptr.To(metav1.Now())
+				createdJob.Status.CompletionTime = ptr.To(now)
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -1796,25 +1798,26 @@ var _ = ginkgo.Describe("Multikueue when not all integrations are enabled", gink
 			gomega.Eventually(func(g gomega.Gomega) {
 				createdJob := batchv1.Job{}
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+				now := metav1.Now()
 				createdJob.Status.Conditions = append(createdJob.Status.Conditions,
 					batchv1.JobCondition{
 						Type:               batchv1.JobSuccessCriteriaMet,
 						Status:             corev1.ConditionTrue,
-						LastProbeTime:      metav1.Now(),
-						LastTransitionTime: metav1.Now(),
+						LastProbeTime:      now,
+						LastTransitionTime: now,
 						Message:            reachedPodsReason,
 					},
 					batchv1.JobCondition{
 						Type:               batchv1.JobComplete,
 						Status:             corev1.ConditionTrue,
-						LastProbeTime:      metav1.Now(),
-						LastTransitionTime: metav1.Now(),
+						LastProbeTime:      now,
+						LastTransitionTime: now,
 						Message:            finishJobReason,
 					},
 				)
 				createdJob.Status.Succeeded = 1
-				createdJob.Status.StartTime = ptr.To(metav1.Now())
-				createdJob.Status.CompletionTime = ptr.To(metav1.Now())
+				createdJob.Status.StartTime = ptr.To(now)
+				createdJob.Status.CompletionTime = ptr.To(now)
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix integration tests fail after upgrade to 1.32.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4027

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```