### PR TITLE
chore: enable nolintlint to detect unused //nolint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,6 +21,11 @@ linters-settings:
       - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
       - dot # Dot section: contains all dot imports.
     skip-generated: true # Skip generated files.
+  nolintlint:
+    # Require nolint directives to mention the specific linter being suppressed.
+    require-specific: true
+    # Require an explanation after each nolint directive.
+    require-explanation: true
   perfsprint:
     int-conversion: false
     errorf: true
@@ -48,6 +53,7 @@ linters:
     - govet
     - loggercheck
     - misspell
+    - nolintlint
     - perfsprint
     - revive
     - unconvert

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -379,7 +379,7 @@ func TestUpdateConfig(t *testing.T) {
 
 			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New[string]("batch/job"))
 			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters)
-			//nolint:fatcontext
+			//nolint:fatcontext // false positive
 			reconciler.rootContext = ctx
 
 			if len(tc.remoteClients) > 0 {

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -522,7 +522,7 @@ func (c *Controller) syncCheckStates(
 	updated := false
 	for check, prc := range checkConfig {
 		checkState := *checksMap[check]
-		//nolint:gocritic
+		//nolint:gocritic // ignore ifElseChain
 		if prc == nil {
 			// the check is not active
 			updated = updateCheckState(&checkState, kueue.CheckStatePending) || updated


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR enables [`nolintlint`](https://golangci-lint.run/usage/linters/#nolintlint) linter in golangci-lint. This simple linter controls `//nolint` directives and suggests removing unused `//nolint` comments.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```