### PR TITLE
test: add WaitForPodsReady e2e test

### DIFF
--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -76,6 +76,16 @@ func (j *JobWrapper) BackoffLimit(limit int32) *JobWrapper {
 	return j
 }
 
+func (j *JobWrapper) BackoffLimitPerIndex(limit int32) *JobWrapper {
+	j.Spec.BackoffLimitPerIndex = ptr.To(limit)
+	return j
+}
+
+func (j *JobWrapper) CompletionMode(mode batchv1.CompletionMode) *JobWrapper {
+	j.Spec.CompletionMode = &mode
+	return j
+}
+
 func (j *JobWrapper) TerminationGracePeriod(seconds int64) *JobWrapper {
 	j.Spec.Template.Spec.TerminationGracePeriodSeconds = ptr.To(seconds)
 	return j

--- a/test/e2e/customconfigs/managejobswithoutqueuename_test.go
+++ b/test/e2e/customconfigs/managejobswithoutqueuename_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package queuename
+package customconfigse2e
 
 import (
 	"github.com/onsi/ginkgo/v2"

--- a/test/e2e/customconfigs/suite_test.go
+++ b/test/e2e/customconfigs/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package queuename
+package customconfigse2e
 
 import (
 	"context"
@@ -25,6 +25,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/kueue/apis/config/v1beta1"
@@ -33,6 +34,8 @@ import (
 
 var (
 	k8sClient       client.WithWatch
+	cfg             *rest.Config
+	restClient      *rest.RESTClient
 	ctx             context.Context
 	defaultKueueCfg *v1beta1.Configuration
 )
@@ -51,7 +54,8 @@ func TestAPIs(t *testing.T) {
 var _ = ginkgo.BeforeSuite(func() {
 	util.SetupLogger()
 
-	k8sClient, _ = util.CreateClientUsingCluster("")
+	k8sClient, cfg = util.CreateClientUsingCluster("")
+	restClient = util.CreateRestClient(cfg)
 	ctx = ginkgo.GinkgoT().Context()
 
 	waitForAvailableStart := time.Now()

--- a/test/e2e/customconfigs/waitforpodsready_test.go
+++ b/test/e2e/customconfigs/waitforpodsready_test.go
@@ -1,0 +1,287 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customconfigse2e
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	"sigs.k8s.io/kueue/pkg/util/testing"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	"sigs.k8s.io/kueue/pkg/workload"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("WaitForPodsReady Job Controller E2E", func() {
+	var (
+		ns    *corev1.Namespace
+		rf    *kueue.ResourceFlavor
+		cq    *kueue.ClusterQueue
+		lq    *kueue.LocalQueue
+		job   *batchv1.Job
+		wl    kueue.Workload
+		wlKey types.NamespacedName
+	)
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "wfpr-")
+
+		rf = testing.MakeResourceFlavor("default").Obj()
+		gomega.Expect(k8sClient.Create(ctx, rf)).Should(gomega.Succeed())
+
+		cq = testing.MakeClusterQueue("cq").
+			ResourceGroup(*testing.MakeFlavorQuotas(rf.Name).Resource(corev1.ResourceCPU, "10").Obj()).
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, cq)).Should(gomega.Succeed())
+
+		lq = testing.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+		gomega.Expect(k8sClient.Create(ctx, lq)).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, rf, true)
+	})
+
+	ginkgo.When("WaitForPodsReady has a tiny Timeout and no RecoveryTimeout", func() {
+		ginkgo.BeforeEach(func() {
+			updateKueueConfiguration(func(cfg *configapi.Configuration) {
+				cfg.WaitForPodsReady = &configapi.WaitForPodsReady{
+					Enable:          true,
+					BlockAdmission:  ptr.To(true),
+					Timeout:         &metav1.Duration{Duration: util.TinyTimeout},
+					RecoveryTimeout: nil,
+					RequeuingStrategy: &configapi.RequeuingStrategy{
+						Timestamp:          ptr.To(configapi.EvictionTimestamp),
+						BackoffBaseSeconds: ptr.To(int32(10)),
+						BackoffLimitCount:  ptr.To(int32(1)),
+					},
+				}
+			})
+		})
+
+		ginkgo.It("should evict and requeue workload when pods readiness timeout is surpassed", func() {
+			ginkgo.By("creating a suspended job so its pods never report Ready", func() {
+				job = testingjob.MakeJob("job-timeout", ns.Name).
+					Queue(lq.Name).
+					Request(corev1.ResourceCPU, "2").
+					Parallelism(1).
+					Obj()
+				gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+			})
+
+			wlKey = types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+				Namespace: ns.Name,
+			}
+
+			ginkgo.By("waiting for the workload to be created and verifying it is not admitted", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+
+					g.Expect(wl.Status.Admission).To(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("waiting for the workload to be evicted", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+
+					g.Expect(
+						workload.HasConditionWithTypeAndReason(&wl, &metav1.Condition{
+							Type:   kueue.WorkloadPodsReady,
+							Status: metav1.ConditionFalse,
+							Reason: kueue.WorkloadWaitForStart,
+						}),
+					).To(gomega.BeTrue())
+
+					g.Expect(
+						workload.HasConditionWithTypeAndReason(&wl, &metav1.Condition{
+							Type:   kueue.WorkloadEvicted,
+							Status: metav1.ConditionTrue,
+							Reason: kueue.WorkloadEvictedByPodsReadyTimeout,
+						}),
+					).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying that the job is suspended", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).Should(gomega.Succeed())
+					g.Expect(ptr.Deref(job.Spec.Suspend, false)).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying that the workload is requeued", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+					g.Expect(wl.Status.RequeueState).ShouldNot(gomega.BeNil())
+					g.Expect(*wl.Status.RequeueState.Count).To(gomega.Equal(int32(1)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying that the workload is deactivated after the second eviction", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+					g.Expect(ptr.Deref(wl.Spec.Active, true)).Should(gomega.BeFalse())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+
+	ginkgo.When("WaitForPodsReady has default Timeout and a tiny RecoveryTimeout", func() {
+		ginkgo.BeforeEach(func() {
+			updateKueueConfiguration(func(cfg *configapi.Configuration) {
+				cfg.WaitForPodsReady = &configapi.WaitForPodsReady{
+					Enable:          true,
+					BlockAdmission:  ptr.To(true),
+					RecoveryTimeout: &metav1.Duration{Duration: util.TinyTimeout},
+					RequeuingStrategy: &configapi.RequeuingStrategy{
+						Timestamp:          ptr.To(configapi.EvictionTimestamp),
+						BackoffBaseSeconds: ptr.To(int32(1)),
+						BackoffLimitCount:  ptr.To(int32(1)),
+					},
+				}
+			})
+		})
+
+		ginkgo.It("should evict and requeue workload when pod failure causes recovery timeout", func() {
+			ginkgo.By("creating a job", func() {
+				job = testingjob.MakeJob("job-recovery-timeout", ns.Name).
+					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+					Queue(lq.Name).
+					Request(corev1.ResourceCPU, "2").
+					Parallelism(1).
+					BackoffLimitPerIndex(2).
+					CompletionMode(batchv1.IndexedCompletion).
+					Completions(1).
+					Obj()
+
+				gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+			})
+
+			wlKey = types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+				Namespace: ns.Name,
+			}
+
+			ginkgo.By("checking workload availability", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+					g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrue(kueue.WorkloadPodsReady))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("simulating pod failure", func() {
+				util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 1, 1)
+			})
+
+			ginkgo.By("verifying that the workload is requeued", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+
+					g.Expect(wl.Status.RequeueState).ShouldNot(gomega.BeNil())
+					g.Expect(*wl.Status.RequeueState.Count).To(gomega.Equal(int32(1)))
+
+					g.Expect(
+						workload.HasConditionWithTypeAndReason(&wl, &metav1.Condition{
+							Type:   kueue.WorkloadPodsReady,
+							Status: metav1.ConditionTrue,
+							Reason: kueue.WorkloadStarted,
+						}),
+					).To(gomega.BeTrue())
+
+					g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusFalse(kueue.WorkloadEvicted))
+
+					g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrue(kueue.WorkloadRequeued))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+
+	ginkgo.When("WaitForPodsReady has default Timeout and a long RecoveryTimeout", func() {
+		ginkgo.BeforeEach(func() {
+			updateKueueConfiguration(func(cfg *configapi.Configuration) {
+				cfg.WaitForPodsReady = &configapi.WaitForPodsReady{
+					Enable:          true,
+					BlockAdmission:  ptr.To(true),
+					RecoveryTimeout: &metav1.Duration{Duration: util.LongTimeout},
+					RequeuingStrategy: &configapi.RequeuingStrategy{
+						Timestamp:          ptr.To(configapi.EvictionTimestamp),
+						BackoffBaseSeconds: ptr.To(int32(1)),
+						BackoffLimitCount:  ptr.To(int32(1)),
+					},
+				}
+			})
+		})
+
+		ginkgo.It("should continue running workload if pod recovers before recoveryTimeout", func() {
+			ginkgo.By("creating a job", func() {
+				job = testingjob.MakeJob("job-recovery-timeout", ns.Name).
+					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+					Queue(lq.Name).
+					Request(corev1.ResourceCPU, "2").
+					Parallelism(1).
+					BackoffLimitPerIndex(2).
+					CompletionMode(batchv1.IndexedCompletion).
+					Completions(1).
+					Obj()
+
+				gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+			})
+
+			wlKey = types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+				Namespace: ns.Name,
+			}
+
+			ginkgo.By("checking workload availability", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+					g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrue(kueue.WorkloadPodsReady))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("simulating pod failure", func() {
+				util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 1, 1)
+			})
+
+			ginkgo.By("verifying the pod is recovered before recoveryTimeout", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+					g.Expect(
+						workload.HasConditionWithTypeAndReason(&wl, &metav1.Condition{
+							Type:   kueue.WorkloadPodsReady,
+							Status: metav1.ConditionTrue,
+							Reason: kueue.WorkloadRecovered,
+						}),
+					).To(gomega.BeTrue())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add e2e tests for WaitForPodsReady feature
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4429 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```