### PR TITLE
refactor: use increment instead of `+= 1`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,6 +31,7 @@ linters-settings:
     rules:
       - name: context-as-argument
       - name: empty-lines
+      - name: increment-decrement
       - name: var-naming
       - name: redundant-import-alias
 

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -913,7 +913,7 @@ func TestDominantResourceShare(t *testing.T) {
 
 				cache.AddOrUpdateWorkload(wl)
 				snapshot.AddWorkload(workload.NewInfo(wl))
-				i += 1
+				i++
 			}
 
 			drVal, drNameCache := dominantResourceShare(cache.hm.ClusterQueues["cq"], tc.flvResQ, 1)

--- a/pkg/cache/resource_node.go
+++ b/pkg/cache/resource_node.go
@@ -152,7 +152,7 @@ func (r ResourceNode) calculateLendable() map[corev1.ResourceName]int64 {
 }
 
 func updateClusterQueueResourceNode(cq *clusterQueue) {
-	cq.AllocatableResourceGeneration += 1
+	cq.AllocatableResourceGeneration++
 	cq.resourceNode.SubtreeQuota = make(resources.FlavorResourceQuantities, len(cq.resourceNode.Quotas))
 	for fr, quota := range cq.resourceNode.Quotas {
 		cq.resourceNode.SubtreeQuota[fr] = quota.Nominal

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -254,13 +254,13 @@ func (c *Controller) syncOwnedProvisionRequest(
 					remainingTime := c.remainingTimeToRetry(oldPr, attempt, prc)
 					if remainingTime <= 0 {
 						shouldCreatePr = true
-						attempt += 1
+						attempt++
 					} else if requeAfter == nil || remainingTime < *requeAfter {
 						requeAfter = &remainingTime
 					}
 				} else {
 					shouldCreatePr = true
-					attempt += 1
+					attempt++
 				}
 			}
 		} else {

--- a/pkg/queue/cluster_queue.go
+++ b/pkg/queue/cluster_queue.go
@@ -295,7 +295,7 @@ func (c *ClusterQueue) Pending() int {
 func (c *ClusterQueue) PendingActive() int {
 	result := c.heap.Len()
 	if c.inflight != nil {
-		result += 1
+		result++
 	}
 	return result
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -3784,7 +3784,7 @@ func TestResourcesToReserve(t *testing.T) {
 				admission := utiltesting.MakeAdmission("cq").Assignment(fr.Resource, fr.Flavor, quantity.String())
 				wl := utiltesting.MakeWorkload(fmt.Sprintf("workload-%d", i), "default-namespace").ReserveQuota(admission.Obj()).Obj()
 				cqCache.AddOrUpdateWorkload(wl)
-				i += 1
+				i++
 			}
 			snapshot, err := cqCache.Snapshot(ctx)
 			if err != nil {

--- a/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
@@ -163,7 +163,7 @@ var _ = ginkgo.Describe("AppWrapper controller", ginkgo.Ordered, ginkgo.Continue
 				Spec: *createdWorkload.Spec.DeepCopy(),
 			}
 			gomega.Expect(ctrl.SetControllerReference(createdAppWrapper, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
-			secondWl.Spec.PodSets[0].Count += 1
+			secondWl.Spec.PodSets[0].Count++
 			gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())
 			key := types.NamespacedName{Name: secondWl.Name, Namespace: secondWl.Namespace}
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -171,7 +171,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			Spec: *createdWorkload.Spec.DeepCopy(),
 		}
 		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
-		secondWl.Spec.PodSets[0].Count += 1
+		secondWl.Spec.PodSets[0].Count++
 		gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, secondWl, false)
 		// check the original wl is still there

--- a/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
@@ -178,7 +178,7 @@ var _ = ginkgo.Describe("JobSet controller", ginkgo.Ordered, ginkgo.ContinueOnFa
 				Spec: *createdWorkload.Spec.DeepCopy(),
 			}
 			gomega.Expect(ctrl.SetControllerReference(createdJobSet, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
-			secondWl.Spec.PodSets[0].Count += 1
+			secondWl.Spec.PodSets[0].Count++
 			gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())
 			key := types.NamespacedName{Name: secondWl.Name, Namespace: secondWl.Namespace}
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/singlecluster/controller/jobs/kubeflow/kubeflowjob.go
+++ b/test/integration/singlecluster/controller/jobs/kubeflow/kubeflowjob.go
@@ -104,7 +104,7 @@ func ShouldReconcileJob(ctx context.Context, k8sClient client.Client, job, creat
 		Spec: *createdWorkload.Spec.DeepCopy(),
 	}
 	gomega.Expect(ctrl.SetControllerReference(createdJob.Object(), secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
-	secondWl.Spec.PodSets[0].Count += 1
+	secondWl.Spec.PodSets[0].Count++
 
 	gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())
 	gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
@@ -138,7 +138,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			Spec: *createdWorkload.Spec.DeepCopy(),
 		}
 		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
-		secondWl.Spec.PodSets[0].Count += 1
+		secondWl.Spec.PodSets[0].Count++
 
 		gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
@@ -129,7 +129,7 @@ var _ = ginkgo.Describe("RayCluster controller", ginkgo.Ordered, ginkgo.Continue
 		}
 
 		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
-		secondWl.Spec.PodSets[0].Count += 1
+		secondWl.Spec.PodSets[0].Count++
 
 		gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -143,7 +143,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			Spec: *createdWorkload.Spec.DeepCopy(),
 		}
 		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
-		secondWl.Spec.PodSets[0].Count += 1
+		secondWl.Spec.PodSets[0].Count++
 
 		gomega.Expect(k8sClient.Create(ctx, secondWl)).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The PR slightly simplify code by refactoring to `++` instead of ` += 1`. Enables `revive.increment-decrement` to prevent such issues in the future.

#### Special notes for your reviewer:

https://go.dev/ref/spec#IncDec_statements

#### Does this PR introduce a user-facing change?

```release-note
NONE
```