### PR TITLE
Do not consider preemption.borrowWithinCohort in FairSharing preemptions (to 0.9)

### DIFF
--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -242,17 +242,22 @@ spec:
               preemption:
                 default: {}
                 description: |-
-                  preemption describes policies to preempt Workloads from this ClusterQueue
-                  or the ClusterQueue's cohort.
+                  ClusterQueuePreemption contains policies to preempt Workloads from this
+                  ClusterQueue or the ClusterQueue's cohort.
 
-                  Preemption can happen in two scenarios:
+                  Preemption may be configured to work in the following scenarios:
 
-                  - When a Workload fits within the nominal quota of the ClusterQueue, but
-                    the quota is currently borrowed by other ClusterQueues in the cohort.
-                    Preempting Workloads in other ClusterQueues allows this ClusterQueue to
-                    reclaim its nominal quota.
-                  - When a Workload doesn't fit within the nominal quota of the ClusterQueue
-                    and there are admitted Workloads in the ClusterQueue with lower priority.
+                    - When a Workload fits within the nominal quota of the ClusterQueue, but
+                      the quota is currently borrowed by other ClusterQueues in the cohort.
+                      We preempt workloads in other ClusterQueues to allow this ClusterQueue to
+                      reclaim its nominal quota. Configured using reclaimWithinCohort.
+                    - When a Workload doesn't fit within the nominal quota of the ClusterQueue
+                      and there are admitted Workloads in the ClusterQueue with lower priority.
+                      Configured using withinClusterQueue.
+                    - When a Workload may fit while both borrowing and preempting
+                      low priority workloads in the Cohort. Configured using borrowWithinCohort.
+                    - When FairSharing is enabled, to maintain fair distribution of
+                      unused resources. See FairSharing documentation.
 
                   The preemption algorithm tries to find a minimal set of Workloads to
                   preempt to accomomdate the pending Workload, preempting Workloads with
@@ -261,8 +266,9 @@ spec:
                   borrowWithinCohort:
                     default: {}
                     description: |-
-                      borrowWithinCohort provides configuration to allow preemption within
-                      cohort while borrowing.
+                      BorrowWithinCohort contains configuration which allows to preempt workloads
+                      within cohort while borrowing. It only works with Classical Preemption,
+                      __not__ with Fair Sharing.
                     properties:
                       maxPriorityThreshold:
                         description: |-

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -227,17 +227,22 @@ spec:
               preemption:
                 default: {}
                 description: |-
-                  preemption describes policies to preempt Workloads from this ClusterQueue
-                  or the ClusterQueue's cohort.
+                  ClusterQueuePreemption contains policies to preempt Workloads from this
+                  ClusterQueue or the ClusterQueue's cohort.
 
-                  Preemption can happen in two scenarios:
+                  Preemption may be configured to work in the following scenarios:
 
-                  - When a Workload fits within the nominal quota of the ClusterQueue, but
-                    the quota is currently borrowed by other ClusterQueues in the cohort.
-                    Preempting Workloads in other ClusterQueues allows this ClusterQueue to
-                    reclaim its nominal quota.
-                  - When a Workload doesn't fit within the nominal quota of the ClusterQueue
-                    and there are admitted Workloads in the ClusterQueue with lower priority.
+                    - When a Workload fits within the nominal quota of the ClusterQueue, but
+                      the quota is currently borrowed by other ClusterQueues in the cohort.
+                      We preempt workloads in other ClusterQueues to allow this ClusterQueue to
+                      reclaim its nominal quota. Configured using reclaimWithinCohort.
+                    - When a Workload doesn't fit within the nominal quota of the ClusterQueue
+                      and there are admitted Workloads in the ClusterQueue with lower priority.
+                      Configured using withinClusterQueue.
+                    - When a Workload may fit while both borrowing and preempting
+                      low priority workloads in the Cohort. Configured using borrowWithinCohort.
+                    - When FairSharing is enabled, to maintain fair distribution of
+                      unused resources. See FairSharing documentation.
 
                   The preemption algorithm tries to find a minimal set of Workloads to
                   preempt to accomomdate the pending Workload, preempting Workloads with
@@ -246,8 +251,9 @@ spec:
                   borrowWithinCohort:
                     default: {}
                     description: |-
-                      borrowWithinCohort provides configuration to allow preemption within
-                      cohort while borrowing.
+                      BorrowWithinCohort contains configuration which allows to preempt workloads
+                      within cohort while borrowing. It only works with Classical Preemption,
+                      __not__ with Fair Sharing.
                     properties:
                       maxPriorityThreshold:
                         description: |-

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -141,16 +141,15 @@ func (p *Preemptor) getTargets(log logr.Logger, wl workload.Info, requests resou
 		return minimalPreemptions(log, requests, cq, snapshot, frsNeedPreemption, candidates, true, nil)
 	}
 
-	borrowWithinCohort, thresholdPrio := canBorrowWithinCohort(cq, wl.Obj)
 	if p.enableFairSharing {
-		return p.fairPreemptions(log, wl, requests, snapshot, frsNeedPreemption, candidates, thresholdPrio)
+		return p.fairPreemptions(log, wl, requests, snapshot, frsNeedPreemption, candidates)
 	}
 	// There is a potential of preemption of workloads from the other queue in the
 	// cohort. We proceed with borrowing only if the dedicated policy
 	// (borrowWithinCohort) is enabled. This ensures the preempted workloads
 	// have lower priority, and so they will not preempt the preemptor when
 	// requeued.
-	if borrowWithinCohort {
+	if borrowWithinCohort, thresholdPrio := canBorrowWithinCohort(cq, wl.Obj); borrowWithinCohort {
 		if !queueUnderNominalInResourcesNeedingPreemption(frsNeedPreemption, cq) {
 			// It can only preempt workloads from another CQ if they are strictly under allowBorrowingBelowPriority.
 			candidates = candidatesFromCQOrUnderThreshold(candidates, wl.ClusterQueue, *thresholdPrio)
@@ -341,9 +340,9 @@ func parseStrategies(s []config.PreemptionStrategy) []fsStrategy {
 	return strategies
 }
 
-func (p *Preemptor) fairPreemptions(log logr.Logger, wl workload.Info, requests resources.FlavorResourceQuantities, snapshot *cache.Snapshot, frsNeedPreemption sets.Set[resources.FlavorResource], candidates []*workload.Info, allowBorrowingBelowPriority *int32) []*Target {
+func (p *Preemptor) fairPreemptions(log logr.Logger, wl workload.Info, requests resources.FlavorResourceQuantities, snapshot *cache.Snapshot, frsNeedPreemption sets.Set[resources.FlavorResource], candidates []*workload.Info) []*Target {
 	if logV := log.V(5); logV.Enabled() {
-		logV.Info("Simulating fair preemption", "candidates", workload.References(candidates), "resourcesRequiringPreemption", frsNeedPreemption, "allowBorrowingBelowPriority", allowBorrowingBelowPriority)
+		logV.Info("Simulating fair preemption", "candidates", workload.References(candidates), "resourcesRequiringPreemption", frsNeedPreemption)
 	}
 	cqHeap := cqHeapFromCandidates(candidates, false, snapshot)
 	nominatedCQ := snapshot.ClusterQueues[wl.ClusterQueue]
@@ -375,15 +374,11 @@ func (p *Preemptor) fairPreemptions(log logr.Logger, wl workload.Info, requests 
 		}
 
 		for i, candWl := range candCQ.workloads {
-			belowThreshold := allowBorrowingBelowPriority != nil && priority.Priority(candWl.Obj) < *allowBorrowingBelowPriority
 			newCandShareVal, _ := candCQ.cq.DominantResourceShareWithout(candWl.FlavorResourceUsage())
 			strategy := p.fsStrategies[0](newNominatedShareValue, candCQ.share, newCandShareVal)
-			if belowThreshold || strategy {
+			if strategy {
 				snapshot.RemoveWorkload(candWl)
 				reason := kueue.InCohortFairSharingReason
-				if !strategy {
-					reason = kueue.InCohortReclaimWhileBorrowingReason
-				}
 
 				targets = append(targets, &Target{
 					WorkloadInfo: candWl,

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -449,8 +449,9 @@ The fields above do the following:
     priority.
 
 - `borrowWithinCohort` determines whether a pending Workload can preempt
-  Workloads from other ClusterQueues if the workload requires borrowing. This
-  field requires to specify `policy` sub-field with possible values:
+  Workloads from other ClusterQueues if the workload requires borrowing.
+  May only be configured with Classical Preemption, and __not__ with Fair Sharing.
+  This field requires to specify `policy` sub-field with possible values:
   - `Never` (default): do not preempt Workloads in the cohort if borrowing is required.
   - `LowerPriority`: if the pending Workload requires borrowing, only preempt
     Workloads in the cohort that have lower priority than the pending Workload.

--- a/site/content/en/docs/concepts/preemption.md
+++ b/site/content/en/docs/concepts/preemption.md
@@ -119,8 +119,8 @@ admitted when accounting back the quota usage of the target Workload.
 
 Fair sharing introduces the concepts of ClusterQueue share values and preemption
 strategies. These work together with the preemption policies set in
-`withinClusterQueue` and `reclaimWithinCohort` to determine if a pending
-Workload can preempt an admitted Workload. Fair sharing uses preemptions to
+`withinClusterQueue` and `reclaimWithinCohort` (but __not__ `borrowWithinCohort`) to determine if a pending
+Workload can preempt an admitted Workload in Fair sharing. Fair sharing uses preemptions to
 achieve an equal or weighted share of the borrowable resources between the
 tenants of a cohort.
 

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -568,7 +568,8 @@ If empty, the AdmissionCheck will run for all workloads submitted to the Cluster
 
 
 <p>BorrowWithinCohort contains configuration which allows to preempt workloads
-within cohort while borrowing.</p>
+within cohort while borrowing. It only works with Classical Preemption,
+<strong>not</strong> with Fair Sharing.</p>
 
 
 <table class="table">
@@ -704,6 +705,23 @@ in the cluster queue.</p>
 
 <p>ClusterQueuePreemption contains policies to preempt Workloads from this
 ClusterQueue or the ClusterQueue's cohort.</p>
+<p>Preemption may be configured to work in the following scenarios:</p>
+<ul>
+<li>When a Workload fits within the nominal quota of the ClusterQueue, but
+the quota is currently borrowed by other ClusterQueues in the cohort.
+We preempt workloads in other ClusterQueues to allow this ClusterQueue to
+reclaim its nominal quota. Configured using reclaimWithinCohort.</li>
+<li>When a Workload doesn't fit within the nominal quota of the ClusterQueue
+and there are admitted Workloads in the ClusterQueue with lower priority.
+Configured using withinClusterQueue.</li>
+<li>When a Workload may fit while both borrowing and preempting
+low priority workloads in the Cohort. Configured using borrowWithinCohort.</li>
+<li>When FairSharing is enabled, to maintain fair distribution of
+unused resources. See FairSharing documentation.</li>
+</ul>
+<p>The preemption algorithm tries to find a minimal set of Workloads to
+preempt to accomomdate the pending Workload, preempting Workloads with
+lower priority first.</p>
 
 
 <table class="table">
@@ -737,9 +755,7 @@ in the cohort that satisfy the fair sharing preemptionStrategies.</li>
 <a href="#kueue-x-k8s-io-v1beta1-BorrowWithinCohort"><code>BorrowWithinCohort</code></a>
 </td>
 <td>
-   <p>borrowWithinCohort provides configuration to allow preemption within
-cohort while borrowing.</p>
-</td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
 <tr><td><code>withinClusterQueue</code> <B>[Required]</B><br/>
 <a href="#kueue-x-k8s-io-v1beta1-PreemptionPolicy"><code>PreemptionPolicy</code></a>
@@ -862,21 +878,7 @@ before borrowing or preempting in the flavor being evaluated.</p>
 <a href="#kueue-x-k8s-io-v1beta1-ClusterQueuePreemption"><code>ClusterQueuePreemption</code></a>
 </td>
 <td>
-   <p>preemption describes policies to preempt Workloads from this ClusterQueue
-or the ClusterQueue's cohort.</p>
-<p>Preemption can happen in two scenarios:</p>
-<ul>
-<li>When a Workload fits within the nominal quota of the ClusterQueue, but
-the quota is currently borrowed by other ClusterQueues in the cohort.
-Preempting Workloads in other ClusterQueues allows this ClusterQueue to
-reclaim its nominal quota.</li>
-<li>When a Workload doesn't fit within the nominal quota of the ClusterQueue
-and there are admitted Workloads in the ClusterQueue with lower priority.</li>
-</ul>
-<p>The preemption algorithm tries to find a minimal set of Workloads to
-preempt to accomomdate the pending Workload, preempting Workloads with
-lower priority first.</p>
-</td>
+   <span class="text-muted">No description provided.</span></td>
 </tr>
 <tr><td><code>admissionChecks</code><br/>
 <code>[]string</code>


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Cherry-pick bug fix https://github.com/kubernetes-sigs/kueue/pull/4165 to 0.9

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Update FairSharing to be incompatible with ClusterQueue.Preemption.BorrowWithinCohort. Using these parameters together is a no-op, and will be validated against in future releases. This change fixes an edge case which triggered an infinite preemption loop when these two parameters were combined.
```