### PR TITLE
Enable rendering of fair sharing for cluster queues

### DIFF
--- a/cmd/experimental/kueue-viz/frontend/src/ClusterQueueDetail.js
+++ b/cmd/experimental/kueue-viz/frontend/src/ClusterQueueDetail.js
@@ -62,6 +62,32 @@ const ClusterQueueDetail = () => {
         </Grid>
       </Grid>
 
+        {/* Fair Sharing Section */}
+      <Typography variant="h5" gutterBottom style={{ marginTop: '20px' }}>
+        Fair Sharing
+      </Typography>
+      {clusterQueue.fairSharing && clusterQueue.fairSharing.length > 0 ? (
+        <TableContainer component={Paper} style={{ marginTop: '20px' }}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Weight</TableCell>
+                <TableCell>Share</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {clusterQueue.fairSharing.map((item, index) => (
+                <TableRow key={index}>
+                  <TableCell>{item.weight}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      ) : (
+        <Typography>No fair sharing details available</Typography>
+      )}
+
       {/* Flavor Fungibility Section */}
       <Typography variant="h5" gutterBottom style={{ marginTop: '20px' }}>
         Flavor Fungibility


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```