### PR TITLE
Allow to change mutable PodSpec fields.

### DIFF
--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -165,7 +165,7 @@ func validateUpdateForMaxExecTime(oldJob, newJob GenericJob) field.ErrorList {
 
 // ValidateImmutablePodGroupPodSpec function is used for serving workloads to ensure no changes are allowed
 // to the PodSpec except fields that required for role-hash generation.
-func ValidateImmutablePodGroupPodSpec(newPodSpec corev1.PodSpec, oldPodSpec corev1.PodSpec, fieldPath *field.Path) field.ErrorList {
+func ValidateImmutablePodGroupPodSpec(newPodSpec *corev1.PodSpec, oldPodSpec *corev1.PodSpec, fieldPath *field.Path) field.ErrorList {
 	return validateImmutablePodGroupPodSpecPath(utilpod.SpecShape(newPodSpec), utilpod.SpecShape(oldPodSpec), fieldPath)
 }
 

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+)
+
+var (
+	testPath = field.NewPath("spec")
+)
+
+func TestValidateImmutablePodSpec(t *testing.T) {
+	testCases := map[string]struct {
+		newPodSpec corev1.PodSpec
+		oldPodSpec corev1.PodSpec
+		wantErr    error
+	}{
+		"add container": {
+			oldPodSpec: corev1.PodSpec{},
+			newPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("containers").String(),
+				},
+			}.ToAggregate(),
+		},
+		"remove container": {
+			oldPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
+			newPodSpec: corev1.PodSpec{},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("containers").String(),
+				},
+			}.ToAggregate(),
+		},
+		"change image on container": {
+			oldPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "other"}}},
+			newPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
+		},
+		"change request on container": {
+			oldPodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("100m"),
+							},
+						},
+					},
+				},
+			},
+			newPodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("200m"),
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("containers").Index(0).Child("resources", "requests").String(),
+				},
+			}.ToAggregate(),
+		},
+		"add init container": {
+			oldPodSpec: corev1.PodSpec{},
+			newPodSpec: corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("initContainers").String(),
+				},
+			}.ToAggregate(),
+		},
+		"remove init container": {
+			oldPodSpec: corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
+			newPodSpec: corev1.PodSpec{},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("initContainers").String(),
+				},
+			}.ToAggregate(),
+		},
+		"change request on init container": {
+			oldPodSpec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("100m"),
+							},
+						},
+					},
+				},
+			},
+			newPodSpec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("initContainers").Index(0).Child("resources", "requests").String(),
+				},
+			}.ToAggregate(),
+		},
+		"change nodeTemplate": {
+			oldPodSpec: corev1.PodSpec{},
+			newPodSpec: corev1.PodSpec{
+				NodeSelector: map[string]string{"key": "value"},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("nodeSelector").String(),
+				},
+			}.ToAggregate(),
+		},
+		"add toleration": {
+			oldPodSpec: corev1.PodSpec{},
+			newPodSpec: corev1.PodSpec{
+				Tolerations: []corev1.Toleration{{
+					Key:      "example.com/gpu",
+					Value:    "present",
+					Operator: corev1.TolerationOpEqual,
+				}},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("tolerations").String(),
+				},
+			}.ToAggregate(),
+		},
+		"change toleration": {
+			oldPodSpec: corev1.PodSpec{
+				Tolerations: []corev1.Toleration{{
+					Key:      "example.com/gpu",
+					Value:    "present",
+					Operator: corev1.TolerationOpEqual,
+				}},
+			},
+			newPodSpec: corev1.PodSpec{
+				Tolerations: []corev1.Toleration{{
+					Key:      "example.com/gpu",
+					Value:    "new",
+					Operator: corev1.TolerationOpEqual,
+				}},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("tolerations").String(),
+				},
+			}.ToAggregate(),
+		},
+		"delete toleration": {
+			oldPodSpec: corev1.PodSpec{
+				Tolerations: []corev1.Toleration{{
+					Key:      "example.com/gpu",
+					Value:    "present",
+					Operator: corev1.TolerationOpEqual,
+				}},
+			},
+			newPodSpec: corev1.PodSpec{},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("tolerations").String(),
+				},
+			}.ToAggregate(),
+		},
+		"change runtimeClassName": {
+			oldPodSpec: corev1.PodSpec{
+				RuntimeClassName: ptr.To("new"),
+			},
+			newPodSpec: corev1.PodSpec{},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("runtimeClassName").String(),
+				},
+			}.ToAggregate(),
+		},
+		"change priority": {
+			oldPodSpec: corev1.PodSpec{},
+			newPodSpec: corev1.PodSpec{
+				Priority: ptr.To[int32](1),
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("priority").String(),
+				},
+			}.ToAggregate(),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			gotErr := ValidateImmutablePodGroupPodSpec(tc.newPodSpec, tc.oldPodSpec, testPath)
+			if diff := cmp.Diff(tc.wantErr, gotErr.ToAggregate(), cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -33,13 +33,13 @@ var (
 
 func TestValidateImmutablePodSpec(t *testing.T) {
 	testCases := map[string]struct {
-		newPodSpec corev1.PodSpec
-		oldPodSpec corev1.PodSpec
+		newPodSpec *corev1.PodSpec
+		oldPodSpec *corev1.PodSpec
 		wantErr    field.ErrorList
 	}{
 		"add container": {
-			oldPodSpec: corev1.PodSpec{},
-			newPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
+			oldPodSpec: &corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -48,8 +48,8 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"remove container": {
-			oldPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
-			newPodSpec: corev1.PodSpec{},
+			oldPodSpec: &corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
+			newPodSpec: &corev1.PodSpec{},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -58,11 +58,11 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"change image on container": {
-			oldPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "other"}}},
-			newPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
+			oldPodSpec: &corev1.PodSpec{Containers: []corev1.Container{{Image: "other"}}},
+			newPodSpec: &corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
 		},
 		"change request on container": {
-			oldPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
 						Resources: corev1.ResourceRequirements{
@@ -73,7 +73,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					},
 				},
 			},
-			newPodSpec: corev1.PodSpec{
+			newPodSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
 						Resources: corev1.ResourceRequirements{
@@ -92,8 +92,8 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"add init container": {
-			oldPodSpec: corev1.PodSpec{},
-			newPodSpec: corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
+			oldPodSpec: &corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -102,8 +102,8 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"remove init container": {
-			oldPodSpec: corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
-			newPodSpec: corev1.PodSpec{},
+			oldPodSpec: &corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
+			newPodSpec: &corev1.PodSpec{},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -112,7 +112,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"change request on init container": {
-			oldPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					{
 						Resources: corev1.ResourceRequirements{
@@ -123,7 +123,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					},
 				},
 			},
-			newPodSpec: corev1.PodSpec{
+			newPodSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					{
 						Resources: corev1.ResourceRequirements{
@@ -140,8 +140,8 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"change nodeTemplate": {
-			oldPodSpec: corev1.PodSpec{},
-			newPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{
 				NodeSelector: map[string]string{"key": "value"},
 			},
 			wantErr: field.ErrorList{
@@ -152,8 +152,8 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"add toleration": {
-			oldPodSpec: corev1.PodSpec{},
-			newPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{
 				Tolerations: []corev1.Toleration{{
 					Key:      "example.com/gpu",
 					Value:    "present",
@@ -168,14 +168,14 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"change toleration": {
-			oldPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{
 				Tolerations: []corev1.Toleration{{
 					Key:      "example.com/gpu",
 					Value:    "present",
 					Operator: corev1.TolerationOpEqual,
 				}},
 			},
-			newPodSpec: corev1.PodSpec{
+			newPodSpec: &corev1.PodSpec{
 				Tolerations: []corev1.Toleration{{
 					Key:      "example.com/gpu",
 					Value:    "new",
@@ -190,14 +190,14 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"delete toleration": {
-			oldPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{
 				Tolerations: []corev1.Toleration{{
 					Key:      "example.com/gpu",
 					Value:    "present",
 					Operator: corev1.TolerationOpEqual,
 				}},
 			},
-			newPodSpec: corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -206,10 +206,10 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"change runtimeClassName": {
-			oldPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{
 				RuntimeClassName: ptr.To("new"),
 			},
-			newPodSpec: corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -218,8 +218,8 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"change priority": {
-			oldPodSpec: corev1.PodSpec{},
-			newPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{
 				Priority: ptr.To[int32](1),
 			},
 			wantErr: field.ErrorList{

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -35,7 +35,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 	testCases := map[string]struct {
 		newPodSpec corev1.PodSpec
 		oldPodSpec corev1.PodSpec
-		wantErr    error
+		wantErr    field.ErrorList
 	}{
 		"add container": {
 			oldPodSpec: corev1.PodSpec{},
@@ -45,7 +45,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("containers").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"remove container": {
 			oldPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
@@ -55,7 +55,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("containers").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"change image on container": {
 			oldPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "other"}}},
@@ -89,7 +89,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("containers").Index(0).Child("resources", "requests").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"add init container": {
 			oldPodSpec: corev1.PodSpec{},
@@ -99,7 +99,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("initContainers").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"remove init container": {
 			oldPodSpec: corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
@@ -109,7 +109,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("initContainers").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"change request on init container": {
 			oldPodSpec: corev1.PodSpec{
@@ -137,7 +137,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("initContainers").Index(0).Child("resources", "requests").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"change nodeTemplate": {
 			oldPodSpec: corev1.PodSpec{},
@@ -149,7 +149,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("nodeSelector").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"add toleration": {
 			oldPodSpec: corev1.PodSpec{},
@@ -165,7 +165,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("tolerations").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"change toleration": {
 			oldPodSpec: corev1.PodSpec{
@@ -187,7 +187,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("tolerations").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"delete toleration": {
 			oldPodSpec: corev1.PodSpec{
@@ -203,7 +203,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("tolerations").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"change runtimeClassName": {
 			oldPodSpec: corev1.PodSpec{
@@ -215,7 +215,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("runtimeClassName").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"change priority": {
 			oldPodSpec: corev1.PodSpec{},
@@ -227,14 +227,14 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("priority").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			gotErr := ValidateImmutablePodGroupPodSpec(tc.newPodSpec, tc.oldPodSpec, testPath)
-			if diff := cmp.Diff(tc.wantErr, gotErr.ToAggregate(), cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
@@ -160,7 +160,7 @@ func validateImmutablePodTemplateSpec(newPodTemplateSpec *corev1.PodTemplateSpec
 	if newPodTemplateSpec == nil || oldPodTemplateSpec == nil {
 		allErrors = append(allErrors, apivalidation.ValidateImmutableField(newPodTemplateSpec, oldPodTemplateSpec, fieldPath)...)
 	} else {
-		allErrors = append(allErrors, jobframework.ValidateImmutablePodGroupPodSpec(newPodTemplateSpec.Spec, oldPodTemplateSpec.Spec, fieldPath.Child("spec"))...)
+		allErrors = append(allErrors, jobframework.ValidateImmutablePodGroupPodSpec(&newPodTemplateSpec.Spec, &oldPodTemplateSpec.Spec, fieldPath.Child("spec"))...)
 	}
 	return allErrors
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
@@ -160,7 +160,7 @@ func validateImmutablePodTemplateSpec(newPodTemplateSpec *corev1.PodTemplateSpec
 	if newPodTemplateSpec == nil || oldPodTemplateSpec == nil {
 		allErrors = append(allErrors, apivalidation.ValidateImmutableField(newPodTemplateSpec, oldPodTemplateSpec, fieldPath)...)
 	} else {
-		allErrors = append(allErrors, jobframework.ValidateImmutablePodSpec(&newPodTemplateSpec.Spec, &oldPodTemplateSpec.Spec, fieldPath.Child("spec"))...)
+		allErrors = append(allErrors, jobframework.ValidateImmutablePodGroupPodSpec(newPodTemplateSpec.Spec, oldPodTemplateSpec.Spec, fieldPath.Child("spec"))...)
 	}
 	return allErrors
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -409,11 +409,11 @@ func TestValidateUpdate(t *testing.T) {
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
-					Field: leaderTemplatePath.Child("spec").String(),
+					Field: leaderTemplatePath.Child("spec", "containers").Index(0).Child("resources", "requests").String(),
 				},
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
-					Field: workerTemplatePath.Child("spec").String(),
+					Field: workerTemplatePath.Child("spec", "containers").Index(0).Child("resources", "requests").String(),
 				},
 			}.ToAggregate(),
 		},
@@ -511,11 +511,11 @@ func TestValidateUpdate(t *testing.T) {
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
-					Field: leaderTemplatePath.Child("spec").String(),
+					Field: leaderTemplatePath.Child("spec", "initContainers").Index(0).Child("resources", "requests").String(),
 				},
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
-					Field: workerTemplatePath.Child("spec").String(),
+					Field: workerTemplatePath.Child("spec", "initContainers").Index(0).Child("resources", "requests").String(),
 				},
 			}.ToAggregate(),
 		},

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -554,7 +554,7 @@ func getRoleHash(p corev1.Pod) (string, error) {
 	if roleHash, ok := p.Annotations[RoleHashAnnotation]; ok {
 		return roleHash, nil
 	}
-	return utilpod.GenerateRoleHash(p.Spec)
+	return utilpod.GenerateRoleHash(&p.Spec)
 }
 
 // Load loads all pods in the group

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -554,7 +554,7 @@ func getRoleHash(p corev1.Pod) (string, error) {
 	if roleHash, ok := p.Annotations[RoleHashAnnotation]; ok {
 		return roleHash, nil
 	}
-	return utilpod.GenerateShape(p.Spec)
+	return utilpod.GenerateRoleHash(p.Spec)
 }
 
 // Load loads all pods in the group

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -147,9 +147,9 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Ob
 	)...)
 
 	if jobframework.IsManagedByKueue(newStatefulSet.Object()) {
-		allErrs = append(allErrs, jobframework.ValidateImmutablePodSpec(
-			&newStatefulSet.Spec.Template.Spec,
-			&oldStatefulSet.Spec.Template.Spec,
+		allErrs = append(allErrs, jobframework.ValidateImmutablePodGroupPodSpec(
+			newStatefulSet.Spec.Template.Spec,
+			oldStatefulSet.Spec.Template.Spec,
 			podSpecPath,
 		)...)
 

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -148,8 +148,8 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Ob
 
 	if jobframework.IsManagedByKueue(newStatefulSet.Object()) {
 		allErrs = append(allErrs, jobframework.ValidateImmutablePodGroupPodSpec(
-			newStatefulSet.Spec.Template.Spec,
-			oldStatefulSet.Spec.Template.Spec,
+			&newStatefulSet.Spec.Template.Spec,
+			&oldStatefulSet.Spec.Template.Spec,
 			podSpecPath,
 		)...)
 

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -548,7 +548,7 @@ func TestValidateUpdate(t *testing.T) {
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
-					Field: podSpecPath.String(),
+					Field: podSpecPath.Child("containers").Index(0).Child("resources", "requests").String(),
 				},
 			}.ToAggregate(),
 		},
@@ -602,7 +602,7 @@ func TestValidateUpdate(t *testing.T) {
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
-					Field: podSpecPath.String(),
+					Field: podSpecPath.Child("containers").Index(0).Child("resources", "requests").String(),
 				},
 			}.ToAggregate(),
 		},

--- a/pkg/util/pod/pod.go
+++ b/pkg/util/pod/pod.go
@@ -107,20 +107,9 @@ func readUIntFromStringBelowBound(value string, bound int) (*int, error) {
 	return ptr.To(int(uintValue)), nil
 }
 
-func GenerateShape(podSpec corev1.PodSpec) (string, error) {
+func GenerateRoleHash(podSpec corev1.PodSpec) (string, error) {
 	shape := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"initContainers":            containersShape(podSpec.InitContainers),
-			"containers":                containersShape(podSpec.Containers),
-			"nodeSelector":              podSpec.NodeSelector,
-			"affinity":                  podSpec.Affinity,
-			"tolerations":               podSpec.Tolerations,
-			"runtimeClassName":          podSpec.RuntimeClassName,
-			"priority":                  podSpec.Priority,
-			"topologySpreadConstraints": podSpec.TopologySpreadConstraints,
-			"overhead":                  podSpec.Overhead,
-			"resourceClaims":            podSpec.ResourceClaims,
-		},
+		"spec": SpecShape(podSpec),
 	}
 
 	shapeJSON, err := json.Marshal(shape)
@@ -132,7 +121,22 @@ func GenerateShape(podSpec corev1.PodSpec) (string, error) {
 	return fmt.Sprintf("%x", sha256.Sum256(shapeJSON))[:8], nil
 }
 
-func containersShape(containers []corev1.Container) (result []map[string]interface{}) {
+func SpecShape(podSpec corev1.PodSpec) (result map[string]interface{}) {
+	return map[string]interface{}{
+		"initContainers":            ContainersShape(podSpec.InitContainers),
+		"containers":                ContainersShape(podSpec.Containers),
+		"nodeSelector":              podSpec.NodeSelector,
+		"affinity":                  podSpec.Affinity,
+		"tolerations":               podSpec.Tolerations,
+		"runtimeClassName":          podSpec.RuntimeClassName,
+		"priority":                  podSpec.Priority,
+		"topologySpreadConstraints": podSpec.TopologySpreadConstraints,
+		"overhead":                  podSpec.Overhead,
+		"resourceClaims":            podSpec.ResourceClaims,
+	}
+}
+
+func ContainersShape(containers []corev1.Container) (result []map[string]interface{}) {
 	for _, c := range containers {
 		result = append(result, map[string]interface{}{
 			"resources": map[string]interface{}{

--- a/pkg/util/pod/pod.go
+++ b/pkg/util/pod/pod.go
@@ -107,7 +107,7 @@ func readUIntFromStringBelowBound(value string, bound int) (*int, error) {
 	return ptr.To(int(uintValue)), nil
 }
 
-func GenerateRoleHash(podSpec corev1.PodSpec) (string, error) {
+func GenerateRoleHash(podSpec *corev1.PodSpec) (string, error) {
 	shape := map[string]interface{}{
 		"spec": SpecShape(podSpec),
 	}
@@ -121,7 +121,7 @@ func GenerateRoleHash(podSpec corev1.PodSpec) (string, error) {
 	return fmt.Sprintf("%x", sha256.Sum256(shapeJSON))[:8], nil
 }
 
-func SpecShape(podSpec corev1.PodSpec) (result map[string]interface{}) {
+func SpecShape(podSpec *corev1.PodSpec) (result map[string]interface{}) {
 	return map[string]interface{}{
 		"initContainers":            ContainersShape(podSpec.InitContainers),
 		"containers":                ContainersShape(podSpec.Containers),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix a bug that allowed changes to PodSpec fields, other than the image field, resulting in the StatefulSet getting stuck on Pods with schedulingGates.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Follow up for https://github.com/kubernetes-sigs/kueue/pull/3952#issuecomment-2618888311.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug that allowed unsupported changes to some PodSpec fields which were resulting in the StatefulSet getting stuck on Pods with schedulingGates. 

The validation blocks mutating the following Pod spec fields: `nodeSelector`, `affinity`, `tolerations`, `runtimeClassName`, `priority`, `topologySpreadConstraints`, `overhead`, `resourceClaims`, plus container (and init container) fields: `ports` and `resources.requests`. 

Mutating other fields, such as container image, command or args, remains allowed and supported.
```