### PR TITLE
chore: Use core ResourceName typed instead of string in GetGreaterKeys()

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2215,7 +2215,7 @@ func TestSchedule(t *testing.T) {
 						errLimitRangeConstraintsUnsatisfiedResources,
 						field.Invalid(
 							workload.PodSetsPath.Index(0).Child("template").Child("spec").Child("containers").Index(0),
-							[]string{corev1.ResourceCPU.String()},
+							[]corev1.ResourceName{corev1.ResourceCPU},
 							limitrange.RequestsMustNotBeAboveLimitRangeMaxMessage,
 						).Error(),
 					),
@@ -2244,7 +2244,7 @@ func TestSchedule(t *testing.T) {
 						errInvalidWLResources,
 						field.Invalid(
 							workload.PodSetsPath.Index(0).Child("template").Child("spec").Child("containers").Index(0),
-							[]string{corev1.ResourceCPU.String()}, workload.RequestsMustNotExceedLimitMessage,
+							[]corev1.ResourceName{corev1.ResourceCPU}, workload.RequestsMustNotExceedLimitMessage,
 						).Error(),
 					),
 				},

--- a/pkg/util/limitrange/limitrange_test.go
+++ b/pkg/util/limitrange/limitrange_test.go
@@ -162,7 +162,7 @@ func TestValidatePodSpec(t *testing.T) {
 			want: field.ErrorList{
 				field.Invalid(
 					podSpecPath.Child("initContainers").Index(1),
-					[]string{"example.com/initContainerGpu"},
+					[]corev1.ResourceName{"example.com/initContainerGpu"},
 					RequestsMustNotBeAboveLimitRangeMaxMessage,
 				),
 			},
@@ -175,7 +175,7 @@ func TestValidatePodSpec(t *testing.T) {
 			want: field.ErrorList{
 				field.Invalid(
 					podSpecPath.Child("initContainers").Index(1),
-					[]string{"example.com/initContainerGpu"},
+					[]corev1.ResourceName{"example.com/initContainerGpu"},
 					RequestsMustNotBeBelowLimitRangeMinMessage,
 				),
 			},
@@ -188,7 +188,7 @@ func TestValidatePodSpec(t *testing.T) {
 			want: field.ErrorList{
 				field.Invalid(
 					podSpecPath.Child("containers").Index(0),
-					[]string{"example.com/mainContainerGpu"},
+					[]corev1.ResourceName{"example.com/mainContainerGpu"},
 					RequestsMustNotBeAboveLimitRangeMaxMessage,
 				),
 			},
@@ -201,7 +201,7 @@ func TestValidatePodSpec(t *testing.T) {
 			want: field.ErrorList{
 				field.Invalid(
 					podSpecPath.Child("containers").Index(0),
-					[]string{"example.com/mainContainerGpu"},
+					[]corev1.ResourceName{"example.com/mainContainerGpu"},
 					RequestsMustNotBeBelowLimitRangeMinMessage,
 				),
 			},
@@ -212,7 +212,7 @@ func TestValidatePodSpec(t *testing.T) {
 				WithValue("Max", corev1.ResourceCPU, "4").
 				Obj()),
 			want: field.ErrorList{
-				field.Invalid(podSpecPath, []string{corev1.ResourceCPU.String()}, RequestsMustNotBeAboveLimitRangeMaxMessage),
+				field.Invalid(podSpecPath, []corev1.ResourceName{corev1.ResourceCPU}, RequestsMustNotBeAboveLimitRangeMaxMessage),
 			},
 		},
 		"pod under": {
@@ -221,7 +221,7 @@ func TestValidatePodSpec(t *testing.T) {
 				WithValue("Min", corev1.ResourceCPU, "6").
 				Obj()),
 			want: field.ErrorList{
-				field.Invalid(podSpecPath, []string{corev1.ResourceCPU.String()}, RequestsMustNotBeBelowLimitRangeMinMessage),
+				field.Invalid(podSpecPath, []corev1.ResourceName{corev1.ResourceCPU}, RequestsMustNotBeBelowLimitRangeMinMessage),
 			},
 		},
 		"multiple": {
@@ -242,15 +242,15 @@ func TestValidatePodSpec(t *testing.T) {
 			want: field.ErrorList{
 				field.Invalid(
 					podSpecPath.Child("initContainers").Index(1),
-					[]string{"example.com/initContainerGpu"},
+					[]corev1.ResourceName{"example.com/initContainerGpu"},
 					RequestsMustNotBeAboveLimitRangeMaxMessage,
 				),
 				field.Invalid(
 					podSpecPath.Child("containers").Index(0),
-					[]string{"example.com/mainContainerGpu"},
+					[]corev1.ResourceName{"example.com/mainContainerGpu"},
 					RequestsMustNotBeBelowLimitRangeMinMessage,
 				),
-				field.Invalid(podSpecPath, []string{corev1.ResourceCPU.String()}, RequestsMustNotBeAboveLimitRangeMaxMessage),
+				field.Invalid(podSpecPath, []corev1.ResourceName{corev1.ResourceCPU}, RequestsMustNotBeAboveLimitRangeMaxMessage),
 			},
 		},
 		"multiple valid": {

--- a/pkg/util/resource/resource.go
+++ b/pkg/util/resource/resource.go
@@ -77,15 +77,15 @@ func MergeResourceListKeepSum(a, b corev1.ResourceList) corev1.ResourceList {
 }
 
 // GetGreaterKeys returns the list of ResourceNames for which the value in a are greater than the value in b.
-func GetGreaterKeys(a, b corev1.ResourceList) []string {
+func GetGreaterKeys(a, b corev1.ResourceList) []corev1.ResourceName {
 	if len(a) == 0 || len(b) == 0 {
 		return nil
 	}
 
-	ret := make([]string, 0, len(a))
+	ret := make([]corev1.ResourceName, 0, len(a))
 	for k, va := range a {
 		if vb, found := b[k]; found && va.Cmp(vb) > 0 {
-			ret = append(ret, k.String())
+			ret = append(ret, k)
 		}
 	}
 	if len(ret) == 0 {

--- a/pkg/util/resource/resource_test.go
+++ b/pkg/util/resource/resource_test.go
@@ -205,7 +205,7 @@ func TestGetGraterKeys(t *testing.T) {
 	}
 	cases := map[string]struct {
 		a, b corev1.ResourceList
-		want []string
+		want []corev1.ResourceName
 	}{
 		"empty_a": {
 			b:    cpuOnly1,
@@ -223,7 +223,7 @@ func TestGetGraterKeys(t *testing.T) {
 		"not less one resource": {
 			a:    cpuOnly1,
 			b:    cpuOnly500m,
-			want: []string{corev1.ResourceCPU.String()},
+			want: []corev1.ResourceName{corev1.ResourceCPU},
 		},
 		"multiple unrelated": {
 			a: corev1.ResourceList{
@@ -245,7 +245,7 @@ func TestGetGraterKeys(t *testing.T) {
 				"r1": resource.MustParse("1"),
 				"r2": resource.MustParse("2"),
 			},
-			want: []string{"r1"},
+			want: []corev1.ResourceName{"r1"},
 		},
 	}
 

--- a/pkg/workload/resources_test.go
+++ b/pkg/workload/resources_test.go
@@ -549,11 +549,11 @@ func TestValidateResources(t *testing.T) {
 			},
 			wantError: field.ErrorList{
 				field.Invalid(PodSetsPath.Index(0).Child("template").Child("spec").Child("initContainers").Index(0),
-					[]string{corev1.ResourceMemory.String()}, RequestsMustNotExceedLimitMessage),
+					[]corev1.ResourceName{corev1.ResourceMemory}, RequestsMustNotExceedLimitMessage),
 				field.Invalid(PodSetsPath.Index(0).Child("template").Child("spec").Child("containers").Index(0),
-					[]string{corev1.ResourceCPU.String()}, RequestsMustNotExceedLimitMessage),
+					[]corev1.ResourceName{corev1.ResourceCPU}, RequestsMustNotExceedLimitMessage),
 				field.Invalid(PodSetsPath.Index(1).Child("template").Child("spec").Child("initContainers").Index(0),
-					[]string{corev1.ResourceCPU.String()}, RequestsMustNotExceedLimitMessage),
+					[]corev1.ResourceName{corev1.ResourceCPU}, RequestsMustNotExceedLimitMessage),
 			},
 		},
 	}
@@ -622,7 +622,7 @@ func TestValidateLimitRange(t *testing.T) {
 			wantError: field.ErrorList{
 				field.Invalid(
 					PodSetsPath.Index(0).Child("template").Child("spec"),
-					[]string{corev1.ResourceCPU.String()},
+					[]corev1.ResourceName{corev1.ResourceCPU},
 					limitrange.RequestsMustNotBeAboveLimitRangeMaxMessage,
 				),
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
It would be better to use core ResourceName typed instead of string in GetGreaterKeys() to avoid casting (`ResourceName` -> `string`) everywhere.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```