### PR TITLE
Automated cherry pick of #4114: Update workload AdmissionChecks status on AdmissionRequest creation error.

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -306,12 +306,9 @@ func (c *Controller) syncOwnedProvisionRequest(
 			}
 
 			if err := c.client.Create(ctx, req); err != nil {
-				msg := fmt.Sprintf("Error creating ProvisioningRequest %q: %v", requestName, err)
-				ac.Message = api.TruncateConditionMessage(msg)
-				workload.SetAdmissionCheckState(&wl.Status.AdmissionChecks, *ac)
-
-				c.record.Eventf(wl, corev1.EventTypeWarning, "FailedCreate", api.TruncateEventMessage(msg))
-				return nil, err
+				msg := api.TruncateEventMessage(fmt.Sprintf("Error creating ProvisioningRequest %q: %v", requestName, err))
+				c.record.Eventf(wl, corev1.EventTypeWarning, "FailedCreate", msg)
+				return nil, c.handleError(ctx, wl, ac, msg, err)
 			}
 			c.record.Eventf(wl, corev1.EventTypeNormal, "ProvisioningRequestCreated", "Created ProvisioningRequest: %q", req.Name)
 			activeOrLastPRForChecks[checkName] = req
@@ -341,6 +338,20 @@ func (c *Controller) remainingTimeToRetry(pr *autoscaling.ProvisioningRequest, f
 	}
 	timeElapsedSinceLastFailure := time.Since(cond.LastTransitionTime.Time)
 	return backoffDuration - timeElapsedSinceLastFailure
+}
+
+func (c *Controller) handleError(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, msg string, err error) error {
+	ac.Message = msg
+	wlPatch := workload.BaseSSAWorkload(wl)
+	workload.SetAdmissionCheckState(&wlPatch.Status.AdmissionChecks, *ac)
+
+	patchErr := c.client.Status().Patch(
+		ctx, wlPatch, client.Apply,
+		client.FieldOwner(kueue.ProvisioningRequestControllerName),
+		client.ForceOwnership,
+	)
+
+	return errors.Join(err, patchErr)
 }
 
 func (c *Controller) syncProvisionRequestsPodTemplates(ctx context.Context, wl *kueue.Workload, prName string, prc *kueue.ProvisioningRequestConfig) error {

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -1146,6 +1146,20 @@ func TestReconcile(t *testing.T) {
 			checks:             []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
 			configs:            []kueue.ProvisioningRequestConfig{*utiltesting.MakeProvisioningRequestConfig("config1").Obj()},
 			wantReconcileError: errInvalidProvisioningRequest,
+			wantWorkloads: map[string]*kueue.Workload{
+				"wl": utiltesting.MakeWorkload("wl", TestNamespace).
+					Annotations(map[string]string{
+						"provreq.kueue.x-k8s.io/ValidUntilSeconds": "0",
+						"invalid-provreq-prefix/Foo1":              "Bar1",
+						"another-invalid-provreq-prefix/Foo2":      "Bar2"}).
+					AdmissionChecks(kueue.AdmissionCheckState{
+						Name:    "check1",
+						State:   kueue.CheckStatePending,
+						Message: "Error creating ProvisioningRequest \"wl-check1-1\": invalid ProvisioningRequest error",
+					}).
+					ReserveQuota(utiltesting.MakeAdmission("q1").Obj()).
+					Obj(),
+			},
 			wantEvents: []utiltesting.EventRecord{
 				{
 					Key:       client.ObjectKeyFromObject(baseWorkload),
@@ -1162,16 +1176,16 @@ func TestReconcile(t *testing.T) {
 			for _, gate := range tc.enableGates {
 				features.SetFeatureGateDuringTest(t, gate, true)
 			}
-			builder, ctx := getClientBuilder()
-			builder = builder.WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 
+			interceptorFuncs := interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}
 			if tc.wantReconcileError != nil {
-				builder = builder.WithInterceptorFuncs(
-					interceptor.Funcs{
-						Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-							return tc.wantReconcileError
-						}})
+				interceptorFuncs.Create = func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					return tc.wantReconcileError
+				}
 			}
+
+			builder, ctx := getClientBuilder()
+			builder = builder.WithInterceptorFuncs(interceptorFuncs)
 			builder = builder.WithObjects(tc.workload)
 			builder = builder.WithStatusSubresource(tc.workload)
 			builder = builder.WithLists(


### PR DESCRIPTION
Cherry pick of #4114 on release-0.10.

#4114: Update workload AdmissionChecks status on AdmissionRequest creation error.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix the bug that prevented Kueue from updating the AdmissionCheck state in the Workload status on a ProvisioningRequest creation error.
```