### PR TITLE
Remove comment for #3841

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -182,20 +182,12 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 	if mkAc == nil || mkAc.State == kueue.CheckStateRejected {
 		log.V(2).Info("Skip Workload", "isDeleted", isDeleted)
 		if isDeleted {
-			// Delete the workload from the cache considering the following cases:
-			// 1. the workload is not admitted by MultiKueue and so there are
+			// Delete the workload from the cache considering the following case:
+			//    The workload is not admitted by MultiKueue and so there are
 			//    no workloads on worker clusters created, we can safely drop it
 			//    from the cache.
 			//    TODO(#3840): Ideally, we would not add it to the cache in the
 			//    first place.
-			// 2. the AdmissionCheck was rejected then, ideally, we trigger
-			//    deletion of the workloads on the worker clusters, rather than
-			//    deleting from cache. However,
-			//    - this is not a regression as the case was not handled anyway.
-			//    - we have the MultiKueue GarbageCollector which will take care
-			//      of the orphaned workloads with a delay.
-			//    TODO(#3841): Ideally, we would delete workloads on the worker
-			//    clusters synchronously.
 			w.deletedWlCache.Delete(req.String())
 		}
 		return reconcile.Result{}, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As agreed in [discussion](https://github.com/kubernetes-sigs/kueue/issues/3841#issuecomment-2614967796) - "remove the TODO as the place may actually be confusing".

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #3841 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```