### PR TITLE
Use consistent naming for prebuilt workload across the codebase

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -70,7 +70,7 @@ var (
 	ErrWorkloadOwnerNotFound    = errors.New("workload owner not found")
 	ErrNoMatchingWorkloads      = errors.New("no matching workloads")
 	ErrExtraWorkloads           = errors.New("extra workloads")
-	ErrPrebuildWorkloadNotFound = errors.New("prebuild workload not found")
+	ErrPrebuiltWorkloadNotFound = errors.New("prebuilt workload not found")
 )
 
 // JobReconciler reconciles a GenericJob object
@@ -1111,7 +1111,7 @@ func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job Generic
 	}
 
 	if usePrebuiltWorkload {
-		return ErrPrebuildWorkloadNotFound
+		return ErrPrebuiltWorkloadNotFound
 	}
 
 	// Create the corresponding workload.

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -65,7 +65,7 @@ var (
 // ValidateJobOnCreate encapsulates all GenericJob validations that must be performed on a Create operation
 func ValidateJobOnCreate(job GenericJob) field.ErrorList {
 	allErrs := ValidateQueueName(job.Object())
-	allErrs = append(allErrs, validateCreateForPrebuildWorkload(job)...)
+	allErrs = append(allErrs, validateCreateForPrebuiltWorkload(job)...)
 	allErrs = append(allErrs, validateCreateForMaxExecTime(job)...)
 	return allErrs
 }
@@ -73,13 +73,13 @@ func ValidateJobOnCreate(job GenericJob) field.ErrorList {
 // ValidateJobOnUpdate encapsulates all GenericJob validations that must be performed on a Update operation
 func ValidateJobOnUpdate(oldJob, newJob GenericJob) field.ErrorList {
 	allErrs := validateUpdateForQueueName(oldJob, newJob)
-	allErrs = append(allErrs, validateUpdateForPrebuildWorkload(oldJob, newJob)...)
+	allErrs = append(allErrs, validateUpdateForPrebuiltWorkload(oldJob, newJob)...)
 	allErrs = append(allErrs, ValidateUpdateForWorkloadPriorityClassName(oldJob.Object(), newJob.Object())...)
 	allErrs = append(allErrs, validateUpdateForMaxExecTime(oldJob, newJob)...)
 	return allErrs
 }
 
-func validateCreateForPrebuildWorkload(job GenericJob) field.ErrorList {
+func validateCreateForPrebuiltWorkload(job GenericJob) field.ErrorList {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, ValidateLabelAsCRDName(job.Object(), constants.PrebuiltWorkloadLabel)...)
 
@@ -128,7 +128,7 @@ func validateUpdateForQueueName(oldJob, newJob GenericJob) field.ErrorList {
 	return allErrs
 }
 
-func validateUpdateForPrebuildWorkload(oldJob, newJob GenericJob) field.ErrorList {
+func validateUpdateForPrebuiltWorkload(oldJob, newJob GenericJob) field.ErrorList {
 	var allErrs field.ErrorList
 	if !newJob.IsSuspended() {
 		oldWlName, _ := PrebuiltWorkloadFor(oldJob)
@@ -136,7 +136,7 @@ func validateUpdateForPrebuildWorkload(oldJob, newJob GenericJob) field.ErrorLis
 
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newWlName, oldWlName, labelsPath.Key(constants.PrebuiltWorkloadLabel))...)
 	} else {
-		allErrs = append(allErrs, validateCreateForPrebuildWorkload(newJob)...)
+		allErrs = append(allErrs, validateCreateForPrebuiltWorkload(newJob)...)
 	}
 	return allErrs
 }

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -2359,7 +2359,7 @@ func TestReconciler(t *testing.T) {
 				Obj(),
 			wantWorkloads: []kueue.Workload{},
 		},
-		"when the prebuilt workload is missing, no new one is created, the job is suspended and prebuild workload not found error is returned": {
+		"when the prebuilt workload is missing, no new one is created, the job is suspended and prebuilt workload not found error is returned": {
 			job: *baseJobWrapper.
 				Clone().
 				Suspend(false).
@@ -2379,7 +2379,7 @@ func TestReconciler(t *testing.T) {
 					Message:   "missing workload",
 				},
 			},
-			wantErr: jobframework.ErrPrebuildWorkloadNotFound,
+			wantErr: jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 		"when the prebuilt workload exists its owner info is updated": {
 			job: *baseJobWrapper.
@@ -2468,7 +2468,7 @@ func TestReconciler(t *testing.T) {
 					Message:   "missing workload",
 				},
 			},
-			wantErr: jobframework.ErrPrebuildWorkloadNotFound,
+			wantErr: jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 		"when the prebuilt workload is not equivalent to the job": {
 			job: *baseJobWrapper.
@@ -2520,7 +2520,7 @@ func TestReconciler(t *testing.T) {
 					Message:   "missing workload",
 				},
 			},
-			wantErr: jobframework.ErrPrebuildWorkloadNotFound,
+			wantErr: jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 		"the workload is not admitted, tolerations and node selector change": {
 			job: *baseJobWrapper.Clone().Toleration(corev1.Toleration{

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler_test.go
@@ -112,7 +112,7 @@ func TestPodReconciler(t *testing.T) {
 				Queue("queue").
 				Group(GetWorkloadName(types.UID(testUID), "lws", "0")).
 				GroupTotalCount("1").
-				PrebuildWorkload(GetWorkloadName(types.UID(testUID), "lws", "0")).
+				PrebuiltWorkload(GetWorkloadName(types.UID(testUID), "lws", "0")).
 				Annotation(podcontroller.SuspendedByParentAnnotation, FrameworkName).
 				Annotation(podcontroller.GroupServingAnnotation, "true").
 				Annotation(podcontroller.RoleHashAnnotation, "main").
@@ -137,7 +137,7 @@ func TestPodReconciler(t *testing.T) {
 				Queue("queue").
 				Group(GetWorkloadName(types.UID(testUID), "lws", "0")).
 				GroupTotalCount("1").
-				PrebuildWorkload(GetWorkloadName(types.UID(testUID), "lws", "0")).
+				PrebuiltWorkload(GetWorkloadName(types.UID(testUID), "lws", "0")).
 				Annotation(podcontroller.SuspendedByParentAnnotation, FrameworkName).
 				Annotation(podcontroller.GroupServingAnnotation, "true").
 				Annotation(podcontroller.RoleHashAnnotation, kueue.DefaultPodSetName).

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -84,7 +84,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	ctx = ctrl.LoggerInto(ctx, log)
 	log.V(2).Info("Reconciling LeaderWorkerSet")
 
-	err = r.createPrebuildWorkloadsIfNotExist(ctx, lws)
+	err = r.createPrebuiltWorkloadsIfNotExist(ctx, lws)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -92,27 +92,27 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) createPrebuildWorkloadsIfNotExist(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet) error {
+func (r *Reconciler) createPrebuiltWorkloadsIfNotExist(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet) error {
 	replicas := ptr.Deref(lws.Spec.Replicas, 1)
 	for i := int32(0); i < replicas; i++ {
-		if err := r.createPrebuildWorkloadIfNotExist(ctx, lws, i); err != nil {
+		if err := r.createPrebuiltWorkloadIfNotExist(ctx, lws, i); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (r *Reconciler) createPrebuildWorkloadIfNotExist(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, index int32) error {
+func (r *Reconciler) createPrebuiltWorkloadIfNotExist(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, index int32) error {
 	wl := &kueue.Workload{}
 	err := r.client.Get(ctx, client.ObjectKey{Name: GetWorkloadName(lws.UID, lws.Name, fmt.Sprint(index)), Namespace: lws.Namespace}, wl)
 	// Ignore if the Workload already exists or an error occurs.
 	if err == nil || client.IgnoreNotFound(err) != nil {
 		return err
 	}
-	return r.createPrebuildWorkload(ctx, lws, index)
+	return r.createPrebuiltWorkload(ctx, lws, index)
 }
 
-func (r *Reconciler) createPrebuildWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, index int32) error {
+func (r *Reconciler) createPrebuiltWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, index int32) error {
 	createdWorkload := r.constructWorkload(lws, index)
 	err := r.client.Create(ctx, createdWorkload)
 	if err != nil {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -62,7 +62,7 @@ func TestReconciler(t *testing.T) {
 		wantEvents          []utiltesting.EventRecord
 		wantErr             error
 	}{
-		"should create prebuild workload": {
+		"should create prebuilt workload": {
 			leaderWorkerSet:     leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testUID).Obj(),
 			wantLeaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testUID).Obj(),
 			wantWorkloads: []kueue.Workload{
@@ -97,7 +97,7 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
-		"should create prebuild workload with leader template": {
+		"should create prebuilt workload with leader template": {
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
 				UID(testUID).
 				Size(3).
@@ -165,7 +165,7 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
-		"should create prebuild workloads with leader template": {
+		"should create prebuilt workloads with leader template": {
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
 				UID(testUID).
 				Replicas(2).
@@ -275,7 +275,7 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
-		"should create prebuild workload with required topology annotation": {
+		"should create prebuilt workload with required topology annotation": {
 			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
 				UID(testUID).
 				Size(3).

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -5400,7 +5400,7 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
-			wantErr:         jobframework.ErrPrebuildWorkloadNotFound,
+			wantErr:         jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 	}
 

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -100,7 +100,7 @@ func (p *PodWrapper) Queue(q string) *PodWrapper {
 	return p.Label(controllerconsts.QueueLabel, q)
 }
 
-func (p *PodWrapper) PrebuildWorkload(name string) *PodWrapper {
+func (p *PodWrapper) PrebuiltWorkload(name string) *PodWrapper {
 	return p.Label(controllerconsts.PrebuiltWorkloadLabel, name)
 }
 

--- a/site/content/en/docs/reference/labels-and-annotations.md
+++ b/site/content/en/docs/reference/labels-and-annotations.md
@@ -152,7 +152,7 @@ The annotation key is used to indicate the integration name of the Pod owner.
 
 Type: Label
 
-Example: `kueue.x-k8s.io/prebuilt-workload-name: "my-prebuild-workload-name"`
+Example: `kueue.x-k8s.io/prebuilt-workload-name: "my-prebuilt-workload-name"`
 
 Used on: Kueue-managed Jobs.
 

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -518,7 +518,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				})
 			})
 
-			ginkgo.It("Should ungate pod with prebuild workload", func() {
+			ginkgo.It("Should ungate pod with prebuilt workload", func() {
 				const (
 					workloadName = "test-workload"
 				)
@@ -526,7 +526,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				pod := testingpod.MakePod(podName, ns.Name).
 					Request(corev1.ResourceCPU, "1").
 					Queue(lq.Name).
-					PrebuildWorkload(workloadName).
+					PrebuiltWorkload(workloadName).
 					Obj()
 
 				ginkgo.By("Creating pod with queue-name", func() {
@@ -539,7 +539,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					Obj()
 				wlLookupKey := types.NamespacedName{Name: workloadName, Namespace: ns.Name}
 
-				ginkgo.By("Creating prebuild workload with queue-name", func() {
+				ginkgo.By("Creating prebuilt workload with queue-name", func() {
 					gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
 				})
 
@@ -1578,7 +1578,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				})
 			})
 
-			ginkgo.It("Should ungate pods with prebuild workload", func() {
+			ginkgo.It("Should ungate pods with prebuilt workload", func() {
 				const (
 					workloadName = "test-workload"
 				)
@@ -1588,7 +1588,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					GroupTotalCount("2").
 					Request(corev1.ResourceCPU, "1").
 					Queue(lq.Name).
-					PrebuildWorkload(workloadName).
+					PrebuiltWorkload(workloadName).
 					RoleHash("leader").
 					Obj()
 				pod2 := testingpod.MakePod("test-pod-2", ns.Name).
@@ -1596,7 +1596,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					GroupTotalCount("2").
 					Request(corev1.ResourceCPU, "2").
 					Queue(lq.Name).
-					PrebuildWorkload(workloadName).
+					PrebuiltWorkload(workloadName).
 					RoleHash("worker").
 					Obj()
 
@@ -1617,7 +1617,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					Obj()
 				wlLookupKey := types.NamespacedName{Name: workloadName, Namespace: ns.Name}
 
-				ginkgo.By("Creating prebuild workload", func() {
+				ginkgo.By("Creating prebuilt workload", func() {
 					gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
 				})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Use consistent naming for prebuilt workload across the codebase

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4324

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```