### PR TITLE
TAS: Fix JobSet validation.

### DIFF
--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -122,7 +122,7 @@ func (w *JobSetWebhook) validateTopologyRequest(jobSet *JobSet) field.ErrorList 
 	var allErrs field.ErrorList
 	for i := range jobSet.Spec.ReplicatedJobs {
 		replicaMetaPath := replicatedJobsPath.Index(i).Child("template", "metadata")
-		allErrs = append(allErrs, jobframework.ValidateTASPodSetRequest(replicaMetaPath, &jobSet.Spec.ReplicatedJobs[i].Template.ObjectMeta)...)
+		allErrs = append(allErrs, jobframework.ValidateTASPodSetRequest(replicaMetaPath, &jobSet.Spec.ReplicatedJobs[i].Template.Spec.Template.ObjectMeta)...)
 	}
 	return allErrs
 }

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -73,12 +73,12 @@ func TestValidateCreate(t *testing.T) {
 			name: "valid topology request",
 			job: testingutil.MakeJobSet("job", "default").ReplicatedJobs(testingutil.ReplicatedJobRequirements{
 				Name: "launcher",
-				Annotations: map[string]string{
+				PodAnnotations: map[string]string{
 					kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 				},
 			}, testingutil.ReplicatedJobRequirements{
 				Name: "worker",
-				Annotations: map[string]string{
+				PodAnnotations: map[string]string{
 					kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 				},
 			}).Obj(),
@@ -87,12 +87,12 @@ func TestValidateCreate(t *testing.T) {
 			name: "invalid topology request",
 			job: testingutil.MakeJobSet("job", "default").ReplicatedJobs(testingutil.ReplicatedJobRequirements{
 				Name: "launcher",
-				Annotations: map[string]string{
+				PodAnnotations: map[string]string{
 					kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 				},
 			}, testingutil.ReplicatedJobRequirements{
 				Name: "worker",
-				Annotations: map[string]string{
+				PodAnnotations: map[string]string{
 					kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 					kueuealpha.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
 				},
@@ -124,12 +124,12 @@ func TestValidateUpdate(t *testing.T) {
 		{
 			name: "set valid topology request",
 			oldJob: testingutil.MakeJobSet("job", "default").ReplicatedJobs(testingutil.ReplicatedJobRequirements{
-				Name:        "worker",
-				Annotations: map[string]string{},
+				Name:           "worker",
+				PodAnnotations: map[string]string{},
 			}).Obj(),
 			newJob: testingutil.MakeJobSet("job", "default").ReplicatedJobs(testingutil.ReplicatedJobRequirements{
 				Name: "worker",
-				Annotations: map[string]string{
+				PodAnnotations: map[string]string{
 					kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 				},
 			}).Obj(),
@@ -137,12 +137,12 @@ func TestValidateUpdate(t *testing.T) {
 		{
 			name: "attempt to set invalid topology request",
 			oldJob: testingutil.MakeJobSet("job", "default").ReplicatedJobs(testingutil.ReplicatedJobRequirements{
-				Name:        "worker",
-				Annotations: map[string]string{},
+				Name:           "worker",
+				PodAnnotations: map[string]string{},
 			}).Obj(),
 			newJob: testingutil.MakeJobSet("job", "default").ReplicatedJobs(testingutil.ReplicatedJobRequirements{
 				Name: "worker",
-				Annotations: map[string]string{
+				PodAnnotations: map[string]string{
 					kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 					kueuealpha.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixed a bug that doesn't allow to validate JobSet when both kueue.x-k8s.io/podset-required-topology and kueue.x-k8s.io/podset-preferred-topology annotations are set.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4122

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fixed a bug that allows to create a JobSet with both kueue.x-k8s.io/podset-required-topology and kueue.x-k8s.io/podset-preferred-topology annotations set on the PodTemplate.
```