### PR TITLE
Check deleted metrics form the test ns

### DIFF
--- a/test/e2e/singlecluster/metrics_test.go
+++ b/test/e2e/singlecluster/metrics_test.go
@@ -195,28 +195,28 @@ var _ = ginkgo.Describe("Metrics", func() {
 			})
 
 			deletedMetrics := [][]string{
-				{"kueue_pending_workloads"},
-				{"kueue_reserving_active_workloads"},
-				{"kueue_admitted_active_workloads"},
-				{"kueue_quota_reserved_workloads_total"},
-				{"kueue_quota_reserved_wait_time_seconds"},
-				{"kueue_admitted_workloads_total"},
-				{"kueue_admission_wait_time_seconds"},
-				{"kueue_cluster_queue_resource_usage"},
-				{"kueue_cluster_queue_status"},
-				{"kueue_cluster_queue_resource_reservation"},
-				{"kueue_cluster_queue_nominal_quota"},
-				{"kueue_cluster_queue_borrowing_limit"},
-				{"kueue_cluster_queue_lending_limit"},
+				{"kueue_pending_workloads", clusterQueue.Name},
+				{"kueue_reserving_active_workloads", clusterQueue.Name},
+				{"kueue_admitted_active_workloads", clusterQueue.Name},
+				{"kueue_quota_reserved_workloads_total", clusterQueue.Name},
+				{"kueue_quota_reserved_wait_time_seconds", clusterQueue.Name},
+				{"kueue_admitted_workloads_total", clusterQueue.Name},
+				{"kueue_admission_wait_time_seconds", clusterQueue.Name},
+				{"kueue_cluster_queue_resource_usage", clusterQueue.Name},
+				{"kueue_cluster_queue_status", clusterQueue.Name},
+				{"kueue_cluster_queue_resource_reservation", clusterQueue.Name},
+				{"kueue_cluster_queue_nominal_quota", clusterQueue.Name},
+				{"kueue_cluster_queue_borrowing_limit", clusterQueue.Name},
+				{"kueue_cluster_queue_lending_limit", clusterQueue.Name},
 
 				// LocalQueueMetrics
-				{"kueue_local_queue_reserving_active_workloads"},
-				{"kueue_local_queue_admitted_active_workloads"},
-				{"kueue_local_queue_quota_reserved_workloads_total"},
-				{"kueue_local_queue_quota_reserved_wait_time_seconds"},
-				{"kueue_local_queue_admitted_workloads_total"},
-				{"kueue_local_queue_admission_wait_time_seconds"},
-				{"kueue_local_queue_status"},
+				{"kueue_local_queue_reserving_active_workloads", ns.Name, localQueue.Name},
+				{"kueue_local_queue_admitted_active_workloads", ns.Name, localQueue.Name},
+				{"kueue_local_queue_quota_reserved_workloads_total", ns.Name, localQueue.Name},
+				{"kueue_local_queue_quota_reserved_wait_time_seconds", ns.Name, localQueue.Name},
+				{"kueue_local_queue_admitted_workloads_total", ns.Name, localQueue.Name},
+				{"kueue_local_queue_admission_wait_time_seconds", ns.Name, localQueue.Name},
+				{"kueue_local_queue_status", ns.Name, localQueue.Name},
 			}
 
 			ginkgo.By("checking that metrics that should have been deleted are no longer available", func() {
@@ -312,7 +312,8 @@ var _ = ginkgo.Describe("Metrics", func() {
 						State: v1beta1.CheckStateReady,
 					}, realClock)
 					g.Expect(k8sClient.Status().
-						Patch(ctx, patch, client.Apply, client.FieldOwner("test-admission-check-controller"), client.ForceOwnership)).Should(gomega.Succeed())
+						Patch(ctx, patch, client.Apply, client.FieldOwner("test-admission-check-controller"), client.ForceOwnership)).
+						Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Strictly check the deleted metrics from the test environment. This way the test will target only the metrics from the current test run, and ignore the metrics that might not have been cleared previously.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #4139 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```