### PR TITLE
TAS: de-couple tracking non-TAS usage and TAS usage

### DIFF
--- a/pkg/cache/tas_flavor.go
+++ b/pkg/cache/tas_flavor.go
@@ -128,7 +128,7 @@ func (c *TASFlavorCache) snapshotForNodes(log logr.Logger, nodes []corev1.Node, 
 	}
 	snapshot.initialize()
 	for domainID, usage := range c.usage {
-		snapshot.addUsage(domainID, usage)
+		snapshot.addTASUsage(domainID, usage)
 	}
 	for _, pod := range pods {
 		// skip unscheduled or terminal pods as they don't use any capacity
@@ -138,7 +138,7 @@ func (c *TASFlavorCache) snapshotForNodes(log logr.Logger, nodes []corev1.Node, 
 		if domainID, ok := nodeToDomain[pod.Spec.NodeName]; ok {
 			requests := resourcehelpers.PodRequests(&pod, resourcehelpers.PodResourcesOptions{})
 			usage := resources.NewRequests(requests)
-			snapshot.addUsage(domainID, usage)
+			snapshot.addNonTASUsage(domainID, usage)
 		}
 	}
 	return snapshot


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Part of  #3761

#### Special notes for your reviewer:

I extract this part to make the review easier. I de-couple the usage so that I can introduce `simulateEmpty` which checks if the workload could help potentially if all workloads would be preempted (or complete on their own). If the workload could fit, then the preemption mode is Preempt, otherwise "NoFit".

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```