### PR TITLE
Add e2e tests for manageJobsWithoutQueueName

### DIFF
--- a/test/e2e/customconfigs/skipjobswithoutqueuename_test.go
+++ b/test/e2e/customconfigs/skipjobswithoutqueuename_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queuename
+
+import (
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	"sigs.k8s.io/kueue/pkg/util/testing"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeAll(func() {
+		configurationUpdate := time.Now()
+		config := defaultKueueCfg.DeepCopy()
+		config.ManageJobsWithoutQueueName = true
+		util.ApplyKueueConfiguration(ctx, k8sClient, config)
+		util.RestartKueueController(ctx, k8sClient)
+		ginkgo.GinkgoLogr.Info("Kueue configuration updated", "took", time.Since(configurationUpdate))
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "e2e-",
+			},
+		}
+		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+	})
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+	ginkgo.When("creating a Job when manageJobsWithoutQueueName=true", func() {
+		var (
+			defaultRf    *kueue.ResourceFlavor
+			localQueue   *kueue.LocalQueue
+			clusterQueue *kueue.ClusterQueue
+		)
+		ginkgo.BeforeEach(func() {
+			defaultRf = testing.MakeResourceFlavor("default").Obj()
+			gomega.Expect(k8sClient.Create(ctx, defaultRf)).Should(gomega.Succeed())
+			clusterQueue = testing.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas(defaultRf.Name).
+						Resource(corev1.ResourceCPU, "2").
+						Resource(corev1.ResourceMemory, "2G").Obj()).Obj()
+			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).Should(gomega.Succeed())
+			localQueue = testing.MakeLocalQueue("main", ns.Name).ClusterQueue("cluster-queue").Obj()
+			gomega.Expect(k8sClient.Create(ctx, localQueue)).Should(gomega.Succeed())
+		})
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			// Force remove workloads to be sure that cluster queue can be removed.
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, clusterQueue, true, util.LongTimeout)
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, defaultRf, true, util.LongTimeout)
+		})
+
+		ginkgo.It("should suspend it", func() {
+			var testJob *batchv1.Job
+			ginkgo.By("creating an unsuspended job without a queue name", func() {
+				testJob = testingjob.MakeJob("test-job", ns.Name).Suspend(false).Obj()
+				gomega.Expect(k8sClient.Create(ctx, testJob)).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying that the job gets suspended", func() {
+				jobLookupKey := types.NamespacedName{Name: testJob.Name, Namespace: ns.Name}
+				createdJob := &batchv1.Job{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, jobLookupKey, createdJob)).Should(gomega.Succeed())
+					g.Expect(ptr.Deref(createdJob.Spec.Suspend, false)).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should unsuspend it", func() {
+			var testJob *batchv1.Job
+			var jobLookupKey types.NamespacedName
+			createdJob := &batchv1.Job{}
+			ginkgo.By("creating a job without queue name", func() {
+				testJob = testingjob.MakeJob("test-job", ns.Name).Suspend(false).Obj()
+				gomega.Expect(k8sClient.Create(ctx, testJob)).Should(gomega.Succeed())
+			})
+			ginkgo.By("setting the queue-name label", func() {
+				jobLookupKey = types.NamespacedName{Name: testJob.Name, Namespace: ns.Name}
+				gomega.Eventually(func() error {
+					if err := k8sClient.Get(ctx, jobLookupKey, createdJob); err != nil {
+						return err
+					}
+					createdJob.Labels["kueue.x-k8s.io/queue-name"] = "main"
+					return k8sClient.Update(ctx, createdJob)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+			ginkgo.By("verifying that the job is unsuspended", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, jobLookupKey, createdJob)).Should(gomega.Succeed())
+					g.Expect(ptr.Deref(createdJob.Spec.Suspend, false)).To(gomega.BeFalse())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+			ginkgo.By("verifying that the job has been admitted", func() {
+				wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(testJob.Name, testJob.UID), Namespace: ns.Name}
+				createdWorkload := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+					g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+})

--- a/test/e2e/customconfigs/suite_test.go
+++ b/test/e2e/customconfigs/suite_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queuename
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kueue/apis/config/v1beta1"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var (
+	k8sClient       client.WithWatch
+	ctx             context.Context
+	defaultKueueCfg *v1beta1.Configuration
+)
+
+func TestAPIs(t *testing.T) {
+	suiteName := "End To End Custom Configs handling Suite"
+	if ver, found := os.LookupEnv("E2E_KIND_VERSION"); found {
+		suiteName = fmt.Sprintf("%s: %s", suiteName, ver)
+	}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t,
+		suiteName,
+	)
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	ctrl.SetLogger(util.NewTestingLogger(ginkgo.GinkgoWriter, -3))
+
+	k8sClient, _ = util.CreateClientUsingCluster("")
+	ctx = context.Background()
+
+	waitForAvailableStart := time.Now()
+	util.WaitForKueueAvailability(ctx, k8sClient)
+	ginkgo.GinkgoLogr.Info("Kueue operator is available in the cluster", "waitingTime", time.Since(waitForAvailableStart))
+	defaultKueueCfg = util.GetKueueConfiguration(ctx, k8sClient)
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	util.ApplyKueueConfiguration(ctx, k8sClient, defaultKueueCfg)
+	util.RestartKueueController(ctx, k8sClient)
+	ginkgo.GinkgoLogr.Info("Default Kueue configuration restored")
+})

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -46,6 +47,7 @@ var (
 	IgnoreConditionTimestampsAndObservedGeneration = cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "ObservedGeneration")
 	IgnoreConditionMessage                         = cmpopts.IgnoreFields(metav1.Condition{}, "Message")
 	IgnoreObjectMetaResourceVersion                = cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")
+	IgnoreDeploymentConditionTimestampsAndMessage  = cmpopts.IgnoreFields(appsv1.DeploymentCondition{}, "LastTransitionTime", "LastUpdateTime", "Message")
 )
 
 var (

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -961,3 +961,13 @@ func KExecute(ctx context.Context, cfg *rest.Config, client *rest.RESTClient, ns
 func GetProjectBaseDir() string {
 	return filepath.Dir(os.Getenv("PROJECT_DIR"))
 }
+
+func FindDeploymentCondition(deployment *appsv1.Deployment, deploymentType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
+	for i := range deployment.Status.Conditions {
+		c := deployment.Status.Conditions[i]
+		if c.Type == deploymentType {
+			return &c
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR adds e2e tests for the `manageJobsWithoutQueueName: true` configuration.  This is one of the tasks required to close #3767 

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

The test suite sets `manageJobsWithoutQueueName: true` during the setup phase of the description block (just before running the test specs). It then initiates a rollout of the controller deployment to ensure that the new configuration is picked up by the pods. To confirm that the deployment rollout has started, the setup function waits for the Deployment to have the condition `DeploymentCondition=false`.

To ensure that this condition is met, the rollout strategy is set to `Recreate`, which guarantees that the pods are terminated before being recreated, resulting in the condition not being satisfied (see [DeploymentConditionTypes](https://pkg.go.dev/k8s.io/api@v0.32.1/apps/v1#DeploymentConditionType) docs).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```