### PR TITLE
[Cleanup] Use PROJECT_DIR for crd path instead of indirect path

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -83,6 +83,7 @@ test: gotestsum ## Run tests.
 .PHONY: test-integration
 test-integration: gomod-download envtest ginkgo dep-crds kueuectl ginkgo-top ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
+	PROJECT_DIR=$(PROJECT_DIR)/ \
 	KUEUE_BIN=$(PROJECT_DIR)/bin \
 	ENVTEST_K8S_VERSION=$(ENVTEST_K8S_VERSION) \
 	API_LOG_LEVEL=$(INTEGRATION_API_LOG_LEVEL) \

--- a/test/integration/controller/admissionchecks/provisioning/suite_test.go
+++ b/test/integration/controller/admissionchecks/provisioning/suite_test.go
@@ -18,7 +18,6 @@ package provisioning
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -35,16 +34,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg         *rest.Config
-	k8sClient   client.Client
-	ctx         context.Context
-	fwk         *framework.Framework
-	crdPath     = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
-	depCRDPaths = []string{filepath.Join("..", "..", "..", "..", "..", "dep-crds", "cluster-autoscaler")}
-	webhookPath = filepath.Join("..", "..", "..", "..", "..", "config", "components", "webhook")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestProvisioning(t *testing.T) {
@@ -56,7 +53,13 @@ func TestProvisioning(t *testing.T) {
 }
 
 var _ = ginkgo.BeforeSuite(func() {
-	fwk = &framework.Framework{CRDPath: crdPath, DepCRDPaths: depCRDPaths, WebhookPath: webhookPath}
+	fwk = &framework.Framework{
+		CRDPath: util.BaseCrd,
+		DepCRDPaths: []string{
+			util.AutoscalerCrds,
+		},
+		WebhookPath: util.WebhookCrds,
+	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)
 })

--- a/test/integration/controller/admissionchecks/provisioning/suite_test.go
+++ b/test/integration/controller/admissionchecks/provisioning/suite_test.go
@@ -54,11 +54,10 @@ func TestProvisioning(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath: util.BaseCrd,
 		DepCRDPaths: []string{
 			util.AutoscalerCrds,
 		},
-		WebhookPath: util.WebhookCrds,
+		WebhookPath: util.WebhookPath,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/controller/core/suite_test.go
+++ b/test/integration/controller/core/suite_test.go
@@ -53,8 +53,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
-		WebhookPath: util.WebhookCrds,
+		WebhookPath: util.WebhookPath,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/controller/core/suite_test.go
+++ b/test/integration/controller/core/suite_test.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -34,15 +33,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg         *rest.Config
-	k8sClient   client.Client
-	ctx         context.Context
-	fwk         *framework.Framework
-	crdPath     = filepath.Join("..", "..", "..", "..", "config", "components", "crd", "bases")
-	webhookPath = filepath.Join("..", "..", "..", "..", "config", "components", "webhook")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestAPIs(t *testing.T) {
@@ -54,7 +52,10 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = ginkgo.BeforeSuite(func() {
-	fwk = &framework.Framework{CRDPath: crdPath, WebhookPath: webhookPath}
+	fwk = &framework.Framework{
+		CRDPath:     util.BaseCrd,
+		WebhookPath: util.WebhookCrds,
+	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)
 })

--- a/test/integration/controller/jobframework/setup/setup_controllers_test.go
+++ b/test/integration/controller/jobframework/setup/setup_controllers_test.go
@@ -46,9 +46,7 @@ var _ = ginkgo.Describe("Setup Controllers", ginkgo.Ordered, ginkgo.ContinueOnFa
 	)
 
 	ginkgo.BeforeEach(func() {
-		fwk = &framework.Framework{
-			CRDPath: util.BaseCrd,
-		}
+		fwk = &framework.Framework{}
 		cfg = fwk.Init()
 		ctx, k8sClient = fwk.SetupClient(cfg)
 		fwk.StartManager(ctx, cfg, managerSetup(jobframework.WithEnabledFrameworks([]string{jobset.FrameworkName})))

--- a/test/integration/controller/jobframework/setup/setup_controllers_test.go
+++ b/test/integration/controller/jobframework/setup/setup_controllers_test.go
@@ -46,7 +46,9 @@ var _ = ginkgo.Describe("Setup Controllers", ginkgo.Ordered, ginkgo.ContinueOnFa
 	)
 
 	ginkgo.BeforeEach(func() {
-		fwk = &framework.Framework{CRDPath: crdPath}
+		fwk = &framework.Framework{
+			CRDPath: util.BaseCrd,
+		}
 		cfg = fwk.Init()
 		ctx, k8sClient = fwk.SetupClient(cfg)
 		fwk.StartManager(ctx, cfg, managerSetup(jobframework.WithEnabledFrameworks([]string{jobset.FrameworkName})))
@@ -99,7 +101,7 @@ var _ = ginkgo.Describe("Setup Controllers", ginkgo.Ordered, ginkgo.ContinueOnFa
 
 		ginkgo.By("Install the JobSet CRDs", func() {
 			options := envtest.CRDInstallOptions{
-				Paths:              []string{jobsetCrdPath},
+				Paths:              []string{util.JobsetCrds},
 				ErrorIfPathMissing: true,
 				CleanUpAfterUse:    true,
 			}

--- a/test/integration/controller/jobframework/setup/suite_test.go
+++ b/test/integration/controller/jobframework/setup/suite_test.go
@@ -18,7 +18,6 @@ package job
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -32,12 +31,10 @@ import (
 )
 
 var (
-	cfg           *rest.Config
-	k8sClient     client.Client
-	ctx           context.Context
-	fwk           *framework.Framework
-	crdPath       = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
-	jobsetCrdPath = filepath.Join("..", "..", "..", "..", "..", "dep-crds", "jobset-operator")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestAPIs(t *testing.T) {

--- a/test/integration/controller/jobs/appwrapper/suite_test.go
+++ b/test/integration/controller/jobs/appwrapper/suite_test.go
@@ -18,7 +18,6 @@ package appwrapper
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -39,15 +38,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg               *rest.Config
-	k8sClient         client.Client
-	ctx               context.Context
-	fwk               *framework.Framework
-	crdPath           = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
-	appwrapperCrdPath = filepath.Join("..", "..", "..", "..", "..", "dep-crds", "appwrapper-crds")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestAPIs(t *testing.T) {
@@ -60,8 +58,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     crdPath,
-		DepCRDPaths: []string{appwrapperCrdPath},
+		CRDPath:     util.BaseCrd,
+		DepCRDPaths: []string{util.AppWrapperCrds},
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/controller/jobs/appwrapper/suite_test.go
+++ b/test/integration/controller/jobs/appwrapper/suite_test.go
@@ -58,7 +58,6 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
 		DepCRDPaths: []string{util.AppWrapperCrds},
 	}
 	cfg = fwk.Init()

--- a/test/integration/controller/jobs/job/suite_test.go
+++ b/test/integration/controller/jobs/job/suite_test.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/test/integration/framework"
-	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
@@ -57,9 +56,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = ginkgo.BeforeSuite(func() {
-	fwk = &framework.Framework{
-		CRDPath: util.BaseCrd,
-	}
+	fwk = &framework.Framework{}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)
 })

--- a/test/integration/controller/jobs/job/suite_test.go
+++ b/test/integration/controller/jobs/job/suite_test.go
@@ -18,7 +18,6 @@ package job
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -39,6 +38,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
@@ -46,7 +46,6 @@ var (
 	k8sClient client.Client
 	ctx       context.Context
 	fwk       *framework.Framework
-	crdPath   = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
 )
 
 func TestAPIs(t *testing.T) {
@@ -59,7 +58,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath: crdPath,
+		CRDPath: util.BaseCrd,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/controller/jobs/jobset/suite_test.go
+++ b/test/integration/controller/jobs/jobset/suite_test.go
@@ -18,7 +18,6 @@ package jobset
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -38,15 +37,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg           *rest.Config
-	k8sClient     client.Client
-	ctx           context.Context
-	fwk           *framework.Framework
-	crdPath       = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
-	jobsetCrdPath = filepath.Join("..", "..", "..", "..", "..", "dep-crds", "jobset-operator")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestAPIs(t *testing.T) {
@@ -59,8 +57,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     crdPath,
-		DepCRDPaths: []string{jobsetCrdPath},
+		CRDPath:     util.BaseCrd,
+		DepCRDPaths: []string{util.JobsetCrds},
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/controller/jobs/jobset/suite_test.go
+++ b/test/integration/controller/jobs/jobset/suite_test.go
@@ -57,7 +57,6 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
 		DepCRDPaths: []string{util.JobsetCrds},
 	}
 	cfg = fwk.Init()

--- a/test/integration/controller/jobs/mpijob/suite_test.go
+++ b/test/integration/controller/jobs/mpijob/suite_test.go
@@ -59,7 +59,6 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
 		DepCRDPaths: []string{util.MpiOperatorCrds},
 	}
 

--- a/test/integration/controller/jobs/mpijob/suite_test.go
+++ b/test/integration/controller/jobs/mpijob/suite_test.go
@@ -18,7 +18,6 @@ package mpijob
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -40,15 +39,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg        *rest.Config
-	k8sClient  client.Client
-	ctx        context.Context
-	fwk        *framework.Framework
-	crdPath    = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
-	mpiCrdPath = filepath.Join("..", "..", "..", "..", "..", "dep-crds", "mpi-operator")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestAPIs(t *testing.T) {
@@ -61,8 +59,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     crdPath,
-		DepCRDPaths: []string{mpiCrdPath},
+		CRDPath:     util.BaseCrd,
+		DepCRDPaths: []string{util.MpiOperatorCrds},
 	}
 
 	cfg = fwk.Init()

--- a/test/integration/controller/jobs/mxjob/suite_test.go
+++ b/test/integration/controller/jobs/mxjob/suite_test.go
@@ -18,7 +18,6 @@ package mxjob
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -39,15 +38,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg          *rest.Config
-	k8sClient    client.Client
-	ctx          context.Context
-	fwk          *framework.Framework
-	crdPath      = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
-	mxnetCrdPath = filepath.Join("..", "..", "..", "..", "..", "dep-crds", "training-operator-crds")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestAPIs(t *testing.T) {
@@ -60,8 +58,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     crdPath,
-		DepCRDPaths: []string{mxnetCrdPath},
+		CRDPath:     util.BaseCrd,
+		DepCRDPaths: []string{util.TrainingOperatorCrds},
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/controller/jobs/mxjob/suite_test.go
+++ b/test/integration/controller/jobs/mxjob/suite_test.go
@@ -58,7 +58,6 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
 		DepCRDPaths: []string{util.TrainingOperatorCrds},
 	}
 	cfg = fwk.Init()

--- a/test/integration/controller/jobs/paddlejob/suite_test.go
+++ b/test/integration/controller/jobs/paddlejob/suite_test.go
@@ -18,7 +18,6 @@ package paddlejob
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -39,15 +38,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg           *rest.Config
-	k8sClient     client.Client
-	ctx           context.Context
-	fwk           *framework.Framework
-	crdPath       = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
-	paddleCrdPath = filepath.Join("..", "..", "..", "..", "..", "dep-crds", "training-operator-crds")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestAPIs(t *testing.T) {
@@ -60,8 +58,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     crdPath,
-		DepCRDPaths: []string{paddleCrdPath},
+		CRDPath:     util.BaseCrd,
+		DepCRDPaths: []string{util.TrainingOperatorCrds},
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/controller/jobs/paddlejob/suite_test.go
+++ b/test/integration/controller/jobs/paddlejob/suite_test.go
@@ -58,7 +58,6 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
 		DepCRDPaths: []string{util.TrainingOperatorCrds},
 	}
 	cfg = fwk.Init()

--- a/test/integration/controller/jobs/pod/suite_test.go
+++ b/test/integration/controller/jobs/pod/suite_test.go
@@ -18,7 +18,6 @@ package pod
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -42,6 +41,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
@@ -50,8 +50,6 @@ var (
 	serverVersionFetcher *kubeversion.ServerVersionFetcher
 	ctx                  context.Context
 	fwk                  *framework.Framework
-	crdPath              = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
-	webhookPath          = filepath.Join("..", "..", "..", "..", "..", "config", "components", "webhook")
 )
 
 func TestAPIs(t *testing.T) {
@@ -64,8 +62,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     crdPath,
-		WebhookPath: webhookPath,
+		CRDPath:     util.BaseCrd,
+		WebhookPath: util.WebhookCrds,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/controller/jobs/pod/suite_test.go
+++ b/test/integration/controller/jobs/pod/suite_test.go
@@ -62,8 +62,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
-		WebhookPath: util.WebhookCrds,
+		WebhookPath: util.WebhookPath,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/controller/jobs/pytorchjob/suite_test.go
+++ b/test/integration/controller/jobs/pytorchjob/suite_test.go
@@ -18,7 +18,6 @@ package pytorchjob
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -39,15 +38,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg            *rest.Config
-	k8sClient      client.Client
-	ctx            context.Context
-	fwk            *framework.Framework
-	crdPath        = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
-	pytorchCrdPath = filepath.Join("..", "..", "..", "..", "..", "dep-crds", "training-operator-crds")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestAPIs(t *testing.T) {
@@ -60,8 +58,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     crdPath,
-		DepCRDPaths: []string{pytorchCrdPath},
+		CRDPath:     util.BaseCrd,
+		DepCRDPaths: []string{util.TrainingOperatorCrds},
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/controller/jobs/pytorchjob/suite_test.go
+++ b/test/integration/controller/jobs/pytorchjob/suite_test.go
@@ -58,7 +58,6 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
 		DepCRDPaths: []string{util.TrainingOperatorCrds},
 	}
 	cfg = fwk.Init()

--- a/test/integration/controller/jobs/raycluster/suite_test.go
+++ b/test/integration/controller/jobs/raycluster/suite_test.go
@@ -57,7 +57,6 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
 		DepCRDPaths: []string{util.RayOperatorCrds},
 	}
 

--- a/test/integration/controller/jobs/raycluster/suite_test.go
+++ b/test/integration/controller/jobs/raycluster/suite_test.go
@@ -18,7 +18,6 @@ package raycluster
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -38,15 +37,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg        *rest.Config
-	k8sClient  client.Client
-	ctx        context.Context
-	fwk        *framework.Framework
-	crdPath    = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
-	rayCrdPath = filepath.Join("..", "..", "..", "..", "..", "dep-crds", "ray-operator-crds")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestAPIs(t *testing.T) {
@@ -59,8 +57,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     crdPath,
-		DepCRDPaths: []string{rayCrdPath},
+		CRDPath:     util.BaseCrd,
+		DepCRDPaths: []string{util.RayOperatorCrds},
 	}
 
 	cfg = fwk.Init()

--- a/test/integration/controller/jobs/rayjob/suite_test.go
+++ b/test/integration/controller/jobs/rayjob/suite_test.go
@@ -18,7 +18,6 @@ package rayjob
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -37,15 +36,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg        *rest.Config
-	k8sClient  client.Client
-	ctx        context.Context
-	fwk        *framework.Framework
-	crdPath    = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
-	rayCrdPath = filepath.Join("..", "..", "..", "..", "..", "dep-crds", "ray-operator-crds")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestAPIs(t *testing.T) {
@@ -58,8 +56,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     crdPath,
-		DepCRDPaths: []string{rayCrdPath},
+		CRDPath:     util.BaseCrd,
+		DepCRDPaths: []string{util.RayOperatorCrds},
 	}
 
 	cfg = fwk.Init()

--- a/test/integration/controller/jobs/rayjob/suite_test.go
+++ b/test/integration/controller/jobs/rayjob/suite_test.go
@@ -56,7 +56,6 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
 		DepCRDPaths: []string{util.RayOperatorCrds},
 	}
 

--- a/test/integration/controller/jobs/tfjob/suite_test.go
+++ b/test/integration/controller/jobs/tfjob/suite_test.go
@@ -18,7 +18,6 @@ package tfjob
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -39,15 +38,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg               *rest.Config
-	k8sClient         client.Client
-	ctx               context.Context
-	fwk               *framework.Framework
-	crdPath           = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
-	tensorflowCrdPath = filepath.Join("..", "..", "..", "..", "..", "dep-crds", "training-operator-crds")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestAPIs(t *testing.T) {
@@ -60,8 +58,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     crdPath,
-		DepCRDPaths: []string{tensorflowCrdPath},
+		CRDPath:     util.BaseCrd,
+		DepCRDPaths: []string{util.TrainingOperatorCrds},
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/controller/jobs/tfjob/suite_test.go
+++ b/test/integration/controller/jobs/tfjob/suite_test.go
@@ -58,7 +58,6 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
 		DepCRDPaths: []string{util.TrainingOperatorCrds},
 	}
 	cfg = fwk.Init()

--- a/test/integration/controller/jobs/xgboostjob/suite_test.go
+++ b/test/integration/controller/jobs/xgboostjob/suite_test.go
@@ -18,7 +18,6 @@ package xgboostjob
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -39,15 +38,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg        *rest.Config
-	k8sClient  client.Client
-	ctx        context.Context
-	fwk        *framework.Framework
-	crdPath    = filepath.Join("..", "..", "..", "..", "..", "config", "components", "crd", "bases")
-	xgbCrdPath = filepath.Join("..", "..", "..", "..", "..", "dep-crds", "training-operator-crds")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestAPIs(t *testing.T) {
@@ -60,8 +58,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     crdPath,
-		DepCRDPaths: []string{xgbCrdPath},
+		CRDPath:     util.BaseCrd,
+		DepCRDPaths: []string{util.TrainingOperatorCrds},
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/controller/jobs/xgboostjob/suite_test.go
+++ b/test/integration/controller/jobs/xgboostjob/suite_test.go
@@ -58,7 +58,6 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
 		DepCRDPaths: []string{util.TrainingOperatorCrds},
 	}
 	cfg = fwk.Init()

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -56,7 +57,6 @@ import (
 type ManagerSetup func(context.Context, manager.Manager)
 
 type Framework struct {
-	CRDPath               string
 	DepCRDPaths           []string
 	WebhookPath           string
 	APIServerFeatureGates []string
@@ -77,8 +77,9 @@ func (f *Framework) Init() *rest.Config {
 
 	var cfg *rest.Config
 	ginkgo.By("bootstrapping test environment", func() {
+		baseCrdPath := filepath.Join(util.GetProjectBaseDir(), "config", "components", "crd", "bases")
 		f.testEnv = &envtest.Environment{
-			CRDDirectoryPaths:     append(f.DepCRDPaths, f.CRDPath),
+			CRDDirectoryPaths:     append(f.DepCRDPaths, baseCrdPath),
 			ErrorIfCRDPathMissing: true,
 		}
 		if len(f.WebhookPath) > 0 {

--- a/test/integration/importer/suite_test.go
+++ b/test/integration/importer/suite_test.go
@@ -18,7 +18,6 @@ package importer
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -38,6 +37,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
@@ -57,7 +57,7 @@ func TestScheduler(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath: filepath.Join("..", "..", "..", "config", "components", "crd", "bases"),
+		CRDPath: util.BaseCrd,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/importer/suite_test.go
+++ b/test/integration/importer/suite_test.go
@@ -37,7 +37,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
-	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
@@ -56,9 +55,7 @@ func TestScheduler(t *testing.T) {
 }
 
 var _ = ginkgo.BeforeSuite(func() {
-	fwk = &framework.Framework{
-		CRDPath: util.BaseCrd,
-	}
+	fwk = &framework.Framework{}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)
 })

--- a/test/integration/kueuectl/suite_test.go
+++ b/test/integration/kueuectl/suite_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"os"
 	"path"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -37,15 +36,14 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg         *rest.Config
-	k8sClient   client.Client
-	ctx         context.Context
-	fwk         *framework.Framework
-	crdPath     = filepath.Join("..", "..", "..", "config", "components", "crd", "bases")
-	webhookPath = filepath.Join("..", "..", "..", "config", "components", "webhook")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 
 	kueuectlPath   string
 	kassetsPath    string
@@ -58,7 +56,10 @@ func TestKueuectl(t *testing.T) {
 }
 
 var _ = ginkgo.BeforeSuite(func() {
-	fwk = &framework.Framework{CRDPath: crdPath, WebhookPath: webhookPath}
+	fwk = &framework.Framework{
+		CRDPath:     util.BaseCrd,
+		WebhookPath: util.WebhookCrds,
+	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)
 	fwk.StartManager(ctx, cfg, managerSetup)

--- a/test/integration/kueuectl/suite_test.go
+++ b/test/integration/kueuectl/suite_test.go
@@ -57,8 +57,7 @@ func TestKueuectl(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
-		WebhookPath: util.WebhookCrds,
+		WebhookPath: util.WebhookPath,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -91,8 +91,7 @@ func TestMultiKueue(t *testing.T) {
 func createCluster(setupFnc framework.ManagerSetup, apiFeatureGates ...string) cluster {
 	c := cluster{}
 	c.fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
-		WebhookPath: util.WebhookCrds,
+		WebhookPath: util.WebhookPath,
 		DepCRDPaths: []string{
 			util.JobsetCrds,
 			util.TrainingOperatorCrds,

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -19,7 +19,6 @@ package multikueue
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -55,6 +54,7 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 const (
@@ -91,11 +91,12 @@ func TestMultiKueue(t *testing.T) {
 func createCluster(setupFnc framework.ManagerSetup, apiFeatureGates ...string) cluster {
 	c := cluster{}
 	c.fwk = &framework.Framework{
-		CRDPath:     filepath.Join("..", "..", "..", "config", "components", "crd", "bases"),
-		WebhookPath: filepath.Join("..", "..", "..", "config", "components", "webhook"),
-		DepCRDPaths: []string{filepath.Join("..", "..", "..", "dep-crds", "jobset-operator"),
-			filepath.Join("..", "..", "..", "dep-crds", "training-operator-crds"),
-			filepath.Join("..", "..", "..", "dep-crds", "mpi-operator"),
+		CRDPath:     util.BaseCrd,
+		WebhookPath: util.WebhookCrds,
+		DepCRDPaths: []string{
+			util.JobsetCrds,
+			util.TrainingOperatorCrds,
+			util.MpiOperatorCrds,
 		},
 		APIServerFeatureGates: apiFeatureGates,
 	}

--- a/test/integration/scheduler/fairsharing/suite_test.go
+++ b/test/integration/scheduler/fairsharing/suite_test.go
@@ -56,8 +56,7 @@ func TestScheduler(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
-		WebhookPath: util.WebhookCrds,
+		WebhookPath: util.WebhookPath,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/scheduler/fairsharing/suite_test.go
+++ b/test/integration/scheduler/fairsharing/suite_test.go
@@ -18,7 +18,6 @@ package fairsharing
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -37,6 +36,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
@@ -56,8 +56,8 @@ func TestScheduler(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     filepath.Join("..", "..", "..", "..", "config", "components", "crd", "bases"),
-		WebhookPath: filepath.Join("..", "..", "..", "..", "config", "components", "webhook"),
+		CRDPath:     util.BaseCrd,
+		WebhookPath: util.WebhookCrds,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/scheduler/podsready/suite_test.go
+++ b/test/integration/scheduler/podsready/suite_test.go
@@ -18,7 +18,6 @@ package podsready
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -37,6 +36,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
@@ -56,8 +56,8 @@ func TestSchedulerWithWaitForPodsReady(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     filepath.Join("..", "..", "..", "..", "config", "components", "crd", "bases"),
-		WebhookPath: filepath.Join("..", "..", "..", "..", "config", "components", "webhook"),
+		CRDPath:     util.BaseCrd,
+		WebhookPath: util.WebhookCrds,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/scheduler/podsready/suite_test.go
+++ b/test/integration/scheduler/podsready/suite_test.go
@@ -56,8 +56,7 @@ func TestSchedulerWithWaitForPodsReady(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
-		WebhookPath: util.WebhookCrds,
+		WebhookPath: util.WebhookPath,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/scheduler/suite_test.go
+++ b/test/integration/scheduler/suite_test.go
@@ -59,8 +59,7 @@ func TestScheduler(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
-		WebhookPath: util.WebhookCrds,
+		WebhookPath: util.WebhookPath,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/scheduler/suite_test.go
+++ b/test/integration/scheduler/suite_test.go
@@ -18,7 +18,6 @@ package scheduler
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -40,6 +39,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
@@ -59,8 +59,8 @@ func TestScheduler(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     filepath.Join("..", "..", "..", "config", "components", "crd", "bases"),
-		WebhookPath: filepath.Join("..", "..", "..", "config", "components", "webhook"),
+		CRDPath:     util.BaseCrd,
+		WebhookPath: util.WebhookCrds,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/tas/suite_test.go
+++ b/test/integration/tas/suite_test.go
@@ -57,8 +57,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
-		WebhookPath: util.WebhookCrds,
+		WebhookPath: util.WebhookPath,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/tas/suite_test.go
+++ b/test/integration/tas/suite_test.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -38,15 +37,14 @@ import (
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
-	cfg         *rest.Config
-	k8sClient   client.Client
-	ctx         context.Context
-	fwk         *framework.Framework
-	crdPath     = filepath.Join("..", "..", "..", "config", "components", "crd", "bases")
-	webhookPath = filepath.Join("..", "..", "..", "config", "components", "webhook")
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
 )
 
 func TestAPIs(t *testing.T) {
@@ -58,7 +56,10 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = ginkgo.BeforeSuite(func() {
-	fwk = &framework.Framework{CRDPath: crdPath, WebhookPath: webhookPath}
+	fwk = &framework.Framework{
+		CRDPath:     util.BaseCrd,
+		WebhookPath: util.WebhookCrds,
+	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)
 })

--- a/test/integration/webhook/core/suite_test.go
+++ b/test/integration/webhook/core/suite_test.go
@@ -52,8 +52,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     util.BaseCrd,
-		WebhookPath: util.WebhookCrds,
+		WebhookPath: util.WebhookPath,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/webhook/core/suite_test.go
+++ b/test/integration/webhook/core/suite_test.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -34,6 +33,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
@@ -52,8 +52,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     filepath.Join("..", "..", "..", "..", "config", "components", "crd", "bases"),
-		WebhookPath: filepath.Join("..", "..", "..", "..", "config", "components", "webhook"),
+		CRDPath:     util.BaseCrd,
+		WebhookPath: util.WebhookCrds,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/webhook/jobs/suite_test.go
+++ b/test/integration/webhook/jobs/suite_test.go
@@ -18,7 +18,6 @@ package jobs
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	"github.com/onsi/ginkgo/v2"
@@ -34,6 +33,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
 )
 
 var (
@@ -42,12 +42,6 @@ var (
 	serverVersionFetcher *kubeversion.ServerVersionFetcher
 	ctx                  context.Context
 	fwk                  *framework.Framework
-	crdPath              = filepath.Join("..", "..", "..", "..", "config", "components", "crd", "bases")
-	webhookPath          = filepath.Join("..", "..", "..", "..", "config", "components", "webhook")
-	mpiCrdPath           = filepath.Join("..", "..", "..", "..", "dep-crds", "mpi-operator")
-	jobsetCrdPath        = filepath.Join("..", "..", "..", "..", "dep-crds", "jobset-operator")
-	rayCrdPath           = filepath.Join("..", "..", "..", "..", "dep-crds", "ray-operator-crds")
-	kubeflowCrdPath      = filepath.Join("..", "..", "..", "..", "dep-crds", "training-operator-crds")
 )
 
 func TestAPIs(t *testing.T) {
@@ -60,9 +54,14 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath:     crdPath,
-		DepCRDPaths: []string{jobsetCrdPath, mpiCrdPath, rayCrdPath, kubeflowCrdPath},
-		WebhookPath: webhookPath,
+		CRDPath: util.BaseCrd,
+		DepCRDPaths: []string{
+			util.MpiOperatorCrds,
+			util.JobsetCrds,
+			util.RayOperatorCrds,
+			util.TrainingOperatorCrds,
+		},
+		WebhookPath: util.WebhookCrds,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/integration/webhook/jobs/suite_test.go
+++ b/test/integration/webhook/jobs/suite_test.go
@@ -54,14 +54,13 @@ func TestAPIs(t *testing.T) {
 
 var _ = ginkgo.BeforeSuite(func() {
 	fwk = &framework.Framework{
-		CRDPath: util.BaseCrd,
 		DepCRDPaths: []string{
 			util.MpiOperatorCrds,
 			util.JobsetCrds,
 			util.RayOperatorCrds,
 			util.TrainingOperatorCrds,
 		},
-		WebhookPath: util.WebhookCrds,
+		WebhookPath: util.WebhookPath,
 	}
 	cfg = fwk.Init()
 	ctx, k8sClient = fwk.SetupClient(cfg)

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"path/filepath"
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -45,4 +46,15 @@ var (
 	IgnoreConditionTimestampsAndObservedGeneration = cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "ObservedGeneration")
 	IgnoreConditionMessage                         = cmpopts.IgnoreFields(metav1.Condition{}, "Message")
 	IgnoreObjectMetaResourceVersion                = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")
+)
+
+var (
+	BaseCrd              = filepath.Join(GetProjectBaseDir(), "config", "components", "crd", "bases")
+	AutoscalerCrds       = filepath.Join(GetProjectBaseDir(), "dep-crds", "cluster-autoscaler")
+	JobsetCrds           = filepath.Join(GetProjectBaseDir(), "dep-crds", "jobset-operator")
+	TrainingOperatorCrds = filepath.Join(GetProjectBaseDir(), "dep-crds", "training-operator-crds")
+	MpiOperatorCrds      = filepath.Join(GetProjectBaseDir(), "dep-crds", "mpi-operator")
+	AppWrapperCrds       = filepath.Join(GetProjectBaseDir(), "dep-crds", "appwrapper-crds")
+	RayOperatorCrds      = filepath.Join(GetProjectBaseDir(), "dep-crds", "ray-operator-crds")
+	WebhookCrds          = filepath.Join(GetProjectBaseDir(), "config", "components", "webhook")
 )

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -49,12 +49,11 @@ var (
 )
 
 var (
-	BaseCrd              = filepath.Join(GetProjectBaseDir(), "config", "components", "crd", "bases")
 	AutoscalerCrds       = filepath.Join(GetProjectBaseDir(), "dep-crds", "cluster-autoscaler")
 	JobsetCrds           = filepath.Join(GetProjectBaseDir(), "dep-crds", "jobset-operator")
 	TrainingOperatorCrds = filepath.Join(GetProjectBaseDir(), "dep-crds", "training-operator-crds")
 	MpiOperatorCrds      = filepath.Join(GetProjectBaseDir(), "dep-crds", "mpi-operator")
 	AppWrapperCrds       = filepath.Join(GetProjectBaseDir(), "dep-crds", "appwrapper-crds")
 	RayOperatorCrds      = filepath.Join(GetProjectBaseDir(), "dep-crds", "ray-operator-crds")
-	WebhookCrds          = filepath.Join(GetProjectBaseDir(), "config", "components", "webhook")
+	WebhookPath          = filepath.Join(GetProjectBaseDir(), "config", "components", "webhook")
 )

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -912,4 +914,8 @@ func NewNamespaceSelectorExcluding(unmanaged ...string) labels.Selector {
 	sel, err := metav1.LabelSelectorAsSelector(ls)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	return sel
+}
+
+func GetProjectBaseDir() string {
+	return filepath.Dir(os.Getenv("PROJECT_DIR"))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Indirect path to CRDs are confusing and varies depending on the folder structure.
Make them follow one direct path based on the PROJECT_DIR.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates #4040 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```