### PR TITLE
Add metrics service to deployments and fix prometheus and helm

### DIFF
--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -81,3 +81,4 @@ The following table lists the configurable parameters of the kueue chart and the
 | `managerConfig.controllerManagerConfigYaml`            | controllerManagerConfigYaml                            | abbr.                                       |
 | `metricsService`                                       | metricsService's ports                                 | abbr.                                       |
 | `webhookService`                                       | webhookService's ports                                 | abbr.                                       |
+| `metrics.prometheusNamespace`                          | prometheus namespace                                   | `monitoring`                                |

--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -47,6 +47,9 @@ spec:
         - containerPort: 9443
           name: webhook-server
           protocol: TCP
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz

--- a/charts/kueue/templates/prometheus/role.yaml
+++ b/charts/kueue/templates/prometheus/role.yaml
@@ -48,8 +48,8 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s
-  namespace: '{{ .Release.Namespace }}'
+  namespace: '{{ .Values.metrics.prometheusNamespace }}'
 - kind: ServiceAccount
   name: prometheus-operator
-  namespace: '{{ .Release.Namespace }}'
+  namespace: '{{ .Values.metrics.prometheusNamespace }}'
 {{- end }}

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -137,7 +137,7 @@ metricsService:
     - name: https
       port: 8443
       protocol: TCP
-      targetPort: https
+      targetPort: 8443
   type: ClusterIP
   annotations: {}
 webhookService:
@@ -153,3 +153,6 @@ webhookService:
 
 # kueue-viz dashboard
 enableKueueViz: false
+
+metrics:
+  prometheusNamespace: monitoring

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -49,6 +49,9 @@ patches:
 # Expose port used by the visibility server
 - path: manager_visibility_patch.yaml
 
+# Expose port used by the metrics service
+- path: manager_metrics_patch.yaml
+
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection

--- a/config/default/manager_metrics_patch.yaml
+++ b/config/default/manager_metrics_patch.yaml
@@ -1,0 +1,15 @@
+# This patch exposes 8443 port used by metrics service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          ports:
+          - containerPort: 8443
+            name: metrics
+            protocol: TCP


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

a) Add metric ports to deployments for both kustomize and helm.
b) Fix prometheus so it does not assume prometheus is deployed in the kueue namespace.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
I found this issue because I was having trouble getting my kind cluster to find my metrics service.

It turns out that we were not binding the metrics service to the deployment.

This was found by checking the endpoints of `kueue-controller-metrics-service` and seeing that it was in fact not being used.

When we dropped kube-rbac-proxy, we dropped the creation of the metrics in the deployment spec.

I don't think this a regression as we dropped kube-rbac-proxy for 0.11. 0.10 seems to be fine.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```