### PR TITLE
TAS: cleanup FindTopologyAssignmentsForFlavor

### DIFF
--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -248,6 +248,10 @@ type TASPodSetRequests struct {
 	Flavor            kueue.ResourceFlavorReference
 }
 
+func (t *TASPodSetRequests) TotalRequests() resources.Requests {
+	return t.SinglePodRequests.ScaledUp(int64(t.Count))
+}
+
 type FailureInfo struct {
 	// PodSetName indicates the name of the PodSet for which computing the
 	// TAS assignment failed.
@@ -291,12 +295,10 @@ func (s *TASFlavorSnapshot) FindTopologyAssignmentsForFlavor(flavorTASRequests F
 		}
 		for _, domain := range assignment.Domains {
 			domainID := utiltas.DomainID(domain.Values)
-			assumedDomainUsage := tr.SinglePodRequests.Clone()
-			assumedDomainUsage.Mul(int64(domain.Count))
 			if assumedUsage[domainID] == nil {
 				assumedUsage[domainID] = resources.Requests{}
 			}
-			assumedUsage[domainID].Add(assumedDomainUsage)
+			assumedUsage[domainID].Add(tr.TotalRequests())
 		}
 	}
 	return result


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

To offload the logic in FindTopologyAssignmentsForFlavor, and to prepare aligning the TASPodSetRequests and PodSetRequests structures.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```