### PR TITLE
Automated cherry pick of #4484: Allow for one to change namespace for roles for prometheus

### DIFF
--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -77,3 +77,4 @@ The following table lists the configurable parameters of the kueue chart and the
 | `managerConfig.controllerManagerConfigYaml`            | controllerManagerConfigYaml                            | abbr.                                       |
 | `metricsService`                                       | metricsService's ports                                 | abbr.                                       |
 | `webhookService`                                       | webhookService's ports                                 | abbr.                                       |
+| `metrics.prometheusNamespace`                          | prometheus namespace                                   | `monitoring`                                |

--- a/charts/kueue/templates/prometheus/role.yaml
+++ b/charts/kueue/templates/prometheus/role.yaml
@@ -48,8 +48,8 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-k8s
-  namespace: '{{ .Release.Namespace }}'
+  namespace: '{{ .Values.metrics.prometheusNamespace }}'
 - kind: ServiceAccount
   name: prometheus-operator
-  namespace: '{{ .Release.Namespace }}'
+  namespace: '{{ .Values.metrics.prometheusNamespace }}'
 {{- end }}

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -155,3 +155,6 @@ webhookService:
       protocol: TCP
       targetPort: 9443
   type: ClusterIP
+
+metrics:
+  prometheusNamespace: monitoring


### PR DESCRIPTION
Cherry pick of #4484 on release-0.10.

#4484: Allow for one to change namespace for roles for prometheus

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Helm: Fixed a bug that prometheus namespace is enforced with namespace the same as kueue-controller-manager
```