### PR TITLE
Automated cherry pick of #3952: [StatefulSet] Disallow changes to PodSpec fields other than the image field
#4081: Allow to change mutable PodSpec fields.

### DIFF
--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -24,6 +24,7 @@ import (
 	kfmpi "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -143,4 +144,29 @@ func validateUpdateForMaxExecTime(oldJob, newJob GenericJob) field.ErrorList {
 		return apivalidation.ValidateImmutableField(newJob.Object().GetLabels()[constants.MaxExecTimeSecondsLabel], oldJob.Object().GetLabels()[constants.MaxExecTimeSecondsLabel], maxExecTimeLabelPath)
 	}
 	return nil
+}
+
+// ValidateImmutablePodSpec function is used for serving workloads to ensure no changes are allowed
+// to the PodSpec except for the image field in containers.
+func ValidateImmutablePodSpec(newPodSpec *corev1.PodSpec, oldPodSpec *corev1.PodSpec, fieldPath *field.Path) field.ErrorList {
+	// handle updateable fields by munging those fields prior to deep equal comparison.
+	mungedPodSpec := newPodSpec.DeepCopy()
+
+	// munge spec.containers[*].image
+	newContainers := make([]corev1.Container, 0, len(newPodSpec.Containers))
+	for i, container := range mungedPodSpec.Containers {
+		container.Image = oldPodSpec.Containers[i].Image
+		newContainers = append(newContainers, container)
+	}
+	mungedPodSpec.Containers = newContainers
+
+	// munge spec.initContainers[*].image
+	newInitContainers := make([]corev1.Container, 0, len(newPodSpec.InitContainers))
+	for ix, container := range mungedPodSpec.InitContainers {
+		container.Image = oldPodSpec.InitContainers[ix].Image
+		newInitContainers = append(newInitContainers, container)
+	}
+	mungedPodSpec.InitContainers = newInitContainers
+
+	return apivalidation.ValidateImmutableField(mungedPodSpec, oldPodSpec, fieldPath)
 }

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -33,6 +33,8 @@ import (
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 )
 
 var (
@@ -146,27 +148,41 @@ func validateUpdateForMaxExecTime(oldJob, newJob GenericJob) field.ErrorList {
 	return nil
 }
 
-// ValidateImmutablePodSpec function is used for serving workloads to ensure no changes are allowed
-// to the PodSpec except for the image field in containers.
-func ValidateImmutablePodSpec(newPodSpec *corev1.PodSpec, oldPodSpec *corev1.PodSpec, fieldPath *field.Path) field.ErrorList {
-	// handle updateable fields by munging those fields prior to deep equal comparison.
-	mungedPodSpec := newPodSpec.DeepCopy()
+// ValidateImmutablePodGroupPodSpec function is used for serving workloads to ensure no changes are allowed
+// to the PodSpec except fields that required for role-hash generation.
+func ValidateImmutablePodGroupPodSpec(newPodSpec corev1.PodSpec, oldPodSpec corev1.PodSpec, fieldPath *field.Path) field.ErrorList {
+	return validateImmutablePodGroupPodSpecPath(utilpod.SpecShape(newPodSpec), utilpod.SpecShape(oldPodSpec), fieldPath)
+}
 
-	// munge spec.containers[*].image
-	newContainers := make([]corev1.Container, 0, len(newPodSpec.Containers))
-	for i, container := range mungedPodSpec.Containers {
-		container.Image = oldPodSpec.Containers[i].Image
-		newContainers = append(newContainers, container)
+func validateImmutablePodGroupPodSpecPath(newShape, oldShape map[string]interface{}, fieldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+
+	fields := sets.New[string]()
+	fields.Insert(utilmaps.Keys(newShape)...)
+	fields.Insert(utilmaps.Keys(oldShape)...)
+
+	for _, fieldName := range fields.UnsortedList() {
+		childFieldPath := fieldPath.Child(fieldName)
+
+		switch newValue := newShape[fieldName].(type) {
+		case []map[string]interface{}:
+			oldValue := oldShape[fieldName].([]map[string]interface{})
+
+			if len(newValue) != len(oldValue) {
+				allErrs = append(allErrs, apivalidation.ValidateImmutableField(newValue, oldValue, childFieldPath)...)
+				continue
+			}
+
+			for i := range newValue {
+				allErrs = append(allErrs, validateImmutablePodGroupPodSpecPath(newValue[i], oldValue[i], childFieldPath.Index(i))...)
+			}
+		case map[string]interface{}:
+			oldValue := oldShape[fieldName].(map[string]interface{})
+			allErrs = append(allErrs, validateImmutablePodGroupPodSpecPath(newValue, oldValue, childFieldPath)...)
+		default:
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newShape[fieldName], oldShape[fieldName], childFieldPath)...)
+		}
 	}
-	mungedPodSpec.Containers = newContainers
 
-	// munge spec.initContainers[*].image
-	newInitContainers := make([]corev1.Container, 0, len(newPodSpec.InitContainers))
-	for ix, container := range mungedPodSpec.InitContainers {
-		container.Image = oldPodSpec.InitContainers[ix].Image
-		newInitContainers = append(newInitContainers, container)
-	}
-	mungedPodSpec.InitContainers = newInitContainers
-
-	return apivalidation.ValidateImmutableField(mungedPodSpec, oldPodSpec, fieldPath)
+	return allErrs
 }

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -150,7 +150,7 @@ func validateUpdateForMaxExecTime(oldJob, newJob GenericJob) field.ErrorList {
 
 // ValidateImmutablePodGroupPodSpec function is used for serving workloads to ensure no changes are allowed
 // to the PodSpec except fields that required for role-hash generation.
-func ValidateImmutablePodGroupPodSpec(newPodSpec corev1.PodSpec, oldPodSpec corev1.PodSpec, fieldPath *field.Path) field.ErrorList {
+func ValidateImmutablePodGroupPodSpec(newPodSpec *corev1.PodSpec, oldPodSpec *corev1.PodSpec, fieldPath *field.Path) field.ErrorList {
 	return validateImmutablePodGroupPodSpecPath(utilpod.SpecShape(newPodSpec), utilpod.SpecShape(oldPodSpec), fieldPath)
 }
 

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+)
+
+var (
+	testPath = field.NewPath("spec")
+)
+
+func TestValidateImmutablePodSpec(t *testing.T) {
+	testCases := map[string]struct {
+		newPodSpec corev1.PodSpec
+		oldPodSpec corev1.PodSpec
+		wantErr    error
+	}{
+		"add container": {
+			oldPodSpec: corev1.PodSpec{},
+			newPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("containers").String(),
+				},
+			}.ToAggregate(),
+		},
+		"remove container": {
+			oldPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
+			newPodSpec: corev1.PodSpec{},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("containers").String(),
+				},
+			}.ToAggregate(),
+		},
+		"change image on container": {
+			oldPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "other"}}},
+			newPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
+		},
+		"change request on container": {
+			oldPodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("100m"),
+							},
+						},
+					},
+				},
+			},
+			newPodSpec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("200m"),
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("containers").Index(0).Child("resources", "requests").String(),
+				},
+			}.ToAggregate(),
+		},
+		"add init container": {
+			oldPodSpec: corev1.PodSpec{},
+			newPodSpec: corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("initContainers").String(),
+				},
+			}.ToAggregate(),
+		},
+		"remove init container": {
+			oldPodSpec: corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
+			newPodSpec: corev1.PodSpec{},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("initContainers").String(),
+				},
+			}.ToAggregate(),
+		},
+		"change request on init container": {
+			oldPodSpec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("100m"),
+							},
+						},
+					},
+				},
+			},
+			newPodSpec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("initContainers").Index(0).Child("resources", "requests").String(),
+				},
+			}.ToAggregate(),
+		},
+		"change nodeTemplate": {
+			oldPodSpec: corev1.PodSpec{},
+			newPodSpec: corev1.PodSpec{
+				NodeSelector: map[string]string{"key": "value"},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("nodeSelector").String(),
+				},
+			}.ToAggregate(),
+		},
+		"add toleration": {
+			oldPodSpec: corev1.PodSpec{},
+			newPodSpec: corev1.PodSpec{
+				Tolerations: []corev1.Toleration{{
+					Key:      "example.com/gpu",
+					Value:    "present",
+					Operator: corev1.TolerationOpEqual,
+				}},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("tolerations").String(),
+				},
+			}.ToAggregate(),
+		},
+		"change toleration": {
+			oldPodSpec: corev1.PodSpec{
+				Tolerations: []corev1.Toleration{{
+					Key:      "example.com/gpu",
+					Value:    "present",
+					Operator: corev1.TolerationOpEqual,
+				}},
+			},
+			newPodSpec: corev1.PodSpec{
+				Tolerations: []corev1.Toleration{{
+					Key:      "example.com/gpu",
+					Value:    "new",
+					Operator: corev1.TolerationOpEqual,
+				}},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("tolerations").String(),
+				},
+			}.ToAggregate(),
+		},
+		"delete toleration": {
+			oldPodSpec: corev1.PodSpec{
+				Tolerations: []corev1.Toleration{{
+					Key:      "example.com/gpu",
+					Value:    "present",
+					Operator: corev1.TolerationOpEqual,
+				}},
+			},
+			newPodSpec: corev1.PodSpec{},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("tolerations").String(),
+				},
+			}.ToAggregate(),
+		},
+		"change runtimeClassName": {
+			oldPodSpec: corev1.PodSpec{
+				RuntimeClassName: ptr.To("new"),
+			},
+			newPodSpec: corev1.PodSpec{},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("runtimeClassName").String(),
+				},
+			}.ToAggregate(),
+		},
+		"change priority": {
+			oldPodSpec: corev1.PodSpec{},
+			newPodSpec: corev1.PodSpec{
+				Priority: ptr.To[int32](1),
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: testPath.Child("priority").String(),
+				},
+			}.ToAggregate(),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			gotErr := ValidateImmutablePodGroupPodSpec(tc.newPodSpec, tc.oldPodSpec, testPath)
+			if diff := cmp.Diff(tc.wantErr, gotErr.ToAggregate(), cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -33,13 +33,13 @@ var (
 
 func TestValidateImmutablePodSpec(t *testing.T) {
 	testCases := map[string]struct {
-		newPodSpec corev1.PodSpec
-		oldPodSpec corev1.PodSpec
+		newPodSpec *corev1.PodSpec
+		oldPodSpec *corev1.PodSpec
 		wantErr    field.ErrorList
 	}{
 		"add container": {
-			oldPodSpec: corev1.PodSpec{},
-			newPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
+			oldPodSpec: &corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -48,8 +48,8 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"remove container": {
-			oldPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
-			newPodSpec: corev1.PodSpec{},
+			oldPodSpec: &corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
+			newPodSpec: &corev1.PodSpec{},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -58,11 +58,11 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"change image on container": {
-			oldPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "other"}}},
-			newPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
+			oldPodSpec: &corev1.PodSpec{Containers: []corev1.Container{{Image: "other"}}},
+			newPodSpec: &corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
 		},
 		"change request on container": {
-			oldPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
 						Resources: corev1.ResourceRequirements{
@@ -73,7 +73,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					},
 				},
 			},
-			newPodSpec: corev1.PodSpec{
+			newPodSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
 						Resources: corev1.ResourceRequirements{
@@ -92,8 +92,8 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"add init container": {
-			oldPodSpec: corev1.PodSpec{},
-			newPodSpec: corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
+			oldPodSpec: &corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -102,8 +102,8 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"remove init container": {
-			oldPodSpec: corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
-			newPodSpec: corev1.PodSpec{},
+			oldPodSpec: &corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
+			newPodSpec: &corev1.PodSpec{},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -112,7 +112,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"change request on init container": {
-			oldPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					{
 						Resources: corev1.ResourceRequirements{
@@ -123,7 +123,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					},
 				},
 			},
-			newPodSpec: corev1.PodSpec{
+			newPodSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					{
 						Resources: corev1.ResourceRequirements{
@@ -140,8 +140,8 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"change nodeTemplate": {
-			oldPodSpec: corev1.PodSpec{},
-			newPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{
 				NodeSelector: map[string]string{"key": "value"},
 			},
 			wantErr: field.ErrorList{
@@ -152,8 +152,8 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"add toleration": {
-			oldPodSpec: corev1.PodSpec{},
-			newPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{
 				Tolerations: []corev1.Toleration{{
 					Key:      "example.com/gpu",
 					Value:    "present",
@@ -168,14 +168,14 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"change toleration": {
-			oldPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{
 				Tolerations: []corev1.Toleration{{
 					Key:      "example.com/gpu",
 					Value:    "present",
 					Operator: corev1.TolerationOpEqual,
 				}},
 			},
-			newPodSpec: corev1.PodSpec{
+			newPodSpec: &corev1.PodSpec{
 				Tolerations: []corev1.Toleration{{
 					Key:      "example.com/gpu",
 					Value:    "new",
@@ -190,14 +190,14 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"delete toleration": {
-			oldPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{
 				Tolerations: []corev1.Toleration{{
 					Key:      "example.com/gpu",
 					Value:    "present",
 					Operator: corev1.TolerationOpEqual,
 				}},
 			},
-			newPodSpec: corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -206,10 +206,10 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"change runtimeClassName": {
-			oldPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{
 				RuntimeClassName: ptr.To("new"),
 			},
-			newPodSpec: corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -218,8 +218,8 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 			},
 		},
 		"change priority": {
-			oldPodSpec: corev1.PodSpec{},
-			newPodSpec: corev1.PodSpec{
+			oldPodSpec: &corev1.PodSpec{},
+			newPodSpec: &corev1.PodSpec{
 				Priority: ptr.To[int32](1),
 			},
 			wantErr: field.ErrorList{

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -35,7 +35,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 	testCases := map[string]struct {
 		newPodSpec corev1.PodSpec
 		oldPodSpec corev1.PodSpec
-		wantErr    error
+		wantErr    field.ErrorList
 	}{
 		"add container": {
 			oldPodSpec: corev1.PodSpec{},
@@ -45,7 +45,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("containers").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"remove container": {
 			oldPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "busybox"}}},
@@ -55,7 +55,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("containers").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"change image on container": {
 			oldPodSpec: corev1.PodSpec{Containers: []corev1.Container{{Image: "other"}}},
@@ -89,7 +89,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("containers").Index(0).Child("resources", "requests").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"add init container": {
 			oldPodSpec: corev1.PodSpec{},
@@ -99,7 +99,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("initContainers").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"remove init container": {
 			oldPodSpec: corev1.PodSpec{InitContainers: []corev1.Container{{Image: "busybox"}}},
@@ -109,7 +109,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("initContainers").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"change request on init container": {
 			oldPodSpec: corev1.PodSpec{
@@ -137,7 +137,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("initContainers").Index(0).Child("resources", "requests").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"change nodeTemplate": {
 			oldPodSpec: corev1.PodSpec{},
@@ -149,7 +149,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("nodeSelector").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"add toleration": {
 			oldPodSpec: corev1.PodSpec{},
@@ -165,7 +165,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("tolerations").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"change toleration": {
 			oldPodSpec: corev1.PodSpec{
@@ -187,7 +187,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("tolerations").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"delete toleration": {
 			oldPodSpec: corev1.PodSpec{
@@ -203,7 +203,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("tolerations").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"change runtimeClassName": {
 			oldPodSpec: corev1.PodSpec{
@@ -215,7 +215,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("runtimeClassName").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 		"change priority": {
 			oldPodSpec: corev1.PodSpec{},
@@ -227,14 +227,14 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 					Type:  field.ErrorTypeInvalid,
 					Field: testPath.Child("priority").String(),
 				},
-			}.ToAggregate(),
+			},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			gotErr := ValidateImmutablePodGroupPodSpec(tc.newPodSpec, tc.oldPodSpec, testPath)
-			if diff := cmp.Diff(tc.wantErr, gotErr.ToAggregate(), cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -19,8 +19,6 @@ package pod
 import (
 	"cmp"
 	"context"
-	"crypto/sha256"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -563,29 +561,7 @@ func getRoleHash(p corev1.Pod) (string, error) {
 	if roleHash, ok := p.Annotations[RoleHashAnnotation]; ok {
 		return roleHash, nil
 	}
-
-	shape := map[string]interface{}{
-		"spec": map[string]interface{}{
-			"initContainers":            containersShape(p.Spec.InitContainers),
-			"containers":                containersShape(p.Spec.Containers),
-			"nodeSelector":              p.Spec.NodeSelector,
-			"affinity":                  p.Spec.Affinity,
-			"tolerations":               p.Spec.Tolerations,
-			"runtimeClassName":          p.Spec.RuntimeClassName,
-			"priority":                  p.Spec.Priority,
-			"topologySpreadConstraints": p.Spec.TopologySpreadConstraints,
-			"overhead":                  p.Spec.Overhead,
-			"resourceClaims":            p.Spec.ResourceClaims,
-		},
-	}
-
-	shapeJSON, err := json.Marshal(shape)
-	if err != nil {
-		return "", err
-	}
-
-	// Trim hash to 8 characters and return
-	return fmt.Sprintf("%x", sha256.Sum256(shapeJSON))[:8], nil
+	return utilpod.GenerateRoleHash(p.Spec)
 }
 
 // Load loads all pods in the group

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -561,7 +561,7 @@ func getRoleHash(p corev1.Pod) (string, error) {
 	if roleHash, ok := p.Annotations[RoleHashAnnotation]; ok {
 		return roleHash, nil
 	}
-	return utilpod.GenerateRoleHash(p.Spec)
+	return utilpod.GenerateRoleHash(&p.Spec)
 }
 
 // Load loads all pods in the group

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -119,19 +119,6 @@ func getPodOptions(integrationOpts map[string]any) (*configapi.PodIntegrationOpt
 
 var _ admission.CustomDefaulter = &PodWebhook{}
 
-func containersShape(containers []corev1.Container) (result []map[string]interface{}) {
-	for _, c := range containers {
-		result = append(result, map[string]interface{}{
-			"resources": map[string]interface{}{
-				"requests": c.Resources.Requests,
-			},
-			"ports": c.Ports,
-		})
-	}
-
-	return result
-}
-
 // addRoleHash calculates the role hash and adds it to the pod's annotations
 func (p *Pod) addRoleHash() error {
 	if p.pod.Annotations == nil {

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -155,9 +155,9 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Ob
 	)...)
 
 	if isManagedByKueue(newStatefulSet.Object()) {
-		allErrs = append(allErrs, jobframework.ValidateImmutablePodSpec(
-			&newStatefulSet.Spec.Template.Spec,
-			&oldStatefulSet.Spec.Template.Spec,
+		allErrs = append(allErrs, jobframework.ValidateImmutablePodGroupPodSpec(
+			newStatefulSet.Spec.Template.Spec,
+			oldStatefulSet.Spec.Template.Spec,
 			podSpecPath,
 		)...)
 

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -156,8 +156,8 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Ob
 
 	if isManagedByKueue(newStatefulSet.Object()) {
 		allErrs = append(allErrs, jobframework.ValidateImmutablePodGroupPodSpec(
-			newStatefulSet.Spec.Template.Spec,
-			oldStatefulSet.Spec.Template.Spec,
+			&newStatefulSet.Spec.Template.Spec,
+			&oldStatefulSet.Spec.Template.Spec,
 			podSpecPath,
 		)...)
 

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -494,7 +494,7 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
-		"change resources in init container": {
+		"attempt to change resources in init container": {
 			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
 				Queue("test-queue").
 				Template(corev1.PodTemplateSpec{

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -490,7 +490,7 @@ func TestValidateUpdate(t *testing.T) {
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
-					Field: podSpecPath.String(),
+					Field: podSpecPath.Child("containers").Index(0).Child("resources", "requests").String(),
 				},
 			}.ToAggregate(),
 		},
@@ -544,7 +544,7 @@ func TestValidateUpdate(t *testing.T) {
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
-					Field: podSpecPath.String(),
+					Field: podSpecPath.Child("containers").Index(0).Child("resources", "requests").String(),
 				},
 			}.ToAggregate(),
 		},

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -438,6 +439,114 @@ func TestValidateUpdate(t *testing.T) {
 			newObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
 				Replicas(4).
 				Obj(),
+		},
+		"change resources in container": {
+			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				Queue("test-queue").
+				Template(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:      "c",
+								Image:     "pause:0.1.1",
+								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
+							},
+						},
+						InitContainers: []corev1.Container{
+							{
+								Name:      "ic",
+								Image:     "pause:0.1.1",
+								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
+							},
+						},
+					},
+				}).
+				Obj(),
+			newObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				Queue("test-queue").
+				Template(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "c",
+								Image: "pause:0.1.1",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+						InitContainers: []corev1.Container{
+							{
+								Name:      "ic",
+								Image:     "pause:0.1.1",
+								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
+							},
+						},
+					},
+				}).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: podSpecPath.String(),
+				},
+			}.ToAggregate(),
+		},
+		"change resources in init container": {
+			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				Queue("test-queue").
+				Template(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:      "c",
+								Image:     "pause:0.1.1",
+								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
+							},
+						},
+						InitContainers: []corev1.Container{
+							{
+								Name:      "ic",
+								Image:     "pause:0.1.1",
+								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
+							},
+						},
+					},
+				}).
+				Obj(),
+			newObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				Queue("test-queue").
+				Template(corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "c",
+								Image: "pause:0.1.1",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+						InitContainers: []corev1.Container{
+							{
+								Name:      "ic",
+								Image:     "pause:0.1.1",
+								Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{}},
+							},
+						},
+					},
+				}).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: podSpecPath.String(),
+				},
+			}.ToAggregate(),
 		},
 	}
 

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -440,7 +440,7 @@ func TestValidateUpdate(t *testing.T) {
 				Replicas(4).
 				Obj(),
 		},
-		"change resources in container": {
+		"attempt to change resources in container": {
 			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
 				Queue("test-queue").
 				Template(corev1.PodTemplateSpec{

--- a/pkg/util/pod/pod.go
+++ b/pkg/util/pod/pod.go
@@ -107,7 +107,7 @@ func readUIntFromStringBelowBound(value string, bound int) (*int, error) {
 	return ptr.To(int(uintValue)), nil
 }
 
-func GenerateRoleHash(podSpec corev1.PodSpec) (string, error) {
+func GenerateRoleHash(podSpec *corev1.PodSpec) (string, error) {
 	shape := map[string]interface{}{
 		"spec": SpecShape(podSpec),
 	}
@@ -121,7 +121,7 @@ func GenerateRoleHash(podSpec corev1.PodSpec) (string, error) {
 	return fmt.Sprintf("%x", sha256.Sum256(shapeJSON))[:8], nil
 }
 
-func SpecShape(podSpec corev1.PodSpec) (result map[string]interface{}) {
+func SpecShape(podSpec *corev1.PodSpec) (result map[string]interface{}) {
 	return map[string]interface{}{
 		"initContainers":            ContainersShape(podSpec.InitContainers),
 		"containers":                ContainersShape(podSpec.Containers),

--- a/pkg/util/pod/pod.go
+++ b/pkg/util/pod/pod.go
@@ -17,6 +17,8 @@ limitations under the License.
 package pod
 
 import (
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -103,4 +105,45 @@ func readUIntFromStringBelowBound(value string, bound int) (*int, error) {
 		return nil, fmt.Errorf("%w: value should be less than %d", ErrValidation, bound)
 	}
 	return ptr.To(int(uintValue)), nil
+}
+
+func GenerateRoleHash(podSpec corev1.PodSpec) (string, error) {
+	shape := map[string]interface{}{
+		"spec": SpecShape(podSpec),
+	}
+
+	shapeJSON, err := json.Marshal(shape)
+	if err != nil {
+		return "", err
+	}
+
+	// Trim hash to 8 characters and return
+	return fmt.Sprintf("%x", sha256.Sum256(shapeJSON))[:8], nil
+}
+
+func SpecShape(podSpec corev1.PodSpec) (result map[string]interface{}) {
+	return map[string]interface{}{
+		"initContainers":            ContainersShape(podSpec.InitContainers),
+		"containers":                ContainersShape(podSpec.Containers),
+		"nodeSelector":              podSpec.NodeSelector,
+		"affinity":                  podSpec.Affinity,
+		"tolerations":               podSpec.Tolerations,
+		"runtimeClassName":          podSpec.RuntimeClassName,
+		"priority":                  podSpec.Priority,
+		"topologySpreadConstraints": podSpec.TopologySpreadConstraints,
+		"overhead":                  podSpec.Overhead,
+		"resourceClaims":            podSpec.ResourceClaims,
+	}
+}
+
+func ContainersShape(containers []corev1.Container) (result []map[string]interface{}) {
+	for _, c := range containers {
+		result = append(result, map[string]interface{}{
+			"resources": map[string]interface{}{
+				"requests": c.Resources.Requests,
+			},
+			"ports": c.Ports,
+		})
+	}
+	return result
 }

--- a/pkg/util/testingjobs/statefulset/wrappers.go
+++ b/pkg/util/testingjobs/statefulset/wrappers.go
@@ -102,6 +102,12 @@ func (ss *StatefulSetWrapper) WithOwnerReference(ownerReference metav1.OwnerRefe
 	return ss
 }
 
+// Template sets the template of the StatefulSet.
+func (ss *StatefulSetWrapper) Template(template corev1.PodTemplateSpec) *StatefulSetWrapper {
+	ss.Spec.Template = template
+	return ss
+}
+
 // PodTemplateSpecLabel sets the label of the pod template spec of the StatefulSet
 func (ss *StatefulSetWrapper) PodTemplateSpecLabel(k, v string) *StatefulSetWrapper {
 	if ss.Spec.Template.Labels == nil {


### PR DESCRIPTION
Cherry pick of #3952 #4081 on release-0.10.

#3952: [StatefulSet] Disallow changes to PodSpec fields other than the image field
#4081: Allow to change mutable PodSpec fields.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
Fix a bug that allowed unsupported changes to some PodSpec fields which were resulting in the StatefulSet getting stuck on Pods with schedulingGates. 

The validation blocks mutating the following Pod spec fields: `nodeSelector`, `affinity`, `tolerations`, `runtimeClassName`, `priority`, `topologySpreadConstraints`, `overhead`, `resourceClaims`, plus container (and init container) fields: `ports` and `resources.requests`. 

Mutating other fields, such as container image, command or args, remains allowed and supported.
```