### PR TITLE
Automated cherry pick of #4267: Stabilizing workload.ValidateLimitRange

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -53,8 +53,9 @@ import (
 )
 
 const (
-	errCouldNotAdmitWL    = "Could not admit Workload and assign flavors in apiserver"
-	errInvalidWLResources = "resource validation failed"
+	errCouldNotAdmitWL                           = "Could not admit Workload and assign flavors in apiserver"
+	errInvalidWLResources                        = "resources validation failed"
+	errLimitRangeConstraintsUnsatisfiedResources = "resources didn't satisfy LimitRange constraints"
 )
 
 var (
@@ -428,7 +429,7 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 		} else if err := workload.ValidateResources(&w); err != nil {
 			e.inadmissibleMsg = fmt.Sprintf("%s: %v", errInvalidWLResources, err.ToAggregate())
 		} else if err := workload.ValidateLimitRange(ctx, s.client, &w); err != nil {
-			e.inadmissibleMsg = err.Error()
+			e.inadmissibleMsg = fmt.Sprintf("%s: %v", errLimitRangeConstraintsUnsatisfiedResources, err.ToAggregate())
 		} else {
 			e.assignment, e.preemptionTargets = s.getAssignments(log, &e.Info, snap)
 			e.inadmissibleMsg = e.assignment.Message()

--- a/pkg/util/limitrange/limitrange.go
+++ b/pkg/util/limitrange/limitrange.go
@@ -17,13 +17,15 @@ limitations under the License.
 package limitrange
 
 import (
-	"fmt"
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"sigs.k8s.io/kueue/pkg/util/resource"
+)
+
+const (
+	RequestsMustNotBeAboveLimitRangeMaxMessage = "requests must not be above the limitRange max"
+	RequestsMustNotBeBelowLimitRangeMinMessage = "requests must not be below the limitRange min"
 )
 
 type Summary map[corev1.LimitType]corev1.LimitRangeItem
@@ -53,31 +55,25 @@ func addToSummary(summary, item corev1.LimitRangeItem) corev1.LimitRangeItem {
 	return summary
 }
 
-func violateMaxMessage(path *field.Path, keys ...string) string {
-	return fmt.Sprintf("the requests of %s[%s] exceeds the limits", path.String(), strings.Join(keys, ", "))
-}
-func violateMinMessage(path *field.Path, keys ...string) string {
-	return fmt.Sprintf("the requests of %s[%s] are less than the limits", path.String(), strings.Join(keys, ", "))
-}
-
-func (s Summary) validatePodSpecContainers(containers []corev1.Container, path *field.Path) []string {
+func (s Summary) validatePodSpecContainers(containers []corev1.Container, path *field.Path) field.ErrorList {
 	containerRange, found := s[corev1.LimitTypeContainer]
 	if !found {
 		return nil
 	}
-	reasons := []string{}
+	var allErrs field.ErrorList
 	for i := range containers {
+		containerPath := path.Index(i)
 		res := &containers[i].Resources
 		cMin := resource.MergeResourceListKeepMin(res.Requests, res.Limits)
 		cMax := resource.MergeResourceListKeepMax(res.Requests, res.Limits)
-		if list := resource.GetGreaterKeys(cMax, containerRange.Max); len(list) > 0 {
-			reasons = append(reasons, violateMaxMessage(path.Index(i), list...))
+		if resNames := resource.GetGreaterKeys(cMax, containerRange.Max); len(resNames) > 0 {
+			allErrs = append(allErrs, field.Invalid(containerPath, resNames, RequestsMustNotBeAboveLimitRangeMaxMessage))
 		}
-		if list := resource.GetGreaterKeys(containerRange.Min, cMin); len(list) > 0 {
-			reasons = append(reasons, violateMinMessage(path.Index(i), list...))
+		if resNames := resource.GetGreaterKeys(containerRange.Min, cMin); len(resNames) > 0 {
+			allErrs = append(allErrs, field.Invalid(containerPath, resNames, RequestsMustNotBeBelowLimitRangeMinMessage))
 		}
 	}
-	return reasons
+	return allErrs
 }
 
 // TotalRequests computes the total resource requests of a pod.
@@ -138,18 +134,18 @@ func isSidecarContainer(container corev1.Container) bool {
 }
 
 // ValidatePodSpec verifies if the provided podSpec (ps) first into the boundaries of the summary (s).
-func (s Summary) ValidatePodSpec(ps *corev1.PodSpec, path *field.Path) []string {
-	reasons := []string{}
-	reasons = append(reasons, s.validatePodSpecContainers(ps.InitContainers, path.Child("initContainers"))...)
-	reasons = append(reasons, s.validatePodSpecContainers(ps.Containers, path.Child("containers"))...)
-	if containerRange, found := s[corev1.LimitTypePod]; found {
+func (s Summary) ValidatePodSpec(ps *corev1.PodSpec, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	allErrs = append(allErrs, s.validatePodSpecContainers(ps.InitContainers, path.Child("initContainers"))...)
+	allErrs = append(allErrs, s.validatePodSpecContainers(ps.Containers, path.Child("containers"))...)
+	if podRange, found := s[corev1.LimitTypePod]; found {
 		total := TotalRequests(ps)
-		if list := resource.GetGreaterKeys(total, containerRange.Max); len(list) > 0 {
-			reasons = append(reasons, violateMaxMessage(path, list...))
+		if resNames := resource.GetGreaterKeys(total, podRange.Max); len(resNames) > 0 {
+			allErrs = append(allErrs, field.Invalid(path, resNames, RequestsMustNotBeAboveLimitRangeMaxMessage))
 		}
-		if list := resource.GetGreaterKeys(containerRange.Min, total); len(list) > 0 {
-			reasons = append(reasons, violateMinMessage(path, list...))
+		if resNames := resource.GetGreaterKeys(podRange.Min, total); len(resNames) > 0 {
+			allErrs = append(allErrs, field.Invalid(path, resNames, RequestsMustNotBeBelowLimitRangeMinMessage))
 		}
 	}
-	return reasons
+	return allErrs
 }

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -19,7 +19,6 @@ package workload
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
@@ -163,12 +162,12 @@ func ValidateResources(wi *Info) field.ErrorList {
 
 // ValidateLimitRange validates that the requested resources fit into the namespace defined
 // limitRanges.
-func ValidateLimitRange(ctx context.Context, c client.Client, wi *Info) error {
-	podsetsPath := field.NewPath("podSets")
-	// get the range summary from the namespace.
+func ValidateLimitRange(ctx context.Context, c client.Client, wi *Info) field.ErrorList {
+	var allErrs field.ErrorList
 	limitRanges := corev1.LimitRangeList{}
 	if err := c.List(ctx, &limitRanges, &client.ListOptions{Namespace: wi.Obj.Namespace}); err != nil {
-		return err
+		allErrs = append(allErrs, field.InternalError(field.NewPath(""), err))
+		return allErrs
 	}
 	if len(limitRanges.Items) == 0 {
 		return nil
@@ -176,13 +175,9 @@ func ValidateLimitRange(ctx context.Context, c client.Client, wi *Info) error {
 	summary := limitrange.Summarize(limitRanges.Items...)
 
 	// verify
-	var allReasons []string
 	for i := range wi.Obj.Spec.PodSets {
 		ps := &wi.Obj.Spec.PodSets[i]
-		allReasons = append(allReasons, summary.ValidatePodSpec(&ps.Template.Spec, podsetsPath.Child(ps.Name))...)
+		allErrs = append(allErrs, summary.ValidatePodSpec(&ps.Template.Spec, PodSetsPath.Index(i).Child("template").Child("spec"))...)
 	}
-	if len(allReasons) > 0 {
-		return fmt.Errorf("didn't satisfy LimitRange constraints: %s", strings.Join(allReasons, "; "))
-	}
-	return nil
+	return allErrs
 }

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -1952,11 +1952,11 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			gomega.Expect(util.DeleteObject(ctx, k8sClient, wl)).To(gomega.Succeed())
 			gomega.Expect(k8sClient.Delete(ctx, lr)).To(gomega.Succeed())
 		},
-			ginkgo.Entry("request more that limits", testParams{reqCPU: "3", limitCPU: "2", wantedStatus: "resource validation failed:"}),
-			ginkgo.Entry("request over container limits", testParams{reqCPU: "2", limitCPU: "3", maxCPU: "1", wantedStatus: "didn't satisfy LimitRange constraints:"}),
-			ginkgo.Entry("request under container limits", testParams{reqCPU: "2", limitCPU: "3", minCPU: "3", wantedStatus: "didn't satisfy LimitRange constraints:"}),
-			ginkgo.Entry("request over pod limits", testParams{reqCPU: "2", limitCPU: "3", maxCPU: "1", limitType: corev1.LimitTypePod, wantedStatus: "didn't satisfy LimitRange constraints:"}),
-			ginkgo.Entry("request under pod limits", testParams{reqCPU: "2", limitCPU: "3", minCPU: "3", limitType: corev1.LimitTypePod, wantedStatus: "didn't satisfy LimitRange constraints:"}),
+			ginkgo.Entry("request more that limits", testParams{reqCPU: "3", limitCPU: "2", wantedStatus: "resources validation failed:"}),
+			ginkgo.Entry("request over container limits", testParams{reqCPU: "2", limitCPU: "3", maxCPU: "1", wantedStatus: "resources didn't satisfy LimitRange constraints:"}),
+			ginkgo.Entry("request under container limits", testParams{reqCPU: "2", limitCPU: "3", minCPU: "3", wantedStatus: "resources didn't satisfy LimitRange constraints:"}),
+			ginkgo.Entry("request over pod limits", testParams{reqCPU: "2", limitCPU: "3", maxCPU: "1", limitType: corev1.LimitTypePod, wantedStatus: "resources didn't satisfy LimitRange constraints:"}),
+			ginkgo.Entry("request under pod limits", testParams{reqCPU: "2", limitCPU: "3", minCPU: "3", limitType: corev1.LimitTypePod, wantedStatus: "resources didn't satisfy LimitRange constraints:"}),
 			ginkgo.Entry("valid", testParams{reqCPU: "2", limitCPU: "3", minCPU: "1", maxCPU: "4", shouldBeAdmitted: true}),
 		)
 	})


### PR DESCRIPTION
Cherry pick of #4267 on release-0.9.

#4267: Stabilizing workload.ValidateLimitRange

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix a bug is incorrect field path in inadmissible reasons and messages when Pod resources requests do not satisfy LimitRange constraints.
```