### PR TITLE
Determine candidate ordering for Fair Sharing in Hierarchical Cohorts

### DIFF
--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -77,7 +77,7 @@ func (c *ClusterQueueSnapshot) SimulateUsageRemoval(workloads []*workload.Info) 
 		usage = append(usage, w.Usage())
 	}
 	for _, u := range usage {
-		c.removeUsage(u)
+		c.RemoveUsage(u)
 	}
 	return func() {
 		for _, u := range usage {
@@ -93,7 +93,7 @@ func (c *ClusterQueueSnapshot) AddUsage(usage workload.Usage) {
 	c.updateTASUsage(usage.TAS, add)
 }
 
-func (c *ClusterQueueSnapshot) removeUsage(usage workload.Usage) {
+func (c *ClusterQueueSnapshot) RemoveUsage(usage workload.Usage) {
 	for fr, q := range usage.Quota {
 		removeUsage(c, fr, q)
 	}

--- a/pkg/cache/cohort_snapshot.go
+++ b/pkg/cache/cohort_snapshot.go
@@ -67,6 +67,11 @@ func (c *CohortSnapshot) subtreeClusterQueueCount() int {
 	return count
 }
 
+func (c *CohortSnapshot) DominantResourceShare() int {
+	share, _ := dominantResourceShare(c, nil)
+	return share
+}
+
 // The methods below implement hierarchicalResourceNode interface.
 
 func (c *CohortSnapshot) getResourceNode() ResourceNode {

--- a/pkg/cache/resource_test.go
+++ b/pkg/cache/resource_test.go
@@ -428,7 +428,7 @@ func TestAvailable(t *testing.T) {
 			// remove usage
 			{
 				for cqName, usage := range tc.usage {
-					snapshot.ClusterQueue(cqName).removeUsage(workload.Usage{Quota: usage})
+					snapshot.ClusterQueue(cqName).RemoveUsage(workload.Usage{Quota: usage})
 				}
 				clusterQueues := snapshot.ClusterQueues()
 				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -44,7 +44,7 @@ type Snapshot struct {
 func (s *Snapshot) RemoveWorkload(wl *workload.Info) {
 	cq := s.ClusterQueue(wl.ClusterQueue)
 	delete(cq.Workloads, workload.Key(wl.Obj))
-	cq.removeUsage(wl.Usage())
+	cq.RemoveUsage(wl.Usage())
 }
 
 // AddWorkload adds a workload from its corresponding ClusterQueue and

--- a/pkg/hierarchy/cohort.go
+++ b/pkg/hierarchy/cohort.go
@@ -45,6 +45,11 @@ func (c *Cohort[CQ, C]) ChildCohorts() []C {
 	return c.childCohorts.UnsortedList()
 }
 
+// ChildCount returns number of Cohorts + ClusterQueues.
+func (c *Cohort[CQ, C]) ChildCount() int {
+	return c.childCohorts.Len() + c.childCqs.Len()
+}
+
 func NewCohort[CQ, C nodeBase]() Cohort[CQ, C] {
 	return Cohort[CQ, C]{
 		childCohorts: sets.New[C](),

--- a/pkg/scheduler/fair_sharing_iterator.go
+++ b/pkg/scheduler/fair_sharing_iterator.go
@@ -1,0 +1,224 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/kueue/pkg/cache"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/priority"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+// fairSharingIterator orders candidates in a "fair" manner for
+// consideration by scheduling when FairSharing is enabled. See
+// runTournament for description of algorithm.
+type fairSharingIterator struct {
+	// cqToEntry tracks ClusterQueues which still have workloads
+	// to schedule, and the corresponding workload entry.
+	cqToEntry     map[*cache.ClusterQueueSnapshot]*entry
+	entryComparer entryComparer
+	log           logr.Logger
+}
+
+func makeFairSharingIterator(ctx context.Context, entries []entry, workloadOrdering workload.Ordering) *fairSharingIterator {
+	f := fairSharingIterator{
+		cqToEntry: make(map[*cache.ClusterQueueSnapshot]*entry, len(entries)),
+		entryComparer: entryComparer{
+			drsValues:        make(map[drsKey]int),
+			workloadOrdering: workloadOrdering,
+		},
+		log: ctrl.LoggerFrom(ctx),
+	}
+	for i := range entries {
+		f.cqToEntry[entries[i].clusterQueueSnapshot] = &entries[i]
+	}
+	return &f
+}
+
+func (f *fairSharingIterator) hasNext() bool {
+	return len(f.cqToEntry) > 0
+}
+
+func (f *fairSharingIterator) pop() *entry {
+	cq := f.getCq()
+
+	// CQ has no Cohort. We simply return its workload.
+	if !cq.HasParent() {
+		f.log.V(3).Info("Returning workload from ClusterQueue without Cohort", "clusterQueue", cq.GetName())
+		entry := f.cqToEntry[cq]
+		delete(f.cqToEntry, cq)
+		return entry
+	}
+
+	// CQ is part of a Cohort. We run a tournament, to select the
+	// most fair workload at each level.
+	root := cq.Parent().Root()
+	f.log.V(3).Info("Running tournament to decide next workload to consider in scheduling cycle", "rootCohort", root.GetName())
+
+	f.entryComparer.computeDRS(root, f.cqToEntry)
+	f.entryComparer.logDRS(f.log)
+	entry := runTournament(root, f.entryComparer, f.cqToEntry)
+
+	delete(f.cqToEntry, entry.clusterQueueSnapshot)
+	return entry
+}
+
+// getCq returns a CQ with a workload pending scheduling. This
+// function is non-deterministic. We don't have any guarantees on
+// scheduling order of workloads in different Cohort. Workload
+// consideration is nearly deterministic within Cohort (only when DRS,
+// Priority, and time are equal it is non-deterministic).
+func (f *fairSharingIterator) getCq() *cache.ClusterQueueSnapshot {
+	for cq := range f.cqToEntry {
+		return cq
+	}
+	return nil
+}
+
+// runTournament is a recursive algorithm which nominates one workload
+// for each Cohort.  It compares the DominantResourceShare (DRS) value
+// of each of the Cohort's children nodes (CQs or Cohorts), including
+// in this DRS value the workload which that child node is
+// nominating. The node with the lowest DRS wins, with some additional
+// tiebreaks (see entryComparer.less).
+//
+// This process results in one workload (or zero if Cohort has no
+// remaining workloads to schedule this cycle) being bubbled up per
+// node, until exactly one workload remains at the root.
+func runTournament(cohort *cache.CohortSnapshot, ec entryComparer, cqToEntry map[*cache.ClusterQueueSnapshot]*entry) *entry {
+	candidates := make([]*entry, 0, cohort.ChildCount())
+
+	// Run algorithm recursively for each of the child Cohorts.
+	for _, childCohort := range cohort.ChildCohorts() {
+		// The tournament returns 0 nodes, when the child
+		// Cohort has no workloads left to be scheduled this
+		// cycle.
+		if candidate := runTournament(childCohort, ec, cqToEntry); candidate != nil {
+			candidates = append(candidates, candidate)
+		}
+	}
+
+	// Collect entries from CQ. If an entry was returned during a
+	// previous call to pop, it will not be in the cqToEntry map.
+	for _, childCq := range cohort.ChildCQs() {
+		if candidate, ok := cqToEntry[childCq]; ok {
+			candidates = append(candidates, candidate)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	// Compare DRS values for each workload, for each of the
+	// children of the current Cohort.
+	best := candidates[0]
+	for _, current := range candidates[1:] {
+		if ec.less(current, best, cohort.GetName()) {
+			best = current
+		}
+	}
+	return best
+}
+
+type drsKey struct {
+	parentCohort string
+	workloadKey  string
+}
+
+type entryComparer struct {
+	drsValues        map[drsKey]int
+	workloadOrdering workload.Ordering
+}
+
+func (e *entryComparer) less(a, b *entry, parentCohort string) bool {
+	aDrs := e.drsValues[drsKey{parentCohort: parentCohort, workloadKey: workload.Key(a.Obj)}]
+	bDrs := e.drsValues[drsKey{parentCohort: parentCohort, workloadKey: workload.Key(b.Obj)}]
+	// 1: DRF
+	if aDrs != bDrs {
+		return aDrs < bDrs
+	}
+
+	// 2: Priority
+	if features.Enabled(features.PrioritySortingWithinCohort) {
+		p1 := priority.Priority(a.Obj)
+		p2 := priority.Priority(b.Obj)
+		if p1 != p2 {
+			return p1 > p2
+		}
+	}
+
+	// 3: FIFO
+	aComparisonTimestamp := e.workloadOrdering.GetQueueOrderTimestamp(a.Obj)
+	bComparisonTimestamp := e.workloadOrdering.GetQueueOrderTimestamp(b.Obj)
+	return aComparisonTimestamp.Before(bComparisonTimestamp)
+}
+
+// computeDRS calculates DominantResourceShare (DRS) for each node
+// after admission of workload, for all nodes on path from CQ to
+// root-1.  During the tournament, these values are used to compare
+// all children the parentCohort, to select the child with the lowest
+// DRS after admission of its nominated workload.
+func (ec *entryComparer) computeDRS(rootCohort *cache.CohortSnapshot, cqToEntry map[*cache.ClusterQueueSnapshot]*entry) {
+	ec.clearDrsValues()
+	for _, cq := range rootCohort.SubtreeClusterQueues() {
+		entry, ok := cqToEntry[cq]
+		if !ok {
+			continue
+		}
+		// We add workload's usage to CQ, so that all
+		// subsequent DRS include the admission of workload.
+		cq.AddUsage(entry.usage())
+
+		// calculate DRS, with workload, for CQ.
+		dominantResourceShare := cq.DominantResourceShare()
+		ec.drsValues[drsKey{parentCohort: cq.Parent().GetName(), workloadKey: workload.Key(entry.Obj)}] = dominantResourceShare
+
+		// calculate DRS, with workload, for all Cohorts on
+		// path to root.
+		cohort := cq.Parent()
+		for cohort.HasParent() {
+			dominantResourceShare := cohort.DominantResourceShare()
+			ec.drsValues[drsKey{parentCohort: cohort.Parent().GetName(), workloadKey: workload.Key(entry.Obj)}] = dominantResourceShare
+			cohort = cohort.Parent()
+		}
+
+		cq.RemoveUsage(entry.usage())
+	}
+}
+
+func (ec *entryComparer) clearDrsValues() {
+	for key := range ec.drsValues {
+		delete(ec.drsValues, key)
+	}
+}
+
+func (ec *entryComparer) logDRS(log logr.Logger) {
+	if logV := log.V(5); logV.Enabled() {
+		serializableDrs := make([]string, 0, len(ec.drsValues))
+		for k, v := range ec.drsValues {
+			serializableDrs = append(serializableDrs, fmt.Sprintf("{parentCohort: %s, workload %s, drs: %d}", k.parentCohort, k.workloadKey, v))
+		}
+		logV.Info("DominantResourceShare values used during tournament", "drsValues", serializableDrs)
+	}
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -199,7 +199,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	entries := s.nominate(ctx, headWorkloads, snapshot)
 
 	// 4. Create iterator which returns ordered entries.
-	var iterator entryIterator = makeIterator(entries, s.workloadOrdering, s.fairSharing.Enable)
+	iterator := makeIterator(ctx, entries, s.workloadOrdering, s.fairSharing.Enable)
 
 	// 5. Admit entries, ensuring that no more than one workload gets
 	// admitted by a cohort (if borrowing).
@@ -313,12 +313,12 @@ type entry struct {
 	// workload.Info holds the workload from the API as well as resource usage
 	// and flavors assigned.
 	workload.Info
-	dominantResourceShare int
-	assignment            flavorassigner.Assignment
-	status                entryStatus
-	inadmissibleMsg       string
-	requeueReason         queue.RequeueReason
-	preemptionTargets     []*preemption.Target
+	assignment           flavorassigner.Assignment
+	status               entryStatus
+	inadmissibleMsg      string
+	requeueReason        queue.RequeueReason
+	preemptionTargets    []*preemption.Target
+	clusterQueueSnapshot *cache.ClusterQueueSnapshot
 }
 
 func (e *entry) usage() workload.Usage {
@@ -332,9 +332,9 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 	entries := make([]entry, 0, len(workloads))
 	for _, w := range workloads {
 		log := log.WithValues("workload", klog.KObj(w.Obj), "clusterQueue", klog.KRef("", w.ClusterQueue))
-		cq := snap.ClusterQueue(w.ClusterQueue)
 		ns := corev1.Namespace{}
 		e := entry{Info: w}
+		e.clusterQueueSnapshot = snap.ClusterQueue(w.ClusterQueue)
 		if s.cache.IsAssumedOrAdmittedWorkload(w) {
 			log.Info("Workload skipped from admission because it's already assumed or admitted", "workload", klog.KObj(w.Obj))
 			continue
@@ -342,11 +342,11 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 			e.inadmissibleMsg = "The workload has failed admission checks"
 		} else if snap.InactiveClusterQueueSets.Has(w.ClusterQueue) {
 			e.inadmissibleMsg = fmt.Sprintf("ClusterQueue %s is inactive", w.ClusterQueue)
-		} else if cq == nil {
+		} else if e.clusterQueueSnapshot == nil {
 			e.inadmissibleMsg = fmt.Sprintf("ClusterQueue %s not found", w.ClusterQueue)
 		} else if err := s.client.Get(ctx, types.NamespacedName{Name: w.Obj.Namespace}, &ns); err != nil {
 			e.inadmissibleMsg = fmt.Sprintf("Could not obtain workload namespace: %v", err)
-		} else if !cq.NamespaceSelector.Matches(labels.Set(ns.Labels)) {
+		} else if !e.clusterQueueSnapshot.NamespaceSelector.Matches(labels.Set(ns.Labels)) {
 			e.inadmissibleMsg = "Workload namespace doesn't match ClusterQueue selector"
 			e.requeueReason = queue.RequeueReasonNamespaceMismatch
 		} else if err := workload.ValidateResources(&w); err != nil {
@@ -357,9 +357,6 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 			e.assignment, e.preemptionTargets = s.getAssignments(log, &e.Info, snap)
 			e.inadmissibleMsg = e.assignment.Message()
 			e.Info.LastAssignment = &e.assignment.LastState
-			if s.fairSharing.Enable && e.assignment.RepresentativeMode() != flavorassigner.NoFit {
-				e.dominantResourceShare = cq.DominantResourceShareWith(e.assignment.TotalRequestsFor(&w))
-			}
 		}
 		entries = append(entries, e)
 	}
@@ -515,9 +512,8 @@ func (s *Scheduler) applyAdmissionWithSSA(ctx context.Context, w *kueue.Workload
 }
 
 type entryOrdering struct {
-	enableFairSharing bool
-	entries           []entry
-	workloadOrdering  workload.Ordering
+	entries          []entry
+	workloadOrdering workload.Ordering
 }
 
 func (e entryOrdering) Len() int {
@@ -540,12 +536,7 @@ func (e entryOrdering) Less(i, j int) bool {
 		return !aBorrows
 	}
 
-	// 2. Fair share, if enabled.
-	if e.enableFairSharing && a.dominantResourceShare != b.dominantResourceShare {
-		return a.dominantResourceShare < b.dominantResourceShare
-	}
-
-	// 3. Higher priority first if not disabled.
+	// 2. Higher priority first if not disabled.
 	if features.Enabled(features.PrioritySortingWithinCohort) {
 		p1 := priority.Priority(a.Obj)
 		p2 := priority.Priority(b.Obj)
@@ -554,7 +545,7 @@ func (e entryOrdering) Less(i, j int) bool {
 		}
 	}
 
-	// 4. FIFO.
+	// 3. FIFO.
 	aComparisonTimestamp := e.workloadOrdering.GetQueueOrderTimestamp(a.Obj)
 	bComparisonTimestamp := e.workloadOrdering.GetQueueOrderTimestamp(b.Obj)
 	return aComparisonTimestamp.Before(bComparisonTimestamp)
@@ -565,6 +556,13 @@ func (e entryOrdering) Less(i, j int) bool {
 type entryIterator interface {
 	pop() *entry
 	hasNext() bool
+}
+
+func makeIterator(ctx context.Context, entries []entry, workloadOrdering workload.Ordering, enableFairSharing bool) entryIterator {
+	if enableFairSharing {
+		return makeFairSharingIterator(ctx, entries, workloadOrdering)
+	}
+	return makeClassicalIterator(entries, workloadOrdering)
 }
 
 // classicalIterator returns entries ordered on:
@@ -586,11 +584,10 @@ func (co *classicalIterator) pop() *entry {
 	return head
 }
 
-func makeIterator(entries []entry, workloadOrdering workload.Ordering, enableFairSharing bool) *classicalIterator {
+func makeClassicalIterator(entries []entry, workloadOrdering workload.Ordering) *classicalIterator {
 	sort.Sort(entryOrdering{
-		entries:           entries,
-		enableFairSharing: enableFairSharing,
-		workloadOrdering:  workloadOrdering,
+		entries:          entries,
+		workloadOrdering: workloadOrdering,
 	})
 	return &classicalIterator{
 		entries: entries,


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
We define the order in which to consider workloads
in the scheduling cycle, that is compatible with Fair Sharing in Hierarchical Cohorts (#3759).

We run a tournament, from leaf to root, where each node nominates
a workload which it considers greedily most fair. This process is repeated
until one workload remains at the root. See comments for detailed description of algorithm.

#### Special notes for your reviewer:
I wanted to get feedback on the algorithm before
investing time in tests. I will add those after initial pass.

#### Does this PR introduce a user-facing change?
No release note for this change, as we will do a single release note for the entire feature

```release-note
NONE
```