### PR TITLE
Refactor computation of TAS assignments

### DIFF
--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -150,15 +150,19 @@ func (c *ClusterQueueSnapshot) DominantResourceShareWithout(wlReq resources.Flav
 	return dominantResourceShare(c, without)
 }
 
-func (c *ClusterQueueSnapshot) FindTopologyAssignments(
-	tasRequestsByFlavor map[kueue.ResourceFlavorReference][]TASPodSetRequests) TASAssignmentsResult {
+type WorkloadTASRequests map[kueue.ResourceFlavorReference]FlavorTASRequests
+
+func (c *ClusterQueueSnapshot) FindTopologyAssignmentsForWorkload(
+	tasRequestsByFlavor WorkloadTASRequests) TASAssignmentsResult {
 	result := make(TASAssignmentsResult)
-	for tasFlavor, tasRequestsForFlavor := range tasRequestsByFlavor {
-		if tasFlavorCache := c.TASFlavors[tasFlavor]; tasFlavorCache != nil {
-			flvResult := tasFlavorCache.FindTopologyAssignments(tasRequestsForFlavor)
-			for psName, psAssignment := range flvResult {
-				result[psName] = psAssignment
-			}
+	for tasFlavor, flavorTASRequests := range tasRequestsByFlavor {
+		// We assume the `tasFlavor` is already in the snapshot as this was
+		// already checked earlier during flavor assignment, and the set of
+		// flavors is immutable in snapshot.
+		tasFlavorCache := c.TASFlavors[tasFlavor]
+		flvResult := tasFlavorCache.FindTopologyAssignmentsForFlavor(flavorTASRequests)
+		for psName, psAssignment := range flvResult {
+			result[psName] = psAssignment
 		}
 	}
 	return result

--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -149,3 +149,17 @@ func (c *ClusterQueueSnapshot) DominantResourceShareWithout(wlReq resources.Flav
 	}
 	return dominantResourceShare(c, without)
 }
+
+func (c *ClusterQueueSnapshot) FindTopologyAssignments(
+	tasRequestsByFlavor map[kueue.ResourceFlavorReference][]TASPodSetRequests) TASAssignmentsResult {
+	result := make(TASAssignmentsResult)
+	for tasFlavor, tasRequestsForFlavor := range tasRequestsByFlavor {
+		if tasFlavorCache := c.TASFlavors[tasFlavor]; tasFlavorCache != nil {
+			flvResult := tasFlavorCache.FindTopologyAssignments(tasRequestsForFlavor)
+			for psName, psAssignment := range flvResult {
+				result[psName] = psAssignment
+			}
+		}
+	}
+	return result
+}

--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -1083,7 +1083,20 @@ func TestFindTopologyAssignment(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to build the snapshot: %v", err)
 			}
-			gotAssignment, reason := snapshot.FindTopologyAssignment(&tc.request, tc.requests, tc.count, tc.tolerations)
+			tasInput := TASPodSetRequests{
+				PodSet: &kueue.PodSet{
+					Name:            "main",
+					TopologyRequest: &tc.request,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Tolerations: tc.tolerations,
+						},
+					},
+				},
+				SinglePodRequests: tc.requests,
+				Count:             tc.count,
+			}
+			gotAssignment, reason := snapshot.findTopologyAssignment(tasInput, nil)
 			if gotAssignment != nil {
 				sort.Slice(tc.wantAssignment.Domains, func(i, j int) bool {
 					return utiltas.DomainID(tc.wantAssignment.Domains[i].Values) < utiltas.DomainID(tc.wantAssignment.Domains[j].Values)

--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -1096,17 +1096,21 @@ func TestFindTopologyAssignment(t *testing.T) {
 				SinglePodRequests: tc.requests,
 				Count:             tc.count,
 			}
-			gotAssignment, reason := snapshot.findTopologyAssignment(tasInput, nil)
-			if gotAssignment != nil {
+			flavorTASRequests := []TASPodSetRequests{tasInput}
+			wantResult := make(TASAssignmentsResult)
+			wantMainPodSetResult := tasPodSetAssignmentResult{
+				FailureReason: tc.wantReason,
+			}
+			if tc.wantAssignment != nil {
 				sort.Slice(tc.wantAssignment.Domains, func(i, j int) bool {
 					return utiltas.DomainID(tc.wantAssignment.Domains[i].Values) < utiltas.DomainID(tc.wantAssignment.Domains[j].Values)
 				})
+				wantMainPodSetResult.TopologyAssignment = tc.wantAssignment
 			}
-			if diff := cmp.Diff(tc.wantAssignment, gotAssignment); diff != "" {
+			wantResult["main"] = wantMainPodSetResult
+			gotResult := snapshot.FindTopologyAssignmentsForFlavor(flavorTASRequests)
+			if diff := cmp.Diff(wantResult, gotResult); diff != "" {
 				t.Errorf("unexpected topology assignment (-want,+got): %s", diff)
-			}
-			if diff := cmp.Diff(tc.wantReason, reason); diff != "" {
-				t.Errorf("unexpected error (-want,+got): %s", diff)
 			}
 		})
 	}

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -231,39 +231,46 @@ type TASPodSetRequests struct {
 }
 
 type FailureInfo struct {
+	// PodSetName indicates the name of the PodSet for which computing the
+	// TAS assignment failed.
 	PodSetName string
-	Reason     string
+
+	// Reason indicates the reason why computing the TAS assignment failed.
+	Reason string
 }
 
-type TASAssignmentsResult map[string]TASPodSetAssignmentResult
+// the key in this map is PodSet name
+type TASAssignmentsResult map[string]tasPodSetAssignmentResult
 
 func (r TASAssignmentsResult) Failure() *FailureInfo {
 	for psName, psAssignment := range r {
-		if psAssignment.Reason != "" {
-			return &FailureInfo{PodSetName: psName, Reason: psAssignment.Reason}
+		if psAssignment.FailureReason != "" {
+			return &FailureInfo{PodSetName: psName, Reason: psAssignment.FailureReason}
 		}
 	}
 	return nil
 }
 
-type TASPodSetAssignmentResult struct {
+type tasPodSetAssignmentResult struct {
 	TopologyAssignment *kueue.TopologyAssignment
-	Reason             string
+	FailureReason      string
 }
 
-func (s *TASFlavorSnapshot) FindTopologyAssignments(tasPodSetRequests []TASPodSetRequests) TASAssignmentsResult {
-	result := make(map[string]TASPodSetAssignmentResult)
+type FlavorTASRequests []TASPodSetRequests
+
+func (s *TASFlavorSnapshot) FindTopologyAssignmentsForFlavor(flavorTASRequests FlavorTASRequests) TASAssignmentsResult {
+	result := make(map[string]tasPodSetAssignmentResult)
 	assumedUsage := make(map[utiltas.TopologyDomainID]resources.Requests)
-	for _, tr := range tasPodSetRequests {
+	for _, tr := range flavorTASRequests {
 		assignment, reason := s.findTopologyAssignment(tr, assumedUsage)
-		result[tr.PodSet.Name] = TASPodSetAssignmentResult{TopologyAssignment: assignment, Reason: reason}
+		result[tr.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: assignment, FailureReason: reason}
 		if reason != "" {
 			return result
 		}
 		for _, domain := range assignment.Domains {
 			domainID := utiltas.DomainID(domain.Values)
 			assumedDomainUsage := tr.SinglePodRequests.Clone()
-			assumedDomainUsage.Multiply(int64(domain.Count))
+			assumedDomainUsage.Mul(int64(domain.Count))
 			if assumedUsage[domainID] == nil {
 				assumedUsage[domainID] = resources.Requests{}
 			}

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -49,7 +49,7 @@ func (r Requests) Divide(f int64) {
 	}
 }
 
-func (r Requests) Multiply(f int64) {
+func (r Requests) Mul(f int64) {
 	for k := range r {
 		r[k] *= f
 	}

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -49,6 +49,12 @@ func (r Requests) Divide(f int64) {
 	}
 }
 
+func (r Requests) Multiply(f int64) {
+	for k := range r {
+		r[k] *= f
+	}
+}
+
 func (r Requests) Add(addRequests Requests) {
 	for k, v := range addRequests {
 		r[k] += v


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Part of #3761

Preparatory for https://github.com/kubernetes-sigs/kueue/pull/4171

#### Special notes for your reviewer:

The main change in this PR is to refactor how the TAS assignment is computed when there are multiple PodSets. Previously the usage from previous podsets was already accounted regardless of the final scheduling result, see [here](https://github.com/kubernetes-sigs/kueue/compare/main...mimowo:tas-refactor-podset-usage?expand=1#diff-5414dcb324187d1d853329b419691cde79632a6d77e1a7c2b503dc1a3688c081L351). This works well only assuming the FindTopologyAssignment function is called once. 

However, to support preemptions I will need to run this function multiple times for a different set of target workloads. Similarly, this assumption is also invalid for cohorts.

So I introduce a concept of `assumedUsage` which is tracked within one FindTopologyAssignment called across all PodSets targeting a flavor, see [here](https://github.com/kubernetes-sigs/kueue/compare/main...mimowo:tas-refactor-podset-usage?expand=1#diff-5414dcb324187d1d853329b419691cde79632a6d77e1a7c2b503dc1a3688c081R243-R263).

This change also improves the error message, which I extracted to yet another preparatory PR: https://github.com/kubernetes-sigs/kueue/pull/4204, so that we can decide about cherry-picking independently.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```