### PR TITLE
chore: Rename podSetFlavor with psAssignment

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1156,7 +1156,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			Request(corev1.ResourceCPU, "5m").
 			Obj(),
 	}
-	podSetFlavors := []kueue.PodSetAssignment{
+	psAssignment := []kueue.PodSetAssignment{
 		{
 			Name: "driver",
 			Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
@@ -1179,7 +1179,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 	cl := utiltesting.NewFakeClient(
 		utiltesting.MakeWorkload("a", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 			ClusterQueue:      "one",
-			PodSetAssignments: podSetFlavors,
+			PodSetAssignments: psAssignment,
 		}).Obj(),
 		utiltesting.MakeWorkload("b", "").ReserveQuota(&kueue.Admission{
 			ClusterQueue: "one",
@@ -1206,7 +1206,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				workloads := []*kueue.Workload{
 					utiltesting.MakeWorkload("a", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 						ClusterQueue:      "one",
-						PodSetAssignments: podSetFlavors,
+						PodSetAssignments: psAssignment,
 					}).Obj(),
 					utiltesting.MakeWorkload("d", "").ReserveQuota(&kueue.Admission{
 						ClusterQueue: "two",
@@ -1288,7 +1288,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				}).Obj()
 				latest := utiltesting.MakeWorkload("a", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 					ClusterQueue:      "two",
-					PodSetAssignments: podSetFlavors,
+					PodSetAssignments: psAssignment,
 				}).Obj()
 				return cache.UpdateWorkload(old, latest)
 			},
@@ -1492,11 +1492,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				workloads := []*kueue.Workload{
 					utiltesting.MakeWorkload("d", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 						ClusterQueue:      "one",
-						PodSetAssignments: podSetFlavors,
+						PodSetAssignments: psAssignment,
 					}).Obj(),
 					utiltesting.MakeWorkload("e", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 						ClusterQueue:      "two",
-						PodSetAssignments: podSetFlavors,
+						PodSetAssignments: psAssignment,
 					}).Obj(),
 				}
 				for i := range workloads {
@@ -1559,11 +1559,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				workloads := []*kueue.Workload{
 					utiltesting.MakeWorkload("d", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 						ClusterQueue:      "one",
-						PodSetAssignments: podSetFlavors,
+						PodSetAssignments: psAssignment,
 					}).Obj(),
 					utiltesting.MakeWorkload("e", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 						ClusterQueue:      "two",
-						PodSetAssignments: podSetFlavors,
+						PodSetAssignments: psAssignment,
 					}).Obj(),
 				}
 				for i := range workloads {
@@ -1626,11 +1626,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				workloads := []*kueue.Workload{
 					utiltesting.MakeWorkload("d", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 						ClusterQueue:      "one",
-						PodSetAssignments: podSetFlavors,
+						PodSetAssignments: psAssignment,
 					}).Obj(),
 					utiltesting.MakeWorkload("e", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 						ClusterQueue:      "two",
-						PodSetAssignments: podSetFlavors,
+						PodSetAssignments: psAssignment,
 					}).Obj(),
 				}
 				for i := range workloads {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1078,13 +1078,13 @@ func getPodSetsInfoFromStatus(ctx context.Context, c client.Client, w *kueue.Wor
 
 	podSetsInfo := make([]podset.PodSetInfo, len(w.Status.Admission.PodSetAssignments))
 
-	for i, podSetFlavor := range w.Status.Admission.PodSetAssignments {
-		info, err := podset.FromAssignment(ctx, c, &podSetFlavor, w.Spec.PodSets[i].Count)
+	for i, psAssignment := range w.Status.Admission.PodSetAssignments {
+		info, err := podset.FromAssignment(ctx, c, &psAssignment, w.Spec.PodSets[i].Count)
 		if err != nil {
 			return nil, err
 		}
 		if features.Enabled(features.TopologyAwareScheduling) {
-			info.Labels[kueuealpha.PodSetLabel] = podSetFlavor.Name
+			info.Labels[kueuealpha.PodSetLabel] = psAssignment.Name
 			info.Annotations[kueuealpha.WorkloadAnnotation] = w.Name
 		}
 		for _, admissionCheck := range w.Status.AdmissionChecks {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We are using `podSetFlavor` for typed [`PodSetAssignment`](https://github.com/kubernetes-sigs/kueue/blob/651e8deb5193e6974db3c2e05636845d2cdcafe9/apis/kueue/v1beta1/workload_types.go#L132) as variable name.

However, today, we have non-RF information like `ResourceUsage` and `TopologyAssignment`.
So, the `podSetFlavor` confuses.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```