### PR TITLE
AppWrapper TAS: full support for PodSetTopologyRequest

### DIFF
--- a/pkg/controller/jobs/appwrapper/appwrapper_controller.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller.go
@@ -140,8 +140,7 @@ func (aw *AppWrapper) PodSets() ([]kueue.PodSet, error) {
 		}
 		if annotation, ok := awPodSets[psIndex].Annotations[awutils.PodSetAnnotationTASSubGroupCount]; ok {
 			if count, err := strconv.Atoi(annotation); err == nil {
-				count32 := int32(count)
-				subGroupCount = &count32
+				subGroupCount = ptr.To[int32](count)
 			} else {
 				ctrl.Log.Error(err, fmt.Sprintf("Malformed %v annotation ignored", awutils.PodSetAnnotationTASSubGroupCount),
 					"annotation", annotation)

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller.go
@@ -153,6 +153,7 @@ func (aw *AppWrapper) PodSets() ([]kueue.PodSet, error) {
 			Count:           awutils.Replicas(awPodSets[psIndex]),
 			TopologyRequest: jobframework.PodSetTopologyRequest(&(podSpecTemplates[psIndex].ObjectMeta), podIndexLabel, subGroupIndexLabel, subGroupCount),
 		}
+	}
 	return podSets, nil
 }
 
@@ -167,7 +168,7 @@ func (aw *AppWrapper) RunWithPodSetsInfo(podSetsInfo []podset.PodSetInfo) error 
 	}
 
 	if err := awutils.SetPodSetInfos((*awv1beta2.AppWrapper)(aw), awPodSetsInfo); err != nil {
-		return fmt.Errorf("%w: %w", podset.ErrInvalidPodsetInfo, err)	
+		return fmt.Errorf("%w: %w", podset.ErrInvalidPodsetInfo, err)
 	}
 	aw.Spec.Suspend = false
 	return nil

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -140,7 +141,7 @@ func (aw *AppWrapper) PodSets() ([]kueue.PodSet, error) {
 		}
 		if annotation, ok := awPodSets[psIndex].Annotations[awutils.PodSetAnnotationTASSubGroupCount]; ok {
 			if count, err := strconv.Atoi(annotation); err == nil {
-				subGroupCount = ptr.To[int32](count)
+				subGroupCount = ptr.To[int32](int32(count))
 			} else {
 				ctrl.Log.Error(err, fmt.Sprintf("Malformed %v annotation ignored", awutils.PodSetAnnotationTASSubGroupCount),
 					"annotation", annotation)

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller.go
@@ -141,10 +141,11 @@ func (aw *AppWrapper) PodSets() ([]kueue.PodSet, error) {
 		}
 		if annotation, ok := awPodSets[psIndex].Annotations[awutils.PodSetAnnotationTASSubGroupCount]; ok {
 			if count, err := strconv.Atoi(annotation); err == nil {
-				subGroupCount = ptr.To[int32](int32(count))
+				subGroupCount = ptr.To(int32(count))
 			} else {
-				ctrl.Log.Error(err, fmt.Sprintf("Malformed %v annotation ignored", awutils.PodSetAnnotationTASSubGroupCount),
-					"annotation", annotation)
+				ctrl.Log.Error(err, "Malformed annotation ignored",
+					"annotationKey", awutils.PodSetAnnotationTASSubGroupCount,
+					"annotationValue", annotation)
 			}
 		}
 		podSets[psIndex] = kueue.PodSet{

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller.go
@@ -142,6 +142,9 @@ func (aw *AppWrapper) PodSets() ([]kueue.PodSet, error) {
 			if count, err := strconv.Atoi(annotation); err == nil {
 				count32 := int32(count)
 				subGroupCount = &count32
+			} else {
+				ctrl.Log.Error(err, fmt.Sprintf("Malformed %v annotation ignored", awutils.PodSetAnnotationTASSubGroupCount),
+					"annotation", annotation)
 			}
 		}
 		podSets[psIndex] = kueue.PodSet{

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller_test.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller_test.go
@@ -27,10 +27,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
@@ -61,6 +63,25 @@ func TestPodSets(t *testing.T) {
 		).
 		SetTypeMeta().
 		Obj()
+	pytorchJobTAS := testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
+		PyTorchReplicaSpecs(
+			testingpytorchjob.PyTorchReplicaSpecRequirement{
+				ReplicaType:  kftraining.PyTorchJobReplicaTypeMaster,
+				ReplicaCount: 1,
+				Annotations: map[string]string{
+					kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/rack",
+				},
+			},
+			testingpytorchjob.PyTorchReplicaSpecRequirement{
+				ReplicaType:  kftraining.PyTorchJobReplicaTypeWorker,
+				ReplicaCount: 4,
+				Annotations: map[string]string{
+					kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block",
+				},
+			},
+		).
+		SetTypeMeta().
+		Obj()
 	batchJob := utiltestingjob.MakeJob("job", "ns").
 		SetTypeMeta().
 		Parallelism(2).
@@ -76,9 +97,35 @@ func TestPodSets(t *testing.T) {
 				Component(batchJob).
 				Obj(),
 			wantPodSets: []kueue.PodSet{
-				{Name: "aw-0", Template: pytorchJob.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeMaster].Template, Count: 1},
-				{Name: "aw-1", Template: pytorchJob.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeWorker].Template, Count: 4},
-				{Name: "aw-2", Template: batchJob.Spec.Template, Count: 2},
+				*utiltesting.MakePodSet("aw-0", 1).
+					PodSpec(pytorchJob.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeMaster].Template.Spec).
+					Obj(),
+				*utiltesting.MakePodSet("aw-1", 4).
+					PodSpec(pytorchJob.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeWorker].Template.Spec).
+					Obj(),
+				*utiltesting.MakePodSet("aw-2", 2).
+					PodSpec(batchJob.Spec.Template.Spec).
+					Obj(),
+			},
+		},
+		"with required and preferred topology annotation": {
+			job: testingappwrapper.MakeAppWrapper("aw", "ns").
+				Component(pytorchJobTAS).
+				Obj(),
+
+			wantPodSets: []kueue.PodSet{
+				*utiltesting.MakePodSet("aw-0", 1).
+					PodSpec(pytorchJobTAS.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeMaster].Template.Spec).
+					Annotations(map[string]string{kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/rack"}).
+					RequiredTopologyRequest("cloud.com/rack").
+					PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+					Obj(),
+				*utiltesting.MakePodSet("aw-1", 4).
+					PodSpec(pytorchJobTAS.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeWorker].Template.Spec).
+					Annotations(map[string]string{kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
+					PreferredTopologyRequest("cloud.com/block").
+					PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+					Obj(),
 			},
 		},
 	}

--- a/test/e2e/tas/appwrapper_test.go
+++ b/test/e2e/tas/appwrapper_test.go
@@ -137,15 +137,14 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 				Parallelism(int32(numPods)).
 				Completions(int32(numPods)).
 				Indexed(true).
+				Suspend(false).
 				Request(extraResource, "1").
 				Limit(extraResource, "1").
-				Obj()
-			wrappedJob = (&utiltestingjob.JobWrapper{Job: *wrappedJob}).
 				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, testing.DefaultBlockTopologyLevel).
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 				SetTypeMeta().
 				Obj()
-			aw := awtesting.MakeAppWrapper("appwrapper", ns.Name).
+			aw := awtesting.MakeAppWrapper("aw-ranks-job", ns.Name).
 				Component(wrappedJob).
 				Queue(localQueue.Name).
 				Obj()

--- a/test/e2e/tas/appwrapper_test.go
+++ b/test/e2e/tas/appwrapper_test.go
@@ -19,6 +19,8 @@ package tase2e
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	awv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -126,6 +128,67 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), listOpts)).To(gomega.Succeed())
 					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("Should place pods based on the ranks-ordering", func() {
+			numPods := 4
+			wrappedJob := utiltestingjob.MakeJob("ranks-job", ns.Name).
+				Parallelism(int32(numPods)).
+				Completions(int32(numPods)).
+				Indexed(true).
+				Request(extraResource, "1").
+				Limit(extraResource, "1").
+				Obj()
+			wrappedJob = (&utiltestingjob.JobWrapper{Job: *wrappedJob}).
+				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, testing.DefaultBlockTopologyLevel).
+				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+				SetTypeMeta().
+				Obj()
+			aw := awtesting.MakeAppWrapper("appwrapper", ns.Name).
+				Component(wrappedJob).
+				Queue(localQueue.Name).
+				Obj()
+
+			gomega.Expect(k8sClient.Create(ctx, aw)).Should(gomega.Succeed())
+
+			ginkgo.By("AppWrapper is unsuspended, and has all Pods active and ready", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(aw), aw)).To(gomega.Succeed())
+					g.Expect(aw.Spec.Suspend).Should(gomega.BeFalse())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(aw), aw)).To(gomega.Succeed())
+					g.Expect(aw.Status.Phase).Should(gomega.Equal(awv1beta2.AppWrapperRunning))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			pods := &corev1.PodList{}
+			ginkgo.By("ensure all pods are created and scheduled", func() {
+				listOpts := &client.ListOptions{
+					FieldSelector: fields.OneTermNotEqualSelector("spec.nodeName", ""),
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), listOpts)).To(gomega.Succeed())
+					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verify the assignment of pods are as expected with rank-based ordering", func() {
+				gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name),
+					client.MatchingLabels(wrappedJob.Spec.Selector.MatchLabels))).To(gomega.Succeed())
+				gotAssignment := make(map[string]string, numPods)
+				for _, pod := range pods.Items {
+					index := pod.Labels[batchv1.JobCompletionIndexAnnotation]
+					gotAssignment[index] = pod.Spec.NodeName
+				}
+				wantAssignment := map[string]string{
+					"0": "kind-worker",
+					"1": "kind-worker2",
+					"2": "kind-worker3",
+					"3": "kind-worker4",
+				}
+				gomega.Expect(wantAssignment).Should(gomega.BeComparableTo(gotAssignment))
 			})
 		})
 	})

--- a/test/e2e/tas/appwrapper_test.go
+++ b/test/e2e/tas/appwrapper_test.go
@@ -175,8 +175,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 			})
 
 			ginkgo.By("verify the assignment of pods are as expected with rank-based ordering", func() {
-				gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name),
-					client.MatchingLabels(wrappedJob.Spec.Selector.MatchLabels))).To(gomega.Succeed())
+				gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				gotAssignment := make(map[string]string, numPods)
 				for _, pod := range pods.Items {
 					index := pod.Labels[batchv1.JobCompletionIndexAnnotation]

--- a/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	awv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -939,7 +940,8 @@ var _ = ginkgo.Describe("AppWrapper controller when TopologyAwareScheduling enab
 					Name:  wl.Spec.PodSets[0].Name,
 					Count: 1,
 					TopologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required:      ptr.To(tasBlockLabel),
+						PodIndexLabel: ptr.To(batchv1.JobCompletionIndexAnnotation),
 					},
 				}}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature
#### What this PR does / why we need it:

We enhanced the AppWrapper controller in v1.0.6 to propagate Kind-specific TAS information via annotations on the AppWrapperPodSetInfo.  This PR updates the Kueue appwrapper integration to process these annotations.  Also minor updates to the integration and test cases to accommodate small changes in the go-level APIs of the AppWrapper utils package that is used to implement the Kueue integration.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```