### PR TITLE
Refactor the accounting for preempted workloads in scheduler

### DIFF
--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -68,6 +68,24 @@ func (c *ClusterQueueSnapshot) RGByResource(resource corev1.ResourceName) *Resou
 	return nil
 }
 
+// SimulateUsageRemoval the snapshot by removing the usage corresponding to the
+// list of workloads. It returns the function which can be used to restore
+// the usage.
+func (c *ClusterQueueSnapshot) SimulateUsageRemoval(workloads []*workload.Info) func() {
+	var usage []workload.Usage
+	for _, w := range workloads {
+		usage = append(usage, w.Usage())
+	}
+	for _, u := range usage {
+		c.removeUsage(u)
+	}
+	return func() {
+		for _, u := range usage {
+			c.AddUsage(u)
+		}
+	}
+}
+
 func (c *ClusterQueueSnapshot) AddUsage(usage workload.Usage) {
 	for fr, q := range usage.Quota {
 		addUsage(c, fr, q)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

To prepare for the main [PR](https://github.com/kubernetes-sigs/kueue/pull/4418)

#### Special notes for your reviewer:

It builds on top of https://github.com/kubernetes-sigs/kueue/pull/4447.

The refactoring is needed for TAS because the concept of netUsage hard to define in the context of TAS. 

It does not worsen the asymptotic computational complexity, because when computing the set of preempted workloads in preemption.go we anyway had to simulate the removal of the usage of the workloads. In the worst case scenario, we re-do, but typically this will be only a small fraction of all computations done during determining the list of workloads to preempt.

Also, with this refactoring we are opening the possibility of allowing preemptions of multiple workloads with overlapping preemptions, but I keep the condition in this PR.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```