### PR TITLE
Automated cherry pick of #4130: TAS: Fix JobSet validation.

### DIFF
--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -140,7 +140,7 @@ func (w *JobSetWebhook) validateTopologyRequest(jobSet *JobSet) field.ErrorList 
 	var allErrs field.ErrorList
 	for i := range jobSet.Spec.ReplicatedJobs {
 		replicaMetaPath := replicatedJobsPath.Index(i).Child("template", "metadata")
-		allErrs = append(allErrs, jobframework.ValidateTASPodSetRequest(replicaMetaPath, &jobSet.Spec.ReplicatedJobs[i].Template.ObjectMeta)...)
+		allErrs = append(allErrs, jobframework.ValidateTASPodSetRequest(replicaMetaPath, &jobSet.Spec.ReplicatedJobs[i].Template.Spec.Template.ObjectMeta)...)
 	}
 	return allErrs
 }

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -73,12 +73,12 @@ func TestValidateCreate(t *testing.T) {
 			name: "valid topology request",
 			job: testingutil.MakeJobSet("job", "default").ReplicatedJobs(testingutil.ReplicatedJobRequirements{
 				Name: "launcher",
-				Annotations: map[string]string{
+				PodAnnotations: map[string]string{
 					kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 				},
 			}, testingutil.ReplicatedJobRequirements{
 				Name: "worker",
-				Annotations: map[string]string{
+				PodAnnotations: map[string]string{
 					kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 				},
 			}).Obj(),
@@ -87,12 +87,12 @@ func TestValidateCreate(t *testing.T) {
 			name: "invalid topology request",
 			job: testingutil.MakeJobSet("job", "default").ReplicatedJobs(testingutil.ReplicatedJobRequirements{
 				Name: "launcher",
-				Annotations: map[string]string{
+				PodAnnotations: map[string]string{
 					kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 				},
 			}, testingutil.ReplicatedJobRequirements{
 				Name: "worker",
-				Annotations: map[string]string{
+				PodAnnotations: map[string]string{
 					kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 					kueuealpha.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
 				},
@@ -124,12 +124,12 @@ func TestValidateUpdate(t *testing.T) {
 		{
 			name: "set valid topology request",
 			oldJob: testingutil.MakeJobSet("job", "default").ReplicatedJobs(testingutil.ReplicatedJobRequirements{
-				Name:        "worker",
-				Annotations: map[string]string{},
+				Name:           "worker",
+				PodAnnotations: map[string]string{},
 			}).Obj(),
 			newJob: testingutil.MakeJobSet("job", "default").ReplicatedJobs(testingutil.ReplicatedJobRequirements{
 				Name: "worker",
-				Annotations: map[string]string{
+				PodAnnotations: map[string]string{
 					kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 				},
 			}).Obj(),
@@ -137,12 +137,12 @@ func TestValidateUpdate(t *testing.T) {
 		{
 			name: "attempt to set invalid topology request",
 			oldJob: testingutil.MakeJobSet("job", "default").ReplicatedJobs(testingutil.ReplicatedJobRequirements{
-				Name:        "worker",
-				Annotations: map[string]string{},
+				Name:           "worker",
+				PodAnnotations: map[string]string{},
 			}).Obj(),
 			newJob: testingutil.MakeJobSet("job", "default").ReplicatedJobs(testingutil.ReplicatedJobRequirements{
 				Name: "worker",
-				Annotations: map[string]string{
+				PodAnnotations: map[string]string{
 					kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
 					kueuealpha.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
 				},

--- a/test/integration/webhook/jobs/jobset_webhook_test.go
+++ b/test/integration/webhook/jobs/jobset_webhook_test.go
@@ -25,6 +25,7 @@ import (
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
+	"sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/jobset"
 	"sigs.k8s.io/kueue/test/util"
 )


### PR DESCRIPTION
Cherry pick of #4130 on release-0.9.

#4130: TAS: Fix JobSet validation.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
TAS: Fixed a bug that allows to create a JobSet with both kueue.x-k8s.io/podset-required-topology and kueue.x-k8s.io/podset-preferred-topology annotations set on the PodTemplate.
```