### PR TITLE
Fix development version installation links

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -161,7 +161,7 @@ To install the latest development version of Kueue in your cluster, run the
 following command:
 
 ```shell
-kubectl apply --server-side -k "github.com/kubernetes-sigs/kueue/config/default?ref=main"
+kubectl apply --server-side -k "github.com/kubernetes-sigs/tree/main/kueue/config/default?ref=main"
 ```
 
 The controller runs in the `kueue-system` namespace.
@@ -171,7 +171,7 @@ The controller runs in the `kueue-system` namespace.
 To uninstall Kueue, run the following command:
 
 ```shell
-kubectl delete -k "github.com/kubernetes-sigs/kueue/config/default?ref=main"
+kubectl delete -k "github.com/kubernetes-sigs/kueue/tree/main/config/default?ref=main"
 ```
 
 ## Build and install from source

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -161,7 +161,7 @@ To install the latest development version of Kueue in your cluster, run the
 following command:
 
 ```shell
-kubectl apply --server-side -k "github.com/kubernetes-sigs/tree/main/kueue/config/default?ref=main"
+kubectl apply --server-side -k "github.com/kubernetes-sigs/kueue/tree/main/config/default"
 ```
 
 The controller runs in the `kueue-system` namespace.
@@ -171,7 +171,7 @@ The controller runs in the `kueue-system` namespace.
 To uninstall Kueue, run the following command:
 
 ```shell
-kubectl delete -k "github.com/kubernetes-sigs/kueue/tree/main/config/default?ref=main"
+kubectl delete -k "github.com/kubernetes-sigs/kueue/tree/main/config/default"
 ```
 
 ## Build and install from source


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
The link shown in the [development version installation instructions](https://kueue.sigs.k8s.io/docs/installation/#install-the-latest-development-version) in the docs leads to a 404; this PR fixes it

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
None