### PR TITLE
Unexport manager fields

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -192,7 +192,7 @@ func (c *Cache) PodsReadyForAllAdmittedWorkloads(log logr.Logger) bool {
 }
 
 func (c *Cache) podsReadyForAllAdmittedWorkloads(log logr.Logger) bool {
-	for _, cq := range c.hm.GetClusterQueuesCopy() {
+	for _, cq := range c.hm.ClusterQueues() {
 		if len(cq.WorkloadsNotReady) > 0 {
 			log.V(3).Info("There is a ClusterQueue with not ready workloads", "clusterQueue", klog.KRef("", cq.Name))
 			return false
@@ -215,7 +215,7 @@ func (c *Cache) CleanUpOnContext(ctx context.Context) {
 func (c *Cache) updateClusterQueues() sets.Set[string] {
 	cqs := sets.New[string]()
 
-	for _, cq := range c.hm.GetClusterQueuesCopy() {
+	for _, cq := range c.hm.ClusterQueues() {
 		prevStatus := cq.Status
 		// We call update on all ClusterQueues irrespective of which CQ actually use this flavor
 		// because it is not expensive to do so, and is not worth tracking which ClusterQueues use
@@ -234,7 +234,7 @@ func (c *Cache) ActiveClusterQueues() sets.Set[string] {
 	c.RLock()
 	defer c.RUnlock()
 	cqs := sets.New[string]()
-	for _, cq := range c.hm.GetClusterQueuesCopy() {
+	for _, cq := range c.hm.ClusterQueues() {
 		if cq.Status == active {
 			cqs.Insert(cq.Name)
 		}
@@ -306,7 +306,7 @@ func (c *Cache) DeleteAdmissionCheck(ac *kueue.AdmissionCheck) sets.Set[string] 
 func (c *Cache) AdmissionChecksForClusterQueue(cqName string) []AdmissionCheck {
 	c.RLock()
 	defer c.RUnlock()
-	cq := c.hm.GetClusterQueue(cqName)
+	cq := c.hm.ClusterQueue(cqName)
 	if cq == nil || len(cq.AdmissionChecks) == 0 {
 		return nil
 	}
@@ -330,7 +330,7 @@ func (c *Cache) ClusterQueueTerminating(name string) bool {
 func (c *Cache) ClusterQueueReadiness(name string) (metav1.ConditionStatus, string, string) {
 	c.RLock()
 	defer c.RUnlock()
-	cq := c.hm.GetClusterQueue(name)
+	cq := c.hm.ClusterQueue(name)
 	if cq == nil {
 		return metav1.ConditionFalse, "NotFound", "ClusterQueue not found"
 	}
@@ -345,7 +345,7 @@ func (c *Cache) clusterQueueInStatus(name string, status metrics.ClusterQueueSta
 	c.RLock()
 	defer c.RUnlock()
 
-	cq := c.hm.GetClusterQueue(name)
+	cq := c.hm.ClusterQueue(name)
 	if cq == nil {
 		return false
 	}
@@ -355,7 +355,7 @@ func (c *Cache) clusterQueueInStatus(name string, status metrics.ClusterQueueSta
 func (c *Cache) TerminateClusterQueue(name string) {
 	c.Lock()
 	defer c.Unlock()
-	if cq := c.hm.GetClusterQueue(name); cq != nil {
+	if cq := c.hm.ClusterQueue(name); cq != nil {
 		cq.Status = terminating
 		metrics.ReportClusterQueueStatus(cq.Name, cq.Status)
 	}
@@ -367,7 +367,7 @@ func (c *Cache) TerminateClusterQueue(name string) {
 func (c *Cache) ClusterQueueEmpty(name string) bool {
 	c.RLock()
 	defer c.RUnlock()
-	cq := c.hm.GetClusterQueue(name)
+	cq := c.hm.ClusterQueue(name)
 	if cq == nil {
 		return true
 	}
@@ -378,7 +378,7 @@ func (c *Cache) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) err
 	c.Lock()
 	defer c.Unlock()
 
-	if oldCq := c.hm.GetClusterQueue(cq.Name); oldCq != nil {
+	if oldCq := c.hm.ClusterQueue(cq.Name); oldCq != nil {
 		return errors.New("ClusterQueue already exists")
 	}
 	cqImpl, err := c.newClusterQueue(cq)
@@ -422,7 +422,7 @@ func (c *Cache) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) err
 func (c *Cache) UpdateClusterQueue(cq *kueue.ClusterQueue) error {
 	c.Lock()
 	defer c.Unlock()
-	cqImpl := c.hm.GetClusterQueue(cq.Name)
+	cqImpl := c.hm.ClusterQueue(cq.Name)
 	if cqImpl == nil {
 		return ErrCqNotFound
 	}
@@ -443,12 +443,12 @@ func (c *Cache) UpdateClusterQueue(cq *kueue.ClusterQueue) error {
 func (c *Cache) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 	c.Lock()
 	defer c.Unlock()
-	curCq := c.hm.GetClusterQueue(cq.Name)
+	curCq := c.hm.ClusterQueue(cq.Name)
 	if curCq == nil {
 		return
 	}
 	if features.Enabled(features.LocalQueueMetrics) {
-		for _, q := range c.hm.GetClusterQueue(cq.Name).localQueues {
+		for _, q := range c.hm.ClusterQueue(cq.Name).localQueues {
 			metrics.ClearLocalQueueCacheMetrics(metrics.LQRefFromLocalQueueKey(q.key))
 		}
 	}
@@ -460,7 +460,7 @@ func (c *Cache) AddOrUpdateCohort(apiCohort *kueuealpha.Cohort) error {
 	c.Lock()
 	defer c.Unlock()
 	c.hm.AddCohort(apiCohort.Name)
-	cohort := c.hm.GetCohort(apiCohort.Name)
+	cohort := c.hm.Cohort(apiCohort.Name)
 	oldParent := cohort.Parent()
 	c.hm.UpdateCohortEdge(apiCohort.Name, apiCohort.Spec.Parent)
 	return cohort.updateCohort(c.hm.CycleChecker, apiCohort, oldParent)
@@ -474,7 +474,7 @@ func (c *Cache) DeleteCohort(cohortName string) {
 	// If the cohort still exists after deletion, it means
 	// that it has one or more children referencing it.
 	// We need to run update algorithm.
-	if cohort := c.hm.GetCohort(cohortName); cohort != nil {
+	if cohort := c.hm.Cohort(cohortName); cohort != nil {
 		updateCohortResourceNode(cohort)
 	}
 }
@@ -482,7 +482,7 @@ func (c *Cache) DeleteCohort(cohortName string) {
 func (c *Cache) AddLocalQueue(q *kueue.LocalQueue) error {
 	c.Lock()
 	defer c.Unlock()
-	cq := c.hm.GetClusterQueue(string(q.Spec.ClusterQueue))
+	cq := c.hm.ClusterQueue(string(q.Spec.ClusterQueue))
 	if cq == nil {
 		return nil
 	}
@@ -492,7 +492,7 @@ func (c *Cache) AddLocalQueue(q *kueue.LocalQueue) error {
 func (c *Cache) DeleteLocalQueue(q *kueue.LocalQueue) {
 	c.Lock()
 	defer c.Unlock()
-	cq := c.hm.GetClusterQueue(string(q.Spec.ClusterQueue))
+	cq := c.hm.ClusterQueue(string(q.Spec.ClusterQueue))
 	if cq == nil {
 		return
 	}
@@ -505,11 +505,11 @@ func (c *Cache) UpdateLocalQueue(oldQ, newQ *kueue.LocalQueue) error {
 	}
 	c.Lock()
 	defer c.Unlock()
-	cq := c.hm.GetClusterQueue(string(oldQ.Spec.ClusterQueue))
+	cq := c.hm.ClusterQueue(string(oldQ.Spec.ClusterQueue))
 	if cq != nil {
 		cq.deleteLocalQueue(oldQ)
 	}
-	cq = c.hm.GetClusterQueue(string(newQ.Spec.ClusterQueue))
+	cq = c.hm.ClusterQueue(string(newQ.Spec.ClusterQueue))
 	if cq != nil {
 		return cq.addLocalQueue(newQ)
 	}
@@ -527,7 +527,7 @@ func (c *Cache) addOrUpdateWorkload(w *kueue.Workload) bool {
 		return false
 	}
 
-	clusterQueue := c.hm.GetClusterQueue(string(w.Status.Admission.ClusterQueue))
+	clusterQueue := c.hm.ClusterQueue(string(w.Status.Admission.ClusterQueue))
 	if clusterQueue == nil {
 		return false
 	}
@@ -548,7 +548,7 @@ func (c *Cache) UpdateWorkload(oldWl, newWl *kueue.Workload) error {
 	c.Lock()
 	defer c.Unlock()
 	if workload.HasQuotaReservation(oldWl) {
-		cq := c.hm.GetClusterQueue(string(oldWl.Status.Admission.ClusterQueue))
+		cq := c.hm.ClusterQueue(string(oldWl.Status.Admission.ClusterQueue))
 		if cq == nil {
 			return errors.New("old ClusterQueue doesn't exist")
 		}
@@ -559,7 +559,7 @@ func (c *Cache) UpdateWorkload(oldWl, newWl *kueue.Workload) error {
 	if !workload.HasQuotaReservation(newWl) {
 		return nil
 	}
-	cq := c.hm.GetClusterQueue(string(newWl.Status.Admission.ClusterQueue))
+	cq := c.hm.ClusterQueue(string(newWl.Status.Admission.ClusterQueue))
 	if cq == nil {
 		return errors.New("new ClusterQueue doesn't exist")
 	}
@@ -595,7 +595,7 @@ func (c *Cache) IsAssumedOrAdmittedWorkload(w workload.Info) bool {
 	if _, assumed := c.assumedWorkloads[k]; assumed {
 		return true
 	}
-	if cq := c.hm.GetClusterQueue(w.ClusterQueue); cq != nil {
+	if cq := c.hm.ClusterQueue(w.ClusterQueue); cq != nil {
 		if _, admitted := cq.Workloads[k]; admitted {
 			return true
 		}
@@ -617,7 +617,7 @@ func (c *Cache) AssumeWorkload(w *kueue.Workload) error {
 		return fmt.Errorf("the workload is already assumed to ClusterQueue %q", assumedCq)
 	}
 
-	cq := c.hm.GetClusterQueue(string(w.Status.Admission.ClusterQueue))
+	cq := c.hm.ClusterQueue(string(w.Status.Admission.ClusterQueue))
 	if cq == nil {
 		return ErrCqNotFound
 	}
@@ -642,7 +642,7 @@ func (c *Cache) ForgetWorkload(w *kueue.Workload) error {
 		return errWorkloadNotAdmitted
 	}
 
-	cq := c.hm.GetClusterQueue(string(w.Status.Admission.ClusterQueue))
+	cq := c.hm.ClusterQueue(string(w.Status.Admission.ClusterQueue))
 	if cq == nil {
 		return ErrCqNotFound
 	}
@@ -666,7 +666,7 @@ func (c *Cache) Usage(cqObj *kueue.ClusterQueue) (*ClusterQueueUsageStats, error
 	c.RLock()
 	defer c.RUnlock()
 
-	cq := c.hm.GetClusterQueue(cqObj.Name)
+	cq := c.hm.ClusterQueue(cqObj.Name)
 	if cq == nil {
 		return nil, ErrCqNotFound
 	}
@@ -733,7 +733,7 @@ func (c *Cache) LocalQueueUsage(qObj *kueue.LocalQueue) (*LocalQueueUsageStats, 
 	c.RLock()
 	defer c.RUnlock()
 
-	cqImpl := c.hm.GetClusterQueue(string(qObj.Spec.ClusterQueue))
+	cqImpl := c.hm.ClusterQueue(string(qObj.Spec.ClusterQueue))
 	if cqImpl == nil {
 		return &LocalQueueUsageStats{}, nil
 	}
@@ -811,7 +811,7 @@ func (c *Cache) cleanupAssumedState(w *kueue.Workload) {
 		// If the workload's assigned ClusterQueue is different from the assumed
 		// one, then we should also clean up the assumed one.
 		if workload.HasQuotaReservation(w) && assumedCQName != string(w.Status.Admission.ClusterQueue) {
-			if assumedCQ := c.hm.GetClusterQueue(assumedCQName); assumedCQ != nil {
+			if assumedCQ := c.hm.ClusterQueue(assumedCQName); assumedCQ != nil {
 				assumedCQ.deleteWorkload(w)
 			}
 		}
@@ -821,10 +821,10 @@ func (c *Cache) cleanupAssumedState(w *kueue.Workload) {
 
 func (c *Cache) clusterQueueForWorkload(w *kueue.Workload) *clusterQueue {
 	if workload.HasQuotaReservation(w) {
-		return c.hm.GetClusterQueue(string(w.Status.Admission.ClusterQueue))
+		return c.hm.ClusterQueue(string(w.Status.Admission.ClusterQueue))
 	}
 	wKey := workload.Key(w)
-	for _, cq := range c.hm.GetClusterQueuesCopy() {
+	for _, cq := range c.hm.ClusterQueues() {
 		if cq.Workloads[wKey] != nil {
 			return cq
 		}
@@ -837,7 +837,7 @@ func (c *Cache) ClusterQueuesUsingFlavor(flavor kueue.ResourceFlavorReference) [
 	defer c.RUnlock()
 	var cqs []string
 
-	for _, cq := range c.hm.GetClusterQueuesCopy() {
+	for _, cq := range c.hm.ClusterQueues() {
 		if cq.flavorInUse(flavor) {
 			cqs = append(cqs, cq.Name)
 		}
@@ -850,7 +850,7 @@ func (c *Cache) ClusterQueuesUsingTopology(tName kueue.TopologyReference) []stri
 	defer c.RUnlock()
 	var cqs []string
 
-	for _, cq := range c.hm.GetClusterQueuesCopy() {
+	for _, cq := range c.hm.ClusterQueues() {
 		for _, tRef := range cq.tasFlavors {
 			if tRef == tName {
 				cqs = append(cqs, cq.Name)
@@ -865,7 +865,7 @@ func (c *Cache) ClusterQueuesUsingAdmissionCheck(ac string) []string {
 	defer c.RUnlock()
 	var cqs []string
 
-	for _, cq := range c.hm.GetClusterQueuesCopy() {
+	for _, cq := range c.hm.ClusterQueues() {
 		if _, found := cq.AdmissionChecks[ac]; found {
 			cqs = append(cqs, cq.Name)
 		}
@@ -878,7 +878,7 @@ func (c *Cache) MatchingClusterQueues(nsLabels map[string]string) sets.Set[strin
 	defer c.RUnlock()
 
 	cqs := sets.New[string]()
-	for _, cq := range c.hm.GetClusterQueuesCopy() {
+	for _, cq := range c.hm.ClusterQueues() {
 		if cq.NamespaceSelector.Matches(labels.Set(nsLabels)) {
 			cqs.Insert(cq.Name)
 		}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1107,7 +1107,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			if err := tc.operation(cache); err != nil {
 				t.Errorf("Unexpected error during test operation: %s", err)
 			}
-			if diff := cmp.Diff(tc.wantClusterQueues, cache.hm.ClusterQueues,
+			if diff := cmp.Diff(tc.wantClusterQueues, cache.hm.GetClusterQueuesCopy(),
 				cmpopts.IgnoreFields(clusterQueue{}, "ResourceGroups"),
 				cmpopts.IgnoreFields(workload.Info{}, "Obj", "LastAssignment"),
 				cmpopts.IgnoreUnexported(clusterQueue{}, hierarchy.ClusterQueue[*cohort]{}),
@@ -1115,8 +1115,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				t.Errorf("Unexpected clusterQueues (-want,+got):\n%s", diff)
 			}
 
-			gotCohorts := make(map[string]sets.Set[string], len(cache.hm.Cohorts))
-			for name, cohort := range cache.hm.Cohorts {
+			cohorts := cache.hm.GetCohortsCopy()
+			gotCohorts := make(map[string]sets.Set[string], len(cohorts))
+			for name, cohort := range cohorts {
 				gotCohort := sets.New[string]()
 				for _, cq := range cohort.ChildCQs() {
 					gotCohort.Insert(cq.Name)
@@ -1681,7 +1682,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}
 			gotResult := make(map[string]result)
-			for name, cq := range cache.hm.ClusterQueues {
+			for name, cq := range cache.hm.GetClusterQueuesCopy() {
 				gotResult[name] = result{
 					Workloads:     sets.KeySet(cq.Workloads),
 					UsedResources: cq.resourceNode.Usage,
@@ -2725,7 +2726,7 @@ func TestCacheQueueOperations(t *testing.T) {
 				}
 			}
 			cacheQueues := make(map[string]*queue)
-			for _, cacheCQ := range cache.hm.ClusterQueues {
+			for _, cacheCQ := range cache.hm.GetClusterQueuesCopy() {
 				for qKey, cacheQ := range cacheCQ.localQueues {
 					if _, ok := cacheQueues[qKey]; ok {
 						t.Fatalf("The cache have a duplicated localQueue %q across multiple clusterQueues", qKey)
@@ -2979,7 +2980,7 @@ func TestCachePodsReadyForAllAdmittedWorkloads(t *testing.T) {
 				return nil
 			},
 			operation: func(cache *Cache) error {
-				wl := cache.hm.ClusterQueues["one"].Workloads["/a"].Obj
+				wl := cache.hm.GetClusterQueue("one").Workloads["/a"].Obj
 				newWl := wl.DeepCopy()
 				apimeta.SetStatusCondition(&newWl.Status.Conditions, metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
@@ -3002,7 +3003,7 @@ func TestCachePodsReadyForAllAdmittedWorkloads(t *testing.T) {
 				return nil
 			},
 			operation: func(cache *Cache) error {
-				wl := cache.hm.ClusterQueues["one"].Workloads["/a"].Obj
+				wl := cache.hm.GetClusterQueue("one").Workloads["/a"].Obj
 				newWl := wl.DeepCopy()
 				apimeta.SetStatusCondition(&newWl.Status.Conditions, metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
@@ -3049,7 +3050,7 @@ func TestCachePodsReadyForAllAdmittedWorkloads(t *testing.T) {
 				return nil
 			},
 			operation: func(cache *Cache) error {
-				wl2 := cache.hm.ClusterQueues["two"].Workloads["/b"].Obj
+				wl2 := cache.hm.GetClusterQueue("two").Workloads["/b"].Obj
 				newWl2 := wl2.DeepCopy()
 				apimeta.SetStatusCondition(&newWl2.Status.Conditions, metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
@@ -3072,7 +3073,7 @@ func TestCachePodsReadyForAllAdmittedWorkloads(t *testing.T) {
 				return nil
 			},
 			operation: func(cache *Cache) error {
-				wl := cache.hm.ClusterQueues["one"].Workloads["/a"].Obj
+				wl := cache.hm.GetClusterQueue("one").Workloads["/a"].Obj
 				return cache.DeleteWorkload(wl)
 			},
 			wantReady: true,
@@ -3089,7 +3090,7 @@ func TestCachePodsReadyForAllAdmittedWorkloads(t *testing.T) {
 				return cache.AssumeWorkload(wl)
 			},
 			operation: func(cache *Cache) error {
-				wl := cache.hm.ClusterQueues["one"].Workloads["/a"].Obj
+				wl := cache.hm.GetClusterQueue("one").Workloads["/a"].Obj
 				return cache.ForgetWorkload(wl)
 			},
 			wantReady: true,
@@ -3231,7 +3232,9 @@ func TestIsAssumedOrAdmittedCheckWorkload(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cache := New(utiltesting.NewFakeClient())
-			cache.hm.ClusterQueues = tc.clusterQueues
+			for _, cq := range tc.clusterQueues {
+				cache.hm.AddClusterQueue(cq)
+			}
 			cache.assumedWorkloads = tc.assumedWorkloads
 			if cache.IsAssumedOrAdmittedWorkload(tc.workload) != tc.expected {
 				t.Error("Unexpected response")
@@ -3542,7 +3545,7 @@ func TestCohortCycles(t *testing.T) {
 		}
 
 		// cohort's SubtreeQuota contains resources from cq.
-		gotResource := cache.hm.Cohorts["cohort"].getResourceNode()
+		gotResource := cache.hm.GetCohort("cohort").getResourceNode()
 		wantResource := ResourceNode{
 			Quotas: map[resources.FlavorResource]ResourceQuota{
 				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000},
@@ -3579,7 +3582,7 @@ func TestCohortCycles(t *testing.T) {
 		}
 
 		// cohort's SubtreeQuota contains resources from cq
-		gotResource := cache.hm.Cohorts["cohort"].getResourceNode()
+		gotResource := cache.hm.GetCohort("cohort").getResourceNode()
 		wantResource := ResourceNode{
 			Quotas: map[resources.FlavorResource]ResourceQuota{
 				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000},
@@ -3600,7 +3603,7 @@ func TestCohortCycles(t *testing.T) {
 		}
 
 		// Cohort's SubtreeQuota no longer contains resources from CQ.
-		gotResource = cache.hm.Cohorts["cohort"].getResourceNode()
+		gotResource = cache.hm.GetCohort("cohort").getResourceNode()
 		wantResource = ResourceNode{
 			Quotas: map[resources.FlavorResource]ResourceQuota{
 				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000},
@@ -3646,10 +3649,10 @@ func TestCohortCycles(t *testing.T) {
 				SubtreeQuota: resources.FlavorResourceQuantities{},
 				Usage:        resources.FlavorResourceQuantities{},
 			}
-			if diff := cmp.Diff(wantRoot1, cache.hm.Cohorts["root1"].getResourceNode()); diff != "" {
+			if diff := cmp.Diff(wantRoot1, cache.hm.GetCohort("root1").getResourceNode()); diff != "" {
 				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
 			}
-			if diff := cmp.Diff(wantRoot2, cache.hm.Cohorts["root2"].getResourceNode()); diff != "" {
+			if diff := cmp.Diff(wantRoot2, cache.hm.GetCohort("root2").getResourceNode()); diff != "" {
 				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
 			}
 		}
@@ -3671,10 +3674,10 @@ func TestCohortCycles(t *testing.T) {
 				},
 				Usage: resources.FlavorResourceQuantities{},
 			}
-			if diff := cmp.Diff(wantRoot1, cache.hm.Cohorts["root1"].getResourceNode()); diff != "" {
+			if diff := cmp.Diff(wantRoot1, cache.hm.GetCohort("root1").getResourceNode()); diff != "" {
 				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
 			}
-			if diff := cmp.Diff(wantRoot2, cache.hm.Cohorts["root2"].getResourceNode()); diff != "" {
+			if diff := cmp.Diff(wantRoot2, cache.hm.GetCohort("root2").getResourceNode()); diff != "" {
 				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
 			}
 		}
@@ -3708,7 +3711,7 @@ func TestCohortCycles(t *testing.T) {
 			},
 			Usage: resources.FlavorResourceQuantities{},
 		}
-		if diff := cmp.Diff(wantRoot, cache.hm.Cohorts["root"].getResourceNode()); diff != "" {
+		if diff := cmp.Diff(wantRoot, cache.hm.GetCohort("root").getResourceNode()); diff != "" {
 			t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
 		}
 	})
@@ -3739,7 +3742,7 @@ func TestCohortCycles(t *testing.T) {
 				},
 				Usage: resources.FlavorResourceQuantities{},
 			}
-			if diff := cmp.Diff(wantRoot, cache.hm.Cohorts["root"].getResourceNode()); diff != "" {
+			if diff := cmp.Diff(wantRoot, cache.hm.GetCohort("root").getResourceNode()); diff != "" {
 				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
 			}
 		}
@@ -3756,7 +3759,7 @@ func TestCohortCycles(t *testing.T) {
 				SubtreeQuota: resources.FlavorResourceQuantities{},
 				Usage:        resources.FlavorResourceQuantities{},
 			}
-			if diff := cmp.Diff(wantRoot, cache.hm.Cohorts["root"].getResourceNode()); diff != "" {
+			if diff := cmp.Diff(wantRoot, cache.hm.GetCohort("root").getResourceNode()); diff != "" {
 				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
 			}
 		}

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -169,7 +169,7 @@ func TestClusterQueueUpdate(t *testing.T) {
 			}
 			if diff := cmp.Diff(
 				tc.wantLastAssignmentGeneration,
-				snapshot.GetClusterQueue("eng-alpha").AllocatableResourceGeneration); diff != "" {
+				snapshot.ClusterQueue("eng-alpha").AllocatableResourceGeneration); diff != "" {
 				t.Errorf("Unexpected assigned clusterQueues in cache (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -169,7 +169,7 @@ func TestClusterQueueUpdate(t *testing.T) {
 			}
 			if diff := cmp.Diff(
 				tc.wantLastAssignmentGeneration,
-				snapshot.ClusterQueues["eng-alpha"].AllocatableResourceGeneration); diff != "" {
+				snapshot.GetClusterQueue("eng-alpha").AllocatableResourceGeneration); diff != "" {
 				t.Errorf("Unexpected assigned clusterQueues in cache (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/cache/fair_sharing_test.go
+++ b/pkg/cache/fair_sharing_test.go
@@ -641,8 +641,8 @@ func TestDominantResourceShare(t *testing.T) {
 				i++
 			}
 
-			gotCache := make([]fairSharingResult, 0, len(snapshot.ClusterQueues)+len(snapshot.Cohorts))
-			for _, cq := range cache.hm.ClusterQueues {
+			gotCache := make([]fairSharingResult, 0, len(snapshot.GetClusterQueueNames())+len(snapshot.GetCohortNames()))
+			for _, cq := range cache.hm.GetClusterQueuesCopy() {
 				drVal, drName := dominantResourceShare(cq, tc.flvResQ)
 				gotCache = append(gotCache, fairSharingResult{
 					Name:     cq.Name,
@@ -651,7 +651,7 @@ func TestDominantResourceShare(t *testing.T) {
 					DrName:   drName,
 				})
 			}
-			for _, cohort := range cache.hm.Cohorts {
+			for _, cohort := range cache.hm.GetCohortsCopy() {
 				drVal, drName := dominantResourceShare(cohort, tc.flvResQ)
 				gotCache = append(gotCache, fairSharingResult{
 					Name:     cohort.Name,
@@ -664,8 +664,8 @@ func TestDominantResourceShare(t *testing.T) {
 				t.Errorf("dominantResourceShare cache mismatch: %s", diff)
 			}
 
-			gotSnapshot := make([]fairSharingResult, 0, len(snapshot.ClusterQueues)+len(snapshot.Cohorts))
-			for _, cq := range snapshot.ClusterQueues {
+			gotSnapshot := make([]fairSharingResult, 0, len(snapshot.GetClusterQueueNames())+len(snapshot.GetCohortNames()))
+			for _, cq := range snapshot.GetClusterQueuesCopy() {
 				drVal, drName := dominantResourceShare(cq, tc.flvResQ)
 				gotSnapshot = append(gotSnapshot, fairSharingResult{
 					Name:     cq.Name,
@@ -674,7 +674,7 @@ func TestDominantResourceShare(t *testing.T) {
 					DrName:   drName,
 				})
 			}
-			for _, cohort := range snapshot.Cohorts {
+			for _, cohort := range snapshot.GetCohortsCopy() {
 				drVal, drName := dominantResourceShare(cohort, tc.flvResQ)
 				gotSnapshot = append(gotSnapshot, fairSharingResult{
 					Name:     cohort.Name,

--- a/pkg/cache/fair_sharing_test.go
+++ b/pkg/cache/fair_sharing_test.go
@@ -641,8 +641,8 @@ func TestDominantResourceShare(t *testing.T) {
 				i++
 			}
 
-			cacheClusterQueuesMap := cache.hm.GetClusterQueuesCopy()
-			cacheCohortsMap := cache.hm.GetCohortsCopy()
+			cacheClusterQueuesMap := cache.hm.ClusterQueues()
+			cacheCohortsMap := cache.hm.Cohorts()
 			gotCache := make([]fairSharingResult, 0, len(cacheClusterQueuesMap)+len(cacheCohortsMap))
 			for _, cq := range cacheClusterQueuesMap {
 				drVal, drName := dominantResourceShare(cq, tc.flvResQ)
@@ -666,8 +666,8 @@ func TestDominantResourceShare(t *testing.T) {
 				t.Errorf("dominantResourceShare cache mismatch: %s", diff)
 			}
 
-			snapshotClusterQueuesMap := snapshot.GetClusterQueuesCopy()
-			snapshotCohortsMap := snapshot.GetCohortsCopy()
+			snapshotClusterQueuesMap := snapshot.ClusterQueues()
+			snapshotCohortsMap := snapshot.Cohorts()
 			gotSnapshot := make([]fairSharingResult, 0, len(snapshotClusterQueuesMap)+len(snapshotCohortsMap))
 			for _, cq := range snapshotClusterQueuesMap {
 				drVal, drName := dominantResourceShare(cq, tc.flvResQ)

--- a/pkg/cache/fair_sharing_test.go
+++ b/pkg/cache/fair_sharing_test.go
@@ -641,8 +641,10 @@ func TestDominantResourceShare(t *testing.T) {
 				i++
 			}
 
-			gotCache := make([]fairSharingResult, 0, len(snapshot.GetClusterQueueNames())+len(snapshot.GetCohortNames()))
-			for _, cq := range cache.hm.GetClusterQueuesCopy() {
+			cacheClusterQueuesMap := cache.hm.GetClusterQueuesCopy()
+			cacheCohortsMap := cache.hm.GetCohortsCopy()
+			gotCache := make([]fairSharingResult, 0, len(cacheClusterQueuesMap)+len(cacheCohortsMap))
+			for _, cq := range cacheClusterQueuesMap {
 				drVal, drName := dominantResourceShare(cq, tc.flvResQ)
 				gotCache = append(gotCache, fairSharingResult{
 					Name:     cq.Name,
@@ -651,7 +653,7 @@ func TestDominantResourceShare(t *testing.T) {
 					DrName:   drName,
 				})
 			}
-			for _, cohort := range cache.hm.GetCohortsCopy() {
+			for _, cohort := range cacheCohortsMap {
 				drVal, drName := dominantResourceShare(cohort, tc.flvResQ)
 				gotCache = append(gotCache, fairSharingResult{
 					Name:     cohort.Name,
@@ -664,8 +666,10 @@ func TestDominantResourceShare(t *testing.T) {
 				t.Errorf("dominantResourceShare cache mismatch: %s", diff)
 			}
 
-			gotSnapshot := make([]fairSharingResult, 0, len(snapshot.GetClusterQueueNames())+len(snapshot.GetCohortNames()))
-			for _, cq := range snapshot.GetClusterQueuesCopy() {
+			snapshotClusterQueuesMap := snapshot.GetClusterQueuesCopy()
+			snapshotCohortsMap := snapshot.GetCohortsCopy()
+			gotSnapshot := make([]fairSharingResult, 0, len(snapshotClusterQueuesMap)+len(snapshotCohortsMap))
+			for _, cq := range snapshotClusterQueuesMap {
 				drVal, drName := dominantResourceShare(cq, tc.flvResQ)
 				gotSnapshot = append(gotSnapshot, fairSharingResult{
 					Name:     cq.Name,
@@ -674,7 +678,7 @@ func TestDominantResourceShare(t *testing.T) {
 					DrName:   drName,
 				})
 			}
-			for _, cohort := range snapshot.GetCohortsCopy() {
+			for _, cohort := range snapshotCohortsMap {
 				drVal, drName := dominantResourceShare(cohort, tc.flvResQ)
 				gotSnapshot = append(gotSnapshot, fairSharingResult{
 					Name:     cohort.Name,

--- a/pkg/cache/resource_node_test.go
+++ b/pkg/cache/resource_node_test.go
@@ -58,7 +58,7 @@ func TestCohortLendable(t *testing.T) {
 		"example.com/gpu":  3,
 	}
 
-	lendable := calculateLendable(cache.hm.GetCohort("test-cohort"))
+	lendable := calculateLendable(cache.hm.Cohort("test-cohort"))
 	if diff := cmp.Diff(wantLendable, lendable); diff != "" {
 		t.Errorf("Unexpected cohort lendable (-want,+got):\n%s", diff)
 	}

--- a/pkg/cache/resource_node_test.go
+++ b/pkg/cache/resource_node_test.go
@@ -58,7 +58,7 @@ func TestCohortLendable(t *testing.T) {
 		"example.com/gpu":  3,
 	}
 
-	lendable := calculateLendable(cache.hm.Cohorts["test-cohort"])
+	lendable := calculateLendable(cache.hm.GetCohort("test-cohort"))
 	if diff := cmp.Diff(wantLendable, lendable); diff != "" {
 		t.Errorf("Unexpected cohort lendable (-want,+got):\n%s", diff)
 	}

--- a/pkg/cache/resource_test.go
+++ b/pkg/cache/resource_test.go
@@ -379,7 +379,7 @@ func TestAvailable(t *testing.T) {
 			}
 			// before adding usage
 			{
-				clusterQueues := snapshot.GetClusterQueuesCopy()
+				clusterQueues := snapshot.ClusterQueues()
 				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
 				gotPotentiallyAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
 				for _, cq := range clusterQueues {
@@ -403,9 +403,9 @@ func TestAvailable(t *testing.T) {
 			// add usage
 			{
 				for cqName, usage := range tc.usage {
-					snapshot.GetClusterQueue(cqName).AddUsage(workload.Usage{Quota: usage})
+					snapshot.ClusterQueue(cqName).AddUsage(workload.Usage{Quota: usage})
 				}
-				clusterQueues := snapshot.GetClusterQueuesCopy()
+				clusterQueues := snapshot.ClusterQueues()
 				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
 				gotPotentiallyAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
 				for _, cq := range clusterQueues {
@@ -428,9 +428,9 @@ func TestAvailable(t *testing.T) {
 			// remove usage
 			{
 				for cqName, usage := range tc.usage {
-					snapshot.GetClusterQueue(cqName).removeUsage(workload.Usage{Quota: usage})
+					snapshot.ClusterQueue(cqName).removeUsage(workload.Usage{Quota: usage})
 				}
-				clusterQueues := snapshot.GetClusterQueuesCopy()
+				clusterQueues := snapshot.ClusterQueues()
 				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
 				gotPotentiallyAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
 				for _, cq := range clusterQueues {

--- a/pkg/cache/resource_test.go
+++ b/pkg/cache/resource_test.go
@@ -428,7 +428,7 @@ func TestAvailable(t *testing.T) {
 			// remove usage
 			{
 				for cqName, usage := range tc.usage {
-					snapshot.GetClusterQueue(cqName).removeUsage(usage)
+					snapshot.GetClusterQueue(cqName).removeUsage(workload.Usage{Quota: usage})
 				}
 				clusterQueues := snapshot.GetClusterQueuesCopy()
 				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))

--- a/pkg/cache/resource_test.go
+++ b/pkg/cache/resource_test.go
@@ -379,9 +379,10 @@ func TestAvailable(t *testing.T) {
 			}
 			// before adding usage
 			{
-				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(snapshot.ClusterQueues))
-				gotPotentiallyAvailable := make(map[string]resources.FlavorResourceQuantities, len(snapshot.ClusterQueues))
-				for _, cq := range snapshot.ClusterQueues {
+				clusterQueues := snapshot.GetClusterQueuesCopy()
+				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
+				gotPotentiallyAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
+				for _, cq := range clusterQueues {
 					numFrs := len(cq.ResourceNode.Quotas)
 					gotAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					gotPotentiallyAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
@@ -402,11 +403,12 @@ func TestAvailable(t *testing.T) {
 			// add usage
 			{
 				for cqName, usage := range tc.usage {
-					snapshot.ClusterQueues[cqName].AddUsage(workload.Usage{Quota: usage})
+					snapshot.GetClusterQueue(cqName).AddUsage(workload.Usage{Quota: usage})
 				}
-				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(snapshot.ClusterQueues))
-				gotPotentiallyAvailable := make(map[string]resources.FlavorResourceQuantities, len(snapshot.ClusterQueues))
-				for _, cq := range snapshot.ClusterQueues {
+				clusterQueues := snapshot.GetClusterQueuesCopy()
+				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
+				gotPotentiallyAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
+				for _, cq := range clusterQueues {
 					numFrs := len(cq.ResourceNode.Quotas)
 					gotAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					gotPotentiallyAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
@@ -426,11 +428,12 @@ func TestAvailable(t *testing.T) {
 			// remove usage
 			{
 				for cqName, usage := range tc.usage {
-					snapshot.ClusterQueues[cqName].removeUsage(workload.Usage{Quota: usage})
+					snapshot.GetClusterQueue(cqName).removeUsage(usage)
 				}
-				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(snapshot.ClusterQueues))
-				gotPotentiallyAvailable := make(map[string]resources.FlavorResourceQuantities, len(snapshot.ClusterQueues))
-				for _, cq := range snapshot.ClusterQueues {
+				clusterQueues := snapshot.GetClusterQueuesCopy()
+				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
+				gotPotentiallyAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
+				for _, cq := range clusterQueues {
 					numFrs := len(cq.ResourceNode.Quotas)
 					gotAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
 					gotPotentiallyAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -56,10 +56,7 @@ func (s *Snapshot) AddWorkload(wl *workload.Info) {
 }
 
 func (s *Snapshot) Log(log logr.Logger) {
-	clusterQueueNames := s.GetClusterQueueNames()
-	for i := range clusterQueueNames {
-		name := clusterQueueNames[i]
-    cq := s.GetClusterQueue(name)
+	for name, cq := range s.GetClusterQueuesCopy() {
 		cohortName := "<none>"
 		if cq.HasParent() {
 			cohortName = cq.Parent().Name
@@ -73,10 +70,7 @@ func (s *Snapshot) Log(log logr.Logger) {
 			"workloads", slices.Collect(maps.Keys(cq.Workloads)),
 		)
 	}
-	cohortNames := s.GetCohortNames()
-	for i := range cohortNames {
-		name := cohortNames[i]
-    cohort := s.GetCohort(name)
+	for name, cohort := range s.GetCohortsCopy() {
 		log.Info("Found cohort",
 			"cohort", name,
 			"resources", cohort.ResourceNode.SubtreeQuota,
@@ -94,9 +88,7 @@ func (c *Cache) Snapshot(ctx context.Context) (*Snapshot, error) {
 		ResourceFlavors:          make(map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor, len(c.resourceFlavors)),
 		InactiveClusterQueueSets: sets.New[string](),
 	}
-	cohortNames := c.hm.GetCohortNames()
-	for i := range cohortNames {
-    cohort := c.hm.GetCohort(cohortNames[i])
+	for _, cohort := range c.hm.GetCohortsCopy() {
 		if c.hm.CycleChecker.HasCycle(cohort) {
 			continue
 		}
@@ -118,9 +110,7 @@ func (c *Cache) Snapshot(ctx context.Context) (*Snapshot, error) {
 			}
 		}
 	}
-	clusterQueueNames := c.hm.GetClusterQueueNames()
-	for i := range clusterQueueNames {
-    cq := c.hm.GetClusterQueue(clusterQueueNames[i])
+	for _, cq := range c.hm.GetClusterQueuesCopy() {
 		if !cq.Active() || (cq.HasParent() && c.hm.CycleChecker.HasCycle(cq.Parent())) {
 			snap.InactiveClusterQueueSets.Insert(cq.Name)
 			continue

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -42,7 +42,7 @@ type Snapshot struct {
 // RemoveWorkload removes a workload from its corresponding ClusterQueue and
 // updates resource usage.
 func (s *Snapshot) RemoveWorkload(wl *workload.Info) {
-	cq := s.GetClusterQueue(wl.ClusterQueue)
+	cq := s.ClusterQueue(wl.ClusterQueue)
 	delete(cq.Workloads, workload.Key(wl.Obj))
 	cq.removeUsage(wl.Usage())
 }
@@ -50,13 +50,13 @@ func (s *Snapshot) RemoveWorkload(wl *workload.Info) {
 // AddWorkload adds a workload from its corresponding ClusterQueue and
 // updates resource usage.
 func (s *Snapshot) AddWorkload(wl *workload.Info) {
-	cq := s.GetClusterQueue(wl.ClusterQueue)
+	cq := s.ClusterQueue(wl.ClusterQueue)
 	cq.Workloads[workload.Key(wl.Obj)] = wl
 	cq.AddUsage(wl.Usage())
 }
 
 func (s *Snapshot) Log(log logr.Logger) {
-	for name, cq := range s.GetClusterQueuesCopy() {
+	for name, cq := range s.ClusterQueues() {
 		cohortName := "<none>"
 		if cq.HasParent() {
 			cohortName = cq.Parent().Name
@@ -70,7 +70,7 @@ func (s *Snapshot) Log(log logr.Logger) {
 			"workloads", slices.Collect(maps.Keys(cq.Workloads)),
 		)
 	}
-	for name, cohort := range s.GetCohortsCopy() {
+	for name, cohort := range s.Cohorts() {
 		log.Info("Found cohort",
 			"cohort", name,
 			"resources", cohort.ResourceNode.SubtreeQuota,
@@ -88,13 +88,13 @@ func (c *Cache) Snapshot(ctx context.Context) (*Snapshot, error) {
 		ResourceFlavors:          make(map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor, len(c.resourceFlavors)),
 		InactiveClusterQueueSets: sets.New[string](),
 	}
-	for _, cohort := range c.hm.GetCohortsCopy() {
+	for _, cohort := range c.hm.Cohorts() {
 		if c.hm.CycleChecker.HasCycle(cohort) {
 			continue
 		}
 		snap.AddCohort(cohort.Name)
-		snap.GetCohort(cohort.Name).ResourceNode = cohort.resourceNode.Clone()
-		snap.GetCohort(cohort.Name).FairWeight = cohort.FairWeight
+		snap.Cohort(cohort.Name).ResourceNode = cohort.resourceNode.Clone()
+		snap.Cohort(cohort.Name).FairWeight = cohort.FairWeight
 		if cohort.HasParent() {
 			snap.UpdateCohortEdge(cohort.Name, cohort.Parent().Name)
 		}
@@ -110,7 +110,7 @@ func (c *Cache) Snapshot(ctx context.Context) (*Snapshot, error) {
 			}
 		}
 	}
-	for _, cq := range c.hm.GetClusterQueuesCopy() {
+	for _, cq := range c.hm.ClusterQueues() {
 		if !cq.Active() || (cq.HasParent() && c.hm.CycleChecker.HasCycle(cq.Parent())) {
 			snap.InactiveClusterQueueSets.Insert(cq.Name)
 			continue

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -928,7 +928,7 @@ func TestSnapshot(t *testing.T) {
 			if diff := cmp.Diff(tc.wantSnapshot, *snapshot, snapCmpOpts...); len(diff) != 0 {
 				t.Errorf("Unexpected Snapshot (-want,+got):\n%s", diff)
 			}
-			for _, cq := range snapshot.GetClusterQueuesCopy() {
+			for _, cq := range snapshot.ClusterQueues() {
 				for i := range cq.ResourceGroups {
 					rg := &cq.ResourceGroups[i]
 					for rName := range rg.CoveredResources {
@@ -1002,7 +1002,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 		}
 	}
 	wlInfos := make(map[string]*workload.Info, len(workloads))
-	for _, cq := range cqCache.hm.GetClusterQueuesCopy() {
+	for _, cq := range cqCache.hm.ClusterQueues() {
 		for _, wl := range cq.Workloads {
 			wlInfos[workload.Key(wl.Obj)] = wl
 		}
@@ -1011,7 +1011,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	initialCohortResources := initialSnapshot.GetClusterQueue("c1").Parent().ResourceNode.SubtreeQuota
+	initialCohortResources := initialSnapshot.ClusterQueue("c1").Parent().ResourceNode.SubtreeQuota
 	cases := map[string]struct {
 		remove []string
 		add    []string
@@ -1045,7 +1045,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							"c1": {
 								Name:              "c1",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.GetClusterQueue("c1").ResourceGroups,
+								ResourceGroups:    cqCache.hm.ClusterQueue("c1").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1064,7 +1064,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							"c2": {
 								Name:                          "c2",
 								Workloads:                     make(map[string]*workload.Info),
-								ResourceGroups:                cqCache.hm.GetClusterQueue("c2").ResourceGroups,
+								ResourceGroups:                cqCache.hm.ClusterQueue("c2").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
@@ -1108,7 +1108,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 									"/c1-memory-alpha": nil,
 									"/c1-memory-beta":  nil,
 								},
-								ResourceGroups:    cqCache.hm.GetClusterQueue("c1").ResourceGroups,
+								ResourceGroups:    cqCache.hm.ClusterQueue("c1").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1130,7 +1130,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 									"/c2-cpu-1": nil,
 									"/c2-cpu-2": nil,
 								},
-								ResourceGroups:                cqCache.hm.GetClusterQueue("c2").ResourceGroups,
+								ResourceGroups:                cqCache.hm.ClusterQueue("c2").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
@@ -1174,7 +1174,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 									"/c1-memory-alpha": nil,
 									"/c1-memory-beta":  nil,
 								},
-								ResourceGroups:    cqCache.hm.GetClusterQueue("c1").ResourceGroups,
+								ResourceGroups:    cqCache.hm.ClusterQueue("c1").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1196,7 +1196,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 									"/c2-cpu-1": nil,
 									"/c2-cpu-2": nil,
 								},
-								ResourceGroups:    cqCache.hm.GetClusterQueue("c2").ResourceGroups,
+								ResourceGroups:    cqCache.hm.ClusterQueue("c2").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1296,7 +1296,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 		}
 	}
 	wlInfos := make(map[string]*workload.Info, len(workloads))
-	for _, cq := range cqCache.hm.GetClusterQueuesCopy() {
+	for _, cq := range cqCache.hm.ClusterQueues() {
 		for _, wl := range cq.Workloads {
 			wlInfos[workload.Key(wl.Obj)] = wl
 		}
@@ -1305,7 +1305,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	initialCohortResources := initialSnapshot.GetClusterQueue("lend-a").Parent().ResourceNode.SubtreeQuota
+	initialCohortResources := initialSnapshot.ClusterQueue("lend-a").Parent().ResourceNode.SubtreeQuota
 	cases := map[string]struct {
 		remove []string
 		add    []string
@@ -1337,7 +1337,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
+								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1352,7 +1352,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:              "lend-b",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
+								ResourceGroups:    cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1390,7 +1390,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
+								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1405,7 +1405,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:                          "lend-b",
 								Workloads:                     make(map[string]*workload.Info),
-								ResourceGroups:                cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
+								ResourceGroups:                cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
@@ -1444,7 +1444,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
+								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1459,7 +1459,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:                          "lend-b",
 								Workloads:                     make(map[string]*workload.Info),
-								ResourceGroups:                cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
+								ResourceGroups:                cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
@@ -1498,7 +1498,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
+								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1513,7 +1513,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:                          "lend-b",
 								Workloads:                     make(map[string]*workload.Info),
-								ResourceGroups:                cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
+								ResourceGroups:                cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
@@ -1553,7 +1553,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
+								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1568,7 +1568,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:                          "lend-b",
 								Workloads:                     make(map[string]*workload.Info),
-								ResourceGroups:                cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
+								ResourceGroups:                cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
@@ -1608,7 +1608,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
+								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1623,7 +1623,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:              "lend-b",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
+								ResourceGroups:    cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1662,7 +1662,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
+								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1677,7 +1677,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:                          "lend-b",
 								Workloads:                     make(map[string]*workload.Info),
-								ResourceGroups:                cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
+								ResourceGroups:                cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -69,8 +69,9 @@ func TestSnapshot(t *testing.T) {
 					ReserveQuota(&kueue.Admission{ClusterQueue: "b"}).Obj(),
 			},
 			wantSnapshot: Snapshot{
-				Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-					ClusterQueues: map[string]*ClusterQueueSnapshot{
+				Manager: hierarchy.NewManagerForTest(
+					map[string]*CohortSnapshot{},
+					map[string]*ClusterQueueSnapshot{
 						"a": {
 							Name:                          "a",
 							NamespaceSelector:             labels.Everything(),
@@ -100,7 +101,7 @@ func TestSnapshot(t *testing.T) {
 							FairWeight: oneQuantity,
 						},
 					},
-				},
+				),
 			},
 		},
 		"inactive clusterQueues": {
@@ -127,9 +128,10 @@ func TestSnapshot(t *testing.T) {
 				utiltesting.MakeResourceFlavor("default").Obj(),
 			},
 			wantSnapshot: Snapshot{
-				Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-					ClusterQueues: map[string]*ClusterQueueSnapshot{},
-				},
+				Manager: hierarchy.NewManagerForTest(
+					map[string]*CohortSnapshot{},
+					map[string]*ClusterQueueSnapshot{},
+				),
 				ResourceFlavors: map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
 					"demand": utiltesting.MakeResourceFlavor("demand").
 						NodeLabel("a", "b").
@@ -226,11 +228,11 @@ func TestSnapshot(t *testing.T) {
 					},
 				}
 				return Snapshot{
-					Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-						Cohorts: map[string]*CohortSnapshot{
+					Manager: hierarchy.NewManagerForTest(
+						map[string]*CohortSnapshot{
 							"borrowing": cohort,
 						},
-						ClusterQueues: map[string]*ClusterQueueSnapshot{
+						map[string]*ClusterQueueSnapshot{
 							"a": {
 								Name:                          "a",
 								AllocatableResourceGeneration: 2,
@@ -354,7 +356,7 @@ func TestSnapshot(t *testing.T) {
 								Status:            active,
 							},
 						},
-					},
+					),
 					ResourceFlavors: map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
 						"demand":  utiltesting.MakeResourceFlavor("demand").NodeLabel("instance", "demand").Obj(),
 						"spot":    utiltesting.MakeResourceFlavor("spot").NodeLabel("instance", "spot").Obj(),
@@ -372,8 +374,9 @@ func TestSnapshot(t *testing.T) {
 					}).Obj(),
 			},
 			wantSnapshot: Snapshot{
-				Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-					ClusterQueues: map[string]*ClusterQueueSnapshot{
+				Manager: hierarchy.NewManagerForTest(
+					map[string]*CohortSnapshot{},
+					map[string]*ClusterQueueSnapshot{
 						"with-preemption": {
 							Name:                          "with-preemption",
 							NamespaceSelector:             labels.Everything(),
@@ -388,7 +391,7 @@ func TestSnapshot(t *testing.T) {
 							FairWeight: oneQuantity,
 						},
 					},
-				},
+				),
 			},
 		},
 		"clusterQueue with fair sharing weight": {
@@ -396,8 +399,9 @@ func TestSnapshot(t *testing.T) {
 				utiltesting.MakeClusterQueue("with-preemption").FairWeight(resource.MustParse("3")).Obj(),
 			},
 			wantSnapshot: Snapshot{
-				Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-					ClusterQueues: map[string]*ClusterQueueSnapshot{
+				Manager: hierarchy.NewManagerForTest(
+					map[string]*CohortSnapshot{},
+					map[string]*ClusterQueueSnapshot{
 						"with-preemption": {
 							Name:                          "with-preemption",
 							NamespaceSelector:             labels.Everything(),
@@ -409,7 +413,7 @@ func TestSnapshot(t *testing.T) {
 							FairWeight:                    resource.MustParse("3"),
 						},
 					},
-				},
+				),
 			},
 		},
 		"lendingLimit with 2 clusterQueues and 2 flavors(whenCanBorrow: Borrow)": {
@@ -471,11 +475,11 @@ func TestSnapshot(t *testing.T) {
 					},
 				}
 				return Snapshot{
-					Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-						Cohorts: map[string]*CohortSnapshot{
+					Manager: hierarchy.NewManagerForTest(
+						map[string]*CohortSnapshot{
 							"lending": cohort,
 						},
-						ClusterQueues: map[string]*ClusterQueueSnapshot{
+						map[string]*ClusterQueueSnapshot{
 							"a": {
 								Name:                          "a",
 								AllocatableResourceGeneration: 2,
@@ -557,7 +561,7 @@ func TestSnapshot(t *testing.T) {
 								Status:            active,
 							},
 						},
-					},
+					),
 					ResourceFlavors: map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
 						"arm": utiltesting.MakeResourceFlavor("arm").NodeLabel("arch", "arm").Obj(),
 						"x86": utiltesting.MakeResourceFlavor("x86").NodeLabel("arch", "x86").Obj(),
@@ -626,11 +630,11 @@ func TestSnapshot(t *testing.T) {
 					},
 				}
 				return Snapshot{
-					Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-						Cohorts: map[string]*CohortSnapshot{
+					Manager: hierarchy.NewManagerForTest(
+						map[string]*CohortSnapshot{
 							"lending": cohort,
 						},
-						ClusterQueues: map[string]*ClusterQueueSnapshot{
+						map[string]*ClusterQueueSnapshot{
 							"a": {
 								Name:                          "a",
 								AllocatableResourceGeneration: 2,
@@ -711,7 +715,7 @@ func TestSnapshot(t *testing.T) {
 								Status:            active,
 							},
 						},
-					},
+					),
 					ResourceFlavors: map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
 						"arm": utiltesting.MakeResourceFlavor("arm").NodeLabel("arch", "arm").Obj(),
 						"x86": utiltesting.MakeResourceFlavor("x86").NodeLabel("arch", "x86").Obj(),
@@ -745,8 +749,26 @@ func TestSnapshot(t *testing.T) {
 					).Obj(),
 			},
 			wantSnapshot: Snapshot{
-				Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-					ClusterQueues: map[string]*ClusterQueueSnapshot{
+				Manager: hierarchy.NewManagerForTest(
+					map[string]*CohortSnapshot{
+						"cohort": {
+							Name: "cohort",
+							ResourceNode: ResourceNode{
+								Quotas: map[resources.FlavorResource]ResourceQuota{
+									{Flavor: "arm", Resource: corev1.ResourceCPU}:  {Nominal: 10_000, BorrowingLimit: nil, LendingLimit: nil},
+									{Flavor: "x86", Resource: corev1.ResourceCPU}:  {Nominal: 20_000, BorrowingLimit: nil, LendingLimit: nil},
+									{Flavor: "mips", Resource: corev1.ResourceCPU}: {Nominal: 42_000, BorrowingLimit: nil, LendingLimit: nil},
+								},
+								SubtreeQuota: resources.FlavorResourceQuantities{
+									{Flavor: "arm", Resource: corev1.ResourceCPU}:  13_000,
+									{Flavor: "x86", Resource: corev1.ResourceCPU}:  25_000,
+									{Flavor: "mips", Resource: corev1.ResourceCPU}: 42_000,
+								},
+							},
+							FairWeight: oneQuantity,
+						},
+					},
+					map[string]*ClusterQueueSnapshot{
 						"cq": {
 							Name:                          "cq",
 							AllocatableResourceGeneration: 2,
@@ -773,25 +795,7 @@ func TestSnapshot(t *testing.T) {
 							Status:            active,
 						},
 					},
-					Cohorts: map[string]*CohortSnapshot{
-						"cohort": {
-							Name: "cohort",
-							ResourceNode: ResourceNode{
-								Quotas: map[resources.FlavorResource]ResourceQuota{
-									{Flavor: "arm", Resource: corev1.ResourceCPU}:  {Nominal: 10_000, BorrowingLimit: nil, LendingLimit: nil},
-									{Flavor: "x86", Resource: corev1.ResourceCPU}:  {Nominal: 20_000, BorrowingLimit: nil, LendingLimit: nil},
-									{Flavor: "mips", Resource: corev1.ResourceCPU}: {Nominal: 42_000, BorrowingLimit: nil, LendingLimit: nil},
-								},
-								SubtreeQuota: resources.FlavorResourceQuantities{
-									{Flavor: "arm", Resource: corev1.ResourceCPU}:  13_000,
-									{Flavor: "x86", Resource: corev1.ResourceCPU}:  25_000,
-									{Flavor: "mips", Resource: corev1.ResourceCPU}: 42_000,
-								},
-							},
-							FairWeight: oneQuantity,
-						},
-					},
-				},
+				),
 				ResourceFlavors: map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
 					"arm":  utiltesting.MakeResourceFlavor("arm").Obj(),
 					"x86":  utiltesting.MakeResourceFlavor("x86").Obj(),
@@ -832,8 +836,19 @@ func TestSnapshot(t *testing.T) {
 					).Obj(),
 			},
 			wantSnapshot: Snapshot{
-				Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-					ClusterQueues: map[string]*ClusterQueueSnapshot{
+				Manager: hierarchy.NewManagerForTest(
+					map[string]*CohortSnapshot{
+						"nocycle": {
+							Name: "nocycle",
+							ResourceNode: ResourceNode{
+								SubtreeQuota: resources.FlavorResourceQuantities{
+									{Flavor: "arm", Resource: corev1.ResourceCPU}: 0,
+								},
+							},
+							FairWeight: oneQuantity,
+						},
+					},
+					map[string]*ClusterQueueSnapshot{
 						"cq-nocycle": {
 							Name:                          "cq-nocycle",
 							AllocatableResourceGeneration: 2,
@@ -858,18 +873,7 @@ func TestSnapshot(t *testing.T) {
 							Status:            active,
 						},
 					},
-					Cohorts: map[string]*CohortSnapshot{
-						"nocycle": {
-							Name: "nocycle",
-							ResourceNode: ResourceNode{
-								SubtreeQuota: resources.FlavorResourceQuantities{
-									{Flavor: "arm", Resource: corev1.ResourceCPU}: 0,
-								},
-							},
-							FairWeight: oneQuantity,
-						},
-					},
-				},
+				),
 				InactiveClusterQueueSets: sets.New("cq-autocycle", "cq-a", "cq-b"),
 				ResourceFlavors: map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
 					"arm": utiltesting.MakeResourceFlavor("arm").Obj(),
@@ -881,14 +885,15 @@ func TestSnapshot(t *testing.T) {
 				utiltesting.MakeCohort("cohort").FairWeight(resource.MustParse("0.5")).Obj(),
 			},
 			wantSnapshot: Snapshot{
-				Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-					Cohorts: map[string]*CohortSnapshot{
+				Manager: hierarchy.NewManagerForTest(
+					map[string]*CohortSnapshot{
 						"cohort": {
 							Name:       "cohort",
 							FairWeight: resource.MustParse("0.5"),
 						},
 					},
-				},
+					map[string]*ClusterQueueSnapshot{},
+				),
 			},
 		},
 	}
@@ -1032,11 +1037,11 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 					},
 				}
 				return Snapshot{
-					Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-						Cohorts: map[string]*CohortSnapshot{
+					Manager: hierarchy.NewManagerForTest(
+						map[string]*CohortSnapshot{
 							"cohort": cohort,
 						},
-						ClusterQueues: map[string]*ClusterQueueSnapshot{
+						map[string]*ClusterQueueSnapshot{
 							"c1": {
 								Name:              "c1",
 								Workloads:         make(map[string]*workload.Info),
@@ -1073,7 +1078,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								},
 							},
 						},
-					},
+					),
 				}
 			}(),
 		},
@@ -1092,11 +1097,11 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 					},
 				}
 				return Snapshot{
-					Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-						Cohorts: map[string]*CohortSnapshot{
+					Manager: hierarchy.NewManagerForTest(
+						map[string]*CohortSnapshot{
 							"cohort": cohort,
 						},
-						ClusterQueues: map[string]*ClusterQueueSnapshot{
+						map[string]*ClusterQueueSnapshot{
 							"c1": {
 								Name: "c1",
 								Workloads: map[string]*workload.Info{
@@ -1139,7 +1144,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								},
 							},
 						},
-					},
+					),
 				}
 			}(),
 		},
@@ -1158,11 +1163,11 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 					},
 				}
 				return Snapshot{
-					Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-						Cohorts: map[string]*CohortSnapshot{
+					Manager: hierarchy.NewManagerForTest(
+						map[string]*CohortSnapshot{
 							"cohort": cohort,
 						},
-						ClusterQueues: map[string]*ClusterQueueSnapshot{
+						map[string]*ClusterQueueSnapshot{
 							"c1": {
 								Name: "c1",
 								Workloads: map[string]*workload.Info{
@@ -1204,7 +1209,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								},
 							},
 						},
-					},
+					),
 				}
 			}(),
 		},
@@ -1324,11 +1329,11 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					},
 				}
 				return Snapshot{
-					Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-						Cohorts: map[string]*CohortSnapshot{
+					Manager: hierarchy.NewManagerForTest(
+						map[string]*CohortSnapshot{
 							"lend": cohort,
 						},
-						ClusterQueues: map[string]*ClusterQueueSnapshot{
+						map[string]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
@@ -1360,7 +1365,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								},
 							},
 						},
-					},
+					),
 				}
 			}(),
 		},
@@ -1377,11 +1382,11 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					},
 				}
 				return Snapshot{
-					Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-						Cohorts: map[string]*CohortSnapshot{
+					Manager: hierarchy.NewManagerForTest(
+						map[string]*CohortSnapshot{
 							"lend": cohort,
 						},
-						ClusterQueues: map[string]*ClusterQueueSnapshot{
+						map[string]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
@@ -1414,7 +1419,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								},
 							},
 						},
-					},
+					),
 				}
 			}(),
 		},
@@ -1431,11 +1436,11 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					},
 				}
 				return Snapshot{
-					Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-						Cohorts: map[string]*CohortSnapshot{
+					Manager: hierarchy.NewManagerForTest(
+						map[string]*CohortSnapshot{
 							"lend": cohort,
 						},
-						ClusterQueues: map[string]*ClusterQueueSnapshot{
+						map[string]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
@@ -1468,7 +1473,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								},
 							},
 						},
-					},
+					),
 				}
 			}(),
 		},
@@ -1485,11 +1490,11 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					},
 				}
 				return Snapshot{
-					Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-						Cohorts: map[string]*CohortSnapshot{
+					Manager: hierarchy.NewManagerForTest(
+						map[string]*CohortSnapshot{
 							"lend": cohort,
 						},
-						ClusterQueues: map[string]*ClusterQueueSnapshot{
+						map[string]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
@@ -1522,7 +1527,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								},
 							},
 						},
-					},
+					),
 				}
 			}(),
 		},
@@ -1540,11 +1545,11 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					},
 				}
 				return Snapshot{
-					Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-						Cohorts: map[string]*CohortSnapshot{
+					Manager: hierarchy.NewManagerForTest(
+						map[string]*CohortSnapshot{
 							"lend": cohort,
 						},
-						ClusterQueues: map[string]*ClusterQueueSnapshot{
+						map[string]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
@@ -1577,7 +1582,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								},
 							},
 						},
-					},
+					),
 				}
 			}(),
 		},
@@ -1595,11 +1600,11 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					},
 				}
 				return Snapshot{
-					Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-						Cohorts: map[string]*CohortSnapshot{
+					Manager: hierarchy.NewManagerForTest(
+						map[string]*CohortSnapshot{
 							"lend": cohort,
 						},
-						ClusterQueues: map[string]*ClusterQueueSnapshot{
+						map[string]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
@@ -1631,7 +1636,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								},
 							},
 						},
-					},
+					),
 				}
 			}(),
 		},
@@ -1649,11 +1654,11 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 					},
 				}
 				return Snapshot{
-					Manager: hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{
-						Cohorts: map[string]*CohortSnapshot{
+					Manager: hierarchy.NewManagerForTest(
+						map[string]*CohortSnapshot{
 							"lend": cohort,
 						},
-						ClusterQueues: map[string]*ClusterQueueSnapshot{
+						map[string]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
@@ -1686,7 +1691,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								},
 							},
 						},
-					},
+					),
 				}
 			}(),
 		},

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -923,7 +923,7 @@ func TestSnapshot(t *testing.T) {
 			if diff := cmp.Diff(tc.wantSnapshot, *snapshot, snapCmpOpts...); len(diff) != 0 {
 				t.Errorf("Unexpected Snapshot (-want,+got):\n%s", diff)
 			}
-			for _, cq := range snapshot.ClusterQueues {
+			for _, cq := range snapshot.GetClusterQueuesCopy() {
 				for i := range cq.ResourceGroups {
 					rg := &cq.ResourceGroups[i]
 					for rName := range rg.CoveredResources {
@@ -997,7 +997,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 		}
 	}
 	wlInfos := make(map[string]*workload.Info, len(workloads))
-	for _, cq := range cqCache.hm.ClusterQueues {
+	for _, cq := range cqCache.hm.GetClusterQueuesCopy() {
 		for _, wl := range cq.Workloads {
 			wlInfos[workload.Key(wl.Obj)] = wl
 		}
@@ -1006,7 +1006,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	initialCohortResources := initialSnapshot.ClusterQueues["c1"].Parent().ResourceNode.SubtreeQuota
+	initialCohortResources := initialSnapshot.GetClusterQueue("c1").Parent().ResourceNode.SubtreeQuota
 	cases := map[string]struct {
 		remove []string
 		add    []string
@@ -1040,7 +1040,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							"c1": {
 								Name:              "c1",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.ClusterQueues["c1"].ResourceGroups,
+								ResourceGroups:    cqCache.hm.GetClusterQueue("c1").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1059,7 +1059,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							"c2": {
 								Name:                          "c2",
 								Workloads:                     make(map[string]*workload.Info),
-								ResourceGroups:                cqCache.hm.ClusterQueues["c2"].ResourceGroups,
+								ResourceGroups:                cqCache.hm.GetClusterQueue("c2").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
@@ -1103,7 +1103,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 									"/c1-memory-alpha": nil,
 									"/c1-memory-beta":  nil,
 								},
-								ResourceGroups:    cqCache.hm.ClusterQueues["c1"].ResourceGroups,
+								ResourceGroups:    cqCache.hm.GetClusterQueue("c1").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1125,7 +1125,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 									"/c2-cpu-1": nil,
 									"/c2-cpu-2": nil,
 								},
-								ResourceGroups:                cqCache.hm.ClusterQueues["c2"].ResourceGroups,
+								ResourceGroups:                cqCache.hm.GetClusterQueue("c2").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
@@ -1169,7 +1169,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 									"/c1-memory-alpha": nil,
 									"/c1-memory-beta":  nil,
 								},
-								ResourceGroups:    cqCache.hm.ClusterQueues["c1"].ResourceGroups,
+								ResourceGroups:    cqCache.hm.GetClusterQueue("c1").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1191,7 +1191,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 									"/c2-cpu-1": nil,
 									"/c2-cpu-2": nil,
 								},
-								ResourceGroups:    cqCache.hm.ClusterQueues["c2"].ResourceGroups,
+								ResourceGroups:    cqCache.hm.GetClusterQueue("c2").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1291,7 +1291,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 		}
 	}
 	wlInfos := make(map[string]*workload.Info, len(workloads))
-	for _, cq := range cqCache.hm.ClusterQueues {
+	for _, cq := range cqCache.hm.GetClusterQueuesCopy() {
 		for _, wl := range cq.Workloads {
 			wlInfos[workload.Key(wl.Obj)] = wl
 		}
@@ -1300,7 +1300,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	initialCohortResources := initialSnapshot.ClusterQueues["lend-a"].Parent().ResourceNode.SubtreeQuota
+	initialCohortResources := initialSnapshot.GetClusterQueue("lend-a").Parent().ResourceNode.SubtreeQuota
 	cases := map[string]struct {
 		remove []string
 		add    []string
@@ -1332,7 +1332,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1347,7 +1347,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:              "lend-b",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
+								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1385,7 +1385,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1400,7 +1400,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:                          "lend-b",
 								Workloads:                     make(map[string]*workload.Info),
-								ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
+								ResourceGroups:                cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
@@ -1439,7 +1439,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1454,7 +1454,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:                          "lend-b",
 								Workloads:                     make(map[string]*workload.Info),
-								ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
+								ResourceGroups:                cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
@@ -1493,7 +1493,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1508,7 +1508,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:                          "lend-b",
 								Workloads:                     make(map[string]*workload.Info),
-								ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
+								ResourceGroups:                cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
@@ -1548,7 +1548,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1563,7 +1563,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:                          "lend-b",
 								Workloads:                     make(map[string]*workload.Info),
-								ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
+								ResourceGroups:                cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
@@ -1603,7 +1603,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1618,7 +1618,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:              "lend-b",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
+								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1657,7 +1657,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
-								ResourceGroups:    cqCache.hm.ClusterQueues["lend-a"].ResourceGroups,
+								ResourceGroups:    cqCache.hm.GetClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
 								ResourceNode: ResourceNode{
@@ -1672,7 +1672,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							"lend-b": {
 								Name:                          "lend-b",
 								Workloads:                     make(map[string]*workload.Info),
-								ResourceGroups:                cqCache.hm.ClusterQueues["lend-b"].ResourceGroups,
+								ResourceGroups:                cqCache.hm.GetClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,

--- a/pkg/controller/core/cohort_controller_test.go
+++ b/pkg/controller/core/cohort_controller_test.go
@@ -47,7 +47,7 @@ func TestCohortReconcileCohortNotFoundDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	if _, ok := snapshot.Cohorts["cohort"]; !ok {
+	if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap == nil {
 		t.Fatal("expected Cohort in snapshot")
 	}
 
@@ -62,7 +62,7 @@ func TestCohortReconcileCohortNotFoundDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	if _, ok := snapshot.Cohorts["cohort"]; ok {
+	if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap != nil {
 		t.Fatal("unexpected Cohort in snapshot")
 	}
 }
@@ -79,7 +79,7 @@ func TestCohortReconcileCohortNotFoundIdempotentDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	if _, ok := snapshot.Cohorts["cohort"]; ok {
+	if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap != nil {
 		t.Fatal("unexpected Cohort in snapshot")
 	}
 
@@ -95,7 +95,7 @@ func TestCohortReconcileCohortNotFoundIdempotentDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	if _, ok := snapshot.Cohorts["cohort"]; ok {
+	if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap != nil {
 		t.Fatal("unexpected Cohort in snapshot")
 	}
 }
@@ -162,7 +162,7 @@ func TestCohortReconcileErrorOtherThanNotFoundNotDeleted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	if _, ok := snapshot.Cohorts["cohort"]; !ok {
+	if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap == nil {
 		t.Fatal("expected Cohort in snapshot")
 	}
 
@@ -177,7 +177,7 @@ func TestCohortReconcileErrorOtherThanNotFoundNotDeleted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	if _, ok := snapshot.Cohorts["cohort"]; !ok {
+	if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap == nil {
 		t.Fatal("expected Cohort in snapshot")
 	}
 }
@@ -205,8 +205,8 @@ func TestCohortReconcileLifecycle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error while building snapshot: %v", err)
 		}
-		cohortSnap, ok := snapshot.Cohorts["cohort"]
-		if !ok {
+		cohortSnap := snapshot.GetCohort("cohort")
+		if cohortSnap == nil {
 			t.Fatal("expected Cohort in snapshot")
 		}
 
@@ -240,8 +240,8 @@ func TestCohortReconcileLifecycle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error while building snapshot: %v", err)
 		}
-		cohortSnap, ok := snapshot.Cohorts["cohort"]
-		if !ok {
+		cohortSnap := snapshot.GetCohort("cohort")
+		if cohortSnap == nil {
 			t.Fatal("expected Cohort in snapshot")
 		}
 
@@ -269,7 +269,7 @@ func TestCohortReconcileLifecycle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error while building snapshot: %v", err)
 		}
-		if _, ok := snapshot.Cohorts["cohort"]; ok {
+		if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap != nil {
 			t.Fatal("unexpected Cohort in snapshot")
 		}
 	}

--- a/pkg/controller/core/cohort_controller_test.go
+++ b/pkg/controller/core/cohort_controller_test.go
@@ -47,7 +47,7 @@ func TestCohortReconcileCohortNotFoundDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap == nil {
+	if cohortSnap := snapshot.Cohort("cohort"); cohortSnap == nil {
 		t.Fatal("expected Cohort in snapshot")
 	}
 
@@ -62,7 +62,7 @@ func TestCohortReconcileCohortNotFoundDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap != nil {
+	if cohortSnap := snapshot.Cohort("cohort"); cohortSnap != nil {
 		t.Fatal("unexpected Cohort in snapshot")
 	}
 }
@@ -79,7 +79,7 @@ func TestCohortReconcileCohortNotFoundIdempotentDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap != nil {
+	if cohortSnap := snapshot.Cohort("cohort"); cohortSnap != nil {
 		t.Fatal("unexpected Cohort in snapshot")
 	}
 
@@ -95,7 +95,7 @@ func TestCohortReconcileCohortNotFoundIdempotentDelete(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap != nil {
+	if cohortSnap := snapshot.Cohort("cohort"); cohortSnap != nil {
 		t.Fatal("unexpected Cohort in snapshot")
 	}
 }
@@ -162,7 +162,7 @@ func TestCohortReconcileErrorOtherThanNotFoundNotDeleted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap == nil {
+	if cohortSnap := snapshot.Cohort("cohort"); cohortSnap == nil {
 		t.Fatal("expected Cohort in snapshot")
 	}
 
@@ -177,7 +177,7 @@ func TestCohortReconcileErrorOtherThanNotFoundNotDeleted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while building snapshot: %v", err)
 	}
-	if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap == nil {
+	if cohortSnap := snapshot.Cohort("cohort"); cohortSnap == nil {
 		t.Fatal("expected Cohort in snapshot")
 	}
 }
@@ -205,7 +205,7 @@ func TestCohortReconcileLifecycle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error while building snapshot: %v", err)
 		}
-		cohortSnap := snapshot.GetCohort("cohort")
+		cohortSnap := snapshot.Cohort("cohort")
 		if cohortSnap == nil {
 			t.Fatal("expected Cohort in snapshot")
 		}
@@ -240,7 +240,7 @@ func TestCohortReconcileLifecycle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error while building snapshot: %v", err)
 		}
-		cohortSnap := snapshot.GetCohort("cohort")
+		cohortSnap := snapshot.Cohort("cohort")
 		if cohortSnap == nil {
 			t.Fatal("expected Cohort in snapshot")
 		}
@@ -269,7 +269,7 @@ func TestCohortReconcileLifecycle(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error while building snapshot: %v", err)
 		}
-		if cohortSnap := snapshot.GetCohort("cohort"); cohortSnap != nil {
+		if cohortSnap := snapshot.Cohort("cohort"); cohortSnap != nil {
 			t.Fatal("unexpected Cohort in snapshot")
 		}
 	}

--- a/pkg/hierarchy/manager.go
+++ b/pkg/hierarchy/manager.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package hierarchy
 
+import "maps"
+
 // Manager stores Cohorts and ClusterQueues, and maintains the edges
 // between them.
 type Manager[CQ clusterQueueNode[C], C cohortNode[CQ, C]] struct {
@@ -54,11 +56,7 @@ func (m *Manager[CQ, C]) ClusterQueuesNames() []string {
 }
 
 func (m *Manager[CQ, C]) ClusterQueues() map[string]CQ {
-	clusterQueuesCopy := make(map[string]CQ)
-	for k, v := range m.clusterQueues {
-		clusterQueuesCopy[k] = v
-	}
-	return clusterQueuesCopy
+	return maps.Clone(m.clusterQueues)
 }
 
 func (m *Manager[CQ, C]) UpdateClusterQueueEdge(name, parentName string) {
@@ -94,11 +92,7 @@ func (m *Manager[CQ, C]) Cohort(name string) C {
 }
 
 func (m *Manager[CQ, C]) Cohorts() map[string]C {
-	cohortCopy := make(map[string]C)
-	for k, v := range m.cohorts {
-		cohortCopy[k] = v
-	}
-	return cohortCopy
+	return maps.Clone(m.cohorts)
 }
 
 func (m *Manager[CQ, C]) UpdateCohortEdge(name, parentName string) {

--- a/pkg/hierarchy/manager.go
+++ b/pkg/hierarchy/manager.go
@@ -93,14 +93,6 @@ func (m *Manager[CQ, C]) GetCohort(name string) C {
   return m.cohorts[name]
 }
 
-func (m *Manager[CQ, C]) GetCohortNames() []string {
-	cohortNames := make([]string, 0, len(m.cohorts))
-	for k := range m.cohorts {
-		cohortNames = append(cohortNames, k)
-	}
-	return cohortNames
-}
-
 func (m *Manager[CQ, C]) GetCohortsCopy() map[string]C {
 	cohortCopy := make(map[string]C)
 	for k, v := range m.cohorts {

--- a/pkg/hierarchy/manager.go
+++ b/pkg/hierarchy/manager.go
@@ -42,7 +42,7 @@ func (m *Manager[CQ, C]) AddClusterQueue(cq CQ) {
 }
 
 func (m *Manager[CQ, C]) GetClusterQueue(name string) CQ {
-  return m.clusterQueues[name]
+	return m.clusterQueues[name]
 }
 
 func (m *Manager[CQ, C]) GetClusterQueueNames() []string {
@@ -90,7 +90,7 @@ func (m *Manager[CQ, C]) AddCohort(cohortName string) {
 }
 
 func (m *Manager[CQ, C]) GetCohort(name string) C {
-  return m.cohorts[name]
+	return m.cohorts[name]
 }
 
 func (m *Manager[CQ, C]) GetCohortsCopy() map[string]C {
@@ -176,6 +176,14 @@ func (m *Manager[CQ, C]) cleanupCohort(cohort C) {
 
 func (m *Manager[CQ, C]) resetCycleChecker() {
 	m.CycleChecker = CycleChecker{make(map[string]bool, len(m.cohorts))}
+}
+
+// A special constructor for using in tests
+func NewManagerForTest[CQ clusterQueueNode[C], C cohortNode[CQ, C]](cohorts map[string]C, clusterQueues map[string]CQ) Manager[CQ, C] {
+	return Manager[CQ, C]{
+		cohorts:       cohorts,
+		clusterQueues: clusterQueues,
+	}
 }
 
 type nodeBase interface {

--- a/pkg/hierarchy/manager.go
+++ b/pkg/hierarchy/manager.go
@@ -41,19 +41,19 @@ func (m *Manager[CQ, C]) AddClusterQueue(cq CQ) {
 	m.clusterQueues[cq.GetName()] = cq
 }
 
-func (m *Manager[CQ, C]) GetClusterQueue(name string) CQ {
+func (m *Manager[CQ, C]) ClusterQueue(name string) CQ {
 	return m.clusterQueues[name]
 }
 
-func (m *Manager[CQ, C]) GetClusterQueueNames() []string {
-	clusterQueueNames := make([]string, 0, len(m.clusterQueues))
+func (m *Manager[CQ, C]) ClusterQueuesNames() []string {
+	clusterQueuesNames := make([]string, 0, len(m.clusterQueues))
 	for k := range m.clusterQueues {
-		clusterQueueNames = append(clusterQueueNames, k)
+		clusterQueuesNames = append(clusterQueuesNames, k)
 	}
-	return clusterQueueNames
+	return clusterQueuesNames
 }
 
-func (m *Manager[CQ, C]) GetClusterQueuesCopy() map[string]CQ {
+func (m *Manager[CQ, C]) ClusterQueues() map[string]CQ {
 	clusterQueuesCopy := make(map[string]CQ)
 	for k, v := range m.clusterQueues {
 		clusterQueuesCopy[k] = v
@@ -89,11 +89,11 @@ func (m *Manager[CQ, C]) AddCohort(cohortName string) {
 	m.cohorts[cohortName].markExplicit()
 }
 
-func (m *Manager[CQ, C]) GetCohort(name string) C {
+func (m *Manager[CQ, C]) Cohort(name string) C {
 	return m.cohorts[name]
 }
 
-func (m *Manager[CQ, C]) GetCohortsCopy() map[string]C {
+func (m *Manager[CQ, C]) Cohorts() map[string]C {
 	cohortCopy := make(map[string]C)
 	for k, v := range m.cohorts {
 		cohortCopy[k] = v

--- a/pkg/hierarchy/manager_test.go
+++ b/pkg/hierarchy/manager_test.go
@@ -327,7 +327,7 @@ func TestManager(t *testing.T) {
 			t.Run("verify clusterqueues", func(t *testing.T) {
 				gotCqs := sets.New[string]()
 				gotEdges := make([]edge, 0, len(tc.wantCqEdge))
-				for _, cq := range mgr.ClusterQueues {
+				for _, cq := range mgr.GetClusterQueuesCopy() {
 					gotCqs.Insert(cq.GetName())
 					if cq.HasParent() {
 						gotEdges = append(gotEdges, edge{cq.GetName(), cq.Parent().GetName()})
@@ -345,7 +345,7 @@ func TestManager(t *testing.T) {
 				gotCqEdges := make([]edge, 0, len(tc.wantCqEdge))
 				gotCohortChildEdges := make([]edge, 0, len(tc.wantCohortEdge))
 				gotCohortParentEdges := make([]edge, 0, len(tc.wantCohortEdge))
-				for _, cohort := range mgr.Cohorts {
+				for _, cohort := range mgr.GetCohortsCopy() {
 					gotCohorts.Insert(cohort.GetName())
 					for _, cq := range cohort.ChildCQs() {
 						gotCqEdges = append(gotCqEdges, edge{cq.GetName(), cohort.GetName()})
@@ -408,7 +408,7 @@ func TestCycles(t *testing.T) {
 				m.AddCohort("root")
 				m.UpdateCohortEdge("root", "root")
 				// we call HasCycle to test invalidation
-				m.CycleChecker.HasCycle(m.Cohorts["root"])
+				m.CycleChecker.HasCycle(m.GetCohort("root"))
 				m.UpdateCohortEdge("root", "")
 			},
 			wantCycles: map[string]bool{
@@ -435,7 +435,7 @@ func TestCycles(t *testing.T) {
 				m.UpdateCohortEdge("cohort-b", "cohort-a")
 
 				// we call HasCycle to test invalidation
-				m.CycleChecker.HasCycle(m.Cohorts["cohort-a"])
+				m.CycleChecker.HasCycle(m.GetCohort("cohort-a"))
 
 				m.UpdateCohortEdge("cohort-a", "cohort-c")
 			},
@@ -451,7 +451,7 @@ func TestCycles(t *testing.T) {
 				m.AddCohort("cohort-b")
 				m.UpdateCohortEdge("cohort-a", "cohort-b")
 				m.UpdateCohortEdge("cohort-b", "cohort-a")
-				m.CycleChecker.HasCycle(m.Cohorts["cohort-a"])
+				m.CycleChecker.HasCycle(m.GetCohort("cohort-a"))
 
 				m.UpdateCohortEdge("cohort-a", "")
 			},
@@ -466,7 +466,7 @@ func TestCycles(t *testing.T) {
 				m.AddCohort("cohort-b")
 				m.UpdateCohortEdge("cohort-a", "cohort-b")
 				m.UpdateCohortEdge("cohort-b", "cohort-a")
-				m.CycleChecker.HasCycle(m.Cohorts["cohort-a"])
+				m.CycleChecker.HasCycle(m.GetCohort("cohort-a"))
 				m.DeleteCohort("cohort-b")
 			},
 			wantCycles: map[string]bool{
@@ -480,7 +480,7 @@ func TestCycles(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			mgr := NewManager(newCohort)
 			tc.operations(mgr)
-			for _, cohort := range mgr.Cohorts {
+			for _, cohort := range mgr.GetCohortsCopy() {
 				got := mgr.CycleChecker.HasCycle(cohort)
 				if got != tc.wantCycles[cohort.GetName()] {
 					t.Errorf("-want +got: %v %v", tc.wantCycles[cohort.GetName()], got)

--- a/pkg/hierarchy/manager_test.go
+++ b/pkg/hierarchy/manager_test.go
@@ -327,7 +327,7 @@ func TestManager(t *testing.T) {
 			t.Run("verify clusterqueues", func(t *testing.T) {
 				gotCqs := sets.New[string]()
 				gotEdges := make([]edge, 0, len(tc.wantCqEdge))
-				for _, cq := range mgr.GetClusterQueuesCopy() {
+				for _, cq := range mgr.ClusterQueues() {
 					gotCqs.Insert(cq.GetName())
 					if cq.HasParent() {
 						gotEdges = append(gotEdges, edge{cq.GetName(), cq.Parent().GetName()})
@@ -345,7 +345,7 @@ func TestManager(t *testing.T) {
 				gotCqEdges := make([]edge, 0, len(tc.wantCqEdge))
 				gotCohortChildEdges := make([]edge, 0, len(tc.wantCohortEdge))
 				gotCohortParentEdges := make([]edge, 0, len(tc.wantCohortEdge))
-				for _, cohort := range mgr.GetCohortsCopy() {
+				for _, cohort := range mgr.Cohorts() {
 					gotCohorts.Insert(cohort.GetName())
 					for _, cq := range cohort.ChildCQs() {
 						gotCqEdges = append(gotCqEdges, edge{cq.GetName(), cohort.GetName()})
@@ -408,7 +408,7 @@ func TestCycles(t *testing.T) {
 				m.AddCohort("root")
 				m.UpdateCohortEdge("root", "root")
 				// we call HasCycle to test invalidation
-				m.CycleChecker.HasCycle(m.GetCohort("root"))
+				m.CycleChecker.HasCycle(m.Cohort("root"))
 				m.UpdateCohortEdge("root", "")
 			},
 			wantCycles: map[string]bool{
@@ -435,7 +435,7 @@ func TestCycles(t *testing.T) {
 				m.UpdateCohortEdge("cohort-b", "cohort-a")
 
 				// we call HasCycle to test invalidation
-				m.CycleChecker.HasCycle(m.GetCohort("cohort-a"))
+				m.CycleChecker.HasCycle(m.Cohort("cohort-a"))
 
 				m.UpdateCohortEdge("cohort-a", "cohort-c")
 			},
@@ -451,7 +451,7 @@ func TestCycles(t *testing.T) {
 				m.AddCohort("cohort-b")
 				m.UpdateCohortEdge("cohort-a", "cohort-b")
 				m.UpdateCohortEdge("cohort-b", "cohort-a")
-				m.CycleChecker.HasCycle(m.GetCohort("cohort-a"))
+				m.CycleChecker.HasCycle(m.Cohort("cohort-a"))
 
 				m.UpdateCohortEdge("cohort-a", "")
 			},
@@ -466,7 +466,7 @@ func TestCycles(t *testing.T) {
 				m.AddCohort("cohort-b")
 				m.UpdateCohortEdge("cohort-a", "cohort-b")
 				m.UpdateCohortEdge("cohort-b", "cohort-a")
-				m.CycleChecker.HasCycle(m.GetCohort("cohort-a"))
+				m.CycleChecker.HasCycle(m.Cohort("cohort-a"))
 				m.DeleteCohort("cohort-b")
 			},
 			wantCycles: map[string]bool{
@@ -480,7 +480,7 @@ func TestCycles(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			mgr := NewManager(newCohort)
 			tc.operations(mgr)
-			for _, cohort := range mgr.GetCohortsCopy() {
+			for _, cohort := range mgr.Cohorts() {
 				got := mgr.CycleChecker.HasCycle(cohort)
 				if got != tc.wantCycles[cohort.GetName()] {
 					t.Errorf("-want +got: %v %v", tc.wantCycles[cohort.GetName()], got)

--- a/pkg/queue/dumper.go
+++ b/pkg/queue/dumper.go
@@ -26,7 +26,10 @@ import (
 func (m *Manager) LogDump(log logr.Logger) {
 	m.Lock()
 	defer m.Unlock()
-	for name, cq := range m.hm.ClusterQueues {
+	clusterQueueNames := m.hm.GetClusterQueueNames()
+	for i := range clusterQueueNames {
+    name := clusterQueueNames[i]
+    cq := m.hm.GetClusterQueue(name)
 		pending, _ := cq.Dump()
 		inadmissible, _ := cq.DumpInadmissible()
 		log.Info("Found pending and inadmissible workloads in ClusterQueue",
@@ -41,11 +44,14 @@ func (m *Manager) LogDump(log logr.Logger) {
 func (m *Manager) Dump() map[string][]string {
 	m.Lock()
 	defer m.Unlock()
-	if len(m.hm.ClusterQueues) == 0 {
+	clusterQueueNames := m.hm.GetClusterQueueNames()
+	if len(clusterQueueNames) == 0 {
 		return nil
 	}
-	dump := make(map[string][]string, len(m.hm.ClusterQueues))
-	for key, cq := range m.hm.ClusterQueues {
+	dump := make(map[string][]string, len(clusterQueueNames))
+	for i := range clusterQueueNames {
+		key := clusterQueueNames[i]
+		cq := m.hm.GetClusterQueue(key)
 		if elements, ok := cq.Dump(); ok {
 			dump[key] = elements
 		}
@@ -61,11 +67,14 @@ func (m *Manager) Dump() map[string][]string {
 func (m *Manager) DumpInadmissible() map[string][]string {
 	m.Lock()
 	defer m.Unlock()
-	if len(m.hm.ClusterQueues) == 0 {
+	clusterQueueNames := m.hm.GetClusterQueueNames()
+	if len(clusterQueueNames) == 0 {
 		return nil
 	}
-	dump := make(map[string][]string, len(m.hm.ClusterQueues))
-	for key, cq := range m.hm.ClusterQueues {
+	dump := make(map[string][]string, len(clusterQueueNames))
+	for i := range clusterQueueNames {
+		key := clusterQueueNames[i]
+		cq := m.hm.GetClusterQueue(key)
 		if elements, ok := cq.DumpInadmissible(); ok {
 			dump[key] = elements
 		}

--- a/pkg/queue/dumper.go
+++ b/pkg/queue/dumper.go
@@ -26,10 +26,7 @@ import (
 func (m *Manager) LogDump(log logr.Logger) {
 	m.Lock()
 	defer m.Unlock()
-	clusterQueueNames := m.hm.GetClusterQueueNames()
-	for i := range clusterQueueNames {
-    name := clusterQueueNames[i]
-    cq := m.hm.GetClusterQueue(name)
+	for name, cq := range m.hm.GetClusterQueuesCopy() {
 		pending, _ := cq.Dump()
 		inadmissible, _ := cq.DumpInadmissible()
 		log.Info("Found pending and inadmissible workloads in ClusterQueue",
@@ -44,14 +41,12 @@ func (m *Manager) LogDump(log logr.Logger) {
 func (m *Manager) Dump() map[string][]string {
 	m.Lock()
 	defer m.Unlock()
-	clusterQueueNames := m.hm.GetClusterQueueNames()
-	if len(clusterQueueNames) == 0 {
+	clusterQueues := m.hm.GetClusterQueuesCopy()
+	if len(clusterQueues) == 0 {
 		return nil
 	}
-	dump := make(map[string][]string, len(clusterQueueNames))
-	for i := range clusterQueueNames {
-		key := clusterQueueNames[i]
-		cq := m.hm.GetClusterQueue(key)
+	dump := make(map[string][]string, len(clusterQueues))
+	for key, cq := range clusterQueues {
 		if elements, ok := cq.Dump(); ok {
 			dump[key] = elements
 		}
@@ -67,14 +62,12 @@ func (m *Manager) Dump() map[string][]string {
 func (m *Manager) DumpInadmissible() map[string][]string {
 	m.Lock()
 	defer m.Unlock()
-	clusterQueueNames := m.hm.GetClusterQueueNames()
-	if len(clusterQueueNames) == 0 {
+	clusterQueues := m.hm.GetClusterQueuesCopy()
+	if len(clusterQueues) == 0 {
 		return nil
 	}
-	dump := make(map[string][]string, len(clusterQueueNames))
-	for i := range clusterQueueNames {
-		key := clusterQueueNames[i]
-		cq := m.hm.GetClusterQueue(key)
+	dump := make(map[string][]string, len(clusterQueues))
+	for key, cq := range clusterQueues {
 		if elements, ok := cq.DumpInadmissible(); ok {
 			dump[key] = elements
 		}

--- a/pkg/queue/dumper.go
+++ b/pkg/queue/dumper.go
@@ -26,7 +26,7 @@ import (
 func (m *Manager) LogDump(log logr.Logger) {
 	m.Lock()
 	defer m.Unlock()
-	for name, cq := range m.hm.GetClusterQueuesCopy() {
+	for name, cq := range m.hm.ClusterQueues() {
 		pending, _ := cq.Dump()
 		inadmissible, _ := cq.DumpInadmissible()
 		log.Info("Found pending and inadmissible workloads in ClusterQueue",
@@ -41,7 +41,7 @@ func (m *Manager) LogDump(log logr.Logger) {
 func (m *Manager) Dump() map[string][]string {
 	m.Lock()
 	defer m.Unlock()
-	clusterQueues := m.hm.GetClusterQueuesCopy()
+	clusterQueues := m.hm.ClusterQueues()
 	if len(clusterQueues) == 0 {
 		return nil
 	}
@@ -62,7 +62,7 @@ func (m *Manager) Dump() map[string][]string {
 func (m *Manager) DumpInadmissible() map[string][]string {
 	m.Lock()
 	defer m.Unlock()
-	clusterQueues := m.hm.GetClusterQueuesCopy()
+	clusterQueues := m.hm.ClusterQueues()
 	if len(clusterQueues) == 0 {
 		return nil
 	}

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -141,7 +141,7 @@ func (m *Manager) AddOrUpdateCohort(ctx context.Context, cohort *kueuealpha.Coho
 	defer m.Unlock()
 	m.hm.AddCohort(cohort.Name)
 	m.hm.UpdateCohortEdge(cohort.Name, cohort.Spec.Parent)
-	if m.requeueWorkloadsCohort(ctx, m.hm.Cohorts[cohort.Name]) {
+	if m.requeueWorkloadsCohort(ctx, m.hm.GetCohort(cohort.Name)) {
 		m.Broadcast()
 	}
 }
@@ -156,7 +156,7 @@ func (m *Manager) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) e
 	m.Lock()
 	defer m.Unlock()
 
-	if _, ok := m.hm.ClusterQueues[cq.Name]; ok {
+	if cq := m.hm.GetClusterQueue(cq.Name); cq != nil {
 		return errClusterQueueAlreadyExists
 	}
 
@@ -204,8 +204,8 @@ func (m *Manager) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) e
 func (m *Manager) UpdateClusterQueue(ctx context.Context, cq *kueue.ClusterQueue, specUpdated bool) error {
 	m.Lock()
 	defer m.Unlock()
-	cqImpl, ok := m.hm.ClusterQueues[cq.Name]
-	if !ok {
+	cqImpl := m.hm.GetClusterQueue(cq.Name)
+	if cqImpl == nil {
 		return ErrClusterQueueDoesNotExist
 	}
 
@@ -235,7 +235,7 @@ func (m *Manager) UpdateClusterQueue(ctx context.Context, cq *kueue.ClusterQueue
 func (m *Manager) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 	m.Lock()
 	defer m.Unlock()
-	cqImpl := m.hm.ClusterQueues[cq.Name]
+	cqImpl := m.hm.GetClusterQueue(cq.Name)
 	if cqImpl == nil {
 		return
 	}
@@ -274,7 +274,7 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 		workload.AdjustResources(ctx, m.client, &w)
 		qImpl.AddOrUpdate(workload.NewInfo(&w, m.workloadInfoOptions...))
 	}
-	cq := m.hm.ClusterQueues[qImpl.ClusterQueue]
+	cq := m.hm.GetClusterQueue(qImpl.ClusterQueue)
 	if cq != nil && cq.AddFromLocalQueue(qImpl) {
 		m.Broadcast()
 	}
@@ -289,11 +289,11 @@ func (m *Manager) UpdateLocalQueue(q *kueue.LocalQueue) error {
 		return ErrLocalQueueDoesNotExistOrInactive
 	}
 	if qImpl.ClusterQueue != string(q.Spec.ClusterQueue) {
-		oldCQ := m.hm.ClusterQueues[qImpl.ClusterQueue]
+		oldCQ := m.hm.GetClusterQueue(qImpl.ClusterQueue)
 		if oldCQ != nil {
 			oldCQ.DeleteFromLocalQueue(qImpl)
 		}
-		newCQ := m.hm.ClusterQueues[string(q.Spec.ClusterQueue)]
+		newCQ := m.hm.GetClusterQueue(string(q.Spec.ClusterQueue))
 		if newCQ != nil && newCQ.AddFromLocalQueue(qImpl) {
 			m.Broadcast()
 		}
@@ -310,7 +310,7 @@ func (m *Manager) DeleteLocalQueue(q *kueue.LocalQueue) {
 	if qImpl == nil {
 		return
 	}
-	cq := m.hm.ClusterQueues[qImpl.ClusterQueue]
+	cq := m.hm.GetClusterQueue(qImpl.ClusterQueue)
 	if cq != nil {
 		cq.DeleteFromLocalQueue(qImpl)
 	}
@@ -336,8 +336,8 @@ func (m *Manager) Pending(cq *kueue.ClusterQueue) (int, error) {
 	m.RLock()
 	defer m.RUnlock()
 
-	cqImpl, ok := m.hm.ClusterQueues[cq.Name]
-	if !ok {
+	cqImpl := m.hm.GetClusterQueue(cq.Name)
+	if cqImpl == nil {
 		return 0, ErrClusterQueueDoesNotExist
 	}
 
@@ -361,7 +361,7 @@ func (m *Manager) ClusterQueueForWorkload(wl *kueue.Workload) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	_, ok = m.hm.ClusterQueues[q.ClusterQueue]
+	ok = m.hm.GetClusterQueue(q.ClusterQueue) != nil
 	return q.ClusterQueue, ok
 }
 
@@ -381,7 +381,7 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(w *kueue.Workload) error {
 	}
 	wInfo := workload.NewInfo(w, m.workloadInfoOptions...)
 	q.AddOrUpdate(wInfo)
-	cq := m.hm.ClusterQueues[q.ClusterQueue]
+	cq := m.hm.GetClusterQueue(q.ClusterQueue)
 	if cq == nil {
 		return ErrClusterQueueDoesNotExist
 	}
@@ -415,7 +415,7 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 	}
 	info.Update(&w)
 	q.AddOrUpdate(info)
-	cq := m.hm.ClusterQueues[q.ClusterQueue]
+	cq := m.hm.GetClusterQueue(q.ClusterQueue)
 	if cq == nil {
 		return false
 	}
@@ -443,7 +443,7 @@ func (m *Manager) deleteWorkloadFromQueueAndClusterQueue(w *kueue.Workload, qKey
 		return
 	}
 	delete(q.items, workload.Key(w))
-	cq := m.hm.ClusterQueues[q.ClusterQueue]
+	cq := m.hm.GetClusterQueue(q.ClusterQueue)
 	if cq != nil {
 		cq.Delete(w)
 		m.reportPendingWorkloads(q.ClusterQueue, cq)
@@ -470,7 +470,7 @@ func (m *Manager) QueueAssociatedInadmissibleWorkloadsAfter(ctx context.Context,
 	if q == nil {
 		return
 	}
-	cq := m.hm.ClusterQueues[q.ClusterQueue]
+	cq := m.hm.GetClusterQueue(q.ClusterQueue)
 	if cq == nil {
 		return
 	}
@@ -492,8 +492,8 @@ func (m *Manager) QueueInadmissibleWorkloads(ctx context.Context, cqNames sets.S
 
 	var queued bool
 	for name := range cqNames {
-		cq, exists := m.hm.ClusterQueues[name]
-		if !exists {
+		cq := m.hm.GetClusterQueue(name)
+		if cq == nil {
 			continue
 		}
 		if m.requeueWorkloadsCQ(ctx, cq) {
@@ -600,7 +600,10 @@ func (m *Manager) Heads(ctx context.Context) []workload.Info {
 
 func (m *Manager) heads() []workload.Info {
 	var workloads []workload.Info
-	for cqName, cq := range m.hm.ClusterQueues {
+  clusterQueueNames := m.hm.GetClusterQueueNames()
+	for i := range clusterQueueNames {
+    cqName := clusterQueueNames[i]
+    cq := m.hm.GetClusterQueue(cqName)
 		// Cache might be nil in tests, if cache is nil, we'll skip the check.
 		if m.statusChecker != nil && !m.statusChecker.ClusterQueueActive(cqName) {
 			continue
@@ -649,22 +652,18 @@ func (m *Manager) reportPendingWorkloads(cqName string, cq *ClusterQueue) {
 func (m *Manager) GetClusterQueueNames() []string {
 	m.RLock()
 	defer m.RUnlock()
-	clusterQueueNames := make([]string, 0, len(m.hm.ClusterQueues))
-	for k := range m.hm.ClusterQueues {
-		clusterQueueNames = append(clusterQueueNames, k)
-	}
-	return clusterQueueNames
+	return m.hm.GetClusterQueueNames()
 }
 
 func (m *Manager) getClusterQueue(cqName string) *ClusterQueue {
 	m.RLock()
 	defer m.RUnlock()
-	return m.hm.ClusterQueues[cqName]
+	return m.hm.GetClusterQueue(cqName)
 }
 
 func (m *Manager) getClusterQueueLockless(cqName string) (val *ClusterQueue, ok bool) {
-	val, ok = m.hm.ClusterQueues[cqName]
-	return
+	val = m.hm.GetClusterQueue(cqName)
+	return val, val != nil
 }
 
 func (m *Manager) PendingWorkloadsInfo(cqName string) []*workload.Info {

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -600,10 +600,7 @@ func (m *Manager) Heads(ctx context.Context) []workload.Info {
 
 func (m *Manager) heads() []workload.Info {
 	var workloads []workload.Info
-  clusterQueueNames := m.hm.GetClusterQueueNames()
-	for i := range clusterQueueNames {
-    cqName := clusterQueueNames[i]
-    cq := m.hm.GetClusterQueue(cqName)
+	for cqName, cq := range m.hm.GetClusterQueuesCopy() {
 		// Cache might be nil in tests, if cache is nil, we'll skip the check.
 		if m.statusChecker != nil && !m.statusChecker.ClusterQueueActive(cqName) {
 			continue

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -118,7 +118,7 @@ func TestAddClusterQueueOrphans(t *testing.T) {
 	if err := manager.AddClusterQueue(ctx, cq); err != nil {
 		t.Fatalf("Could not re-add ClusterQueue: %v", err)
 	}
-	workloads := popNamesFromCQ(manager.hm.GetClusterQueue("cq"))
+	workloads := popNamesFromCQ(manager.hm.ClusterQueue("cq"))
 	wantWorkloads := []string{"/b", "/a"}
 	if diff := cmp.Diff(wantWorkloads, workloads); diff != "" {
 		t.Errorf("Workloads popped in the wrong order from clusterQueue:\n%s", diff)
@@ -191,7 +191,7 @@ func TestUpdateClusterQueue(t *testing.T) {
 		"alpha": sets.New("cq1", "cq2"),
 	}
 	gotCohorts := make(map[string]sets.Set[string])
-	for name, cohort := range manager.hm.GetCohortsCopy() {
+	for name, cohort := range manager.hm.Cohorts() {
 		gotCohorts[name] = sets.New[string]()
 		for _, cq := range cohort.ChildCQs() {
 			gotCohorts[name].Insert(cq.GetName())
@@ -249,7 +249,7 @@ func TestRequeueWorkloadsCohortCycle(t *testing.T) {
 
 	// This method is where we do a cycle check. We call it to ensure
 	// it behaves properly when a cycle exists
-	if manager.requeueWorkloadsCohort(ctx, manager.hm.GetCohort("cohort-a")) {
+	if manager.requeueWorkloadsCohort(ctx, manager.hm.Cohort("cohort-a")) {
 		t.Fatal("Expected moveWorkloadsCohort to return false")
 	}
 }
@@ -359,7 +359,7 @@ func TestUpdateLocalQueue(t *testing.T) {
 
 	// Verification.
 	workloadOrders := make(map[string][]string)
-	for name, cq := range manager.hm.GetClusterQueuesCopy() {
+	for name, cq := range manager.hm.ClusterQueues() {
 		workloadOrders[name] = popNamesFromCQ(cq)
 	}
 	wantWorkloadOrders := map[string][]string{
@@ -827,7 +827,7 @@ func TestUpdateWorkload(t *testing.T) {
 				} else if diff := cmp.Diff(wl, item.Obj); diff != "" {
 					t.Errorf("Object stored in queue differs (-want,+got):\n%s", diff)
 				}
-				cq := manager.hm.GetClusterQueue(q.ClusterQueue)
+				cq := manager.hm.ClusterQueue(q.ClusterQueue)
 				if cq != nil {
 					item := cq.Info(key)
 					if item == nil {
@@ -838,7 +838,7 @@ func TestUpdateWorkload(t *testing.T) {
 				}
 			}
 			queueOrder := make(map[string][]string)
-			for name, cq := range manager.hm.GetClusterQueuesCopy() {
+			for name, cq := range manager.hm.ClusterQueues() {
 				queueOrder[name] = popNamesFromCQ(cq)
 			}
 			if diff := cmp.Diff(tc.wantQueueOrder, queueOrder); diff != "" {

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -118,7 +118,7 @@ func TestAddClusterQueueOrphans(t *testing.T) {
 	if err := manager.AddClusterQueue(ctx, cq); err != nil {
 		t.Fatalf("Could not re-add ClusterQueue: %v", err)
 	}
-	workloads := popNamesFromCQ(manager.hm.ClusterQueues["cq"])
+	workloads := popNamesFromCQ(manager.hm.GetClusterQueue("cq"))
 	wantWorkloads := []string{"/b", "/a"}
 	if diff := cmp.Diff(wantWorkloads, workloads); diff != "" {
 		t.Errorf("Workloads popped in the wrong order from clusterQueue:\n%s", diff)
@@ -191,7 +191,7 @@ func TestUpdateClusterQueue(t *testing.T) {
 		"alpha": sets.New("cq1", "cq2"),
 	}
 	gotCohorts := make(map[string]sets.Set[string])
-	for name, cohort := range manager.hm.Cohorts {
+	for name, cohort := range manager.hm.GetCohortsCopy() {
 		gotCohorts[name] = sets.New[string]()
 		for _, cq := range cohort.ChildCQs() {
 			gotCohorts[name].Insert(cq.GetName())
@@ -249,7 +249,7 @@ func TestRequeueWorkloadsCohortCycle(t *testing.T) {
 
 	// This method is where we do a cycle check. We call it to ensure
 	// it behaves properly when a cycle exists
-	if manager.requeueWorkloadsCohort(ctx, manager.hm.Cohorts["cohort-a"]) {
+	if manager.requeueWorkloadsCohort(ctx, manager.hm.GetCohort("cohort-a")) {
 		t.Fatal("Expected moveWorkloadsCohort to return false")
 	}
 }
@@ -359,7 +359,7 @@ func TestUpdateLocalQueue(t *testing.T) {
 
 	// Verification.
 	workloadOrders := make(map[string][]string)
-	for name, cq := range manager.hm.ClusterQueues {
+	for name, cq := range manager.hm.GetClusterQueuesCopy() {
 		workloadOrders[name] = popNamesFromCQ(cq)
 	}
 	wantWorkloadOrders := map[string][]string{
@@ -827,7 +827,7 @@ func TestUpdateWorkload(t *testing.T) {
 				} else if diff := cmp.Diff(wl, item.Obj); diff != "" {
 					t.Errorf("Object stored in queue differs (-want,+got):\n%s", diff)
 				}
-				cq := manager.hm.ClusterQueues[q.ClusterQueue]
+				cq := manager.hm.GetClusterQueue(q.ClusterQueue)
 				if cq != nil {
 					item := cq.Info(key)
 					if item == nil {
@@ -838,7 +838,7 @@ func TestUpdateWorkload(t *testing.T) {
 				}
 			}
 			queueOrder := make(map[string][]string)
-			for name, cq := range manager.hm.ClusterQueues {
+			for name, cq := range manager.hm.GetClusterQueuesCopy() {
 				queueOrder[name] = popNamesFromCQ(cq)
 			}
 			if diff := cmp.Diff(tc.wantQueueOrder, queueOrder); diff != "" {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -1961,7 +1961,7 @@ func TestAssignFlavors(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			clusterQueue := snapshot.ClusterQueues[tc.clusterQueue.Name]
+			clusterQueue := snapshot.GetClusterQueue(tc.clusterQueue.Name)
 
 			if clusterQueue == nil {
 				t.Fatalf("Failed to create CQ snapshot")
@@ -1971,7 +1971,7 @@ func TestAssignFlavors(t *testing.T) {
 			}
 
 			if tc.secondaryClusterQueue != nil {
-				secondaryClusterQueue := snapshot.ClusterQueues[tc.secondaryClusterQueue.Name]
+				secondaryClusterQueue := snapshot.GetClusterQueue(tc.secondaryClusterQueue.Name)
 				if secondaryClusterQueue == nil {
 					t.Fatalf("Failed to create secondary CQ snapshot")
 				}
@@ -2124,10 +2124,10 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			otherClusterQueue := snapshot.ClusterQueues["other-clusterqueue"]
+			otherClusterQueue := snapshot.GetClusterQueue("other-clusterqueue")
 			otherClusterQueue.AddUsage(workload.Usage{Quota: tc.otherClusterQueueUsage})
 
-			testClusterQueue := snapshot.ClusterQueues["test-clusterqueue"]
+			testClusterQueue := snapshot.GetClusterQueue("test-clusterqueue")
 			testClusterQueue.AddUsage(workload.Usage{Quota: tc.testClusterQueueUsage})
 
 			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{})
@@ -2252,7 +2252,7 @@ func TestDeletedFlavors(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			clusterQueue := snapshot.ClusterQueues[tc.clusterQueue.Name]
+			clusterQueue := snapshot.GetClusterQueue(tc.clusterQueue.Name)
 			if clusterQueue == nil {
 				t.Fatalf("Failed to create CQ snapshot")
 			}

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -1961,7 +1961,7 @@ func TestAssignFlavors(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			clusterQueue := snapshot.GetClusterQueue(tc.clusterQueue.Name)
+			clusterQueue := snapshot.ClusterQueue(tc.clusterQueue.Name)
 
 			if clusterQueue == nil {
 				t.Fatalf("Failed to create CQ snapshot")
@@ -1971,7 +1971,7 @@ func TestAssignFlavors(t *testing.T) {
 			}
 
 			if tc.secondaryClusterQueue != nil {
-				secondaryClusterQueue := snapshot.GetClusterQueue(tc.secondaryClusterQueue.Name)
+				secondaryClusterQueue := snapshot.ClusterQueue(tc.secondaryClusterQueue.Name)
 				if secondaryClusterQueue == nil {
 					t.Fatalf("Failed to create secondary CQ snapshot")
 				}
@@ -2124,10 +2124,10 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			otherClusterQueue := snapshot.GetClusterQueue("other-clusterqueue")
+			otherClusterQueue := snapshot.ClusterQueue("other-clusterqueue")
 			otherClusterQueue.AddUsage(workload.Usage{Quota: tc.otherClusterQueueUsage})
 
-			testClusterQueue := snapshot.GetClusterQueue("test-clusterqueue")
+			testClusterQueue := snapshot.ClusterQueue("test-clusterqueue")
 			testClusterQueue.AddUsage(workload.Usage{Quota: tc.testClusterQueueUsage})
 
 			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{})
@@ -2252,7 +2252,7 @@ func TestDeletedFlavors(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			clusterQueue := snapshot.GetClusterQueue(tc.clusterQueue.Name)
+			clusterQueue := snapshot.ClusterQueue(tc.clusterQueue.Name)
 			if clusterQueue == nil {
 				t.Fatalf("Failed to create CQ snapshot")
 			}

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -124,7 +124,7 @@ type Target struct {
 // GetTargets returns the list of workloads that should be evicted in
 // order to make room for wl.
 func (p *Preemptor) GetTargets(log logr.Logger, wl workload.Info, assignment flavorassigner.Assignment, snapshot *cache.Snapshot) []*Target {
-	cq := snapshot.GetClusterQueue(wl.ClusterQueue)
+	cq := snapshot.ClusterQueue(wl.ClusterQueue)
 	tasRequests := assignment.WorkloadsTopologyRequests(&wl, cq)
 	return p.getTargets(&preemptionCtx{
 		log:               log,
@@ -259,7 +259,7 @@ func minimalPreemptions(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 	var targets []*Target
 	fits := false
 	for _, candWl := range candidates {
-		candCQ := preemptionCtx.snapshot.GetClusterQueue(candWl.ClusterQueue)
+		candCQ := preemptionCtx.snapshot.ClusterQueue(candWl.ClusterQueue)
 		reason := kueue.InClusterQueueReason
 		if preemptionCtx.preemptorCQ != candCQ {
 			if !cqIsBorrowing(candCQ, preemptionCtx.frsNeedPreemption) {
@@ -472,7 +472,7 @@ func cqHeapFromCandidates(candidates []*workload.Info, firstOnly bool, snapshot 
 	for _, cand := range candidates {
 		candCQ := cqHeap.GetByKey(cand.ClusterQueue)
 		if candCQ == nil {
-			cq := snapshot.GetClusterQueue(cand.ClusterQueue)
+			cq := snapshot.ClusterQueue(cand.ClusterQueue)
 			share, _ := cq.DominantResourceShare()
 			candCQ = &candidateCQ{
 				cq:        cq,

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -124,7 +124,7 @@ type Target struct {
 // GetTargets returns the list of workloads that should be evicted in
 // order to make room for wl.
 func (p *Preemptor) GetTargets(log logr.Logger, wl workload.Info, assignment flavorassigner.Assignment, snapshot *cache.Snapshot) []*Target {
-	cq := snapshot.ClusterQueues[wl.ClusterQueue]
+	cq := snapshot.GetClusterQueue(wl.ClusterQueue)
 	tasRequests := assignment.WorkloadsTopologyRequests(&wl, cq)
 	return p.getTargets(&preemptionCtx{
 		log:               log,
@@ -259,7 +259,7 @@ func minimalPreemptions(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 	var targets []*Target
 	fits := false
 	for _, candWl := range candidates {
-		candCQ := preemptionCtx.snapshot.ClusterQueues[candWl.ClusterQueue]
+		candCQ := preemptionCtx.snapshot.GetClusterQueue(candWl.ClusterQueue)
 		reason := kueue.InClusterQueueReason
 		if preemptionCtx.preemptorCQ != candCQ {
 			if !cqIsBorrowing(candCQ, preemptionCtx.frsNeedPreemption) {
@@ -472,7 +472,7 @@ func cqHeapFromCandidates(candidates []*workload.Info, firstOnly bool, snapshot 
 	for _, cand := range candidates {
 		candCQ := cqHeap.GetByKey(cand.ClusterQueue)
 		if candCQ == nil {
-			cq := snapshot.ClusterQueues[cand.ClusterQueue]
+			cq := snapshot.GetClusterQueue(cand.ClusterQueue)
 			share, _ := cq.DominantResourceShare()
 			candCQ = &candidateCQ{
 				cq:        cq,

--- a/pkg/scheduler/preemption/preemption_oracle.go
+++ b/pkg/scheduler/preemption/preemption_oracle.go
@@ -44,7 +44,7 @@ func (p *PreemptionOracle) IsReclaimPossible(log logr.Logger, cq *cache.ClusterQ
 	for _, candidate := range p.preemptor.getTargets(&preemptionCtx{
 		log:               log,
 		preemptor:         wl,
-		preemptorCQ:       p.snapshot.ClusterQueues[wl.ClusterQueue],
+		preemptorCQ:       p.snapshot.GetClusterQueue(wl.ClusterQueue),
 		snapshot:          p.snapshot,
 		frsNeedPreemption: sets.New(fr),
 		requests:          resources.FlavorResourceQuantities{fr: quantity},

--- a/pkg/scheduler/preemption/preemption_oracle.go
+++ b/pkg/scheduler/preemption/preemption_oracle.go
@@ -44,7 +44,7 @@ func (p *PreemptionOracle) IsReclaimPossible(log logr.Logger, cq *cache.ClusterQ
 	for _, candidate := range p.preemptor.getTargets(&preemptionCtx{
 		log:               log,
 		preemptor:         wl,
-		preemptorCQ:       p.snapshot.GetClusterQueue(wl.ClusterQueue),
+		preemptorCQ:       p.snapshot.ClusterQueue(wl.ClusterQueue),
 		snapshot:          p.snapshot,
 		frsNeedPreemption: sets.New(fr),
 		requests:          resources.FlavorResourceQuantities{fr: quantity},

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -218,7 +218,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 			continue
 		}
 
-		cq := snapshot.GetClusterQueue(e.ClusterQueue)
+		cq := snapshot.ClusterQueue(e.ClusterQueue)
 		log := log.WithValues("workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", e.ClusterQueue))
 		ctx := ctrl.LoggerInto(ctx, log)
 
@@ -358,7 +358,7 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 	entries := make([]entry, 0, len(workloads))
 	for _, w := range workloads {
 		log := log.WithValues("workload", klog.KObj(w.Obj), "clusterQueue", klog.KRef("", w.ClusterQueue))
-		cq := snap.GetClusterQueue(w.ClusterQueue)
+		cq := snap.ClusterQueue(w.ClusterQueue)
 		ns := corev1.Namespace{}
 		e := entry{Info: w}
 		if s.cache.IsAssumedOrAdmittedWorkload(w) {
@@ -425,7 +425,7 @@ type partialAssignment struct {
 }
 
 func (s *Scheduler) getAssignments(log logr.Logger, wl *workload.Info, snap *cache.Snapshot) (flavorassigner.Assignment, []*preemption.Target) {
-	cq := snap.GetClusterQueue(wl.ClusterQueue)
+	cq := snap.ClusterQueue(wl.ClusterQueue)
 	flvAssigner := flavorassigner.New(wl, cq, snap.ResourceFlavors, s.fairSharing.Enable, preemption.NewOracle(s.preemptor, snap))
 	fullAssignment := flvAssigner.Assign(log, nil)
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -218,7 +218,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 			continue
 		}
 
-		cq := snapshot.ClusterQueues[e.ClusterQueue]
+		cq := snapshot.GetClusterQueue(e.ClusterQueue)
 		log := log.WithValues("workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", e.ClusterQueue))
 		ctx := ctrl.LoggerInto(ctx, log)
 
@@ -358,7 +358,7 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 	entries := make([]entry, 0, len(workloads))
 	for _, w := range workloads {
 		log := log.WithValues("workload", klog.KObj(w.Obj), "clusterQueue", klog.KRef("", w.ClusterQueue))
-		cq := snap.ClusterQueues[w.ClusterQueue]
+		cq := snap.GetClusterQueue(w.ClusterQueue)
 		ns := corev1.Namespace{}
 		e := entry{Info: w}
 		if s.cache.IsAssumedOrAdmittedWorkload(w) {
@@ -425,7 +425,7 @@ type partialAssignment struct {
 }
 
 func (s *Scheduler) getAssignments(log logr.Logger, wl *workload.Info, snap *cache.Snapshot) (flavorassigner.Assignment, []*preemption.Target) {
-	cq := snap.ClusterQueues[wl.ClusterQueue]
+	cq := snap.GetClusterQueue(wl.ClusterQueue)
 	flvAssigner := flavorassigner.New(wl, cq, snap.ResourceFlavors, s.fairSharing.Enable, preemption.NewOracle(s.preemptor, snap))
 	fullAssignment := flvAssigner.Assign(log, nil)
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2659,7 +2659,7 @@ func TestSchedule(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			for cqName, c := range snapshot.GetClusterQueuesCopy() {
+			for cqName, c := range snapshot.ClusterQueues() {
 				for name, w := range c.Workloads {
 					gotWorkloads = append(gotWorkloads, *w.Obj)
 					switch {
@@ -3466,7 +3466,7 @@ func TestLastSchedulingContext(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			for cqName, c := range snapshot.GetClusterQueuesCopy() {
+			for cqName, c := range snapshot.ClusterQueues() {
 				for name, w := range c.Workloads {
 					switch {
 					case !workload.IsAdmitted(w.Obj):
@@ -3815,7 +3815,7 @@ func TestResourcesToReserve(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			cqSnapshot := snapshot.GetClusterQueue("cq")
+			cqSnapshot := snapshot.ClusterQueue("cq")
 
 			got := resourcesToReserve(e, cqSnapshot)
 			if !reflect.DeepEqual(tc.wantReserved, got.Quota) {
@@ -5073,7 +5073,7 @@ func TestScheduleForTAS(t *testing.T) {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
 			gotAssignments := make(map[string]kueue.Admission)
-			for cqName, c := range snapshot.GetClusterQueuesCopy() {
+			for cqName, c := range snapshot.ClusterQueues() {
 				for name, w := range c.Workloads {
 					if initiallyAdmittedWorkloads.Has(workload.Key(w.Obj)) {
 						continue
@@ -5645,7 +5645,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 				t.Errorf("Unexpected preemptions (-want,+got):\n%s", diff)
 			}
 			gotAssignments := make(map[string]kueue.Admission)
-			for cqName, c := range snapshot.GetClusterQueuesCopy() {
+			for cqName, c := range snapshot.ClusterQueues() {
 				for name, w := range c.Workloads {
 					if initiallyAdmittedWorkloads.Has(workload.Key(w.Obj)) {
 						continue

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2659,7 +2659,7 @@ func TestSchedule(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			for cqName, c := range snapshot.ClusterQueues {
+			for cqName, c := range snapshot.GetClusterQueuesCopy() {
 				for name, w := range c.Workloads {
 					gotWorkloads = append(gotWorkloads, *w.Obj)
 					switch {
@@ -3466,7 +3466,7 @@ func TestLastSchedulingContext(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			for cqName, c := range snapshot.ClusterQueues {
+			for cqName, c := range snapshot.GetClusterQueuesCopy() {
 				for name, w := range c.Workloads {
 					switch {
 					case !workload.IsAdmitted(w.Obj):
@@ -3815,7 +3815,7 @@ func TestResourcesToReserve(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			cqSnapshot := snapshot.ClusterQueues["cq"]
+			cqSnapshot := snapshot.GetClusterQueue("cq")
 
 			got := resourcesToReserve(e, cqSnapshot)
 			if !reflect.DeepEqual(tc.wantReserved, got.Quota) {
@@ -5073,7 +5073,7 @@ func TestScheduleForTAS(t *testing.T) {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
 			gotAssignments := make(map[string]kueue.Admission)
-			for cqName, c := range snapshot.ClusterQueues {
+			for cqName, c := range snapshot.GetClusterQueuesCopy() {
 				for name, w := range c.Workloads {
 					if initiallyAdmittedWorkloads.Has(workload.Key(w.Obj)) {
 						continue
@@ -5645,7 +5645,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 				t.Errorf("Unexpected preemptions (-want,+got):\n%s", diff)
 			}
 			gotAssignments := make(map[string]kueue.Admission)
-			for cqName, c := range snapshot.ClusterQueues {
+			for cqName, c := range snapshot.GetClusterQueuesCopy() {
 				for name, w := range c.Workloads {
 					if initiallyAdmittedWorkloads.Has(workload.Key(w.Obj)) {
 						continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
#### What this PR does / why we need it:
Unexports two map fields in `hierarchy.Manager` so that they can be modified only by corresponding `Add...` and `Delete...` methods. 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2996 

#### Special notes for your reviewer:
I added `GetClusterQueue` and `GetCohort` methods to get objects by name and `GetClusterQueuesCopy` and `GetCohortsCopy` to get copy of map for using in range loops.

Also `NewManagerForTest` constructor was added to use only in tests, specifically in `cache/snapshot_test.go` where large map literals are used to initialize managers before comparing snapshots.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
None
```release-note
NONE
```