### PR TITLE
statefulset should have same namespace selector as pod and deployment

### DIFF
--- a/charts/kueue/templates/webhook/webhook.yaml
+++ b/charts/kueue/templates/webhook/webhook.yaml
@@ -274,8 +274,19 @@ webhooks:
         name: '{{ include "kueue.fullname" . }}-webhook-service'
         namespace: '{{ .Release.Namespace }}'
         path: /mutate-apps-v1-statefulset
+    {{- if has "statefulset" $integrationsConfig.frameworks }}
     failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     name: mstatefulset.kb.io
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
     rules:
       - apiGroups:
           - apps
@@ -630,8 +641,19 @@ webhooks:
         name: '{{ include "kueue.fullname" . }}-webhook-service'
         namespace: '{{ .Release.Namespace }}'
         path: /validate-apps-v1-statefulset
+    {{- if has "statefulset" $integrationsConfig.frameworks }}
     failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
     name: vstatefulset.kb.io
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
     rules:
       - apiGroups:
           - apps

--- a/config/components/webhook/kustomization.yaml
+++ b/config/components/webhook/kustomization.yaml
@@ -28,6 +28,14 @@ patches:
           values:
             - kube-system
             - kueue-system
+    - name: mstatefulset.kb.io
+      namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - kueue-system
 - patch: |-
     apiVersion: admissionregistration.k8s.io/v1
     kind: ValidatingWebhookConfiguration
@@ -50,3 +58,11 @@ patches:
           values:
           - kube-system
           - kueue-system
+    - name: vstatefulset.kb.io
+      namespaceSelector:
+        matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - kueue-system

--- a/hack/update-helm.sh
+++ b/hack/update-helm.sh
@@ -103,6 +103,8 @@ search_webhook_pod_mutate="        path: /mutate--v1-pod"
 search_webhook_pod_validate="        path: /validate--v1-pod"
 search_webhook_deployment_mutate="        path: /mutate-apps-v1-deployment"
 search_webhook_deployment_validate="        path: /validate-apps-v1-deployment"
+search_webhook_statefulset_mutate="        path: /mutate-apps-v1-statefulset"
+search_webhook_statefulset_validate="        path: /validate-apps-v1-statefulset"
 search_mutate_webhook_annotations='  name: '\''{{ include "kueue.fullname" . }}-mutating-webhook-configuration'\'''
 search_validate_webhook_annotations='  name: '\''{{ include "kueue.fullname" . }}-validating-webhook-configuration'\'''
 add_webhook_line=$(
@@ -187,6 +189,40 @@ add_webhook_deployment_validate=$(
     failurePolicy: Ignore
     {{- end }}
     name: vdeployment.kb.io
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+EOF
+)
+add_webhook_statefulset_mutate=$(
+  cat <<'EOF'
+    {{- if has "statefulset" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
+    name: mstatefulset.kb.io
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+EOF
+)
+add_webhook_statefulset_validate=$(
+  cat <<'EOF'
+    {{- if has "statefulset" $integrationsConfig.frameworks }}
+    failurePolicy: Fail
+    {{- else }}
+    failurePolicy: Ignore
+    {{- end }}
+    name: vstatefulset.kb.io
     namespaceSelector:
       matchExpressions:
         - key: kubernetes.io/metadata.name
@@ -305,6 +341,14 @@ for output_file in "${new_files[@]}"; do
     if [[ $line == "$search_webhook_deployment_validate" ]]; then
       count=$((count+2))
       echo "$add_webhook_deployment_validate" >>"$output_file"
+    fi
+    if [[ $line == "$search_webhook_statefulset_mutate" ]]; then
+      count=$((count+2))
+      echo "$add_webhook_statefulset_mutate" >>"$output_file"
+    fi
+    if [[ $line == "$search_webhook_statefulset_validate" ]]; then
+      count=$((count+2))
+      echo "$add_webhook_statefulset_validate" >>"$output_file"
     fi
   done < "$input_file"
   rm "$input_file"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Pod and Deployments are guarded by a namespace selector. I think statefulset should have a similar pattern.

For kind deployments, I'm not sure anyone would have statefulsets in the namespace kueue-system or kube-system. But this is a template that people would follow and I think this namespace selector is useful.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Disable the StatefulSet webhook in the kube-system and kueue-system namespaces by default. 
This aligns the default StatefulSet webhook configuration with the Pod and Deployment configurations.
```