### PR TITLE
Fix preemption with TAS failure in the case of fulfilled pods count limit on Nodes

### DIFF
--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -88,7 +88,7 @@ func (c *ClusterQueueSnapshot) updateTASUsage(usage workload.TASUsage, op usageO
 			if tasFlvCache := c.TASFlavors[tasFlavor]; tasFlvCache != nil {
 				for _, tr := range tasUsage {
 					domainID := utiltas.DomainID(tr.Values)
-					tasFlvCache.updateTASUsage(domainID, tr.TotalRequests(), op)
+					tasFlvCache.updateTASUsage(domainID, tr.TotalRequests(), op, tr.Count)
 				}
 			}
 		}

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -212,11 +212,13 @@ func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, us
 	s.leaves[domainID].freeCapacity.Sub(resources.Requests{corev1.ResourcePods: 1})
 }
 
-func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp) {
+func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp, count int32) {
+	u := usage.Clone()
+	u.Add(resources.Requests{corev1.ResourcePods: int64(count)})
 	if op == add {
-		s.addTASUsage(domainID, usage)
+		s.addTASUsage(domainID, u)
 	} else {
-		s.removeTASUsage(domainID, usage)
+		s.removeTASUsage(domainID, u)
 	}
 }
 
@@ -321,7 +323,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
 	simulateEmpty bool) (*kueue.TopologyAssignment, string) {
 	topologyRequest := tasPodSetRequests.PodSet.TopologyRequest
-	requests := tasPodSetRequests.SinglePodRequests
+	requests := tasPodSetRequests.SinglePodRequests.Clone()
 	requests.Add(resources.Requests{corev1.ResourcePods: 1})
 	podSetTolerations := tasPodSetRequests.PodSet.Template.Spec.Tolerations
 	count := tasPodSetRequests.Count

--- a/pkg/util/testingjobs/node/wrappers.go
+++ b/pkg/util/testingjobs/node/wrappers.go
@@ -41,6 +41,11 @@ func (n *NodeWrapper) Obj() *corev1.Node {
 	return &n.Node
 }
 
+// Clone returns a deep copy of the NodeWrapper.
+func (n *NodeWrapper) Clone() *NodeWrapper {
+	return &NodeWrapper{Node: *n.Obj().DeepCopy()}
+}
+
 // Name updates the name of the node
 func (n *NodeWrapper) Name(name string) *NodeWrapper {
 	n.ObjectMeta.Name = name
@@ -63,8 +68,13 @@ func (n *NodeWrapper) StatusConditions(conditions ...corev1.NodeCondition) *Node
 }
 
 // StatusAllocatable updates the allocatable resources of the Node.
-func (n *NodeWrapper) StatusAllocatable(resourceList corev1.ResourceList) *NodeWrapper {
-	n.Status.Allocatable = resourceList
+func (n *NodeWrapper) StatusAllocatable(resources corev1.ResourceList) *NodeWrapper {
+	if n.Status.Allocatable == nil {
+		n.Status.Allocatable = make(corev1.ResourceList, len(resources))
+	}
+	for rName, rQuantity := range resources {
+		n.Status.Allocatable[rName] = rQuantity
+	}
 	return n
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
I fixed two bugs as I described in #4436 and #4439.

The solution for #4436 is cloning the SinglePodRequests object to avoid write operation propagation.

The solution for #4439 is to count up and down the number of Pods in the `TASFlavorSnapshot.updateTASUsage`.
By this pods count, the preemptor can appropriately simulate if candidates preemptee allows higher workloads to make a room in the following:

https://github.com/kubernetes-sigs/kueue/blob/6e25ebfcf2491236e385f644e4f7280c3d315ead/pkg/scheduler/preemption/preemption.go#L289-L297

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4436
Fixes #4439

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```