### PR TITLE
Define FairShare Score for Cohorts; Generalize to Hierarchical Case

### DIFF
--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -43,7 +43,6 @@ import (
 
 var (
 	errQueueAlreadyExists = errors.New("queue already exists")
-	oneQuantity           = resource.MustParse("1")
 )
 
 // clusterQueue is the internal implementation of kueue.clusterQueue that
@@ -171,10 +170,7 @@ func (c *clusterQueue) updateClusterQueue(cycleChecker hierarchy.CycleChecker, i
 		c.FlavorFungibility = defaultFlavorFungibility
 	}
 
-	c.FairWeight = oneQuantity
-	if fs := in.Spec.FairSharing; fs != nil && fs.Weight != nil {
-		c.FairWeight = *fs.Weight
-	}
+	c.FairWeight = parseFairWeight(in.Spec.FairSharing)
 
 	return nil
 }

--- a/pkg/cache/cohort.go
+++ b/pkg/cache/cohort.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cache
 
 import (
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 )
@@ -27,17 +29,21 @@ type cohort struct {
 	hierarchy.Cohort[*clusterQueue, *cohort]
 
 	resourceNode ResourceNode
+
+	FairWeight resource.Quantity
 }
 
 func newCohort(name string) *cohort {
 	return &cohort{
-		name,
-		hierarchy.NewCohort[*clusterQueue, *cohort](),
-		NewResourceNode(),
+		Name:         name,
+		Cohort:       hierarchy.NewCohort[*clusterQueue, *cohort](),
+		resourceNode: NewResourceNode(),
 	}
 }
 
 func (c *cohort) updateCohort(cycleChecker hierarchy.CycleChecker, apiCohort *kueuealpha.Cohort, oldParent *cohort) error {
+	c.FairWeight = parseFairWeight(apiCohort.Spec.FairSharing)
+
 	c.resourceNode.Quotas = createResourceQuotas(apiCohort.Spec.ResourceGroups)
 	if oldParent != nil && oldParent != c.Parent() {
 		// ignore error when old Cohort has cycle.
@@ -71,4 +77,10 @@ func (c *cohort) parentHRN() hierarchicalResourceNode {
 
 func (c *cohort) CCParent() hierarchy.CycleCheckable {
 	return c.Parent()
+}
+
+// Implements dominantResourceShareNode interface.
+
+func (c *cohort) fairWeight() *resource.Quantity {
+	return &c.FairWeight
 }

--- a/pkg/cache/cohort_snapshot.go
+++ b/pkg/cache/cohort_snapshot.go
@@ -16,13 +16,19 @@ limitations under the License.
 
 package cache
 
-import "sigs.k8s.io/kueue/pkg/hierarchy"
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"sigs.k8s.io/kueue/pkg/hierarchy"
+)
 
 type CohortSnapshot struct {
 	Name string
 
 	ResourceNode ResourceNode
 	hierarchy.Cohort[*ClusterQueueSnapshot, *CohortSnapshot]
+
+	FairWeight resource.Quantity
 }
 
 func (c *CohortSnapshot) GetName() string {
@@ -69,4 +75,10 @@ func (c *CohortSnapshot) getResourceNode() ResourceNode {
 
 func (c *CohortSnapshot) parentHRN() hierarchicalResourceNode {
 	return c.Parent()
+}
+
+// Implements dominantResourceShareNode interface.
+
+func (c *CohortSnapshot) fairWeight() *resource.Quantity {
+	return &c.FairWeight
 }

--- a/pkg/cache/fair_sharing_test.go
+++ b/pkg/cache/fair_sharing_test.go
@@ -21,9 +21,12 @@ import (
 	"math"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -31,13 +34,26 @@ import (
 )
 
 func TestDominantResourceShare(t *testing.T) {
+	type nodeType bool
+	var (
+		nodeTypeCq     nodeType = false
+		nodeTypeCohort nodeType = true
+	)
+
+	type fairSharingResult struct {
+		Name     string
+		NodeType nodeType
+		DrValue  int
+		DrName   corev1.ResourceName
+	}
+
 	cases := map[string]struct {
 		usage               resources.FlavorResourceQuantities
 		clusterQueue        *kueue.ClusterQueue
 		lendingClusterQueue *kueue.ClusterQueue
+		cohorts             []*kueuealpha.Cohort
 		flvResQ             resources.FlavorResourceQuantities
-		wantDRValue         int
-		wantDRName          corev1.ResourceName
+		want                []fairSharingResult
 	}{
 		"no cohort": {
 			usage: resources.FlavorResourceQuantities{
@@ -51,6 +67,14 @@ func TestDominantResourceShare(t *testing.T) {
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
 						FlavorQuotas,
 				).Obj(),
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					DrName:   "",
+					DrValue:  0,
+				},
+			},
 		},
 		"usage below nominal": {
 			usage: resources.FlavorResourceQuantities{
@@ -75,6 +99,26 @@ func TestDominantResourceShare(t *testing.T) {
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
 						FlavorQuotas,
 				).Obj(),
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					DrName:   "",
+					DrValue:  0,
+				},
+				{
+					Name:     "lending-cq",
+					NodeType: nodeTypeCq,
+					DrName:   "",
+					DrValue:  0,
+				},
+				{
+					Name:     "test-cohort",
+					NodeType: nodeTypeCohort,
+					DrName:   "",
+					DrValue:  0,
+				},
+			},
 		},
 		"usage above nominal": {
 			usage: resources.FlavorResourceQuantities{
@@ -99,8 +143,26 @@ func TestDominantResourceShare(t *testing.T) {
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
 						FlavorQuotas,
 				).Obj(),
-			wantDRName:  "example.com/gpu",
-			wantDRValue: 200, // (7-5)*1000/10
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					DrName:   "example.com/gpu",
+					DrValue:  200, // (7-5)*1000/10
+				},
+				{
+					Name:     "lending-cq",
+					NodeType: nodeTypeCq,
+					DrName:   "",
+					DrValue:  0,
+				},
+				{
+					Name:     "test-cohort",
+					NodeType: nodeTypeCohort,
+					DrName:   "",
+					DrValue:  0,
+				},
+			},
 		},
 		"one resource above nominal": {
 			usage: resources.FlavorResourceQuantities{
@@ -125,8 +187,26 @@ func TestDominantResourceShare(t *testing.T) {
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
 						FlavorQuotas,
 				).Obj(),
-			wantDRName:  corev1.ResourceCPU,
-			wantDRValue: 100, // (3-2)*1000/10
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					DrName:   corev1.ResourceCPU,
+					DrValue:  100, // (3-2)*1000/10
+				},
+				{
+					Name:     "lending-cq",
+					NodeType: nodeTypeCq,
+					DrName:   "",
+					DrValue:  0,
+				},
+				{
+					Name:     "test-cohort",
+					NodeType: nodeTypeCohort,
+					DrName:   "",
+					DrValue:  0,
+				},
+			},
 		},
 		"usage with workload above nominal": {
 			usage: resources.FlavorResourceQuantities{
@@ -155,8 +235,26 @@ func TestDominantResourceShare(t *testing.T) {
 				{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
 				{Flavor: "default", Resource: "example.com/gpu"}:  4,
 			},
-			wantDRName:  corev1.ResourceCPU,
-			wantDRValue: 300, // (1+4-2)*1000/10
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					DrName:   corev1.ResourceCPU,
+					DrValue:  300, // (1+4-2)*1000/10
+				},
+				{
+					Name:     "lending-cq",
+					NodeType: nodeTypeCq,
+					DrName:   "",
+					DrValue:  0,
+				},
+				{
+					Name:     "test-cohort",
+					NodeType: nodeTypeCohort,
+					DrName:   "",
+					DrValue:  0,
+				},
+			},
 		},
 		"A resource with zero lendable": {
 			usage: resources.FlavorResourceQuantities{
@@ -185,8 +283,26 @@ func TestDominantResourceShare(t *testing.T) {
 				{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
 				{Flavor: "default", Resource: "example.com/gpu"}:  4,
 			},
-			wantDRName:  corev1.ResourceCPU,
-			wantDRValue: 300, // (1+4-2)*1000/10
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					DrName:   corev1.ResourceCPU,
+					DrValue:  300, // (1+4-2)*1000/10
+				},
+				{
+					Name:     "lending-cq",
+					NodeType: nodeTypeCq,
+					DrName:   "",
+					DrValue:  0,
+				},
+				{
+					Name:     "test-cohort",
+					NodeType: nodeTypeCohort,
+					DrName:   "",
+					DrValue:  0,
+				},
+			},
 		},
 		"multiple flavors": {
 			usage: resources.FlavorResourceQuantities{
@@ -215,8 +331,26 @@ func TestDominantResourceShare(t *testing.T) {
 			flvResQ: resources.FlavorResourceQuantities{
 				{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10_000,
 			},
-			wantDRName:  corev1.ResourceCPU,
-			wantDRValue: 25, // ((15+10-20)+0)*1000/200 (spot under nominal)
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					DrName:   corev1.ResourceCPU,
+					DrValue:  25, // ((15+10-20)+0)*1000/200 (spot under nominal)
+				},
+				{
+					Name:     "lending-cq",
+					NodeType: nodeTypeCq,
+					DrName:   "",
+					DrValue:  0,
+				},
+				{
+					Name:     "test-cohort",
+					NodeType: nodeTypeCohort,
+					DrName:   "",
+					DrValue:  0,
+				},
+			},
 		},
 		"above nominal with integer weight": {
 			usage: resources.FlavorResourceQuantities{
@@ -238,8 +372,26 @@ func TestDominantResourceShare(t *testing.T) {
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
 						FlavorQuotas,
 				).Obj(),
-			wantDRName:  "example.com/gpu",
-			wantDRValue: 100, // ((7-5)*1000/10)/2
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					DrName:   "example.com/gpu",
+					DrValue:  100, // ((7-5)*1000/10)/2
+				},
+				{
+					Name:     "lending-cq",
+					NodeType: nodeTypeCq,
+					DrName:   "",
+					DrValue:  0,
+				},
+				{
+					Name:     "test-cohort",
+					NodeType: nodeTypeCohort,
+					DrName:   "",
+					DrValue:  0,
+				},
+			},
 		},
 		"above nominal with decimal weight": {
 			usage: resources.FlavorResourceQuantities{
@@ -261,8 +413,26 @@ func TestDominantResourceShare(t *testing.T) {
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
 						FlavorQuotas,
 				).Obj(),
-			wantDRName:  "example.com/gpu",
-			wantDRValue: 400, // ((7-5)*1000/10)/(1/2)
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					DrName:   "example.com/gpu",
+					DrValue:  400, // ((7-5)*1000/10)/(1/2)
+				},
+				{
+					Name:     "lending-cq",
+					NodeType: nodeTypeCq,
+					DrName:   "",
+					DrValue:  0,
+				},
+				{
+					Name:     "test-cohort",
+					NodeType: nodeTypeCohort,
+					DrName:   "",
+					DrValue:  0,
+				},
+			},
 		},
 		"above nominal with zero weight": {
 			usage: resources.FlavorResourceQuantities{
@@ -270,7 +440,6 @@ func TestDominantResourceShare(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("cq").
 				Cohort("test-cohort").
-				FairWeight(oneQuantity).
 				FairWeight(resource.MustParse("0")).
 				ResourceGroup(
 					utiltesting.MakeFlavorQuotas("default").
@@ -285,7 +454,155 @@ func TestDominantResourceShare(t *testing.T) {
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("10").Append().
 						FlavorQuotas,
 				).Obj(),
-			wantDRValue: math.MaxInt,
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					DrName:   "",
+					DrValue:  math.MaxInt,
+				},
+				{
+					Name:     "lending-cq",
+					NodeType: nodeTypeCq,
+					DrName:   "",
+					DrValue:  0,
+				},
+				{
+					Name:     "test-cohort",
+					NodeType: nodeTypeCohort,
+					DrName:   "",
+					DrValue:  0,
+				},
+			},
+		},
+		"cohort has resource share": {
+			usage: resources.FlavorResourceQuantities{
+				{Flavor: "default", Resource: "example.com/gpu"}: 10,
+			},
+			clusterQueue: utiltesting.MakeClusterQueue("cq").
+				Cohort("child-cohort").
+				FairWeight(oneQuantity).
+				ResourceGroup(
+					utiltesting.MakeFlavorQuotas("default").
+						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
+						FlavorQuotas,
+				).Obj(),
+			cohorts: []*kueuealpha.Cohort{
+				utiltesting.MakeCohort("child-cohort").FairWeight(resource.MustParse("2")).Parent("root").Obj(),
+				utiltesting.MakeCohort("root").ResourceGroup(
+					utiltesting.MakeFlavorQuotas("default").
+						ResourceQuotaWrapper("example.com/gpu").NominalQuota("45").Append().
+						FlavorQuotas,
+				).Obj(),
+			},
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					DrName:   "example.com/gpu",
+					DrValue:  100, // (5 / 50) * 1000
+				},
+				{
+					Name:     "child-cohort",
+					NodeType: nodeTypeCohort,
+					DrName:   "example.com/gpu",
+					DrValue:  50, // (5 / 50) * 1000 / 2
+				},
+				{
+					Name:     "root",
+					NodeType: nodeTypeCohort,
+					DrName:   "",
+					DrValue:  0,
+				},
+			},
+		},
+		"resource share defined for resources only available at the root cohort": {
+			usage: resources.FlavorResourceQuantities{
+				{Flavor: "default", Resource: "example.com/gpu"}: 10,
+			},
+			clusterQueue: utiltesting.MakeClusterQueue("cq").
+				Cohort("child-cohort").
+				FairWeight(oneQuantity).
+				ResourceGroup(
+					utiltesting.MakeFlavorQuotas("default").
+						ResourceQuotaWrapper("example.com/gpu").NominalQuota("0").Append().
+						FlavorQuotas,
+				).Obj(),
+			cohorts: []*kueuealpha.Cohort{
+				utiltesting.MakeCohort("child-cohort").FairWeight(resource.MustParse("2")).Parent("root").Obj(),
+				utiltesting.MakeCohort("root").ResourceGroup(
+					utiltesting.MakeFlavorQuotas("default").
+						ResourceQuotaWrapper("example.com/gpu").NominalQuota("50").Append().
+						FlavorQuotas,
+				).Obj(),
+			},
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					DrName:   "example.com/gpu",
+					DrValue:  200, // (10 / 50) * 1000
+				},
+				{
+					Name:     "child-cohort",
+					NodeType: nodeTypeCohort,
+					DrName:   "example.com/gpu",
+					DrValue:  100, // (10 / 50) * 1000 / 2
+				},
+				{
+					Name:     "root",
+					NodeType: nodeTypeCohort,
+					DrName:   "",
+					DrValue:  0,
+				},
+			},
+		},
+		"resource share affected by borrowing limit": {
+			// Cohort resources from view of CQ are 10, while
+			// from view of child-cohort are 50. So, they get
+			// different FairSharing values.
+			usage: resources.FlavorResourceQuantities{
+				{Flavor: "default", Resource: "example.com/gpu"}: 10,
+			},
+			clusterQueue: utiltesting.MakeClusterQueue("cq").
+				Cohort("child-cohort").
+				ResourceGroup(
+					utiltesting.MakeFlavorQuotas("default").
+						ResourceQuotaWrapper("example.com/gpu").NominalQuota("0").Append().
+						FlavorQuotas,
+				).Obj(),
+			cohorts: []*kueuealpha.Cohort{
+				utiltesting.MakeCohort("child-cohort").ResourceGroup(
+					utiltesting.MakeFlavorQuotas("default").
+						ResourceQuotaWrapper("example.com/gpu").NominalQuota("0").BorrowingLimit("10").Append().
+						FlavorQuotas,
+				).Parent("root").Obj(),
+				utiltesting.MakeCohort("root").ResourceGroup(
+					utiltesting.MakeFlavorQuotas("default").
+						ResourceQuotaWrapper("example.com/gpu").NominalQuota("50").Append().
+						FlavorQuotas,
+				).Obj(),
+			},
+			want: []fairSharingResult{
+				{
+					Name:     "cq",
+					NodeType: nodeTypeCq,
+					DrName:   "example.com/gpu",
+					DrValue:  1000, // (10 / 10) * 1000
+				},
+				{
+					Name:     "child-cohort",
+					NodeType: nodeTypeCohort,
+					DrName:   "example.com/gpu",
+					DrValue:  200, // (10 / 50) * 1000
+				},
+				{
+					Name:     "root",
+					NodeType: nodeTypeCohort,
+					DrName:   "",
+					DrValue:  0,
+				},
+			},
 		},
 	}
 	for name, tc := range cases {
@@ -301,6 +618,10 @@ func TestDominantResourceShare(t *testing.T) {
 			if tc.lendingClusterQueue != nil {
 				// we create a second cluster queue to add lendable capacity to the cohort.
 				_ = cache.AddClusterQueue(ctx, tc.lendingClusterQueue)
+			}
+
+			for _, cohort := range tc.cohorts {
+				_ = cache.AddOrUpdateCohort(cohort)
 			}
 
 			snapshot, err := cache.Snapshot(ctx)
@@ -320,20 +641,50 @@ func TestDominantResourceShare(t *testing.T) {
 				i++
 			}
 
-			drVal, drNameCache := dominantResourceShare(cache.hm.ClusterQueues["cq"], tc.flvResQ)
-			if drVal != tc.wantDRValue {
-				t.Errorf("cache.DominantResourceShare(_) returned value %d, want %d", drVal, tc.wantDRValue)
+			gotCache := make([]fairSharingResult, 0, len(snapshot.ClusterQueues)+len(snapshot.Cohorts))
+			for _, cq := range cache.hm.ClusterQueues {
+				drVal, drName := dominantResourceShare(cq, tc.flvResQ)
+				gotCache = append(gotCache, fairSharingResult{
+					Name:     cq.Name,
+					NodeType: nodeTypeCq,
+					DrValue:  drVal,
+					DrName:   drName,
+				})
 			}
-			if drNameCache != tc.wantDRName {
-				t.Errorf("cache.DominantResourceShare(_) returned resource %s, want %s", drNameCache, tc.wantDRName)
+			for _, cohort := range cache.hm.Cohorts {
+				drVal, drName := dominantResourceShare(cohort, tc.flvResQ)
+				gotCache = append(gotCache, fairSharingResult{
+					Name:     cohort.Name,
+					NodeType: nodeTypeCohort,
+					DrValue:  drVal,
+					DrName:   drName,
+				})
+			}
+			if diff := cmp.Diff(sets.New(tc.want...), sets.New(gotCache...)); diff != "" {
+				t.Errorf("dominantResourceShare cache mismatch: %s", diff)
 			}
 
-			drValSnap, drNameSnap := snapshot.ClusterQueues["cq"].DominantResourceShareWith(tc.flvResQ)
-			if drValSnap != tc.wantDRValue {
-				t.Errorf("snapshot.DominantResourceShare(_) returned value %d, want %d", drValSnap, tc.wantDRValue)
+			gotSnapshot := make([]fairSharingResult, 0, len(snapshot.ClusterQueues)+len(snapshot.Cohorts))
+			for _, cq := range snapshot.ClusterQueues {
+				drVal, drName := dominantResourceShare(cq, tc.flvResQ)
+				gotSnapshot = append(gotSnapshot, fairSharingResult{
+					Name:     cq.Name,
+					NodeType: nodeTypeCq,
+					DrValue:  drVal,
+					DrName:   drName,
+				})
 			}
-			if drNameSnap != tc.wantDRName {
-				t.Errorf("snapshot.DominantResourceShare(_) returned resource %s, want %s", drNameSnap, tc.wantDRName)
+			for _, cohort := range snapshot.Cohorts {
+				drVal, drName := dominantResourceShare(cohort, tc.flvResQ)
+				gotSnapshot = append(gotSnapshot, fairSharingResult{
+					Name:     cohort.Name,
+					NodeType: nodeTypeCohort,
+					DrValue:  drVal,
+					DrName:   drName,
+				})
+			}
+			if diff := cmp.Diff(sets.New(tc.want...), sets.New(gotSnapshot...)); diff != "" {
+				t.Errorf("dominantResourceShare snapshot mismatch: %s", diff)
 			}
 		})
 	}

--- a/pkg/cache/resource_node.go
+++ b/pkg/cache/resource_node.go
@@ -20,8 +20,6 @@ import (
 	"errors"
 	"maps"
 
-	corev1 "k8s.io/api/core/v1"
-
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 	"sigs.k8s.io/kueue/pkg/resources"
 )
@@ -144,16 +142,6 @@ func removeUsage(node hierarchicalResourceNode, fr resources.FlavorResource, val
 	}
 	deltaParentUsage := min(val, usageStoredInParent)
 	removeUsage(node.parentHRN(), fr, deltaParentUsage)
-}
-
-// calculateLendable aggregates capacity for resources across all
-// FlavorResources.
-func (r ResourceNode) calculateLendable() map[corev1.ResourceName]int64 {
-	lendable := make(map[corev1.ResourceName]int64, len(r.SubtreeQuota))
-	for fr, q := range r.SubtreeQuota {
-		lendable[fr.Resource] += q
-	}
-	return lendable
 }
 
 func updateClusterQueueResourceNode(cq *clusterQueue) {

--- a/pkg/cache/resource_node_test.go
+++ b/pkg/cache/resource_node_test.go
@@ -57,7 +57,7 @@ func TestCohortLendable(t *testing.T) {
 		"example.com/gpu":  3,
 	}
 
-	lendable := cache.hm.Cohorts["test-cohort"].resourceNode.calculateLendable()
+	lendable := calculateLendable(cache.hm.Cohorts["test-cohort"])
 	if diff := cmp.Diff(wantLendable, lendable); diff != "" {
 		t.Errorf("Unexpected cohort lendable (-want,+got):\n%s", diff)
 	}

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -94,6 +94,7 @@ func (c *Cache) Snapshot(ctx context.Context) (*Snapshot, error) {
 		}
 		snap.AddCohort(cohort.Name)
 		snap.Cohorts[cohort.Name].ResourceNode = cohort.resourceNode.Clone()
+		snap.Cohorts[cohort.Name].FairWeight = cohort.FairWeight
 		if cohort.HasParent() {
 			snap.UpdateCohortEdge(cohort.Name, cohort.Parent().Name)
 		}

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -788,6 +788,7 @@ func TestSnapshot(t *testing.T) {
 									{Flavor: "mips", Resource: corev1.ResourceCPU}: 42_000,
 								},
 							},
+							FairWeight: oneQuantity,
 						},
 					},
 				},
@@ -865,12 +866,28 @@ func TestSnapshot(t *testing.T) {
 									{Flavor: "arm", Resource: corev1.ResourceCPU}: 0,
 								},
 							},
+							FairWeight: oneQuantity,
 						},
 					},
 				},
 				InactiveClusterQueueSets: sets.New("cq-autocycle", "cq-a", "cq-b"),
 				ResourceFlavors: map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
 					"arm": utiltesting.MakeResourceFlavor("arm").Obj(),
+				},
+			},
+		},
+		"cohort snapshot has fair sharing weight": {
+			cohorts: []*kueuealpha.Cohort{
+				utiltesting.MakeCohort("cohort").FairWeight(resource.MustParse("0.5")).Obj(),
+			},
+			wantSnapshot: Snapshot{
+				Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
+					Cohorts: map[string]*CohortSnapshot{
+						"cohort": {
+							Name:       "cohort",
+							FairWeight: resource.MustParse("0.5"),
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
We define FairShare (DominantResourceShare) score for Cohorts.

We additionally support the case where a CQ or Cohort has some lendable resource available to it, but not in its direct parent. Rather than counting only lendable resources in the parent Cohort, we use the `potentiallyAvailable` function to see how much capacity is available to that Cohort, when it borrows from its parent. While this doesn't differentiate capacity available in the parent Cohort's subtree, versus capacity that the parent Cohort borrows, the FairShare score should only be used for local comparisons: comparing two children of the same node. Therefore, this will serve as a valid denominator.

#### Which issue(s) this PR fixes:
Part of #3759

#### Special notes for your reviewer:
No release note for this change, as we will do a single release note for the entire feature.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```