### PR TITLE
Automated cherry pick of #4309: docs: update pod integration name in documentation

### DIFF
--- a/site/content/en/docs/tasks/run/deployment.md
+++ b/site/content/en/docs/tasks/run/deployment.md
@@ -24,7 +24,7 @@ For more information, see [Kueue's overview](/docs/overview).
 1. Learn how to [install Kueue with a custom manager configuration](/docs/installation/#install-a-custom-configured-released-version).
 
 2. Follow steps in [Run Plain Pods](/docs/tasks/run/plain_pods/#before-you-begin)
-to learn how to enable and configure the `v1/pod` integration.
+to learn how to enable and configure the `pod` integration.
 
 3. Check [Administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial Kueue setup.
 

--- a/site/content/en/docs/tasks/run/external_workloads/argo_workflow.md
+++ b/site/content/en/docs/tasks/run/external_workloads/argo_workflow.md
@@ -1,0 +1,52 @@
+---
+title: "Run An Argo Workflow"
+linkTitle: "Argo Workflow"
+date: 2025-01-23
+weight: 3
+description: >
+  Integrate Kueue with Argo Workflows.
+---
+
+This page shows how to leverage Kueue's scheduling and resource management capabilities when running [Argo Workflows](https://argo-workflows.readthedocs.io/en/latest/).
+
+This guide is for [batch users](/docs/tasks#batch-user) that have a basic understanding of Kueue. For more information, see [Kueue's overview](/docs/overview).
+
+Currently Kueue doesn't support Argo Workflows [Workflow](https://argo-workflows.readthedocs.io/en/latest/workflow-concepts/) resources directly,
+but you can take advantage of the ability for Kueue to [manage plain pods](/docs/tasks/run_plain_pods) to integrate them.
+
+## Before you begin
+
+1. Learn how to [install Kueue with a custom manager configuration](/docs/installation/#install-a-custom-configured-released-version).
+
+2. Follow steps in [Run Plain Pods](/docs/tasks/run/plain_pods/#before-you-begin)
+to learn how to enable and configure the `pod` integration.
+
+3. Install [Argo Workflows](https://argo-workflows.readthedocs.io/en/latest/installation/#installation)
+
+## Workflow definition
+
+### a. Targeting a single LocalQueue
+
+If you want the entire workflow to target a single [local queue](/docs/concepts/local_queue),
+it should be specified in the `spec.podMetadata` section of the Workflow configuration.
+
+{{< include "examples/pod-based-workloads/workflow-single-queue.yaml" "yaml" >}}
+
+### b. Targeting a different LocalQueue per template
+
+If prefer to target a different [local queue](/docs/concepts/local_queue) for each step of your Workflow,
+you can define the queue in the `spec.templates[].metadata` section of the Workflow configuration.
+
+In this example `hello1` and `hello2a` will target `user-queue` and `hello2b` will
+target `user-queue-2`.
+
+{{< include "examples/pod-based-workloads/workflow-queue-per-template.yaml" "yaml" >}}
+
+### c. Limitations
+
+- Kueue will only manage pods created by Argo Workflows. It does not manage the Argo Workflows resources in any way.
+- Each pod in a Workflow will create a new Workload resource and must wait for admission by Kueue.
+- There is no way to ensure that a Workflow will complete before it is started. If one step of a multi-step Workflow does not have
+available quota, Argo Workflows will run all previous steps and then wait for quota to become available.
+- Kueue does not understand Argo Workflows `suspend` flag and will not manage it.
+- Kueue does not manage `suspend`, `http`, or `resource` template types since they do not create pods.

--- a/site/content/en/docs/tasks/run/external_workloads/tektoncd.md
+++ b/site/content/en/docs/tasks/run/external_workloads/tektoncd.md
@@ -1,0 +1,63 @@
+---
+title: "Run A Tekton Pipeline"
+linkTitle: "Tekton Pipeline"
+date: 2025-02-01
+weight: 7
+description: >
+  Integrate Kueue with Tekton Pipelines.
+---
+
+This page shows how to leverage Kueue's scheduling and resource management capabilities when running [Tekton pipelines](https://tekton.dev/docs/).
+
+This guide is for [batch users](/docs/tasks#batch-user) that have a basic understanding of Kueue. For more information, see [Kueue's overview](/docs/overview).
+
+We demonstrate how to support scheduling Tekton Pipelines Tasks in Kueue based on the [Plain Pod](/docs/tasks/run_plain_pods) integration, where every Pod from a Pipeline is represented as a single independent Plain Pod.
+
+## Before you begin
+
+1. Learn how to [install Kueue with a custom manager configuration](/docs/installation/#install-a-custom-configured-released-version).
+
+1. Follow the steps in [Run Plain Pods](docs/tasks/run/plain_pods/#before-you-begin) to learn how to enable and configure the `pod` integration.
+
+1. Check [Administrator cluster quotas](/docs/tasks/manage/administer_cluster_quotas/) for details on the initial Kueue step.
+
+1. Your cluster has tekton pipelines [installed](https://tekton.dev/docs/installation/pipelines/).
+
+
+## Tekton Background
+
+Tekton has the concept of [Pipelines](https://tekton.dev/vault/pipelines-v0.59.x-lts/pipelines/), [Tasks](https://tekton.dev/vault/pipelines-v0.59.x-lts/tasks/) and [PipelineRun](https://tekton.dev/vault/pipelines-v0.59.x-lts/pipelineruns/).
+
+A pipeline consists of tasks. Tasks and pipelines must be created before running a pipeline.
+
+A PipelineRun runs the pipeline.
+
+A TaskRun runs a single task. PipelineRuns will reuse TaskRuns to run each task in a pipeline.
+
+### Tekton Defintions
+
+As a simple example, we will define two tasks named sleep and hello:
+
+{{< include "examples/pod-based-workloads/tekton-sleep-task.yaml" "yaml" >}}
+
+{{< include "examples/pod-based-workloads/tekton-hello-task.yaml" "yaml" >}}
+
+A pipeline composes these tasks.
+
+{{< include "examples/pod-based-workloads/tekton-pipeline.yaml" "yaml" >}}
+
+## a. Targeting a single LocalQueue
+
+If you want every task to target a single [local queue](/docs/concepts/local_queue),
+it should be specified in the `metadata.label` section of the PipelineRun configuration.
+
+{{< include "examples/pod-based-workloads/tekton-pipeline-run.yaml" "yaml" >}}
+
+This will inject the kueue label on every pod of the pipeline. Kueue will gate the pods once you are over the quota limits.
+
+## Limitations 
+
+- Kueue will only manage pods created by Tekton.
+- Each pod in a Workflow will create a new Workload resource and must wait for admission by Kueue.
+- There is no way to ensure that a Workflow will complete before it is started. If one step of a multi-step Workflow does not have
+available quota, Tekton pipelines will run all previous steps and then wait for quota to become available.

--- a/site/content/en/docs/tasks/run/plain_pods.md
+++ b/site/content/en/docs/tasks/run/plain_pods.md
@@ -16,7 +16,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 ## Before you begin
 
-1. By default, the integration for `v1/pod` is not enabled.
+1. By default, the integration for `pod` is not enabled.
    Learn how to [install Kueue with a custom manager configuration](/docs/installation/#install-a-custom-configured-released-version)
    and enable the `pod` integration.
 

--- a/site/content/en/docs/tasks/run/statefulset.md
+++ b/site/content/en/docs/tasks/run/statefulset.md
@@ -31,7 +31,7 @@ For more information, see [Kueue's overview](/docs/overview).
       - "statefulset"
    ```
    Also, follow steps in [Run Plain Pods](/docs/tasks/run/plain_pods/#before-you-begin)
-   to learn how to enable and configure the `v1/pod` integration.
+   to learn how to enable and configure the `pod` integration.
 
 3. Check [Administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial Kueue setup.
 


### PR DESCRIPTION
Cherry pick of #4309 on website.

#4309: docs: update pod integration name in documentation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```