### PR TITLE
Use ManagedByKueueLabelKey from pkg/constants.

### DIFF
--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -149,7 +149,7 @@ func checkError(err error) (retry, reload bool, timeout time.Duration) {
 
 func addLabels(ctx context.Context, c client.Client, p *corev1.Pod, queue string, addLabels map[string]string) error {
 	p.Labels[controllerconstants.QueueLabel] = queue
-	p.Labels[pod.ManagedLabelKey] = pod.ManagedLabelValue
+	p.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
 	maps.Copy(p.Labels, addLabels)
 
 	err := c.Update(ctx, p)
@@ -170,7 +170,7 @@ func addLabels(ctx context.Context, c client.Client, p *corev1.Pod, queue string
 				continue
 			}
 			p.Labels[controllerconstants.QueueLabel] = queue
-			p.Labels[pod.ManagedLabelKey] = pod.ManagedLabelValue
+			p.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
 			maps.Copy(p.Labels, addLabels)
 		}
 		err = c.Update(ctx, p)

--- a/cmd/importer/pod/import_test.go
+++ b/cmd/importer/pod/import_test.go
@@ -28,8 +28,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/cmd/importer/util"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
-	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 )
@@ -43,7 +42,7 @@ func TestImportNamespace(t *testing.T) {
 
 	baseWlWrapper := utiltesting.MakeWorkload("pod-pod-b17ab", testingNamespace).
 		ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "pod").
-		Label(constants.JobUIDLabel, "pod").
+		Label(controllerconstants.JobUIDLabel, "pod").
 		Finalizers(kueue.ResourceInUseFinalizerName).
 		Queue("lq1").
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -118,8 +117,8 @@ func TestImportNamespace(t *testing.T) {
 
 			wantPods: []corev1.Pod{
 				*basePodWrapper.Clone().
-					Label(constants.QueueLabel, "lq1").
-					Label(pod.ManagedLabelKey, pod.ManagedLabelValue).
+					Label(controllerconstants.QueueLabel, "lq1").
+					ManagedByKueueLabel().
 					Obj(),
 			},
 
@@ -154,8 +153,8 @@ func TestImportNamespace(t *testing.T) {
 
 			wantPods: []corev1.Pod{
 				*basePodWrapper.Clone().
-					Label(constants.QueueLabel, "lq1").
-					Label(pod.ManagedLabelKey, pod.ManagedLabelValue).
+					Label(controllerconstants.QueueLabel, "lq1").
+					ManagedByKueueLabel().
 					Label("new.lbl", "val").
 					Obj(),
 			},

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -41,6 +41,7 @@ const (
 
 	DefaultPendingWorkloadsLimit = 1000
 
-	// ManagedByKueueLabel label that signalize that an object is managed by Kueue
-	ManagedByKueueLabel = "kueue.x-k8s.io/managed"
+	// ManagedByKueueLabelKey label that signalize that an object is managed by Kueue
+	ManagedByKueueLabelKey   = "kueue.x-k8s.io/managed"
+	ManagedByKueueLabelValue = "true"
 )

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -279,7 +279,7 @@ func (c *Controller) syncOwnedProvisionRequest(
 					Name:      requestName,
 					Namespace: wl.Namespace,
 					Labels: map[string]string{
-						constants.ManagedByKueueLabel: "true",
+						constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue,
 					},
 				},
 				Spec: autoscaling.ProvisioningRequestSpec{
@@ -383,7 +383,7 @@ func (c *Controller) createPodTemplate(ctx context.Context, wl *kueue.Workload, 
 			Name:      name,
 			Namespace: wl.Namespace,
 			Labels: map[string]string{
-				constants.ManagedByKueueLabel: "true",
+				constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue,
 			},
 		},
 		Template: ps.Template,

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -163,7 +163,7 @@ func TestReconcile(t *testing.T) {
 			Namespace: TestNamespace,
 			Name:      "wl-check1-1",
 			Labels: map[string]string{
-				constants.ManagedByKueueLabel: "true",
+				constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue,
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
@@ -194,7 +194,7 @@ func TestReconcile(t *testing.T) {
 	}
 
 	baseTemplate1 := utiltesting.MakePodTemplate("ppt-wl-check1-1-ps1", TestNamespace).
-		Label(constants.ManagedByKueueLabel, "true").
+		Label(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue).
 		Containers(corev1.Container{
 			Name: "c",
 			Resources: corev1.ResourceRequirements{
@@ -212,7 +212,7 @@ func TestReconcile(t *testing.T) {
 		})
 
 	baseTemplate2 := utiltesting.MakePodTemplate("ppt-wl-check1-1-ps2", TestNamespace).
-		Label(constants.ManagedByKueueLabel, "true").
+		Label(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue).
 		Containers(corev1.Container{
 			Name: "c",
 			Resources: corev1.ResourceRequirements{
@@ -338,7 +338,7 @@ func TestReconcile(t *testing.T) {
 						Namespace: TestNamespace,
 						Name:      ProvisioningRequestName("wl", baseCheck.Name, 1),
 						Labels: map[string]string{
-							constants.ManagedByKueueLabel: "true",
+							constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue,
 						},
 						OwnerReferences: []metav1.OwnerReference{
 							{
@@ -661,7 +661,7 @@ func TestReconcile(t *testing.T) {
 				"wl-check1-1": {
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							constants.ManagedByKueueLabel: "true",
+							constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue,
 						},
 					},
 					Spec: autoscaling.ProvisioningRequestSpec{
@@ -710,7 +710,7 @@ func TestReconcile(t *testing.T) {
 				"wl-check1-1": {
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							constants.ManagedByKueueLabel: "true",
+							constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue,
 						},
 					},
 					Spec: autoscaling.ProvisioningRequestSpec{
@@ -1019,7 +1019,7 @@ func TestReconcile(t *testing.T) {
 						Namespace: TestNamespace,
 						Name:      "wl-check1-2",
 						Labels: map[string]string{
-							constants.ManagedByKueueLabel: "true",
+							constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue,
 						},
 						OwnerReferences: []metav1.OwnerReference{
 							{

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -536,7 +536,7 @@ func (p *Pod) Finalize(ctx context.Context, c client.Client) error {
 
 func (p *Pod) Skip() bool {
 	// Skip pod reconciliation, if pod is found, and it's managed label is not set or incorrect.
-	if v, ok := p.pod.GetLabels()[ManagedLabelKey]; p.isFound && (!ok || v != ManagedLabelValue) {
+	if v, ok := p.pod.GetLabels()[constants.ManagedByKueueLabelKey]; p.isFound && (!ok || v != constants.ManagedByKueueLabelValue) {
 		return true
 	}
 	return false

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -40,7 +40,6 @@ import (
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
-	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/podset"
@@ -248,13 +247,13 @@ func TestReconciler(t *testing.T) {
 			},
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				KueueSchedulingGate().
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				NodeSelector(corev1.LabelArchStable, "arm64").
 				KueueFinalizer().
 				Obj()},
@@ -298,7 +297,7 @@ func TestReconciler(t *testing.T) {
 		"non-matching admitted workload is deleted and pod is finalized": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				Obj()},
 			wantPods: nil,
@@ -330,14 +329,14 @@ func TestReconciler(t *testing.T) {
 		"the workload is created when queue name is set": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				KueueSchedulingGate().
 				Queue("test-queue").
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				KueueSchedulingGate().
 				Queue("test-queue").
@@ -381,13 +380,13 @@ func TestReconciler(t *testing.T) {
 		"pod is stopped when workload is evicted": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				Queue("test-queue").
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				Queue("test-queue").
 				StatusConditions(corev1.PodCondition{
@@ -438,14 +437,14 @@ func TestReconciler(t *testing.T) {
 		"pod is finalized when it's succeeded": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				StatusPhase(corev1.PodSucceeded).
 				StatusMessage("Job finished successfully").
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				StatusPhase(corev1.PodSucceeded).
 				StatusMessage("Job finished successfully").
 				Obj()},
@@ -493,13 +492,13 @@ func TestReconciler(t *testing.T) {
 		"workload status condition is added even if the pod is finalized": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				StatusPhase(corev1.PodSucceeded).
 				StatusMessage("Job finished successfully").
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				StatusPhase(corev1.PodSucceeded).
 				StatusMessage("Job finished successfully").
 				Obj()},
@@ -538,12 +537,12 @@ func TestReconciler(t *testing.T) {
 		"pod without scheduling gate is terminated if workload is not admitted": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				StatusConditions(corev1.PodCondition{
 					Type:    "TerminationTarget",
@@ -583,7 +582,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
@@ -594,7 +593,7 @@ func TestReconciler(t *testing.T) {
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
 					Annotation("invalid-provreq-prefix/test-annotation-2", "test-val-2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
@@ -627,7 +626,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
@@ -638,7 +637,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
@@ -650,7 +649,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
@@ -661,7 +660,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
@@ -701,7 +700,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
@@ -715,7 +714,7 @@ func TestReconciler(t *testing.T) {
 				// Other pods are created on second reconcile
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Annotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
@@ -755,7 +754,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
@@ -765,7 +764,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
@@ -776,7 +775,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
@@ -786,7 +785,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
@@ -826,7 +825,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
@@ -836,7 +835,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
@@ -863,7 +862,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
@@ -873,7 +872,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 					KueueFinalizer().
 					KueueSchedulingGate().
@@ -911,7 +910,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -920,7 +919,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -930,7 +929,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -939,7 +938,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -983,7 +982,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -992,7 +991,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -1002,7 +1001,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1011,7 +1010,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1066,7 +1065,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1075,7 +1074,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1084,7 +1083,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1093,7 +1092,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1135,7 +1134,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1144,7 +1143,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1154,7 +1153,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -1162,7 +1161,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -1215,14 +1214,14 @@ func TestReconciler(t *testing.T) {
 		"workload is not deleted if the pod in group has been deleted after admission": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				Group("test-group").
 				GroupTotalCount("2").
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				Group("test-group").
 				GroupTotalCount("2").
@@ -1271,7 +1270,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
@@ -1281,7 +1280,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
@@ -1292,7 +1291,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
@@ -1302,7 +1301,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
@@ -1347,7 +1346,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					KueueFinalizer().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -1356,7 +1355,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -1427,7 +1426,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
@@ -1437,7 +1436,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("new-test-queue").
@@ -1448,7 +1447,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("test-queue").
@@ -1458,7 +1457,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Queue("new-test-queue").
@@ -1475,7 +1474,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Queue("test-queue").
 					Group("test-group").
@@ -1484,7 +1483,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Queue("test-queue").
 					Group("test-group").
@@ -1529,7 +1528,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -1538,7 +1537,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -1548,7 +1547,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -1557,7 +1556,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -1617,7 +1616,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -1626,7 +1625,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -1635,7 +1634,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -1644,7 +1643,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -1670,7 +1669,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -1679,7 +1678,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodFailed).
@@ -1687,7 +1686,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -1696,7 +1695,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -1743,7 +1742,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1752,7 +1751,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1761,7 +1760,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -1771,7 +1770,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
@@ -1779,7 +1778,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -1787,7 +1786,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -1843,7 +1842,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -1854,7 +1853,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -1922,7 +1921,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -1933,7 +1932,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -2022,7 +2021,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Queue("test-queue").
 					Group("test-group").
@@ -2033,7 +2032,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Queue("test-queue").
 					Group("test-group").
@@ -2045,7 +2044,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Queue("test-queue").
 					Group("test-group").
@@ -2056,7 +2055,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Queue("test-queue").
 					Group("test-group").
@@ -2103,7 +2102,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2112,7 +2111,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2122,7 +2121,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2131,7 +2130,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2184,7 +2183,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2194,7 +2193,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2251,7 +2250,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2260,7 +2259,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2270,7 +2269,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -2278,7 +2277,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodSucceeded).
@@ -2292,7 +2291,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2301,7 +2300,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2311,7 +2310,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2320,7 +2319,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2357,7 +2356,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2366,7 +2365,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2376,7 +2375,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2385,7 +2384,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
@@ -2408,7 +2407,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Annotation("kueue.x-k8s.io/retriable-in-group", "false").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2417,7 +2416,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2426,7 +2425,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
@@ -2438,7 +2437,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Annotation("kueue.x-k8s.io/retriable-in-group", "false").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodFailed).
@@ -2446,7 +2445,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("3").
 					StatusPhase(corev1.PodSucceeded).
@@ -2454,7 +2453,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
 					GroupTotalCount("3").
@@ -2533,7 +2532,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2542,7 +2541,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2551,7 +2550,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
@@ -2562,7 +2561,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2571,7 +2570,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2580,7 +2579,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
@@ -2645,7 +2644,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2655,7 +2654,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2665,7 +2664,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
@@ -2677,7 +2676,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2687,7 +2686,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -2697,7 +2696,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					Request(corev1.ResourceMemory, "1Gi").
@@ -2762,7 +2761,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2772,7 +2771,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2783,7 +2782,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2826,7 +2825,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2836,7 +2835,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2846,7 +2845,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2857,7 +2856,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2867,7 +2866,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2917,7 +2916,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -2926,7 +2925,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -2937,7 +2936,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3006,7 +3005,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -3016,7 +3015,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					UID("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -3026,7 +3025,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -3037,7 +3036,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -3047,7 +3046,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					UID("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -3057,7 +3056,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -3099,7 +3098,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3109,7 +3108,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					UID("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					CreationTimestamp(now.Add(time.Minute)).
@@ -3118,7 +3117,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -3129,7 +3128,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3139,7 +3138,7 @@ func TestReconciler(t *testing.T) {
 					Clone().
 					Name("pod2").
 					UID("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					CreationTimestamp(now.Add(time.Minute)).
@@ -3192,7 +3191,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -3202,7 +3201,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueSchedulingGate().
 					Finalizer("kubernetes").
 					Group("test-group").
@@ -3214,7 +3213,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -3224,7 +3223,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueSchedulingGate().
 					Finalizer("kubernetes").
 					Group("test-group").
@@ -3264,7 +3263,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("p1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("group").
@@ -3275,7 +3274,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("p2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("group").
@@ -3313,7 +3312,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
@@ -3321,7 +3320,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Delete().
 					Group("test-group").
@@ -3330,7 +3329,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement-for-pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3340,7 +3339,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
@@ -3348,7 +3347,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Delete().
 					Group("test-group").
@@ -3357,7 +3356,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement-for-pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3419,7 +3418,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -3427,7 +3426,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Delete().
 					Group("test-group").
@@ -3436,7 +3435,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -3446,7 +3445,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -3460,7 +3459,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Delete().
 					Group("test-group").
@@ -3469,7 +3468,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod3").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("3").
@@ -3556,7 +3555,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -3566,7 +3565,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("1").
@@ -3641,7 +3640,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("active-pod").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3649,7 +3648,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3664,7 +3663,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("deleted").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3680,7 +3679,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3695,7 +3694,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3703,7 +3702,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3713,7 +3712,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("active-pod").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3721,7 +3720,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("4").
 					StatusPhase(corev1.PodFailed).
@@ -3735,7 +3734,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3750,7 +3749,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3758,7 +3757,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("4").
@@ -3825,7 +3824,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("active-pod").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3833,7 +3832,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3848,7 +3847,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3858,7 +3857,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("active-pod").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3866,7 +3865,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3881,7 +3880,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3926,7 +3925,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3941,7 +3940,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error-no-finalizer").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
@@ -3955,7 +3954,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3965,7 +3964,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -3980,7 +3979,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("finished-with-error-no-finalizer").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Group("test-group").
 					GroupTotalCount("2").
 					StatusPhase(corev1.PodFailed).
@@ -3994,7 +3993,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -4054,7 +4053,7 @@ func TestReconciler(t *testing.T) {
 		"workload is created with correct labels for a single pod": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				Label("toCopyKey", "toCopyValue").
 				Label("dontCopyKey", "dontCopyValue").
 				KueueFinalizer().
@@ -4096,7 +4095,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label("toCopyKey1", "toCopyValue1").
 					Label("dontCopyKey", "dontCopyValue").
 					KueueFinalizer().
@@ -4108,7 +4107,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label("toCopyKey1", "toCopyValue1").
 					Label("toCopyKey2", "toCopyValue2").
 					Label("dontCopyKey", "dontCopyValue").
@@ -4156,7 +4155,7 @@ func TestReconciler(t *testing.T) {
 		"reconciler returns error in case pod group pod index is bigger or equal pod group total count": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				KueueSchedulingGate().
 				Group("test-group").
@@ -4169,7 +4168,7 @@ func TestReconciler(t *testing.T) {
 		"reconciler returns error in case pod group pod index is less than 0": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				KueueSchedulingGate().
 				Group("test-group").
@@ -4183,7 +4182,7 @@ func TestReconciler(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.
 					Clone().
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label("toCopyKey1", "toCopyValue1").
 					Label("dontCopyKey", "dontCopyValue").
 					KueueFinalizer().
@@ -4194,7 +4193,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label("toCopyKey1", "otherValue").
 					Label("toCopyKey2", "toCopyValue2").
 					Label("dontCopyKey", "dontCopyValue").
@@ -4214,7 +4213,7 @@ func TestReconciler(t *testing.T) {
 		"admission check message is recorded as event for a single pod": {
 			pods: []corev1.Pod{*basePodWrapper.
 				Clone().
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueFinalizer().
 				KueueSchedulingGate().
 				Obj()},
@@ -4294,7 +4293,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -4303,7 +4302,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -4384,7 +4383,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodRunning).
 					Group("test-group").
@@ -4394,7 +4393,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Delete().
 					StatusPhase(corev1.PodPending).
@@ -4405,7 +4404,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					KueueSchedulingGate().
 					Group("test-group").
@@ -4433,7 +4432,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodRunning).
 					Group("test-group").
@@ -4443,7 +4442,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("replacement").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Group("test-group").
 					GroupTotalCount("2").
@@ -4486,7 +4485,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4496,7 +4495,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4523,7 +4522,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4533,7 +4532,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4561,7 +4560,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4571,7 +4570,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4598,7 +4597,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4608,7 +4607,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4642,7 +4641,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4652,7 +4651,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4680,7 +4679,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4690,7 +4689,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Delete().
@@ -4725,7 +4724,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4735,7 +4734,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Delete().
 					StatusPhase(corev1.PodPending).
@@ -4770,7 +4769,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4780,7 +4779,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4822,7 +4821,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4832,7 +4831,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					Delete().
 					StatusPhase(corev1.PodPending).
@@ -4872,7 +4871,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4882,7 +4881,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4922,7 +4921,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4932,7 +4931,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -4973,7 +4972,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodFailed).
 					Group("test-group").
@@ -4983,7 +4982,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -5025,7 +5024,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -5035,7 +5034,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -5068,7 +5067,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -5078,7 +5077,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
 					Group("test-group").
@@ -5112,7 +5111,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
@@ -5122,7 +5121,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
@@ -5141,7 +5140,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
@@ -5157,7 +5156,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
@@ -5207,7 +5206,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
@@ -5217,7 +5216,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
@@ -5237,7 +5236,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
@@ -5253,7 +5252,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
@@ -5303,7 +5302,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
@@ -5313,7 +5312,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
@@ -5334,7 +5333,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod1").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
@@ -5350,7 +5349,7 @@ func TestReconciler(t *testing.T) {
 				*basePodWrapper.
 					Clone().
 					Name("pod2").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Label(controllerconsts.PrebuiltWorkloadLabel, "prebuilt-workload").
 					KueueFinalizer().
 					StatusPhase(corev1.PodPending).
@@ -5495,7 +5494,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 
 	pod := *basePodWrapper.
 		Clone().
-		Label(constants.ManagedByKueueLabel, "true").
+		ManagedByKueueLabel().
 		KueueFinalizer().
 		StatusPhase(corev1.PodSucceeded).
 		StatusMessage("Job finished successfully").
@@ -5567,7 +5566,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 	// Validate that pod has no finalizer after the second reconcile
 	wantPod := *basePodWrapper.
 		Clone().
-		Label(constants.ManagedByKueueLabel, "true").
+		ManagedByKueueLabel().
 		StatusPhase(corev1.PodSucceeded).
 		StatusMessage("Job finished successfully").
 		Obj()
@@ -5690,7 +5689,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 	pods := []corev1.Pod{
 		*basePodWrapper.
 			Clone().
-			Label(constants.ManagedByKueueLabel, "true").
+			ManagedByKueueLabel().
 			KueueFinalizer().
 			Group("test-group").
 			GroupTotalCount("2").
@@ -5699,7 +5698,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 		*basePodWrapper.
 			Clone().
 			Name("pod2").
-			Label(constants.ManagedByKueueLabel, "true").
+			ManagedByKueueLabel().
 			KueueFinalizer().
 			Group("test-group").
 			CreationTimestamp(now.Add(time.Minute)).
@@ -5708,7 +5707,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 		*basePodWrapper.
 			Clone().
 			Name("excessPod").
-			Label(constants.ManagedByKueueLabel, "true").
+			ManagedByKueueLabel().
 			KueueFinalizer().
 			Group("test-group").
 			CreationTimestamp(now.Add(time.Minute * 2)).

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -46,9 +46,7 @@ import (
 )
 
 const (
-	ManagedLabelKey              = constants.ManagedByKueueLabel
-	ManagedLabelValue            = "true"
-	PodFinalizer                 = ManagedLabelKey
+	PodFinalizer                 = constants.ManagedByKueueLabelKey
 	GroupNameLabel               = "kueue.x-k8s.io/pod-group-name"
 	GroupTotalCountAnnotation    = "kueue.x-k8s.io/pod-group-total-count"
 	GroupFastAdmissionAnnotation = "kueue.x-k8s.io/pod-group-fast-admission"
@@ -62,7 +60,7 @@ var (
 	metaPath                       = field.NewPath("metadata")
 	labelsPath                     = metaPath.Child("labels")
 	annotationsPath                = metaPath.Child("annotations")
-	managedLabelPath               = labelsPath.Key(ManagedLabelKey)
+	managedLabelPath               = labelsPath.Key(constants.ManagedByKueueLabelKey)
 	groupNameLabelPath             = labelsPath.Key(GroupNameLabel)
 	prebuiltWorkloadLabelPath      = labelsPath.Key(ctrlconstants.PrebuiltWorkloadLabel)
 	groupTotalCountAnnotationPath  = annotationsPath.Key(GroupTotalCountAnnotation)
@@ -211,7 +209,7 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		if pod.pod.Labels == nil {
 			pod.pod.Labels = make(map[string]string)
 		}
-		pod.pod.Labels[ManagedLabelKey] = ManagedLabelValue
+		pod.pod.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
 
 		gate(&pod.pod)
 
@@ -299,8 +297,8 @@ func validateCommon(pod *Pod) field.ErrorList {
 func validateManagedLabel(pod *Pod) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if managedLabel, ok := pod.pod.GetLabels()[ManagedLabelKey]; ok && managedLabel != ManagedLabelValue {
-		return append(allErrs, field.Forbidden(managedLabelPath, fmt.Sprintf("managed label value can only be '%s'", ManagedLabelValue)))
+	if managedLabel, ok := pod.pod.GetLabels()[constants.ManagedByKueueLabelKey]; ok && managedLabel != constants.ManagedByKueueLabelValue {
+		return append(allErrs, field.Forbidden(managedLabelPath, fmt.Sprintf("managed label value can only be '%s'", constants.ManagedByKueueLabelValue)))
 	}
 
 	return allErrs
@@ -308,10 +306,10 @@ func validateManagedLabel(pod *Pod) field.ErrorList {
 
 // warningForPodManagedLabel returns a warning message if the pod has a managed label, and it's parent is managed by kueue
 func warningForPodManagedLabel(p *Pod) string {
-	managedLabel := p.pod.GetLabels()[ManagedLabelKey]
-	if managedLabel == ManagedLabelValue && jobframework.IsOwnerManagedByKueueForObject(p.Object()) {
+	managedLabel := p.pod.GetLabels()[constants.ManagedByKueueLabelKey]
+	if managedLabel == constants.ManagedByKueueLabelValue && jobframework.IsOwnerManagedByKueueForObject(p.Object()) {
 		return fmt.Sprintf("pod owner is managed by kueue, label '%s=%s' might lead to unexpected behaviour",
-			ManagedLabelKey, ManagedLabelValue)
+			constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue)
 	}
 
 	return ""

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -33,7 +33,6 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	"sigs.k8s.io/kueue/pkg/cache"
-	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/queue"
@@ -85,7 +84,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueSchedulingGate().
 				KueueFinalizer().
 				Obj(),
@@ -99,7 +98,7 @@ func TestDefault(t *testing.T) {
 			podSelector:       &metav1.LabelSelector{},
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueSchedulingGate().
 				KueueFinalizer().
 				Obj(),
@@ -112,7 +111,7 @@ func TestDefault(t *testing.T) {
 			namespaceSelector:          defaultNamespaceSelector,
 			podSelector:                &metav1.LabelSelector{},
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueSchedulingGate().
 				KueueFinalizer().
 				Obj(),
@@ -127,7 +126,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueSchedulingGate().
 				KueueFinalizer().
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
@@ -273,7 +272,7 @@ func TestDefault(t *testing.T) {
 				Queue("test-queue").
 				Group("test-group").
 				RoleHash("a9f06f3a").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueSchedulingGate().
 				KueueFinalizer().
 				Obj(),
@@ -290,7 +289,7 @@ func TestDefault(t *testing.T) {
 				Queue("test-queue").
 				Group("test-group").
 				RoleHash("a9f06f3a").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueSchedulingGate().
 				KueueFinalizer().
 				Obj(),
@@ -307,7 +306,7 @@ func TestDefault(t *testing.T) {
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("test-queue").
 				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, "block").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				Label(kueuealpha.TASLabel, "true").
 				KueueFinalizer().
 				KueueSchedulingGate().
@@ -324,7 +323,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("default").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueSchedulingGate().
 				KueueFinalizer().
 				Obj(),
@@ -351,7 +350,7 @@ func TestDefault(t *testing.T) {
 				Obj(),
 			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("queue").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				KueueSchedulingGate().
 				KueueFinalizer().
 				Obj(),
@@ -418,7 +417,7 @@ func TestGetRoleHash(t *testing.T) {
 		"kueue.x-k8s.io/* labels shouldn't affect the role": {
 			pods: []*Pod{
 				{pod: *testingpod.MakePod("pod1", "test-ns").
-					Label(constants.ManagedByKueueLabel, "true").
+					ManagedByKueueLabel().
 					Obj()},
 				{pod: *testingpod.MakePod("pod2", "test-ns").
 					Obj()},
@@ -506,7 +505,7 @@ func TestValidateCreate(t *testing.T) {
 	}{
 		"pod owner is managed by kueue": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
 			wantWarns: admission.Warnings{
@@ -515,7 +514,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"pod with group name and no group total count": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				Group("test-group").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -527,7 +526,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"pod with group total count and no group name": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				GroupTotalCount("3").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -539,7 +538,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"pod with 0 group total count": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				Group("test-group").
 				GroupTotalCount("0").
 				Obj(),
@@ -552,7 +551,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"pod with empty group total count": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				Group("test-group").
 				GroupTotalCount("").
 				Obj(),
@@ -565,7 +564,7 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"pod with incorrect group name": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				Group("notAdns1123Subdomain*").
 				GroupTotalCount("2").
 				Obj(),
@@ -578,13 +577,13 @@ func TestValidateCreate(t *testing.T) {
 		},
 		"valid topology request": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
 		},
 		"invalid topology request": {
 			pod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Annotation(kueuealpha.PodSetPreferredTopologyAnnotation, "cloud.com/block").
 				Obj(),
@@ -654,11 +653,11 @@ func TestValidateUpdate(t *testing.T) {
 	}{
 		"pods owner is managed by kueue, managed label is set for both pods": {
 			oldPod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
 			wantWarns: admission.Warnings{
@@ -670,7 +669,7 @@ func TestValidateUpdate(t *testing.T) {
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
 			wantWarns: admission.Warnings{
@@ -682,7 +681,7 @@ func TestValidateUpdate(t *testing.T) {
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Annotation(SuspendedByParentAnnotation, "job").
 				Obj(),
@@ -690,7 +689,7 @@ func TestValidateUpdate(t *testing.T) {
 		"pod with group name and no group total count": {
 			oldPod: testingpod.MakePod("test-pod", "test-ns").Group("test-group").Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				Group("test-group").
 				Obj(),
 			wantErr: field.ErrorList{
@@ -703,7 +702,7 @@ func TestValidateUpdate(t *testing.T) {
 		"pod with 0 group total count": {
 			oldPod: testingpod.MakePod("test-pod", "test-ns").Group("test-group").Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				Group("test-group").
 				GroupTotalCount("0").
 				Obj(),
@@ -717,7 +716,7 @@ func TestValidateUpdate(t *testing.T) {
 		"pod with empty group total count": {
 			oldPod: testingpod.MakePod("test-pod", "test-ns").Group("test-group").Obj(),
 			newPod: testingpod.MakePod("test-pod", "test-ns").
-				Label(constants.ManagedByKueueLabel, "true").
+				ManagedByKueueLabel().
 				Group("test-group").
 				GroupTotalCount("").
 				Obj(),

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -151,6 +151,10 @@ func (p *PodWrapper) Annotation(key, content string) *PodWrapper {
 	return p
 }
 
+func (p *PodWrapper) ManagedByKueueLabel() *PodWrapper {
+	return p.Label(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue)
+}
+
 func (p *PodWrapper) PodGroupServingAnnotation(enabled bool) *PodWrapper {
 	return p.Annotation("kueue.x-k8s.io/pod-group-serving", strconv.FormatBool(enabled))
 }
@@ -191,7 +195,7 @@ func (p *PodWrapper) Finalizer(f string) *PodWrapper {
 
 // KueueFinalizer adds kueue finalizer to the Pod
 func (p *PodWrapper) KueueFinalizer() *PodWrapper {
-	return p.Finalizer(constants.ManagedByKueueLabel)
+	return p.Finalizer(constants.ManagedByKueueLabelKey)
 }
 
 // NodeSelector adds a node selector to the Pod.

--- a/test/e2e/customconfigs/skipjobswithoutqueuename_test.go
+++ b/test/e2e/customconfigs/skipjobswithoutqueuename_test.go
@@ -33,6 +33,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/constants"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 	awtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/appwrapper"
 	testingdeploy "sigs.k8s.io/kueue/pkg/util/testingjobs/deployment"
@@ -251,8 +252,8 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 					g.Expect(createdPod.Spec.SchedulingGates).Should(gomega.BeComparableTo([]corev1.PodSchedulingGate{
 						{Name: "kueue.x-k8s.io/admission"},
 					}))
-					g.Expect(createdPod.ObjectMeta.Labels).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabel: "true"}))
-					g.Expect(createdPod.Finalizers).Should(gomega.ContainElement(constants.ManagedByKueueLabel))
+					g.Expect(createdPod.ObjectMeta.Labels).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue}))
+					g.Expect(createdPod.Finalizers).Should(gomega.ContainElement(podcontroller.PodFinalizer))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
@@ -307,8 +308,8 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 						g.Expect(pod.Spec.SchedulingGates).Should(gomega.BeComparableTo([]corev1.PodSchedulingGate{
 							{Name: "kueue.x-k8s.io/admission"},
 						}))
-						g.Expect(pod.ObjectMeta.Labels).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabel: "true"}))
-						g.Expect(pod.Finalizers).Should(gomega.ContainElement(constants.ManagedByKueueLabel))
+						g.Expect(pod.ObjectMeta.Labels).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue}))
+						g.Expect(pod.Finalizers).Should(gomega.ContainElement(podcontroller.PodFinalizer))
 					}
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/integration/multikueue/multikueue_test.go
+++ b/test/integration/multikueue/multikueue_test.go
@@ -45,7 +45,6 @@ import (
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
-	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/admissionchecks/multikueue"
 	workloadappwrapper "sigs.k8s.io/kueue/pkg/controller/jobs/appwrapper"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
@@ -1266,7 +1265,7 @@ var _ = ginkgo.Describe("Multikueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 	ginkgo.It("Should create a pod on worker if admitted", func() {
 		pod := testingpod.MakePod("pod1", managerNs.Name).
 			Queue(managerLq.Name).
-			Label(constants.ManagedByKueueLabel, "true").
+			ManagedByKueueLabel().
 			KueueSchedulingGate().
 			Obj()
 

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -232,7 +232,7 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 					"ValidUntilSeconds": "0",
 				}))
 				gomega.Expect(createdRequest.Spec.PodSets).To(gomega.HaveLen(2))
-				gomega.Expect(createdRequest.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabel: "true"}))
+				gomega.Expect(createdRequest.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue}))
 
 				ps1 := createdRequest.Spec.PodSets[0]
 				gomega.Expect(ps1.Count).To(gomega.Equal(int32(3)))
@@ -249,7 +249,7 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				gomega.Expect(createdTemplate.Template.Spec.Containers).To(gomega.BeComparableTo(updatedWl.Spec.PodSets[0].Template.Spec.Containers, ignoreContainersDefaults))
 				gomega.Expect(createdTemplate.Template.Spec.NodeSelector).To(gomega.BeComparableTo(map[string]string{"ns1": "ns1v"}))
-				gomega.Expect(createdTemplate.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabel: "true"}))
+				gomega.Expect(createdTemplate.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue}))
 
 				ps2 := createdRequest.Spec.PodSets[1]
 				gomega.Expect(ps2.Count).To(gomega.Equal(int32(4)))
@@ -262,7 +262,7 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				gomega.Expect(createdTemplate.Template.Spec.Containers).To(gomega.BeComparableTo(updatedWl.Spec.PodSets[1].Template.Spec.Containers, ignoreContainersDefaults))
 				gomega.Expect(createdTemplate.Template.Spec.NodeSelector).To(gomega.BeComparableTo(map[string]string{"ns1": "ns1v"}))
-				gomega.Expect(createdTemplate.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabel: "true"}))
+				gomega.Expect(createdTemplate.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue}))
 			})
 
 			ginkgo.By("Removing the quota reservation from the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -158,11 +158,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				)
 
 				gomega.Expect(createdPod.Labels).To(
-					gomega.HaveKeyWithValue(constants.ManagedByKueueLabel, "true"),
+					gomega.HaveKeyWithValue(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue),
 					"Pod should have the label",
 				)
 
-				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement(constants.ManagedByKueueLabel),
+				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement(constants.ManagedByKueueLabelKey),
 					"Pod should have finalizer")
 
 				ginkgo.By("checking that workload is created for pod with the queue name")
@@ -229,7 +229,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					g.Expect(k8sClient.Get(ctx, lookupKey, createdPod)).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement(constants.ManagedByKueueLabel),
+				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement(constants.ManagedByKueueLabelKey),
 					"Pod should have finalizer")
 
 				ginkgo.By("checking that workload is created for pod with the queue name")
@@ -375,11 +375,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					)
 
 					gomega.Expect(createdPod.Labels).NotTo(
-						gomega.HaveKeyWithValue(constants.ManagedByKueueLabel, "true"),
+						gomega.HaveKeyWithValue(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue),
 						"Pod shouldn't have the label",
 					)
 
-					gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabel),
+					gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabelKey),
 						"Pod shouldn't have finalizer")
 
 					wlLookupKey := types.NamespacedName{Name: podcontroller.GetWorkloadNameForPod(createdPod.Name, createdPod.UID), Namespace: ns.Name}
@@ -853,7 +853,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					gomega.Eventually(func(g gomega.Gomega) {
 						createdPod := &corev1.Pod{}
 						g.Expect(client.IgnoreNotFound(k8sClient.Get(ctx, pod2LookupKey, createdPod))).Should(gomega.Succeed())
-						g.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabel))
+						g.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabelKey))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 
@@ -943,7 +943,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				createdPod := &corev1.Pod{}
 				gomega.Consistently(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, podLookupKey, createdPod)).To(gomega.Succeed())
-					g.Expect(createdPod.Finalizers).Should(gomega.ContainElement(constants.ManagedByKueueLabel), "Pod should have finalizer")
+					g.Expect(createdPod.Finalizers).Should(gomega.ContainElement(constants.ManagedByKueueLabelKey), "Pod should have finalizer")
 				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 				gomega.Expect(createdPod.Status.Phase).To(gomega.Equal(corev1.PodFailed))
 
@@ -1113,12 +1113,12 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 					gomega.Consistently(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, pod1LookupKey, createdPod)).To(gomega.Succeed())
-						g.Expect(createdPod.Finalizers).Should(gomega.ContainElement(constants.ManagedByKueueLabel), "Pod should have finalizer")
+						g.Expect(createdPod.Finalizers).Should(gomega.ContainElement(constants.ManagedByKueueLabelKey), "Pod should have finalizer")
 					}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 
 					gomega.Consistently(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, pod2LookupKey, createdPod)).To(gomega.Succeed())
-						g.Expect(createdPod.Finalizers).Should(gomega.ContainElement(constants.ManagedByKueueLabel), "Pod should have finalizer")
+						g.Expect(createdPod.Finalizers).Should(gomega.ContainElement(constants.ManagedByKueueLabelKey), "Pod should have finalizer")
 					}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 				})
 
@@ -1338,12 +1338,12 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				ginkgo.By("checking that workload is finalized when all pods in the group are deleted", func() {
 					createdPod := corev1.Pod{}
 					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod1), &createdPod)).To(gomega.Succeed())
-					controllerutil.RemoveFinalizer(&createdPod, constants.ManagedByKueueLabel)
+					controllerutil.RemoveFinalizer(&createdPod, constants.ManagedByKueueLabelKey)
 					gomega.Expect(k8sClient.Update(ctx, &createdPod)).To(gomega.Succeed())
 					gomega.Expect(k8sClient.Delete(ctx, &createdPod)).To(gomega.Succeed())
 
 					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod2), &createdPod)).To(gomega.Succeed())
-					controllerutil.RemoveFinalizer(&createdPod, constants.ManagedByKueueLabel)
+					controllerutil.RemoveFinalizer(&createdPod, constants.ManagedByKueueLabelKey)
 					gomega.Expect(k8sClient.Update(ctx, &createdPod)).To(gomega.Succeed())
 					gomega.Expect(k8sClient.Delete(ctx, &createdPod)).To(gomega.Succeed())
 

--- a/test/integration/singlecluster/importer/importer_test.go
+++ b/test/integration/singlecluster/importer/importer_test.go
@@ -124,7 +124,7 @@ var _ = ginkgo.Describe("Importer", func() {
 
 			pod3 := utiltestingpod.MakePod("pod3", ns.Name).
 				Queue("lq1").
-				Label(constants.ManagedByKueueLabel, "true").
+				Label(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue).
 				Request(corev1.ResourceCPU, "2").
 				KueueSchedulingGate().
 				Obj()

--- a/test/integration/singlecluster/webhook/jobs/pod_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/pod_webhook_test.go
@@ -103,11 +103,11 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				)
 
 				gomega.Expect(createdPod.Labels).To(
-					gomega.HaveKeyWithValue(constants.ManagedByKueueLabel, "true"),
+					gomega.HaveKeyWithValue(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue),
 					"Pod should have the label",
 				)
 
-				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement(constants.ManagedByKueueLabel),
+				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement(constants.ManagedByKueueLabelKey),
 					"Pod should have finalizer set")
 			})
 
@@ -127,11 +127,11 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				)
 
 				gomega.Expect(createdPod.Labels).NotTo(
-					gomega.HaveKeyWithValue(constants.ManagedByKueueLabel, "true"),
+					gomega.HaveKeyWithValue(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue),
 					"Pod shouldn't have the label",
 				)
 
-				gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabel),
+				gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabelKey),
 					"Pod shouldn't have finalizer set")
 			})
 		})
@@ -161,11 +161,11 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				)
 
 				gomega.Expect(createdPod.Labels).NotTo(
-					gomega.HaveKeyWithValue(constants.ManagedByKueueLabel, "true"),
+					gomega.HaveKeyWithValue(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue),
 					"Pod shouldn't have the label",
 				)
 
-				gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabel),
+				gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabelKey),
 					"Pod shouldn't have finalizer set")
 			})
 		})
@@ -235,11 +235,11 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				)
 
 				gomega.Expect(createdPod.Labels).To(
-					gomega.HaveKeyWithValue(constants.ManagedByKueueLabel, "true"),
+					gomega.HaveKeyWithValue(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue),
 					"Pod should have the label",
 				)
 
-				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement(constants.ManagedByKueueLabel),
+				gomega.Expect(createdPod.Finalizers).To(gomega.ContainElement(constants.ManagedByKueueLabelKey),
 					"Pod should have finalizer set")
 			})
 
@@ -259,11 +259,11 @@ var _ = ginkgo.Describe("Pod Webhook", func() {
 				)
 
 				gomega.Expect(createdPod.Labels).NotTo(
-					gomega.HaveKeyWithValue(constants.ManagedByKueueLabel, "true"),
+					gomega.HaveKeyWithValue(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue),
 					"Pod shouldn't have the label",
 				)
 
-				gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabel),
+				gomega.Expect(createdPod.Finalizers).NotTo(gomega.ContainElement(constants.ManagedByKueueLabelKey),
 					"Pod shouldn't have finalizer set")
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Currently we are using `ManagedByKueueLabelKey` from pkg/controller/jobs/pod

https://github.com/kubernetes-sigs/kueue/blob/68fb53181457ec3f794888fb2397236c4735ea6f/pkg/controller/jobs/pod/pod_webhook.go#L49-L50

This constant is just  a copy of ManagedByKueueLabel from pkg/constants.

To do not duplicate value we can use constant from pkg/constants.

Also replace `true` to `ManagedByKueueLabelValue`.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
/kind cleanup

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #3653

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```