### PR TITLE
ClusterQueueReference; CohortReference

### DIFF
--- a/apis/kueue/v1alpha1/cohort_types.go
+++ b/apis/kueue/v1alpha1/cohort_types.go
@@ -34,11 +34,7 @@ type CohortSpec struct {
 	// Cohort, including ClusterQueues, until the cycle is
 	// removed.  We prevent further admission while the cycle
 	// exists.
-	//
-	//+kubebuilder:validation:MaxLength=253
-	//+kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-	//
-	Parent string `json:"parent,omitempty"`
+	Parent kueuebeta.CohortReference `json:"parent,omitempty"`
 
 	// ResourceGroups describes groupings of Resources and
 	// Flavors.  Each ResourceGroup defines a list of Resources

--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -39,6 +39,14 @@ const (
 	ClusterQueueActiveReasonReady                                           = "Ready"
 )
 
+// CohortReference is the name of the Cohort.
+//
+// Validation of a cohort name is equivalent to that of object names:
+// subdomain in DNS (RFC 1123).
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+type CohortReference string
+
 // ClusterQueueSpec defines the desired state of ClusterQueue
 // +kubebuilder:validation:XValidation:rule="!has(self.cohort) && has(self.resourceGroups) ? self.resourceGroups.all(rg, rg.flavors.all(f, f.resources.all(r, !has(r.borrowingLimit)))) : true", message="borrowingLimit must be nil when cohort is empty"
 type ClusterQueueSpec struct {
@@ -63,12 +71,7 @@ type ClusterQueueSpec struct {
 	//
 	// A cohort is a name that links CQs together, but it doesn't reference any
 	// object.
-	//
-	// Validation of a cohort name is equivalent to that of object names:
-	// subdomain in DNS (RFC 1123).
-	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-	Cohort string `json:"cohort,omitempty"`
+	Cohort CohortReference `json:"cohort,omitempty"`
 
 	// QueueingStrategy indicates the queueing strategy of the workloads
 	// across the queues in this ClusterQueue.

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -126,9 +126,6 @@ spec:
 
                   A cohort is a name that links CQs together, but it doesn't reference any
                   object.
-
-                  Validation of a cohort name is equivalent to that of object names:
-                  subdomain in DNS (RFC 1123).
                 maxLength: 253
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string

--- a/client-go/applyconfiguration/kueue/v1beta1/clusterqueuespec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/clusterqueuespec.go
@@ -26,7 +26,7 @@ import (
 // with apply.
 type ClusterQueueSpecApplyConfiguration struct {
 	ResourceGroups          []ResourceGroupApplyConfiguration          `json:"resourceGroups,omitempty"`
-	Cohort                  *string                                    `json:"cohort,omitempty"`
+	Cohort                  *kueuev1beta1.CohortReference              `json:"cohort,omitempty"`
 	QueueingStrategy        *kueuev1beta1.QueueingStrategy             `json:"queueingStrategy,omitempty"`
 	NamespaceSelector       *v1.LabelSelectorApplyConfiguration        `json:"namespaceSelector,omitempty"`
 	FlavorFungibility       *FlavorFungibilityApplyConfiguration       `json:"flavorFungibility,omitempty"`
@@ -59,7 +59,7 @@ func (b *ClusterQueueSpecApplyConfiguration) WithResourceGroups(values ...*Resou
 // WithCohort sets the Cohort field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Cohort field is set to the value of the last call.
-func (b *ClusterQueueSpecApplyConfiguration) WithCohort(value string) *ClusterQueueSpecApplyConfiguration {
+func (b *ClusterQueueSpecApplyConfiguration) WithCohort(value kueuev1beta1.CohortReference) *ClusterQueueSpecApplyConfiguration {
 	b.Cohort = &value
 	return b
 }

--- a/cmd/kueuectl/app/create/create_clusterqueue.go
+++ b/cmd/kueuectl/app/create/create_clusterqueue.go
@@ -269,7 +269,7 @@ func (o *ClusterQueueOptions) createClusterQueue() *v1beta1.ClusterQueue {
 		TypeMeta:   metav1.TypeMeta{APIVersion: v1beta1.SchemeGroupVersion.String(), Kind: "ClusterQueue"},
 		ObjectMeta: metav1.ObjectMeta{Name: o.Name},
 		Spec: v1beta1.ClusterQueueSpec{
-			Cohort:            o.Cohort,
+			Cohort:            v1beta1.CohortReference(o.Cohort),
 			QueueingStrategy:  o.QueueingStrategy,
 			NamespaceSelector: &o.NamespaceSelector,
 			Preemption: &v1beta1.ClusterQueuePreemption{

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -111,9 +111,6 @@ spec:
 
                   A cohort is a name that links CQs together, but it doesn't reference any
                   object.
-
-                  Validation of a cohort name is equivalent to that of object names:
-                  subdomain in DNS (RFC 1123).
                 maxLength: 253
                 pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                 type: string

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -97,8 +97,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		name                string
 		operation           func(*Cache) error
 		clientObjects       []client.Object
-		wantClusterQueues   map[string]*clusterQueue
-		wantCohorts         map[string]sets.Set[string]
+		wantClusterQueues   map[kueue.ClusterQueueReference]*clusterQueue
+		wantCohorts         map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]
 		disableLendingLimit bool
 	}{
 		{
@@ -106,7 +106,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			operation: func(cache *Cache) error {
 				return setup(cache)
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"a": {
 					Name:                          "a",
 					AllocatableResourceGeneration: 2,
@@ -165,9 +165,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					FairWeight: oneQuantity,
 				},
 			},
-			wantCohorts: map[string]sets.Set[string]{
-				"one": sets.New("a", "b"),
-				"two": sets.New("c", "e", "f"),
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{
+				"one": sets.New[kueue.ClusterQueueReference]("a", "b"),
+				"two": sets.New[kueue.ClusterQueueReference]("c", "e", "f"),
 			},
 		},
 		{
@@ -182,7 +182,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				}
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"foo": {
 					Name:                          "foo",
 					AllocatableResourceGeneration: 1,
@@ -206,7 +206,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				}
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"foo": {
 					Name:                          "foo",
 					AllocatableResourceGeneration: 1,
@@ -232,7 +232,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 						Obj())
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"a": {
 					Name:                          "a",
 					AllocatableResourceGeneration: 2,
@@ -291,9 +291,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					FairWeight: oneQuantity,
 				},
 			},
-			wantCohorts: map[string]sets.Set[string]{
-				"one": sets.New("a", "b"),
-				"two": sets.New("c", "e", "f"),
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{
+				"one": sets.New[kueue.ClusterQueueReference]("a", "b"),
+				"two": sets.New[kueue.ClusterQueueReference]("c", "e", "f"),
 			},
 		},
 		{
@@ -333,7 +333,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 						Obj())
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"a": {
 					Name:                          "a",
 					AllocatableResourceGeneration: 4,
@@ -392,9 +392,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					FairWeight: oneQuantity,
 				},
 			},
-			wantCohorts: map[string]sets.Set[string]{
-				"one": sets.New("b"),
-				"two": sets.New("a", "c", "e", "f"),
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{
+				"one": sets.New[kueue.ClusterQueueReference]("b"),
+				"two": sets.New[kueue.ClusterQueueReference]("a", "c", "e", "f"),
 			},
 		},
 		{
@@ -439,7 +439,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"a": {
 					Name:                          "a",
 					AllocatableResourceGeneration: 2,
@@ -478,8 +478,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					},
 				},
 			},
-			wantCohorts: map[string]sets.Set[string]{
-				"one": sets.New("a"),
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{
+				"one": sets.New[kueue.ClusterQueueReference]("a"),
 			},
 		},
 		{
@@ -507,7 +507,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				}
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"a": {
 					Name:                          "a",
 					AllocatableResourceGeneration: 4,
@@ -536,8 +536,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector:             labels.Nothing(),
 				},
 			},
-			wantCohorts: map[string]sets.Set[string]{
-				"three": sets.New("a", "c"),
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{
+				"three": sets.New[kueue.ClusterQueueReference]("a", "c"),
 			},
 		},
 		{
@@ -556,7 +556,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				}
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"b": {
 					Name:                          "b",
 					AllocatableResourceGeneration: 1,
@@ -597,9 +597,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					FairWeight: oneQuantity,
 				},
 			},
-			wantCohorts: map[string]sets.Set[string]{
-				"one": sets.New("b"),
-				"two": sets.New("c", "e", "f"),
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{
+				"one": sets.New[kueue.ClusterQueueReference]("b"),
+				"two": sets.New[kueue.ClusterQueueReference]("c", "e", "f"),
 			},
 		},
 		{
@@ -612,7 +612,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("nonexistent-flavor").Obj())
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"a": {
 					Name:                          "a",
 					AllocatableResourceGeneration: 2,
@@ -671,9 +671,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					FairWeight: oneQuantity,
 				},
 			},
-			wantCohorts: map[string]sets.Set[string]{
-				"one": sets.New("a", "b"),
-				"two": sets.New("c", "e", "f"),
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{
+				"one": sets.New[kueue.ClusterQueueReference]("a", "b"),
+				"two": sets.New[kueue.ClusterQueueReference]("c", "e", "f"),
 			},
 		},
 		{
@@ -701,7 +701,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				}
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"foo": {
 					Name:                          "foo",
 					NamespaceSelector:             labels.Everything(),
@@ -725,7 +725,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				}
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"foo": {
 					Name:                          "foo",
 					NamespaceSelector:             labels.Everything(),
@@ -740,7 +740,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					FairWeight: oneQuantity,
 				},
 			},
-			wantCohorts: map[string]sets.Set[string]{},
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{},
 		},
 		{
 			name: "add check after queue creation",
@@ -757,7 +757,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionTrue).Obj())
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"foo": {
 					Name:                          "foo",
 					NamespaceSelector:             labels.Everything(),
@@ -772,7 +772,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					FairWeight: oneQuantity,
 				},
 			},
-			wantCohorts: map[string]sets.Set[string]{},
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{},
 		},
 		{
 			name: "remove check after queue creation",
@@ -790,7 +790,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				cache.DeleteAdmissionCheck(utiltesting.MakeAdmissionCheck("check2").Obj())
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"foo": {
 					Name:                          "foo",
 					NamespaceSelector:             labels.Everything(),
@@ -805,7 +805,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					FairWeight: oneQuantity,
 				},
 			},
-			wantCohorts: map[string]sets.Set[string]{},
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{},
 		},
 		{
 			name: "inactivate check after queue creation",
@@ -823,7 +823,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionFalse).Obj())
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"foo": {
 					Name:                          "foo",
 					NamespaceSelector:             labels.Everything(),
@@ -838,7 +838,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					FairWeight: oneQuantity,
 				},
 			},
-			wantCohorts: map[string]sets.Set[string]{},
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{},
 		},
 		{
 			name: "add cluster queue after finished workloads",
@@ -874,7 +874,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				}
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"cq1": {
 					Name:                          "cq1",
 					NamespaceSelector:             labels.Everything(),
@@ -921,7 +921,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					},
 				},
 			},
-			wantCohorts: map[string]sets.Set[string]{},
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{},
 		},
 		{
 			name: "add CQ with multiple resource groups and flavors",
@@ -974,7 +974,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					Obj()
 				return cache.AddClusterQueue(context.Background(), cq)
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"foo": {
 					Name:                          "foo",
 					NamespaceSelector:             labels.Everything(),
@@ -1038,7 +1038,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					Obj()
 				return cache.AddClusterQueue(context.Background(), cq)
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"foo": {
 					Name:                          "foo",
 					NamespaceSelector:             labels.Everything(),
@@ -1056,7 +1056,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				cohort := utiltesting.MakeCohort("cohort").Obj()
 				return cache.AddOrUpdateCohort(cohort)
 			},
-			wantCohorts: map[string]sets.Set[string]{
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{
 				"cohort": nil,
 			},
 		},
@@ -1065,7 +1065,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			operation: func(cache *Cache) error {
 				cohort := utiltesting.MakeCohort("cohort").Obj()
 				_ = cache.AddOrUpdateCohort(cohort)
-				cache.DeleteCohort(cohort.Name)
+				cache.DeleteCohort(kueue.CohortReference(cohort.Name))
 				return nil
 			},
 			wantCohorts: nil,
@@ -1078,10 +1078,10 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 
 				_ = cache.AddClusterQueue(context.Background(),
 					utiltesting.MakeClusterQueue("cq").Cohort("cohort").Obj())
-				cache.DeleteCohort(cohort.Name)
+				cache.DeleteCohort(kueue.CohortReference(cohort.Name))
 				return nil
 			},
-			wantClusterQueues: map[string]*clusterQueue{
+			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"cq": {
 					Name:                          "cq",
 					NamespaceSelector:             labels.Everything(),
@@ -1092,8 +1092,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					FairWeight:                    oneQuantity,
 				},
 			},
-			wantCohorts: map[string]sets.Set[string]{
-				"cohort": sets.New("cq"),
+			wantCohorts: map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference]{
+				"cohort": sets.New[kueue.ClusterQueueReference]("cq"),
 			},
 		},
 	}
@@ -1116,9 +1116,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			}
 
 			cohorts := cache.hm.Cohorts()
-			gotCohorts := make(map[string]sets.Set[string], len(cohorts))
+			gotCohorts := make(map[kueue.CohortReference]sets.Set[kueue.ClusterQueueReference], len(cohorts))
 			for name, cohort := range cohorts {
-				gotCohort := sets.New[string]()
+				gotCohort := sets.New[kueue.ClusterQueueReference]()
 				for _, cq := range cohort.ChildCQs() {
 					gotCohort.Insert(cq.Name)
 				}
@@ -1197,8 +1197,8 @@ func TestCacheWorkloadOperations(t *testing.T) {
 	steps := []struct {
 		name                 string
 		operation            func(cache *Cache) error
-		wantResults          map[string]result
-		wantAssumedWorkloads map[string]string
+		wantResults          map[kueue.ClusterQueueReference]result
+		wantAssumedWorkloads map[string]kueue.ClusterQueueReference
 		wantError            string
 	}{
 		{
@@ -1219,7 +1219,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				}
 				return nil
 			},
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1244,7 +1244,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				return nil
 			},
 			wantError: "failed to add workload",
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1268,7 +1268,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				}
 				return nil
 			},
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1293,7 +1293,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				}).Obj()
 				return cache.UpdateWorkload(old, latest)
 			},
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1322,7 +1322,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				return cache.UpdateWorkload(old, latest)
 			},
 			wantError: "old ClusterQueue doesn't exist",
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1347,7 +1347,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				return cache.UpdateWorkload(old, latest)
 			},
 			wantError: "new ClusterQueue doesn't exist",
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1371,7 +1371,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				}).Obj()
 				return cache.UpdateWorkload(old, latest)
 			},
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1392,7 +1392,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				}).Obj()
 				return cache.DeleteWorkload(w)
 			},
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1411,7 +1411,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				w := utiltesting.MakeWorkload("a", "").Obj()
 				return cache.DeleteWorkload(w)
 			},
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1431,7 +1431,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				return cache.DeleteWorkload(w)
 			},
 			wantError: "cluster queue not found",
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1453,7 +1453,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				return cache.DeleteWorkload(w)
 			},
 			wantError: "cluster queue not found",
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1474,7 +1474,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				}).Obj()
 				return cache.DeleteWorkload(w)
 			},
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1507,7 +1507,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				}
 				return nil
 			},
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b", "/d"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1523,7 +1523,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 					},
 				},
 			},
-			wantAssumedWorkloads: map[string]string{
+			wantAssumedWorkloads: map[string]kueue.ClusterQueueReference{
 				"/d": "one",
 				"/e": "two",
 			},
@@ -1540,7 +1540,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				return nil
 			},
 			wantError: "cluster queue not found",
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1552,7 +1552,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 					Workloads: sets.New("/c"),
 				},
 			},
-			wantAssumedWorkloads: map[string]string{},
+			wantAssumedWorkloads: map[string]kueue.ClusterQueueReference{},
 		},
 		{
 			name: "forget",
@@ -1576,7 +1576,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				w := workloads[0]
 				return cache.ForgetWorkload(w)
 			},
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1592,7 +1592,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 					},
 				},
 			},
-			wantAssumedWorkloads: map[string]string{
+			wantAssumedWorkloads: map[string]kueue.ClusterQueueReference{
 				"/e": "two",
 			},
 		},
@@ -1608,7 +1608,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				return nil
 			},
 			wantError: "the workload is not assumed",
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1646,7 +1646,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				}
 				return nil
 			},
-			wantResults: map[string]result{
+			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
 					Workloads: sets.New("/a", "/b", "/d"),
 					UsedResources: resources.FlavorResourceQuantities{
@@ -1662,7 +1662,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 					},
 				},
 			},
-			wantAssumedWorkloads: map[string]string{
+			wantAssumedWorkloads: map[string]kueue.ClusterQueueReference{
 				"/e": "two",
 			},
 		},
@@ -1681,7 +1681,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			if diff := cmp.Diff(step.wantError, messageOrEmpty(gotError)); diff != "" {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}
-			gotResult := make(map[string]result)
+			gotResult := make(map[kueue.ClusterQueueReference]result)
 			for name, cq := range cache.hm.ClusterQueues() {
 				gotResult[name] = result{
 					Workloads:     sets.KeySet(cq.Workloads),
@@ -1692,7 +1692,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				t.Errorf("Unexpected clusterQueues (-want,+got):\n%s", diff)
 			}
 			if step.wantAssumedWorkloads == nil {
-				step.wantAssumedWorkloads = map[string]string{}
+				step.wantAssumedWorkloads = map[string]kueue.ClusterQueueReference{}
 			}
 			if diff := cmp.Diff(step.wantAssumedWorkloads, cache.assumedWorkloads); diff != "" {
 				t.Errorf("Unexpected assumed workloads (-want,+got):\n%s", diff)
@@ -2759,14 +2759,14 @@ func TestClusterQueuesUsingFlavor(t *testing.T) {
 	tests := []struct {
 		name                       string
 		clusterQueues              []*kueue.ClusterQueue
-		wantInUseClusterQueueNames []string
+		wantInUseClusterQueueNames []kueue.ClusterQueueReference
 	}{
 		{
 			name: "single clusterQueue with flavor in use",
 			clusterQueues: []*kueue.ClusterQueue{
 				fooCq,
 			},
-			wantInUseClusterQueueNames: []string{fooCq.Name},
+			wantInUseClusterQueueNames: []kueue.ClusterQueueReference{kueue.ClusterQueueReference(fooCq.Name)},
 		},
 		{
 			name: "single clusterQueue with no flavor",
@@ -2781,7 +2781,10 @@ func TestClusterQueuesUsingFlavor(t *testing.T) {
 				barCq,
 				fizzCq,
 			},
-			wantInUseClusterQueueNames: []string{fooCq.Name, fizzCq.Name},
+			wantInUseClusterQueueNames: []kueue.ClusterQueueReference{
+				kueue.ClusterQueueReference(fooCq.Name),
+				kueue.ClusterQueueReference(fizzCq.Name),
+			},
 		},
 	}
 	for _, tc := range tests {
@@ -2797,7 +2800,7 @@ func TestClusterQueuesUsingFlavor(t *testing.T) {
 			}
 
 			cqs := cache.ClusterQueuesUsingFlavor("x86")
-			if diff := cmp.Diff(tc.wantInUseClusterQueueNames, cqs, cmpopts.SortSlices(func(a, b string) bool {
+			if diff := cmp.Diff(tc.wantInUseClusterQueueNames, cqs, cmpopts.SortSlices(func(a, b kueue.ClusterQueueReference) bool {
 				return a < b
 			})); len(diff) != 0 {
 				t.Errorf("Unexpected flavor is in use by clusterQueues (-want,+got):\n%s", diff)
@@ -2823,7 +2826,7 @@ func TestMatchingClusterQueues(t *testing.T) {
 				},
 			}).Obj(),
 	}
-	wantCQs := sets.New("matching1", "matching2")
+	wantCQs := sets.New[kueue.ClusterQueueReference]("matching1", "matching2")
 
 	cache := New(utiltesting.NewFakeClient())
 	for _, cq := range clusterQueues {
@@ -3132,13 +3135,13 @@ func TestIsAssumedOrAdmittedCheckWorkload(t *testing.T) {
 	tests := []struct {
 		name             string
 		clusterQueues    map[string]*clusterQueue
-		assumedWorkloads map[string]string
+		assumedWorkloads map[string]kueue.ClusterQueueReference
 		workload         workload.Info
 		expected         bool
 	}{
 		{
 			name:             "Workload Is Assumed and not Admitted",
-			assumedWorkloads: map[string]string{"workload_namespace/workload_name": "test", "test2": "test2"},
+			assumedWorkloads: map[string]kueue.ClusterQueueReference{"workload_namespace/workload_name": "test", "test2": "test2"},
 			workload: workload.Info{
 				ClusterQueue: "ClusterQueue1",
 				Obj: &kueue.Workload{
@@ -3190,7 +3193,7 @@ func TestIsAssumedOrAdmittedCheckWorkload(t *testing.T) {
 						},
 					}},
 				}},
-			assumedWorkloads: map[string]string{"workload_namespace/workload_name": "test", "test2": "test2"},
+			assumedWorkloads: map[string]kueue.ClusterQueueReference{"workload_namespace/workload_name": "test", "test2": "test2"},
 			workload: workload.Info{
 				ClusterQueue: "ClusterQueue1",
 				Obj: &kueue.Workload{
@@ -3272,17 +3275,17 @@ func TestClusterQueuesUsingAdmissionChecks(t *testing.T) {
 
 	cases := map[string]struct {
 		clusterQueues              []*kueue.ClusterQueue
-		wantInUseClusterQueueNames []string
+		wantInUseClusterQueueNames []kueue.ClusterQueueReference
 		check                      string
 	}{
 		"single clusterQueue with check in use": {
 			clusterQueues:              []*kueue.ClusterQueue{fooCq},
-			wantInUseClusterQueueNames: []string{fooCq.Name},
+			wantInUseClusterQueueNames: []kueue.ClusterQueueReference{kueue.ClusterQueueReference(fooCq.Name)},
 			check:                      "ac1",
 		},
 		"single clusterQueue with AdmissionCheckStrategy in use": {
 			clusterQueues:              []*kueue.ClusterQueue{strategyCq},
-			wantInUseClusterQueueNames: []string{strategyCq.Name},
+			wantInUseClusterQueueNames: []kueue.ClusterQueueReference{kueue.ClusterQueueReference(strategyCq.Name)},
 			check:                      "ac3",
 		},
 		"single clusterQueue with no checks": {
@@ -3296,8 +3299,12 @@ func TestClusterQueuesUsingAdmissionChecks(t *testing.T) {
 				fizzCq,
 				strategyCq,
 			},
-			wantInUseClusterQueueNames: []string{fooCq.Name, fizzCq.Name, strategyCq.Name},
-			check:                      "ac1",
+			wantInUseClusterQueueNames: []kueue.ClusterQueueReference{
+				kueue.ClusterQueueReference(fooCq.Name),
+				kueue.ClusterQueueReference(fizzCq.Name),
+				kueue.ClusterQueueReference(strategyCq.Name),
+			},
+			check: "ac1",
 		},
 	}
 	for name, tc := range cases {
@@ -3314,7 +3321,7 @@ func TestClusterQueuesUsingAdmissionChecks(t *testing.T) {
 			}
 
 			cqs := cache.ClusterQueuesUsingAdmissionCheck(tc.check)
-			if diff := cmp.Diff(tc.wantInUseClusterQueueNames, cqs, cmpopts.SortSlices(func(a, b string) bool {
+			if diff := cmp.Diff(tc.wantInUseClusterQueueNames, cqs, cmpopts.SortSlices(func(a, b kueue.ClusterQueueReference) bool {
 				return a < b
 			})); len(diff) != 0 {
 				t.Errorf("Unexpected AdmissionCheck is in use by clusterQueues (-want,+got):\n%s", diff)
@@ -3337,7 +3344,7 @@ func TestClusterQueueReadiness(t *testing.T) {
 		clusterQueues    []*kueue.ClusterQueue
 		resourceFlavors  []*kueue.ResourceFlavor
 		admissionChecks  []*kueue.AdmissionCheck
-		clusterQueueName string
+		clusterQueueName kueue.ClusterQueueReference
 		terminate        bool
 		wantStatus       metav1.ConditionStatus
 		wantReason       string

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -48,7 +48,7 @@ var (
 // clusterQueue is the internal implementation of kueue.clusterQueue that
 // holds admitted workloads.
 type clusterQueue struct {
-	Name              string
+	Name              kueue.ClusterQueueReference
 	ResourceGroups    []ResourceGroup
 	Workloads         map[string]*workload.Info
 	WorkloadsNotReady sets.Set[string]
@@ -88,7 +88,7 @@ type clusterQueue struct {
 	tasCache *TASCache
 }
 
-func (c *clusterQueue) GetName() string {
+func (c *clusterQueue) GetName() kueue.ClusterQueueReference {
 	return c.Name
 }
 
@@ -485,8 +485,8 @@ func (c *clusterQueue) deleteWorkload(w *kueue.Workload) {
 }
 
 func (c *clusterQueue) reportActiveWorkloads() {
-	metrics.AdmittedActiveWorkloads.WithLabelValues(c.Name).Set(float64(c.admittedWorkloadsCount))
-	metrics.ReservingActiveWorkloads.WithLabelValues(c.Name).Set(float64(len(c.Workloads)))
+	metrics.AdmittedActiveWorkloads.WithLabelValues(string(c.Name)).Set(float64(c.admittedWorkloadsCount))
+	metrics.ReservingActiveWorkloads.WithLabelValues(string(c.Name)).Set(float64(len(c.Workloads)))
 }
 
 func (q *queue) reportActiveWorkloads() {

--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -34,7 +34,7 @@ import (
 )
 
 type ClusterQueueSnapshot struct {
-	Name              string
+	Name              kueue.ClusterQueueReference
 	ResourceGroups    []ResourceGroup
 	Workloads         map[string]*workload.Info
 	WorkloadsNotReady sets.Set[string]
@@ -157,7 +157,7 @@ func (c *ClusterQueueSnapshot) PotentialAvailable(fr resources.FlavorResource) i
 	return potentialAvailable(c, fr)
 }
 
-func (c *ClusterQueueSnapshot) GetName() string {
+func (c *ClusterQueueSnapshot) GetName() kueue.ClusterQueueReference {
 	return c.Name
 }
 

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -772,7 +772,7 @@ func TestClusterQueueReadinessWithTAS(t *testing.T) {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
 
-			_, gotReason, gotMessage := cqCache.ClusterQueueReadiness(tc.cq.Name)
+			_, gotReason, gotMessage := cqCache.ClusterQueueReadiness(kueue.ClusterQueueReference(tc.cq.Name))
 			if diff := cmp.Diff(tc.wantReason, gotReason); diff != "" {
 				t.Errorf("Unexpected inactiveReason (-want,+got):\n%s", diff)
 			}

--- a/pkg/cache/cohort.go
+++ b/pkg/cache/cohort.go
@@ -20,12 +20,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 )
 
 // cohort is a set of ClusterQueues that can borrow resources from each other.
 type cohort struct {
-	Name string
+	Name kueue.CohortReference
 	hierarchy.Cohort[*clusterQueue, *cohort]
 
 	resourceNode ResourceNode
@@ -33,7 +34,7 @@ type cohort struct {
 	FairWeight resource.Quantity
 }
 
-func newCohort(name string) *cohort {
+func newCohort(name kueue.CohortReference) *cohort {
 	return &cohort{
 		Name:         name,
 		Cohort:       hierarchy.NewCohort[*clusterQueue, *cohort](),
@@ -52,7 +53,7 @@ func (c *cohort) updateCohort(cycleChecker hierarchy.CycleChecker, apiCohort *ku
 	return updateCohortTreeResources(c, cycleChecker)
 }
 
-func (c *cohort) GetName() string {
+func (c *cohort) GetName() kueue.CohortReference {
 	return c.Name
 }
 
@@ -75,7 +76,7 @@ func (c *cohort) parentHRN() hierarchicalResourceNode {
 
 // implement hierarchy.CycleCheckable interface
 
-func (c *cohort) CCParent() hierarchy.CycleCheckable {
+func (c *cohort) CCParent() hierarchy.CycleCheckable[kueue.CohortReference] {
 	return c.Parent()
 }
 

--- a/pkg/cache/cohort_snapshot.go
+++ b/pkg/cache/cohort_snapshot.go
@@ -19,11 +19,12 @@ package cache
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 )
 
 type CohortSnapshot struct {
-	Name string
+	Name kueue.CohortReference
 
 	ResourceNode ResourceNode
 	hierarchy.Cohort[*ClusterQueueSnapshot, *CohortSnapshot]
@@ -31,7 +32,7 @@ type CohortSnapshot struct {
 	FairWeight resource.Quantity
 }
 
-func (c *CohortSnapshot) GetName() string {
+func (c *CohortSnapshot) GetName() kueue.CohortReference {
 	return c.Name
 }
 

--- a/pkg/cache/fair_sharing_test.go
+++ b/pkg/cache/fair_sharing_test.go
@@ -647,7 +647,7 @@ func TestDominantResourceShare(t *testing.T) {
 			for _, cq := range cacheClusterQueuesMap {
 				drVal, drName := dominantResourceShare(cq, tc.flvResQ)
 				gotCache = append(gotCache, fairSharingResult{
-					Name:     cq.Name,
+					Name:     string(cq.Name),
 					NodeType: nodeTypeCq,
 					DrValue:  drVal,
 					DrName:   drName,
@@ -656,7 +656,7 @@ func TestDominantResourceShare(t *testing.T) {
 			for _, cohort := range cacheCohortsMap {
 				drVal, drName := dominantResourceShare(cohort, tc.flvResQ)
 				gotCache = append(gotCache, fairSharingResult{
-					Name:     cohort.Name,
+					Name:     string(cohort.Name),
 					NodeType: nodeTypeCohort,
 					DrValue:  drVal,
 					DrName:   drName,
@@ -672,7 +672,7 @@ func TestDominantResourceShare(t *testing.T) {
 			for _, cq := range snapshotClusterQueuesMap {
 				drVal, drName := dominantResourceShare(cq, tc.flvResQ)
 				gotSnapshot = append(gotSnapshot, fairSharingResult{
-					Name:     cq.Name,
+					Name:     string(cq.Name),
 					NodeType: nodeTypeCq,
 					DrValue:  drVal,
 					DrName:   drName,
@@ -681,7 +681,7 @@ func TestDominantResourceShare(t *testing.T) {
 			for _, cohort := range snapshotCohortsMap {
 				drVal, drName := dominantResourceShare(cohort, tc.flvResQ)
 				gotSnapshot = append(gotSnapshot, fairSharingResult{
-					Name:     cohort.Name,
+					Name:     string(cohort.Name),
 					NodeType: nodeTypeCohort,
 					DrValue:  drVal,
 					DrName:   drName,

--- a/pkg/cache/resource_test.go
+++ b/pkg/cache/resource_test.go
@@ -33,9 +33,9 @@ func TestAvailable(t *testing.T) {
 	cases := map[string]struct {
 		cohorts                  []kueuealpha.Cohort
 		clusterQueues            []kueue.ClusterQueue
-		usage                    map[string]resources.FlavorResourceQuantities
-		wantAvailable            map[string]resources.FlavorResourceQuantities
-		wantPotentiallyAvailable map[string]resources.FlavorResourceQuantities
+		usage                    map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities
+		wantAvailable            map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities
+		wantPotentiallyAvailable map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities
 	}{
 		"base cqs": {
 			clusterQueues: []kueue.ClusterQueue{
@@ -49,18 +49,18 @@ func TestAvailable(t *testing.T) {
 						*utiltesting.MakeFlavorQuotas("blue").Resource("cpu", "10").Obj(),
 					).ClusterQueue,
 			},
-			usage: map[string]resources.FlavorResourceQuantities{
+			usage: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 1000},
 				"cq2": {
 					{Flavor: "red", Resource: "cpu"}:  2_500,
 					{Flavor: "blue", Resource: "cpu"}: 1_000,
 				},
 			},
-			wantAvailable: map[string]resources.FlavorResourceQuantities{
+			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 0},
 				"cq2": {{Flavor: "red", Resource: "cpu"}: 2_500, {Flavor: "blue", Resource: "cpu"}: 9_000},
 			},
-			wantPotentiallyAvailable: map[string]resources.FlavorResourceQuantities{
+			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 0},
 				"cq2": {{Flavor: "red", Resource: "cpu"}: 5_000, {Flavor: "blue", Resource: "cpu"}: 10_000},
 			},
@@ -84,15 +84,15 @@ func TestAvailable(t *testing.T) {
 						*utiltesting.MakeFlavorQuotas("red").Resource("cpu", "10").Obj(),
 					).Cohort,
 			},
-			usage: map[string]resources.FlavorResourceQuantities{
+			usage: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 1000},
 				"cq2": {{Flavor: "red", Resource: "cpu"}: 500},
 			},
-			wantAvailable: map[string]resources.FlavorResourceQuantities{
+			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 28_000},
 				"cq2": {{Flavor: "red", Resource: "cpu"}: 28_500},
 			},
-			wantPotentiallyAvailable: map[string]resources.FlavorResourceQuantities{
+			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 29_000},
 				"cq2": {{Flavor: "red", Resource: "cpu"}: 30_000},
 			},
@@ -111,9 +111,9 @@ func TestAvailable(t *testing.T) {
 						*utiltesting.MakeFlavorQuotas("red").Resource("cpu", "10").Obj(),
 					).Cohort,
 			},
-			usage:                    map[string]resources.FlavorResourceQuantities{"cq1": {{Flavor: "red", Resource: "cpu"}: 11_000}},
-			wantAvailable:            map[string]resources.FlavorResourceQuantities{"cq1": {{Flavor: "red", Resource: "cpu"}: 9_000}},
-			wantPotentiallyAvailable: map[string]resources.FlavorResourceQuantities{"cq1": {{Flavor: "red", Resource: "cpu"}: 20_000}},
+			usage:                    map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{"cq1": {{Flavor: "red", Resource: "cpu"}: 11_000}},
+			wantAvailable:            map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{"cq1": {{Flavor: "red", Resource: "cpu"}: 9_000}},
+			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{"cq1": {{Flavor: "red", Resource: "cpu"}: 20_000}},
 		},
 		"cq oversubscription spills into cohort": {
 			clusterQueues: []kueue.ClusterQueue{
@@ -134,10 +134,10 @@ func TestAvailable(t *testing.T) {
 						*utiltesting.MakeFlavorQuotas("red").Resource("cpu", "10").Obj(),
 					).Cohort,
 			},
-			usage: map[string]resources.FlavorResourceQuantities{
+			usage: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 31_000},
 			},
-			wantAvailable: map[string]resources.FlavorResourceQuantities{
+			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 0},
 				// even though cq2 doesn't borrow/lend
 				// resources from Cohort, the
@@ -147,7 +147,7 @@ func TestAvailable(t *testing.T) {
 				// the CohortTree.
 				"cq2": {{Flavor: "red", Resource: "cpu"}: 0},
 			},
-			wantPotentiallyAvailable: map[string]resources.FlavorResourceQuantities{
+			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 20_000},
 				"cq2": {{Flavor: "red", Resource: "cpu"}: 10_000},
 			},
@@ -180,12 +180,12 @@ func TestAvailable(t *testing.T) {
 						*utiltesting.MakeFlavorQuotas("red").Resource("cpu", "10").Obj(),
 					).Cohort,
 			},
-			usage: map[string]resources.FlavorResourceQuantities{
+			usage: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 20_000},
 				"cq2": {{Flavor: "red", Resource: "cpu"}: 10_000},
 				"cq3": {{Flavor: "red", Resource: "cpu"}: 6_000},
 			},
-			wantAvailable: map[string]resources.FlavorResourceQuantities{
+			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				// cq1 uses 20k, cq2 uses 10k, and
 				// cq3 uses 1k (not counting first 5k
 				// in guaranteedQuota), resulting in
@@ -198,7 +198,7 @@ func TestAvailable(t *testing.T) {
 				// 40k - (20k + 10k + 6k) = 4k
 				"cq3": {{Flavor: "red", Resource: "cpu"}: 4_000},
 			},
-			wantPotentiallyAvailable: map[string]resources.FlavorResourceQuantities{
+			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 35_000},
 				"cq2": {{Flavor: "red", Resource: "cpu"}: 12_000},
 				"cq3": {{Flavor: "red", Resource: "cpu"}: 40_000},
@@ -235,18 +235,18 @@ func TestAvailable(t *testing.T) {
 						*utiltesting.MakeFlavorQuotas("red").Resource("cpu", "10").Obj(),
 					).Cohort,
 			},
-			usage: map[string]resources.FlavorResourceQuantities{
+			usage: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 10_000},
 				"cq2": {{Flavor: "red", Resource: "cpu"}: 5_000},
 			},
-			wantAvailable: map[string]resources.FlavorResourceQuantities{
+			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				// 30k available - 10k usage.
 				// no capacity/usage from right subtree
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 20_000},
 				// 40k available - 15k usage.
 				"cq2": {{Flavor: "red", Resource: "cpu"}: 25_000},
 			},
-			wantPotentiallyAvailable: map[string]resources.FlavorResourceQuantities{
+			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"cq1": {{Flavor: "red", Resource: "cpu"}: 30_000},
 				"cq2": {{Flavor: "red", Resource: "cpu"}: 40_000},
 			},
@@ -287,7 +287,7 @@ func TestAvailable(t *testing.T) {
 						*utiltesting.MakeFlavorQuotas("red").Resource("cpu", "10").Obj(),
 					).Cohort,
 			},
-			wantAvailable: map[string]resources.FlavorResourceQuantities{
+			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				// 30k in "left" subtree + 5k limit above tree
 				"left-cq1": {{Flavor: "red", Resource: "cpu"}: 35_000},
 				// 10k + 5k lending limit
@@ -295,7 +295,7 @@ func TestAvailable(t *testing.T) {
 				// all 50k in "root" subtree
 				"right-cq": {{Flavor: "red", Resource: "cpu"}: 50_000},
 			},
-			wantPotentiallyAvailable: map[string]resources.FlavorResourceQuantities{
+			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"left-cq1": {{Flavor: "red", Resource: "cpu"}: 35_000},
 				"left-cq2": {{Flavor: "red", Resource: "cpu"}: 15_000},
 				"right-cq": {{Flavor: "red", Resource: "cpu"}: 50_000},
@@ -342,7 +342,7 @@ func TestAvailable(t *testing.T) {
 						*utiltesting.MakeFlavorQuotas("red").Resource("cpu", "0").Obj(),
 					).Cohort,
 			},
-			wantAvailable: map[string]resources.FlavorResourceQuantities{
+			wantAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"left-cq1": {{Flavor: "red", Resource: "cpu"}: 20_000},
 				// only 5k of left-cq1's resources are available,
 				// plus 10k of its own.
@@ -351,7 +351,7 @@ func TestAvailable(t *testing.T) {
 				"right-cq": {{Flavor: "red", Resource: "cpu"}: 5_000},
 				"root-cq":  {{Flavor: "red", Resource: "cpu"}: 5_000},
 			},
-			wantPotentiallyAvailable: map[string]resources.FlavorResourceQuantities{
+			wantPotentiallyAvailable: map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities{
 				"left-cq1": {{Flavor: "red", Resource: "cpu"}: 20_000},
 				"left-cq2": {{Flavor: "red", Resource: "cpu"}: 15_000},
 				"right-cq": {{Flavor: "red", Resource: "cpu"}: 5_000},
@@ -380,8 +380,8 @@ func TestAvailable(t *testing.T) {
 			// before adding usage
 			{
 				clusterQueues := snapshot.ClusterQueues()
-				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
-				gotPotentiallyAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
+				gotAvailable := make(map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities, len(clusterQueues))
+				gotPotentiallyAvailable := make(map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities, len(clusterQueues))
 				for _, cq := range clusterQueues {
 					numFrs := len(cq.ResourceNode.Quotas)
 					gotAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
@@ -406,8 +406,8 @@ func TestAvailable(t *testing.T) {
 					snapshot.ClusterQueue(cqName).AddUsage(workload.Usage{Quota: usage})
 				}
 				clusterQueues := snapshot.ClusterQueues()
-				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
-				gotPotentiallyAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
+				gotAvailable := make(map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities, len(clusterQueues))
+				gotPotentiallyAvailable := make(map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities, len(clusterQueues))
 				for _, cq := range clusterQueues {
 					numFrs := len(cq.ResourceNode.Quotas)
 					gotAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)
@@ -431,8 +431,8 @@ func TestAvailable(t *testing.T) {
 					snapshot.ClusterQueue(cqName).RemoveUsage(workload.Usage{Quota: usage})
 				}
 				clusterQueues := snapshot.ClusterQueues()
-				gotAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
-				gotPotentiallyAvailable := make(map[string]resources.FlavorResourceQuantities, len(clusterQueues))
+				gotAvailable := make(map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities, len(clusterQueues))
+				gotPotentiallyAvailable := make(map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities, len(clusterQueues))
 				for _, cq := range clusterQueues {
 					numFrs := len(cq.ResourceNode.Quotas)
 					gotAvailable[cq.Name] = make(resources.FlavorResourceQuantities, numFrs)

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -70,8 +70,8 @@ func TestSnapshot(t *testing.T) {
 			},
 			wantSnapshot: Snapshot{
 				Manager: hierarchy.NewManagerForTest(
-					map[string]*CohortSnapshot{},
-					map[string]*ClusterQueueSnapshot{
+					map[kueue.CohortReference]*CohortSnapshot{},
+					map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 						"a": {
 							Name:                          "a",
 							NamespaceSelector:             labels.Everything(),
@@ -112,7 +112,7 @@ func TestSnapshot(t *testing.T) {
 					Obj(),
 			},
 			wantSnapshot: Snapshot{
-				InactiveClusterQueueSets: sets.New("flavor-nonexistent-cq"),
+				InactiveClusterQueueSets: sets.New[kueue.ClusterQueueReference]("flavor-nonexistent-cq"),
 			},
 		},
 		"resourceFlavors": {
@@ -129,8 +129,8 @@ func TestSnapshot(t *testing.T) {
 			},
 			wantSnapshot: Snapshot{
 				Manager: hierarchy.NewManagerForTest(
-					map[string]*CohortSnapshot{},
-					map[string]*ClusterQueueSnapshot{},
+					map[kueue.CohortReference]*CohortSnapshot{},
+					map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{},
 				),
 				ResourceFlavors: map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
 					"demand": utiltesting.MakeResourceFlavor("demand").
@@ -229,10 +229,10 @@ func TestSnapshot(t *testing.T) {
 				}
 				return Snapshot{
 					Manager: hierarchy.NewManagerForTest(
-						map[string]*CohortSnapshot{
+						map[kueue.CohortReference]*CohortSnapshot{
 							"borrowing": cohort,
 						},
-						map[string]*ClusterQueueSnapshot{
+						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"a": {
 								Name:                          "a",
 								AllocatableResourceGeneration: 2,
@@ -375,8 +375,8 @@ func TestSnapshot(t *testing.T) {
 			},
 			wantSnapshot: Snapshot{
 				Manager: hierarchy.NewManagerForTest(
-					map[string]*CohortSnapshot{},
-					map[string]*ClusterQueueSnapshot{
+					map[kueue.CohortReference]*CohortSnapshot{},
+					map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 						"with-preemption": {
 							Name:                          "with-preemption",
 							NamespaceSelector:             labels.Everything(),
@@ -400,8 +400,8 @@ func TestSnapshot(t *testing.T) {
 			},
 			wantSnapshot: Snapshot{
 				Manager: hierarchy.NewManagerForTest(
-					map[string]*CohortSnapshot{},
-					map[string]*ClusterQueueSnapshot{
+					map[kueue.CohortReference]*CohortSnapshot{},
+					map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 						"with-preemption": {
 							Name:                          "with-preemption",
 							NamespaceSelector:             labels.Everything(),
@@ -476,10 +476,10 @@ func TestSnapshot(t *testing.T) {
 				}
 				return Snapshot{
 					Manager: hierarchy.NewManagerForTest(
-						map[string]*CohortSnapshot{
+						map[kueue.CohortReference]*CohortSnapshot{
 							"lending": cohort,
 						},
-						map[string]*ClusterQueueSnapshot{
+						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"a": {
 								Name:                          "a",
 								AllocatableResourceGeneration: 2,
@@ -631,10 +631,10 @@ func TestSnapshot(t *testing.T) {
 				}
 				return Snapshot{
 					Manager: hierarchy.NewManagerForTest(
-						map[string]*CohortSnapshot{
+						map[kueue.CohortReference]*CohortSnapshot{
 							"lending": cohort,
 						},
-						map[string]*ClusterQueueSnapshot{
+						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"a": {
 								Name:                          "a",
 								AllocatableResourceGeneration: 2,
@@ -750,7 +750,7 @@ func TestSnapshot(t *testing.T) {
 			},
 			wantSnapshot: Snapshot{
 				Manager: hierarchy.NewManagerForTest(
-					map[string]*CohortSnapshot{
+					map[kueue.CohortReference]*CohortSnapshot{
 						"cohort": {
 							Name: "cohort",
 							ResourceNode: ResourceNode{
@@ -768,7 +768,7 @@ func TestSnapshot(t *testing.T) {
 							FairWeight: oneQuantity,
 						},
 					},
-					map[string]*ClusterQueueSnapshot{
+					map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 						"cq": {
 							Name:                          "cq",
 							AllocatableResourceGeneration: 2,
@@ -837,7 +837,7 @@ func TestSnapshot(t *testing.T) {
 			},
 			wantSnapshot: Snapshot{
 				Manager: hierarchy.NewManagerForTest(
-					map[string]*CohortSnapshot{
+					map[kueue.CohortReference]*CohortSnapshot{
 						"nocycle": {
 							Name: "nocycle",
 							ResourceNode: ResourceNode{
@@ -848,7 +848,7 @@ func TestSnapshot(t *testing.T) {
 							FairWeight: oneQuantity,
 						},
 					},
-					map[string]*ClusterQueueSnapshot{
+					map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 						"cq-nocycle": {
 							Name:                          "cq-nocycle",
 							AllocatableResourceGeneration: 2,
@@ -874,7 +874,7 @@ func TestSnapshot(t *testing.T) {
 						},
 					},
 				),
-				InactiveClusterQueueSets: sets.New("cq-autocycle", "cq-a", "cq-b"),
+				InactiveClusterQueueSets: sets.New[kueue.ClusterQueueReference]("cq-autocycle", "cq-a", "cq-b"),
 				ResourceFlavors: map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
 					"arm": utiltesting.MakeResourceFlavor("arm").Obj(),
 				},
@@ -886,13 +886,13 @@ func TestSnapshot(t *testing.T) {
 			},
 			wantSnapshot: Snapshot{
 				Manager: hierarchy.NewManagerForTest(
-					map[string]*CohortSnapshot{
+					map[kueue.CohortReference]*CohortSnapshot{
 						"cohort": {
 							Name:       "cohort",
 							FairWeight: resource.MustParse("0.5"),
 						},
 					},
-					map[string]*ClusterQueueSnapshot{},
+					map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{},
 				),
 			},
 		},
@@ -1038,10 +1038,10 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 				}
 				return Snapshot{
 					Manager: hierarchy.NewManagerForTest(
-						map[string]*CohortSnapshot{
+						map[kueue.CohortReference]*CohortSnapshot{
 							"cohort": cohort,
 						},
-						map[string]*ClusterQueueSnapshot{
+						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"c1": {
 								Name:              "c1",
 								Workloads:         make(map[string]*workload.Info),
@@ -1098,10 +1098,10 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 				}
 				return Snapshot{
 					Manager: hierarchy.NewManagerForTest(
-						map[string]*CohortSnapshot{
+						map[kueue.CohortReference]*CohortSnapshot{
 							"cohort": cohort,
 						},
-						map[string]*ClusterQueueSnapshot{
+						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"c1": {
 								Name: "c1",
 								Workloads: map[string]*workload.Info{
@@ -1164,10 +1164,10 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 				}
 				return Snapshot{
 					Manager: hierarchy.NewManagerForTest(
-						map[string]*CohortSnapshot{
+						map[kueue.CohortReference]*CohortSnapshot{
 							"cohort": cohort,
 						},
-						map[string]*ClusterQueueSnapshot{
+						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"c1": {
 								Name: "c1",
 								Workloads: map[string]*workload.Info{
@@ -1330,10 +1330,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				}
 				return Snapshot{
 					Manager: hierarchy.NewManagerForTest(
-						map[string]*CohortSnapshot{
+						map[kueue.CohortReference]*CohortSnapshot{
 							"lend": cohort,
 						},
-						map[string]*ClusterQueueSnapshot{
+						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
@@ -1383,10 +1383,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				}
 				return Snapshot{
 					Manager: hierarchy.NewManagerForTest(
-						map[string]*CohortSnapshot{
+						map[kueue.CohortReference]*CohortSnapshot{
 							"lend": cohort,
 						},
-						map[string]*ClusterQueueSnapshot{
+						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
@@ -1437,10 +1437,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				}
 				return Snapshot{
 					Manager: hierarchy.NewManagerForTest(
-						map[string]*CohortSnapshot{
+						map[kueue.CohortReference]*CohortSnapshot{
 							"lend": cohort,
 						},
-						map[string]*ClusterQueueSnapshot{
+						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
@@ -1491,10 +1491,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				}
 				return Snapshot{
 					Manager: hierarchy.NewManagerForTest(
-						map[string]*CohortSnapshot{
+						map[kueue.CohortReference]*CohortSnapshot{
 							"lend": cohort,
 						},
-						map[string]*ClusterQueueSnapshot{
+						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
@@ -1546,10 +1546,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				}
 				return Snapshot{
 					Manager: hierarchy.NewManagerForTest(
-						map[string]*CohortSnapshot{
+						map[kueue.CohortReference]*CohortSnapshot{
 							"lend": cohort,
 						},
-						map[string]*ClusterQueueSnapshot{
+						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
@@ -1601,10 +1601,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				}
 				return Snapshot{
 					Manager: hierarchy.NewManagerForTest(
-						map[string]*CohortSnapshot{
+						map[kueue.CohortReference]*CohortSnapshot{
 							"lend": cohort,
 						},
-						map[string]*ClusterQueueSnapshot{
+						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),
@@ -1655,10 +1655,10 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 				}
 				return Snapshot{
 					Manager: hierarchy.NewManagerForTest(
-						map[string]*CohortSnapshot{
+						map[kueue.CohortReference]*CohortSnapshot{
 							"lend": cohort,
 						},
-						map[string]*ClusterQueueSnapshot{
+						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
 								Workloads:         make(map[string]*workload.Info),

--- a/pkg/controller/core/cohort_controller.go
+++ b/pkg/controller/core/cohort_controller.go
@@ -31,6 +31,7 @@ import (
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/queue"
 )
@@ -98,8 +99,8 @@ func (r *CohortReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.client.Get(ctx, req.NamespacedName, &cohort); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.V(2).Info("Cohort is being deleted")
-			r.cache.DeleteCohort(req.NamespacedName.Name)
-			r.qManager.DeleteCohort(req.NamespacedName.Name)
+			r.cache.DeleteCohort(v1beta1.CohortReference(req.NamespacedName.Name))
+			r.qManager.DeleteCohort(v1beta1.CohortReference(req.NamespacedName.Name))
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}

--- a/pkg/hierarchy/clusterqueue.go
+++ b/pkg/hierarchy/clusterqueue.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package hierarchy
 
-type ClusterQueue[C nodeBase] struct {
+import kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+
+type ClusterQueue[C nodeBase[kueue.CohortReference]] struct {
 	cohort C
 }
 

--- a/pkg/hierarchy/cohort.go
+++ b/pkg/hierarchy/cohort.go
@@ -16,10 +16,14 @@ limitations under the License.
 
 package hierarchy
 
-import "k8s.io/apimachinery/pkg/util/sets"
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+)
 
 //lint:ignore U1000 due to https://github.com/dominikh/go-tools/issues/1602.
-type Cohort[CQ, C nodeBase] struct {
+type Cohort[CQ clusterQueueNode[C], C nodeBase[kueue.CohortReference]] struct {
 	parent       C
 	childCohorts sets.Set[C]
 	childCqs     sets.Set[CQ]
@@ -50,7 +54,7 @@ func (c *Cohort[CQ, C]) ChildCount() int {
 	return c.childCohorts.Len() + c.childCqs.Len()
 }
 
-func NewCohort[CQ, C nodeBase]() Cohort[CQ, C] {
+func NewCohort[CQ clusterQueueNode[C], C nodeBase[kueue.CohortReference]]() Cohort[CQ, C] {
 	return Cohort[CQ, C]{
 		childCohorts: sets.New[C](),
 		childCqs:     sets.New[CQ](),

--- a/pkg/hierarchy/cycle.go
+++ b/pkg/hierarchy/cycle.go
@@ -16,19 +16,21 @@ limitations under the License.
 
 package hierarchy
 
+import kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+
+type CycleCheckable[T comparable] interface {
+	GetName() T
+	HasParent() bool
+	CCParent() CycleCheckable[T]
+}
+
 // cycleChecker checks for cycles in Cohorts, while memoizing the
 // result.
 type CycleChecker struct {
-	cycles map[string]bool
+	cycles map[kueue.CohortReference]bool
 }
 
-type CycleCheckable interface {
-	GetName() string
-	HasParent() bool
-	CCParent() CycleCheckable
-}
-
-func (c *CycleChecker) HasCycle(cohort CycleCheckable) bool {
+func (c *CycleChecker) HasCycle(cohort CycleCheckable[kueue.CohortReference]) bool {
 	if cycle, seen := c.cycles[cohort.GetName()]; seen {
 		return cycle
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -408,9 +408,9 @@ func LocalQueueAdmissionChecksWaitTime(lq LocalQueueReference, waitTime time.Dur
 	localQueueAdmissionChecksWaitTime.WithLabelValues(lq.Name, lq.Namespace).Observe(waitTime.Seconds())
 }
 
-func ReportPendingWorkloads(cqName string, active, inadmissible int) {
-	PendingWorkloads.WithLabelValues(cqName, PendingStatusActive).Set(float64(active))
-	PendingWorkloads.WithLabelValues(cqName, PendingStatusInadmissible).Set(float64(inadmissible))
+func ReportPendingWorkloads(cqName kueue.ClusterQueueReference, active, inadmissible int) {
+	PendingWorkloads.WithLabelValues(string(cqName), PendingStatusActive).Set(float64(active))
+	PendingWorkloads.WithLabelValues(string(cqName), PendingStatusInadmissible).Set(float64(inadmissible))
 }
 
 func ReportLocalQueuePendingWorkloads(lq LocalQueueReference, active, inadmissible int) {
@@ -418,16 +418,16 @@ func ReportLocalQueuePendingWorkloads(lq LocalQueueReference, active, inadmissib
 	LocalQueuePendingWorkloads.WithLabelValues(lq.Name, lq.Namespace, PendingStatusInadmissible).Set(float64(inadmissible))
 }
 
-func ReportEvictedWorkloads(cqName, reason string) {
-	EvictedWorkloadsTotal.WithLabelValues(cqName, reason).Inc()
+func ReportEvictedWorkloads(cqName kueue.ClusterQueueReference, reason string) {
+	EvictedWorkloadsTotal.WithLabelValues(string(cqName), reason).Inc()
 }
 
 func ReportLocalQueueEvictedWorkloads(lq LocalQueueReference, reason string) {
 	LocalQueueEvictedWorkloadsTotal.WithLabelValues(lq.Name, lq.Namespace, reason).Inc()
 }
 
-func ReportPreemption(preemptingCqName, preemptingReason, targetCqName string) {
-	PreemptedWorkloadsTotal.WithLabelValues(preemptingCqName, preemptingReason).Inc()
+func ReportPreemption(preemptingCqName kueue.ClusterQueueReference, preemptingReason string, targetCqName kueue.ClusterQueueReference) {
+	PreemptedWorkloadsTotal.WithLabelValues(string(preemptingCqName), preemptingReason).Inc()
 	ReportEvictedWorkloads(targetCqName, kueue.WorkloadEvictedByPreemption)
 }
 
@@ -470,13 +470,13 @@ func ClearLocalQueueMetrics(lq LocalQueueReference) {
 	LocalQueueEvictedWorkloadsTotal.DeletePartialMatch(prometheus.Labels{"name": lq.Name, "namespace": lq.Namespace})
 }
 
-func ReportClusterQueueStatus(cqName string, cqStatus ClusterQueueStatus) {
+func ReportClusterQueueStatus(cqName kueue.ClusterQueueReference, cqStatus ClusterQueueStatus) {
 	for _, status := range CQStatuses {
 		var v float64
 		if status == cqStatus {
 			v = 1
 		}
-		ClusterQueueByStatus.WithLabelValues(cqName, string(status)).Set(v)
+		ClusterQueueByStatus.WithLabelValues(string(cqName), string(status)).Set(v)
 	}
 }
 
@@ -510,24 +510,24 @@ func ClearLocalQueueCacheMetrics(lq LocalQueueReference) {
 	}
 }
 
-func ReportClusterQueueQuotas(cohort, queue, flavor, resource string, nominal, borrowing, lending float64) {
-	ClusterQueueResourceNominalQuota.WithLabelValues(cohort, queue, flavor, resource).Set(nominal)
-	ClusterQueueResourceBorrowingLimit.WithLabelValues(cohort, queue, flavor, resource).Set(borrowing)
+func ReportClusterQueueQuotas(cohort kueue.CohortReference, queue, flavor, resource string, nominal, borrowing, lending float64) {
+	ClusterQueueResourceNominalQuota.WithLabelValues(string(cohort), queue, flavor, resource).Set(nominal)
+	ClusterQueueResourceBorrowingLimit.WithLabelValues(string(cohort), queue, flavor, resource).Set(borrowing)
 	if features.Enabled(features.LendingLimit) {
-		ClusterQueueResourceLendingLimit.WithLabelValues(cohort, queue, flavor, resource).Set(lending)
+		ClusterQueueResourceLendingLimit.WithLabelValues(string(cohort), queue, flavor, resource).Set(lending)
 	}
 }
 
-func ReportClusterQueueResourceReservations(cohort, queue, flavor, resource string, usage float64) {
-	ClusterQueueResourceReservations.WithLabelValues(cohort, queue, flavor, resource).Set(usage)
+func ReportClusterQueueResourceReservations(cohort kueue.CohortReference, queue, flavor, resource string, usage float64) {
+	ClusterQueueResourceReservations.WithLabelValues(string(cohort), queue, flavor, resource).Set(usage)
 }
 
 func ReportLocalQueueResourceReservations(lq LocalQueueReference, flavor, resource string, usage float64) {
 	LocalQueueResourceReservations.WithLabelValues(lq.Name, lq.Namespace, flavor, resource).Set(usage)
 }
 
-func ReportClusterQueueResourceUsage(cohort, queue, flavor, resource string, usage float64) {
-	ClusterQueueResourceUsage.WithLabelValues(cohort, queue, flavor, resource).Set(usage)
+func ReportClusterQueueResourceUsage(cohort kueue.CohortReference, queue, flavor, resource string, usage float64) {
+	ClusterQueueResourceUsage.WithLabelValues(string(cohort), queue, flavor, resource).Set(usage)
 }
 
 func ReportLocalQueueResourceUsage(lq LocalQueueReference, flavor, resource string, usage float64) {

--- a/pkg/queue/cluster_queue.go
+++ b/pkg/queue/cluster_queue.go
@@ -52,7 +52,7 @@ var (
 
 type ClusterQueue struct {
 	hierarchy.ClusterQueue[*cohort]
-	name              string
+	name              kueue.ClusterQueueReference
 	heap              heap.Heap[workload.Info]
 	namespaceSelector labels.Selector
 	active            bool
@@ -81,7 +81,7 @@ type ClusterQueue struct {
 	clock clock.Clock
 }
 
-func (c *ClusterQueue) GetName() string {
+func (c *ClusterQueue) GetName() kueue.ClusterQueueReference {
 	return c.name
 }
 
@@ -114,7 +114,7 @@ func newClusterQueueImpl(wo workload.Ordering, clock clock.Clock) *ClusterQueue 
 func (c *ClusterQueue) Update(apiCQ *kueue.ClusterQueue) error {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
-	c.name = apiCQ.Name
+	c.name = kueue.ClusterQueueReference(apiCQ.Name)
 	c.queueingStrategy = apiCQ.Spec.QueueingStrategy
 	nsSelector, err := metav1.LabelSelectorAsSelector(apiCQ.Spec.NamespaceSelector)
 	if err != nil {

--- a/pkg/queue/cohort.go
+++ b/pkg/queue/cohort.go
@@ -16,28 +16,31 @@ limitations under the License.
 
 package queue
 
-import "sigs.k8s.io/kueue/pkg/hierarchy"
+import (
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/hierarchy"
+)
 
 // cohort is a set of ClusterQueues that can borrow resources from
 // each other.
 type cohort struct {
-	Name string
+	Name kueue.CohortReference
 	hierarchy.Cohort[*ClusterQueue, *cohort]
 }
 
-func newCohort(name string) *cohort {
+func newCohort(name kueue.CohortReference) *cohort {
 	return &cohort{
 		name,
 		hierarchy.NewCohort[*ClusterQueue, *cohort](),
 	}
 }
 
-func (c *cohort) GetName() string {
+func (c *cohort) GetName() kueue.CohortReference {
 	return c.Name
 }
 
 // CCParent satisfies the CycleCheckable interface.
-func (c *cohort) CCParent() hierarchy.CycleCheckable {
+func (c *cohort) CCParent() hierarchy.CycleCheckable[kueue.CohortReference] {
 	return c.Parent()
 }
 

--- a/pkg/queue/dumper.go
+++ b/pkg/queue/dumper.go
@@ -19,6 +19,8 @@ package queue
 import (
 	"github.com/go-logr/logr"
 	"k8s.io/klog/v2"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 // LogDump dumps the pending and inadmissible workloads for each ClusterQueue into the log,
@@ -30,7 +32,7 @@ func (m *Manager) LogDump(log logr.Logger) {
 		pending, _ := cq.Dump()
 		inadmissible, _ := cq.DumpInadmissible()
 		log.Info("Found pending and inadmissible workloads in ClusterQueue",
-			"clusterQueue", klog.KRef("", name),
+			"clusterQueue", klog.KRef("", string(name)),
 			"pending", pending,
 			"inadmissible", inadmissible)
 	}
@@ -38,14 +40,14 @@ func (m *Manager) LogDump(log logr.Logger) {
 
 // Dump is a dump of the queues and it's elements (unordered).
 // Only use for testing purposes.
-func (m *Manager) Dump() map[string][]string {
+func (m *Manager) Dump() map[kueue.ClusterQueueReference][]string {
 	m.Lock()
 	defer m.Unlock()
 	clusterQueues := m.hm.ClusterQueues()
 	if len(clusterQueues) == 0 {
 		return nil
 	}
-	dump := make(map[string][]string, len(clusterQueues))
+	dump := make(map[kueue.ClusterQueueReference][]string, len(clusterQueues))
 	for key, cq := range clusterQueues {
 		if elements, ok := cq.Dump(); ok {
 			dump[key] = elements
@@ -59,14 +61,14 @@ func (m *Manager) Dump() map[string][]string {
 
 // DumpInadmissible is a dump of the inadmissible workloads list.
 // Only use for testing purposes.
-func (m *Manager) DumpInadmissible() map[string][]string {
+func (m *Manager) DumpInadmissible() map[kueue.ClusterQueueReference][]string {
 	m.Lock()
 	defer m.Unlock()
 	clusterQueues := m.hm.ClusterQueues()
 	if len(clusterQueues) == 0 {
 		return nil
 	}
-	dump := make(map[string][]string, len(clusterQueues))
+	dump := make(map[kueue.ClusterQueueReference][]string, len(clusterQueues))
 	for key, cq := range clusterQueues {
 		if elements, ok := cq.DumpInadmissible(); ok {
 			dump[key] = elements

--- a/pkg/queue/local_queue.go
+++ b/pkg/queue/local_queue.go
@@ -36,7 +36,7 @@ func DefaultQueueKey(namespace string) string {
 // LocalQueue is the internal implementation of kueue.LocalQueue.
 type LocalQueue struct {
 	Key          string
-	ClusterQueue string
+	ClusterQueue kueue.ClusterQueueReference
 
 	items map[string]*workload.Info
 }
@@ -51,7 +51,7 @@ func newLocalQueue(q *kueue.LocalQueue) *LocalQueue {
 }
 
 func (q *LocalQueue) update(apiQueue *kueue.LocalQueue) {
-	q.ClusterQueue = string(apiQueue.Spec.ClusterQueue)
+	q.ClusterQueue = apiQueue.Spec.ClusterQueue
 }
 
 func (q *LocalQueue) AddOrUpdate(info *workload.Info) {

--- a/pkg/queue/status_checker.go
+++ b/pkg/queue/status_checker.go
@@ -16,8 +16,10 @@ limitations under the License.
 
 package queue
 
+import kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+
 // StatusChecker checks status of clusterQueue.
 type StatusChecker interface {
 	// ClusterQueueActive returns whether the clusterQueue is active.
-	ClusterQueueActive(name string) bool
+	ClusterQueueActive(name kueue.ClusterQueueReference) bool
 }

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -1961,7 +1961,7 @@ func TestAssignFlavors(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			clusterQueue := snapshot.ClusterQueue(tc.clusterQueue.Name)
+			clusterQueue := snapshot.ClusterQueue(kueue.ClusterQueueReference(tc.clusterQueue.Name))
 
 			if clusterQueue == nil {
 				t.Fatalf("Failed to create CQ snapshot")
@@ -1971,7 +1971,7 @@ func TestAssignFlavors(t *testing.T) {
 			}
 
 			if tc.secondaryClusterQueue != nil {
-				secondaryClusterQueue := snapshot.ClusterQueue(tc.secondaryClusterQueue.Name)
+				secondaryClusterQueue := snapshot.ClusterQueue(kueue.ClusterQueueReference(tc.secondaryClusterQueue.Name))
 				if secondaryClusterQueue == nil {
 					t.Fatalf("Failed to create secondary CQ snapshot")
 				}
@@ -2252,7 +2252,7 @@ func TestDeletedFlavors(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			clusterQueue := snapshot.ClusterQueue(tc.clusterQueue.Name)
+			clusterQueue := snapshot.ClusterQueue(kueue.ClusterQueueReference(tc.clusterQueue.Name))
 			if clusterQueue == nil {
 				t.Fatalf("Failed to create CQ snapshot")
 			}

--- a/pkg/scheduler/logging.go
+++ b/pkg/scheduler/logging.go
@@ -32,7 +32,7 @@ func logAdmissionAttemptIfVerbose(log logr.Logger, e *entry) {
 	}
 	args := []any{
 		"workload", klog.KObj(e.Obj),
-		"clusterQueue", klog.KRef("", e.ClusterQueue),
+		"clusterQueue", klog.KRef("", string(e.ClusterQueue)),
 		"status", e.status,
 		"reason", e.inadmissibleMsg,
 	}

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -56,8 +56,8 @@ var snapCmpOpts = []cmp.Option{
 	cmpopts.IgnoreUnexported(hierarchy.Manager[*cache.ClusterQueueSnapshot, *cache.CohortSnapshot]{}),
 	cmpopts.IgnoreUnexported(hierarchy.CycleChecker{}),
 	cmpopts.IgnoreFields(cache.ClusterQueueSnapshot{}, "AllocatableResourceGeneration"),
-	cmp.Transformer("Cohort.Members", func(s sets.Set[*cache.ClusterQueueSnapshot]) sets.Set[string] {
-		result := make(sets.Set[string], len(s))
+	cmp.Transformer("Cohort.Members", func(s sets.Set[*cache.ClusterQueueSnapshot]) sets.Set[kueue.ClusterQueueReference] {
+		result := make(sets.Set[kueue.ClusterQueueReference], len(s))
 		for cq := range s {
 			result.Insert(cq.Name)
 		}
@@ -284,7 +284,7 @@ func TestPreemption(t *testing.T) {
 		cohorts             []*kueuealpha.Cohort
 		admitted            []kueue.Workload
 		incoming            *kueue.Workload
-		targetCQ            string
+		targetCQ            kueue.ClusterQueueReference
 		assignment          flavorassigner.Assignment
 		wantPreempted       sets.Set[string]
 		disableLendingLimit bool
@@ -1935,7 +1935,7 @@ func TestFairPreemptions(t *testing.T) {
 		strategies    []config.PreemptionStrategy
 		admitted      []kueue.Workload
 		incoming      *kueue.Workload
-		targetCQ      string
+		targetCQ      kueue.ClusterQueueReference
 		wantPreempted sets.Set[string]
 	}{
 		"reclaim nominal from user using the most": {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -167,9 +167,9 @@ func setSkipped(e *entry, inadmissibleMsg string) {
 	e.LastAssignment = nil
 }
 
-func reportSkippedPreemptions(p map[string]int) {
+func reportSkippedPreemptions(p map[kueue.ClusterQueueReference]int) {
 	for cqName, count := range p {
-		metrics.AdmissionCyclePreemptionSkips.WithLabelValues(cqName).Set(float64(count))
+		metrics.AdmissionCyclePreemptionSkips.WithLabelValues(string(cqName)).Set(float64(count))
 	}
 }
 
@@ -207,14 +207,14 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	// head got admitted that should be scheduled in the cohort before the heads
 	// of other clusterQueues.
 	preemptedWorkloads := make(preemptedWorkloads)
-	skippedPreemptions := make(map[string]int)
+	skippedPreemptions := make(map[kueue.ClusterQueueReference]int)
 	for iterator.hasNext() {
 		e := iterator.pop()
 
 		cq := snapshot.ClusterQueue(e.ClusterQueue)
-		log := log.WithValues("workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", e.ClusterQueue))
+		log := log.WithValues("workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", string(e.ClusterQueue)))
 		if cq.HasParent() {
-			log = log.WithValues("parentCohort", klog.KRef("", cq.Parent().GetName()), "rootCohort", klog.KRef("", cq.Parent().Root().GetName()))
+			log = log.WithValues("parentCohort", klog.KRef("", string(cq.Parent().GetName())), "rootCohort", klog.KRef("", string(cq.Parent().Root().GetName())))
 		}
 		ctx := ctrl.LoggerInto(ctx, log)
 
@@ -340,7 +340,7 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 	log := ctrl.LoggerFrom(ctx)
 	entries := make([]entry, 0, len(workloads))
 	for _, w := range workloads {
-		log := log.WithValues("workload", klog.KObj(w.Obj), "clusterQueue", klog.KRef("", w.ClusterQueue))
+		log := log.WithValues("workload", klog.KObj(w.Obj), "clusterQueue", klog.KRef("", string(w.ClusterQueue)))
 		ns := corev1.Namespace{}
 		e := entry{Info: w}
 		e.clusterQueueSnapshot = snap.ClusterQueue(w.ClusterQueue)
@@ -494,7 +494,7 @@ func (s *Scheduler) admit(ctx context.Context, e *entry, cq *cache.ClusterQueueS
 	log := ctrl.LoggerFrom(ctx)
 	newWorkload := e.Obj.DeepCopy()
 	admission := &kueue.Admission{
-		ClusterQueue:      kueue.ClusterQueueReference(e.ClusterQueue),
+		ClusterQueue:      e.ClusterQueue,
 		PodSetAssignments: e.assignment.ToAPI(),
 	}
 
@@ -643,7 +643,7 @@ func (s *Scheduler) requeueAndUpdate(ctx context.Context, e entry) {
 		e.requeueReason = queue.RequeueReasonFailedAfterNomination
 	}
 	added := s.queues.RequeueWorkload(ctx, &e.Info, e.requeueReason)
-	log.V(2).Info("Workload re-queued", "workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", e.ClusterQueue), "queue", klog.KRef(e.Obj.Namespace, e.Obj.Spec.QueueName), "requeueReason", e.requeueReason, "added", added, "status", e.status)
+	log.V(2).Info("Workload re-queued", "workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", string(e.ClusterQueue)), "queue", klog.KRef(e.Obj.Namespace, e.Obj.Spec.QueueName), "requeueReason", e.requeueReason, "added", added, "status", e.status)
 
 	if e.status == notNominated || e.status == skipped {
 		patch := workload.BaseSSAWorkload(e.Obj)

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -688,10 +688,10 @@ type CohortWrapper struct {
 	kueuealpha.Cohort
 }
 
-func MakeCohort(name string) *CohortWrapper {
+func MakeCohort(name kueue.CohortReference) *CohortWrapper {
 	return &CohortWrapper{kueuealpha.Cohort{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name: string(name),
 		},
 	}}
 }
@@ -700,7 +700,7 @@ func (c *CohortWrapper) Obj() *kueuealpha.Cohort {
 	return &c.Cohort
 }
 
-func (c *CohortWrapper) Parent(parentName string) *CohortWrapper {
+func (c *CohortWrapper) Parent(parentName kueue.CohortReference) *CohortWrapper {
 	c.Cohort.Spec.Parent = parentName
 	return c
 }
@@ -746,7 +746,7 @@ func (c *ClusterQueueWrapper) Obj() *kueue.ClusterQueue {
 }
 
 // Cohort sets the borrowing cohort.
-func (c *ClusterQueueWrapper) Cohort(cohort string) *ClusterQueueWrapper {
+func (c *ClusterQueueWrapper) Cohort(cohort kueue.CohortReference) *ClusterQueueWrapper {
 	c.Spec.Cohort = cohort
 	return c
 }

--- a/pkg/visibility/api/v1beta1/pending_workloads_cq.go
+++ b/pkg/visibility/api/v1beta1/pending_workloads_cq.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	visibility "sigs.k8s.io/kueue/apis/visibility/v1beta1"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/queue"
@@ -68,7 +69,7 @@ func (m *pendingWorkloadsInCqREST) Get(_ context.Context, name string, opts runt
 	offset := pendingWorkloadOpts.Offset
 
 	wls := make([]visibility.PendingWorkload, 0, limit)
-	pendingWorkloadsInfo := m.queueMgr.PendingWorkloadsInfo(name)
+	pendingWorkloadsInfo := m.queueMgr.PendingWorkloadsInfo(kueue.ClusterQueueReference(name))
 	if pendingWorkloadsInfo == nil {
 		return nil, errors.NewNotFound(visibility.Resource("clusterqueue"), name)
 	}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -156,7 +156,7 @@ type Info struct {
 	TotalRequests []PodSetResources
 	// Populated from the queue during admission or from the admission field if
 	// already admitted.
-	ClusterQueue   string
+	ClusterQueue   kueue.ClusterQueueReference
 	LastAssignment *AssignmentClusterQueueState
 }
 
@@ -223,7 +223,7 @@ func NewInfo(w *kueue.Workload, opts ...InfoOption) *Info {
 		Obj: w,
 	}
 	if w.Status.Admission != nil {
-		info.ClusterQueue = string(w.Status.Admission.ClusterQueue)
+		info.ClusterQueue = w.Status.Admission.ClusterQueue
 		info.TotalRequests = totalRequestsFromAdmission(w)
 	} else {
 		info.TotalRequests = totalRequestsFromPodSets(w, &options)
@@ -879,7 +879,7 @@ func AdmissionChecksForWorkload(log logr.Logger, wl *kueue.Workload, admissionCh
 	return acNames
 }
 
-func ReportEvictedWorkload(recorder record.EventRecorder, wl *kueue.Workload, cqName, reason, message string) {
+func ReportEvictedWorkload(recorder record.EventRecorder, wl *kueue.Workload, cqName kueue.ClusterQueueReference, reason, message string) {
 	metrics.ReportEvictedWorkloads(cqName, reason)
 	if features.Enabled(features.LocalQueueMetrics) {
 		metrics.ReportLocalQueueEvictedWorkloads(metrics.LQRefFromWorkload(wl), reason)

--- a/site/content/en/docs/reference/kueue-alpha.v1alpha1.md
+++ b/site/content/en/docs/reference/kueue-alpha.v1alpha1.md
@@ -83,7 +83,7 @@ results in undefined behavior in 0.9</p>
     
   
 <tr><td><code>parent</code> <B>[Required]</B><br/>
-<code>string</code>
+<a href="#kueue-x-k8s-io-v1beta1-CohortReference"><code>CohortReference</code></a>
 </td>
 <td>
    <p>Parent references the name of the Cohort's parent, if

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -805,7 +805,7 @@ resourceGroups can be up to 16.</p>
 </td>
 </tr>
 <tr><td><code>cohort</code> <B>[Required]</B><br/>
-<code>string</code>
+<a href="#kueue-x-k8s-io-v1beta1-CohortReference"><code>CohortReference</code></a>
 </td>
 <td>
    <p>cohort that this ClusterQueue belongs to. CQs that belong to the
@@ -818,8 +818,6 @@ If empty, this ClusterQueue cannot borrow from any other ClusterQueue and
 vice versa.</p>
 <p>A cohort is a name that links CQs together, but it doesn't reference any
 object.</p>
-<p>Validation of a cohort name is equivalent to that of object names:
-subdomain in DNS (RFC 1123).</p>
 </td>
 </tr>
 <tr><td><code>queueingStrategy</code> <B>[Required]</B><br/>
@@ -1004,6 +1002,22 @@ instead.</p>
 </tr>
 </tbody>
 </table>
+
+## `CohortReference`     {#kueue-x-k8s-io-v1beta1-CohortReference}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [ClusterQueueSpec](#kueue-x-k8s-io-v1beta1-ClusterQueueSpec)
+
+
+<p>CohortReference is the name of the Cohort.</p>
+<p>Validation of a cohort name is equivalent to that of object names:
+subdomain in DNS (RFC 1123).</p>
+
+
+
 
 ## `FairSharing`     {#kueue-x-k8s-io-v1beta1-FairSharing}
     

--- a/test/integration/singlecluster/kueuectl/create_test.go
+++ b/test/integration/singlecluster/kueuectl/create_test.go
@@ -204,7 +204,7 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
 					g.Expect(createdQueue.Name).Should(gomega.Equal(cqName))
-					g.Expect(createdQueue.Spec.Cohort).Should(gomega.Equal("cohort"))
+					g.Expect(createdQueue.Spec.Cohort).Should(gomega.Equal(v1beta1.CohortReference("cohort")))
 					g.Expect(createdQueue.Spec.QueueingStrategy).Should(gomega.Equal(v1beta1.StrictFIFO))
 					g.Expect(*createdQueue.Spec.NamespaceSelector).Should(gomega.Equal(metav1.LabelSelector{
 						MatchLabels: map[string]string{"fooX": "barX", "fooY": "barY"},
@@ -392,7 +392,7 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: cqName, Namespace: ns.Name}, &createdQueue)).To(gomega.Succeed())
 					g.Expect(createdQueue.Name).Should(gomega.Equal(cqName))
-					g.Expect(createdQueue.Spec.Cohort).Should(gomega.Equal("cohort"))
+					g.Expect(createdQueue.Spec.Cohort).Should(gomega.Equal(v1beta1.CohortReference("cohort")))
 					g.Expect(createdQueue.Spec.QueueingStrategy).Should(gomega.Equal(v1beta1.StrictFIFO))
 					g.Expect(*createdQueue.Spec.NamespaceSelector).Should(gomega.Equal(metav1.LabelSelector{
 						MatchLabels: map[string]string{"fooX": "barX", "fooY": "barY"},

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -1660,7 +1660,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		var (
 			strictFIFOClusterQ *kueue.ClusterQueue
 			matchingNS         *corev1.Namespace
-			chName             string
+			chName             kueue.CohortReference
 		)
 
 		ginkgo.BeforeEach(func() {

--- a/test/performance/scheduler/runner/generator/generator.go
+++ b/test/performance/scheduler/runner/generator/generator.go
@@ -131,7 +131,7 @@ func generateWlSet(ctx context.Context, c client.Client, wlSet WorkloadsSet, nam
 	return nil
 }
 
-func generateQueue(ctx context.Context, c client.Client, qSet QueuesSet, cohortName string, queueSetIdx int, queueIndex int) error {
+func generateQueue(ctx context.Context, c client.Client, qSet QueuesSet, cohortName kueue.CohortReference, queueSetIdx int, queueIndex int) error {
 	log := ctrl.LoggerFrom(ctx).WithName("generate queue").WithValues("idx", queueIndex, "prefix", qSet.ClassName)
 	log.Info("Start generation")
 	defer log.Info("End generation")
@@ -170,7 +170,7 @@ func generateQueue(ctx context.Context, c client.Client, qSet QueuesSet, cohortN
 	})
 }
 
-func generateQueueSet(ctx context.Context, c client.Client, qSet QueuesSet, cohortName string, queueSetIdx int) error {
+func generateQueueSet(ctx context.Context, c client.Client, qSet QueuesSet, cohortName kueue.CohortReference, queueSetIdx int) error {
 	log := ctrl.LoggerFrom(ctx).WithName("generate queue set").WithValues("count", qSet.Count, "prefix", qSet.ClassName)
 	log.Info("Start generation")
 	defer log.Info("End generation")
@@ -185,7 +185,7 @@ func generateCohort(ctx context.Context, c client.Client, cSet CohortSet, cohort
 	defer log.Info("End generation")
 	cohortName := fmt.Sprintf("%s-%d", cSet.ClassName, cohortIdx)
 	return concurrent(cSet, func(cs CohortSet) int { return len(cs.QueuesSets) }, func(idx int) error {
-		return generateQueueSet(ctx, c, cSet.QueuesSets[idx], cohortName, idx)
+		return generateQueueSet(ctx, c, cSet.QueuesSets[idx], kueue.CohortReference(cohortName), idx)
 	})
 }
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -603,7 +603,7 @@ func ExpectLocalQueueResourceReservationsMetric(queue *kueue.LocalQueue, flavorN
 }
 
 func ExpectCQResourceNominalQuota(cq *kueue.ClusterQueue, flavor, resource string, value float64) {
-	metric := metrics.ClusterQueueResourceNominalQuota.WithLabelValues(cq.Spec.Cohort, cq.Name, flavor, resource)
+	metric := metrics.ClusterQueueResourceNominalQuota.WithLabelValues(string(cq.Spec.Cohort), cq.Name, flavor, resource)
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
 		v, err := testutil.GetGaugeMetricValue(metric)
 		g.Expect(err).ToNot(gomega.HaveOccurred())
@@ -612,7 +612,7 @@ func ExpectCQResourceNominalQuota(cq *kueue.ClusterQueue, flavor, resource strin
 }
 
 func ExpectCQResourceBorrowingQuota(cq *kueue.ClusterQueue, flavor, resource string, value float64) {
-	metric := metrics.ClusterQueueResourceBorrowingLimit.WithLabelValues(cq.Spec.Cohort, cq.Name, flavor, resource)
+	metric := metrics.ClusterQueueResourceBorrowingLimit.WithLabelValues(string(cq.Spec.Cohort), cq.Name, flavor, resource)
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
 		v, err := testutil.GetGaugeMetricValue(metric)
 		g.Expect(err).ToNot(gomega.HaveOccurred())
@@ -621,7 +621,7 @@ func ExpectCQResourceBorrowingQuota(cq *kueue.ClusterQueue, flavor, resource str
 }
 
 func ExpectCQResourceReservations(cq *kueue.ClusterQueue, flavor, resource string, value float64) {
-	metric := metrics.ClusterQueueResourceReservations.WithLabelValues(cq.Spec.Cohort, cq.Name, flavor, resource)
+	metric := metrics.ClusterQueueResourceReservations.WithLabelValues(string(cq.Spec.Cohort), cq.Name, flavor, resource)
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
 		v, err := testutil.GetGaugeMetricValue(metric)
 		g.Expect(err).ToNot(gomega.HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
To make it easier to analyze the code and see what the "string" is.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4442

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```