### PR TITLE
Always use FairSharing preemption logic when FS enabled

### DIFF
--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -144,6 +144,9 @@ func (p *Preemptor) getTargets(preemptionCtx *preemptionCtx) []*Target {
 		return nil
 	}
 	sort.Slice(candidates, candidatesOrdering(candidates, preemptionCtx.preemptorCQ.Name, p.clock.Now()))
+	if p.enableFairSharing {
+		return fairPreemptions(preemptionCtx, candidates, p.fsStrategies)
+	}
 
 	sameQueueCandidates := candidatesOnlyFromQueue(candidates, preemptionCtx.preemptorCQ.Name)
 
@@ -158,9 +161,6 @@ func (p *Preemptor) getTargets(preemptionCtx *preemptionCtx) []*Target {
 		return minimalPreemptions(preemptionCtx, candidates, true, nil)
 	}
 
-	if p.enableFairSharing {
-		return fairPreemptions(preemptionCtx, candidates, p.fsStrategies)
-	}
 	// There is a potential of preemption of workloads from the other queue in the
 	// cohort. We proceed with borrowing only if the dedicated policy
 	// (borrowWithinCohort) is enabled. This ensures the preempted workloads


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Previously, we'd fall back on non FairSharing logic if there were
only candidates from the preempting ClusterQueue.

I was debugging some unit tests in #4572, and had
to write some strange logic to make sure we hit the FairSharing branch,
if there were only candidates from the ClusterQueue.

For consistency, and ease of debugging when FS is enabled, it is
better that FairSharing is a well lit path, and that we will only go down
that branch when the FairSharing flag is enabled.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```