### PR TITLE
Automated cherry pick of #4150: Finalize Pods if StatefulSet is not found.

### DIFF
--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -18,20 +18,32 @@ package statefulset
 
 import (
 	"context"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
+	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 	"sigs.k8s.io/kueue/pkg/util/parallelize"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
+)
+
+const (
+	podBatchPeriod = time.Second
 )
 
 // +kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch
@@ -45,58 +57,152 @@ type Reconciler struct {
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	sts := &appsv1.StatefulSet{}
-	err := r.client.Get(ctx, req.NamespacedName, sts)
-	if err != nil {
-		// we'll ignore not-found errors, since there is nothing to do.
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-
-	log := ctrl.LoggerFrom(ctx).WithValues("statefulset", klog.KObj(sts))
+	log := ctrl.LoggerFrom(ctx).WithValues("statefulset", klog.KRef(req.Namespace, req.Name))
 	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling StatefulSet")
 
-	err = r.fetchAndFinalizePods(ctx, req.Namespace, req.Name)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, nil
+	err := r.fetchAndFinalizePods(ctx, req)
+	return ctrl.Result{}, err
 }
 
-func (r *Reconciler) fetchAndFinalizePods(ctx context.Context, namespace, statefulSetName string) error {
+func (r *Reconciler) fetchAndFinalizePods(ctx context.Context, req reconcile.Request) error {
 	podList := &corev1.PodList{}
-	if err := r.client.List(ctx, podList, client.InNamespace(namespace), client.MatchingLabels{
-		pod.GroupNameLabel: GetWorkloadName(statefulSetName),
+	if err := r.client.List(ctx, podList, client.InNamespace(req.Namespace), client.MatchingLabels{
+		podcontroller.GroupNameLabel: GetWorkloadName(req.Name),
 	}); err != nil {
 		return err
 	}
-	return r.finalizePods(ctx, podList.Items)
+
+	sts := &appsv1.StatefulSet{}
+	err := r.client.Get(ctx, req.NamespacedName, sts)
+	if client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	if err != nil {
+		sts = nil
+	}
+
+	return r.finalizePods(ctx, sts, podList.Items)
 }
 
-func (r *Reconciler) finalizePods(ctx context.Context, pods []corev1.Pod) error {
-	log := ctrl.LoggerFrom(ctx)
+func (r *Reconciler) finalizePods(ctx context.Context, sts *appsv1.StatefulSet, pods []corev1.Pod) error {
 	return parallelize.Until(ctx, len(pods), func(i int) error {
-		p := &pods[i]
-		if p.Status.Phase != corev1.PodSucceeded && p.Status.Phase != corev1.PodFailed {
-			return nil
-		}
-		err := clientutil.Patch(ctx, r.client, p, true, func() (bool, error) {
-			removed := controllerutil.RemoveFinalizer(p, pod.PodFinalizer)
-			if removed {
-				log.V(3).Info("Finalizing pod in group", "pod", klog.KObj(p), "group", p.Labels[pod.GroupNameLabel])
-			}
-			return removed, nil
-		})
-		return client.IgnoreNotFound(err)
+		return r.finalizePod(ctx, sts, &pods[i])
 	})
+}
+
+func (r *Reconciler) finalizePod(ctx context.Context, sts *appsv1.StatefulSet, pod *corev1.Pod) error {
+	log := ctrl.LoggerFrom(ctx)
+	return client.IgnoreNotFound(clientutil.Patch(ctx, r.client, pod, true, func() (bool, error) {
+		if ungateAndFinalize(sts, pod) {
+			log.V(3).Info(
+				"Finalizing pod in group",
+				"pod", klog.KObj(pod),
+				"group", pod.Labels[podcontroller.GroupNameLabel],
+			)
+			return true, nil
+		}
+		return false, nil
+	}))
+}
+
+func ungateAndFinalize(sts *appsv1.StatefulSet, pod *corev1.Pod) bool {
+	var updated bool
+
+	if shouldUngate(sts, pod) && utilpod.Ungate(pod, podcontroller.SchedulingGateName) {
+		updated = true
+	}
+
+	if shouldFinalize(sts, pod) && controllerutil.RemoveFinalizer(pod, podcontroller.PodFinalizer) {
+		updated = true
+	}
+
+	return updated
+}
+
+func shouldUngate(sts *appsv1.StatefulSet, pod *corev1.Pod) bool {
+	return sts == nil || sts.Status.CurrentRevision != sts.Status.UpdateRevision &&
+		sts.Status.CurrentRevision == pod.Labels[appsv1.ControllerRevisionHashLabelKey]
+}
+
+func shouldFinalize(sts *appsv1.StatefulSet, pod *corev1.Pod) bool {
+	return shouldUngate(sts, pod) || pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	ctrl.Log.V(3).Info("Setting up StatefulSet reconciler")
-	return ctrl.NewControllerManagedBy(mgr).For(&appsv1.StatefulSet{}).Complete(r)
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.StatefulSet{}).
+		WithEventFilter(r).
+		Watches(&corev1.Pod{}, &podHandler{}).
+		Complete(r)
 }
 
 func NewReconciler(client client.Client, _ record.EventRecorder, _ ...jobframework.Option) jobframework.JobReconcilerInterface {
 	return &Reconciler{client: client}
+}
+
+var _ predicate.Predicate = (*Reconciler)(nil)
+
+func (r *Reconciler) Generic(event.GenericEvent) bool {
+	return false
+}
+
+func (r *Reconciler) Create(e event.CreateEvent) bool {
+	return r.handle(e.Object)
+}
+
+func (r *Reconciler) Update(e event.UpdateEvent) bool {
+	return r.handle(e.ObjectNew)
+}
+
+func (r *Reconciler) Delete(e event.DeleteEvent) bool {
+	return r.handle(e.Object)
+}
+
+func (r *Reconciler) handle(obj client.Object) bool {
+	sts, isSts := obj.(*appsv1.StatefulSet)
+	if !isSts {
+		return true
+	}
+	// Handle only statefulset managed by kueue.
+	return isManagedByKueue(sts)
+}
+
+var _ handler.EventHandler = (*podHandler)(nil)
+
+type podHandler struct{}
+
+func (h *podHandler) Generic(context.Context, event.GenericEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *podHandler) Create(_ context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// To watch for pod ADDED events.
+	h.handle(e.Object, q)
+}
+
+func (h *podHandler) Update(_ context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *podHandler) Delete(context.Context, event.DeleteEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *podHandler) handle(obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	pod, isPod := obj.(*corev1.Pod)
+	if !isPod || pod.Annotations[podcontroller.SuspendedByParentAnnotation] != FrameworkName {
+		return
+	}
+	if controllerRef := metav1.GetControllerOf(pod); controllerRef != nil {
+		if controllerRef.Kind != gvk.Kind || controllerRef.APIVersion != gvk.GroupVersion().String() {
+			// The pod is controlled by an owner that is not an apps/v1 StatefulSet.
+			return
+		}
+		q.AddAfter(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: pod.Namespace,
+				Name:      controllerRef.Name,
+			},
+		}, podBatchPeriod)
+	}
 }

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -42,18 +42,52 @@ var (
 
 func TestReconciler(t *testing.T) {
 	cases := map[string]struct {
-		statefulSet     appsv1.StatefulSet
+		stsKey          client.ObjectKey
+		statefulSet     *appsv1.StatefulSet
 		pods            []corev1.Pod
-		wantStatefulSet appsv1.StatefulSet
+		wantStatefulSet *appsv1.StatefulSet
 		wantPods        []corev1.Pod
 		wantErr         error
 	}{
+		"statefulset not found": {
+			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			pods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					KueueFinalizer().
+					StatusPhase(corev1.PodSucceeded).
+					Obj(),
+				*testingjobspod.MakePod("pod2", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					KueueFinalizer().
+					StatusPhase(corev1.PodFailed).
+					Obj(),
+				*testingjobspod.MakePod("pod3", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					KueueFinalizer().
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					StatusPhase(corev1.PodSucceeded).
+					Obj(),
+				*testingjobspod.MakePod("pod2", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					StatusPhase(corev1.PodFailed).
+					Obj(),
+				*testingjobspod.MakePod("pod3", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					Obj(),
+			},
+		},
 		"statefulset with finished pods": {
-			statefulSet: *statefulsettesting.MakeStatefulSet("sts", "ns").
+			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				Replicas(0).
 				Queue("lq").
 				DeepCopy(),
-			wantStatefulSet: *statefulsettesting.MakeStatefulSet("sts", "ns").
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
 				Replicas(0).
 				Queue("lq").
 				DeepCopy(),
@@ -94,7 +128,11 @@ func TestReconciler(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			clientBuilder := utiltesting.NewClientBuilder()
 
-			objs := []client.Object{&tc.statefulSet}
+			objs := make([]client.Object, 0, len(tc.pods)+1)
+			if tc.statefulSet != nil {
+				objs = append(objs, tc.statefulSet)
+			}
+
 			for _, p := range tc.pods {
 				objs = append(objs, p.DeepCopy())
 			}
@@ -103,15 +141,18 @@ func TestReconciler(t *testing.T) {
 
 			reconciler := NewReconciler(kClient, nil)
 
-			statefulSetKey := client.ObjectKeyFromObject(&tc.statefulSet)
-			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: statefulSetKey})
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: tc.stsKey})
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Reconcile returned error (-want,+got):\n%s", diff)
 			}
 
-			gotStatefulSet := appsv1.StatefulSet{}
-			if err := kClient.Get(ctx, statefulSetKey, &gotStatefulSet); err != nil {
+			gotStatefulSet := &appsv1.StatefulSet{}
+			err = kClient.Get(ctx, tc.stsKey, gotStatefulSet)
+			if client.IgnoreNotFound(err) != nil {
 				t.Fatalf("Could not get StatefuleSet after reconcile: %v", err)
+			}
+			if err != nil {
+				gotStatefulSet = nil
 			}
 
 			if diff := cmp.Diff(tc.wantStatefulSet, gotStatefulSet, baseCmpOpts...); diff != "" {


### PR DESCRIPTION
Cherry pick of #4150 on release-0.10.

#4150: Finalize Pods if StatefulSet is not found.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a bug that doesn't allow Kueue to delete Pods after a StatefulSet is deleted.
```