### PR TITLE
[Cleanup] make terminating pods not racy

### DIFF
--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -259,7 +259,7 @@ func WaitForActivePodsAndTerminate(ctx context.Context, k8sClient client.Client,
 		g.Expect(k8sClient.List(ctx, &pods, podListOpts)).To(gomega.Succeed())
 		activePods = make([]corev1.Pod, 0)
 		for _, p := range pods.Items {
-			if (len(p.Status.PodIP) != 0 && p.Status.PodIP != "0.0.0.0") && (p.Status.Phase == corev1.PodRunning || p.Status.Phase == corev1.PodPending) {
+			if len(p.Status.PodIP) != 0 && p.Status.Phase == corev1.PodRunning {
 				activePods = append(activePods, p)
 			}
 		}

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -260,6 +260,9 @@ func WaitForActivePodsAndTerminate(ctx context.Context, k8sClient client.Client,
 		activePods = make([]corev1.Pod, 0)
 		for _, p := range pods.Items {
 			if len(p.Status.PodIP) != 0 && p.Status.Phase == corev1.PodRunning {
+				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("curl \"http://%s:8080/readyz\"", p.Status.PodIP)}
+				_, _, err := KExecute(ctx, cfg, restClient, namespace, p.Name, p.Spec.Containers[0].Name, cmd)
+				g.Expect(err).ToNot(gomega.HaveOccurred())
 				activePods = append(activePods, p)
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Thanks to @mimowo we identified 2 issues with `WaitForActivePodsAndTerminate`:
* we consider pods in Pending state, which is too early
* we do not check if the agnhost service is ready and listen on the port
Due to that some of request were send into void or to not completely ready test pod.

This PR addresses both of those issues.
We consider only Running pods and they must also response to `readyz` request.

This fix will potentially resolve many flakiness of the e2e tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4514


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```