### PR TITLE
Automated cherry pick of #4095: Increase log level for Kubernetes components.

### DIFF
--- a/hack/kind-cluster.yaml
+++ b/hack/kind-cluster.yaml
@@ -8,29 +8,29 @@ nodes:
     apiVersion: kubeadm.k8s.io/v1beta3
     scheduler:
       extraArgs:
-        v: "2"
+        v: "3"
     controllerManager:
       extraArgs:
-        v: "2"
+        v: "3"
     apiServer:
       extraArgs:
         enable-aggregator-routing: "true"
-        v: "2"
+        v: "3"
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "3"
 - role: worker
   labels:
     instance-type: on-demand
-  kubeadmConfigPatches:
-  - |
-    kind: InitConfiguration
-    nodeRegistration:
-      kubeletExtraArgs:
-        v: "2"
 - role: worker
   labels:
     instance-type: spot
-  kubeadmConfigPatches:
+
+kubeadmConfigPatches:
   - |
-    kind: InitConfiguration
+    kind: JoinConfiguration
     nodeRegistration:
       kubeletExtraArgs:
-        v: "2"
+        v: "3"

--- a/hack/multikueue/manager-cluster.kind.yaml
+++ b/hack/multikueue/manager-cluster.kind.yaml
@@ -8,11 +8,16 @@ nodes:
     apiVersion: kubeadm.k8s.io/v1beta3
     scheduler:
       extraArgs:
-        v: "2"
+        v: "3"
     controllerManager:
       extraArgs:
-        v: "2"
+        v: "3"
     apiServer:
       extraArgs:
         enable-aggregator-routing: "true"
-        v: "2"
+        v: "3"
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "3"

--- a/hack/multikueue/worker-cluster.kind.yaml
+++ b/hack/multikueue/worker-cluster.kind.yaml
@@ -8,11 +8,16 @@ nodes:
     apiVersion: kubeadm.k8s.io/v1beta3
     scheduler:
       extraArgs:
-        v: "2"
+        v: "3"
     controllerManager:
       extraArgs:
-        v: "2"
+        v: "3"
     apiServer:
       extraArgs:
         enable-aggregator-routing: "true"
-        v: "2"
+        v: "3"
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        v: "3"


### PR DESCRIPTION
Cherry pick of #4095 on release-0.9.

#4095: Increase log level for Kubernetes components.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```