### PR TITLE
Introduce PodSetReference type for better static code analysis

### DIFF
--- a/apis/kueue/v1beta1/constants.go
+++ b/apis/kueue/v1beta1/constants.go
@@ -17,8 +17,8 @@ limitations under the License.
 package v1beta1
 
 const (
-	ResourceInUseFinalizerName = "kueue.x-k8s.io/resource-in-use"
-	DefaultPodSetName          = "main"
+	ResourceInUseFinalizerName                 = "kueue.x-k8s.io/resource-in-use"
+	DefaultPodSetName          PodSetReference = "main"
 )
 
 type StopPolicy string

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -129,12 +131,19 @@ type Admission struct {
 	PodSetAssignments []PodSetAssignment `json:"podSetAssignments"`
 }
 
+// PodSetReference is the name of a PodSet.
+// +kubebuilder:validation:MaxLength=63
+// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+type PodSetReference string
+
+func NewPodSetReference(name string) PodSetReference {
+	return PodSetReference(strings.ToLower(name))
+}
+
 type PodSetAssignment struct {
 	// Name is the name of the podSet. It should match one of the names in .spec.podSets.
 	// +kubebuilder:default=main
-	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern="^(?i)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-	Name string `json:"name"`
+	Name PodSetReference `json:"name"`
 
 	// Flavors are the flavors assigned to the workload for each resource.
 	Flavors map[corev1.ResourceName]ResourceFlavorReference `json:"flavors,omitempty"`
@@ -245,9 +254,7 @@ type TopologyDomainAssignment struct {
 type PodSet struct {
 	// name is the PodSet name.
 	// +kubebuilder:default=main
-	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-	Name string `json:"name,omitempty"`
+	Name PodSetReference `json:"name,omitempty"`
 
 	// template is the Pod template.
 	//
@@ -410,7 +417,7 @@ type PodSetUpdate struct {
 	// Name of the PodSet to modify. Should match to one of the Workload's PodSets.
 	// +required
 	// +kubebuilder:validation:Required
-	Name string `json:"name"`
+	Name PodSetReference `json:"name"`
 
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
@@ -433,7 +440,7 @@ type PodSetUpdate struct {
 
 type ReclaimablePod struct {
 	// name is the PodSet name.
-	Name string `json:"name"`
+	Name PodSetReference `json:"name"`
 
 	// count is the number of pods for which the requested resources are no longer needed.
 	// +kubebuilder:validation:Minimum=0
@@ -445,9 +452,7 @@ type PodSetRequest struct {
 	// +kubebuilder:default=main
 	// +required
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern="^(?i)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-	Name string `json:"name"`
+	Name PodSetReference `json:"name"`
 
 	// resources is the total resources all the pods in the podset need to run.
 	//

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -8437,7 +8437,7 @@ spec:
                           description: Name is the name of the podSet. It should match
                             one of the names in .spec.podSets.
                           maxLength: 63
-                          pattern: ^(?i)[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         resourceUsage:
                           additionalProperties:
@@ -8596,6 +8596,8 @@ spec:
                           name:
                             description: Name of the PodSet to modify. Should match
                               to one of the Workload's PodSets.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           nodeSelector:
                             additionalProperties:
@@ -8769,6 +8771,8 @@ spec:
                       type: integer
                     name:
                       description: name is the PodSet name.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                   required:
                   - count
@@ -8813,7 +8817,7 @@ spec:
                       description: name is the name of the podSet. It should match
                         one of the names in .spec.podSets.
                       maxLength: 63
-                      pattern: ^(?i)[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     resources:
                       additionalProperties:

--- a/client-go/applyconfiguration/kueue/v1beta1/podset.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/podset.go
@@ -19,12 +19,13 @@ package v1beta1
 
 import (
 	v1 "k8s.io/client-go/applyconfigurations/core/v1"
+	kueuev1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 // PodSetApplyConfiguration represents a declarative configuration of the PodSet type for use
 // with apply.
 type PodSetApplyConfiguration struct {
-	Name            *string                                  `json:"name,omitempty"`
+	Name            *kueuev1beta1.PodSetReference            `json:"name,omitempty"`
 	Template        *v1.PodTemplateSpecApplyConfiguration    `json:"template,omitempty"`
 	Count           *int32                                   `json:"count,omitempty"`
 	MinCount        *int32                                   `json:"minCount,omitempty"`
@@ -40,7 +41,7 @@ func PodSet() *PodSetApplyConfiguration {
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Name field is set to the value of the last call.
-func (b *PodSetApplyConfiguration) WithName(value string) *PodSetApplyConfiguration {
+func (b *PodSetApplyConfiguration) WithName(value kueuev1beta1.PodSetReference) *PodSetApplyConfiguration {
 	b.Name = &value
 	return b
 }

--- a/client-go/applyconfiguration/kueue/v1beta1/podsetassignment.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/podsetassignment.go
@@ -25,7 +25,7 @@ import (
 // PodSetAssignmentApplyConfiguration represents a declarative configuration of the PodSetAssignment type for use
 // with apply.
 type PodSetAssignmentApplyConfiguration struct {
-	Name               *string                                                  `json:"name,omitempty"`
+	Name               *kueuev1beta1.PodSetReference                            `json:"name,omitempty"`
 	Flavors            map[v1.ResourceName]kueuev1beta1.ResourceFlavorReference `json:"flavors,omitempty"`
 	ResourceUsage      *v1.ResourceList                                         `json:"resourceUsage,omitempty"`
 	Count              *int32                                                   `json:"count,omitempty"`
@@ -41,7 +41,7 @@ func PodSetAssignment() *PodSetAssignmentApplyConfiguration {
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Name field is set to the value of the last call.
-func (b *PodSetAssignmentApplyConfiguration) WithName(value string) *PodSetAssignmentApplyConfiguration {
+func (b *PodSetAssignmentApplyConfiguration) WithName(value kueuev1beta1.PodSetReference) *PodSetAssignmentApplyConfiguration {
 	b.Name = &value
 	return b
 }

--- a/client-go/applyconfiguration/kueue/v1beta1/podsetrequest.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/podsetrequest.go
@@ -19,13 +19,14 @@ package v1beta1
 
 import (
 	v1 "k8s.io/api/core/v1"
+	kueuev1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 // PodSetRequestApplyConfiguration represents a declarative configuration of the PodSetRequest type for use
 // with apply.
 type PodSetRequestApplyConfiguration struct {
-	Name      *string          `json:"name,omitempty"`
-	Resources *v1.ResourceList `json:"resources,omitempty"`
+	Name      *kueuev1beta1.PodSetReference `json:"name,omitempty"`
+	Resources *v1.ResourceList              `json:"resources,omitempty"`
 }
 
 // PodSetRequestApplyConfiguration constructs a declarative configuration of the PodSetRequest type for use with
@@ -37,7 +38,7 @@ func PodSetRequest() *PodSetRequestApplyConfiguration {
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Name field is set to the value of the last call.
-func (b *PodSetRequestApplyConfiguration) WithName(value string) *PodSetRequestApplyConfiguration {
+func (b *PodSetRequestApplyConfiguration) WithName(value kueuev1beta1.PodSetReference) *PodSetRequestApplyConfiguration {
 	b.Name = &value
 	return b
 }

--- a/client-go/applyconfiguration/kueue/v1beta1/podsetupdate.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/podsetupdate.go
@@ -19,12 +19,13 @@ package v1beta1
 
 import (
 	v1 "k8s.io/client-go/applyconfigurations/core/v1"
+	kueuev1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 // PodSetUpdateApplyConfiguration represents a declarative configuration of the PodSetUpdate type for use
 // with apply.
 type PodSetUpdateApplyConfiguration struct {
-	Name         *string                           `json:"name,omitempty"`
+	Name         *kueuev1beta1.PodSetReference     `json:"name,omitempty"`
 	Labels       map[string]string                 `json:"labels,omitempty"`
 	Annotations  map[string]string                 `json:"annotations,omitempty"`
 	NodeSelector map[string]string                 `json:"nodeSelector,omitempty"`
@@ -40,7 +41,7 @@ func PodSetUpdate() *PodSetUpdateApplyConfiguration {
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Name field is set to the value of the last call.
-func (b *PodSetUpdateApplyConfiguration) WithName(value string) *PodSetUpdateApplyConfiguration {
+func (b *PodSetUpdateApplyConfiguration) WithName(value kueuev1beta1.PodSetReference) *PodSetUpdateApplyConfiguration {
 	b.Name = &value
 	return b
 }

--- a/client-go/applyconfiguration/kueue/v1beta1/reclaimablepod.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/reclaimablepod.go
@@ -17,11 +17,15 @@ limitations under the License.
 
 package v1beta1
 
+import (
+	kueuev1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+)
+
 // ReclaimablePodApplyConfiguration represents a declarative configuration of the ReclaimablePod type for use
 // with apply.
 type ReclaimablePodApplyConfiguration struct {
-	Name  *string `json:"name,omitempty"`
-	Count *int32  `json:"count,omitempty"`
+	Name  *kueuev1beta1.PodSetReference `json:"name,omitempty"`
+	Count *int32                        `json:"count,omitempty"`
 }
 
 // ReclaimablePodApplyConfiguration constructs a declarative configuration of the ReclaimablePod type for use with
@@ -33,7 +37,7 @@ func ReclaimablePod() *ReclaimablePodApplyConfiguration {
 // WithName sets the Name field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Name field is set to the value of the last call.
-func (b *ReclaimablePodApplyConfiguration) WithName(value string) *ReclaimablePodApplyConfiguration {
+func (b *ReclaimablePodApplyConfiguration) WithName(value kueuev1beta1.PodSetReference) *ReclaimablePodApplyConfiguration {
 	b.Name = &value
 	return b
 }

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -8422,7 +8422,7 @@ spec:
                           description: Name is the name of the podSet. It should match
                             one of the names in .spec.podSets.
                           maxLength: 63
-                          pattern: ^(?i)[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         resourceUsage:
                           additionalProperties:
@@ -8581,6 +8581,8 @@ spec:
                           name:
                             description: Name of the PodSet to modify. Should match
                               to one of the Workload's PodSets.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           nodeSelector:
                             additionalProperties:
@@ -8754,6 +8756,8 @@ spec:
                       type: integer
                     name:
                       description: name is the PodSet name.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                   required:
                   - count
@@ -8798,7 +8802,7 @@ spec:
                       description: name is the name of the podSet. It should match
                         one of the names in .spec.podSets.
                       maxLength: 63
-                      pattern: ^(?i)[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                       type: string
                     resources:
                       additionalProperties:

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -251,14 +251,14 @@ type TASPodSetRequests struct {
 type FailureInfo struct {
 	// PodSetName indicates the name of the PodSet for which computing the
 	// TAS assignment failed.
-	PodSetName string
+	PodSetName kueue.PodSetReference
 
 	// Reason indicates the reason why computing the TAS assignment failed.
 	Reason string
 }
 
 // the key in this map is PodSet name
-type TASAssignmentsResult map[string]tasPodSetAssignmentResult
+type TASAssignmentsResult map[kueue.PodSetReference]tasPodSetAssignmentResult
 
 func (r TASAssignmentsResult) Failure() *FailureInfo {
 	for psName, psAssignment := range r {
@@ -281,7 +281,7 @@ type FlavorTASRequests []TASPodSetRequests
 // The simulateEmpty parameter allows to look for the assignment under the
 // assumption that all TAS workloads are preempted.
 func (s *TASFlavorSnapshot) FindTopologyAssignmentsForFlavor(flavorTASRequests FlavorTASRequests, simulateEmpty bool) TASAssignmentsResult {
-	result := make(map[string]tasPodSetAssignmentResult)
+	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
 	assumedUsage := make(map[utiltas.TopologyDomainID]resources.Requests)
 	for _, tr := range flavorTASRequests {
 		assignment, reason := s.findTopologyAssignment(tr, assumedUsage, simulateEmpty)

--- a/pkg/controller/admissionchecks/provisioning/provisioning.go
+++ b/pkg/controller/admissionchecks/provisioning/provisioning.go
@@ -62,7 +62,7 @@ func getProvisioningRequestNamePrefix(workloadName, checkName string) string {
 	return limitObjectName(fullName)
 }
 
-func getProvisioningRequestPodTemplateName(prName, podsetName string) string {
+func getProvisioningRequestPodTemplateName(prName string, podsetName kueue.PodSetReference) string {
 	fullName := fmt.Sprintf("%s-%s-%s", podTemplatesPrefix, prName, podsetName)
 	return limitObjectName(fullName)
 }

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -836,7 +836,7 @@ func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Work
 	if err != nil {
 		return nil
 	}
-	infoMap := slices.ToRefMap(info, func(psi *podset.PodSetInfo) string { return psi.Name })
+	infoMap := slices.ToRefMap(info, func(psi *podset.PodSetInfo) kueue.PodSetReference { return psi.Name })
 	runningPodSets := wl.Spec.DeepCopy().PodSets
 	canBePartiallyAdmitted := workload.CanBePartiallyAdmitted(wl)
 	for i := range runningPodSets {
@@ -1086,7 +1086,7 @@ func getPodSetsInfoFromStatus(ctx context.Context, c client.Client, w *kueue.Wor
 			return nil, err
 		}
 		if features.Enabled(features.TopologyAwareScheduling) {
-			info.Labels[kueuealpha.PodSetLabel] = psAssignment.Name
+			info.Labels[kueuealpha.PodSetLabel] = string(psAssignment.Name)
 			info.Annotations[kueuealpha.WorkloadAnnotation] = w.Name
 		}
 		for _, admissionCheck := range w.Status.AdmissionChecks {

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller.go
@@ -149,7 +149,7 @@ func (aw *AppWrapper) PodSets() ([]kueue.PodSet, error) {
 			}
 		}
 		podSets[psIndex] = kueue.PodSet{
-			Name:            fmt.Sprintf("%s-%v", aw.Name, psIndex),
+			Name:            kueue.NewPodSetReference(fmt.Sprintf("%s-%v", aw.Name, psIndex)),
 			Template:        *podSpecTemplates[psIndex],
 			Count:           awutils.Replicas(awPodSets[psIndex]),
 			TopologyRequest: jobframework.PodSetTopologyRequest(&(podSpecTemplates[psIndex].ObjectMeta), podIndexLabel, subGroupIndexLabel, subGroupCount),

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -812,7 +812,7 @@ func TestReconciler(t *testing.T) {
 			job: *baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
 				Suspend(false).
-				PodLabel(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+				PodLabel(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 				PodAnnotation(kueuealpha.WorkloadAnnotation, "wl").
 				Obj(),
 			workloads: []kueue.Workload{

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -121,7 +121,7 @@ func (j *JobSet) PodSets() ([]kueue.PodSet, error) {
 	podSets := make([]kueue.PodSet, len(j.Spec.ReplicatedJobs))
 	for index, replicatedJob := range j.Spec.ReplicatedJobs {
 		podSets[index] = kueue.PodSet{
-			Name:     replicatedJob.Name,
+			Name:     kueue.NewPodSetReference(replicatedJob.Name),
 			Template: *replicatedJob.Template.Spec.Template.DeepCopy(),
 			Count:    podsCount(&replicatedJob),
 			TopologyRequest: jobframework.PodSetTopologyRequest(&replicatedJob.Template.Spec.Template.ObjectMeta,
@@ -198,7 +198,7 @@ func (j *JobSet) ReclaimablePods() ([]kueue.ReclaimablePod, error) {
 		if status, found := statuses[spec.Name]; found && status.Succeeded > 0 {
 			if status.Succeeded > 0 && status.Succeeded <= spec.Replicas {
 				ret = append(ret, kueue.ReclaimablePod{
-					Name:  spec.Name,
+					Name:  kueue.NewPodSetReference(spec.Name),
 					Count: status.Succeeded * podsCountPerReplica(spec),
 				})
 			}

--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -216,10 +216,10 @@ func TestPodSets(t *testing.T) {
 				Obj()),
 			wantPodSets: func(jobSet *JobSet) []kueue.PodSet {
 				return []kueue.PodSet{
-					*utiltesting.MakePodSet(jobSet.Spec.ReplicatedJobs[0].Name, 2).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(jobSet.Spec.ReplicatedJobs[0].Name), 2).
 						PodSpec(*jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.DeepCopy()).
 						Obj(),
-					*utiltesting.MakePodSet(jobSet.Spec.ReplicatedJobs[1].Name, 6).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(jobSet.Spec.ReplicatedJobs[1].Name), 6).
 						PodSpec(*jobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.DeepCopy()).
 						Obj(),
 				}
@@ -242,7 +242,7 @@ func TestPodSets(t *testing.T) {
 				Obj()),
 			wantPodSets: func(jobSet *JobSet) []kueue.PodSet {
 				return []kueue.PodSet{
-					*utiltesting.MakePodSet(jobSet.Spec.ReplicatedJobs[0].Name, 2).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(jobSet.Spec.ReplicatedJobs[0].Name), 2).
 						PodSpec(*jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.DeepCopy()).
 						Annotations(map[string]string{kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 						RequiredTopologyRequest("cloud.com/block").
@@ -250,7 +250,7 @@ func TestPodSets(t *testing.T) {
 						SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
 						SubGroupCount(ptr.To[int32](2)).
 						Obj(),
-					*utiltesting.MakePodSet(jobSet.Spec.ReplicatedJobs[1].Name, 6).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(jobSet.Spec.ReplicatedJobs[1].Name), 6).
 						PodSpec(*jobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.DeepCopy()).
 						Obj(),
 				}
@@ -273,10 +273,10 @@ func TestPodSets(t *testing.T) {
 				Obj()),
 			wantPodSets: func(jobSet *JobSet) []kueue.PodSet {
 				return []kueue.PodSet{
-					*utiltesting.MakePodSet(jobSet.Spec.ReplicatedJobs[0].Name, 2).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(jobSet.Spec.ReplicatedJobs[0].Name), 2).
 						PodSpec(*jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.DeepCopy()).
 						Obj(),
-					*utiltesting.MakePodSet(jobSet.Spec.ReplicatedJobs[1].Name, 6).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(jobSet.Spec.ReplicatedJobs[1].Name), 6).
 						PodSpec(*jobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.DeepCopy()).
 						Annotations(map[string]string{kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 						PreferredTopologyRequest("cloud.com/block").

--- a/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package paddlejob
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -252,10 +251,10 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			wantPodSets: func(job *kftraining.PaddleJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.PaddleJobReplicaTypeMaster)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.PaddleJobReplicaTypeMaster)), 1).
 						PodSpec(job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeMaster].Template.Spec).
 						Obj(),
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.PaddleJobReplicaTypeWorker)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.PaddleJobReplicaTypeWorker)), 1).
 						PodSpec(job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeWorker].Template.Spec).
 						Obj(),
 				}
@@ -282,13 +281,13 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			wantPodSets: func(job *kftraining.PaddleJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.PaddleJobReplicaTypeMaster)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.PaddleJobReplicaTypeMaster)), 1).
 						PodSpec(job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeMaster].Template.Spec).
 						Annotations(map[string]string{kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/rack"}).
 						RequiredTopologyRequest("cloud.com/rack").
 						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
 						Obj(),
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.PaddleJobReplicaTypeWorker)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.PaddleJobReplicaTypeWorker)), 1).
 						PodSpec(job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeWorker].Template.Spec).
 						Annotations(map[string]string{kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 						PreferredTopologyRequest("cloud.com/block").

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pytorchjob
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -244,10 +243,10 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			wantPodSets: func(job *kftraining.PyTorchJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.PyTorchJobReplicaTypeMaster)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.PyTorchJobReplicaTypeMaster)), 1).
 						PodSpec(job.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeMaster].Template.Spec).
 						Obj(),
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.PyTorchJobReplicaTypeWorker)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.PyTorchJobReplicaTypeWorker)), 1).
 						PodSpec(job.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeWorker].Template.Spec).
 						Obj(),
 				}
@@ -274,13 +273,13 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			wantPodSets: func(job *kftraining.PyTorchJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.PyTorchJobReplicaTypeMaster)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.PyTorchJobReplicaTypeMaster)), 1).
 						PodSpec(job.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeMaster].Template.Spec).
 						Annotations(map[string]string{kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/rack"}).
 						RequiredTopologyRequest("cloud.com/rack").
 						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
 						Obj(),
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.PyTorchJobReplicaTypeWorker)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.PyTorchJobReplicaTypeWorker)), 1).
 						PodSpec(job.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeWorker].Template.Spec).
 						Annotations(map[string]string{kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 						PreferredTopologyRequest("cloud.com/block").

--- a/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tfjob
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -251,13 +250,13 @@ func TestPodSets(t *testing.T) {
 			job: testingtfjob.MakeTFJob("tfjob", "ns").TFReplicaSpecsDefault().Obj(),
 			wantPodSets: func(job *kftraining.TFJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.TFJobReplicaTypeChief)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypeChief)), 1).
 						PodSpec(job.Spec.TFReplicaSpecs[kftraining.TFJobReplicaTypeChief].Template.Spec).
 						Obj(),
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.TFJobReplicaTypePS)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypePS)), 1).
 						PodSpec(job.Spec.TFReplicaSpecs[kftraining.TFJobReplicaTypePS].Template.Spec).
 						Obj(),
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.TFJobReplicaTypeWorker)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypeWorker)), 1).
 						PodSpec(job.Spec.TFReplicaSpecs[kftraining.TFJobReplicaTypeWorker].Template.Spec).
 						Obj(),
 				}
@@ -288,19 +287,19 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			wantPodSets: func(job *kftraining.TFJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.TFJobReplicaTypeChief)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypeChief)), 1).
 						PodSpec(job.Spec.TFReplicaSpecs[kftraining.TFJobReplicaTypeChief].Template.Spec).
 						Annotations(map[string]string{kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/rack"}).
 						RequiredTopologyRequest("cloud.com/rack").
 						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
 						Obj(),
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.TFJobReplicaTypePS)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypePS)), 1).
 						PodSpec(job.Spec.TFReplicaSpecs[kftraining.TFJobReplicaTypePS].Template.Spec).
 						Annotations(map[string]string{kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 						PreferredTopologyRequest("cloud.com/block").
 						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
 						Obj(),
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.TFJobReplicaTypeWorker)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypeWorker)), 1).
 						PodSpec(job.Spec.TFReplicaSpecs[kftraining.TFJobReplicaTypeWorker].Template.Spec).
 						Obj(),
 				}

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package xgboostjob
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -250,10 +249,10 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			wantPodSets: func(job *kftraining.XGBoostJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.XGBoostJobReplicaTypeMaster)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.XGBoostJobReplicaTypeMaster)), 1).
 						PodSpec(job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeMaster].Template.Spec).
 						Obj(),
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.XGBoostJobReplicaTypeWorker)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.XGBoostJobReplicaTypeWorker)), 1).
 						PodSpec(job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeWorker].Template.Spec).
 						Obj(),
 				}
@@ -280,13 +279,13 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			wantPodSets: func(job *kftraining.XGBoostJob) []kueue.PodSet {
 				return []kueue.PodSet{
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.XGBoostJobReplicaTypeMaster)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.XGBoostJobReplicaTypeMaster)), 1).
 						PodSpec(job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeMaster].Template.Spec).
 						Annotations(map[string]string{kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/rack"}).
 						RequiredTopologyRequest("cloud.com/rack").
 						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
 						Obj(),
-					*utiltesting.MakePodSet(strings.ToLower(string(kftraining.XGBoostJobReplicaTypeWorker)), 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kftraining.XGBoostJobReplicaTypeWorker)), 1).
 						PodSpec(job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeWorker].Template.Spec).
 						Annotations(map[string]string{kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 						PreferredTopologyRequest("cloud.com/block").

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
@@ -18,7 +18,6 @@ package kubeflowjob
 
 import (
 	"sort"
-	"strings"
 
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -104,7 +103,7 @@ func (j *KubeflowJob) PodSets() ([]kueue.PodSet, error) {
 	podSets := make([]kueue.PodSet, len(replicaTypes))
 	for index, replicaType := range replicaTypes {
 		podSets[index] = kueue.PodSet{
-			Name:     strings.ToLower(string(replicaType)),
+			Name:     kueue.NewPodSetReference(string(replicaType)),
 			Template: *j.KFJobControl.ReplicaSpecs()[replicaType].Template.DeepCopy(),
 			Count:    podsCount(j.KFJobControl.ReplicaSpecs(), replicaType),
 			TopologyRequest: jobframework.PodSetTopologyRequest(&j.KFJobControl.ReplicaSpecs()[replicaType].Template.ObjectMeta,

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler.go
@@ -132,7 +132,7 @@ func (r *PodReconciler) setDefault(ctx context.Context, pod *corev1.Pod) (bool, 
 	}
 
 	pod.Annotations[podcontroller.GroupTotalCountAnnotation] = fmt.Sprint(ptr.Deref(lws.Spec.LeaderWorkerTemplate.Size, 1))
-	pod.Annotations[podcontroller.RoleHashAnnotation] = kueue.DefaultPodSetName
+	pod.Annotations[podcontroller.RoleHashAnnotation] = string(kueue.DefaultPodSetName)
 
 	if lws.Spec.LeaderWorkerTemplate.LeaderTemplate != nil {
 		if _, ok := pod.Annotations[leaderworkersetv1.LeaderPodNameAnnotationKey]; !ok {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler_test.go
@@ -115,7 +115,7 @@ func TestPodReconciler(t *testing.T) {
 				PrebuiltWorkload(GetWorkloadName(types.UID(testUID), "lws", "0")).
 				Annotation(podcontroller.SuspendedByParentAnnotation, FrameworkName).
 				Annotation(podcontroller.GroupServingAnnotation, "true").
-				Annotation(podcontroller.RoleHashAnnotation, kueue.DefaultPodSetName).
+				Annotation(podcontroller.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
 				Obj(),
 		},
 		"should set default values and priority class when has value": {
@@ -140,7 +140,7 @@ func TestPodReconciler(t *testing.T) {
 				PrebuiltWorkload(GetWorkloadName(types.UID(testUID), "lws", "0")).
 				Annotation(podcontroller.SuspendedByParentAnnotation, FrameworkName).
 				Annotation(podcontroller.GroupServingAnnotation, "true").
-				Annotation(podcontroller.RoleHashAnnotation, kueue.DefaultPodSetName).
+				Annotation(podcontroller.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
 				Obj(),
 		},
 	}

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -121,7 +121,7 @@ func (j *MPIJob) PodSets() ([]kueue.PodSet, error) {
 	podSets := make([]kueue.PodSet, len(replicaTypes))
 	for index, mpiReplicaType := range replicaTypes {
 		podSets[index] = kueue.PodSet{
-			Name:            strings.ToLower(string(mpiReplicaType)),
+			Name:            kueue.NewPodSetReference(string(mpiReplicaType)),
 			Template:        *j.Spec.MPIReplicaSpecs[mpiReplicaType].Template.DeepCopy(),
 			Count:           podsCount(&j.Spec, mpiReplicaType),
 			TopologyRequest: jobframework.PodSetTopologyRequest(&j.Spec.MPIReplicaSpecs[mpiReplicaType].Template.ObjectMeta, ptr.To(kfmpi.ReplicaIndexLabel), nil, nil),

--- a/pkg/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package mpijob
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -203,10 +202,10 @@ func TestPodSets(t *testing.T) {
 		"no annotations": {
 			job: (*MPIJob)(jobTemplate.DeepCopy()),
 			wantPodSets: []kueue.PodSet{
-				*utiltesting.MakePodSet(strings.ToLower(string(kfmpi.MPIReplicaTypeLauncher)), 1).
+				*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeLauncher)), 1).
 					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec).
 					Obj(),
-				*utiltesting.MakePodSet(strings.ToLower(string(kfmpi.MPIReplicaTypeWorker)), 3).
+				*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeWorker)), 3).
 					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec).
 					Obj(),
 			},
@@ -226,13 +225,13 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			),
 			wantPodSets: []kueue.PodSet{
-				*utiltesting.MakePodSet(strings.ToLower(string(kfmpi.MPIReplicaTypeLauncher)), 1).
+				*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeLauncher)), 1).
 					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec).
 					Annotations(map[string]string{kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 					RequiredTopologyRequest("cloud.com/block").
 					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
 					Obj(),
-				*utiltesting.MakePodSet(strings.ToLower(string(kfmpi.MPIReplicaTypeWorker)), 3).
+				*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeWorker)), 3).
 					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec).
 					Annotations(map[string]string{kueuealpha.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 					RequiredTopologyRequest("cloud.com/block").
@@ -255,13 +254,13 @@ func TestPodSets(t *testing.T) {
 				Obj(),
 			),
 			wantPodSets: []kueue.PodSet{
-				*utiltesting.MakePodSet(strings.ToLower(string(kfmpi.MPIReplicaTypeLauncher)), 1).
+				*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeLauncher)), 1).
 					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec).
 					Annotations(map[string]string{kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 					PreferredTopologyRequest("cloud.com/block").
 					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
 					Obj(),
-				*utiltesting.MakePodSet(strings.ToLower(string(kfmpi.MPIReplicaTypeWorker)), 3).
+				*utiltesting.MakePodSet(kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeWorker)), 3).
 					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec).
 					Annotations(map[string]string{kueuealpha.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 					PreferredTopologyRequest("cloud.com/block").

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -672,7 +672,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -727,7 +727,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 3).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 3).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -948,7 +948,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -962,7 +962,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -1019,11 +1019,11 @@ func TestReconciler(t *testing.T) {
 			},
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(*utiltesting.MakePodSet(podUID, 2).Request(corev1.ResourceCPU, "1").Obj()).
+					PodSets(*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).Request(corev1.ResourceCPU, "1").Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", podUID).
+						utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).
 							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 							AssignmentPodCount(2).
 							Obj(),
@@ -1033,11 +1033,11 @@ func TestReconciler(t *testing.T) {
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(*utiltesting.MakePodSet(podUID, 2).Request(corev1.ResourceCPU, "1").Obj()).
+					PodSets(*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).Request(corev1.ResourceCPU, "1").Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", podUID).
+						utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).
 							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 							AssignmentPodCount(2).
 							Obj(),
@@ -1102,7 +1102,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1116,7 +1116,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1125,7 +1125,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Admitted(true).
-					ReclaimablePods(kueue.ReclaimablePod{Name: podUID, Count: 1}).
+					ReclaimablePods(kueue.ReclaimablePod{Name: kueue.NewPodSetReference(podUID), Count: 1}).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -1170,7 +1170,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1184,7 +1184,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1229,7 +1229,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1248,7 +1248,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1311,7 +1311,7 @@ func TestReconciler(t *testing.T) {
 			},
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(*utiltesting.MakePodSet(podUID, 2).Request(corev1.ResourceCPU, "1").Obj()).
+					PodSets(*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue("test-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1326,7 +1326,7 @@ func TestReconciler(t *testing.T) {
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(*utiltesting.MakePodSet(podUID, 2).Request(corev1.ResourceCPU, "1").Obj()).
+					PodSets(*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue("test-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1365,7 +1365,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1390,7 +1390,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1494,7 +1494,7 @@ func TestReconciler(t *testing.T) {
 			wantPods: []corev1.Pod{},
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(*utiltesting.MakePodSet(podUID, 2).Request(corev1.ResourceCPU, "1").Obj()).
+					PodSets(*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).Request(corev1.ResourceCPU, "1").Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Queue("test-queue").
@@ -1565,14 +1565,14 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(1).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1585,14 +1585,14 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(1).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1653,17 +1653,17 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 3).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(3).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(3).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReclaimablePods(kueue.ReclaimablePod{Name: podUID, Count: 1}).
+					ReclaimablePods(kueue.ReclaimablePod{Name: kueue.NewPodSetReference(podUID), Count: 1}).
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
@@ -1704,14 +1704,14 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 3).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(3).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(3).Obj()).
 					ReclaimablePods(kueue.ReclaimablePod{
-						Name:  podUID,
+						Name:  kueue.NewPodSetReference(podUID),
 						Count: 1,
 					}).
 					Admitted(true).
@@ -1719,7 +1719,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement", "test-uid").
-					ReclaimablePods(kueue.ReclaimablePod{Name: podUID, Count: 1}).
+					ReclaimablePods(kueue.ReclaimablePod{Name: kueue.NewPodSetReference(podUID), Count: 1}).
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
@@ -1795,7 +1795,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1810,7 +1810,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1864,7 +1864,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 1).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1891,7 +1891,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 1).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1943,7 +1943,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 1).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -1970,7 +1970,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 1).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2079,7 +2079,7 @@ func TestReconciler(t *testing.T) {
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
-					PodSets(*utiltesting.MakePodSet(podUID, 2).Request(corev1.ResourceCPU, "1").NodeName("test-node").Obj()).
+					PodSets(*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).Request(corev1.ResourceCPU, "1").NodeName("test-node").Obj()).
 					Queue("test-queue").
 					Priority(0).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
@@ -2140,7 +2140,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2160,7 +2160,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2206,7 +2206,7 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("absent-pod-role", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
-						*utiltesting.MakePodSet(podUID, 1).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2228,7 +2228,7 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("absent-pod-role", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
-						*utiltesting.MakePodSet(podUID, 1).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2330,7 +2330,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
@@ -2467,7 +2467,7 @@ func TestReconciler(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Request(corev1.ResourceMemory, "1Gi").
 							Obj(),
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2492,7 +2492,7 @@ func TestReconciler(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Request(corev1.ResourceMemory, "1Gi").
 							Obj(),
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2594,7 +2594,7 @@ func TestReconciler(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Request(corev1.ResourceMemory, "1Gi").
 							Obj(),
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2619,7 +2619,7 @@ func TestReconciler(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Request(corev1.ResourceMemory, "1Gi").
 							Obj(),
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2712,7 +2712,7 @@ func TestReconciler(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Request(corev1.ResourceMemory, "1Gi").
 							Obj(),
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2737,7 +2737,7 @@ func TestReconciler(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Request(corev1.ResourceMemory, "1Gi").
 							Obj(),
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2794,7 +2794,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 1).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -2877,7 +2877,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2890,7 +2890,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2949,7 +2949,7 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("aaf269e6", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
-						*utiltesting.MakePodSet(podUID, 1).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -2971,7 +2971,7 @@ func TestReconciler(t *testing.T) {
 						*utiltesting.MakePodSet("aaf269e6", 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
-						*utiltesting.MakePodSet(podUID, 1).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3067,7 +3067,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 1).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3079,7 +3079,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 1).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3148,7 +3148,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3163,7 +3163,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3236,7 +3236,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 1).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -3365,7 +3365,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 3).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3385,7 +3385,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 3).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3483,7 +3483,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 3).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3510,7 +3510,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 3).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3580,7 +3580,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 3).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3604,7 +3604,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 3).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 3).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3766,7 +3766,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 4).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 4).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3788,7 +3788,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 4).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 4).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3889,7 +3889,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -3903,7 +3903,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -4002,7 +4002,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 4).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 4).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -4022,7 +4022,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 4).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 4).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -4125,7 +4125,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -4322,7 +4322,7 @@ func TestReconciler(t *testing.T) {
 						Message: "Not admitted, ETA: 2024-02-22T10:36:40Z.",
 					}).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -4349,7 +4349,7 @@ func TestReconciler(t *testing.T) {
 						Message: "Not admitted, ETA: 2024-02-22T10:36:40Z.",
 					}).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: "kueue.x-k8s.io/admission"}).
 							Obj(),
@@ -4416,7 +4416,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -4424,7 +4424,7 @@ func TestReconciler(t *testing.T) {
 					Priority(0).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4452,7 +4452,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
@@ -4461,7 +4461,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4507,14 +4507,14 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4543,14 +4543,14 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4582,14 +4582,14 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4618,14 +4618,14 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4664,14 +4664,14 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4701,14 +4701,14 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4747,14 +4747,14 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -4790,14 +4790,14 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -4844,14 +4844,14 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadEvicted,
@@ -4892,14 +4892,14 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadEvicted,
@@ -4943,14 +4943,14 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -4993,14 +4993,14 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -5046,14 +5046,14 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -5088,14 +5088,14 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(
-						*utiltesting.MakePodSet(podUID, 2).
+						*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", podUID).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -5717,7 +5717,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 
 	wl := *utiltesting.MakeWorkload("test-group", "ns").
 		PodSets(
-			*utiltesting.MakePodSet(podUID, 2).
+			*utiltesting.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 				Request(corev1.ResourceCPU, "1").
 				Obj(),
 		).

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -125,7 +125,7 @@ func (j *RayCluster) PodSets() ([]kueue.PodSet, error) {
 			count *= wgs.NumOfHosts
 		}
 		podSets[index+1] = kueue.PodSet{
-			Name:            strings.ToLower(wgs.GroupName),
+			Name:            kueue.NewPodSetReference(wgs.GroupName),
 			Template:        *wgs.Template.DeepCopy(),
 			Count:           count,
 			TopologyRequest: jobframework.PodSetTopologyRequest(&wgs.Template.ObjectMeta, nil, nil, nil),

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -134,7 +134,7 @@ func (j *RayJob) PodSets() ([]kueue.PodSet, error) {
 			count *= wgs.NumOfHosts
 		}
 		podSets = append(podSets, kueue.PodSet{
-			Name:            strings.ToLower(wgs.GroupName),
+			Name:            kueue.NewPodSetReference(wgs.GroupName),
 			Template:        *wgs.Template.DeepCopy(),
 			Count:           count,
 			TopologyRequest: jobframework.PodSetTopologyRequest(&wgs.Template.ObjectMeta, nil, nil, nil),

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -120,12 +120,12 @@ func TestPodSets(t *testing.T) {
 						Annotations(rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Annotations).
 						RequiredTopologyRequest("cloud.com/block").
 						Obj(),
-					*utiltesting.MakePodSet(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName, 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName), 1).
 						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
 						Annotations(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Annotations).
 						RequiredTopologyRequest("cloud.com/block").
 						Obj(),
-					*utiltesting.MakePodSet(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].GroupName, 3).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].GroupName), 3).
 						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Spec.DeepCopy()).
 						Obj(),
 				}
@@ -173,10 +173,10 @@ func TestPodSets(t *testing.T) {
 						Annotations(rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Annotations).
 						PreferredTopologyRequest("cloud.com/block").
 						Obj(),
-					*utiltesting.MakePodSet(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName, 1).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName), 1).
 						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
 						Obj(),
-					*utiltesting.MakePodSet(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].GroupName, 3).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].GroupName), 3).
 						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Spec.DeepCopy()).
 						Annotations(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Annotations).
 						PreferredTopologyRequest("cloud.com/block").
@@ -216,10 +216,10 @@ func TestPodSets(t *testing.T) {
 					*utiltesting.MakePodSet(headGroupPodSetName, 1).
 						PodSpec(*rayJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.DeepCopy()).
 						Obj(),
-					*utiltesting.MakePodSet(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName, 4).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName), 4).
 						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.DeepCopy()).
 						Obj(),
-					*utiltesting.MakePodSet(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].GroupName, 12).
+					*utiltesting.MakePodSet(kueue.NewPodSetReference(rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].GroupName), 12).
 						PodSpec(*rayJob.Spec.RayClusterSpec.WorkerGroupSpecs[1].Template.Spec.DeepCopy()).
 						Obj(),
 				}

--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -253,10 +253,10 @@ func (r *topologyUngater) Generic(event event.GenericEvent) bool {
 	return false
 }
 
-func (r *topologyUngater) podsForPodSet(ctx context.Context, ns, wlName, psName string) ([]*corev1.Pod, error) {
+func (r *topologyUngater) podsForPodSet(ctx context.Context, ns, wlName string, psName kueue.PodSetReference) ([]*corev1.Pod, error) {
 	var pods corev1.PodList
 	if err := r.client.List(ctx, &pods, client.InNamespace(ns), client.MatchingLabels{
-		kueuealpha.PodSetLabel: psName,
+		kueuealpha.PodSetLabel: string(psName),
 	}, client.MatchingFields{
 		indexer.WorkloadNameKey: wlName,
 	}); err != nil {

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -143,14 +143,14 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 			},
 			wantCounts: []counts{
@@ -191,23 +191,23 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 			},
 			wantCounts: []counts{
@@ -255,23 +255,23 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 			},
 			wantCounts: []counts{
@@ -300,14 +300,14 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -328,14 +328,14 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -368,14 +368,14 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -407,13 +407,13 @@ func TestReconcile(t *testing.T) {
 			},
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -484,7 +484,7 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Gate("example.com/gate").
@@ -493,7 +493,7 @@ func TestReconcile(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Gate("example.com/gate").
@@ -537,7 +537,7 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Gate("example.com/gate").
 					Obj(),
@@ -545,7 +545,7 @@ func TestReconcile(t *testing.T) {
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Gate("example.com/gate").
@@ -589,28 +589,28 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod-already-running", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodRunning).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod-already-running", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodRunning).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -652,28 +652,28 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod-already-running", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodFailed).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod-already-running", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodFailed).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -716,26 +716,26 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").UID("x").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").UID("y").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").UID("x").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").UID("y").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -778,28 +778,28 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod-already-succeeded", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodSucceeded).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod-already-succeeded", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodSucceeded).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod-gated", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 			},
 			wantCounts: []counts{
@@ -841,26 +841,26 @@ func TestReconcile(t *testing.T) {
 			pods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").UID("x").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").UID("y").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
 				*testingpod.MakePod("pod1", "ns").UID("x").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("pod2", "ns").UID("y").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -921,33 +921,33 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "3").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p4", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "4").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -956,35 +956,35 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "3").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p4", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "4").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1059,31 +1059,31 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "3").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p4", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "4").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1092,35 +1092,35 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "3").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("p4", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "4").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1196,25 +1196,25 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1223,22 +1223,22 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					Obj(),
 			},
 			wantCounts: []counts{
@@ -1296,7 +1296,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodFailed).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
@@ -1304,7 +1304,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1313,7 +1313,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					StatusPhase(corev1.PodFailed).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
@@ -1321,7 +1321,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("p1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1386,7 +1386,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
@@ -1394,7 +1394,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p2", "ns").
@@ -1402,7 +1402,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
@@ -1410,7 +1410,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1421,7 +1421,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1430,7 +1430,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1439,7 +1439,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -1448,7 +1448,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1527,7 +1527,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p1", "ns").
@@ -1535,7 +1535,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1544,7 +1544,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -1553,7 +1553,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1564,7 +1564,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1573,7 +1573,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1582,7 +1582,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "0").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -1591,7 +1591,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1670,7 +1670,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("p3", "ns").
@@ -1678,7 +1678,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1689,7 +1689,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "0").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1698,7 +1698,7 @@ func TestReconcile(t *testing.T) {
 					Label(batchv1.JobCompletionIndexAnnotation, "1").
 					Label(jobset.JobIndexKey, "1").
 					Label(jobset.ReplicatedJobReplicas, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1766,28 +1766,28 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("l0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "launcher").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -1796,7 +1796,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("l0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "launcher").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1804,7 +1804,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1812,7 +1812,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -1820,7 +1820,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1895,21 +1895,21 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("l0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "launcher").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1917,7 +1917,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -1927,7 +1927,7 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("l0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "launcher").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1935,7 +1935,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1943,7 +1943,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -1951,7 +1951,7 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kftraining.JobRoleLabel, "worker").
 					Label(kftraining.ReplicaIndexLabel, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -2026,25 +2026,25 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("w0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w3", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "3").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 			},
@@ -2053,28 +2053,28 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("w0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("w1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("w2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
 				*testingpod.MakePod("w3", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "3").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
@@ -2149,26 +2149,26 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("w0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("w2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					TopologySchedulingGate().
 					Obj(),
 				*testingpod.MakePod("w3", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "3").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
@@ -2178,28 +2178,28 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("w0", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "0").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("w1", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "1").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),
 				*testingpod.MakePod("w2", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "2").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b1").
 					NodeSelector(tasRackLabel, "r2").
 					Obj(),
 				*testingpod.MakePod("w3", "ns").
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(kueuealpha.PodGroupPodIndexLabel, "3").
-					Label(kueuealpha.PodSetLabel, kueue.DefaultPodSetName).
+					Label(kueuealpha.PodSetLabel, string(kueue.DefaultPodSetName)).
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),

--- a/pkg/podset/podset.go
+++ b/pkg/podset/podset.go
@@ -42,7 +42,7 @@ var (
 )
 
 type PodSetInfo struct {
-	Name            string
+	Name            kueue.PodSetReference
 	Count           int32
 	Annotations     map[string]string
 	Labels          map[string]string

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -58,7 +58,7 @@ func (a *Assignment) Borrows() bool {
 	return a.Borrowing
 }
 
-func (a *Assignment) podSetAssignmentByName(psName string) *PodSetAssignment {
+func (a *Assignment) podSetAssignmentByName(psName kueue.PodSetReference) *PodSetAssignment {
 	if idx := slices.IndexFunc(a.PodSets, func(ps PodSetAssignment) bool { return ps.Name == psName }); idx != -1 {
 		return &a.PodSets[idx]
 	}
@@ -99,7 +99,7 @@ func (a *Assignment) Message() string {
 			builder.WriteString("; ")
 		}
 		builder.WriteString("couldn't assign flavors to pod set ")
-		builder.WriteString(ps.Name)
+		builder.WriteString(string(ps.Name))
 		builder.WriteString(": ")
 		builder.WriteString(ps.Status.Message())
 	}
@@ -177,7 +177,7 @@ func (s *Status) Equal(o *Status) bool {
 // .Flavors and .Status can't be empty at the same time, once PodSetAssignment
 // is fully calculated.
 type PodSetAssignment struct {
-	Name     string
+	Name     kueue.PodSetReference
 	Flavors  ResourceAssignment
 	Status   *Status
 	Requests corev1.ResourceList

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -363,7 +363,7 @@ func (w *WorkloadWrapper) PastAdmittedTime(v int32) *WorkloadWrapper {
 
 type PodSetWrapper struct{ kueue.PodSet }
 
-func MakePodSet(name string, count int) *PodSetWrapper {
+func MakePodSet(name kueue.PodSetReference, count int) *PodSetWrapper {
 	return &PodSetWrapper{
 		kueue.PodSet{
 			Name:  name,
@@ -532,7 +532,7 @@ func (p *PodSetWrapper) PodOverHead(resources corev1.ResourceList) *PodSetWrappe
 // AdmissionWrapper wraps an Admission
 type AdmissionWrapper struct{ kueue.Admission }
 
-func MakeAdmission(cq string, podSetNames ...string) *AdmissionWrapper {
+func MakeAdmission(cq string, podSetNames ...kueue.PodSetReference) *AdmissionWrapper {
 	wrap := &AdmissionWrapper{kueue.Admission{
 		ClusterQueue: kueue.ClusterQueueReference(cq),
 	}}

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -1564,7 +1564,7 @@ workloads assigned to this LocalQueue.</p>
     
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
-<code>string</code>
+<a href="#kueue-x-k8s-io-v1beta1-PodSetReference"><code>PodSetReference</code></a>
 </td>
 <td>
    <p>name is the PodSet name.</p>
@@ -1630,7 +1630,7 @@ enabled.</p>
     
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
-<code>string</code>
+<a href="#kueue-x-k8s-io-v1beta1-PodSetReference"><code>PodSetReference</code></a>
 </td>
 <td>
    <p>Name is the name of the podSet. It should match one of the names in .spec.podSets.</p>
@@ -1717,6 +1717,28 @@ count: 2</li>
 </tbody>
 </table>
 
+## `PodSetReference`     {#kueue-x-k8s-io-v1beta1-PodSetReference}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [PodSet](#kueue-x-k8s-io-v1beta1-PodSet)
+
+- [PodSetAssignment](#kueue-x-k8s-io-v1beta1-PodSetAssignment)
+
+- [PodSetRequest](#kueue-x-k8s-io-v1beta1-PodSetRequest)
+
+- [PodSetUpdate](#kueue-x-k8s-io-v1beta1-PodSetUpdate)
+
+- [ReclaimablePod](#kueue-x-k8s-io-v1beta1-ReclaimablePod)
+
+
+<p>PodSetReference is the name of a PodSet.</p>
+
+
+
+
 ## `PodSetRequest`     {#kueue-x-k8s-io-v1beta1-PodSetRequest}
     
 
@@ -1732,7 +1754,7 @@ count: 2</li>
     
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
-<code>string</code>
+<a href="#kueue-x-k8s-io-v1beta1-PodSetReference"><code>PodSetReference</code></a>
 </td>
 <td>
    <p>name is the name of the podSet. It should match one of the names in .spec.podSets.</p>
@@ -1837,7 +1859,7 @@ result in failure during workload admission.</p>
     
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
-<code>string</code>
+<a href="#kueue-x-k8s-io-v1beta1-PodSetReference"><code>PodSetReference</code></a>
 </td>
 <td>
    <p>Name of the PodSet to modify. Should match to one of the Workload's PodSets.</p>
@@ -2020,7 +2042,7 @@ re-queuing an evicted workload.</p>
     
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
-<code>string</code>
+<a href="#kueue-x-k8s-io-v1beta1-PodSetReference"><code>PodSetReference</code></a>
 </td>
 <td>
    <p>name is the PodSet name.</p>

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -550,7 +550,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					createdWl := kueue.Workload{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &createdWl)).To(gomega.Succeed())
 
-					admission := testing.MakeAdmission("cq", container.Name).Obj()
+					admission := testing.MakeAdmission("cq", kueue.NewPodSetReference(container.Name)).Obj()
 					g.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, admission)).To(gomega.Succeed())
 					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -620,7 +620,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			admission := testing.MakeAdmission("q", job.Spec.Template.Spec.Containers[0].Name).Obj()
+			admission := testing.MakeAdmission("q", kueue.NewPodSetReference(job.Spec.Template.Spec.Containers[0].Name)).Obj()
 			gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, admission)).To(gomega.Succeed())
 			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
 		})

--- a/test/integration/singlecluster/controller/jobs/kubeflow/kubeflowjob.go
+++ b/test/integration/singlecluster/controller/jobs/kubeflow/kubeflowjob.go
@@ -320,15 +320,15 @@ type PodSetsResource struct {
 }
 
 func CreatePodSetAssignment(createdWorkload *kueue.Workload, podSetsResource []PodSetsResource) []kueue.PodSetAssignment {
-	pda := []kueue.PodSetAssignment{}
+	pda := make([]kueue.PodSetAssignment, len(podSetsResource))
 	for i, psr := range podSetsResource {
-		pda = append(pda, kueue.PodSetAssignment{
-			Name: string(psr.RoleName),
+		pda[i] = kueue.PodSetAssignment{
+			Name: kueue.NewPodSetReference(string(psr.RoleName)),
 			Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 				corev1.ResourceCPU: psr.ResourceCPU,
 			},
 			Count: ptr.To(createdWorkload.Spec.PodSets[i].Count),
-		})
+		}
 	}
 	return pda
 }

--- a/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
@@ -18,7 +18,6 @@ package mpijob
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	kfmpi "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
@@ -166,14 +165,14 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 		admission := testing.MakeAdmission(clusterQueue.Name).
 			PodSets(
 				kueue.PodSetAssignment{
-					Name: "Launcher",
+					Name: kueue.NewPodSetReference("launcher"),
 					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 						corev1.ResourceCPU: "on-demand",
 					},
 					Count: ptr.To(createdWorkload.Spec.PodSets[0].Count),
 				},
 				kueue.PodSetAssignment{
-					Name: "Worker",
+					Name: kueue.NewPodSetReference("worker"),
 					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 						corev1.ResourceCPU: "spot",
 					},
@@ -228,14 +227,14 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 		admission = testing.MakeAdmission(clusterQueue.Name).
 			PodSets(
 				kueue.PodSetAssignment{
-					Name: "Launcher",
+					Name: kueue.NewPodSetReference("launcher"),
 					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 						corev1.ResourceCPU: "on-demand",
 					},
 					Count: ptr.To(createdWorkload.Spec.PodSets[0].Count),
 				},
 				kueue.PodSetAssignment{
-					Name: "Worker",
+					Name: kueue.NewPodSetReference("worker"),
 					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 						corev1.ResourceCPU: "spot",
 					},
@@ -391,14 +390,14 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				admission := testing.MakeAdmission(clusterQueueAc.Name).
 					PodSets(
 						kueue.PodSetAssignment{
-							Name: "launcher",
+							Name: kueue.NewPodSetReference("launcher"),
 							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 								corev1.ResourceCPU: "test-flavor",
 							},
 							Count: ptr.To(createdWorkload.Spec.PodSets[0].Count),
 						},
 						kueue.PodSetAssignment{
-							Name: "worker",
+							Name: kueue.NewPodSetReference("worker"),
 							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 								corev1.ResourceCPU: "test-flavor",
 							},
@@ -639,14 +638,14 @@ var _ = ginkgo.Describe("Job controller when waitForPodsReady enabled", ginkgo.O
 			admission := testing.MakeAdmission("foo").
 				PodSets(
 					kueue.PodSetAssignment{
-						Name: "Launcher",
+						Name: kueue.NewPodSetReference("launcher"),
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "default",
 						},
 						Count: ptr.To(createdWorkload.Spec.PodSets[0].Count),
 					},
 					kueue.PodSetAssignment{
-						Name: "Worker",
+						Name: kueue.NewPodSetReference("worker"),
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "default",
 						},
@@ -1028,7 +1027,7 @@ var _ = ginkgo.Describe("MPIJob controller when TopologyAwareScheduling enabled"
 				g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).Should(gomega.Succeed())
 				g.Expect(wl.Spec.PodSets).Should(gomega.BeComparableTo([]kueue.PodSet{
 					{
-						Name:  strings.ToLower(string(kfmpi.MPIReplicaTypeLauncher)),
+						Name:  kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeLauncher)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
 							Required:      ptr.To(testing.DefaultBlockTopologyLevel),
@@ -1036,7 +1035,7 @@ var _ = ginkgo.Describe("MPIJob controller when TopologyAwareScheduling enabled"
 						},
 					},
 					{
-						Name:  strings.ToLower(string(kfmpi.MPIReplicaTypeWorker)),
+						Name:  kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
 							Preferred:     ptr.To(testing.DefaultRackTopologyLevel),

--- a/test/integration/singlecluster/controller/jobs/paddlejob/paddlejob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/paddlejob/paddlejob_controller_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package paddlejob
 
 import (
-	"strings"
-
 	"github.com/google/go-cmp/cmp/cmpopts"
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	"github.com/onsi/ginkgo/v2"
@@ -414,7 +412,7 @@ var _ = ginkgo.Describe("PaddleJob controller when TopologyAwareScheduling enabl
 				g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).Should(gomega.Succeed())
 				g.Expect(wl.Spec.PodSets).Should(gomega.BeComparableTo([]kueue.PodSet{
 					{
-						Name:  strings.ToLower(string(kftraining.PaddleJobReplicaTypeMaster)),
+						Name:  kueue.NewPodSetReference(string(kftraining.PaddleJobReplicaTypeMaster)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
 							Required:      ptr.To(testing.DefaultRackTopologyLevel),
@@ -422,7 +420,7 @@ var _ = ginkgo.Describe("PaddleJob controller when TopologyAwareScheduling enabl
 						},
 					},
 					{
-						Name:  strings.ToLower(string(kftraining.PaddleJobReplicaTypeWorker)),
+						Name:  kueue.NewPodSetReference(string(kftraining.PaddleJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
 							Preferred:     ptr.To(testing.DefaultBlockTopologyLevel),

--- a/test/integration/singlecluster/controller/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package pytorchjob
 
 import (
-	"strings"
-
 	"github.com/google/go-cmp/cmp/cmpopts"
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	"github.com/onsi/ginkgo/v2"
@@ -721,7 +719,7 @@ var _ = ginkgo.Describe("PyTorchJob controller when TopologyAwareScheduling enab
 				g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).Should(gomega.Succeed())
 				g.Expect(wl.Spec.PodSets).Should(gomega.BeComparableTo([]kueue.PodSet{
 					{
-						Name:  strings.ToLower(string(kftraining.PyTorchJobReplicaTypeMaster)),
+						Name:  kueue.NewPodSetReference(string(kftraining.PyTorchJobReplicaTypeMaster)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
 							Required:      ptr.To(testing.DefaultRackTopologyLevel),
@@ -729,7 +727,7 @@ var _ = ginkgo.Describe("PyTorchJob controller when TopologyAwareScheduling enab
 						},
 					},
 					{
-						Name:  strings.ToLower(string(kftraining.PyTorchJobReplicaTypeWorker)),
+						Name:  kueue.NewPodSetReference(string(kftraining.PyTorchJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
 							Preferred:     ptr.To(testing.DefaultBlockTopologyLevel),

--- a/test/integration/singlecluster/controller/jobs/tfjob/tfjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/tfjob/tfjob_controller_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package tfjob
 
 import (
-	"strings"
-
 	"github.com/google/go-cmp/cmp/cmpopts"
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	"github.com/onsi/ginkgo/v2"
@@ -436,7 +434,7 @@ var _ = ginkgo.Describe("TFJob controller when TopologyAwareScheduling enabled",
 				g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).Should(gomega.Succeed())
 				g.Expect(wl.Spec.PodSets).Should(gomega.BeComparableTo([]kueue.PodSet{
 					{
-						Name:  strings.ToLower(string(kftraining.TFJobReplicaTypeChief)),
+						Name:  kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypeChief)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
 							Required:      ptr.To(testing.DefaultRackTopologyLevel),
@@ -444,7 +442,7 @@ var _ = ginkgo.Describe("TFJob controller when TopologyAwareScheduling enabled",
 						},
 					},
 					{
-						Name:  strings.ToLower(string(kftraining.TFJobReplicaTypePS)),
+						Name:  kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypePS)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
 							Required:      ptr.To(testing.DefaultRackTopologyLevel),
@@ -452,7 +450,7 @@ var _ = ginkgo.Describe("TFJob controller when TopologyAwareScheduling enabled",
 						},
 					},
 					{
-						Name:  strings.ToLower(string(kftraining.TFJobReplicaTypeWorker)),
+						Name:  kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
 							Preferred:     ptr.To(testing.DefaultBlockTopologyLevel),

--- a/test/integration/singlecluster/controller/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package xgboostjob
 
 import (
-	"strings"
-
 	"github.com/google/go-cmp/cmp/cmpopts"
 	kftraining "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
 	"github.com/onsi/ginkgo/v2"
@@ -411,7 +409,7 @@ var _ = ginkgo.Describe("XGBoostJob controller when TopologyAwareScheduling enab
 				g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).Should(gomega.Succeed())
 				g.Expect(wl.Spec.PodSets).Should(gomega.BeComparableTo([]kueue.PodSet{
 					{
-						Name:  strings.ToLower(string(kftraining.XGBoostJobReplicaTypeMaster)),
+						Name:  kueue.NewPodSetReference(string(kftraining.XGBoostJobReplicaTypeMaster)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
 							Required:      ptr.To(testing.DefaultRackTopologyLevel),
@@ -419,7 +417,7 @@ var _ = ginkgo.Describe("XGBoostJob controller when TopologyAwareScheduling enab
 						},
 					},
 					{
-						Name:  strings.ToLower(string(kftraining.XGBoostJobReplicaTypeWorker)),
+						Name:  kueue.NewPodSetReference(string(kftraining.XGBoostJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
 							Preferred:     ptr.To(testing.DefaultBlockTopologyLevel),

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -111,7 +111,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 		ginkgo.DescribeTable("Should have valid PodSet when creating", func(podSetsCapacity int, podSetCount int, isInvalid bool) {
 			podSets := make([]kueue.PodSet, podSetsCapacity)
 			for i := range podSets {
-				podSets[i] = *testing.MakePodSet(fmt.Sprintf("ps%d", i), podSetCount).Obj()
+				podSets[i] = *testing.MakePodSet(kueue.NewPodSetReference(fmt.Sprintf("ps%d", i)), podSetCount).Obj()
 			}
 			workload := testing.MakeWorkload(workloadName, ns.Name).PodSets(podSets...).Obj()
 			err := k8sClient.Create(ctx, workload)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
To introduce additional compile-time checking for the types. This way we know the key represented as "string" is PodSet name, not a random string.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4242

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ACTION REQUIRED: If you implement the GenericJob interface you need to update the implementation as
the PodSet.Name field has changed its type from string to PodSetReference.
```