### PR TITLE
Differentiate error message for cohort and cluster queue

### DIFF
--- a/pkg/webhooks/clusterqueue_webhook_test.go
+++ b/pkg/webhooks/clusterqueue_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package webhooks
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -156,7 +157,7 @@ func TestValidateClusterQueue(t *testing.T) {
 					*testingutil.MakeFlavorQuotas("x86").Resource("cpu", "1", "", "1").Obj()).
 				Obj(),
 			wantErr: field.ErrorList{
-				field.Invalid(resourceGroupsPath.Index(0).Child("flavors").Index(0).Child("resources").Index(0).Child("lendingLimit"), "1", limitIsEmptyErrorMsg),
+				field.Invalid(resourceGroupsPath.Index(0).Child("flavors").Index(0).Child("resources").Index(0).Child("lendingLimit"), "1", fmt.Sprintf(limitIsEmptyErrorMsgTemplate, "cohort")),
 			},
 		},
 		{

--- a/pkg/webhooks/clusterqueue_webhook_test.go
+++ b/pkg/webhooks/clusterqueue_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhooks
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -157,7 +156,7 @@ func TestValidateClusterQueue(t *testing.T) {
 					*testingutil.MakeFlavorQuotas("x86").Resource("cpu", "1", "", "1").Obj()).
 				Obj(),
 			wantErr: field.ErrorList{
-				field.Invalid(resourceGroupsPath.Index(0).Child("flavors").Index(0).Child("resources").Index(0).Child("lendingLimit"), "1", fmt.Sprintf(limitIsEmptyErrorMsgTemplate, "cohort")),
+				field.Invalid(resourceGroupsPath.Index(0).Child("flavors").Index(0).Child("resources").Index(0).Child("lendingLimit"), "1", "must be nil when cohort is empty"),
 			},
 		},
 		{

--- a/pkg/webhooks/cohort_webhook.go
+++ b/pkg/webhooks/cohort_webhook.go
@@ -75,6 +75,6 @@ func validateCohort(cohort *kueuealpha.Cohort) field.ErrorList {
 	var allErrs field.ErrorList
 
 	allErrs = append(allErrs, validateFairSharing(cohort.Spec.FairSharing, path.Child("fairSharing"))...)
-	allErrs = append(allErrs, validateResourceGroups(cohort.Spec.ResourceGroups, config, path.Child("resourceGroups"))...)
+	allErrs = append(allErrs, validateResourceGroups(cohort.Spec.ResourceGroups, config, path.Child("resourceGroups"), true)...)
 	return allErrs
 }

--- a/pkg/webhooks/cohort_webhook_test.go
+++ b/pkg/webhooks/cohort_webhook_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	"sigs.k8s.io/kueue/pkg/features"
+	testingutil "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+func TestValidateCohort(t *testing.T) {
+	specPath := field.NewPath("spec")
+	resourceGroupsPath := specPath.Child("resourceGroups")
+
+	testcases := []struct {
+		name                string
+		cohort              *kueue.Cohort
+		wantErr             field.ErrorList
+		disableLendingLimit bool
+	}{
+		{
+			name: "flavor quota with lendingLimit and empty parent",
+			cohort: testingutil.MakeCohort("cohort").
+				ResourceGroup(
+					*testingutil.MakeFlavorQuotas("x86").Resource("cpu", "1", "", "1").Obj()).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(resourceGroupsPath.Index(0).Child("flavors").Index(0).Child("resources").Index(0).Child("lendingLimit"), "1", "must be nil when parent is empty"),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.disableLendingLimit {
+				features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
+			}
+			gotErr := validateCohort(tc.cohort)
+			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{}, "BadValue")); diff != "" {
+				t.Errorf("ValidateResources() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When parent cohort is empty it uses "parent" for cohort and "cohort" for cluster queue.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
It fixes misleading error message in case of empty parent for hierarchical cohort and non-zero borrowing/lending limit.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4392 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```