### PR TITLE
CountIn() does not assume the requests has 2 or more pods count

### DIFF
--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -533,6 +533,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests,
 		}
 		var err error
 		if leaf.state, err = requests.CountIn(remainingCapacity); err != nil {
+			s.log.Info("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", "requests", requests)
 			return err
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
I refined the `CountIn()` in the resources package since this does not consider the Pods count despite this being exposed to the external package.
Additionally, I replaced `req` receiver with `r` to use the same receiver name all for `Requests` receivers.

As we discussed in this PR, we decided not to handle that requests have 2 or more Pods.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
This is a follow-up PR of https://github.com/kubernetes-sigs/kueue/pull/4271.

https://github.com/kubernetes-sigs/kueue/pull/4271#issuecomment-2663729105
> But if we pass two or more Pods as requests like {"pods": 2} to the CountIn() function, it will be broken.
The CountIn() function is exposed, and the current impl can not enforce passing only 1 Pod request as a receiver. So, I would like to add any guard to the CountIn(). But we can do it in a separate PR since the refining does not directly contribute to this bug fixe. @mimowo @PBundyra

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```