### PR TITLE
TAS: Update KEP with the implicit defaulting of TAS annotations

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -27,6 +27,7 @@
   - [User-facing API](#user-facing-api)
   - [Validation](#validation)
   - [Internal APIs](#internal-apis)
+  - [Implicit defaulting of TAS annotations](#implicit-defaulting-of-tas-annotations)
   - [Computing the assignment](#computing-the-assignment)
   - [Enforcing the assignment](#enforcing-the-assignment)
   - [Test Plan](#test-plan)
@@ -620,6 +621,20 @@ The above API does not support [Story 2](#story-2). We will defer the support
 for [Beta](#beta). The initial approach for the design is left in the
 [Support for ReplicatedJobs in JobSet](#support-for-replicatedjobs-in-jobset)
 section.
+
+### Implicit defaulting of TAS annotations
+
+Requiring to set the TAS annotations (see [User facing API](#user-facing-api))
+on every PodSet creates a friction for adoption of TAS, and a point of failure.
+
+In order to reduce friction we assume that TAS is used for scheduling workloads
+targetting CQs with only TAS Resource Flavors (RFs with the `spec.topologyName`
+field specified).
+
+A PodSet scheduled with TAS without the explicit annotation is handled as
+if it had the `podset-preferred-topology` annotation pointing to the lowest
+topology level defined in the Topology referenced by the selected TAS flavor.
+We call it "implicit default" as the annotation isn't persisted.
 
 ### Computing the assignment
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of  #3754

#### Special notes for your reviewer:

This is a follow up to the implementation PR: https://github.com/kubernetes-sigs/kueue/pull/4519

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```