### PR TITLE
KueueCtl: Use stable node label in help description

### DIFF
--- a/cmd/kueuectl/app/create/create_resourceflavor.go
+++ b/cmd/kueuectl/app/create/create_resourceflavor.go
@@ -46,7 +46,7 @@ var (
 
   		# Create a resource flavor with labels
 		kueuectl create resourceflavor my-resource-flavor \
-		--node-labels beta.kubernetes.io/arch=arm64,beta.kubernetes.io/os=linux
+		--node-labels kubernetes.io/arch=arm64,kubernetes.io/os=linux
 
 		# Create a resource flavor with node taints
   		kueuectl create resourceflavor my-resource-flavor \

--- a/cmd/kueuectl/app/create/create_resourceflavor_test.go
+++ b/cmd/kueuectl/app/create/create_resourceflavor_test.go
@@ -264,14 +264,14 @@ func TestResourceFlavorCmd(t *testing.T) {
 		},
 		"should create resource flavor with node labels": {
 			rfName: "rf",
-			args:   []string{"--node-labels", "beta.kubernetes.io/arch=arm64,beta.kubernetes.io/os=linux"},
+			args:   []string{"--node-labels", "kubernetes.io/arch=arm64,kubernetes.io/os=linux"},
 			wantRf: &v1beta1.ResourceFlavor{
 				TypeMeta:   metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: "ResourceFlavor"},
 				ObjectMeta: metav1.ObjectMeta{Name: "rf"},
 				Spec: v1beta1.ResourceFlavorSpec{
 					NodeLabels: map[string]string{
-						"beta.kubernetes.io/arch": "arm64",
-						"beta.kubernetes.io/os":   "linux",
+						"kubernetes.io/arch": "arm64",
+						"kubernetes.io/os":   "linux",
 					},
 				},
 			},

--- a/site/content/en/docs/reference/kubectl-kueue/commands/kueuectl_create/kueuectl_create_resourceflavor.md
+++ b/site/content/en/docs/reference/kubectl-kueue/commands/kueuectl_create/kueuectl_create_resourceflavor.md
@@ -28,7 +28,7 @@ kueuectl create resourceflavor NAME [--node-labels KEY=VALUE] [--node-taints KEY
   
   # Create a resource flavor with labels
   kueuectl create resourceflavor my-resource-flavor \
-  --node-labels beta.kubernetes.io/arch=arm64,beta.kubernetes.io/os=linux
+  --node-labels kubernetes.io/arch=arm64,kubernetes.io/os=linux
   
   # Create a resource flavor with node taints
   kueuectl create resourceflavor my-resource-flavor \

--- a/test/integration/singlecluster/kueuectl/create_test.go
+++ b/test/integration/singlecluster/kueuectl/create_test.go
@@ -477,7 +477,7 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 				kueuectl.SetErr(outErr)
 
 				kueuectl.SetArgs([]string{"create", "resourceflavor", rfName,
-					"--node-labels", "beta.kubernetes.io/arch=arm64,beta.kubernetes.io/os=linux",
+					"--node-labels", "kubernetes.io/arch=arm64,kubernetes.io/os=linux",
 					"--node-taints", "key1=value1:NoSchedule,key2=value2:NoSchedule",
 					"--tolerations", "key1=value1:NoSchedule,key2:NoSchedule",
 				})
@@ -495,8 +495,8 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: rfName, Namespace: ns.Name}, &resourceFlavor)).To(gomega.Succeed())
 					g.Expect(resourceFlavor.Name).Should(gomega.Equal(rfName))
 					g.Expect(resourceFlavor.Spec.NodeLabels).Should(gomega.Equal(map[string]string{
-						"beta.kubernetes.io/arch": "arm64",
-						"beta.kubernetes.io/os":   "linux",
+						"kubernetes.io/arch": "arm64",
+						"kubernetes.io/os":   "linux",
 					}))
 					g.Expect(resourceFlavor.Spec.NodeTaints).Should(gomega.ContainElements(
 						corev1.Taint{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
I replaced `beta.kubernetes.io/arch` and `beta.kubernetes.io/os` node labels with `kubernetes.io/arch` and `kubernetes.io/os` since as we can see the below, those node labes are deprecated in K8s 1.14.

- [`beta.kubernetes.io/arch`](https://github.com/kubernetes/kubernetes/blob/69ab91a5c59617872c9f48737c64409a9dec2957/pkg/api/node/util.go#L30)
- [`beta.kubernetes.io/os`](https://github.com/kubernetes/kubernetes/blob/69ab91a5c59617872c9f48737c64409a9dec2957/pkg/api/node/util.go#L31)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```