### PR TITLE
docs: create RemoveFinalizersWithStrictPatch KEP

### DIFF
--- a/keps/3899-remove-finalizers-with-strict-patch/README.md
+++ b/keps/3899-remove-finalizers-with-strict-patch/README.md
@@ -1,0 +1,89 @@
+# KEP-3899: Remove finalizers using strict patch
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories (Optional)](#user-stories-optional)
+  - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Test Plan](#test-plan)
+    - [Integration tests](#integration-tests)
+  - [Graduation Criteria](#graduation-criteria)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Summary
+
+Remove finalizers using strict patch.
+This would force every finalizer update to be handled individually, removing the possibility of
+race conditions.
+
+## Motivation
+
+Updates to the finalizers [could be lost if they were made at the time when
+Kueue removed its system finalizers](https://github.com/kubernetes-sigs/kueue/issues/3899). 
+This could result in the unexpected and faulty behavior of the resources. 
+To prevent this, we need to use strict mode that ensures the concurrently-safe finalizer handling.
+
+### Goals
+
+- Remove finalizers using a strict patch.
+
+
+### Non-Goals
+
+- Implement a feature to provide a knob if Kueue uses strict mode or not.
+
+## Proposal
+
+Make Kueue remove and update finalizers from resources using a strict patch to ensure
+concurrently-safe finalizer handling.
+
+
+### User Stories (Optional)
+
+
+### Notes/Constraints/Caveats (Optional)
+
+Removing finalizers using a strict patch will force the reconciler to requeue
+every change to the finalizers individually, which could result in a performance
+hit when used on a large scale.
+
+
+### Risks and Mitigations
+
+## Design Details
+
+### Test Plan
+
+[x] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes necessary
+to implement this enhancement.
+
+#### Integration tests
+
+- Test that verifies that no error happens when the strict mode is engaged.
+
+
+### Graduation Criteria
+
+GA/Stable:
+* Positive feedback from users
+* No critical performance hit
+* There are no significant performance disadvantages in manual performance testings by real K8s cluster or KWOK.
+
+## Implementation History
+
+KEP: 2025-02-26
+
+## Drawbacks
+
+
+## Alternatives
+

--- a/keps/3899-remove-finalizers-with-strict-patch/kep.yaml
+++ b/keps/3899-remove-finalizers-with-strict-patch/kep.yaml
@@ -1,0 +1,29 @@
+title: Remove finalizers using strict patch
+kep-number: 3899
+authors:
+  - "@mykysha"
+status: implementable
+creation-date: 2025-02-26
+reviewers:
+  - "@mimowo"
+  - "@tenzen-y"
+approvers:
+  - "@mimowo"
+  - "@tenzen-y"
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: beta
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v0.11"
+
+milestone:
+    beta: "v0.11"
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
+feature-gates:
+  - name: RemoveFinalizersWithStrictPatch
+disable-supported: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Create a KEP for RemoveFinalizersWithStrictMode feature-gate.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #3899 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```