### PR TITLE
Don't run 'test-e2e-customconfigs' Makefile target as part of 'run-test-e2e' Makefile target

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -104,10 +104,8 @@ test-multikueue-integration: gomod-download envtest ginkgo dep-crds kueuectl gin
 
 CREATE_KIND_CLUSTER ?= true
 
-SINGLECLUSTER-E2E_TARGETS := $(addprefix run-test-e2e-singlecluster-,$(E2E_KIND_VERSION:kindest/node:v%=%))
-CUSTOMCONFIGS-E2E_TARGETS := $(addprefix run-test-e2e-customconfigs-,$(E2E_KIND_VERSION:kindest/node:v%=%))
 .PHONY: test-e2e
-test-e2e: kustomize ginkgo yq gomod-download dep-crds kueuectl ginkgo-top $(SINGLECLUSTER-E2E_TARGETS) $(CUSTOMCONFIGS-E2E_TARGETS)
+test-e2e: kustomize ginkgo yq gomod-download dep-crds kueuectl ginkgo-top run-test-e2e-singlecluster-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-multikueue-e2e
 test-multikueue-e2e: kustomize ginkgo yq gomod-download dep-crds ginkgo-top run-test-multikueue-e2e-$(E2E_KIND_VERSION:kindest/node:v%=%)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR removes the `test-e2e-customconfigs` Makefile target invocation from the `run-test-e2e` Makefile target. This is a follow-up of #4112 .

#### Which issue(s) this PR fixes:
Part of #3767

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```