### PR TITLE
TAS: Exclude unschedulable Nodes for allocatable cluster capacities

### DIFF
--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -956,6 +956,32 @@ func TestFindTopologyAssignment(t *testing.T) {
 			count:      1,
 			wantReason: "no topology domains at level: kubernetes.io/hostname",
 		},
+		"no assignment as node is unschedulable": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-r1-x1").
+					Label("zone", "zone-a").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					}).
+					Ready().
+					Unschedulable().
+					Obj(),
+			},
+			request: kueue.PodSetTopologyRequest{
+				Required: ptr.To(corev1.LabelHostname),
+			},
+			nodeLabels: map[string]string{
+				"zone": "zone-a",
+			},
+			levels: defaultOneLevel,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count:      1,
+			wantReason: "no topology domains at level: kubernetes.io/hostname",
+		},
 		"skip node which has untolerated taint": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("x1").

--- a/pkg/cache/tas_flavor.go
+++ b/pkg/cache/tas_flavor.go
@@ -92,7 +92,10 @@ func (c *TASFlavorCache) snapshot(ctx context.Context) (*TASFlavorSnapshot, erro
 	}
 	requiredLabelKeys := client.HasLabels{}
 	requiredLabelKeys = append(requiredLabelKeys, c.Levels...)
-	err := c.client.List(ctx, nodes, requiredLabels, requiredLabelKeys, client.MatchingFields{indexer.ReadyNode: "true"})
+	err := c.client.List(ctx, nodes, requiredLabels, requiredLabelKeys, client.MatchingFields{
+		indexer.ReadyNode:       "true",
+		indexer.SchedulableNode: "true",
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list nodes for TAS: %w", err)
 	}

--- a/pkg/util/testingjobs/node/wrappers.go
+++ b/pkg/util/testingjobs/node/wrappers.go
@@ -91,3 +91,9 @@ func (n *NodeWrapper) NotReady() *NodeWrapper {
 	})
 	return n
 }
+
+// Unschedulable sets the Node to an unschedulable state.
+func (n *NodeWrapper) Unschedulable() *NodeWrapper {
+	n.Spec.Unschedulable = true
+	return n
+}

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -56,7 +56,7 @@ the "cloud.provider.com/topology-rack" label, but in different blocks.
 For each PodSet TAS determines the current free capacity per each topology
 domain (like a given rack) by:
 - including Node allocatable capacity (based on the `.status.allocatable` field)
-  of only ready Nodes (with `Ready=True` condition),
+  of only ready (with `Ready=True` condition) and schedulable (with `.spec.unschedulable=false`) Nodes,
 - subtracting the usage coming from all other admitted TAS workloads,
 - subtracting the usage coming from all other non-TAS Pods (owned mainly by
   DaemonSets, but also including static Pods, Deployments, etc.).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Exclude unschedulable Nodes by client field indexer when calculating cluster capacities.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4180

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fix a bug that unschedulable nodes (".spec.unschedulable=true") are counted as allocatable capacities
```