### PR TITLE
TAS: Improve error message for TAS workloads when no flavor assigned

### DIFF
--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -36,6 +36,8 @@ func assignTopology(log logr.Logger,
 	switch {
 	case psAssignment.Status.IsError():
 		log.V(2).Info("There is no resource quota assignment for the workload. No need to check TAS.", "message", psAssignment.Status.Message())
+	case len(psAssignment.Flavors) == 0:
+		log.V(2).Info("There is no flavor assignment for the workload. No need to check TAS.", "message", psAssignment.Status.Message())
 	case len(cq.TASFlavors) == 0:
 		if psAssignment.Status == nil {
 			psAssignment.Status = &Status{}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4053,7 +4053,7 @@ func TestScheduleForTAS(t *testing.T) {
 					Key:       types.NamespacedName{Namespace: "default", Name: "foo"},
 					EventType: "Warning",
 					Reason:    "Pending",
-					Message:   "failed to assign flavors to pod set one: no flavor assigned",
+					Message:   `couldn't assign flavors to pod set one: Flavor "tas-default" does not contain the requested level`,
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Prepares for https://github.com/kubernetes-sigs/kueue/pull/4200

#### Special notes for your reviewer:

Do you think worth a cherry-pick?

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Improve error message in the event when scheduling for TAS workload fails due to unassigned flavors.
```