### PR TITLE
Automated cherry pick of #4150: Finalize Pods if StatefulSet is not found.

### DIFF
--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -80,6 +80,14 @@ rules:
       - update
       - watch
   - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - autoscaling.x-k8s.io
     resources:
       - provisioningrequests

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -79,6 +79,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - autoscaling.x-k8s.io
   resources:
   - provisioningrequests

--- a/pkg/controller/jobs/statefulset/statefulset_controller.go
+++ b/pkg/controller/jobs/statefulset/statefulset_controller.go
@@ -39,7 +39,7 @@ const (
 func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:   SetupIndexes,
-		NewReconciler:  jobframework.NewNoopReconcilerFactory(gvk),
+		NewReconciler:  NewReconciler,
 		SetupWebhook:   SetupWebhook,
 		JobType:        &appsv1.StatefulSet{},
 		AddToScheme:    appsv1.AddToScheme,

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statefulset
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
+	clientutil "sigs.k8s.io/kueue/pkg/util/client"
+	"sigs.k8s.io/kueue/pkg/util/parallelize"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
+)
+
+const (
+	podBatchPeriod = time.Second
+)
+
+// +kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;list;watch
+
+var (
+	_ jobframework.JobReconcilerInterface = (*Reconciler)(nil)
+)
+
+type Reconciler struct {
+	client client.Client
+}
+
+func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx).WithValues("statefulset", klog.KRef(req.Namespace, req.Name))
+	ctx = ctrl.LoggerInto(ctx, log)
+	log.V(2).Info("Reconciling StatefulSet")
+
+	err := r.fetchAndFinalizePods(ctx, req)
+	return ctrl.Result{}, err
+}
+
+func (r *Reconciler) fetchAndFinalizePods(ctx context.Context, req reconcile.Request) error {
+	podList := &corev1.PodList{}
+	if err := r.client.List(ctx, podList, client.InNamespace(req.Namespace), client.MatchingLabels{
+		podcontroller.GroupNameLabel: GetWorkloadName(req.Name),
+	}); err != nil {
+		return err
+	}
+
+	sts := &appsv1.StatefulSet{}
+	err := r.client.Get(ctx, req.NamespacedName, sts)
+	if client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	if err != nil {
+		sts = nil
+	}
+
+	return r.finalizePods(ctx, sts, podList.Items)
+}
+
+func (r *Reconciler) finalizePods(ctx context.Context, sts *appsv1.StatefulSet, pods []corev1.Pod) error {
+	return parallelize.Until(ctx, len(pods), func(i int) error {
+		return r.finalizePod(ctx, sts, &pods[i])
+	})
+}
+
+func (r *Reconciler) finalizePod(ctx context.Context, sts *appsv1.StatefulSet, pod *corev1.Pod) error {
+	log := ctrl.LoggerFrom(ctx)
+	return client.IgnoreNotFound(clientutil.Patch(ctx, r.client, pod, true, func() (bool, error) {
+		if ungateAndFinalize(sts, pod) {
+			log.V(3).Info(
+				"Finalizing pod in group",
+				"pod", klog.KObj(pod),
+				"group", pod.Labels[podcontroller.GroupNameLabel],
+			)
+			return true, nil
+		}
+		return false, nil
+	}))
+}
+
+func ungateAndFinalize(sts *appsv1.StatefulSet, pod *corev1.Pod) bool {
+	var updated bool
+
+	if shouldUngate(sts, pod) && utilpod.Ungate(pod, podcontroller.SchedulingGateName) {
+		updated = true
+	}
+
+	if shouldFinalize(sts, pod) && controllerutil.RemoveFinalizer(pod, podcontroller.PodFinalizer) {
+		updated = true
+	}
+
+	return updated
+}
+
+func shouldUngate(sts *appsv1.StatefulSet, pod *corev1.Pod) bool {
+	return sts == nil || sts.Status.CurrentRevision != sts.Status.UpdateRevision &&
+		sts.Status.CurrentRevision == pod.Labels[appsv1.ControllerRevisionHashLabelKey]
+}
+
+func shouldFinalize(sts *appsv1.StatefulSet, pod *corev1.Pod) bool {
+	return shouldUngate(sts, pod) || pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
+}
+
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	ctrl.Log.V(3).Info("Setting up StatefulSet reconciler")
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.StatefulSet{}).
+		WithEventFilter(r).
+		Watches(&corev1.Pod{}, &podHandler{}).
+		Complete(r)
+}
+
+func NewReconciler(client client.Client, _ record.EventRecorder, _ ...jobframework.Option) jobframework.JobReconcilerInterface {
+	return &Reconciler{client: client}
+}
+
+var _ predicate.Predicate = (*Reconciler)(nil)
+
+func (r *Reconciler) Generic(event.GenericEvent) bool {
+	return false
+}
+
+func (r *Reconciler) Create(e event.CreateEvent) bool {
+	return r.handle(e.Object)
+}
+
+func (r *Reconciler) Update(e event.UpdateEvent) bool {
+	return r.handle(e.ObjectNew)
+}
+
+func (r *Reconciler) Delete(e event.DeleteEvent) bool {
+	return r.handle(e.Object)
+}
+
+func (r *Reconciler) handle(obj client.Object) bool {
+	sts, isSts := obj.(*appsv1.StatefulSet)
+	if !isSts {
+		return true
+	}
+	// Handle only statefulset managed by kueue.
+	return isManagedByKueue(sts)
+}
+
+var _ handler.EventHandler = (*podHandler)(nil)
+
+type podHandler struct{}
+
+func (h *podHandler) Generic(context.Context, event.GenericEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *podHandler) Create(_ context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// To watch for pod ADDED events.
+	h.handle(e.Object, q)
+}
+
+func (h *podHandler) Update(_ context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *podHandler) Delete(context.Context, event.DeleteEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *podHandler) handle(obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	pod, isPod := obj.(*corev1.Pod)
+	if !isPod {
+		return
+	}
+	if controllerRef := metav1.GetControllerOf(pod); controllerRef != nil {
+		if controllerRef.Kind != gvk.Kind || controllerRef.APIVersion != gvk.GroupVersion().String() {
+			// The pod is controlled by an owner that is not an apps/v1 StatefulSet.
+			return
+		}
+		// The check for the "group-name" label is introduced specifically for the 0.9
+		// branch to avoid reconciling all StatefulSets, as the 0.9 branch does not yet
+		// have the `pod-suspending-parent` annotation.
+		if _, ok := pod.Labels[podcontroller.GroupNameLabel]; !ok {
+			return
+		}
+		q.AddAfter(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: pod.Namespace,
+				Name:      controllerRef.Name,
+			},
+		}, podBatchPeriod)
+	}
+}

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statefulset
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingjobspod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	statefulsettesting "sigs.k8s.io/kueue/pkg/util/testingjobs/statefulset"
+)
+
+var (
+	baseCmpOpts = []cmp.Option{
+		cmpopts.EquateEmpty(),
+		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+	}
+)
+
+func TestReconciler(t *testing.T) {
+	cases := map[string]struct {
+		stsKey          client.ObjectKey
+		statefulSet     *appsv1.StatefulSet
+		pods            []corev1.Pod
+		wantStatefulSet *appsv1.StatefulSet
+		wantPods        []corev1.Pod
+		wantErr         error
+	}{
+		"statefulset not found": {
+			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			pods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					KueueFinalizer().
+					StatusPhase(corev1.PodSucceeded).
+					Obj(),
+				*testingjobspod.MakePod("pod2", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					KueueFinalizer().
+					StatusPhase(corev1.PodFailed).
+					Obj(),
+				*testingjobspod.MakePod("pod3", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					KueueFinalizer().
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					StatusPhase(corev1.PodSucceeded).
+					Obj(),
+				*testingjobspod.MakePod("pod2", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					StatusPhase(corev1.PodFailed).
+					Obj(),
+				*testingjobspod.MakePod("pod3", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					Obj(),
+			},
+		},
+		"statefulset with finished pods": {
+			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				Replicas(0).
+				Queue("lq").
+				DeepCopy(),
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				Replicas(0).
+				Queue("lq").
+				DeepCopy(),
+			pods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					KueueFinalizer().
+					StatusPhase(corev1.PodSucceeded).
+					Obj(),
+				*testingjobspod.MakePod("pod2", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					KueueFinalizer().
+					StatusPhase(corev1.PodFailed).
+					Obj(),
+				*testingjobspod.MakePod("pod3", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					KueueFinalizer().
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					StatusPhase(corev1.PodSucceeded).
+					Obj(),
+				*testingjobspod.MakePod("pod2", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					StatusPhase(corev1.PodFailed).
+					Obj(),
+				*testingjobspod.MakePod("pod3", "ns").
+					Label(pod.GroupNameLabel, GetWorkloadName("sts")).
+					KueueFinalizer().
+					Obj(),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			clientBuilder := utiltesting.NewClientBuilder()
+
+			objs := make([]client.Object, 0, len(tc.pods)+1)
+			if tc.statefulSet != nil {
+				objs = append(objs, tc.statefulSet)
+			}
+
+			for _, p := range tc.pods {
+				objs = append(objs, p.DeepCopy())
+			}
+
+			kClient := clientBuilder.WithObjects(objs...).Build()
+
+			reconciler := NewReconciler(kClient, nil)
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: tc.stsKey})
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Reconcile returned error (-want,+got):\n%s", diff)
+			}
+
+			gotStatefulSet := &appsv1.StatefulSet{}
+			err = kClient.Get(ctx, tc.stsKey, gotStatefulSet)
+			if client.IgnoreNotFound(err) != nil {
+				t.Fatalf("Could not get StatefuleSet after reconcile: %v", err)
+			}
+			if err != nil {
+				gotStatefulSet = nil
+			}
+
+			if diff := cmp.Diff(tc.wantStatefulSet, gotStatefulSet, baseCmpOpts...); diff != "" {
+				t.Errorf("StatefuleSet after reconcile (-want,+got):\n%s", diff)
+			}
+
+			gotPodList := &corev1.PodList{}
+			if err := kClient.List(ctx, gotPodList); err != nil {
+				t.Fatalf("Could not get PodList after reconcile: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.wantPods, gotPodList.Items, baseCmpOpts...); diff != "" {
+				t.Errorf("Pods after reconcile (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/test/e2e/singlecluster/statefulset_test.go
+++ b/test/e2e/singlecluster/statefulset_test.go
@@ -133,5 +133,50 @@ var _ = ginkgo.Describe("Stateful set integration", func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, statefulSet, true)
 			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, createdWorkload, false, util.LongTimeout)
 		})
+
+		ginkgo.It("should delete all Pods if StatefulSet was deleted after being partially ready", func() {
+			statefulSet := statefulsettesting.MakeStatefulSet("sts", ns.Name).
+				Image(util.E2eTestSleepImage, []string{"10m"}).
+				Request(corev1.ResourceCPU, "100m").
+				Replicas(3).
+				Queue(localQueueName).
+				Obj()
+			wlLookupKey := types.NamespacedName{Name: statefulset.GetWorkloadName(statefulSet.Name), Namespace: ns.Name}
+
+			ginkgo.By("Create StatefulSet", func() {
+				gomega.Expect(k8sClient.Create(ctx, statefulSet)).To(gomega.Succeed())
+			})
+
+			createdWorkload := &kueue.Workload{}
+			ginkgo.By("Check workload is created", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Check workload is admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, createdWorkload)
+			})
+
+			ginkgo.By("Waiting for replicas is partially ready", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdStatefulSet := &appsv1.StatefulSet{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).To(gomega.Succeed())
+					g.Expect(createdStatefulSet.Status.ReadyReplicas).To(gomega.BeNumerically(">", 0))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Delete StatefulSet", func() {
+				gomega.Expect(k8sClient.Delete(ctx, statefulSet)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("Check all pods are deleted", func() {
+				pods := &corev1.PodList{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(pods.Items).Should(gomega.BeEmpty())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
 	})
 })


### PR DESCRIPTION
Cherry pick of #4150 on release-0.9.

#4150: Finalize Pods if StatefulSet is not found.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a bug that doesn't allow Kueue to delete Pods after a StatefulSet is deleted.
```