### PR TITLE
add feature gates table for graduated or deprecated features

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -234,7 +234,7 @@ spec:
 +       - --feature-gates=PartialAdmission=true
 ```
 
-The currently supported features are:
+### Feature gates for alpha and beta features
 
 | Feature                               | Default | Stage      | Since | Until |
 |---------------------------------------|---------|------------|-------|-------|
@@ -247,7 +247,6 @@ The currently supported features are:
 | `ProvisioningACC`                     | `false` | Alpha      | 0.5   | 0.6   |
 | `ProvisioningACC`                     | `true`  | Beta       | 0.7   |       |
 | `QueueVisibility`                     | `false` | Alpha      | 0.5   | 0.9   |
-| `QueueVisibility`                     | `false` | Deprecated | 0.9   |       |
 | `VisibilityOnDemand`                  | `false` | Alpha      | 0.6   |  0.8  |
 | `VisibilityOnDemand`                  | `true`  | Beta       | 0.9   |       |
 | `PrioritySortingWithinCohort`         | `true`  | Beta       | 0.6   |       |
@@ -260,11 +259,24 @@ The currently supported features are:
 | `ConfigurableResourceTransformations` | `true`  | Beta       | 0.10  |       |
 | `WorkloadResourceRequestsSummary`     | `false` | Alpha      | 0.9   | 0.9   |
 | `WorkloadResourceRequestsSummary`     | `true`  | Beta       | 0.10  | 0.10  |
-| `AdmissionCheckValidationRules`       | `false` | Deprecated | 0.9   | 0.9   |
-| `KeepQuotaForProvReqRetry`            | `false` | Deprecated | 0.9   | 0.9   |
 | `ManagedJobsNamespaceSelector`        | `true`  | Beta       | 0.10  |       |
 | `LocalQueueDefaulting`                | `false` | Alpha      | 0.10  |       |
 | `LocalQueueMetrics`                   | `false` | Alpha      | 0.10  |       |
+
+### Feature gates for graduated or deprecated features
+
+| Feature                               | Default | Stage      | Since | Until |
+|---------------------------------------|---------|------------|-------|-------|
+| `QueueVisibility`                     | `false` | Alpha      | 0.4   | 0.9   |
+| `QueueVisibility`                     | `false` | Deprecated | 0.9   |       |
+| `AdmissionCheckValidationRules`       | `false` | Deprecated | 0.9   |       |
+| `KeepQuotaForProvReqRetry`            | `false` | Deprecated | 0.9   |       |
+| `MultiplePreemptions`                 | `false` | Alpha      | 0.8   | 0.8   |
+| `MultiplePreemptions`                 | `true`  | Beta       | 0.9   | 0.9   |
+| `MultiplePreemptions`                 | `true`  | GA         | 0.10  |       |
+| `WorkloadResourceRequestsSummary`     | `false` | Alpha      | 0.9   | 0.10  |
+| `WorkloadResourceRequestsSummary`     | `true`  | Beta       | 0.10  | 0.11  |
+| `WorkloadResourceRequestsSummary`     | `true`  | GA         | 0.11  |       |
 
 ## What's next
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add a table that mentions deprecated/ga features.

This is necessary because over time feature gates will be removed or they will be deprecated on particular versions. This is helpful for end-users to know what state features are in.

Kubernetes has two separate tables for this.

https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4230 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```