### PR TITLE
Use SinglePodRequests internally for TopologyDomainRequests

### DIFF
--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -86,7 +86,7 @@ func (c *ClusterQueueSnapshot) updateTASUsage(wi *workload.Info, op usageOp) {
 			if tasFlvCache := c.TASFlavors[tasFlavor]; tasFlvCache != nil {
 				for _, tr := range tasUsage {
 					domainID := utiltas.DomainID(tr.Values)
-					tasFlvCache.updateTASUsage(domainID, tr.Requests, op)
+					tasFlvCache.updateTASUsage(domainID, tr.TotalRequests(), op)
 				}
 			}
 		}

--- a/pkg/cache/tas_flavor.go
+++ b/pkg/cache/tas_flavor.go
@@ -162,10 +162,10 @@ func (c *TASFlavorCache) updateUsage(topologyRequests []workload.TopologyDomainR
 			c.usage[domainID] = resources.Requests{}
 		}
 		if op == subtract {
-			c.usage[domainID].Sub(tr.Requests)
+			c.usage[domainID].Sub(tr.TotalRequests())
 			c.usage[domainID].Sub(resources.Requests{corev1.ResourcePods: int64(tr.Count)})
 		} else {
-			c.usage[domainID].Add(tr.Requests)
+			c.usage[domainID].Add(tr.TotalRequests())
 			c.usage[domainID].Add(resources.Requests{corev1.ResourcePods: int64(tr.Count)})
 		}
 	}

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -43,6 +43,18 @@ func (r Requests) Clone() Requests {
 	return maps.Clone(r)
 }
 
+func (r Requests) ScaledUp(f int64) Requests {
+	ret := r.Clone()
+	ret.Mul(f)
+	return ret
+}
+
+func (r Requests) ScaledDown(f int64) Requests {
+	ret := r.Clone()
+	ret.Divide(f)
+	return ret
+}
+
 func (r Requests) Divide(f int64) {
 	for k := range r {
 		r[k] /= f

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -56,8 +56,7 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 		return nil, errors.New("workload requires Topology, but there is no TAS cache information")
 	}
 	psResources := wl.TotalRequests[podSetIndex]
-	singlePodRequests := psResources.Requests.Clone()
-	singlePodRequests.Divide(int64(psResources.Count))
+	singlePodRequests := psResources.SinglePodRequests()
 	podCount := psAssignment.Count
 	tasFlvr, err := onlyFlavor(psAssignment.Flavors)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

To simplify the code in tas_flavorassigner.go and workload.go.

And to make transitioning between SinglePodRequests and TotalRequests one-liners.

#### Special notes for your reviewer:

Longer term I would consider something like "PodGroupResources" with two functions: SinglePodResources() and TotalResources(), and it could be used in the TopologyDomainRequests.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```