### PR TITLE
Deprecate integrations.podOptions

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -48,8 +48,8 @@ type Configuration struct {
 	// unsuspended, they will start immediately.
 	ManageJobsWithoutQueueName bool `json:"manageJobsWithoutQueueName"`
 
-	// ManagedJobsNamespaceSelector can be used to selectively exempt namespaces when
-	// enabling ManagedJobsWithoutQueueName. The selector is respected for all workload
+	// ManagedJobsNamespaceSelector can be used to selectively exempt namespaces
+	// from management by Kueue. The selector is respected for all workload
 	// types consistently - Jobs and Pod-based integrations (pod, deployment, statefulset, etc).
 	ManagedJobsNamespaceSelector *metav1.LabelSelector `json:"managedJobsNamespaceSelector,omitempty"`
 

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -48,9 +48,21 @@ type Configuration struct {
 	// unsuspended, they will start immediately.
 	ManageJobsWithoutQueueName bool `json:"manageJobsWithoutQueueName"`
 
-	// ManagedJobsNamespaceSelector can be used to selectively exempt namespaces
-	// from management by Kueue. The selector is respected for all workload
-	// types consistently - Jobs and Pod-based integrations (pod, deployment, statefulset, etc).
+	// ManagedJobsNamespaceSelector provides a namespace-based mechanism to exempt jobs
+	// from management by Kueue.
+	//
+	// It provides a strong exemption for the Pod-based integrations (pod, deployment, statefulset, etc.),
+	// For Pod-based integrations, only jobs whose namespaces match ManagedJobsNamespaceSelector are
+	// eligible to be managed by Kueue.  Pods, deployments, etc. in non-matching namespaces will
+	// never be managed by Kueue, even if they have a kueue.x-k8s.io/queue-name label.
+	// This strong exemption ensures that Kueue will not interfere with the basic operation
+	// of system namespace.
+	//
+	// For all other integrations, ManagedJobsNamespaceSelector provides a weaker exemption
+	// by only modulating the effects of ManageJobsWithoutQueueName.  For these integrations,
+	// a job that has a kueue.x-k8s.io/queue-name label will always be managed by Kueue. Jobs without
+	// a kueue.x-k8s.io/queue-name label will be managed by Kueue only when ManageJobsWithoutQueueName is
+	// true and the job's namespace matches ManagedJobsNamespaceSelector.
 	ManagedJobsNamespaceSelector *metav1.LabelSelector `json:"managedJobsNamespaceSelector,omitempty"`
 
 	// InternalCertManagement is configuration for internalCertManagement

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -48,7 +48,8 @@ type Configuration struct {
 	// unsuspended, they will start immediately.
 	ManageJobsWithoutQueueName bool `json:"manageJobsWithoutQueueName"`
 
-	// ManagedJobsNamespaceSelector can be used to omit some namespaces from ManagedJobsWithoutQueueName
+	// ManagedJobsNamespaceSelector can be used to selectively exempt namespaces from both
+	// ManagedJobsWithoutQueueName and Pod-based integrations (pod, deployment, statefulset, etc).
 	ManagedJobsNamespaceSelector *metav1.LabelSelector `json:"managedJobsNamespaceSelector,omitempty"`
 
 	// InternalCertManagement is configuration for internalCertManagement
@@ -339,6 +340,9 @@ type Integrations struct {
 	// the expected format is `Kind.version.group.com`.
 	ExternalFrameworks []string `json:"externalFrameworks,omitempty"`
 	// PodOptions defines kueue controller behaviour for pod objects
+	// Deprecated: This field will be removed on v1beta2, use ManagedJobsNamespaceSelector
+	// (https://kueue.sigs.k8s.io/docs/tasks/run/plain_pods/)
+	// instead.
 	PodOptions *PodIntegrationOptions `json:"podOptions,omitempty"`
 
 	// labelKeysToCopy is a list of label keys that should be copied from the job into the

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -48,8 +48,9 @@ type Configuration struct {
 	// unsuspended, they will start immediately.
 	ManageJobsWithoutQueueName bool `json:"manageJobsWithoutQueueName"`
 
-	// ManagedJobsNamespaceSelector can be used to selectively exempt namespaces from both
-	// ManagedJobsWithoutQueueName and Pod-based integrations (pod, deployment, statefulset, etc).
+	// ManagedJobsNamespaceSelector can be used to selectively exempt namespaces when
+	// enabling ManagedJobsWithoutQueueName. The selector is respected for all workload
+	// types consistently - Jobs and Pod-based integrations (pod, deployment, statefulset, etc).
 	ManagedJobsNamespaceSelector *metav1.LabelSelector `json:"managedJobsNamespaceSelector,omitempty"`
 
 	// InternalCertManagement is configuration for internalCertManagement

--- a/apis/config/v1beta1/defaults.go
+++ b/apis/config/v1beta1/defaults.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	configv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/ptr"
+
 	"sigs.k8s.io/kueue/pkg/features"
 )
 
@@ -160,7 +161,7 @@ func SetDefaults_Configuration(cfg *Configuration) {
 	}
 
 	if !features.Enabled((features.ManagedJobsNamespaceSelector)) {
-		// Backwards compatability: default podOptions.NamespaceSelector if ManagedJobsNamespaceSelector disabled
+		// Backwards compatibility: default podOptions.NamespaceSelector if ManagedJobsNamespaceSelector disabled
 		if cfg.Integrations.PodOptions == nil {
 			cfg.Integrations.PodOptions = &PodIntegrationOptions{}
 		}

--- a/apis/config/v1beta1/defaults.go
+++ b/apis/config/v1beta1/defaults.go
@@ -158,28 +158,6 @@ func SetDefaults_Configuration(cfg *Configuration) {
 		}
 	}
 
-	if cfg.Integrations.PodOptions == nil {
-		cfg.Integrations.PodOptions = &PodIntegrationOptions{}
-	}
-
-	if cfg.Integrations.PodOptions.NamespaceSelector == nil {
-		matchExpressionsValues := []string{"kube-system", *cfg.Namespace}
-
-		cfg.Integrations.PodOptions.NamespaceSelector = &metav1.LabelSelector{
-			MatchExpressions: []metav1.LabelSelectorRequirement{
-				{
-					Key:      corev1.LabelMetadataName,
-					Operator: metav1.LabelSelectorOpNotIn,
-					Values:   matchExpressionsValues,
-				},
-			},
-		}
-	}
-
-	if cfg.Integrations.PodOptions.PodSelector == nil {
-		cfg.Integrations.PodOptions.PodSelector = &metav1.LabelSelector{}
-	}
-
 	if cfg.ManagedJobsNamespaceSelector == nil {
 		matchExpressionsValues := []string{"kube-system", *cfg.Namespace}
 

--- a/apis/config/v1beta1/defaults_test.go
+++ b/apis/config/v1beta1/defaults_test.go
@@ -61,18 +61,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 	}
 	defaultIntegrations := &Integrations{
 		Frameworks: []string{defaultJobFrameworkName},
-		PodOptions: &PodIntegrationOptions{
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      corev1.LabelMetadataName,
-						Operator: metav1.LabelSelectorOpNotIn,
-						Values:   []string{"kube-system", "kueue-system"},
-					},
-				},
-			},
-			PodSelector: &metav1.LabelSelector{},
-		},
 	}
 	defaultQueueVisibility := &QueueVisibility{
 		UpdateIntervalSeconds: DefaultQueueVisibilityUpdateIntervalSeconds,
@@ -92,18 +80,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 
 	overwriteNamespaceIntegrations := &Integrations{
 		Frameworks: []string{defaultJobFrameworkName},
-		PodOptions: &PodIntegrationOptions{
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      corev1.LabelMetadataName,
-						Operator: metav1.LabelSelectorOpNotIn,
-						Values:   []string{"kube-system", overwriteNamespace},
-					},
-				},
-			},
-			PodSelector: &metav1.LabelSelector{},
-		},
 	}
 
 	overwriteNamespaceSelector := &metav1.LabelSelector{
@@ -497,7 +473,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				ClientConnection: defaultClientConnection,
 				Integrations: &Integrations{
 					Frameworks: []string{"a", "b"},
-					PodOptions: defaultIntegrations.PodOptions,
 				},
 				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,

--- a/charts/kueue/templates/webhook/webhook.yaml
+++ b/charts/kueue/templates/webhook/webhook.yaml
@@ -1,4 +1,5 @@
 {{- $integrationsConfig := (fromYaml .Values.managerConfig.controllerManagerConfigYaml).integrations }}
+{{- $managerConfig := (fromYaml .Values.managerConfig.controllerManagerConfigYaml) }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -44,8 +45,8 @@ webhooks:
     {{- end }}
     name: mpod.kb.io
     namespaceSelector:
-      {{- if and (hasKey $integrationsConfig "podOptions") (hasKey ($integrationsConfig.podOptions) "namespaceSelector") }}
-        {{- toYaml $integrationsConfig.podOptions.namespaceSelector | nindent 6 -}}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
       {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
@@ -78,12 +79,16 @@ webhooks:
     {{- end }}
     name: mdeployment.kb.io
     namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
           operator: NotIn
           values:
             - kube-system
             - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - apps
@@ -300,12 +305,16 @@ webhooks:
     {{- end }}
     name: mstatefulset.kb.io
     namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
           operator: NotIn
           values:
             - kube-system
             - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - apps
@@ -421,8 +430,8 @@ webhooks:
     {{- end }}
     name: vpod.kb.io
     namespaceSelector:
-      {{- if and (hasKey $integrationsConfig "podOptions") (hasKey ($integrationsConfig.podOptions) "namespaceSelector") }}
-        {{- toYaml $integrationsConfig.podOptions.namespaceSelector | nindent 6 -}}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
       {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
@@ -456,12 +465,16 @@ webhooks:
     {{- end }}
     name: vdeployment.kb.io
     namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
           operator: NotIn
           values:
             - kube-system
             - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - apps
@@ -687,12 +700,16 @@ webhooks:
     {{- end }}
     name: vstatefulset.kb.io
     namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
           operator: NotIn
           values:
             - kube-system
             - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - apps

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -119,12 +119,6 @@ managerConfig:
     #  - "leaderworkerset.x-k8s.io/leaderworkerset" (requires enabling pod integration)
     #  externalFrameworks:
     #  - "Foo.v1.example.com"
-    #  podOptions:
-    #    namespaceSelector:
-    #      matchExpressions:
-    #        - key: kubernetes.io/metadata.name
-    #          operator: NotIn
-    #          values: [ kube-system, kueue-system ]
     #fairSharing:
     #  enable: true
     #  preemptionStrategies: [LessThanOrEqualToFinalShare, LessThanInitialShare]

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -326,13 +326,15 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *cache.Cache
 		jobframework.WithManageJobsWithoutQueueName(cfg.ManageJobsWithoutQueueName),
 		jobframework.WithWaitForPodsReady(cfg.WaitForPodsReady),
 		jobframework.WithKubeServerVersion(serverVersionFetcher),
-		jobframework.WithIntegrationOptions(corev1.SchemeGroupVersion.WithKind("Pod").String(), cfg.Integrations.PodOptions),
 		jobframework.WithEnabledFrameworks(cfg.Integrations.Frameworks),
 		jobframework.WithEnabledExternalFrameworks(cfg.Integrations.ExternalFrameworks),
 		jobframework.WithManagerName(constants.KueueName),
 		jobframework.WithLabelKeysToCopy(cfg.Integrations.LabelKeysToCopy),
 		jobframework.WithCache(cCache),
 		jobframework.WithQueues(queues),
+	}
+	if cfg.Integrations.PodOptions != nil {
+		opts = append(opts, jobframework.WithIntegrationOptions(corev1.SchemeGroupVersion.WithKind("Pod").String(), cfg.Integrations.PodOptions))
 	}
 	if features.Enabled(features.ManagedJobsNamespaceSelector) {
 		nsSelector, err := metav1.LabelSelectorAsSelector(cfg.ManagedJobsNamespaceSelector)

--- a/config/components/manager/controller_manager_config.yaml
+++ b/config/components/manager/controller_manager_config.yaml
@@ -60,12 +60,6 @@ integrations:
 #  - "leaderworkerset.x-k8s.io/leaderworkerset" # requires enabling pod integration
 #  externalFrameworks:
 #  - "Foo.v1.example.com"
-#  podOptions:
-#    namespaceSelector:
-#      matchExpressions:
-#        - key: kubernetes.io/metadata.name
-#          operator: NotIn
-#          values: [ kube-system, kueue-system ]
 #fairSharing:
 #  enable: true
 #  preemptionStrategies: [LessThanOrEqualToFinalShare, LessThanInitialShare]

--- a/hack/update-helm.sh
+++ b/hack/update-helm.sh
@@ -110,6 +110,7 @@ search_validate_webhook_annotations='  name: '\''{{ include "kueue.fullname" . }
 add_webhook_line=$(
   cat <<'EOF'
 {{- $integrationsConfig := (fromYaml .Values.managerConfig.controllerManagerConfigYaml).integrations }}
+{{- $managerConfig := (fromYaml .Values.managerConfig.controllerManagerConfigYaml) }}
 EOF
 )
 add_annotations_line=$(
@@ -130,8 +131,8 @@ add_webhook_pod_mutate=$(
     {{- end }}
     name: mpod.kb.io
     namespaceSelector:
-      {{- if and (hasKey $integrationsConfig "podOptions") (hasKey ($integrationsConfig.podOptions) "namespaceSelector") }}
-        {{- toYaml $integrationsConfig.podOptions.namespaceSelector | nindent 6 -}}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
       {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
@@ -151,8 +152,8 @@ add_webhook_pod_validate=$(
     {{- end }}
     name: vpod.kb.io
     namespaceSelector:
-      {{- if and (hasKey $integrationsConfig "podOptions") (hasKey ($integrationsConfig.podOptions) "namespaceSelector") }}
-        {{- toYaml $integrationsConfig.podOptions.namespaceSelector | nindent 6 -}}
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
       {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
@@ -173,12 +174,16 @@ add_webhook_deployment_mutate=$(
     {{- end }}
     name: mdeployment.kb.io
     namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
           operator: NotIn
           values:
             - kube-system
             - '{{ .Release.Namespace }}'
+      {{- end }}
 EOF
 )
 add_webhook_deployment_validate=$(
@@ -190,12 +195,16 @@ add_webhook_deployment_validate=$(
     {{- end }}
     name: vdeployment.kb.io
     namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
           operator: NotIn
           values:
             - kube-system
             - '{{ .Release.Namespace }}'
+      {{- end }}
 EOF
 )
 add_webhook_statefulset_mutate=$(
@@ -207,12 +216,16 @@ add_webhook_statefulset_mutate=$(
     {{- end }}
     name: mstatefulset.kb.io
     namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
           operator: NotIn
           values:
             - kube-system
             - '{{ .Release.Namespace }}'
+      {{- end }}
 EOF
 )
 add_webhook_statefulset_validate=$(
@@ -224,12 +237,16 @@ add_webhook_statefulset_validate=$(
     {{- end }}
     name: vstatefulset.kb.io
     namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
       matchExpressions:
         - key: kubernetes.io/metadata.name
           operator: NotIn
           values:
             - kube-system
             - '{{ .Release.Namespace }}'
+      {{- end }}
 EOF
 )
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -248,6 +248,28 @@ queueVisibility:
 		t.Fatal(err)
 	}
 
+	podIntegrationOptionsConfig := filepath.Join(tmpDir, "podIntegrationOptions.yaml")
+	if err := os.WriteFile(podIntegrationOptionsConfig, []byte(`
+apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
+integrations:
+  frameworks:
+  - pod
+  podOptions:
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values: [ kube-system, kueue-system, prohibited-namespace ]
+    podSelector:
+      matchExpressions:
+      - key: kueue-job
+        operator: In
+        values: [ "true", "True", "yes" ]
+`), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
 	multiKueueConfig := filepath.Join(tmpDir, "multiKueue.yaml")
 	if err := os.WriteFile(multiKueueConfig, []byte(`
 apiVersion: config.kueue.x-k8s.io/v1beta1
@@ -746,6 +768,66 @@ webhook:
 					UpdateIntervalSeconds: 10,
 					ClusterQueues: &configapi.ClusterQueueVisibility{
 						MaxCount: 0,
+					},
+				},
+				MultiKueue:                   defaultMultiKueue,
+				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
+			},
+			wantOptions: ctrl.Options{
+				HealthProbeBindAddress: configapi.DefaultHealthProbeBindAddress,
+				Metrics: metricsserver.Options{
+					BindAddress: configapi.DefaultMetricsBindAddress,
+				},
+				LeaderElection:                true,
+				LeaderElectionID:              configapi.DefaultLeaderElectionID,
+				LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
+				LeaderElectionReleaseOnCancel: true,
+				LeaseDuration:                 ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
+				RenewDeadline:                 ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
+				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
+				WebhookServer: &webhook.DefaultServer{
+					Options: webhook.Options{
+						Port: configapi.DefaultWebhookPort,
+					},
+				},
+			},
+		},
+		{
+			name:       "pod integration options config",
+			configFile: podIntegrationOptionsConfig,
+			wantConfiguration: configapi.Configuration{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: configapi.GroupVersion.String(),
+					Kind:       "Configuration",
+				},
+				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				ManageJobsWithoutQueueName: false,
+				InternalCertManagement:     enableDefaultInternalCertManagement,
+				ClientConnection:           defaultClientConnection,
+				QueueVisibility:            defaultQueueVisibility,
+				Integrations: &configapi.Integrations{
+					Frameworks: []string{
+						"pod",
+					},
+					PodOptions: &configapi.PodIntegrationOptions{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      corev1.LabelMetadataName,
+									Operator: metav1.LabelSelectorOpNotIn,
+									Values:   []string{"kube-system", "kueue-system", "prohibited-namespace"},
+								},
+							},
+						},
+						PodSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "kueue-job",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"true", "True", "yes"},
+								},
+							},
+						},
 					},
 				},
 				MultiKueue:                   defaultMultiKueue,

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -208,7 +208,7 @@ func validatePodIntegrationOptions(c *configapi.Configuration) field.ErrorList {
 		return allErrs
 	}
 
-	var namespaceSelector *metav1.LabelSelector = nil
+	var namespaceSelector *metav1.LabelSelector
 	namespaceSelectorPath := managedJobsNamespaceSelectorPath
 	if c.Integrations.PodOptions != nil && c.Integrations.PodOptions.NamespaceSelector != nil {
 		namespaceSelector = c.Integrations.PodOptions.NamespaceSelector

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -208,14 +208,15 @@ func validatePodIntegrationOptions(c *configapi.Configuration) field.ErrorList {
 		return allErrs
 	}
 
-	var namespaceSelector *metav1.LabelSelector
+	var namespaceSelector *metav1.LabelSelector = nil
 	namespaceSelectorPath := managedJobsNamespaceSelectorPath
 	if c.Integrations.PodOptions != nil && c.Integrations.PodOptions.NamespaceSelector != nil {
 		namespaceSelector = c.Integrations.PodOptions.NamespaceSelector
 		namespaceSelectorPath = podOptionsNamespaceSelectorPath
 	} else if c.ManagedJobsNamespaceSelector != nil {
 		namespaceSelector = c.ManagedJobsNamespaceSelector
-	} else {
+	}
+	if namespaceSelector == nil {
 		return field.ErrorList{field.Required(managedJobsNamespaceSelectorPath, "cannot be empty when pod integration is enabled")}
 	}
 	prohibitedNamespaces := []labels.Set{{corev1.LabelMetadataName: metav1.NamespaceSystem}}

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -208,6 +208,22 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		"nil PodIntegrationOptions and nil managedJobsNamespaceSelector with mjns feature gate disabled": {
+			cfg: &configapi.Configuration{
+				QueueVisibility: defaultQueueVisibility,
+				Integrations: &configapi.Integrations{
+					Frameworks: []string{"pod"},
+					PodOptions: nil,
+				},
+			},
+			managedJobsFeatureGate: false,
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeRequired,
+					Field: "integrations.podOptions",
+				},
+			},
+		},
 		"nil PodIntegrationOptions and nil managedJobsNamespaceSelector": {
 			cfg: &configapi.Configuration{
 				QueueVisibility: defaultQueueVisibility,
@@ -216,7 +232,12 @@ func TestValidate(t *testing.T) {
 					PodOptions: nil,
 				},
 			},
+			managedJobsFeatureGate: true,
 			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeRequired,
+					Field: "managedJobsNamespaceSelector",
+				},
 				&field.Error{
 					Type:  field.ErrorTypeRequired,
 					Field: "managedJobsNamespaceSelector",
@@ -233,10 +254,11 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
+			managedJobsFeatureGate: false,
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeRequired,
-					Field: "managedJobsNamespaceSelector",
+					Field: "integrations.podOptions.namespaceSelector",
 				},
 			},
 		},

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -208,7 +208,7 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
-		"nil PodIntegrationOptions without managedJobsNamespaceSelector": {
+		"nil PodIntegrationOptions and nil managedJobsNamespaceSelector": {
 			cfg: &configapi.Configuration{
 				QueueVisibility: defaultQueueVisibility,
 				Integrations: &configapi.Integrations{
@@ -219,11 +219,11 @@ func TestValidate(t *testing.T) {
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeRequired,
-					Field: "integrations.podOptions",
+					Field: "managedJobsNamespaceSelector",
 				},
 			},
 		},
-		"nil PodIntegrationOptions.NamespaceSelector without managedJobsNamespaceSelector": {
+		"nil PodIntegrationOptions.NamespaceSelector and nil managedJobsNamespaceSelector": {
 			cfg: &configapi.Configuration{
 				QueueVisibility: defaultQueueVisibility,
 				Integrations: &configapi.Integrations{
@@ -236,7 +236,7 @@ func TestValidate(t *testing.T) {
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeRequired,
-					Field: "integrations.podOptions.namespaceSelector",
+					Field: "managedJobsNamespaceSelector",
 				},
 			},
 		},

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -220,7 +220,7 @@ func TestValidate(t *testing.T) {
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeRequired,
-					Field: "integrations.podOptions",
+					Field: "integrations.podOptions.namespaceSelector",
 				},
 			},
 		},

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -85,6 +85,9 @@ func TestDefault(t *testing.T) {
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
+				Label(constants.ManagedByKueueLabel, "true").
+				KueueSchedulingGate().
+				KueueFinalizer().
 				Obj(),
 		},
 		"pod with queue matching ns selector": {
@@ -814,7 +817,7 @@ func TestGetPodOptions(t *testing.T) {
 			integrationOpts: map[string]any{
 				batchv1.SchemeGroupVersion.WithKind("Job").String(): nil,
 			},
-			wantOpts: &configapi.PodIntegrationOptions{},
+			wantOpts: nil,
 		},
 		"podIntegrationOptions isn't of type PodIntegrationOptions": {
 			integrationOpts: map[string]any{

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -119,7 +119,8 @@ unsuspended, they will start immediately.</p>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector</code></a>
 </td>
 <td>
-   <p>ManagedJobsNamespaceSelector can be used to omit some namespaces from ManagedJobsWithoutQueueName</p>
+   <p>ManagedJobsNamespaceSelector can be used to selectively exempt namespaces from both
+ManagedJobsWithoutQueueName and Pod-based integrations (pod, deployment, statefulset, etc).</p>
 </td>
 </tr>
 <tr><td><code>internalCertManagement</code> <B>[Required]</B><br/>
@@ -526,7 +527,10 @@ the expected format is <code>Kind.version.group.com</code>.</p>
 <a href="#PodIntegrationOptions"><code>PodIntegrationOptions</code></a>
 </td>
 <td>
-   <p>PodOptions defines kueue controller behaviour for pod objects</p>
+   <p>PodOptions defines kueue controller behaviour for pod objects
+Deprecated: This field will be removed on v1beta2, use ManagedJobsNamespaceSelector
+(https://kueue.sigs.k8s.io/docs/tasks/run/plain_pods/)
+instead.</p>
 </td>
 </tr>
 <tr><td><code>labelKeysToCopy</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -119,8 +119,9 @@ unsuspended, they will start immediately.</p>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector</code></a>
 </td>
 <td>
-   <p>ManagedJobsNamespaceSelector can be used to selectively exempt namespaces from both
-ManagedJobsWithoutQueueName and Pod-based integrations (pod, deployment, statefulset, etc).</p>
+   <p>ManagedJobsNamespaceSelector can be used to selectively exempt namespaces
+from management by Kueue. The selector is respected for all workload
+types consistently - Jobs and Pod-based integrations (pod, deployment, statefulset, etc).</p>
 </td>
 </tr>
 <tr><td><code>internalCertManagement</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -119,9 +119,19 @@ unsuspended, they will start immediately.</p>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector</code></a>
 </td>
 <td>
-   <p>ManagedJobsNamespaceSelector can be used to selectively exempt namespaces
-from management by Kueue. The selector is respected for all workload
-types consistently - Jobs and Pod-based integrations (pod, deployment, statefulset, etc).</p>
+   <p>ManagedJobsNamespaceSelector provides a namespace-based mechanism to exempt jobs
+from management by Kueue.</p>
+<p>It provides a strong exemption for the Pod-based integrations (pod, deployment, statefulset, etc.),
+For Pod-based integrations, only jobs whose namespaces match ManagedJobsNamespaceSelector are
+eligible to be managed by Kueue.  Pods, deployments, etc. in non-matching namespaces will
+never be managed by Kueue, even if they have a kueue.x-k8s.io/queue-name label.
+This strong exemption ensures that Kueue will not interfere with the basic operation
+of system namespace.</p>
+<p>For all other integrations, ManagedJobsNamespaceSelector provides a weaker exemption
+by only modulating the effects of ManageJobsWithoutQueueName.  For these integrations,
+a job that has a kueue.x-k8s.io/queue-name label will always be managed by Kueue. Jobs without
+a kueue.x-k8s.io/queue-name label will be managed by Kueue only when ManageJobsWithoutQueueName is
+true and the job's namespace matches ManagedJobsNamespaceSelector.</p>
 </td>
 </tr>
 <tr><td><code>internalCertManagement</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/tasks/manage/enforce_job_management/manage_jobs_without_queue_name.md
+++ b/site/content/en/docs/tasks/manage/enforce_job_management/manage_jobs_without_queue_name.md
@@ -18,11 +18,10 @@ Learn how to [install Kueue with a custom manager configuration](/docs/installat
 You will need to modify the manage configuration to set `manageJobsWithoutQueueName` to true.
 
 If you also modify the default configuration to enable the `Pod`, `Deployment` or `StatefulSet` integrations,
-you may also need to override the default value of `integrations.podOptions.namespaceSelector` (Kueue 0.9 or earlier)
-or `managedJobsNamespaceSelector` (Kueue 0.10 or later) to limit the scope of `manageJobsWithoutQueueName`
-to only apply to _batch user_ namespaces.
+you may also need to override the default value of `managedJobsNamespaceSelector` to limit the scope of
+`manageJobsWithoutQueueName` to only apply to _batch user_ namespaces.
 
-The default value for both `integrations.podOptions.namespaceSelector` and `managedJobsNamespaceSelector` is
+The default value for `managedJobsNamespaceSelector` is
 ```yaml
 matchExpressions:
 - key: kubernetes.io/metadata.name

--- a/site/content/en/docs/tasks/run/plain_pods.md
+++ b/site/content/en/docs/tasks/run/plain_pods.md
@@ -52,13 +52,12 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 {{% alert title="Note" color="primary" %}}
 
 `managedJobsNamespaceSelector` is a Beta feature that is enabled by default.
-
 You can disable it by setting the `ManagedJobsNamespaceSelector` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
-{{% /alert %}}
 
   Prior to Kueue v0.10, the Configuration fields `integrations.podOptions.namespaceSelector`
   and `integrations.podOptions.podSelector` were used instead. The use of `podOptions` was
   deprecated in Kueue v0.11. Users should migrate to using `managedJobsNamespaceSelector`.
+{{% /alert %}}
 
 
 2. Kueue will run webhooks for all created pods if the pod integration is enabled. The webhook namespaceSelector could be 

--- a/site/content/en/docs/tasks/run/plain_pods.md
+++ b/site/content/en/docs/tasks/run/plain_pods.md
@@ -57,8 +57,8 @@ You can disable it by setting the `ManagedJobsNamespaceSelector` feature gate. C
 {{% /alert %}}
 
   Prior to Kueue v0.10, the Configuration fields `integrations.podOptions.namespaceSelector`
-  and `integrations.podOptions.podSelector` were used instead. Although `podOptions` is
-  still supported in Kueue v0.10, it is expected to be deprecated in a future release.
+  and `integrations.podOptions.podSelector` were used instead. The use of `podOptions` was
+  deprecated in Kueue v0.11. Users should migrate to using `managedJobsNamespaceSelector`.
 
 
 2. Kueue will run webhooks for all created pods if the pod integration is enabled. The webhook namespaceSelector could be 
@@ -71,7 +71,7 @@ You can disable it by setting the `ManagedJobsNamespaceSelector` feature gate. C
    ```
    
    When you [install Kueue via Helm](/docs/installation/#install-via-helm), the webhook namespace selector 
-   will match the `integrations.podOptions.namespaceSelector` in the `values.yaml`.
+   will match the `managedJobsNamespaceSelector` in the `values.yaml`.
 
    Make sure that namespaceSelector never matches the kueue namespace, otherwise the 
    Kueue deployment won't be able to create Pods.

--- a/site/content/en/docs/tasks/troubleshooting/troubleshooting_pods.md
+++ b/site/content/en/docs/tasks/troubleshooting/troubleshooting_pods.md
@@ -29,6 +29,17 @@ A Pod might not have the `kueue.x-k8s.io/managed` due to one of the following re
 4. The Pod doesn't have a `kueue.x-k8s.io/queue-name` label and [`manageJobsWithoutQueueName`](/docs/reference/kueue-config.v1beta1/#Configuration)
    is set to `false`.
 
+{{< feature-state state="beta" for_version="v0.10" >}}
+{{% alert title="Note" color="primary" %}}
+
+`managedJobsNamespaceSelector` is a Beta feature that is enabled by default.
+You can disable it by setting the `ManagedJobsNamespaceSelector` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
+
+Prior to Kueue v0.10, the Configuration field `integrations.podOptions.namespaceSelector`
+was used instead. The use of `podOptions` was
+deprecated in Kueue v0.11. Users should migrate to using `managedJobsNamespaceSelector`.
+{{% /alert %}}
+
 ## Identifying the Workload for your Pod
 
 When using [Pod groups](/docs/tasks/run/plain_pods/#running-a-group-of-pods-to-be-admitted-together),

--- a/site/content/en/docs/tasks/troubleshooting/troubleshooting_pods.md
+++ b/site/content/en/docs/tasks/troubleshooting/troubleshooting_pods.md
@@ -23,8 +23,8 @@ resource usage of this Pod directly.
 A Pod might not have the `kueue.x-k8s.io/managed` due to one of the following reasons:
 
 1. The [Pod integration is disabled](/docs/tasks/run/plain_pods/#before-you-begin).
-2. The Pod belongs to a namespace or has labels that don't satisfy the requirements of
-   the [`podOptions`](/docs/reference/kueue-config.v1beta1/#PodIntegrationOptions) configured for the Pod integration.
+2. The Pod belongs to a namespace that don't satisfy the requirements of
+   the [`managedJobsNamespaceSelector`](/docs/reference/kueue-config.v1beta1/#Configuration).
 3. The Pod is owned by a Job or equivalent CRD that is managed by Kueue.
 4. The Pod doesn't have a `kueue.x-k8s.io/queue-name` label and [`manageJobsWithoutQueueName`](/docs/reference/kueue-config.v1beta1/#Configuration)
    is set to `false`.

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -88,11 +88,8 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				jobframework.WithManageJobsWithoutQueueName(false),
 				jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
 				jobframework.WithKubeServerVersion(serverVersionFetcher),
-				jobframework.WithIntegrationOptions(corev1.SchemeGroupVersion.WithKind("Pod").String(), &configapi.PodIntegrationOptions{
-					PodSelector:       &metav1.LabelSelector{},
-					NamespaceSelector: nsSelector,
-				}),
 				jobframework.WithLabelKeysToCopy([]string{"toCopyKey"}),
+				jobframework.WithEnabledFrameworks([]string{"pod"}),
 			))
 			gomega.Expect(k8sClient.Create(ctx, defaultFlavor)).To(gomega.Succeed())
 			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
@@ -1719,10 +1716,7 @@ var _ = ginkgo.Describe("Pod controller interacting with scheduler", ginkgo.Orde
 			&configuration,
 			jobframework.WithManageJobsWithoutQueueName(false),
 			jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
-			jobframework.WithIntegrationOptions(corev1.SchemeGroupVersion.WithKind("Pod").String(), &configapi.PodIntegrationOptions{
-				PodSelector:       &metav1.LabelSelector{},
-				NamespaceSelector: nsSelector,
-			}),
+			jobframework.WithEnabledFrameworks([]string{"pod"}),
 		))
 		spotUntaintedFlavor = testing.MakeResourceFlavor("spot-untainted").NodeLabel(instanceKey, "spot-untainted").Obj()
 		gomega.Expect(k8sClient.Create(ctx, spotUntaintedFlavor)).Should(gomega.Succeed())
@@ -1979,10 +1973,7 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 			false,
 			&configapi.Configuration{WaitForPodsReady: waitForPodsReady},
 			jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
-			jobframework.WithIntegrationOptions(corev1.SchemeGroupVersion.WithKind("Pod").String(), &configapi.PodIntegrationOptions{
-				PodSelector:       &metav1.LabelSelector{},
-				NamespaceSelector: nsSelector,
-			}),
+			jobframework.WithEnabledFrameworks([]string{"pod"}),
 		))
 	})
 	ginkgo.AfterAll(func() {
@@ -2176,10 +2167,7 @@ var _ = ginkgo.Describe("Pod controller when TopologyAwareScheduling enabled", g
 	ginkgo.BeforeAll(func() {
 		fwk.StartManager(ctx, cfg, managerSetup(true, true, nil,
 			jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
-			jobframework.WithIntegrationOptions(corev1.SchemeGroupVersion.WithKind("Pod").String(), &configapi.PodIntegrationOptions{
-				PodSelector:       &metav1.LabelSelector{},
-				NamespaceSelector: nsSelector,
-			}),
+			jobframework.WithEnabledFrameworks([]string{"pod"}),
 		))
 	})
 

--- a/test/integration/singlecluster/webhook/jobs/pod_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/pod_webhook_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/discovery"
 
-	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
@@ -61,10 +60,6 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				jobframework.WithManageJobsWithoutQueueName(false),
 				jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
 				jobframework.WithKubeServerVersion(serverVersionFetcher),
-				jobframework.WithIntegrationOptions(corev1.SchemeGroupVersion.WithKind("Pod").String(), &configapi.PodIntegrationOptions{
-					PodSelector:       &metav1.LabelSelector{},
-					NamespaceSelector: nsSelector,
-				}),
 			))
 		})
 		ginkgo.BeforeEach(func() {
@@ -200,10 +195,6 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				jobframework.WithManageJobsWithoutQueueName(true),
 				jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
 				jobframework.WithKubeServerVersion(serverVersionFetcher),
-				jobframework.WithIntegrationOptions(corev1.SchemeGroupVersion.WithKind("Pod").String(), &configapi.PodIntegrationOptions{
-					PodSelector:       &metav1.LabelSelector{},
-					NamespaceSelector: nsSelector,
-				}),
 			))
 		})
 		ginkgo.BeforeEach(func() {

--- a/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
@@ -50,10 +49,6 @@ var _ = ginkgo.Describe("StatefulSet Webhook", func() {
 				statefulset.SetupWebhook,
 				jobframework.WithManageJobsWithoutQueueName(false),
 				jobframework.WithKubeServerVersion(serverVersionFetcher),
-				jobframework.WithIntegrationOptions(
-					corev1.SchemeGroupVersion.WithKind("Pod").String(),
-					&configapi.PodIntegrationOptions{},
-				),
 			))
 		})
 		ginkgo.AfterAll(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:

Deprecates integrations.podOptions:
+ mark podOptions as deprecated
+ remove defaulting of podOptions
+ adjust impl and tests to not assume podOptions is defaulted
+ update documentation to steer users to managedJobsNamespaceSelector
+ update helm chart generation tooling

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4168 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The configuration field `integrations.podOptions` is deprecated. 

ACTION_REQUIRED: Users who set the `Integrations.PodOptions` namespace selector to a non-default
value should plan for migrating to use `managedJobsNamespaceSelector` instead, as the PodOptions
selector is going to be removed in a future release.
```