### PR TITLE
PodsReady accounts for uncountedTerminatedsSuccededPods in batchv1.Job implementation

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1116,12 +1116,8 @@ func (r *JobReconciler) ignoreUnretryableError(log logr.Logger, err error) error
 func generatePodsReadyCondition(job GenericJob, wl *kueue.Workload) metav1.Condition {
 	conditionStatus := metav1.ConditionFalse
 	message := "Not all pods are ready or succeeded"
-	// Once PodsReady=True it stays as long as the workload remains admitted to
-	// avoid unnecessary flickering the condition when the pods transition
-	// from Ready to Completed. As pods finish, they transition first into the
-	// uncountedTerminatedPods staging area, before passing to the
-	// succeeded/failed counters.
-	if workload.IsAdmitted(wl) && (job.PodsReady() || apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadPodsReady)) {
+
+	if workload.IsAdmitted(wl) && job.PodsReady() {
 		conditionStatus = metav1.ConditionTrue
 		message = "All pods were ready or succeeded since the workload admission"
 	}

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -314,7 +314,11 @@ func (j *Job) Finished() (message string, success, finished bool) {
 
 func (j *Job) PodsReady() bool {
 	ready := ptr.Deref(j.Status.Ready, 0)
-	return j.Status.Succeeded+ready >= j.podsCount()
+	uncountedTerminatedSucceeded := 0
+	if j.Status.UncountedTerminatedPods != nil {
+		uncountedTerminatedSucceeded = len(j.Status.UncountedTerminatedPods.Succeeded)
+	}
+	return j.Status.Succeeded+ready+int32(uncountedTerminatedSucceeded) >= j.podsCount()
 }
 
 func (j *Job) CanDefaultManagedBy() bool {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -1082,11 +1082,53 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 				Message: "All pods were ready or succeeded since the workload admission",
 			},
 		}),
+		ginkgo.Entry("One pod ready, one terminating succeeded", podsReadyTestSpec{
+			jobStatus: batchv1.JobStatus{
+				Active: 1,
+				Ready:  ptr.To[int32](1),
+				UncountedTerminatedPods: &batchv1.UncountedTerminatedPods{
+					Succeeded: []types.UID{"foo"},
+				},
+			},
+			wantCondition: &metav1.Condition{
+				Type:    kueue.WorkloadPodsReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  "PodsReady",
+				Message: "All pods were ready or succeeded since the workload admission",
+			},
+		}),
 		ginkgo.Entry("One pod ready, one succeeded", podsReadyTestSpec{
 			jobStatus: batchv1.JobStatus{
 				Active:    1,
 				Ready:     ptr.To[int32](1),
 				Succeeded: 1,
+			},
+			wantCondition: &metav1.Condition{
+				Type:    kueue.WorkloadPodsReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  "PodsReady",
+				Message: "All pods were ready or succeeded since the workload admission",
+			},
+		}),
+		ginkgo.Entry("One pod succeeded, one terminating succeeded", podsReadyTestSpec{
+			jobStatus: batchv1.JobStatus{
+				Succeeded: 1,
+				UncountedTerminatedPods: &batchv1.UncountedTerminatedPods{
+					Succeeded: []types.UID{"foo"},
+				},
+			},
+			wantCondition: &metav1.Condition{
+				Type:    kueue.WorkloadPodsReady,
+				Status:  metav1.ConditionTrue,
+				Reason:  "PodsReady",
+				Message: "All pods were ready or succeeded since the workload admission",
+			},
+		}),
+		ginkgo.Entry("All pods terminating succeeded", podsReadyTestSpec{
+			jobStatus: batchv1.JobStatus{
+				UncountedTerminatedPods: &batchv1.UncountedTerminatedPods{
+					Succeeded: []types.UID{"foo", "bar"},
+				},
 			},
 			wantCondition: &metav1.Condition{
 				Type:    kueue.WorkloadPodsReady,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
`PodsReady()` method accounts for uncountedTerminatedsSuccededPods in batchv1.Job implementation
This change is part of the KEP: https://github.com/kubernetes-sigs/kueue/blob/main/keps/349-all-or-nothing/README.md?plain=1#L314-L319

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #2732

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```