### PR TITLE
Automated cherry pick of #4089: TAS fix the topology create event logging

### DIFF
--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -155,7 +155,7 @@ func (h *topologyHandler) Create(ctx context.Context, e event.CreateEvent, q wor
 	}
 
 	log := ctrl.LoggerFrom(ctx).WithValues("topology", klog.KObj(topology))
-	log.V(2).Info("Topology delete event")
+	log.V(2).Info("Topology create event")
 
 	flavors := &kueue.ResourceFlavorList{}
 	if err := h.client.List(ctx, flavors, client.MatchingFields{indexer.ResourceFlavorTopologyNameKey: topology.Name}); err != nil {


### PR DESCRIPTION
Cherry pick of #4089 on release-0.10.

#4089: TAS fix the topology create event logging

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```