### PR TITLE
Automated cherry pick of #4191: Add missing external types to apply configurations

### DIFF
--- a/client-go/applyconfiguration/kueue/v1beta1/localqueueflavorstatus.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/localqueueflavorstatus.go
@@ -19,6 +19,7 @@ package v1beta1
 
 import (
 	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	v1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
@@ -28,7 +29,7 @@ type LocalQueueFlavorStatusApplyConfiguration struct {
 	Name       *v1beta1.ResourceFlavorReference `json:"name,omitempty"`
 	Resources  []v1.ResourceName                `json:"resources,omitempty"`
 	NodeLabels map[string]string                `json:"nodeLabels,omitempty"`
-	NodeTaints []v1.Taint                       `json:"nodeTaints,omitempty"`
+	NodeTaints []corev1.TaintApplyConfiguration `json:"nodeTaints,omitempty"`
 }
 
 // LocalQueueFlavorStatusApplyConfiguration constructs a declarative configuration of the LocalQueueFlavorStatus type for use with
@@ -72,9 +73,12 @@ func (b *LocalQueueFlavorStatusApplyConfiguration) WithNodeLabels(entries map[st
 // WithNodeTaints adds the given value to the NodeTaints field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the NodeTaints field.
-func (b *LocalQueueFlavorStatusApplyConfiguration) WithNodeTaints(values ...v1.Taint) *LocalQueueFlavorStatusApplyConfiguration {
+func (b *LocalQueueFlavorStatusApplyConfiguration) WithNodeTaints(values ...*corev1.TaintApplyConfiguration) *LocalQueueFlavorStatusApplyConfiguration {
 	for i := range values {
-		b.NodeTaints = append(b.NodeTaints, values[i])
+		if values[i] == nil {
+			panic("nil value passed to WithNodeTaints")
+		}
+		b.NodeTaints = append(b.NodeTaints, *values[i])
 	}
 	return b
 }

--- a/client-go/applyconfiguration/kueue/v1beta1/podset.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/podset.go
@@ -18,14 +18,14 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
 // PodSetApplyConfiguration represents a declarative configuration of the PodSet type for use
 // with apply.
 type PodSetApplyConfiguration struct {
 	Name            *string                                  `json:"name,omitempty"`
-	Template        *v1.PodTemplateSpec                      `json:"template,omitempty"`
+	Template        *v1.PodTemplateSpecApplyConfiguration    `json:"template,omitempty"`
 	Count           *int32                                   `json:"count,omitempty"`
 	MinCount        *int32                                   `json:"minCount,omitempty"`
 	TopologyRequest *PodSetTopologyRequestApplyConfiguration `json:"topologyRequest,omitempty"`
@@ -48,8 +48,8 @@ func (b *PodSetApplyConfiguration) WithName(value string) *PodSetApplyConfigurat
 // WithTemplate sets the Template field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Template field is set to the value of the last call.
-func (b *PodSetApplyConfiguration) WithTemplate(value v1.PodTemplateSpec) *PodSetApplyConfiguration {
-	b.Template = &value
+func (b *PodSetApplyConfiguration) WithTemplate(value *v1.PodTemplateSpecApplyConfiguration) *PodSetApplyConfiguration {
+	b.Template = value
 	return b
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/podsetupdate.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/podsetupdate.go
@@ -18,17 +18,17 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
 // PodSetUpdateApplyConfiguration represents a declarative configuration of the PodSetUpdate type for use
 // with apply.
 type PodSetUpdateApplyConfiguration struct {
-	Name         *string           `json:"name,omitempty"`
-	Labels       map[string]string `json:"labels,omitempty"`
-	Annotations  map[string]string `json:"annotations,omitempty"`
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
-	Tolerations  []v1.Toleration   `json:"tolerations,omitempty"`
+	Name         *string                           `json:"name,omitempty"`
+	Labels       map[string]string                 `json:"labels,omitempty"`
+	Annotations  map[string]string                 `json:"annotations,omitempty"`
+	NodeSelector map[string]string                 `json:"nodeSelector,omitempty"`
+	Tolerations  []v1.TolerationApplyConfiguration `json:"tolerations,omitempty"`
 }
 
 // PodSetUpdateApplyConfiguration constructs a declarative configuration of the PodSetUpdate type for use with
@@ -90,9 +90,12 @@ func (b *PodSetUpdateApplyConfiguration) WithNodeSelector(entries map[string]str
 // WithTolerations adds the given value to the Tolerations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Tolerations field.
-func (b *PodSetUpdateApplyConfiguration) WithTolerations(values ...v1.Toleration) *PodSetUpdateApplyConfiguration {
+func (b *PodSetUpdateApplyConfiguration) WithTolerations(values ...*v1.TolerationApplyConfiguration) *PodSetUpdateApplyConfiguration {
 	for i := range values {
-		b.Tolerations = append(b.Tolerations, values[i])
+		if values[i] == nil {
+			panic("nil value passed to WithTolerations")
+		}
+		b.Tolerations = append(b.Tolerations, *values[i])
 	}
 	return b
 }

--- a/client-go/applyconfiguration/kueue/v1beta1/resourceflavorspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/resourceflavorspec.go
@@ -18,17 +18,17 @@ limitations under the License.
 package v1beta1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/client-go/applyconfigurations/core/v1"
 	v1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 // ResourceFlavorSpecApplyConfiguration represents a declarative configuration of the ResourceFlavorSpec type for use
 // with apply.
 type ResourceFlavorSpecApplyConfiguration struct {
-	NodeLabels   map[string]string          `json:"nodeLabels,omitempty"`
-	NodeTaints   []v1.Taint                 `json:"nodeTaints,omitempty"`
-	Tolerations  []v1.Toleration            `json:"tolerations,omitempty"`
-	TopologyName *v1beta1.TopologyReference `json:"topologyName,omitempty"`
+	NodeLabels   map[string]string                 `json:"nodeLabels,omitempty"`
+	NodeTaints   []v1.TaintApplyConfiguration      `json:"nodeTaints,omitempty"`
+	Tolerations  []v1.TolerationApplyConfiguration `json:"tolerations,omitempty"`
+	TopologyName *v1beta1.TopologyReference        `json:"topologyName,omitempty"`
 }
 
 // ResourceFlavorSpecApplyConfiguration constructs a declarative configuration of the ResourceFlavorSpec type for use with
@@ -54,9 +54,12 @@ func (b *ResourceFlavorSpecApplyConfiguration) WithNodeLabels(entries map[string
 // WithNodeTaints adds the given value to the NodeTaints field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the NodeTaints field.
-func (b *ResourceFlavorSpecApplyConfiguration) WithNodeTaints(values ...v1.Taint) *ResourceFlavorSpecApplyConfiguration {
+func (b *ResourceFlavorSpecApplyConfiguration) WithNodeTaints(values ...*v1.TaintApplyConfiguration) *ResourceFlavorSpecApplyConfiguration {
 	for i := range values {
-		b.NodeTaints = append(b.NodeTaints, values[i])
+		if values[i] == nil {
+			panic("nil value passed to WithNodeTaints")
+		}
+		b.NodeTaints = append(b.NodeTaints, *values[i])
 	}
 	return b
 }
@@ -64,9 +67,12 @@ func (b *ResourceFlavorSpecApplyConfiguration) WithNodeTaints(values ...v1.Taint
 // WithTolerations adds the given value to the Tolerations field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Tolerations field.
-func (b *ResourceFlavorSpecApplyConfiguration) WithTolerations(values ...v1.Toleration) *ResourceFlavorSpecApplyConfiguration {
+func (b *ResourceFlavorSpecApplyConfiguration) WithTolerations(values ...*v1.TolerationApplyConfiguration) *ResourceFlavorSpecApplyConfiguration {
 	for i := range values {
-		b.Tolerations = append(b.Tolerations, values[i])
+		if values[i] == nil {
+			panic("nil value passed to WithTolerations")
+		}
+		b.Tolerations = append(b.Tolerations, *values[i])
 	}
 	return b
 }

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -42,10 +42,22 @@ kube::codegen::gen_openapi \
   --update-report \
   "${KUEUE_ROOT}/apis/visibility"
 
+externals=(
+  "k8s.io/api/core/v1.PodTemplateSpec:k8s.io/client-go/applyconfigurations/core/v1"
+  "k8s.io/api/core/v1.Taint:k8s.io/client-go/applyconfigurations/core/v1"
+  "k8s.io/api/core/v1.Toleration:k8s.io/client-go/applyconfigurations/core/v1"
+)
+
+apply_config_externals="${externals[0]}"
+for external in "${externals[@]:1}"; do
+  apply_config_externals="${apply_config_externals},${external}"
+done
+
 kube::codegen::gen_client \
   --boilerplate "${KUEUE_ROOT}/hack/boilerplate.go.txt" \
   --output-dir "${KUEUE_ROOT}/client-go" \
   --output-pkg "${KUEUE_PKG}/client-go" \
   --with-watch \
   --with-applyconfig \
+  --applyconfig-externals "${apply_config_externals}" \
   "${KUEUE_ROOT}/apis"


### PR DESCRIPTION
Cherry pick of #4191 on release-0.9.

#4191: Add missing external types to apply configurations

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Add missing external types to apply configurations
```