### PR TITLE
Fork/uidlabel

### DIFF
--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -38,6 +38,7 @@ import (
 	config "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
@@ -205,6 +206,24 @@ var HumanReadablePreemptionReasons = map[string]string{
 	kueue.InCohortReclamationReason:           "reclamation within the cohort",
 	kueue.InCohortFairSharingReason:           "fair sharing within the cohort",
 	kueue.InCohortReclaimWhileBorrowingReason: "reclamation within the cohort while borrowing",
+	"": "UNKNOWN",
+}
+
+func preemptionMessage(preemptor *kueue.Workload, reason string) string {
+	var wUID, jUID string
+	if preemptor == nil || preemptor.UID == "" {
+		wUID = "UNKNOWN"
+	} else {
+		wUID = string(preemptor.UID)
+	}
+	uid, ok := preemptor.Labels[constants.JobUIDLabel]
+	if !ok || uid == "" {
+		jUID = "UNKNOWN"
+	} else {
+		jUID = uid
+	}
+
+	return fmt.Sprintf("Preempted to accommodate a workload (UID: %s, JobUID: %s) due to %s", wUID, jUID, HumanReadablePreemptionReasons[reason])
 }
 
 // IssuePreemptions marks the target workloads as evicted.
@@ -214,10 +233,11 @@ func (p *Preemptor) IssuePreemptions(ctx context.Context, preemptor *workload.In
 	ctx, cancel := context.WithCancel(ctx)
 	var successfullyPreempted atomic.Int64
 	defer cancel()
+
 	workqueue.ParallelizeUntil(ctx, parallelPreemptions, len(targets), func(i int) {
 		target := targets[i]
 		if !meta.IsStatusConditionTrue(target.WorkloadInfo.Obj.Status.Conditions, kueue.WorkloadEvicted) {
-			message := fmt.Sprintf("Preempted to accommodate a workload (UID: %s) due to %s", preemptor.Obj.UID, HumanReadablePreemptionReasons[target.Reason])
+			message := preemptionMessage(preemptor.Obj, target.Reason)
 			err := p.applyPreemption(ctx, target.WorkloadInfo.Obj, target.Reason, message)
 			if err != nil {
 				errCh.SendErrorWithCancel(err, cancel)

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -41,6 +41,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/constants"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
@@ -2447,5 +2448,37 @@ func singlePodSetAssignment(assignments flavorassigner.ResourceAssignment) flavo
 			Flavors: assignments,
 			Count:   1,
 		}},
+	}
+}
+
+func TestPreemptionMessage(t *testing.T) {
+	cases := []struct {
+		preemptor *kueue.Workload
+		reason    string
+		want      string
+	}{
+		{
+			preemptor: &kueue.Workload{},
+			want:      "Preempted to accommodate a workload (UID: UNKNOWN, JobUID: UNKNOWN) due to UNKNOWN",
+		},
+		{
+			preemptor: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{UID: "uid"}},
+			want:      "Preempted to accommodate a workload (UID: uid, JobUID: UNKNOWN) due to UNKNOWN",
+		},
+		{
+			preemptor: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{UID: "uid", Labels: map[string]string{controllerconstants.JobUIDLabel: "juid"}}},
+			want:      "Preempted to accommodate a workload (UID: uid, JobUID: juid) due to UNKNOWN",
+		},
+		{
+			preemptor: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{UID: "uid", Labels: map[string]string{controllerconstants.JobUIDLabel: "juid"}}},
+			reason:    kueue.InClusterQueueReason,
+			want:      "Preempted to accommodate a workload (UID: uid, JobUID: juid) due to prioritization in the ClusterQueue",
+		},
+	}
+	for _, tc := range cases {
+		got := preemptionMessage(tc.preemptor, tc.reason)
+		if got != tc.want {
+			t.Errorf("preemptionMessage(preemptor=kueue.Workload{UID:%v, Labels:%v}, reason=%q) returned %q, want %q", tc.preemptor.UID, tc.preemptor.Labels, tc.reason, got, tc.want)
+		}
 	}
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -5630,7 +5630,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Key:       types.NamespacedName{Namespace: "default", Name: "low-priority-admitted"},
 					EventType: "Normal",
 					Reason:    "Preempted",
-					Message:   "Preempted to accommodate a workload (UID: ) due to prioritization in the ClusterQueue",
+					Message:   "Preempted to accommodate a workload (UID: UNKNOWN, JobUID: UNKNOWN) due to prioritization in the ClusterQueue",
 				},
 				{
 					Key:       types.NamespacedName{Namespace: "default", Name: "foo"},
@@ -5695,7 +5695,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Key:       types.NamespacedName{Namespace: "default", Name: "low-priority-admitted"},
 					EventType: "Normal",
 					Reason:    "Preempted",
-					Message:   "Preempted to accommodate a workload (UID: ) due to prioritization in the ClusterQueue",
+					Message:   "Preempted to accommodate a workload (UID: UNKNOWN, JobUID: UNKNOWN) due to prioritization in the ClusterQueue",
 				},
 				{
 					Key:       types.NamespacedName{Namespace: "default", Name: "high-priority-waiting"},
@@ -5781,7 +5781,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Key:       types.NamespacedName{Namespace: "default", Name: "low-priority-admitted"},
 					EventType: "Normal",
 					Reason:    "Preempted",
-					Message:   "Preempted to accommodate a workload (UID: ) due to prioritization in the ClusterQueue",
+					Message:   "Preempted to accommodate a workload (UID: UNKNOWN, JobUID: UNKNOWN) due to prioritization in the ClusterQueue",
 				},
 				{
 					Key:       types.NamespacedName{Namespace: "default", Name: "foo"},
@@ -5869,7 +5869,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Key:       types.NamespacedName{Namespace: "default", Name: "low-priority-admitted"},
 					EventType: "Normal",
 					Reason:    "Preempted",
-					Message:   "Preempted to accommodate a workload (UID: ) due to prioritization in the ClusterQueue",
+					Message:   "Preempted to accommodate a workload (UID: UNKNOWN, JobUID: UNKNOWN) due to prioritization in the ClusterQueue",
 				},
 				{
 					Key:       types.NamespacedName{Namespace: "default", Name: "foo"},

--- a/site/content/en/docs/concepts/preemption.md
+++ b/site/content/en/docs/concepts/preemption.md
@@ -48,7 +48,7 @@ status:
 The `Evicted` condition indicates that the Workload was evicted with a reason `Preempted`,
 whereas the `Preempted` condition gives more details about the preemption reason.
 
-More information about the preempting workload can be found by running `kubectl get workloads --selector=kueue.x-k8s.io/job-uid=<JobUID>`.
+The preempting workload can be found by running `kubectl get workloads --selector=kueue.x-k8s.io/job-uid=<JobUID> --all-namespaces`.
 
 ## Preemption algorithms
 

--- a/site/content/en/docs/concepts/preemption.md
+++ b/site/content/en/docs/concepts/preemption.md
@@ -31,15 +31,15 @@ that is similar to the following:
 status:
   conditions:
   - lastTransitionTime: "2024-05-31T18:42:33Z"
-    message: 'Preempted to accommodate a workload (UID: 5515f7da-d2ea-4851-9e9c-6b8b3333734d)
-      in the ClusterQueue'
+    message: 'Preempted to accommodate a workload (UID: 5515f7da-d2ea-4851-9e9c-6b8b3333734d, JobUID: 639a596b-d05f-469c-bbd1-5788c9f13f16)
+      due to prioritization in the ClusterQueue'
     observedGeneration: 1
     reason: Preempted
     status: "True"
     type: Evicted
   - lastTransitionTime: "2024-05-31T18:42:33Z"
-    message: 'Preempted to accommodate a workload (UID: 5515f7da-d2ea-4851-9e9c-6b8b3333734d)
-      in the ClusterQueue'
+    message: 'Preempted to accommodate a workload (UID: 5515f7da-d2ea-4851-9e9c-6b8b3333734d, JobUID: 639a596b-d05f-469c-bbd1-5788c9f13f16)
+      due to prioritization in the ClusterQueue'
     reason: InClusterQueue
     status: "True"
     type: Preempted
@@ -47,6 +47,8 @@ status:
 
 The `Evicted` condition indicates that the Workload was evicted with a reason `Preempted`,
 whereas the `Preempted` condition gives more details about the preemption reason.
+
+More information about the preempting workload can be found by running `kubectl get workloads --selector=kueue.x-k8s.io/job-uid=<JobUID>`.
 
 ## Preemption algorithms
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -828,7 +828,7 @@ readCh:
 	gomega.ExpectWithOffset(1, gotObjs).To(gomega.Equal(objs))
 }
 
-func ExpectPreemptedCondition(ctx context.Context, k8sClient client.Client, reason string, status metav1.ConditionStatus, preemptedWl, preempteeWl *kueue.Workload) {
+func ExpectPreemptedCondition(ctx context.Context, k8sClient client.Client, reason string, status metav1.ConditionStatus, preemptedWl, preempteeWl *kueue.Workload, preemteeWorkloadUID, preempteeJobUID string) {
 	conditionCmpOpts := cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "ObservedGeneration")
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
 		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(preemptedWl), preemptedWl)).To(gomega.Succeed())
@@ -836,7 +836,7 @@ func ExpectPreemptedCondition(ctx context.Context, k8sClient client.Client, reas
 			Type:    kueue.WorkloadPreempted,
 			Status:  status,
 			Reason:  reason,
-			Message: fmt.Sprintf("Preempted to accommodate a workload (UID: %s) due to %s", preempteeWl.UID, preemption.HumanReadablePreemptionReasons[reason]),
+			Message: fmt.Sprintf("Preempted to accommodate a workload (UID: %s, JobUID: %s) due to %s", preemteeWorkloadUID, preempteeJobUID, preemption.HumanReadablePreemptionReasons[reason]),
 		}, conditionCmpOpts)))
 	}, Timeout, Interval).Should(gomega.Succeed())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Makes it easy to kubectl describe the Workload that preempted another workload using the --selector CLI flag.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/4038

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds JobUID to preemption conditions so that the preempting workload is easily retrieved with `kubectl get workloads --selector=kueue.x-k8s.io/job-uid=<JobUID> --all-namespaces`
```