### PR TITLE
Add RF API comments for evaluated nodeTaints effect

### DIFF
--- a/apis/kueue/v1beta1/resourceflavor_types.go
+++ b/apis/kueue/v1beta1/resourceflavor_types.go
@@ -63,6 +63,8 @@ type ResourceFlavorSpec struct {
 	// have.
 	// Workloads' podsets must have tolerations for these nodeTaints in order to
 	// get assigned this ResourceFlavor during admission.
+	// Only the 'NoSchedule' and 'NoExecute' taint effects are evaluated,
+	// while 'PreferNoSchedule' is ignored.
 	//
 	// An example of a nodeTaint is
 	// cloud.provider.com/preemptible="true":NoSchedule

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
@@ -81,6 +81,8 @@ spec:
                   have.
                   Workloads' podsets must have tolerations for these nodeTaints in order to
                   get assigned this ResourceFlavor during admission.
+                  Only the 'NoSchedule' and 'NoExecute' taint effects are evaluated,
+                  while 'PreferNoSchedule' is ignored.
 
                   An example of a nodeTaint is
                   cloud.provider.com/preemptible="true":NoSchedule

--- a/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
@@ -66,6 +66,8 @@ spec:
                   have.
                   Workloads' podsets must have tolerations for these nodeTaints in order to
                   get assigned this ResourceFlavor during admission.
+                  Only the 'NoSchedule' and 'NoExecute' taint effects are evaluated,
+                  while 'PreferNoSchedule' is ignored.
 
                   An example of a nodeTaint is
                   cloud.provider.com/preemptible="true":NoSchedule

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -2133,7 +2133,9 @@ controller that integrates with the Workload object.</p>
    <p>nodeTaints are taints that the nodes associated with this ResourceFlavor
 have.
 Workloads' podsets must have tolerations for these nodeTaints in order to
-get assigned this ResourceFlavor during admission.</p>
+get assigned this ResourceFlavor during admission.
+Only the 'NoSchedule' and 'NoExecute' taint effects are evaluated,
+while 'PreferNoSchedule' is ignored.</p>
 <p>An example of a nodeTaint is
 cloud.provider.com/preemptible=&quot;true&quot;:NoSchedule</p>
 <p>nodeTaints can be up to 8 elements.</p>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
As I described in https://github.com/kubernetes-sigs/kueue/issues/4257, cluster admins can specify the nodeTaints with `effect=PreferNoSchedule` in ResourceFlavor, but the flavorassigner never respects the taints.

So, I added API comments for which effects will be evaluated.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```