### PR TITLE
TAS: use exit fast images wherever possible (cleanup)

### DIFF
--- a/test/e2e/tas/appwrapper_test.go
+++ b/test/e2e/tas/appwrapper_test.go
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 					Request(extraResource, "1").
 					Limit(extraResource, "1").
 					Suspend(false).
-					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+					Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 					PodAnnotation(kueuealpha.PodSetPreferredTopologyAnnotation, testing.DefaultRackTopologyLevel).
 					SetTypeMeta().Obj()).
 				Queue(localQueue.Name).
@@ -141,7 +141,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 				Request(extraResource, "1").
 				Limit(extraResource, "1").
 				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, testing.DefaultBlockTopologyLevel).
-				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				SetTypeMeta().
 				Obj()
 			aw := awtesting.MakeAppWrapper("aw-ranks-job", ns.Name).

--- a/test/e2e/tas/jobset_test.go
+++ b/test/e2e/tas/jobset_test.go
@@ -99,7 +99,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", func() {
 					testingjobset.ReplicatedJobRequirements{
 						Name:        "replicated-job-1",
 						Image:       util.E2eTestAgnHostImage,
-						Args:        util.BehaviorWaitForDeletion,
+						Args:        util.BehaviorExitFast,
 						Replicas:    int32(replicas),
 						Parallelism: int32(parallelism),
 						Completions: int32(parallelism),

--- a/test/e2e/tas/mpijob_test.go
+++ b/test/e2e/tas/mpijob_test.go
@@ -115,8 +115,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for MPIJob", func() {
 						},
 					},
 				).
-				Image(kfmpi.MPIReplicaTypeLauncher, util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-				Image(kfmpi.MPIReplicaTypeWorker, util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+				Image(kfmpi.MPIReplicaTypeLauncher, util.E2eTestAgnHostImage, util.BehaviorExitFast).
+				Image(kfmpi.MPIReplicaTypeWorker, util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Request(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "100m").
 				Limit(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "100m").
 				Request(kfmpi.MPIReplicaTypeWorker, extraResource, "1").

--- a/test/e2e/tas/pod_group_test.go
+++ b/test/e2e/tas/pod_group_test.go
@@ -91,6 +91,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Pod group", func() {
 				Queue("test-queue").
 				Request(extraResource, "1").
 				Limit(extraResource, "1").
+				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, testing.DefaultBlockTopologyLevel)
 			podGroup := basePod.MakeIndexedGroup(numPods)
 

--- a/test/e2e/tas/pytorch_test.go
+++ b/test/e2e/tas/pytorch_test.go
@@ -114,8 +114,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", func() {
 						},
 					},
 				).
-				Image(kftraining.PyTorchJobReplicaTypeMaster, util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-				Image(kftraining.PyTorchJobReplicaTypeWorker, util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+				Image(kftraining.PyTorchJobReplicaTypeMaster, util.E2eTestAgnHostImage, util.BehaviorExitFast).
+				Image(kftraining.PyTorchJobReplicaTypeWorker, util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Request(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "100m").
 				Limit(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "100m").
 				Request(kftraining.PyTorchJobReplicaTypeWorker, extraResource, "1").


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Cleanup to exit tests cleanly. Also, killing pods occassionally might be taking long - if the DELETE request hits the "Running" Pods before the SIGTERM trap is registered, then SIGKILL will be triggered in 30s, but this takes unnecessary time.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```