### PR TITLE
Extend the WaitForPodsReady API with `.recoveryTimeout` field

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -211,6 +211,16 @@ type WaitForPodsReady struct {
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
+	// RecoveryTimeout defines an optional timeout, measured since the
+	// last transition to the PodsReady=false condition after a Workload is Admitted and running.
+	// Such a transition may happen when a Pod failed and the replacement Pod
+	// is awaited to be scheduled.
+	// After exceeding the timeout the corresponding job gets suspended again
+	// and requeued after the backoff delay. The timeout is enforced only if waitForPodsReady.enable=true.
+	// Defaults to 3 mins.
+	// +optional
+	RecoveryTimeout *metav1.Duration `json:"recoveryTimeout,omitempty"`
+
 	// BlockAdmission when true, cluster queue will block admissions for all
 	// subsequent jobs until the jobs reach the PodsReady=true condition.
 	// This setting is only honored when `Enable` is set to true.

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -211,16 +211,6 @@ type WaitForPodsReady struct {
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
-	// RecoveryTimeout defines an optional timeout, measured since the
-	// last transition to the PodsReady=false condition after a Workload is Admitted and running.
-	// Such a transition may happen when a Pod failed and the replacement Pod
-	// is awaited to be scheduled.
-	// After exceeding the timeout the corresponding job gets suspended again
-	// and requeued after the backoff delay. The timeout is enforced only if waitForPodsReady.enable=true.
-	// Defaults to 3 mins.
-	// +optional
-	RecoveryTimeout *metav1.Duration `json:"recoveryTimeout,omitempty"`
-
 	// BlockAdmission when true, cluster queue will block admissions for all
 	// subsequent jobs until the jobs reach the PodsReady=true condition.
 	// This setting is only honored when `Enable` is set to true.
@@ -229,6 +219,16 @@ type WaitForPodsReady struct {
 	// RequeuingStrategy defines the strategy for requeuing a Workload.
 	// +optional
 	RequeuingStrategy *RequeuingStrategy `json:"requeuingStrategy,omitempty"`
+
+	// RecoveryTimeout defines an opt-in timeout, measured since the
+	// last transition to the PodsReady=false condition after a Workload is Admitted and running.
+	// Such a transition may happen when a Pod failed and the replacement Pod
+	// is awaited to be scheduled.
+	// After exceeding the timeout the corresponding job gets suspended again
+	// and requeued after the backoff delay. The timeout is enforced only if waitForPodsReady.enable=true.
+	// If not set, there is no timeout.
+	// +optional
+	RecoveryTimeout *metav1.Duration `json:"recoveryTimeout,omitempty"`
 }
 
 type MultiKueue struct {

--- a/apis/config/v1beta1/defaults.go
+++ b/apis/config/v1beta1/defaults.go
@@ -42,7 +42,6 @@ const (
 	DefaultClientConnectionQPS                  float32 = 20.0
 	DefaultClientConnectionBurst                int32   = 30
 	defaultPodsReadyTimeout                             = 5 * time.Minute
-	defaultPodsRecoveryTimeout                          = 3 * time.Minute
 	DefaultQueueVisibilityUpdateIntervalSeconds int32   = 5
 	DefaultClusterQueuesMaxCount                int32   = 10
 	defaultJobFrameworkName                             = "batch/job"
@@ -120,9 +119,6 @@ func SetDefaults_Configuration(cfg *Configuration) {
 	if cfg.WaitForPodsReady != nil {
 		if cfg.WaitForPodsReady.Timeout == nil {
 			cfg.WaitForPodsReady.Timeout = &metav1.Duration{Duration: defaultPodsReadyTimeout}
-		}
-		if cfg.WaitForPodsReady.RecoveryTimeout == nil {
-			cfg.WaitForPodsReady.RecoveryTimeout = &metav1.Duration{Duration: defaultPodsRecoveryTimeout}
 		}
 		if cfg.WaitForPodsReady.BlockAdmission == nil {
 			defaultBlockAdmission := true

--- a/apis/config/v1beta1/defaults.go
+++ b/apis/config/v1beta1/defaults.go
@@ -42,6 +42,7 @@ const (
 	DefaultClientConnectionQPS                  float32 = 20.0
 	DefaultClientConnectionBurst                int32   = 30
 	defaultPodsReadyTimeout                             = 5 * time.Minute
+	defaultPodsRecoveryTimeout                          = 3 * time.Minute
 	DefaultQueueVisibilityUpdateIntervalSeconds int32   = 5
 	DefaultClusterQueuesMaxCount                int32   = 10
 	defaultJobFrameworkName                             = "batch/job"
@@ -119,6 +120,9 @@ func SetDefaults_Configuration(cfg *Configuration) {
 	if cfg.WaitForPodsReady != nil {
 		if cfg.WaitForPodsReady.Timeout == nil {
 			cfg.WaitForPodsReady.Timeout = &metav1.Duration{Duration: defaultPodsReadyTimeout}
+		}
+		if cfg.WaitForPodsReady.RecoveryTimeout == nil {
+			cfg.WaitForPodsReady.RecoveryTimeout = &metav1.Duration{Duration: defaultPodsRecoveryTimeout}
 		}
 		if cfg.WaitForPodsReady.BlockAdmission == nil {
 			defaultBlockAdmission := true

--- a/apis/config/v1beta1/defaults_test.go
+++ b/apis/config/v1beta1/defaults_test.go
@@ -123,7 +123,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 	}
 
 	podsReadyTimeout := metav1.Duration{Duration: defaultPodsReadyTimeout}
-	podsReadyRecoveryTimeout := metav1.Duration{Duration: defaultPodsRecoveryTimeout}
 	podsReadyTimeoutOverwrite := metav1.Duration{Duration: time.Minute}
 
 	testCases := map[string]struct {
@@ -392,7 +391,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Enable:          true,
 					BlockAdmission:  ptr.To(true),
 					Timeout:         &podsReadyTimeout,
-					RecoveryTimeout: &podsReadyRecoveryTimeout,
+					RecoveryTimeout: nil,
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          ptr.To(EvictionTimestamp),
 						BackoffBaseSeconds: ptr.To[int32](DefaultRequeuingBackoffBaseSeconds),
@@ -411,7 +410,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 			},
 		},
-		"set waitForPodsReady.blockAdmission to false when enable is false": {
+		"set waitForPodsReady.blockAdmission to false, and waitForPodsReady.recoveryTimeout to nil when enable is false": {
 			original: &Configuration{
 				WaitForPodsReady: &WaitForPodsReady{
 					Enable: false,
@@ -422,10 +421,9 @@ func TestSetDefaults_Configuration(t *testing.T) {
 			},
 			want: &Configuration{
 				WaitForPodsReady: &WaitForPodsReady{
-					Enable:          false,
-					BlockAdmission:  ptr.To(false),
-					Timeout:         &podsReadyTimeout,
-					RecoveryTimeout: &podsReadyRecoveryTimeout,
+					Enable:         false,
+					BlockAdmission: ptr.To(false),
+					Timeout:        &podsReadyTimeout,
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          ptr.To(EvictionTimestamp),
 						BackoffBaseSeconds: ptr.To[int32](DefaultRequeuingBackoffBaseSeconds),
@@ -454,6 +452,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 						BackoffBaseSeconds: ptr.To[int32](63),
 						BackoffMaxSeconds:  ptr.To[int32](1800),
 					},
+					RecoveryTimeout: &metav1.Duration{Duration: time.Minute},
 				},
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
@@ -464,7 +463,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Enable:          true,
 					BlockAdmission:  ptr.To(true),
 					Timeout:         &podsReadyTimeoutOverwrite,
-					RecoveryTimeout: &podsReadyRecoveryTimeout,
+					RecoveryTimeout: &metav1.Duration{Duration: time.Minute},
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          ptr.To(CreationTimestamp),
 						BackoffBaseSeconds: ptr.To[int32](63),

--- a/apis/config/v1beta1/defaults_test.go
+++ b/apis/config/v1beta1/defaults_test.go
@@ -122,7 +122,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 		WorkerLostTimeout: &metav1.Duration{Duration: DefaultMultiKueueWorkerLostTimeout},
 	}
 
-	podsReadyTimeoutTimeout := metav1.Duration{Duration: defaultPodsReadyTimeout}
+	podsReadyTimeout := metav1.Duration{Duration: defaultPodsReadyTimeout}
+	podsReadyRecoveryTimeout := metav1.Duration{Duration: defaultPodsRecoveryTimeout}
 	podsReadyTimeoutOverwrite := metav1.Duration{Duration: time.Minute}
 
 	testCases := map[string]struct {
@@ -388,9 +389,10 @@ func TestSetDefaults_Configuration(t *testing.T) {
 			},
 			want: &Configuration{
 				WaitForPodsReady: &WaitForPodsReady{
-					Enable:         true,
-					BlockAdmission: ptr.To(true),
-					Timeout:        &podsReadyTimeoutTimeout,
+					Enable:          true,
+					BlockAdmission:  ptr.To(true),
+					Timeout:         &podsReadyTimeout,
+					RecoveryTimeout: &podsReadyRecoveryTimeout,
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          ptr.To(EvictionTimestamp),
 						BackoffBaseSeconds: ptr.To[int32](DefaultRequeuingBackoffBaseSeconds),
@@ -420,9 +422,10 @@ func TestSetDefaults_Configuration(t *testing.T) {
 			},
 			want: &Configuration{
 				WaitForPodsReady: &WaitForPodsReady{
-					Enable:         false,
-					BlockAdmission: ptr.To(false),
-					Timeout:        &podsReadyTimeoutTimeout,
+					Enable:          false,
+					BlockAdmission:  ptr.To(false),
+					Timeout:         &podsReadyTimeout,
+					RecoveryTimeout: &podsReadyRecoveryTimeout,
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          ptr.To(EvictionTimestamp),
 						BackoffBaseSeconds: ptr.To[int32](DefaultRequeuingBackoffBaseSeconds),
@@ -458,9 +461,10 @@ func TestSetDefaults_Configuration(t *testing.T) {
 			},
 			want: &Configuration{
 				WaitForPodsReady: &WaitForPodsReady{
-					Enable:         true,
-					BlockAdmission: ptr.To(true),
-					Timeout:        &podsReadyTimeoutOverwrite,
+					Enable:          true,
+					BlockAdmission:  ptr.To(true),
+					Timeout:         &podsReadyTimeoutOverwrite,
+					RecoveryTimeout: &podsReadyRecoveryTimeout,
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          ptr.To(CreationTimestamp),
 						BackoffBaseSeconds: ptr.To[int32](63),

--- a/apis/config/v1beta1/zz_generated.deepcopy.go
+++ b/apis/config/v1beta1/zz_generated.deepcopy.go
@@ -512,11 +512,6 @@ func (in *WaitForPodsReady) DeepCopyInto(out *WaitForPodsReady) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
-	if in.RecoveryTimeout != nil {
-		in, out := &in.RecoveryTimeout, &out.RecoveryTimeout
-		*out = new(v1.Duration)
-		**out = **in
-	}
 	if in.BlockAdmission != nil {
 		in, out := &in.BlockAdmission, &out.BlockAdmission
 		*out = new(bool)
@@ -526,6 +521,11 @@ func (in *WaitForPodsReady) DeepCopyInto(out *WaitForPodsReady) {
 		in, out := &in.RequeuingStrategy, &out.RequeuingStrategy
 		*out = new(RequeuingStrategy)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.RecoveryTimeout != nil {
+		in, out := &in.RecoveryTimeout, &out.RecoveryTimeout
+		*out = new(v1.Duration)
+		**out = **in
 	}
 }
 

--- a/apis/config/v1beta1/zz_generated.deepcopy.go
+++ b/apis/config/v1beta1/zz_generated.deepcopy.go
@@ -512,6 +512,11 @@ func (in *WaitForPodsReady) DeepCopyInto(out *WaitForPodsReady) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.RecoveryTimeout != nil {
+		in, out := &in.RecoveryTimeout, &out.RecoveryTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.BlockAdmission != nil {
 		in, out := &in.BlockAdmission, &out.BlockAdmission
 		*out = new(bool)

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -584,7 +584,7 @@ const (
 	WorkloadWaitForPodsStart = "WaitForPodsStart"
 
 	// WorkloadWaitForPodsStart indicates the reason for the PodsReady=False condition
-	// when the Pods were ready since the workload admission, but some pod has failed, 
+	// when the Pods were ready since the workload admission, but some pod has failed,
 	// and workload waits for recovering.
 	WorkloadWaitForPodsRecovery = "WaitForPodsRecovery"
 )

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -583,9 +583,10 @@ const (
 	// when the pods have not been ready since admission, or the workload is not admitted.
 	WorkloadWaitForPodsStart = "WaitForPodsStart"
 
-	// WorkloadWaitForPodsStart indicates that the PodsReady condition is set after
-	// the workload has started, some pod has failed, and workload waits for recovering
-	WorkloadWaitForPodsRecovery = "WorkloadWaitForPodsRecovery"
+	// WorkloadWaitForPodsStart indicates the reason for the PodsReady=False condition
+	// when the Pods were ready since the workload admission, but some pod has failed, 
+	// and workload waits for recovering.
+	WorkloadWaitForPodsRecovery = "WaitForPodsRecovery"
 )
 
 const (

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -581,7 +581,7 @@ const (
 
 	// WorkloadWaitForPodsStart indicates the reason for PodsReady=False condition
 	// when the pods have not been ready since admission, or the workload is not admitted.
-	WorkloadWaitForPodsStart = "WorkloadWaitForPodsStart"
+	WorkloadWaitForPodsStart = "WaitForPodsStart"
 
 	// WorkloadWaitForPodsStart indicates that the PodsReady condition is set after
 	// the workload has started, some pod has failed, and workload waits for recovering

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -578,6 +578,14 @@ const (
 	// WorkloadMaximumExecutionTimeExceeded indicates that the workload exceeded its
 	// maximum execution time.
 	WorkloadMaximumExecutionTimeExceeded = "MaximumExecutionTimeExceeded"
+
+	// WorkloadWaitForPodsStart indicates that the PodsReady condition is set before
+	// the workload has started
+	WorkloadWaitForPodsStart = "WorkloadWaitForPodsStart"
+
+	// WorkloadWaitForPodsStart indicates that the PodsReady condition is set after
+	// the workload has started, some pod has failed, and workload waits for recovering
+	WorkloadWaitForPodsRecovery = "WorkloadWaitForPodsRecovery"
 )
 
 const (

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -579,8 +579,8 @@ const (
 	// maximum execution time.
 	WorkloadMaximumExecutionTimeExceeded = "MaximumExecutionTimeExceeded"
 
-	// WorkloadWaitForPodsStart indicates that the PodsReady condition is set before
-	// the workload has started
+	// WorkloadWaitForPodsStart indicates the reason for PodsReady=False condition
+	// when the pods have not been ready since admission, or the workload is not admitted.
 	WorkloadWaitForPodsStart = "WorkloadWaitForPodsStart"
 
 	// WorkloadWaitForPodsStart indicates that the PodsReady condition is set after

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -85,6 +85,7 @@ managerConfig:
     #waitForPodsReady:
     #  enable: false
     #  timeout: 5m
+    #  recoveryTimeout: 3m
     #  blockAdmission: false
     #  requeuingStrategy:
     #    timestamp: Eviction

--- a/config/components/manager/controller_manager_config.yaml
+++ b/config/components/manager/controller_manager_config.yaml
@@ -26,6 +26,7 @@ clientConnection:
 #waitForPodsReady:
 #  enable: false
 #  timeout: 5m
+#  recoveryTimeout: 3m
 #  blockAdmission: false
 #  requeuingStrategy:
 #    timestamp: Eviction

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -626,9 +626,10 @@ webhook:
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement:     enableDefaultInternalCertManagement,
 				WaitForPodsReady: &configapi.WaitForPodsReady{
-					Enable:         true,
-					BlockAdmission: ptr.To(false),
-					Timeout:        &metav1.Duration{Duration: 50 * time.Second},
+					Enable:          true,
+					BlockAdmission:  ptr.To(false),
+					Timeout:         &metav1.Duration{Duration: 50 * time.Second},
+					RecoveryTimeout: &metav1.Duration{Duration: 3 * time.Minute},
 					RequeuingStrategy: &configapi.RequeuingStrategy{
 						Timestamp:          ptr.To(configapi.CreationTimestamp),
 						BackoffLimitCount:  ptr.To[int32](10),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -158,6 +158,7 @@ waitForPodsReady:
   enable: true
   timeout: 50s
   blockAdmission: false
+  recoveryTimeout: 3m
   requeuingStrategy:
     timestamp: Creation
     backoffLimitCount: 10

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -123,6 +123,10 @@ func validateWaitForPodsReady(c *configapi.Configuration) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(waitForPodsReadyPath.Child("timeout"),
 			c.WaitForPodsReady.Timeout, apimachineryvalidation.IsNegativeErrorMsg))
 	}
+	if c.WaitForPodsReady.RecoveryTimeout != nil && c.WaitForPodsReady.RecoveryTimeout.Duration < 0 {
+		allErrs = append(allErrs, field.Invalid(waitForPodsReadyPath.Child("recoveryTimeout"),
+			c.WaitForPodsReady.RecoveryTimeout, apimachineryvalidation.IsNegativeErrorMsg))
+	}
 	if strategy := c.WaitForPodsReady.RequeuingStrategy; strategy != nil {
 		if strategy.Timestamp != nil &&
 			*strategy.Timestamp != configapi.CreationTimestamp && *strategy.Timestamp != configapi.EvictionTimestamp {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -429,6 +429,23 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		"negative waitForPodsReady.recoveryTimeout": {
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				WaitForPodsReady: &configapi.WaitForPodsReady{
+					Enable: true,
+					RecoveryTimeout: &metav1.Duration{
+						Duration: -1,
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "waitForPodsReady.recoveryTimeout",
+				},
+			},
+		},
 		"valid waitForPodsReady": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
@@ -436,6 +453,9 @@ func TestValidate(t *testing.T) {
 					Enable: true,
 					Timeout: &metav1.Duration{
 						Duration: 50,
+					},
+					RecoveryTimeout: &metav1.Duration{
+						Duration: 5,
 					},
 					BlockAdmission: ptr.To(false),
 					RequeuingStrategy: &configapi.RequeuingStrategy{

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -455,7 +455,7 @@ func TestValidate(t *testing.T) {
 						Duration: 50,
 					},
 					RecoveryTimeout: &metav1.Duration{
-						Duration: 5,
+						Duration: 3,
 					},
 					BlockAdmission: ptr.To(false),
 					RequeuingStrategy: &configapi.RequeuingStrategy{

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -92,7 +92,8 @@ func waitForPodsReady(cfg *configapi.WaitForPodsReady) *waitForPodsReadyConfig {
 		return nil
 	}
 	result := waitForPodsReadyConfig{
-		timeout: cfg.Timeout.Duration,
+		timeout:         cfg.Timeout.Duration,
+		recoveryTimeout: cfg.RecoveryTimeout.Duration,
 	}
 	if cfg.RequeuingStrategy != nil {
 		result.requeuingBackoffBaseSeconds = *cfg.RequeuingStrategy.BackoffBaseSeconds

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -92,8 +92,10 @@ func waitForPodsReady(cfg *configapi.WaitForPodsReady) *waitForPodsReadyConfig {
 		return nil
 	}
 	result := waitForPodsReadyConfig{
-		timeout:         cfg.Timeout.Duration,
-		recoveryTimeout: cfg.RecoveryTimeout.Duration,
+		timeout: cfg.Timeout.Duration,
+	}
+	if cfg.RecoveryTimeout != nil {
+		result.recoveryTimeout = &cfg.RecoveryTimeout.Duration
 	}
 	if cfg.RequeuingStrategy != nil {
 		result.requeuingBackoffBaseSeconds = *cfg.RequeuingStrategy.BackoffBaseSeconds

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -62,7 +62,7 @@ var (
 
 type waitForPodsReadyConfig struct {
 	timeout                     time.Duration
-	recoveryTimeout             time.Duration
+	recoveryTimeout             *time.Duration
 	requeuingBackoffLimitCount  *int32
 	requeuingBackoffBaseSeconds int32
 	requeuingBackoffMaxDuration time.Duration

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -62,6 +62,7 @@ var (
 
 type waitForPodsReadyConfig struct {
 	timeout                     time.Duration
+	recoveryTimeout             time.Duration
 	requeuingBackoffLimitCount  *int32
 	requeuingBackoffBaseSeconds int32
 	requeuingBackoffMaxDuration time.Duration

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -903,19 +903,6 @@ evicted and requeued in the same cluster queue.
 Defaults to 5min.</p>
 </td>
 </tr>
-<tr><td><code>recoveryTimeout</code><br/>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Duration</code></a>
-</td>
-<td>
-   <p>RecoveryTimeout defines an optional timeout, measured since the
-last transition to the PodsReady=false condition after a Workload is Admitted and running.
-Such a transition may happen when a Pod failed and the replacement Pod
-is awaited to be scheduled.
-After exceeding the timeout the corresponding job gets suspended again
-and requeued after the backoff delay. The timeout is enforced only if waitForPodsReady.enable=true.
-Defaults to 3 mins.</p>
-</td>
-</tr>
 <tr><td><code>blockAdmission</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>
@@ -930,6 +917,19 @@ This setting is only honored when <code>Enable</code> is set to true.</p>
 </td>
 <td>
    <p>RequeuingStrategy defines the strategy for requeuing a Workload.</p>
+</td>
+</tr>
+<tr><td><code>recoveryTimeout</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>RecoveryTimeout defines an opt-in timeout, measured since the
+last transition to the PodsReady=false condition after a Workload is Admitted and running.
+Such a transition may happen when a Pod failed and the replacement Pod
+is awaited to be scheduled.
+After exceeding the timeout the corresponding job gets suspended again
+and requeued after the backoff delay. The timeout is enforced only if waitForPodsReady.enable=true.
+If not set, there is no timeout.</p>
 </td>
 </tr>
 </tbody>

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -903,6 +903,19 @@ evicted and requeued in the same cluster queue.
 Defaults to 5min.</p>
 </td>
 </tr>
+<tr><td><code>recoveryTimeout</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.Duration</code></a>
+</td>
+<td>
+   <p>RecoveryTimeout defines an optional timeout, measured since the
+last transition to the PodsReady=false condition after a Workload is Admitted and running.
+Such a transition may happen when a Pod failed and the replacement Pod
+is awaited to be scheduled.
+After exceeding the timeout the corresponding job gets suspended again
+and requeued after the backoff delay. The timeout is enforced only if waitForPodsReady.enable=true.
+Defaults to 3 mins.</p>
+</td>
+</tr>
 <tr><td><code>blockAdmission</code> <B>[Required]</B><br/>
 <code>bool</code>
 </td>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Introduces a new `waitForPodsReady.recoveryTimeout` API, following [this KEP](https://github.com/kubernetes-sigs/kueue/pull/2737)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #2732 

#### Special notes for your reviewer:
This is one of two PRs for this feature. This one introduces API only, and the second one adds logic.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Kueue exposes a new recovery mechanism as part of the WaitForPodsReady API. This evicts jobs which surpasses configured threshold for pod's recovery during runtime
```