### PR TITLE
TAS: Add TAS profiles and the LeastFreeCapacityFit algorithm

### DIFF
--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -360,5 +360,22 @@ func ValidateFeatureGates(featureGateCLI string, featureGateMap map[string]bool)
 	if featureGateCLI != "" && featureGateMap != nil {
 		return errors.New("feature gates for CLI and configuration cannot both specified")
 	}
+	TASProfilesEnabled := []bool{features.Enabled(features.TASProfileMixed),
+		features.Enabled(features.TASProfileLeastFreeCapacity),
+		features.Enabled(features.TASProfileMostFreeCapacity),
+	}
+	enabledProfilesCount := 0
+	for _, enabled := range TASProfilesEnabled {
+		if enabled {
+			enabledProfilesCount++
+		}
+	}
+	if enabledProfilesCount > 1 {
+		return errors.New("Cannot use more than one TAS profiles")
+	}
+	if !features.Enabled(features.TopologyAwareScheduling) && enabledProfilesCount > 0 {
+		return errors.New("Cannot use a TAS profile with TAS disabled")
+	}
+
 	return nil
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -772,6 +772,20 @@ func TestValidateFeatureGates(t *testing.T) {
 
 			errorStr: "feature gates for CLI and configuration cannot both specified",
 		},
+		"cannot specify more than one TAS profile using GateMap": {
+			featureGateMap: map[string]bool{"TASProfileMostFreeCapacity": true,
+				"TASProfileLeastFreeCapacity": true},
+			errorStr: "Cannot use more than one TAS profiles",
+		},
+		"cannot specify more than one TAS profile using GatesCLI": {
+			featureGatesCLI: "TASProfileMostFreeCapacity:true,TASProfileMixed:true",
+			errorStr:        "Cannot use more than one TAS profiles",
+		},
+		"cannot set TAS profile with TAS disabled": {
+			featureGateMap: map[string]bool{"TASProfileMostFreeCapacity": true,
+				"TopologyAwareScheduling": true},
+			errorStr: "Cannot use a TAS profile with TAS disabled",
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -150,7 +150,19 @@ const (
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
 	//
 	// Enable to set use LeastAlloactedFit algorithm for TAS
-	TASMostFreeCapacity featuregate.Feature = "TASMostFreeCapacity"
+	TASProfileMostFreeCapacity featuregate.Feature = "TASProfileMostFreeCapacity"
+
+	// owner: @pbundyra
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
+	//
+	// Enable to set use LeastAlloactedFit algorithm for TAS
+	TASProfileLeastFreeCapacity featuregate.Feature = "TASProfileLeastFreeCapacity"
+
+	// owner: @pbundyra
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
+	//
+	// Enable to set use LeastAlloactedFit algorithm for TAS
+	TASProfileMixed featuregate.Feature = "TASProfileMixed"
 
 	// owner: @pbundyra
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
@@ -237,7 +249,13 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	LocalQueueDefaulting: {
 		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},
 	},
-	TASMostFreeCapacity: {
+	TASProfileMostFreeCapacity: {
+		{Version: version.MustParse("0.11"), Default: false, PreRelease: featuregate.Deprecated},
+	},
+	TASProfileLeastFreeCapacity: {
+		{Version: version.MustParse("0.11"), Default: false, PreRelease: featuregate.Deprecated},
+	},
+	TASProfileMixed: {
 		{Version: version.MustParse("0.11"), Default: false, PreRelease: featuregate.Deprecated},
 	},
 	TASImplicitDefaultUnconstrained: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR introduces changes described in this KEP #4542 :
- Adds TAS profiles 
- Adds LeastFreeCapacityFit algorithm

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes-sigs/kueue/issues/4474
Part of https://github.com/kubernetes-sigs/kueue/issues/4570

#### Special notes for your reviewer:
I'll add more integration test, but it's already ready for the first pass

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TopologyAwareScheduling can now be used with profiles based on feature gates. TopologyAwareScheduling has now a new algorithm LeastFreeCapacityFit
```