### PR TITLE
Graduate WorkloadResourceRequestsSummary to Stable

### DIFF
--- a/keps/2937-resource-transformer/kep.yaml
+++ b/keps/2937-resource-transformer/kep.yaml
@@ -17,7 +17,7 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.10"
+latest-milestone: "v0.11"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -126,6 +126,9 @@ const (
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2937-resource-transformer
 	// alpha: v0.9
 	// beta: v0.10
+	// stable: v0.11
+	//
+	// remove in v0.13
 	//
 	// Summarize the resource requests of non-admitted Workloads in Workload.Status.resourceRequest
 	// to improve observability
@@ -194,7 +197,7 @@ var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	MultiplePreemptions:                 {Default: true, PreRelease: featuregate.GA},
 	TopologyAwareScheduling:             {Default: false, PreRelease: featuregate.Alpha},
 	ConfigurableResourceTransformations: {Default: true, PreRelease: featuregate.Beta},
-	WorkloadResourceRequestsSummary:     {Default: true, PreRelease: featuregate.Beta},
+	WorkloadResourceRequestsSummary:     {Default: true, PreRelease: featuregate.GA},
 	ExposeFlavorsInLocalQueue:           {Default: true, PreRelease: featuregate.Beta},
 	AdmissionCheckValidationRules:       {Default: false, PreRelease: featuregate.Deprecated},
 	KeepQuotaForProvReqRetry:            {Default: false, PreRelease: featuregate.Deprecated},

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -632,9 +632,6 @@ func SetEvictedCondition(w *kueue.Workload, reason string, message string) {
 // PropagateResourceRequests synchronizes w.Status.ResourceRequests to
 // with info.TotalRequests if the feature gate is enabled and returns true if w was updated
 func PropagateResourceRequests(w *kueue.Workload, info *Info) bool {
-	if !features.Enabled(features.WorkloadResourceRequestsSummary) {
-		return false
-	}
 	if len(w.Status.ResourceRequests) == len(info.TotalRequests) {
 		match := true
 		for idx := range w.Status.ResourceRequests {

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -259,7 +259,7 @@ The currently supported features are:
 | `ConfigurableResourceTransformations` | `false` | Alpha      | 0.9   | 0.9   |
 | `ConfigurableResourceTransformations` | `true`  | Beta       | 0.10  |       |
 | `WorkloadResourceRequestsSummary`     | `false` | Alpha      | 0.9   | 0.9   |
-| `WorkloadResourceRequestsSummary`     | `true`  | Beta       | 0.10  | 0.11  |
+| `WorkloadResourceRequestsSummary`     | `true`  | Beta       | 0.10  | 0.10  |
 | `AdmissionCheckValidationRules`       | `false` | Deprecated | 0.9   | 0.9   |
 | `KeepQuotaForProvReqRetry`            | `false` | Deprecated | 0.9   | 0.9   |
 | `ManagedJobsNamespaceSelector`        | `true`  | Beta       | 0.10  |       |

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -259,7 +259,7 @@ The currently supported features are:
 | `ConfigurableResourceTransformations` | `false` | Alpha      | 0.9   | 0.9   |
 | `ConfigurableResourceTransformations` | `true`  | Beta       | 0.10  |       |
 | `WorkloadResourceRequestsSummary`     | `false` | Alpha      | 0.9   | 0.9   |
-| `WorkloadResourceRequestsSummary`     | `true`  | Beta       | 0.10  |       |
+| `WorkloadResourceRequestsSummary`     | `true`  | Beta       | 0.10  | 0.11  |
 | `AdmissionCheckValidationRules`       | `false` | Deprecated | 0.9   | 0.9   |
 | `KeepQuotaForProvReqRetry`            | `false` | Deprecated | 0.9   | 0.9   |
 | `ManagedJobsNamespaceSelector`        | `true`  | Beta       | 0.10  |       |

--- a/site/content/en/docs/tasks/troubleshooting/troubleshooting_jobs.md
+++ b/site/content/en/docs/tasks/troubleshooting/troubleshooting_jobs.md
@@ -174,14 +174,6 @@ status:
       Memory: 600Mi
 ```
 
-{{< feature-state state="beta" for_version="v0.10" >}}
-{{% alert title="Note" color="primary" %}}
-
-Populating the `status.resourceRequests` field of pending workloads is a Beta feature that is enabled by default.
-
-You can disable it by setting the `WorkloadResourceRequestsSummary` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
-{{% /alert %}}
-
 ### Does my ClusterQueue have the resource requests that the job requires?
 
 When you submit a job that has a resource request, for example:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

Graduate WorkloadResourceRequestsSummary to stable and cleanup code/tests for WorkloadResourceRequestsSummary=false

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Promote WorkloadResourceRequestsSummary feature gate to stable
```