### PR TITLE
chore: Use PodSet wrapper during UTs

### DIFF
--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -216,16 +216,12 @@ func TestPodSets(t *testing.T) {
 				Obj()),
 			wantPodSets: func(jobSet *JobSet) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     jobSet.Spec.ReplicatedJobs[0].Name,
-						Template: *jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.DeepCopy(),
-						Count:    2,
-					},
-					{
-						Name:     jobSet.Spec.ReplicatedJobs[1].Name,
-						Template: *jobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.DeepCopy(),
-						Count:    6,
-					},
+					*utiltesting.MakePodSet(jobSet.Spec.ReplicatedJobs[0].Name, 2).
+						PodSpec(*jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.DeepCopy()).
+						Obj(),
+					*utiltesting.MakePodSet(jobSet.Spec.ReplicatedJobs[1].Name, 6).
+						PodSpec(*jobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.DeepCopy()).
+						Obj(),
 				}
 			},
 		},
@@ -246,21 +242,17 @@ func TestPodSets(t *testing.T) {
 				Obj()),
 			wantPodSets: func(jobSet *JobSet) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     jobSet.Spec.ReplicatedJobs[0].Name,
-						Template: *jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.DeepCopy(),
-						Count:    2,
-						TopologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To("cloud.com/block"),
-							PodIndexLabel:      ptr.To(batchv1.JobCompletionIndexAnnotation),
-							SubGroupIndexLabel: ptr.To(jobset.JobIndexKey),
-							SubGroupCount:      ptr.To[int32](2),
-						},
-					},
-					{
-						Name:     jobSet.Spec.ReplicatedJobs[1].Name,
-						Template: *jobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.DeepCopy(),
-						Count:    6,
-					},
+					*utiltesting.MakePodSet(jobSet.Spec.ReplicatedJobs[0].Name, 2).
+						PodSpec(*jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.DeepCopy()).
+						Annotations(map[string]string{kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
+						RequiredTopologyRequest("cloud.com/block").
+						PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+						SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
+						SubGroupCount(ptr.To[int32](2)).
+						Obj(),
+					*utiltesting.MakePodSet(jobSet.Spec.ReplicatedJobs[1].Name, 6).
+						PodSpec(*jobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.DeepCopy()).
+						Obj(),
 				}
 			},
 		},
@@ -281,21 +273,17 @@ func TestPodSets(t *testing.T) {
 				Obj()),
 			wantPodSets: func(jobSet *JobSet) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     jobSet.Spec.ReplicatedJobs[0].Name,
-						Template: *jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.DeepCopy(),
-						Count:    2,
-					},
-					{
-						Name:     jobSet.Spec.ReplicatedJobs[1].Name,
-						Template: *jobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.DeepCopy(),
-						Count:    6,
-						TopologyRequest: &kueue.PodSetTopologyRequest{Preferred: ptr.To("cloud.com/block"),
-							PodIndexLabel:      ptr.To(batchv1.JobCompletionIndexAnnotation),
-							SubGroupIndexLabel: ptr.To(jobset.JobIndexKey),
-							SubGroupCount:      ptr.To[int32](3),
-						},
-					},
+					*utiltesting.MakePodSet(jobSet.Spec.ReplicatedJobs[0].Name, 2).
+						PodSpec(*jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.DeepCopy()).
+						Obj(),
+					*utiltesting.MakePodSet(jobSet.Spec.ReplicatedJobs[1].Name, 6).
+						PodSpec(*jobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.DeepCopy()).
+						Annotations(map[string]string{kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
+						PreferredTopologyRequest("cloud.com/block").
+						PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+						SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
+						SubGroupCount(ptr.To[int32](3)).
+						Obj(),
 				}
 			},
 		},

--- a/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
@@ -252,16 +252,12 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			wantPodSets: func(job *kftraining.PaddleJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     strings.ToLower(string(kftraining.PaddleJobReplicaTypeMaster)),
-						Template: job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeMaster].Template,
-						Count:    1,
-					},
-					{
-						Name:     strings.ToLower(string(kftraining.PaddleJobReplicaTypeWorker)),
-						Template: job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeWorker].Template,
-						Count:    1,
-					},
+					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.PaddleJobReplicaTypeMaster)), 1).
+						PodSpec(job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeMaster].Template.Spec).
+						Obj(),
+					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.PaddleJobReplicaTypeWorker)), 1).
+						PodSpec(job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeWorker].Template.Spec).
+						Obj(),
 				}
 			},
 		},
@@ -286,20 +282,18 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			wantPodSets: func(job *kftraining.PaddleJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     strings.ToLower(string(kftraining.PaddleJobReplicaTypeMaster)),
-						Template: job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeMaster].Template,
-						Count:    1,
-						TopologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To("cloud.com/rack"),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel)},
-					},
-					{
-						Name:     strings.ToLower(string(kftraining.PaddleJobReplicaTypeWorker)),
-						Template: job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeWorker].Template,
-						Count:    1,
-						TopologyRequest: &kueue.PodSetTopologyRequest{Preferred: ptr.To("cloud.com/block"),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel)},
-					},
+					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.PaddleJobReplicaTypeMaster)), 1).
+						PodSpec(job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeMaster].Template.Spec).
+						Annotations(map[string]string{kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/rack"}).
+						RequiredTopologyRequest("cloud.com/rack").
+						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						Obj(),
+					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.PaddleJobReplicaTypeWorker)), 1).
+						PodSpec(job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeWorker].Template.Spec).
+						Annotations(map[string]string{kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
+						PreferredTopologyRequest("cloud.com/block").
+						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						Obj(),
 				}
 			},
 		},

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -250,16 +250,12 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			wantPodSets: func(job *kftraining.XGBoostJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     strings.ToLower(string(kftraining.XGBoostJobReplicaTypeMaster)),
-						Template: job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeMaster].Template,
-						Count:    1,
-					},
-					{
-						Name:     strings.ToLower(string(kftraining.XGBoostJobReplicaTypeWorker)),
-						Template: job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeWorker].Template,
-						Count:    1,
-					},
+					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.XGBoostJobReplicaTypeMaster)), 1).
+						PodSpec(job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeMaster].Template.Spec).
+						Obj(),
+					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.XGBoostJobReplicaTypeWorker)), 1).
+						PodSpec(job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeWorker].Template.Spec).
+						Obj(),
 				}
 			},
 		},
@@ -284,20 +280,18 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			wantPodSets: func(job *kftraining.XGBoostJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     strings.ToLower(string(kftraining.XGBoostJobReplicaTypeMaster)),
-						Template: job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeMaster].Template,
-						Count:    1,
-						TopologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To("cloud.com/rack"),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel)},
-					},
-					{
-						Name:     strings.ToLower(string(kftraining.XGBoostJobReplicaTypeWorker)),
-						Template: job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeWorker].Template,
-						Count:    1,
-						TopologyRequest: &kueue.PodSetTopologyRequest{Preferred: ptr.To("cloud.com/block"),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel)},
-					},
+					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.XGBoostJobReplicaTypeMaster)), 1).
+						PodSpec(job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeMaster].Template.Spec).
+						Annotations(map[string]string{kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/rack"}).
+						RequiredTopologyRequest("cloud.com/rack").
+						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						Obj(),
+					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.XGBoostJobReplicaTypeWorker)), 1).
+						PodSpec(job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeWorker].Template.Spec).
+						Annotations(map[string]string{kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
+						PreferredTopologyRequest("cloud.com/block").
+						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						Obj(),
 				}
 			},
 		},

--- a/pkg/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller_test.go
@@ -203,16 +203,12 @@ func TestPodSets(t *testing.T) {
 		"no annotations": {
 			job: (*MPIJob)(jobTemplate.DeepCopy()),
 			wantPodSets: []kueue.PodSet{
-				{
-					Name:     strings.ToLower(string(kfmpi.MPIReplicaTypeLauncher)),
-					Count:    1,
-					Template: *jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.DeepCopy(),
-				},
-				{
-					Name:     strings.ToLower(string(kfmpi.MPIReplicaTypeWorker)),
-					Count:    3,
-					Template: *jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.DeepCopy(),
-				},
+				*utiltesting.MakePodSet(strings.ToLower(string(kfmpi.MPIReplicaTypeLauncher)), 1).
+					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec).
+					Obj(),
+				*utiltesting.MakePodSet(strings.ToLower(string(kfmpi.MPIReplicaTypeWorker)), 3).
+					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec).
+					Obj(),
 			},
 		},
 		"with required topology annotation": {
@@ -230,46 +226,18 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			),
 			wantPodSets: []kueue.PodSet{
-				{
-					Name:  strings.ToLower(string(kfmpi.MPIReplicaTypeLauncher)),
-					Count: 1,
-					Template: jobTemplate.
-						Clone().
-						PodAnnotation(
-							kfmpi.MPIReplicaTypeLauncher,
-							kueuealpha.PodSetRequiredTopologyAnnotation,
-							"cloud.com/block",
-						).
-						PodAnnotation(
-							kfmpi.MPIReplicaTypeWorker,
-							kueuealpha.PodSetRequiredTopologyAnnotation,
-							"cloud.com/block",
-						).
-						Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template,
-					TopologyRequest: &kueue.PodSetTopologyRequest{
-						Required:      ptr.To("cloud.com/block"),
-						PodIndexLabel: ptr.To(kfmpi.ReplicaIndexLabel)},
-				},
-				{
-					Name:  strings.ToLower(string(kfmpi.MPIReplicaTypeWorker)),
-					Count: 3,
-					Template: jobTemplate.
-						Clone().
-						PodAnnotation(
-							kfmpi.MPIReplicaTypeLauncher,
-							kueuealpha.PodSetRequiredTopologyAnnotation,
-							"cloud.com/block",
-						).
-						PodAnnotation(
-							kfmpi.MPIReplicaTypeWorker,
-							kueuealpha.PodSetRequiredTopologyAnnotation,
-							"cloud.com/block",
-						).
-						Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template,
-					TopologyRequest: &kueue.PodSetTopologyRequest{
-						Required:      ptr.To("cloud.com/block"),
-						PodIndexLabel: ptr.To(kfmpi.ReplicaIndexLabel)},
-				},
+				*utiltesting.MakePodSet(strings.ToLower(string(kfmpi.MPIReplicaTypeLauncher)), 1).
+					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec).
+					Annotations(map[string]string{kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
+					RequiredTopologyRequest("cloud.com/block").
+					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+					Obj(),
+				*utiltesting.MakePodSet(strings.ToLower(string(kfmpi.MPIReplicaTypeWorker)), 3).
+					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec).
+					Annotations(map[string]string{kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
+					RequiredTopologyRequest("cloud.com/block").
+					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+					Obj(),
 			},
 		},
 		"with preferred topology annotation": {
@@ -287,46 +255,18 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			),
 			wantPodSets: []kueue.PodSet{
-				{
-					Name:  strings.ToLower(string(kfmpi.MPIReplicaTypeLauncher)),
-					Count: 1,
-					Template: jobTemplate.
-						Clone().
-						PodAnnotation(
-							kfmpi.MPIReplicaTypeLauncher,
-							kueuealpha.PodSetPreferredTopologyAnnotation,
-							"cloud.com/block",
-						).
-						PodAnnotation(
-							kfmpi.MPIReplicaTypeWorker,
-							kueuealpha.PodSetPreferredTopologyAnnotation,
-							"cloud.com/block",
-						).
-						Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template,
-					TopologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred:     ptr.To("cloud.com/block"),
-						PodIndexLabel: ptr.To(kfmpi.ReplicaIndexLabel)},
-				},
-				{
-					Name:  strings.ToLower(string(kfmpi.MPIReplicaTypeWorker)),
-					Count: 3,
-					Template: jobTemplate.
-						Clone().
-						PodAnnotation(
-							kfmpi.MPIReplicaTypeLauncher,
-							kueuealpha.PodSetPreferredTopologyAnnotation,
-							"cloud.com/block",
-						).
-						PodAnnotation(
-							kfmpi.MPIReplicaTypeWorker,
-							kueuealpha.PodSetPreferredTopologyAnnotation,
-							"cloud.com/block",
-						).
-						Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template,
-					TopologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred:     ptr.To("cloud.com/block"),
-						PodIndexLabel: ptr.To(kfmpi.ReplicaIndexLabel)},
-				},
+				*utiltesting.MakePodSet(strings.ToLower(string(kfmpi.MPIReplicaTypeLauncher)), 1).
+					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec).
+					Annotations(map[string]string{kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
+					PreferredTopologyRequest("cloud.com/block").
+					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+					Obj(),
+				*utiltesting.MakePodSet(strings.ToLower(string(kfmpi.MPIReplicaTypeWorker)), 3).
+					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec).
+					Annotations(map[string]string{kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
+					PreferredTopologyRequest("cloud.com/block").
+					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+					Obj(),
 			},
 		},
 	}

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -137,11 +137,9 @@ func TestPodSets(t *testing.T) {
 			pod: FromObject(testingpod.MakePod("pod", "ns").Obj()),
 			wantPodSets: func(pod *Pod) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     kueue.DefaultPodSetName,
-						Count:    1,
-						Template: corev1.PodTemplateSpec{Spec: *pod.pod.Spec.DeepCopy()},
-					},
+					*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).
+						PodSpec(*pod.pod.Spec.DeepCopy()).
+						Obj(),
 				}
 			},
 		},
@@ -152,13 +150,11 @@ func TestPodSets(t *testing.T) {
 			),
 			wantPodSets: func(pod *Pod) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     kueue.DefaultPodSetName,
-						Count:    1,
-						Template: corev1.PodTemplateSpec{Spec: *pod.pod.Spec.DeepCopy()},
-						TopologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To("cloud.com/block"),
-							PodIndexLabel: ptr.To(kueuealpha.PodGroupPodIndexLabel)},
-					},
+					*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).
+						PodSpec(*pod.pod.Spec.DeepCopy()).
+						RequiredTopologyRequest("cloud.com/block").
+						PodIndexLabel(ptr.To(kueuealpha.PodGroupPodIndexLabel)).
+						Obj(),
 				}
 			},
 		},
@@ -169,13 +165,11 @@ func TestPodSets(t *testing.T) {
 			),
 			wantPodSets: func(pod *Pod) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     kueue.DefaultPodSetName,
-						Count:    1,
-						Template: corev1.PodTemplateSpec{Spec: *pod.pod.Spec.DeepCopy()},
-						TopologyRequest: &kueue.PodSetTopologyRequest{Preferred: ptr.To("cloud.com/block"),
-							PodIndexLabel: ptr.To(kueuealpha.PodGroupPodIndexLabel)},
-					},
+					*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).
+						PodSpec(*pod.pod.Spec.DeepCopy()).
+						PreferredTopologyRequest("cloud.com/block").
+						PodIndexLabel(ptr.To(kueuealpha.PodGroupPodIndexLabel)).
+						Obj(),
 				}
 			},
 		},

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -30,6 +30,7 @@ import (
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/podset"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingrayutil "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
 )
 
@@ -65,21 +66,15 @@ func TestPodSets(t *testing.T) {
 				Obj()),
 			wantPodSets: func(rayJob *RayJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     headGroupPodSetName,
-						Count:    1,
-						Template: *rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.DeepCopy(),
-					},
-					{
-						Name:     "group1",
-						Count:    1,
-						Template: *rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.DeepCopy(),
-					},
-					{
-						Name:     "group2",
-						Count:    3,
-						Template: *rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.DeepCopy(),
-					},
+					*utiltesting.MakePodSet(headGroupPodSetName, 1).
+						PodSpec(*rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
+						Obj(),
+					*utiltesting.MakePodSet("group1", 1).
+						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
+						Obj(),
+					*utiltesting.MakePodSet("group2", 3).
+						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Spec.DeepCopy()).
+						Obj(),
 				}
 			},
 		},
@@ -120,23 +115,19 @@ func TestPodSets(t *testing.T) {
 				Obj()),
 			wantPodSets: func(rayJob *RayJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:            headGroupPodSetName,
-						Count:           1,
-						Template:        *rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.DeepCopy(),
-						TopologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To("cloud.com/block")},
-					},
-					{
-						Name:            rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName,
-						Count:           1,
-						Template:        *rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.DeepCopy(),
-						TopologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To("cloud.com/block")},
-					},
-					{
-						Name:     rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].GroupName,
-						Count:    3,
-						Template: *rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.DeepCopy(),
-					},
+					*utiltesting.MakePodSet(headGroupPodSetName, 1).
+						PodSpec(*rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
+						Annotations(rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Annotations).
+						RequiredTopologyRequest("cloud.com/block").
+						Obj(),
+					*utiltesting.MakePodSet(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName, 1).
+						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
+						Annotations(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Annotations).
+						RequiredTopologyRequest("cloud.com/block").
+						Obj(),
+					*utiltesting.MakePodSet(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].GroupName, 3).
+						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Spec.DeepCopy()).
+						Obj(),
 				}
 			},
 		},
@@ -177,23 +168,19 @@ func TestPodSets(t *testing.T) {
 				Obj()),
 			wantPodSets: func(rayJob *RayJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:            headGroupPodSetName,
-						Count:           1,
-						Template:        *rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.DeepCopy(),
-						TopologyRequest: &kueue.PodSetTopologyRequest{Preferred: ptr.To("cloud.com/block")},
-					},
-					{
-						Name:     rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName,
-						Count:    1,
-						Template: *rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.DeepCopy(),
-					},
-					{
-						Name:            rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].GroupName,
-						Count:           3,
-						Template:        *rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.DeepCopy(),
-						TopologyRequest: &kueue.PodSetTopologyRequest{Preferred: ptr.To("cloud.com/block")},
-					},
+					*utiltesting.MakePodSet(headGroupPodSetName, 1).
+						PodSpec(*rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
+						Annotations(rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Annotations).
+						PreferredTopologyRequest("cloud.com/block").
+						Obj(),
+					*utiltesting.MakePodSet(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName, 1).
+						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
+						Obj(),
+					*utiltesting.MakePodSet(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].GroupName, 3).
+						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Spec.DeepCopy()).
+						Annotations(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Annotations).
+						PreferredTopologyRequest("cloud.com/block").
+						Obj(),
 				}
 			},
 		},
@@ -226,21 +213,15 @@ func TestPodSets(t *testing.T) {
 				Obj()),
 			wantPodSets: func(rayJob *RayJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     headGroupPodSetName,
-						Count:    1,
-						Template: *rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.DeepCopy(),
-					},
-					{
-						Name:     "group1",
-						Count:    4,
-						Template: *rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.DeepCopy(),
-					},
-					{
-						Name:     "group2",
-						Count:    12,
-						Template: *rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.DeepCopy(),
-					},
+					*utiltesting.MakePodSet(headGroupPodSetName, 1).
+						PodSpec(*rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
+						Obj(),
+					*utiltesting.MakePodSet(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName, 4).
+						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
+						Obj(),
+					*utiltesting.MakePodSet(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].GroupName, 12).
+						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Spec.DeepCopy()).
+						Obj(),
 				}
 			},
 		},
@@ -272,26 +253,18 @@ func TestPodSets(t *testing.T) {
 				Obj()),
 			wantPodSets: func(rayJob *RayJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     headGroupPodSetName,
-						Count:    1,
-						Template: *rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.DeepCopy(),
-					},
-					{
-						Name:     "group1",
-						Count:    1,
-						Template: *rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.DeepCopy(),
-					},
-					{
-						Name:     "group2",
-						Count:    3,
-						Template: *rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.DeepCopy(),
-					},
-					{
-						Name:     "submitter",
-						Count:    1,
-						Template: *getSubmitterTemplate(rayJob),
-					},
+					*utiltesting.MakePodSet(headGroupPodSetName, 1).
+						PodSpec(*rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
+						Obj(),
+					*utiltesting.MakePodSet("group1", 1).
+						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
+						Obj(),
+					*utiltesting.MakePodSet("group2", 3).
+						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Spec.DeepCopy()).
+						Obj(),
+					*utiltesting.MakePodSet("submitter", 1).
+						PodSpec(getSubmitterTemplate(rayJob).Spec).
+						Obj(),
 				}
 			},
 		},
@@ -339,41 +312,27 @@ func TestPodSets(t *testing.T) {
 				Obj()),
 			wantPodSets: func(rayJob *RayJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					{
-						Name:     headGroupPodSetName,
-						Count:    1,
-						Template: *rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.DeepCopy(),
-					},
-					{
-						Name:     "group1",
-						Count:    1,
-						Template: *rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.DeepCopy(),
-					},
-					{
-						Name:     "group2",
-						Count:    3,
-						Template: *rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.DeepCopy(),
-					},
-					{
-						Name:  "submitter",
-						Count: 1,
-						Template: corev1.PodTemplateSpec{
-							Spec: corev1.PodSpec{
-								Containers: []corev1.Container{
-									{
-										Name: "ray-job-submitter",
-										Resources: corev1.ResourceRequirements{
-											Requests: corev1.ResourceList{
-												corev1.ResourceCPU:    resource.MustParse("50m"),
-												corev1.ResourceMemory: resource.MustParse("100Mi"),
-											},
-										},
-									},
-								},
-								RestartPolicy: corev1.RestartPolicyNever,
+					*utiltesting.MakePodSet(headGroupPodSetName, 1).
+						PodSpec(*rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
+						Obj(),
+					*utiltesting.MakePodSet("group1", 1).
+						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
+						Obj(),
+					*utiltesting.MakePodSet("group2", 3).
+						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Spec.DeepCopy()).
+						Obj(),
+					*utiltesting.MakePodSet("submitter", 1).
+						PodSpec(corev1.PodSpec{
+							RestartPolicy: corev1.RestartPolicyNever,
+							Containers: []corev1.Container{
+								*utiltesting.MakeContainer().
+									Name("ray-job-submitter").
+									WithResourceReq(corev1.ResourceCPU, "50m").
+									WithResourceReq(corev1.ResourceMemory, "100Mi").
+									Obj(),
 							},
-						},
-					},
+						}).
+						Obj(),
 				}
 			},
 		},

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -487,6 +487,23 @@ func (p *PodSetWrapper) NodeSelector(kv map[string]string) *PodSetWrapper {
 	return p
 }
 
+func (p *PodSetWrapper) RequiredDuringSchedulingIgnoredDuringExecution(nodeSelectorTerms []corev1.NodeSelectorTerm) *PodSetWrapper {
+	if p.Template.Spec.Affinity == nil {
+		p.Template.Spec.Affinity = &corev1.Affinity{}
+	}
+	if p.Template.Spec.Affinity.NodeAffinity == nil {
+		p.Template.Spec.Affinity.NodeAffinity = &corev1.NodeAffinity{}
+	}
+	if p.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		p.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
+	}
+	p.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(
+		p.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+		nodeSelectorTerms...,
+	)
+	return p
+}
+
 func (p *PodSetWrapper) NodeName(name string) *PodSetWrapper {
 	p.Template.Spec.NodeName = name
 	return p
@@ -1324,6 +1341,12 @@ func MakeContainer() *ContainerWrapper {
 // Obj returns the inner corev1.Container.
 func (c *ContainerWrapper) Obj() *corev1.Container {
 	return &c.Container
+}
+
+// Name sets the name of the container.
+func (c *ContainerWrapper) Name(name string) *ContainerWrapper {
+	c.Container.Name = name
+	return c
 }
 
 // WithResourceReq appends a resource request to the container.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
There are many places where we directly define PodSet instead of using `PodSetWrapper`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```