### PR TITLE
Introduce preemption context to reduce passing of parameters

### DIFF
--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -359,15 +359,14 @@ func (p *Preemptor) fairPreemptions(preemptionCtx *preemptionCtx, candidates []*
 	}
 	requests := preemptionCtx.requests
 	cqHeap := cqHeapFromCandidates(candidates, false, preemptionCtx.snapshot)
-	nominatedCQ := preemptionCtx.snapshot.ClusterQueues[preemptionCtx.preemptor.ClusterQueue]
-	newNominatedShareValue, _ := nominatedCQ.DominantResourceShareWith(requests)
+	newNominatedShareValue, _ := preemptionCtx.preemptorCQ.DominantResourceShareWith(requests)
 	var targets []*Target
 	fits := false
 	var retryCandidates []*workload.Info
 	for cqHeap.Len() > 0 && !fits {
 		candCQ := cqHeap.Pop()
 
-		if candCQ.cq == nominatedCQ {
+		if candCQ.cq == preemptionCtx.preemptorCQ {
 			candWl := candCQ.workloads[0]
 			preemptionCtx.snapshot.RemoveWorkload(candWl)
 			targets = append(targets, &Target{
@@ -378,7 +377,7 @@ func (p *Preemptor) fairPreemptions(preemptionCtx *preemptionCtx, candidates []*
 				fits = true
 				break
 			}
-			newNominatedShareValue, _ = nominatedCQ.DominantResourceShareWith(requests)
+			newNominatedShareValue, _ = preemptionCtx.preemptorCQ.DominantResourceShareWith(requests)
 			candCQ.workloads = candCQ.workloads[1:]
 			if len(candCQ.workloads) > 0 {
 				candCQ.share, _ = candCQ.cq.DominantResourceShare()

--- a/pkg/scheduler/preemption/preemption_oracle.go
+++ b/pkg/scheduler/preemption/preemption_oracle.go
@@ -42,11 +42,11 @@ func (p *PreemptionOracle) IsReclaimPossible(log logr.Logger, cq *cache.ClusterQ
 		return false
 	}
 	for _, candidate := range p.preemptor.getTargets(&preemptionCtx{
-		log:               log,
-		wl:                wl,
-		snapshot:          p.snapshot,
-		frsNeedPreemption: sets.New(fr),
-		quantities:        resources.FlavorResourceQuantities{fr: quantity},
+		log:                    log,
+		preemptor:              wl,
+		snapshot:               p.snapshot,
+		frsNeedPreemption:      sets.New(fr),
+		requestsNeedPreemption: resources.FlavorResourceQuantities{fr: quantity},
 	}) {
 		if candidate.WorkloadInfo.ClusterQueue == cq.Name {
 			return false

--- a/pkg/scheduler/preemption/preemption_oracle.go
+++ b/pkg/scheduler/preemption/preemption_oracle.go
@@ -41,8 +41,13 @@ func (p *PreemptionOracle) IsReclaimPossible(log logr.Logger, cq *cache.ClusterQ
 	if cq.BorrowingWith(fr, quantity) {
 		return false
 	}
-
-	for _, candidate := range p.preemptor.getTargets(log, wl, resources.FlavorResourceQuantities{fr: quantity}, sets.New(fr), p.snapshot) {
+	for _, candidate := range p.preemptor.getTargets(&preemptionCtx{
+		log:               log,
+		wl:                wl,
+		snapshot:          p.snapshot,
+		frsNeedPreemption: sets.New(fr),
+		quantities:        resources.FlavorResourceQuantities{fr: quantity},
+	}) {
 		if candidate.WorkloadInfo.ClusterQueue == cq.Name {
 			return false
 		}

--- a/pkg/scheduler/preemption/preemption_oracle.go
+++ b/pkg/scheduler/preemption/preemption_oracle.go
@@ -42,11 +42,12 @@ func (p *PreemptionOracle) IsReclaimPossible(log logr.Logger, cq *cache.ClusterQ
 		return false
 	}
 	for _, candidate := range p.preemptor.getTargets(&preemptionCtx{
-		log:                    log,
-		preemptor:              wl,
-		snapshot:               p.snapshot,
-		frsNeedPreemption:      sets.New(fr),
-		requestsNeedPreemption: resources.FlavorResourceQuantities{fr: quantity},
+		log:               log,
+		preemptor:         wl,
+		preemptorCQ:       p.snapshot.ClusterQueues[wl.ClusterQueue],
+		snapshot:          p.snapshot,
+		frsNeedPreemption: sets.New(fr),
+		requests:          resources.FlavorResourceQuantities{fr: quantity},
 	}) {
 		if candidate.WorkloadInfo.ClusterQueue == cq.Name {
 			return false


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Preparatory PR for https://github.com/kubernetes-sigs/kueue/pull/4171

While working on that PR I needed to pass a new parameter representing "tasRequests" and it becomes a chore to pump the parameter through all interfaces (such as the `minimalPreemptions` and `fairSharingPreemptions`  functions) down to the `workloadFits` function (such as currently `requests are passed). 

#### Special notes for your reviewer:

This concept is analogous to what we do in the core k8s Job controller: https://github.com/kubernetes/kubernetes/blob/39f1c90ac014828803a156b40d49f0c58fb7384a/pkg/controller/job/job_controller.go#L128 for the very same reason.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```