### PR TITLE
Refactor and Introduce Types to FairSharingStrategy

### DIFF
--- a/pkg/scheduler/fairsharing/strategy.go
+++ b/pkg/scheduler/fairsharing/strategy.go
@@ -30,14 +30,14 @@ type TargetNewShare int
 // its workload has been removed. It is used for rule S2-b.
 type TargetOldShare int
 
-type Strategy func(preemptorNewShare PreemptorNewShare, preempteeOldShare TargetOldShare, preempteeNewShare TargetNewShare) bool
+type Strategy func(PreemptorNewShare, TargetOldShare, TargetNewShare) bool
 
 // LessThanOrEqualToFinalShare implements Rule S2-a in https://sigs.k8s.io/kueue/keps/1714-fair-sharing#choosing-workloads-from-clusterqueues-for-preemption
-func LessThanOrEqualToFinalShare(preemptorNewShare PreemptorNewShare, _ TargetOldShare, preempteeNewShare TargetNewShare) bool {
-	return int(preemptorNewShare) <= int(preempteeNewShare)
+func LessThanOrEqualToFinalShare(preemptorNewShare PreemptorNewShare, _ TargetOldShare, targetNewShare TargetNewShare) bool {
+	return int(preemptorNewShare) <= int(targetNewShare)
 }
 
 // LessThanInitialShare implements rule S2-b in https://sigs.k8s.io/kueue/keps/1714-fair-sharing#choosing-workloads-from-clusterqueues-for-preemption
-func LessThanInitialShare(preemptorNewShare PreemptorNewShare, preempteeOldShare TargetOldShare, _ TargetNewShare) bool {
-	return int(preemptorNewShare) < int(preempteeOldShare)
+func LessThanInitialShare(preemptorNewShare PreemptorNewShare, targetOldShare TargetOldShare, _ TargetNewShare) bool {
+	return int(preemptorNewShare) < int(targetOldShare)
 }

--- a/pkg/scheduler/fairsharing/strategy.go
+++ b/pkg/scheduler/fairsharing/strategy.go
@@ -1,0 +1,29 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fairsharing
+
+type Strategy func(preemptorNewShare, preempteeOldShare, preempteeNewShare int) bool
+
+// LessThanOrEqualToFinalShare implements Rule S2-a in https://sigs.k8s.io/kueue/keps/1714-fair-sharing#choosing-workloads-from-clusterqueues-for-preemption
+func LessThanOrEqualToFinalShare(preemptorNewShare, _, preempteeNewShare int) bool {
+	return preemptorNewShare <= preempteeNewShare
+}
+
+// LessThanInitialShare implements rule S2-b in https://sigs.k8s.io/kueue/keps/1714-fair-sharing#choosing-workloads-from-clusterqueues-for-preemption
+func LessThanInitialShare(preemptorNewShare, preempteeOldShare, _ int) bool {
+	return preemptorNewShare < preempteeOldShare
+}

--- a/pkg/scheduler/fairsharing/strategy.go
+++ b/pkg/scheduler/fairsharing/strategy.go
@@ -16,14 +16,28 @@ limitations under the License.
 
 package fairsharing
 
-type Strategy func(preemptorNewShare, preempteeOldShare, preempteeNewShare int) bool
+// PreemptorNewShare is the DominantResourceShare of the Preemptor
+// after the incoming workload's usage has been added. It is used for
+// both rules S2-a and S2-b
+type PreemptorNewShare int
+
+// TargetNewShare is the DominantResourceShare of the Preemptee after
+// its preempted workload's usage has been removed. It is used for
+// rule S2-a.
+type TargetNewShare int
+
+// TargetOldShare is the DominantResourceShare of the Preemptee before
+// its workload has been removed. It is used for rule S2-b.
+type TargetOldShare int
+
+type Strategy func(preemptorNewShare PreemptorNewShare, preempteeOldShare TargetOldShare, preempteeNewShare TargetNewShare) bool
 
 // LessThanOrEqualToFinalShare implements Rule S2-a in https://sigs.k8s.io/kueue/keps/1714-fair-sharing#choosing-workloads-from-clusterqueues-for-preemption
-func LessThanOrEqualToFinalShare(preemptorNewShare, _, preempteeNewShare int) bool {
-	return preemptorNewShare <= preempteeNewShare
+func LessThanOrEqualToFinalShare(preemptorNewShare PreemptorNewShare, _ TargetOldShare, preempteeNewShare TargetNewShare) bool {
+	return int(preemptorNewShare) <= int(preempteeNewShare)
 }
 
 // LessThanInitialShare implements rule S2-b in https://sigs.k8s.io/kueue/keps/1714-fair-sharing#choosing-workloads-from-clusterqueues-for-preemption
-func LessThanInitialShare(preemptorNewShare, preempteeOldShare, _ int) bool {
-	return preemptorNewShare < preempteeOldShare
+func LessThanInitialShare(preemptorNewShare PreemptorNewShare, preempteeOldShare TargetOldShare, _ TargetNewShare) bool {
+	return int(preemptorNewShare) < int(preempteeOldShare)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Part of #https://github.com/kubernetes-sigs/kueue/issues/3759. This will help to reduce diff in #4572.

Introducing the new types will ensure that the correct DominantResourceShare is passed to the fairsharing.Strategy. Additionally, move FairSharing strategies to a new package/file. Finally, we rename variables to match new types.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
Please review each commit individually

#### Does this PR introduce a user-facing change?
```release-note
NONE
```