### PR TITLE
chore: Enable nilerr, nilnesserr

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -53,6 +53,8 @@ linters:
     - govet
     - loggercheck
     - misspell
+    - nilerr
+    - nilnesserr
     - nolintlint
     - perfsprint
     - revive

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -400,7 +400,7 @@ func (c *clustersReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 
 	if err != nil || !cluster.DeletionTimestamp.IsZero() {
 		c.stopAndRemoveCluster(req.Name)
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
 	// get the kubeconfig

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -400,7 +400,7 @@ func (c *clustersReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 
 	if err != nil || !cluster.DeletionTimestamp.IsZero() {
 		c.stopAndRemoveCluster(req.Name)
-		return reconcile.Result{}, client.IgnoreNotFound(err)
+		return reconcile.Result{}, nil //nolint:nilerr // nil is intentional, as either the cluster is deleted, or not found
 	}
 
 	// get the kubeconfig

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -144,7 +144,7 @@ func (j *JobSet) RunWithPodSetsInfo(podSetsInfo []podset.PodSetInfo) error {
 		template := &j.Spec.ReplicatedJobs[index].Template.Spec.Template
 		info := podSetsInfo[index]
 		if err := podset.Merge(&template.ObjectMeta, &template.Spec, info); err != nil {
-			return nil
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Enable `nilerr` and `nilnesserr` linters to find places where returning `nil` may be wrong.
[`nilerr`](https://golangci-lint.run/usage/linters/#nilerr) finds places that return nil even if it checks that the error is not nil.
[`nilnesserr`](https://golangci-lint.run/usage/linters/#nilnesserr) reports constructs that checks for err != nil, but returns a different nil value error.

#### Special notes for your reviewer:

The `nilerr` linter founds two places where `err` is not `nil`, but returned value is `nil`:

1. In the `clustersReconciler.Reconcile`:
```go
	err := c.localClient.Get(ctx, req.NamespacedName, cluster)
	if client.IgnoreNotFound(err) != nil {
		return reconcile.Result{}, err
	}
	log.V(2).Info("Reconcile MultiKueueCluster")

	if err != nil || !cluster.DeletionTimestamp.IsZero() {
		c.stopAndRemoveCluster(req.Name)
		return reconcile.Result{}, nil
	}
```

Returning `nil` is expected because `err` is `NotFound` and we ignore it. To silence the linter, I added `//nolint:nilerr` comment.

2. In the `JobSet.RunWithPodSetsInfo`:
```go
	if err := podset.Merge(&template.ObjectMeta, &template.Spec, info); err != nil {
		return nil
	}
```

I suspect there is a bug here, and I changed to return `err`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```