### PR TITLE
TAS: Use TAS implicitly when CQ is TAS-only

### DIFF
--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -508,7 +508,7 @@ func (c *clusterQueue) updateWorkloadUsage(wi *workload.Info, m int64) {
 			removeUsage(c, fr, q)
 		}
 	}
-	if features.Enabled(features.TopologyAwareScheduling) && wi.IsRequestingTAS() {
+	if features.Enabled(features.TopologyAwareScheduling) && wi.IsUsingTAS() {
 		for tasFlavor, tasUsage := range wi.TASUsage() {
 			if tasFlvCache := c.tasFlavorCache(tasFlavor); tasFlvCache != nil {
 				if m == 1 {
@@ -626,4 +626,15 @@ func workloadBelongsToLocalQueue(wl *kueue.Workload, q *kueue.LocalQueue) bool {
 
 func (c *clusterQueue) fairWeight() *resource.Quantity {
 	return &c.FairWeight
+}
+
+func (c *clusterQueue) isTASOnly() bool {
+	for _, rg := range c.ResourceGroups {
+		for _, fName := range rg.Flavors {
+			if _, found := c.tasFlavors[fName]; !found {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -55,6 +55,7 @@ type ClusterQueueSnapshot struct {
 	hierarchy.ClusterQueue[*CohortSnapshot]
 
 	TASFlavors map[kueue.ResourceFlavorReference]*TASFlavorSnapshot
+	tasOnly    bool
 }
 
 // RGByResource returns the ResourceGroup which contains capacity
@@ -213,4 +214,8 @@ func (c *ClusterQueueSnapshot) FindTopologyAssignmentsForWorkload(
 		}
 	}
 	return result
+}
+
+func (c *ClusterQueueSnapshot) IsTASOnly() bool {
+	return c.tasOnly
 }

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -173,6 +173,7 @@ func snapshotClusterQueue(c *clusterQueue) *ClusterQueueSnapshot {
 		AdmissionChecks:               utilmaps.DeepCopySets[kueue.ResourceFlavorReference](c.AdmissionChecks),
 		ResourceNode:                  c.resourceNode.Clone(),
 		TASFlavors:                    make(map[kueue.ResourceFlavorReference]*TASFlavorSnapshot),
+		tasOnly:                       c.isTASOnly(),
 	}
 	for i, rg := range c.ResourceGroups {
 		cc.ResourceGroups[i] = rg.Clone()

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -460,7 +460,7 @@ func (s *Scheduler) getInitialAssignments(log logr.Logger, wl *workload.Info, sn
 }
 
 func updateAssignmentForTAS(cq *cache.ClusterQueueSnapshot, wl *workload.Info, assignment *flavorassigner.Assignment, targets []*preemption.Target) {
-	if features.Enabled(features.TopologyAwareScheduling) && assignment.RepresentativeMode() == flavorassigner.Preempt && wl.IsRequestingTAS() {
+	if features.Enabled(features.TopologyAwareScheduling) && assignment.RepresentativeMode() == flavorassigner.Preempt && (wl.IsRequestingTAS() || cq.IsTASOnly()) {
 		tasRequests := assignment.WorkloadsTopologyRequests(wl, cq)
 		var tasResult cache.TASAssignmentsResult
 		if len(targets) > 0 {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -281,7 +281,7 @@ func dropExcludedResources(input corev1.ResourceList, excludedPrefixes []string)
 	return res
 }
 
-// IsUsingTAS returns information if the workload is requesting TAS
+// IsUsingTAS returns information if the workload is using TAS
 func (i *Info) IsUsingTAS() bool {
 	return slices.ContainsFunc(i.TotalRequests,
 		func(ps PodSetResources) bool {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -281,6 +281,14 @@ func dropExcludedResources(input corev1.ResourceList, excludedPrefixes []string)
 	return res
 }
 
+// IsUsingTAS returns information if the workload is requesting TAS
+func (i *Info) IsUsingTAS() bool {
+	return slices.ContainsFunc(i.TotalRequests,
+		func(ps PodSetResources) bool {
+			return ps.TopologyRequest != nil
+		})
+}
+
 // IsRequestingTAS returns information if the workload is requesting TAS
 func (i *Info) IsRequestingTAS() bool {
 	return slices.ContainsFunc(i.Obj.Spec.PodSets,
@@ -291,7 +299,7 @@ func (i *Info) IsRequestingTAS() bool {
 
 // TASUsage returns topology usage requested by the Workload
 func (i *Info) TASUsage() TASUsage {
-	if !features.Enabled(features.TopologyAwareScheduling) || !i.IsRequestingTAS() {
+	if !features.Enabled(features.TopologyAwareScheduling) || !i.IsUsingTAS() {
 		return nil
 	}
 	result := make(TASUsage, 0)

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -810,7 +810,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				})
 			})
 
-			ginkgo.It("should admit workload which fits", func() {
+			ginkgo.It("should admit workload using TAS without explicit TAS annotation", func() {
 				var wl1, wl2 *kueue.Workload
 				ginkgo.By("creating a workload without explicit TAS annotation which can fit", func() {
 					wl1 = testing.MakeWorkload("wl1", ns.Name).

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -809,6 +809,49 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
 				})
 			})
+
+			ginkgo.It("should admit workload which fits", func() {
+				var wl1, wl2 *kueue.Workload
+				ginkgo.By("creating a workload without explicit TAS annotation which can fit", func() {
+					wl1 = testing.MakeWorkload("wl1", ns.Name).
+						PodSets(*testing.MakePodSet("worker", 2).
+							Obj()).
+						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+					gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify the workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+					gomega.Expect(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+						&kueue.TopologyAssignment{
+							Levels: []string{corev1.LabelHostname},
+							Domains: []kueue.TopologyDomainAssignment{
+								{Count: 1, Values: []string{"x1"}},
+								{Count: 1, Values: []string{"x2"}},
+							},
+						},
+					))
+				})
+
+				ginkgo.By("creating the second workload without explicit TAS annotation which cannot fit", func() {
+					wl2 = testing.MakeWorkload("wl2", ns.Name).
+						PodSets(*testing.MakePodSet("worker-2", 3).
+							Obj()).
+						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+					gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify the wl2 has not been admitted", func() {
+					util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+				})
+
+				ginkgo.By("finish wl1 and verify wl2 can fit now", func() {
+					util.FinishWorkloads(ctx, k8sClient, wl1)
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+				})
+			})
 		})
 
 		ginkgo.When("Preemption is enabled within ClusterQueue", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #3754

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Use TAS for workloads implicitly (without TAS annotations) when the target CQ is TAS-only, meaning
all the resource flavors have spec.topologyName specified. The implied behavior is as for the "preferred" 
annotation pointing to the lowest topology level.
```