### PR TITLE
TAS: allow to dump the usage of domains for TAS ResourceFlavors

### DIFF
--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -82,10 +82,19 @@ func (s *Snapshot) Log(log logr.Logger) {
 	if features.Enabled(features.TopologyAwareScheduling) {
 		for cqName, cq := range s.ClusterQueues() {
 			for tasFlavor, tasSnapshot := range cq.TASFlavors {
+				freeCapacityPerDomain, err := tasSnapshot.SerializeFreeCapacityPerDomain()
+				if err != nil {
+					log.Error(err, "Failed to serialize TAS snapshot free capacity",
+						"clusterQueue", cqName,
+						"resourceFlavor", tasFlavor,
+					)
+					continue
+				}
+
 				log.Info("TAS Snapshot Free Capacity",
 					"clusterQueue", cqName,
 					"resourceFlavor", tasFlavor,
-					"freeCapacityPerDomain", tasSnapshot.PrettyPrintFreeCapacityPerDomain(),
+					"freeCapacityPerDomain", freeCapacityPerDomain,
 				)
 			}
 		}

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -80,12 +80,12 @@ func (s *Snapshot) Log(log logr.Logger) {
 
 	// Dump TAS snapshots if the feature is enabled
 	if features.Enabled(features.TopologyAwareScheduling) {
-		for cqName, cq := range s.ClusterQueues {
+		for cqName, cq := range s.ClusterQueues() {
 			for tasFlavor, tasSnapshot := range cq.TASFlavors {
 				log.Info("TAS Snapshot Free Capacity",
 					"clusterQueue", cqName,
 					"resourceFlavor", tasFlavor,
-					"freeCapacityPerDomain", tasSnapshot.FreeCapacityPerDomain(),
+					"freeCapacityPerDomain", tasSnapshot.PrettyPrintFreeCapacityPerDomain(),
 				)
 			}
 		}

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -77,6 +77,19 @@ func (s *Snapshot) Log(log logr.Logger) {
 			"usage", cohort.ResourceNode.Usage,
 		)
 	}
+
+	// Dump TAS snapshots if the feature is enabled
+	if features.Enabled(features.TopologyAwareScheduling) {
+		for cqName, cq := range s.ClusterQueues {
+			for tasFlavor, tasSnapshot := range cq.TASFlavors {
+				log.Info("TAS Snapshot Free Capacity",
+					"clusterQueue", cqName,
+					"resourceFlavor", tasFlavor,
+					"freeCapacityPerDomain", tasSnapshot.FreeCapacityPerDomain(),
+				)
+			}
+		}
+	}
 }
 
 func (c *Cache) Snapshot(ctx context.Context) (*Snapshot, error) {

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -244,6 +244,22 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 	s.leaves[domainID].tasUsage.Sub(usage)
 }
 
+func (s *TASFlavorSnapshot) FreeCapacityPerDomain() map[string]int {
+	freeCapacityPerDomain := make(map[string]int)
+
+	for domainID, leaf := range s.leaves {
+		// Calculate the total free capacity for the domain
+		totalFreeCapacity := 0
+		for _, quantity := range leaf.freeCapacity {
+			totalFreeCapacity += int(quantity)
+		}
+
+		freeCapacityPerDomain[string(domainID)] = totalFreeCapacity
+	}
+
+	return freeCapacityPerDomain
+}
+
 type TASPodSetRequests struct {
 	PodSet            *kueue.PodSet
 	SinglePodRequests resources.Requests

--- a/pkg/cache/tas_flavor_snapshot_test.go
+++ b/pkg/cache/tas_flavor_snapshot_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/kueue/pkg/resources"
+)
+
+func TestFreeCapacityPerDomain(t *testing.T) {
+	snapshot := &TASFlavorSnapshot{
+		leaves: leafDomainByID{
+			"domain2": &leafDomain{
+				freeCapacity: resources.Requests{
+					corev1.ResourceCPU:    1000,
+					corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 2 GiB
+				},
+				tasUsage: resources.Requests{
+					corev1.ResourceCPU:    500,
+					corev1.ResourceMemory: 1 * 1024 * 1024 * 1024, // 1 GiB
+				},
+			},
+			"domain1": &leafDomain{
+				freeCapacity: resources.Requests{
+					corev1.ResourceCPU:    2000,
+					corev1.ResourceMemory: 4 * 1024 * 1024 * 1024, // 4 GiB
+					"nvidia.com/gpu":      1,
+				},
+				tasUsage: resources.Requests{
+					corev1.ResourceCPU:    500,
+					corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 1 GiB
+					"nvidia.com/gpu":      1,
+				},
+			},
+		},
+	}
+
+	expected := "domain1={\nfreeCapacity: cpu: 2; memory: 4Gi; nvidia.com/gpu: 1\ntasUsage: cpu: 500m; memory: 2Gi; nvidia.com/gpu: 1\n},\ndomain2={\nfreeCapacity: cpu: 1; memory: 2Gi\ntasUsage: cpu: 500m; memory: 1Gi\n}"
+
+	got := snapshot.PrettyPrintFreeCapacityPerDomain()
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("PrettyPrintFreeCapacityPerDomain() mismatch (-expected +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Allows to dump the free capacity of TAS snapshots per domain.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3493

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```