### PR TITLE
Fix a typo in the 'AccumulatedPastExecutionTimeSecond' field name

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -347,11 +347,11 @@ type WorkloadStatus struct {
 	// +kubebuilder:validation:MaxItems=8
 	ResourceRequests []PodSetRequest `json:"resourceRequests,omitempty"`
 
-	// accumulatedPastExexcutionTimeSeconds holds the total time, in seconds, the workload spent
+	// accumulatedPastExecutionTimeSeconds holds the total time, in seconds, the workload spent
 	// in Admitted state, in the previous `Admit` - `Evict` cycles.
 	//
 	// +optional
-	AccumulatedPastExexcutionTimeSeconds *int32 `json:"accumulatedPastExexcutionTimeSeconds,omitempty"`
+	AccumulatedPastExecutionTimeSeconds *int32 `json:"accumulatedPastExecutionTimeSeconds,omitempty"`
 }
 
 type RequeueState struct {

--- a/apis/kueue/v1beta1/zz_generated.deepcopy.go
+++ b/apis/kueue/v1beta1/zz_generated.deepcopy.go
@@ -1687,8 +1687,8 @@ func (in *WorkloadStatus) DeepCopyInto(out *WorkloadStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.AccumulatedPastExexcutionTimeSeconds != nil {
-		in, out := &in.AccumulatedPastExexcutionTimeSeconds, &out.AccumulatedPastExexcutionTimeSeconds
+	if in.AccumulatedPastExecutionTimeSeconds != nil {
+		in, out := &in.AccumulatedPastExecutionTimeSeconds, &out.AccumulatedPastExecutionTimeSeconds
 		*out = new(int32)
 		**out = **in
 	}

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -8390,9 +8390,9 @@ spec:
           status:
             description: WorkloadStatus defines the observed state of Workload
             properties:
-              accumulatedPastExexcutionTimeSeconds:
+              accumulatedPastExecutionTimeSeconds:
                 description: |-
-                  accumulatedPastExexcutionTimeSeconds holds the total time, in seconds, the workload spent
+                  accumulatedPastExecutionTimeSeconds holds the total time, in seconds, the workload spent
                   in Admitted state, in the previous `Admit` - `Evict` cycles.
                 format: int32
                 type: integer

--- a/client-go/applyconfiguration/kueue/v1beta1/workloadstatus.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/workloadstatus.go
@@ -24,13 +24,13 @@ import (
 // WorkloadStatusApplyConfiguration represents a declarative configuration of the WorkloadStatus type for use
 // with apply.
 type WorkloadStatusApplyConfiguration struct {
-	Admission                            *AdmissionApplyConfiguration            `json:"admission,omitempty"`
-	RequeueState                         *RequeueStateApplyConfiguration         `json:"requeueState,omitempty"`
-	Conditions                           []v1.ConditionApplyConfiguration        `json:"conditions,omitempty"`
-	ReclaimablePods                      []ReclaimablePodApplyConfiguration      `json:"reclaimablePods,omitempty"`
-	AdmissionChecks                      []AdmissionCheckStateApplyConfiguration `json:"admissionChecks,omitempty"`
-	ResourceRequests                     []PodSetRequestApplyConfiguration       `json:"resourceRequests,omitempty"`
-	AccumulatedPastExexcutionTimeSeconds *int32                                  `json:"accumulatedPastExexcutionTimeSeconds,omitempty"`
+	Admission                           *AdmissionApplyConfiguration            `json:"admission,omitempty"`
+	RequeueState                        *RequeueStateApplyConfiguration         `json:"requeueState,omitempty"`
+	Conditions                          []v1.ConditionApplyConfiguration        `json:"conditions,omitempty"`
+	ReclaimablePods                     []ReclaimablePodApplyConfiguration      `json:"reclaimablePods,omitempty"`
+	AdmissionChecks                     []AdmissionCheckStateApplyConfiguration `json:"admissionChecks,omitempty"`
+	ResourceRequests                    []PodSetRequestApplyConfiguration       `json:"resourceRequests,omitempty"`
+	AccumulatedPastExecutionTimeSeconds *int32                                  `json:"accumulatedPastExecutionTimeSeconds,omitempty"`
 }
 
 // WorkloadStatusApplyConfiguration constructs a declarative configuration of the WorkloadStatus type for use with
@@ -107,10 +107,10 @@ func (b *WorkloadStatusApplyConfiguration) WithResourceRequests(values ...*PodSe
 	return b
 }
 
-// WithAccumulatedPastExexcutionTimeSeconds sets the AccumulatedPastExexcutionTimeSeconds field in the declarative configuration to the given value
+// WithAccumulatedPastExecutionTimeSeconds sets the AccumulatedPastExecutionTimeSeconds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the AccumulatedPastExexcutionTimeSeconds field is set to the value of the last call.
-func (b *WorkloadStatusApplyConfiguration) WithAccumulatedPastExexcutionTimeSeconds(value int32) *WorkloadStatusApplyConfiguration {
-	b.AccumulatedPastExexcutionTimeSeconds = &value
+// If called multiple times, the AccumulatedPastExecutionTimeSeconds field is set to the value of the last call.
+func (b *WorkloadStatusApplyConfiguration) WithAccumulatedPastExecutionTimeSeconds(value int32) *WorkloadStatusApplyConfiguration {
+	b.AccumulatedPastExecutionTimeSeconds = &value
 	return b
 }

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -8375,9 +8375,9 @@ spec:
           status:
             description: WorkloadStatus defines the observed state of Workload
             properties:
-              accumulatedPastExexcutionTimeSeconds:
+              accumulatedPastExecutionTimeSeconds:
                 description: |-
-                  accumulatedPastExexcutionTimeSeconds holds the total time, in seconds, the workload spent
+                  accumulatedPastExecutionTimeSeconds holds the total time, in seconds, the workload spent
                   in Admitted state, in the previous `Admit` - `Evict` cycles.
                 format: int32
                 type: integer

--- a/keps/3125-maximum-execution-time/README.md
+++ b/keps/3125-maximum-execution-time/README.md
@@ -105,7 +105,7 @@ type WorkloadStatus struct {
 	// AccumulatedPastExecutionTimeSeconds holds the total duration the workload spent in Admitted state
 	// in the previous `Admit` - `Evict` cycles.
     // +optional
-	AccumulatedPastExexcutionTimeSecond *int32 `json:"accumulatedPastExexcutionTimeSeconds,omitempty"`
+	AccumulatedPastExecutionTimeSecond *int32 `json:"accumulatedPastExecutionTimeSeconds,omitempty"`
 }
 
 ```
@@ -207,4 +207,3 @@ Add "A job is suspended when its maximum execution time expires"
 
 
 ## Alternatives
-

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -350,14 +350,14 @@ func (r *WorkloadReconciler) reconcileMaxExecutionTime(ctx context.Context, wl *
 		return 0, nil
 	}
 
-	remainingTime := time.Duration(*wl.Spec.MaximumExecutionTimeSeconds-ptr.Deref(wl.Status.AccumulatedPastExexcutionTimeSeconds, 0))*time.Second - r.clock.Since(admittedCondition.LastTransitionTime.Time)
+	remainingTime := time.Duration(*wl.Spec.MaximumExecutionTimeSeconds-ptr.Deref(wl.Status.AccumulatedPastExecutionTimeSeconds, 0))*time.Second - r.clock.Since(admittedCondition.LastTransitionTime.Time)
 	if remainingTime > 0 {
 		return remainingTime, nil
 	}
 
 	if !apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadDeactivationTarget) {
 		workload.SetDeactivationTarget(wl, kueue.WorkloadMaximumExecutionTimeExceeded, "exceeding the maximum execution time")
-		wl.Status.AccumulatedPastExexcutionTimeSeconds = nil
+		wl.Status.AccumulatedPastExecutionTimeSeconds = nil
 		if err := workload.ApplyAdmissionStatus(ctx, r.client, wl, true, r.clock); err != nil {
 			return 0, err
 		}

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -357,7 +357,7 @@ func (w *WorkloadWrapper) MaximumExecutionTimeSeconds(v int32) *WorkloadWrapper 
 }
 
 func (w *WorkloadWrapper) PastAdmittedTime(v int32) *WorkloadWrapper {
-	w.Status.AccumulatedPastExexcutionTimeSeconds = &v
+	w.Status.AccumulatedPastExecutionTimeSeconds = &v
 	return w
 }
 

--- a/pkg/workload/admissionchecks.go
+++ b/pkg/workload/admissionchecks.go
@@ -66,10 +66,10 @@ func SyncAdmittedCondition(w *kueue.Workload, now time.Time) bool {
 		// in practice the oldCondition cannot be nil, however we should try to avoid nil ptr deref.
 		if oldCondition != nil {
 			d := int32(now.Sub(oldCondition.LastTransitionTime.Time).Seconds())
-			if w.Status.AccumulatedPastExexcutionTimeSeconds != nil {
-				*w.Status.AccumulatedPastExexcutionTimeSeconds += d
+			if w.Status.AccumulatedPastExecutionTimeSeconds != nil {
+				*w.Status.AccumulatedPastExecutionTimeSeconds += d
 			} else {
-				w.Status.AccumulatedPastExexcutionTimeSeconds = &d
+				w.Status.AccumulatedPastExecutionTimeSeconds = &d
 			}
 		}
 	}

--- a/pkg/workload/admissionchecks_test.go
+++ b/pkg/workload/admissionchecks_test.go
@@ -276,12 +276,12 @@ func TestSyncAdmittedCondition(t *testing.T) {
 			}
 
 			if tc.wantAdmittedTime > 0 {
-				if wl.Status.AccumulatedPastExexcutionTimeSeconds == nil {
-					t.Fatalf("Expecting AccumulatedPastExexcutionTimeSeconds not to be nil")
+				if wl.Status.AccumulatedPastExecutionTimeSeconds == nil {
+					t.Fatalf("Expecting AccumulatedPastExecutionTimeSeconds not to be nil")
 				}
 
-				if diff := cmp.Diff(tc.wantAdmittedTime, *wl.Status.AccumulatedPastExexcutionTimeSeconds); diff != "" {
-					t.Errorf("Unexpected AccumulatedPastExexcutionTimeSeconds (- want/+ got):\n%s", diff)
+				if diff := cmp.Diff(tc.wantAdmittedTime, *wl.Status.AccumulatedPastExecutionTimeSeconds); diff != "" {
+					t.Errorf("Unexpected AccumulatedPastExecutionTimeSeconds (- want/+ got):\n%s", diff)
 				}
 			}
 		})

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -679,7 +679,7 @@ func AdmissionStatusPatch(w *kueue.Workload, wlCopy *kueue.Workload, strict bool
 	if strict {
 		wlCopy.ResourceVersion = w.ResourceVersion
 	}
-	wlCopy.Status.AccumulatedPastExexcutionTimeSeconds = w.Status.AccumulatedPastExexcutionTimeSeconds
+	wlCopy.Status.AccumulatedPastExecutionTimeSeconds = w.Status.AccumulatedPastExecutionTimeSeconds
 }
 
 func AdmissionChecksStatusPatch(w *kueue.Workload, wlCopy *kueue.Workload, c clock.Clock) {

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -2569,11 +2569,11 @@ If admission is non-null, resourceRequests will be empty because
 admission.resourceUsage contains the detailed information.</p>
 </td>
 </tr>
-<tr><td><code>accumulatedPastExexcutionTimeSeconds</code><br/>
+<tr><td><code>accumulatedPastExecutionTimeSeconds</code><br/>
 <code>int32</code>
 </td>
 <td>
-   <p>accumulatedPastExexcutionTimeSeconds holds the total time, in seconds, the workload spent
+   <p>accumulatedPastExecutionTimeSeconds holds the total time, in seconds, the workload spent
 in Admitted state, in the previous <code>Admit</code> - <code>Evict</code> cycles.</p>
 </td>
 </tr>

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -520,14 +520,14 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Ordered, ginkgo.ContinueOn
 					g.Expect(k8sClient.Get(ctx, key, wl)).To(gomega.Succeed())
 					g.Expect(workload.IsAdmitted(wl)).To(gomega.BeFalse())
 					g.Expect(workload.IsActive(wl)).To(gomega.BeTrue())
-					g.Expect(ptr.Deref(wl.Status.AccumulatedPastExexcutionTimeSeconds, 0)).To(gomega.BeNumerically(">", int32(0)))
+					g.Expect(ptr.Deref(wl.Status.AccumulatedPastExecutionTimeSeconds, 0)).To(gomega.BeNumerically(">", int32(0)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("setting the accumulated admission time closer to maximum", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, key, wl)).To(gomega.Succeed())
-					wl.Status.AccumulatedPastExexcutionTimeSeconds = ptr.To(*wl.Spec.MaximumExecutionTimeSeconds - 1)
+					wl.Status.AccumulatedPastExecutionTimeSeconds = ptr.To(*wl.Spec.MaximumExecutionTimeSeconds - 1)
 					g.Expect(k8sClient.Status().Update(ctx, wl)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -304,14 +304,14 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						Obj()
 				},
 				testing.BeForbiddenError()),
-			ginkgo.Entry("invalid maximumExexcutionTimeSeconds",
+			ginkgo.Entry("invalid maximumExecutionTimeSeconds",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
 						MaximumExecutionTimeSeconds(0).
 						Obj()
 				},
 				testing.BeInvalidError()),
-			ginkgo.Entry("valid maximumExexcutionTimeSeconds",
+			ginkgo.Entry("valid maximumExecutionTimeSeconds",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).
 						MaximumExecutionTimeSeconds(1).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind api-change

#### What this PR does / why we need it:

Fix a typo in the `WorkloadStatus.AccumulatedPastExecutionTimeSecond` property (both the field name and JSON).

#### Special notes for your reviewer:

I guess this is a breaking change. The field was added 4 months ago in #3200.

#### Does this PR introduce a user-facing change?

```release-note
Rename workload status property from `accumulatedPastExexcutionTimeSecond` to `accumulatedPastExecutionTimeSecond`.
```