### PR TITLE
Serialization support for FlavorResource, FlavorResourceSet and FlavorResourceQuantities

### DIFF
--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"encoding/json"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -29,20 +30,16 @@ type FlavorResource struct {
 	Resource corev1.ResourceName
 }
 
-func (fr FlavorResource) MarshalJSON() ([]byte, error) {
-	return json.Marshal(string(fr.Flavor) + " - " + string(fr.Resource))
+func (fr FlavorResource) String() string {
+	return fmt.Sprintf(`{"Flavor":"%s","Resource":"%s"}`, string(fr.Flavor), string(fr.Resource))
 }
 
 type FlavorResourceQuantities map[FlavorResource]int64
 
 func (q FlavorResourceQuantities) MarshalJSON() ([]byte, error) {
-	temp := make(map[string]int64)
+	temp := make(map[string]int64, len(q))
 	for flavourResource, num := range q {
-		keyJSON, err := json.Marshal(flavourResource)
-		if err != nil {
-			return nil, err
-		}
-		temp[string(keyJSON)] = num
+		temp[flavourResource.String()] = num
 	}
 	return json.Marshal(temp)
 }

--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resources
 
 import (
+	"encoding/json"
+
 	corev1 "k8s.io/api/core/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -27,4 +29,20 @@ type FlavorResource struct {
 	Resource corev1.ResourceName
 }
 
+func (fr FlavorResource) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(fr.Flavor) + " - " + string(fr.Resource))
+}
+
 type FlavorResourceQuantities map[FlavorResource]int64
+
+func (q FlavorResourceQuantities) MarshalJSON() ([]byte, error) {
+	temp := make(map[string]int64)
+	for flavourResource, num := range q {
+		keyJSON, err := json.Marshal(flavourResource)
+		if err != nil {
+			return nil, err
+		}
+		temp[string(keyJSON)] = num
+	}
+	return json.Marshal(temp)
+}

--- a/pkg/scheduler/preemption/preemption_oracle.go
+++ b/pkg/scheduler/preemption/preemption_oracle.go
@@ -18,6 +18,7 @@ package preemption
 
 import (
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/resources"
@@ -45,7 +46,7 @@ func (p *PreemptionOracle) IsReclaimPossible(log logr.Logger, cq *cache.ClusterQ
 		preemptor:         wl,
 		preemptorCQ:       p.snapshot.ClusterQueue(wl.ClusterQueue),
 		snapshot:          p.snapshot,
-		frsNeedPreemption: NewFlavorResourceSet(fr),
+		frsNeedPreemption: sets.New(fr),
 		requests:          resources.FlavorResourceQuantities{fr: quantity},
 	}) {
 		if candidate.WorkloadInfo.ClusterQueue == cq.Name {

--- a/pkg/scheduler/preemption/preemption_oracle.go
+++ b/pkg/scheduler/preemption/preemption_oracle.go
@@ -18,7 +18,6 @@ package preemption
 
 import (
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/resources"
@@ -46,7 +45,7 @@ func (p *PreemptionOracle) IsReclaimPossible(log logr.Logger, cq *cache.ClusterQ
 		preemptor:         wl,
 		preemptorCQ:       p.snapshot.ClusterQueue(wl.ClusterQueue),
 		snapshot:          p.snapshot,
-		frsNeedPreemption: sets.New(fr),
+		frsNeedPreemption: NewFlavorResourceSet(fr),
 		requests:          resources.FlavorResourceQuantities{fr: quantity},
 	}) {
 		if candidate.WorkloadInfo.ClusterQueue == cq.Name {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
/kind bug
-->

#### What this PR does / why we need it:
Properly serializes FlavorResource, FlavorResourceSet and FlavorResourceQuantities types which are logged in integration tests.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4137 

#### Special notes for your reviewer:
As discussed in #4137 part of this issue depends on making serializable `k8s.io/apimachinery/pkg/util/sets.Set` in upstream repo.  In the second commit I created `FlavorResourceSet` type to make it work without changing upstream code.   Possible options are to keep it temporarily until upstream is fixed, keep it permanently, or just discart and keep only the first commit and wait till upstream issue is fixed.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```