### PR TITLE
chore: Replace deprecated NewSimpleClientset with NewClientset

### DIFF
--- a/cmd/kueuectl/app/completion/completion_test.go
+++ b/cmd/kueuectl/app/completion/completion_test.go
@@ -79,7 +79,7 @@ func TestWorkloadNameCompletionFunc(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewSimpleClientset(tc.objs...))
+			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewClientset(tc.objs...))
 			if len(tc.ns) > 0 {
 				tcg.WithNamespace(tc.ns)
 			}
@@ -148,7 +148,7 @@ func TestClusterQueueNameCompletionFunc(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewSimpleClientset(tc.objs...))
+			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewClientset(tc.objs...))
 			if len(tc.ns) > 0 {
 				tcg.WithNamespace(tc.ns)
 			}
@@ -216,7 +216,7 @@ func TestLocalQueueNameCompletionFunc(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewSimpleClientset(tc.objs...))
+			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewClientset(tc.objs...))
 			if len(tc.ns) > 0 {
 				tcg.WithNamespace(tc.ns)
 			}

--- a/cmd/kueuectl/app/create/create_resourceflavor_test.go
+++ b/cmd/kueuectl/app/create/create_resourceflavor_test.go
@@ -324,7 +324,7 @@ func TestResourceFlavorCmd(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			streams, _, out, outErr := genericiooptions.NewTestIOStreams()
 
-			clientset := fake.NewSimpleClientset()
+			clientset := fake.NewClientset()
 			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(clientset)
 
 			cmd := NewResourceFlavorCmd(tcg, streams)

--- a/cmd/kueuectl/app/delete/delete_workload_test.go
+++ b/cmd/kueuectl/app/delete/delete_workload_test.go
@@ -284,7 +284,7 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 			}
 
 			streams, in, out, outErr := genericiooptions.NewTestIOStreams()
-			clientset := fake.NewSimpleClientset(tc.workloads...)
+			clientset := fake.NewClientset(tc.workloads...)
 			clientset.PrependReactor("delete", "workloads", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 				if slices.Contains(action.(kubetesting.DeleteAction).GetDeleteOptions().DryRun, metav1.DryRunAll) {
 					handled = true

--- a/cmd/kueuectl/app/list/list_clusterqueue_test.go
+++ b/cmd/kueuectl/app/list/list_clusterqueue_test.go
@@ -144,7 +144,7 @@ cq1    cohort1   1                   2                    true     60m
 		t.Run(name, func(t *testing.T) {
 			streams, _, out, outErr := genericiooptions.NewTestIOStreams()
 
-			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewSimpleClientset(tc.objs...))
+			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewClientset(tc.objs...))
 
 			cmd := NewClusterQueueCmd(tcg, streams, testingclock.NewFakeClock(testStartTime))
 			cmd.SetArgs(tc.args)

--- a/cmd/kueuectl/app/list/list_localqueue_test.go
+++ b/cmd/kueuectl/app/list/list_localqueue_test.go
@@ -202,7 +202,7 @@ lq1    cq1            1                   1                    60m
 		t.Run(name, func(t *testing.T) {
 			streams, _, out, outErr := genericiooptions.NewTestIOStreams()
 
-			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewSimpleClientset(tc.objs...))
+			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewClientset(tc.objs...))
 			if len(tc.ns) > 0 {
 				tcg.WithNamespace(tc.ns)
 			}

--- a/cmd/kueuectl/app/list/list_resourceflavor_test.go
+++ b/cmd/kueuectl/app/list/list_resourceflavor_test.go
@@ -112,7 +112,7 @@ rf1                  60m
 		t.Run(name, func(t *testing.T) {
 			streams, _, out, outErr := genericiooptions.NewTestIOStreams()
 
-			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewSimpleClientset(tc.objs...))
+			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewClientset(tc.objs...))
 
 			cmd := NewResourceFlavorCmd(tcg, streams, testingclock.NewFakeClock(testStartTime))
 			cmd.SetOut(out)

--- a/cmd/kueuectl/app/list/list_test.go
+++ b/cmd/kueuectl/app/list/list_test.go
@@ -158,7 +158,7 @@ ns2         wl2               j2         lq2          cq2            PENDING    
 		t.Run(name, func(t *testing.T) {
 			streams, _, out, outErr := genericiooptions.NewTestIOStreams()
 
-			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewSimpleClientset(tc.objs...))
+			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(fake.NewClientset(tc.objs...))
 			if len(tc.ns) > 0 {
 				tcg.WithNamespace(tc.ns)
 			}

--- a/cmd/kueuectl/app/list/list_workload_test.go
+++ b/cmd/kueuectl/app/list/list_workload_test.go
@@ -875,7 +875,7 @@ wl2               j2         lq2          cq2            PENDING   22           
 		t.Run(name, func(t *testing.T) {
 			streams, _, out, outErr := genericiooptions.NewTestIOStreams()
 
-			clientset := fake.NewSimpleClientset(tc.objs...)
+			clientset := fake.NewClientset(tc.objs...)
 
 			tcg := cmdtesting.NewTestClientGetter().WithKueueClientset(clientset)
 			if len(tc.ns) > 0 {

--- a/cmd/kueuectl/app/testing/fake.go
+++ b/cmd/kueuectl/app/testing/fake.go
@@ -53,8 +53,8 @@ func NewTestClientGetter() *TestClientGetter {
 		WithNamespace(metav1.NamespaceDefault)
 	return &TestClientGetter{
 		ClientGetter:   util.NewClientGetter(configFlags),
-		kueueClientset: kueuefake.NewSimpleClientset(),
-		k8sClientset:   k8sfake.NewSimpleClientset(),
+		kueueClientset: kueuefake.NewClientset(),
+		k8sClientset:   k8sfake.NewClientset(),
 		configFlags:    configFlags,
 	}
 }

--- a/cmd/kueuectl/app/version/version_test.go
+++ b/cmd/kueuectl/app/version/version_test.go
@@ -74,7 +74,7 @@ Kueue Controller Manager Image: registry.k8s.io/kueue/kueue:v0.0.0
 
 			tcg := cmdtesting.NewTestClientGetter()
 			if tc.deployment != nil {
-				tcg.WithK8sClientset(k8sfake.NewSimpleClientset(tc.deployment))
+				tcg.WithK8sClientset(k8sfake.NewClientset(tc.deployment))
 			}
 
 			cmd := NewVersionCmd(tcg, streams)

--- a/pkg/util/kubeversion/kubeversion_test.go
+++ b/pkg/util/kubeversion/kubeversion_test.go
@@ -32,7 +32,7 @@ import (
 
 // FetchServerVersion gets API server version
 func TestFetchServerVersion(t *testing.T) {
-	fakeClient := fakeclientset.NewSimpleClientset()
+	fakeClient := fakeclientset.NewClientset()
 	fakeDiscovery, ok := fakeClient.Discovery().(*fakediscovery.FakeDiscovery)
 	if !ok {
 		t.Fatalf("couldn't convert Discovery() to *FakeDiscovery")
@@ -52,7 +52,7 @@ func TestFetchServerVersion(t *testing.T) {
 func TestFetchServerVersionWithError(t *testing.T) {
 	expectedError := errors.New("an error occurred")
 
-	fakeClient := fakeclientset.NewSimpleClientset()
+	fakeClient := fakeclientset.NewClientset()
 	fakeDiscovery, ok := fakeClient.Discovery().(*fakediscovery.FakeDiscovery)
 	if !ok {
 		t.Fatalf("couldn't convert Discovery() to *FakeDiscovery")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The `NewSimpleClientset` has been deprecated.

https://pkg.go.dev/k8s.io/client-go/kubernetes/fake#NewSimpleClientset

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```