### PR TITLE
Introduce the helper struct for preemptedWorkloads

### DIFF
--- a/pkg/scheduler/preempted_workloads.go
+++ b/pkg/scheduler/preempted_workloads.go
@@ -1,0 +1,39 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+type preemptedWorkloads map[string]*workload.Info
+
+func (p preemptedWorkloads) hasAny(newTargets []*preemption.Target) bool {
+	for _, target := range newTargets {
+		if _, found := p[workload.Key(target.WorkloadInfo.Obj)]; found {
+			return true
+		}
+	}
+	return false
+}
+
+func (p preemptedWorkloads) insert(newTargets []*preemption.Target) {
+	for _, target := range newTargets {
+		p[workload.Key(target.WorkloadInfo.Obj)] = target.WorkloadInfo
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

To offload the code of the main schedule function, and to prepare for https://github.com/kubernetes-sigs/kueue/pull/4418 and https://github.com/kubernetes-sigs/kueue/pull/4449 which requires to know the list of preempted workloads as `[]*workload.Info`, not just set of strings.


#### Special notes for your reviewer:

The computational complexity of `hasAny` and `insert` is `O(|newTargets|)` as before.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```