### PR TITLE
Increase the timeout for integration tests

### DIFF
--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -27,7 +27,7 @@ import (
 const (
 	TinyTimeout  = 10 * time.Millisecond
 	ShortTimeout = time.Second
-	Timeout      = 5 * time.Second
+	Timeout      = 10 * time.Second
 	// LongTimeout is meant for E2E tests when waiting for complex operations
 	// such as running pods to completion.
 	LongTimeout = 45 * time.Second


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Related to #4033

#### Special notes for your reviewer:

To minimize the chance the tests fail occasionally due to the machines being under load. 
I suppose the slow propagation of events could be the reason for the flake https://github.com/kubernetes-sigs/kueue/issues/4033.

I seem to remember in the past we also observed flakes which we attributed to slow processing of events, so having a bit extra time seems reasonable. 

We use [10s timeout](https://github.com/kubernetes-sigs/jobset/blob/ec942521899668e414d1775da8a2acffbd1b1d17/test/integration/controller/jobset_controller_test.go#L45
) for JobSet integration tests. 

The core k8s integration tests mostly use [5s](https://github.com/kubernetes/kubernetes/blob/3bc8f01c74e80cb85e6f3813db1b410adba22bfe/test/integration/job/job_test.go#L4104), [10s](https://github.com/kubernetes/kubernetes/blob/3bc8f01c74e80cb85e6f3813db1b410adba22bfe/test/integration/job/job_test.go#L85), [30s](https://github.com/kubernetes/kubernetes/blob/3bc8f01c74e80cb85e6f3813db1b410adba22bfe/test/integration/job/job_test.go#L4544), [1min](https://github.com/kubernetes/kubernetes/blob/master/test/integration/job/job_test.go#L209) depending on a place :). 

I would like to cherry-pick this PR as a cleanup to 0.9 and 0.10.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```