### PR TITLE
Automated cherry pick of #4217: Use compatible controller name with Prometheus

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/admissioncheck.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck.go
@@ -177,7 +177,7 @@ func newACReconciler(c client.Client, helper *multiKueueStoreHelper) *ACReconcil
 
 func (a *ACReconciler) setupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		Named("multikueue-admissioncheck").
+		Named("multikueue_admissioncheck").
 		For(&kueue.AdmissionCheck{}).
 		Watches(&kueue.MultiKueueConfig{}, &mkConfigHandler{client: a.client}).
 		Watches(&kueue.MultiKueueCluster{}, &mkClusterHandler{client: a.client}).

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -500,7 +500,7 @@ func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		Named("multikueue-workload").
+		Named("multikueue_workload").
 		For(&kueue.Workload{}).
 		WatchesRawSource(source.Channel(w.clusters.wlUpdateCh, syncHndl)).
 		WithEventFilter(w).

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -808,7 +808,7 @@ func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 		acHandlerOverride: ach.reconcileWorkloadsUsing,
 	}
 	err := ctrl.NewControllerManagedBy(mgr).
-		Named("provisioning-workload").
+		Named("provisioning_workload").
 		For(&kueue.Workload{}).
 		Owns(&autoscaling.ProvisioningRequest{}).
 		Watches(&kueue.AdmissionCheck{}, ach).
@@ -827,7 +827,7 @@ func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		Named("provisioning-admissioncheck").
+		Named("provisioning_admissioncheck").
 		For(&kueue.AdmissionCheck{}).
 		Watches(&kueue.ProvisioningRequestConfig{}, prcACh).
 		Complete(acReconciler)

--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -79,7 +79,7 @@ func (r *rfReconciler) setupWithManager(mgr ctrl.Manager, cache *cache.Cache, cf
 		tasCache: cache.TASCache(),
 	}
 	return TASResourceFlavorController, ctrl.NewControllerManagedBy(mgr).
-		Named(TASResourceFlavorController).
+		Named("tas_resource_flavor_controller").
 		For(&kueue.ResourceFlavor{}).
 		Watches(&corev1.Node{}, &nodeHandler).
 		Watches(&kueuealpha.Topology{}, r.tHandler).

--- a/pkg/controller/tas/topology_controller.go
+++ b/pkg/controller/tas/topology_controller.go
@@ -72,7 +72,7 @@ func newTopologyReconciler(c client.Client, queues *queue.Manager, cache *cache.
 
 func (r *topologyReconciler) setupWithManager(mgr ctrl.Manager, cfg *configapi.Configuration) (string, error) {
 	return TASTopologyController, ctrl.NewControllerManagedBy(mgr).
-		Named(TASTopologyController).
+		Named("tas_topology_controller").
 		For(&kueuealpha.Topology{}).
 		WithOptions(controller.Options{NeedLeaderElection: ptr.To(false)}).
 		Watches(&kueue.ResourceFlavor{}, r.resourceFlavorHandler).

--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -93,7 +93,7 @@ func (r *topologyUngater) setupWithManager(mgr ctrl.Manager, cfg *configapi.Conf
 		expectationsStore: r.expectationsStore,
 	}
 	return TASTopologyUngater, ctrl.NewControllerManagedBy(mgr).
-		Named(TASTopologyUngater).
+		Named("tas_topology_ungater").
 		For(&kueue.Workload{}).
 		Watches(&corev1.Pod{}, &podHandler).
 		WithOptions(controller.Options{NeedLeaderElection: ptr.To(false)}).


### PR DESCRIPTION
Cherry pick of #4217 on release-0.10.

#4217: Use compatible controller name with Prometheus

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a bug that prevented tracking some of the controller-runtime metrics in Prometheus.
```