### PR TITLE
limit traversal of ancestor links in getAncestorJobManagedByKueue

### DIFF
--- a/pkg/controller/jobframework/events.go
+++ b/pkg/controller/jobframework/events.go
@@ -27,4 +27,5 @@ const (
 	ReasonFinishedWorkload      = "FinishedWorkload"
 	ReasonErrWorkloadCompose    = "ErrWorkloadCompose"
 	ReasonUpdatedAdmissionCheck = "UpdatedAdmissionCheck"
+	ReasonJobNestingTooDeep     = "JobNestingTooDeep"
 )

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -626,7 +626,6 @@ func (r *JobReconciler) getAncestorJobManagedByKueue(ctx context.Context, jobObj
 				"Terminated search for Kueue-managed Job because ancestor depth exceeded limit of %d", managedOwnersChainLimit)
 			ctrl.LoggerFrom(ctx).V(2).Info(
 				"Terminated search for Kueue-managed Job because ancestor depth exceeded managedOwnersChainlimit",
-				"jobObj", jobObj,
 				"limit ", managedOwnersChainLimit,
 				"lastParentReached", parentJob,
 			)

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -163,7 +163,7 @@ func TestIsAncestorJobManaged(t *testing.T) {
 			wantEvents: []utiltesting.EventRecord{
 				{
 					Key:       types.NamespacedName{Namespace: jobNamespace, Name: childJobName},
-					EventType: "Warning",
+					EventType: corev1.EventTypeWarning,
 					Reason:    ReasonJobNestingTooDeep,
 					Message:   "Terminated search for Kueue-managed Job because ancestor depth exceeded limit of 10",
 				},
@@ -173,6 +173,7 @@ func TestIsAncestorJobManaged(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Cleanup(EnableIntegrationsForTest(t, "kubeflow.org/mpijob", "workload.codeflare.dev/appwrapper", "batch/job"))
+			ctx, _ := utiltestings.ContextWithLog(t)
 			recorder := &utiltesting.EventRecorder{}
 			builder := utiltesting.NewClientBuilder(kfmpi.AddToScheme, awv1beta2.AddToScheme)
 			builder = builder.WithObjects(tc.ancestors...)
@@ -181,7 +182,7 @@ func TestIsAncestorJobManaged(t *testing.T) {
 			}
 			cl := builder.Build()
 			r := NewReconciler(cl, recorder)
-			got, gotErr := r.IsAncestorJobManaged(context.Background(), tc.job, jobNamespace)
+			got, gotErr := r.IsAncestorJobManaged(ctx, tc.job, jobNamespace)
 			if tc.wantManaged != got {
 				t.Errorf("Unexpected response from IsAncestorJobManaged want: %v,got: %v", tc.wantManaged, got)
 			}

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package jobframework_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -173,7 +172,7 @@ func TestIsAncestorJobManaged(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			t.Cleanup(EnableIntegrationsForTest(t, "kubeflow.org/mpijob", "workload.codeflare.dev/appwrapper", "batch/job"))
-			ctx, _ := utiltestings.ContextWithLog(t)
+			ctx, _ := utiltesting.ContextWithLog(t)
 			recorder := &utiltesting.EventRecorder{}
 			builder := utiltesting.NewClientBuilder(kfmpi.AddToScheme, awv1beta2.AddToScheme)
 			builder = builder.WithObjects(tc.ancestors...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Follow up from #4251.  Limit number of ancestor links traversed and emit warning event when search is terminated because the limit is reached.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Happy to change the Reason text if you have a better idea. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```