### PR TITLE
Validate prebuilt workload for Pod groups.

### DIFF
--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -64,6 +64,7 @@ var (
 	annotationsPath                = metaPath.Child("annotations")
 	managedLabelPath               = labelsPath.Key(ManagedLabelKey)
 	groupNameLabelPath             = labelsPath.Key(GroupNameLabel)
+	prebuiltWorkloadLabelPath      = labelsPath.Key(ctrlconstants.PrebuiltWorkloadLabel)
 	groupTotalCountAnnotationPath  = annotationsPath.Key(GroupTotalCountAnnotation)
 	retriableInGroupAnnotationPath = annotationsPath.Key(RetriableInGroupAnnotation)
 
@@ -291,6 +292,7 @@ func validateCommon(pod *Pod) field.ErrorList {
 	allErrs := validateManagedLabel(pod)
 	allErrs = append(allErrs, validatePodGroupMetadata(pod)...)
 	allErrs = append(allErrs, validateTopologyRequest(pod)...)
+	allErrs = append(allErrs, validatePrebuiltWorkloadName(pod)...)
 	return allErrs
 }
 
@@ -360,4 +362,14 @@ func validateUpdateForRetriableInGroupAnnotation(oldPod, newPod *Pod) field.Erro
 	}
 
 	return field.ErrorList{}
+}
+
+func validatePrebuiltWorkloadName(pod *Pod) field.ErrorList {
+	allErrs := field.ErrorList{}
+	prebuiltWorkloadName, hasPrebuiltWorkload := jobframework.PrebuiltWorkloadFor(pod)
+	groupName := podGroupName(pod.pod)
+	if hasPrebuiltWorkload && groupName != "" && prebuiltWorkloadName != groupName {
+		allErrs = append(allErrs, field.Invalid(prebuiltWorkloadLabelPath, prebuiltWorkloadLabelPath, "prebuilt workload and pod group should be equal"))
+	}
+	return allErrs
 }

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -595,6 +595,31 @@ func TestValidateCreate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
+		"prebuilt workload for pod": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkload("workload-name").
+				Obj(),
+		},
+		"prebuilt workload for pod group valid": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkload("group-name").
+				Group("group-name").
+				GroupTotalCount("3").
+				Obj(),
+		},
+		"prebuilt workload for pod group invalid": {
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkload("workload-name").
+				Group("group-name").
+				GroupTotalCount("3").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.labels[kueue.x-k8s.io/prebuilt-workload-name]",
+				},
+			}.ToAggregate(),
+		},
 	}
 
 	for name, tc := range testCases {
@@ -759,6 +784,26 @@ func TestValidateUpdate(t *testing.T) {
 				&field.Error{
 					Type:  field.ErrorTypeForbidden,
 					Field: "metadata.annotations[kueue.x-k8s.io/retriable-in-group]",
+				},
+			}.ToAggregate(),
+		},
+		"prebuilt workload for pod group invalid": {
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkload("group-name").
+				Group("group-name").
+				GroupTotalCount("3").
+				KueueSchedulingGate().
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				PrebuiltWorkload("group-name-new").
+				Group("group-name").
+				GroupTotalCount("3").
+				KueueSchedulingGate().
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.labels[kueue.x-k8s.io/prebuilt-workload-name]",
 				},
 			}.ToAggregate(),
 		},

--- a/site/content/en/docs/reference/labels-and-annotations.md
+++ b/site/content/en/docs/reference/labels-and-annotations.md
@@ -160,6 +160,9 @@ The label key of the job holds the name of the pre-built workload to be used.
 The intended use of prebuilt workload is to create the Job once the workload
 is created. In other scenarios the behavior is undefined.
 
+Note: When using `kueue.x-k8s.io/pod-group-name`, the prebuilt workload name 
+and the pod group name should be the same.
+
 ### kueue.x-k8s.io/priority-class
 
 Type: Label

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -1581,7 +1581,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				)
 
 				pod1 := testingpod.MakePod("test-pod-1", ns.Name).
-					Group("test-group").
+					Group(workloadName).
 					GroupTotalCount("2").
 					Request(corev1.ResourceCPU, "1").
 					Queue(lq.Name).
@@ -1589,7 +1589,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					RoleHash("leader").
 					Obj()
 				pod2 := testingpod.MakePod("test-pod-2", ns.Name).
-					Group("test-group").
+					Group(workloadName).
 					GroupTotalCount("2").
 					Request(corev1.ResourceCPU, "2").
 					Queue(lq.Name).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Fix "Should ungate pods with prebuild workload" integration test.
- Add validation for prebuilt workloads in Pod groups to ensure that the prebuilt workload name cannot be different from the workload name.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4113

#### Special notes for your reviewer:

When updating the Workload, we should catch an event to trigger the PodReconciler.

We send this event here 

https://github.com/kubernetes-sigs/kueue/blob/c74db07260c20ff8a4e3a611b9ac20f5b1f48582/pkg/controller/jobs/pod/event_handlers.go#L150-L153 

But the problem is that we send the group name instead of the prebuilt Workload name.

And here

https://github.com/kubernetes-sigs/kueue/blob/c74db07260c20ff8a4e3a611b9ac20f5b1f48582/pkg/controller/jobs/pod/pod_controller.go#L614-L618

we will not find it due to workload name different.

To fix this, I propose restricting users from setting different names for the Pod group and the prebuilt workload.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```