### PR TITLE
TAS: KEP update: Add Relaxed fit algorithm to TAS

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -429,6 +429,14 @@ const (
   // at the highest topology level, then it gets admitted as distributed
   // among multiple topology domains.
   PodSetPreferredTopologyAnnotation = "kueue.x-k8s.io/podset-preferred-topology"
+
+  // PodSetRelaxedTopologyAnnotation indicates that a PodSet requires
+  // Topology Aware Scheduling, but it promotes filling up nodes to maximum over
+  // compact placement. The pods have lower chance of being scheduled on the same
+  // node, but it mitigates resource fragmentation, and can lead to better
+  // node utilization. Recommended for PodSets that don't require heave inter pod
+  // communication
+  PodSetRelaxedTopologyAnnotation = "kueue.x-k8s.io/podset-relaxed-topology"
 )
 ```
 
@@ -648,11 +656,13 @@ For a given PodSet Kueue:
   level. Kueue starts the search from the specified level, but if the PodSet
   does not fit, then it tries higher levels in the hierarchy.
 
-Kueue packs pods on domains starting from the domains with the most free capacity. However, Kueue can operate in two modes when it comes to choosing the last domain if there is more than one capable of accommodating the remaining pods:
+Kueue packs pods on domains starting from the domains with the most free capacity. However, Kueue can operate in three modes when it comes to choosing the last domain if there is more than one capable of accommodating the remaining pods:
 - `MostAllocated` - Kueue chooses the domain with the least available resource that is capable of accommodating all the pods to mitigate resource fragmentation
 - `LeastAllocated` - Kueue chooses the domain that has the most available resources, providing better nodes utilization
+- `Relaxed` - Kueue chooses the domain with least available resources. It promotes minimizing resource fragmentation, and higher node utilization over compact placement. This is signalized by the `kueue.x-k8s.io/podset-relaxed-topology: true` PodSet annotation.
 
-By default Kueue uses the `MostAllocated` algorithm. To use `LeastAllocated` algorithm, a user needs to set the feature gate `TASLeastAllocated` to `true`
+By default Kueue uses the `MostAllocated` algorithm. To use `LeastAllocated` algorithm, a user needs to set the feature gate `TASLeastAllocated` to `true`.
+To use `Relaxed` algorithm, a PodSet needs to have the `kueue.x-k8s.io/podset-relaxed-topology: true` annotation set. To default this annotation for all Workloads in the cluster a user can set the feature gate `TASImplicitDefaultRelaxed` to `true`.
 
 ### Enforcing the assignment
 

--- a/keps/2724-topology-aware-scheduling/kep.yaml
+++ b/keps/2724-topology-aware-scheduling/kep.yaml
@@ -32,6 +32,7 @@ milestone:
 feature-gates:
   - name: TopologyAwareScheduling
   - name: TASLeastAllocated
+  - name: TASImplicitDefaultRelaxed
 disable-supported: true
 
 # The following PRR answers are required at beta release


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Describes new Relaxed fit algorithm for TAS

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #4474 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```