### PR TITLE
Automated cherry pick of #4309: docs: update pod integration name in documentation

### DIFF
--- a/site/content/en/docs/tasks/run/deployment.md
+++ b/site/content/en/docs/tasks/run/deployment.md
@@ -24,7 +24,7 @@ For more information, see [Kueue's overview](/docs/overview).
 1. Learn how to [install Kueue with a custom manager configuration](/docs/installation/#install-a-custom-configured-released-version).
 
 2. Follow steps in [Run Plain Pods](/docs/tasks/run/plain_pods/#before-you-begin)
-to learn how to enable and configure the `v1/pod` integration.
+to learn how to enable and configure the `pod` integration.
 
 3. Check [Administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial Kueue setup.
 

--- a/site/content/en/docs/tasks/run/plain_pods.md
+++ b/site/content/en/docs/tasks/run/plain_pods.md
@@ -16,7 +16,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
 
 ## Before you begin
 
-1. By default, the integration for `v1/pod` is not enabled.
+1. By default, the integration for `pod` is not enabled.
    Learn how to [install Kueue with a custom manager configuration](/docs/installation/#install-a-custom-configured-released-version)
    and enable the `pod` integration.
 

--- a/site/content/en/docs/tasks/run/statefulset.md
+++ b/site/content/en/docs/tasks/run/statefulset.md
@@ -31,7 +31,7 @@ For more information, see [Kueue's overview](/docs/overview).
       - "statefulset"
    ```
    Also, follow steps in [Run Plain Pods](/docs/tasks/run/plain_pods/#before-you-begin)
-   to learn how to enable and configure the `v1/pod` integration.
+   to learn how to enable and configure the `pod` integration.
 
 3. Check [Administer cluster quotas](/docs/tasks/manage/administer_cluster_quotas) for details on the initial Kueue setup.
 


### PR DESCRIPTION
Cherry pick of #4309 on website.

#4309: docs: update pod integration name in documentation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```