### PR TITLE
Update workload AdmissionChecks status on AdmissionRequest creation error.

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -306,12 +306,9 @@ func (c *Controller) syncOwnedProvisionRequest(
 			}
 
 			if err := c.client.Create(ctx, req); err != nil {
-				msg := fmt.Sprintf("Error creating ProvisioningRequest %q: %v", requestName, err)
-				ac.Message = api.TruncateConditionMessage(msg)
-				workload.SetAdmissionCheckState(&wl.Status.AdmissionChecks, *ac, c.clock)
-
-				c.record.Eventf(wl, corev1.EventTypeWarning, "FailedCreate", api.TruncateEventMessage(msg))
-				return nil, err
+				msg := api.TruncateEventMessage(fmt.Sprintf("Error creating ProvisioningRequest %q: %v", requestName, err))
+				c.record.Eventf(wl, corev1.EventTypeWarning, "FailedCreate", msg)
+				return nil, c.handleError(ctx, wl, ac, msg, err)
 			}
 			c.record.Eventf(wl, corev1.EventTypeNormal, "ProvisioningRequestCreated", "Created ProvisioningRequest: %q", req.Name)
 			activeOrLastPRForChecks[checkName] = req
@@ -341,6 +338,20 @@ func (c *Controller) remainingTimeToRetry(pr *autoscaling.ProvisioningRequest, f
 	}
 	timeElapsedSinceLastFailure := time.Since(cond.LastTransitionTime.Time)
 	return backoffDuration - timeElapsedSinceLastFailure
+}
+
+func (c *Controller) handleError(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, msg string, err error) error {
+	ac.Message = msg
+	wlPatch := workload.BaseSSAWorkload(wl)
+	workload.SetAdmissionCheckState(&wlPatch.Status.AdmissionChecks, *ac, c.clock)
+
+	patchErr := c.client.Status().Patch(
+		ctx, wlPatch, client.Apply,
+		client.FieldOwner(kueue.ProvisioningRequestControllerName),
+		client.ForceOwnership,
+	)
+
+	return errors.Join(err, patchErr)
 }
 
 func (c *Controller) syncProvisionRequestsPodTemplates(ctx context.Context, wl *kueue.Workload, prName string, prc *kueue.ProvisioningRequestConfig) error {

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -1151,6 +1151,20 @@ func TestReconcile(t *testing.T) {
 			checks:             []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
 			configs:            []kueue.ProvisioningRequestConfig{*utiltesting.MakeProvisioningRequestConfig("config1").Obj()},
 			wantReconcileError: errInvalidProvisioningRequest,
+			wantWorkloads: map[string]*kueue.Workload{
+				"wl": utiltesting.MakeWorkload("wl", TestNamespace).
+					Annotations(map[string]string{
+						"provreq.kueue.x-k8s.io/ValidUntilSeconds": "0",
+						"invalid-provreq-prefix/Foo1":              "Bar1",
+						"another-invalid-provreq-prefix/Foo2":      "Bar2"}).
+					AdmissionChecks(kueue.AdmissionCheckState{
+						Name:    "check1",
+						State:   kueue.CheckStatePending,
+						Message: "Error creating ProvisioningRequest \"wl-check1-1\": invalid ProvisioningRequest error",
+					}).
+					ReserveQuota(utiltesting.MakeAdmission("q1").Obj()).
+					Obj(),
+			},
 			wantEvents: []utiltesting.EventRecord{
 				{
 					Key:       client.ObjectKeyFromObject(baseWorkload),
@@ -1167,16 +1181,16 @@ func TestReconcile(t *testing.T) {
 			for _, gate := range tc.enableGates {
 				features.SetFeatureGateDuringTest(t, gate, true)
 			}
-			builder, ctx := getClientBuilder()
-			builder = builder.WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 
+			interceptorFuncs := interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}
 			if tc.wantReconcileError != nil {
-				builder = builder.WithInterceptorFuncs(
-					interceptor.Funcs{
-						Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-							return tc.wantReconcileError
-						}})
+				interceptorFuncs.Create = func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					return tc.wantReconcileError
+				}
 			}
+
+			builder, ctx := getClientBuilder()
+			builder = builder.WithInterceptorFuncs(interceptorFuncs)
 			builder = builder.WithObjects(tc.workload)
 			builder = builder.WithStatusSubresource(tc.workload)
 			builder = builder.WithLists(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Update workload AdmissionChecks status on AdmissionRequest creation error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3025

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix the bug that prevented Kueue from updating the AdmissionCheck state in the Workload status on a ProvisioningRequest creation error.
```