### PR TITLE
Update ResourceFlavor site documentation

### DIFF
--- a/site/content/en/docs/concepts/resource_flavor.md
+++ b/site/content/en/docs/concepts/resource_flavor.md
@@ -8,16 +8,14 @@ description: >
 
 Resources in a cluster are typically not homogeneous. Resources could differ in:
 
-- pricing and availability (for example, spot versus on-demand VMs)
-- architecture (for example, x86 versus ARM CPUs)
-- brands and models (for example, Radeon 7000 versus Nvidia A100 versus T4 GPUs)
+- Pricing and availability (for example, spot versus on-demand VMs)
+- Architecture (for example, x86 versus ARM CPUs)
+- Brands and models (for example, Radeon 7000 versus Nvidia A100 versus T4 GPUs)
 
-A ResourceFlavor is an object that represents these resource variations and
-allows you to associate them with cluster nodes through labels, taints and tolerations.
+A ResourceFlavor is an object that represents these resource variations and allows you to associate them with cluster nodes through labels, taints and tolerations.
 
 {{% alert title="Note" color="primary" %}}
-If the resources in your cluster are homogeneous, you can use 
-an [empty ResourceFlavor](#empty-resourceflavor) instead of adding labels to custom ResourceFlavors.
+If the resources in your cluster are homogeneous, you can use an [empty ResourceFlavor](#empty-resourceflavor) instead of adding labels to custom ResourceFlavors.
 {{% /alert %}}
 
 ## ResourceFlavor tolerations for automatic scheduling
@@ -26,39 +24,21 @@ an [empty ResourceFlavor](#empty-resourceflavor) instead of adding labels to cus
 
 This approach may be best for teams that wish to schedule pods onto the appropriate nodes automatically. However, a limitation arises when multiple types of specialized hardware are present, such as two different nvidia.com/gpu resources present in the cluster, i.e., T4 and A100 GPUs. The system may not differentiate between them, meaning the pods could be scheduled on any of both types of hardware.
 
-To associate a ResourceFlavor with a subset of nodes of your cluster, you can
-configure the `.spec.nodeLabels` field with matching node labels that uniquely identify
-the nodes. If you are using [cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler)
-(or equivalent controllers), make sure that the controller is configured to add those labels when
-adding new nodes.
+To associate a ResourceFlavor with a subset of nodes of your cluster, you can configure the `.spec.nodeLabels` field with matching node labels that uniquely identify the nodes. If you are using [cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) (or equivalent controllers), make sure that the controller is configured to add those labels when adding new nodes.
 
-To guarantee that the Pods in the [Workload](/docs/concepts/workload) run on the nodes associated to the flavor
-that Kueue selected, Kueue performs the following steps:
+To guarantee that the Pods in the [Workload](/docs/concepts/workload) run on the nodes associated to the flavor that Kueue selected, Kueue performs the following steps:
 
-1. When admitting a Workload, Kueue evaluates the
-   [`.nodeSelector`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
-   and [`.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity)
-   fields in the PodSpecs of your [Workload](/docs/concepts/workload) against the
-   ResourceFlavor labels.
-   `ResourceFlavors` that don't match the node affinity of the Workload
-   cannot be assigned to a Workload's podSet.
+1. When admitting a Workload, Kueue evaluates the [`.nodeSelector`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) and [`.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) fields in the PodSpecs of your [Workload](/docs/concepts/workload) against the ResourceFlavor labels. `ResourceFlavors` that don't match the node affinity of the Workload cannot be assigned to a Workload's podSet.
 
 
 2. Once the Workload is admitted:
-   - Kueue adds the ResourceFlavor labels to the
-    `.nodeSelector` of the underlying Workload Pod templates. This occurs if the Workload
-     didn't specify the `ResourceFlavor` labels already as part of its nodeSelector.
+   - Kueue adds the ResourceFlavor labels to the `.nodeSelector` of the underlying Workload Pod templates. This occurs if the Workload didn't specify the `ResourceFlavor` labels already as part of its nodeSelector.
 
-     For example, for a [batch/v1.Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/),
-     Kueue adds the labels to the `.spec.template.spec.nodeSelector` field. This
-     guarantees that the workload's Pods can only be scheduled on the nodes
-     targeted by the flavor that Kueue assigned to the Workload.
+     For example, for a [batch/v1.Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/), Kueue adds the labels to the `.spec.template.spec.nodeSelector` field. This guarantees that the workload's Pods can only be scheduled on the nodes targeted by the flavor that Kueue assigned to the Workload.
 
    - Kueue adds the tolerations to the underlying Workload Pod templates.
 
-     For example, for a [batch/v1.Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/),
-     Kueue adds the tolerations to the `.spec.template.spec.tolerations` field. This allows that the 
-     workloads Pods to be scheduled on nodes having specific taints.
+     For example, for a [batch/v1.Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/), Kueue adds the tolerations to the `.spec.template.spec.tolerations` field. This allows that the workloads Pods to be scheduled on nodes having specific taints.
 
 A sample ResourceFlavor of this type looks like the following:
 
@@ -77,8 +57,7 @@ spec:
 ```
 
 When defining a ResourceFlavor as above, you can set the following values:
-- The `.metadata.name` field to reference a ResourceFlavor from a
-[ClusterQueue](/docs/concepts/cluster_queue) in the `.spec.resourceGroups[*].flavors[*].name` field.
+- The `.metadata.name` field to reference a ResourceFlavor from a [ClusterQueue](/docs/concepts/cluster_queue) in the `.spec.resourceGroups[*].flavors[*].name` field.
 - `spec.nodeLabels` associates the ResourceFlavor with a node or subset of nodes.
 - `spec.tolerations` adds the specified tolerations to the pods that require GPUs.
 
@@ -92,10 +71,7 @@ By adding the taint at the ResourceFlavor level, we ensure that only workloads t
 Taints on the ResourceFlavor work similarly to [Node taints](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/),
 but only support the `NoExecute` and `NoSchedule` effects, while `PreferNoSchedule` is ignored.
 
-For Kueue to [admit](/docs/concepts#admission) a Workload to use the ResourceFlavor, the PodSpecs in the
-Workload should have a toleration for it. As opposed to the behavior for
-[ResourceFlavor tolerations for automatic scheduling](#ResourceFlavor-tolerations-for-automatic-scheduling), Kueue does not add tolerations
-for the flavor taints.
+For Kueue to [admit](/docs/concepts#admission) a Workload to use the ResourceFlavor, the PodSpecs in the Workload should have a toleration for it. As opposed to the behavior for [ResourceFlavor tolerations for automatic scheduling](#ResourceFlavor-tolerations-for-automatic-scheduling), Kueue does not add tolerations for the flavor taints.
 
 A sample ResourceFlavor looks like the following:
 
@@ -108,23 +84,19 @@ spec:
   nodeLabels:
     instance-type: spot
   nodeTaints:
-  - effect: NoSchedule ## Supported effects are NoSchedule and NoExecute.
+  - effect: NoSchedule ## Supported effects are NoSchedule and NoExecute, while PreferNoSchedule is ignored.
     key: spot
     value: "true"
 ```
 
 When defining a ResourceFlavor as above, you can set the following values:
-- The `.metadata.name` field to reference a ResourceFlavor from a
-[ClusterQueue](/docs/concepts/cluster_queue) in the `.spec.resourceGroups[*].flavors[*].name` field.
+- The `.metadata.name` field to reference a ResourceFlavor from a [ClusterQueue](/docs/concepts/cluster_queue) in the `.spec.resourceGroups[*].flavors[*].name` field.
 - `spec.nodeLabels` associates the ResourceFlavor with a node or subset of nodes.
 - `spec.nodeTaints` restricts usage of a ResourceFlavor. These taints should typically match the taints of the Nodes associated with the ResourceFlavor.
 
 ## Empty ResourceFlavor
 
-If your cluster has homogeneous resources, or if you don't need to manage
-quotas for the different flavors of a resource separately, you can create a
-ResourceFlavor without any labels or taints. Such ResourceFlavor is called an
-empty ResourceFlavor and its definition looks like the following:
+If your cluster has homogeneous resources, or if you don't need to manage quotas for the different flavors of a resource separately, you can create a ResourceFlavor without any labels or taints. Such ResourceFlavor is called an empty ResourceFlavor and its definition looks like the following:
 
 ```yaml
 apiVersion: kueue.x-k8s.io/v1beta1

--- a/site/content/en/docs/concepts/resource_flavor.md
+++ b/site/content/en/docs/concepts/resource_flavor.md
@@ -40,40 +40,28 @@ To guarantee that the Pods in the [Workload](/docs/concepts/workload) run on the
    This occurs if the Workload didn't specify the `ResourceFlavor` labels already as part of its nodeSelector.
 
      For example, for a [batch/v1.Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/), Kueue adds the labels to the `.spec.template.spec.nodeSelector` field.
-     This guarantees that the workload's Pods can only be scheduled on the nodes targeted by the flavor that Kueue assigned to the Workload.
+     This guarantees that the Workload's Pods can only be scheduled on the nodes targeted by the flavor that Kueue assigned to the Workload.
 
    - Kueue adds the tolerations to the underlying Workload Pod templates.
 
      For example, for a [batch/v1.Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/), Kueue adds the tolerations to the `.spec.template.spec.tolerations` field.
-     This allows that the workloads Pods to be scheduled on nodes having specific taints.
+     This allows the Workload's Pods to be scheduled on nodes having specific taints.
 
 A sample ResourceFlavor of this type looks like the following:
 
-```yaml
-apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: "spot"
-spec:
-  nodeLabels:
-    instance-type: spot
-  tolerations:
-  - key: "spot-taint" ## The key of the node taint.
-    operator: "Exists"
-    effect: "NoSchedule" ## Supported effects are NoSchedule, NoExecute, and PreferNoSchedule.
-```
+{{< include "examples/admin/resource-flavor-tolerations.yaml" "yaml" >}}
 
-When defining a ResourceFlavor as above, you can set the following values:
-- The `.metadata.name` field to reference a ResourceFlavor from a [ClusterQueue](/docs/concepts/cluster_queue) in the `.spec.resourceGroups[*].flavors[*].name` field.
+When defining a ResourceFlavor as above, you should set the following values:
+- The `.metadata.name` field, which is required to reference a ResourceFlavor from a [ClusterQueue](/docs/concepts/cluster_queue) in the `.spec.resourceGroups[*].flavors[*].name` field.
 - `spec.nodeLabels` associates the ResourceFlavor with a node or subset of nodes.
 - `spec.tolerations` adds the specified tolerations to the pods that require GPUs.
 
 
 ## ResourceFlavor taints for user-selective scheduling
 
-This approach may be best for teams that wish to schedule their workload to a specific hardware type selectively.
+This approach may be best for teams that wish to schedule their Workload to a specific hardware type selectively.
 An additional ResourceFlavor can be created per type of special hardware with a different set of taints and tolerations.
-The user can then add the tolerations to their workload to schedule the pods onto the appropriate node.
+The user can then add the tolerations to their Workload to schedule the pods onto the appropriate node.
 
 By adding the taint at the ResourceFlavor level, we ensure that only workloads that explicitly tolerate that taint can consume the quota.
 
@@ -85,22 +73,10 @@ As opposed to the behavior for [ResourceFlavor tolerations for automatic schedul
 
 A sample ResourceFlavor looks like the following:
 
-```yaml
-apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: "spot"
-spec:
-  nodeLabels:
-    instance-type: spot
-  nodeTaints:
-  - effect: NoSchedule ## Supported effects are NoSchedule and NoExecute, while PreferNoSchedule is ignored.
-    key: spot
-    value: "true"
-```
+{{< include "examples/admin/resource-flavor-taints.yaml" "yaml" >}}
 
-When defining a ResourceFlavor as above, you can set the following values:
-- The `.metadata.name` field to reference a ResourceFlavor from a [ClusterQueue](/docs/concepts/cluster_queue) in the `.spec.resourceGroups[*].flavors[*].name` field.
+When defining a ResourceFlavor as above, you should set the following values:
+- The `.metadata.name` field, which is required to reference a ResourceFlavor from a [ClusterQueue](/docs/concepts/cluster_queue) in the `.spec.resourceGroups[*].flavors[*].name` field.
 - `spec.nodeLabels` associates the ResourceFlavor with a node or subset of nodes.
 - `spec.nodeTaints` restricts usage of a ResourceFlavor.
 These taints should typically match the taints of the Nodes associated with the ResourceFlavor.
@@ -110,12 +86,7 @@ These taints should typically match the taints of the Nodes associated with the 
 If your cluster has homogeneous resources, or if you don't need to manage quotas for the different flavors of a resource separately, you can create a ResourceFlavor without any labels or taints.
 Such ResourceFlavor is called an empty ResourceFlavor and its definition looks like the following:
 
-```yaml
-apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: default-flavor
-```
+{{< include "examples/admin/resource-flavor-empty.yaml" "yaml" >}}
 
 ## What's next?
 

--- a/site/content/en/docs/concepts/resource_flavor.md
+++ b/site/content/en/docs/concepts/resource_flavor.md
@@ -22,23 +22,30 @@ If the resources in your cluster are homogeneous, you can use an [empty Resource
 
 **Requires Kubernetes 1.23 or newer**
 
-This approach may be best for teams that wish to schedule pods onto the appropriate nodes automatically. However, a limitation arises when multiple types of specialized hardware are present, such as two different nvidia.com/gpu resources present in the cluster, i.e., T4 and A100 GPUs. The system may not differentiate between them, meaning the pods could be scheduled on any of both types of hardware.
+This approach may be best for teams that wish to schedule pods onto the appropriate nodes automatically.
+However, a limitation arises when multiple types of specialized hardware are present, such as two different nvidia.com/gpu resources present in the cluster, i.e., T4 and A100 GPUs.
+The system may not differentiate between them, meaning the pods could be scheduled on any of both types of hardware.
 
-To associate a ResourceFlavor with a subset of nodes of your cluster, you can configure the `.spec.nodeLabels` field with matching node labels that uniquely identify the nodes. If you are using [cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) (or equivalent controllers), make sure that the controller is configured to add those labels when adding new nodes.
+To associate a ResourceFlavor with a subset of nodes of your cluster, you can configure the `.spec.nodeLabels` field with matching node labels that uniquely identify the nodes.
+If you are using [cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) (or equivalent controllers), make sure that the controller is configured to add those labels when adding new nodes.
 
 To guarantee that the Pods in the [Workload](/docs/concepts/workload) run on the nodes associated to the flavor that Kueue selected, Kueue performs the following steps:
 
-1. When admitting a Workload, Kueue evaluates the [`.nodeSelector`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) and [`.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) fields in the PodSpecs of your [Workload](/docs/concepts/workload) against the ResourceFlavor labels. `ResourceFlavors` that don't match the node affinity of the Workload cannot be assigned to a Workload's podSet.
+1. When admitting a Workload, Kueue evaluates the [`.nodeSelector`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) and [`.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity) fields in the PodSpecs of your [Workload](/docs/concepts/workload) against the ResourceFlavor labels.
+`ResourceFlavors` that don't match the node affinity of the Workload cannot be assigned to a Workload's podSet.
 
 
 2. Once the Workload is admitted:
-   - Kueue adds the ResourceFlavor labels to the `.nodeSelector` of the underlying Workload Pod templates. This occurs if the Workload didn't specify the `ResourceFlavor` labels already as part of its nodeSelector.
+   - Kueue adds the ResourceFlavor labels to the `.nodeSelector` of the underlying Workload Pod templates.
+   This occurs if the Workload didn't specify the `ResourceFlavor` labels already as part of its nodeSelector.
 
-     For example, for a [batch/v1.Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/), Kueue adds the labels to the `.spec.template.spec.nodeSelector` field. This guarantees that the workload's Pods can only be scheduled on the nodes targeted by the flavor that Kueue assigned to the Workload.
+     For example, for a [batch/v1.Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/), Kueue adds the labels to the `.spec.template.spec.nodeSelector` field.
+     This guarantees that the workload's Pods can only be scheduled on the nodes targeted by the flavor that Kueue assigned to the Workload.
 
    - Kueue adds the tolerations to the underlying Workload Pod templates.
 
-     For example, for a [batch/v1.Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/), Kueue adds the tolerations to the `.spec.template.spec.tolerations` field. This allows that the workloads Pods to be scheduled on nodes having specific taints.
+     For example, for a [batch/v1.Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/), Kueue adds the tolerations to the `.spec.template.spec.tolerations` field.
+     This allows that the workloads Pods to be scheduled on nodes having specific taints.
 
 A sample ResourceFlavor of this type looks like the following:
 
@@ -64,14 +71,17 @@ When defining a ResourceFlavor as above, you can set the following values:
 
 ## ResourceFlavor taints for user-selective scheduling
 
-This approach may be best for teams that wish to schedule their workload to a specific hardware type selectively. An additional ResourceFlavor can be created per type of special hardware with a different set of taints and tolerations. The user can then add the tolerations to their workload to schedule the pods onto the appropriate node.
+This approach may be best for teams that wish to schedule their workload to a specific hardware type selectively.
+An additional ResourceFlavor can be created per type of special hardware with a different set of taints and tolerations.
+The user can then add the tolerations to their workload to schedule the pods onto the appropriate node.
 
 By adding the taint at the ResourceFlavor level, we ensure that only workloads that explicitly tolerate that taint can consume the quota.
 
 Taints on the ResourceFlavor work similarly to [Node taints](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/),
 but only support the `NoExecute` and `NoSchedule` effects, while `PreferNoSchedule` is ignored.
 
-For Kueue to [admit](/docs/concepts#admission) a Workload to use the ResourceFlavor, the PodSpecs in the Workload should have a toleration for it. As opposed to the behavior for [ResourceFlavor tolerations for automatic scheduling](#ResourceFlavor-tolerations-for-automatic-scheduling), Kueue does not add tolerations for the flavor taints.
+For Kueue to [admit](/docs/concepts#admission) a Workload to use the ResourceFlavor, the PodSpecs in the Workload should have a toleration for it.
+As opposed to the behavior for [ResourceFlavor tolerations for automatic scheduling](#ResourceFlavor-tolerations-for-automatic-scheduling), Kueue does not add tolerations for the flavor taints.
 
 A sample ResourceFlavor looks like the following:
 
@@ -92,11 +102,13 @@ spec:
 When defining a ResourceFlavor as above, you can set the following values:
 - The `.metadata.name` field to reference a ResourceFlavor from a [ClusterQueue](/docs/concepts/cluster_queue) in the `.spec.resourceGroups[*].flavors[*].name` field.
 - `spec.nodeLabels` associates the ResourceFlavor with a node or subset of nodes.
-- `spec.nodeTaints` restricts usage of a ResourceFlavor. These taints should typically match the taints of the Nodes associated with the ResourceFlavor.
+- `spec.nodeTaints` restricts usage of a ResourceFlavor.
+These taints should typically match the taints of the Nodes associated with the ResourceFlavor.
 
 ## Empty ResourceFlavor
 
-If your cluster has homogeneous resources, or if you don't need to manage quotas for the different flavors of a resource separately, you can create a ResourceFlavor without any labels or taints. Such ResourceFlavor is called an empty ResourceFlavor and its definition looks like the following:
+If your cluster has homogeneous resources, or if you don't need to manage quotas for the different flavors of a resource separately, you can create a ResourceFlavor without any labels or taints.
+Such ResourceFlavor is called an empty ResourceFlavor and its definition looks like the following:
 
 ```yaml
 apiVersion: kueue.x-k8s.io/v1beta1

--- a/site/static/examples/admin/resource-flavor-empty.yaml
+++ b/site/static/examples/admin/resource-flavor-empty.yaml
@@ -1,0 +1,4 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor

--- a/site/static/examples/admin/resource-flavor-taints.yaml
+++ b/site/static/examples/admin/resource-flavor-taints.yaml
@@ -1,0 +1,11 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: "spot"
+spec:
+  nodeLabels:
+    instance-type: spot
+  nodeTaints:
+  - effect: NoSchedule ## Supported effects are NoSchedule and NoExecute, while PreferNoSchedule is ignored.
+    key: spot
+    value: "true"

--- a/site/static/examples/admin/resource-flavor-tolerations.yaml
+++ b/site/static/examples/admin/resource-flavor-tolerations.yaml
@@ -1,0 +1,11 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: "spot"
+spec:
+  nodeLabels:
+    instance-type: spot
+  tolerations:
+  - key: "spot-taint" ## The key of the node taint.
+    operator: "Exists"
+    effect: "NoSchedule" ## Supported effects are NoSchedule, NoExecute, and PreferNoSchedule.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

#### What this PR does / why we need it:
- Update the ResourceFlavor site documentation to enhance readability and ensure a smoother user experience.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4499 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```