### PR TITLE
Improve output messages in case of failed e2e tests for metrics

### DIFF
--- a/pkg/util/testing/metrics_matchers.go
+++ b/pkg/util/testing/metrics_matchers.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+
+	utilstrings "sigs.k8s.io/kueue/pkg/util/strings"
+)
+
+type mode string
+
+const (
+	containsAll mode = "contains-all"
+	excludesAll mode = "excludes-all"
+)
+
+func ContainMetrics(expectedMetrics [][]string) types.GomegaMatcher {
+	return &metricsMatcher{
+		expectedMetrics: expectedMetrics,
+		mode:            containsAll,
+	}
+}
+
+func ExcludeMetrics(expectedMetrics [][]string) types.GomegaMatcher {
+	return &metricsMatcher{
+		expectedMetrics: expectedMetrics,
+		mode:            excludesAll,
+	}
+}
+
+type metricsMatcher struct {
+	mode             mode
+	expectedMetrics  [][]string
+	lastFailedMetric []string
+}
+
+func containsMetric(output []string, metric []string) bool {
+	for _, line := range output {
+		if utilstrings.StringContainsSubstrings(line, metric...) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (matcher *metricsMatcher) Match(actual any) (bool, error) {
+	input, ok := actual.(string)
+	if !ok {
+		return false, fmt.Errorf("Metrics matcher expects a string. Got:\n%s", format.Object(actual, 1))
+	}
+
+	lines := strings.Split(input, "\n")
+
+	var assertFunction func(output []string, metric []string) bool
+
+	switch matcher.mode {
+	case containsAll:
+		assertFunction = containsMetric
+	case excludesAll:
+		assertFunction = func(output []string, metric []string) bool {
+			return !containsMetric(output, metric)
+		}
+	default:
+		return false, fmt.Errorf("unsupported matcher mode: %s", matcher.mode)
+	}
+
+	for _, metric := range matcher.expectedMetrics {
+		if !assertFunction(lines, metric) {
+			matcher.lastFailedMetric = metric
+
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func filterOutputWithKueueMetrics(input string) string {
+	lines := strings.Split(input, "\n")
+
+	output := make([]string, 0, len(lines))
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "kueue_") {
+			output = append(output, line)
+		}
+	}
+
+	return strings.Join(output, "\n")
+}
+
+func actualToOutput(actual any) any {
+	if actualStr, ok := actual.(string); ok {
+		return filterOutputWithKueueMetrics(actualStr)
+	}
+
+	return actual
+}
+
+func (matcher *metricsMatcher) FailureMessage(actual any) string {
+	var messageIntro string
+	switch matcher.mode {
+	case containsAll:
+		messageIntro = fmt.Sprintf(
+			"Expected to contain metric:\n%s\n",
+			format.Object(matcher.lastFailedMetric, 1),
+		)
+	case excludesAll:
+		messageIntro = fmt.Sprintf(
+			"Expected not to contain metric:\n%s\n",
+			format.Object(matcher.lastFailedMetric, 1),
+		)
+	default:
+		return fmt.Sprintf("unsupported matcher mode: %s", matcher.mode)
+	}
+
+	return fmt.Sprintf(
+		"%s\nActual:\n%s",
+		messageIntro,
+		format.Object(actualToOutput(actual), 1),
+	)
+}
+
+func (matcher *metricsMatcher) NegatedFailureMessage(_ any) string {
+	panic("metricsMatcher does not support negated testing. Please implement if needed.")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Improve output of metrics e2e tests to understand potential failures more clearly.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4139 

#### Special notes for your reviewer:
Example of failed test output:
```
  Expected to contain metric:
      <[]string | len:3, cap:3>: [
          "kueue_nonexistent_metric",
          "tag1",
          "tag2",
      ]

  Actual:
      <string>: kueue_admission_attempt_duration_seconds_bucket{result="success",le="0.005"} 0
      kueue_admission_attempt_duration_seconds_bucket{result="success",le="0.01"} 1
      kueue_admission_attempt_duration_seconds_bucket{result="success",le="0.025"} 1
      kueue_admission_attempt_duration_seconds_bucket{result="success",le="0.05"} 1
      kueue_admission_attempt_duration_seconds_bucket{result="success",le="0.1"} 1
      kueue_admission_attempt_duration_seconds_bucket{result="success",le="0.25"} 1
      kueue_admission_attempt_duration_seconds_bucket{result="success",le="0.5"} 1
      ...
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```