### PR TITLE
Make Preemption.BorrowWithinCohort Incompatible with FairSharing

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -317,7 +317,8 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *cache.Cache
 		}
 	}
 
-	if failedWebhook, err := webhooks.Setup(mgr); err != nil {
+	if failedWebhook, err := webhooks.Setup(mgr,
+		webhooks.WebhookConfiguration{FairSharingEnabled: cfg.FairSharing.Enable}); err != nil {
 		setupLog.Error(err, "Unable to create webhook", "webhook", failedWebhook)
 		os.Exit(1)
 	}

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -20,9 +20,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
+type WebhookConfiguration struct {
+	FairSharingEnabled bool
+}
+
 // Setup sets up the webhooks for core controllers. It returns the name of the
 // webhook that failed to create and an error, if any.
-func Setup(mgr ctrl.Manager) (string, error) {
+func Setup(mgr ctrl.Manager, cfg WebhookConfiguration) (string, error) {
 	if err := setupWebhookForWorkload(mgr); err != nil {
 		return "Workload", err
 	}
@@ -31,7 +35,7 @@ func Setup(mgr ctrl.Manager) (string, error) {
 		return "ResourceFlavor", err
 	}
 
-	if err := setupWebhookForClusterQueue(mgr); err != nil {
+	if err := setupWebhookForClusterQueue(mgr, cfg); err != nil {
 		return "ClusterQueue", err
 	}
 

--- a/test/e2e/singlecluster/metrics_test.go
+++ b/test/e2e/singlecluster/metrics_test.go
@@ -374,7 +374,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 					ReclaimWithinCohort: v1beta1.PreemptionPolicyAny,
 					WithinClusterQueue:  v1beta1.PreemptionPolicyLowerPriority,
 					BorrowWithinCohort: &v1beta1.BorrowWithinCohort{
-						Policy: v1beta1.BorrowWithinCohortPolicyLowerPriority,
+						Policy: v1beta1.BorrowWithinCohortPolicyNever,
 					},
 				}).
 				Obj()
@@ -392,7 +392,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 					ReclaimWithinCohort: v1beta1.PreemptionPolicyAny,
 					WithinClusterQueue:  v1beta1.PreemptionPolicyLowerPriority,
 					BorrowWithinCohort: &v1beta1.BorrowWithinCohort{
-						Policy: v1beta1.BorrowWithinCohortPolicyLowerPriority,
+						Policy: v1beta1.BorrowWithinCohortPolicyNever,
 					},
 				}).
 				Obj()

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -126,7 +126,7 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
-	failedWebhook, err := webhooks.Setup(mgr)
+	failedWebhook, err := webhooks.Setup(mgr, webhooks.WebhookConfiguration{})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
 	err = workloadjob.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/suite_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/suite_test.go
@@ -72,7 +72,7 @@ func managerSetup() framework.ManagerSetup {
 		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		failedWebhook, err := webhooks.Setup(mgr)
+		failedWebhook, err := webhooks.Setup(mgr, webhooks.WebhookConfiguration{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
 		controllersCfg := &config.Configuration{}

--- a/test/integration/singlecluster/controller/core/suite_test.go
+++ b/test/integration/singlecluster/controller/core/suite_test.go
@@ -67,7 +67,7 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	failedWebhook, err := webhooks.Setup(mgr)
+	failedWebhook, err := webhooks.Setup(mgr, webhooks.WebhookConfiguration{})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
 	controllersCfg := &config.Configuration{}

--- a/test/integration/singlecluster/controller/jobs/pod/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/suite_test.go
@@ -125,7 +125,7 @@ func managerSetup(
 
 		err = pod.SetupWebhook(mgr, opts...)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		failedWebhook, err := webhooks.Setup(mgr)
+		failedWebhook, err := webhooks.Setup(mgr, webhooks.WebhookConfiguration{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
 		if setupTASControllers {

--- a/test/integration/singlecluster/importer/suite_test.go
+++ b/test/integration/singlecluster/importer/suite_test.go
@@ -77,7 +77,7 @@ func managerAndSchedulerSetup(ctx context.Context, mgr manager.Manager) {
 	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
-	failedWebhook, err := webhooks.Setup(mgr)
+	failedWebhook, err := webhooks.Setup(mgr, webhooks.WebhookConfiguration{})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
 	err = workloadjob.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/singlecluster/kueuectl/suite_test.go
+++ b/test/integration/singlecluster/kueuectl/suite_test.go
@@ -79,7 +79,7 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	failedWebhook, err := webhooks.Setup(mgr)
+	failedWebhook, err := webhooks.Setup(mgr, webhooks.WebhookConfiguration{})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
 	controllersCfg := &config.Configuration{}

--- a/test/integration/singlecluster/scheduler/fairsharing/suite_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/suite_test.go
@@ -83,7 +83,7 @@ func managerAndSchedulerSetup(ctx context.Context, mgr manager.Manager) {
 	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
-	failedWebhook, err := webhooks.Setup(mgr)
+	failedWebhook, err := webhooks.Setup(mgr, webhooks.WebhookConfiguration{FairSharingEnabled: fairSharing.Enable})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
 	err = workloadjob.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/singlecluster/scheduler/podsready/suite_test.go
+++ b/test/integration/singlecluster/scheduler/podsready/suite_test.go
@@ -101,7 +101,7 @@ func managerAndSchedulerSetup(configuration *config.Configuration) framework.Man
 		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
-		failedWebhook, err := webhooks.Setup(mgr)
+		failedWebhook, err := webhooks.Setup(mgr, webhooks.WebhookConfiguration{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
 		err = workloadjob.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/singlecluster/scheduler/suite_test.go
+++ b/test/integration/singlecluster/scheduler/suite_test.go
@@ -90,7 +90,7 @@ func managerAndSchedulerSetup(ctx context.Context, mgr manager.Manager) {
 	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, configuration)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
-	failedWebhook, err := webhooks.Setup(mgr)
+	failedWebhook, err := webhooks.Setup(mgr, webhooks.WebhookConfiguration{})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
 	err = workloadjob.SetupIndexes(ctx, mgr.GetFieldIndexer())

--- a/test/integration/singlecluster/tas/suite_test.go
+++ b/test/integration/singlecluster/tas/suite_test.go
@@ -71,7 +71,7 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	failedWebhook, err := webhooks.Setup(mgr)
+	failedWebhook, err := webhooks.Setup(mgr, webhooks.WebhookConfiguration{})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
 	controllersCfg := &config.Configuration{}

--- a/test/integration/singlecluster/webhook/core/suite_test.go
+++ b/test/integration/singlecluster/webhook/core/suite_test.go
@@ -60,7 +60,7 @@ var _ = ginkgo.BeforeSuite(func() {
 		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		failedWebhook, err := webhooks.Setup(mgr)
+		failedWebhook, err := webhooks.Setup(mgr, webhooks.WebhookConfiguration{})
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
 		cCache := cache.New(mgr.GetClient())

--- a/test/integration/singlecluster/webhook/jobs/raycluster_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/raycluster_webhook_test.go
@@ -96,7 +96,7 @@ var _ = ginkgo.Describe("RayCluster Webhook", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				jobframework.EnableIntegration(workloadrayjob.FrameworkName)
 
-				failedWebhook, err := webhooks.Setup(mgr)
+				failedWebhook, err := webhooks.Setup(mgr, webhooks.WebhookConfiguration{})
 				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
 				return nil


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
With #4165, these parameters together becomes a no-op.

Based on https://github.com/kubernetes-sigs/kueue/pull/4165#issuecomment-2663187270, we decided to split out the logic and documentation change from the validation changes, as we may only cherry-pick the first set.

#### Which issue(s) this PR fixes:
Related to #3779

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
ClusterQueue.Preemption.BorrowWithinCohort is now incompatible with FairSharing. This will be enforced upon ClusterQueue creation and update.
```