### PR TITLE
Use RequestAndLimit on e2e tests.

### DIFF
--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -122,6 +122,10 @@ func (w *WorkloadWrapper) Limit(r corev1.ResourceName, q string) *WorkloadWrappe
 	return w
 }
 
+func (w *WorkloadWrapper) RequestAndLimit(r corev1.ResourceName, q string) *WorkloadWrapper {
+	return w.Request(r, q).Limit(r, q)
+}
+
 func (w *WorkloadWrapper) Queue(q string) *WorkloadWrapper {
 	w.Spec.QueueName = q
 	return w

--- a/pkg/util/testingjobs/deployment/wrappers.go
+++ b/pkg/util/testingjobs/deployment/wrappers.go
@@ -107,6 +107,20 @@ func (d *DeploymentWrapper) Request(r corev1.ResourceName, v string) *Deployment
 	return d
 }
 
+// Limit adds a resource limit to the default container.
+func (d *DeploymentWrapper) Limit(r corev1.ResourceName, v string) *DeploymentWrapper {
+	if d.Spec.Template.Spec.Containers[0].Resources.Limits == nil {
+		d.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{}
+	}
+	d.Spec.Template.Spec.Containers[0].Resources.Limits[r] = resource.MustParse(v)
+	return d
+}
+
+// RequestAndLimit adds a resource request and limit to the default container.
+func (d *DeploymentWrapper) RequestAndLimit(r corev1.ResourceName, v string) *DeploymentWrapper {
+	return d.Request(r, v).Limit(r, v)
+}
+
 // Replicas updated the replicas of the Deployment
 func (d *DeploymentWrapper) Replicas(replicas int32) *DeploymentWrapper {
 	d.Spec.Replicas = &replicas

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -186,6 +186,11 @@ func (j *JobWrapper) Limit(r corev1.ResourceName, v string) *JobWrapper {
 	return j
 }
 
+// RequestAndLimit adds a resource request and limit to the default container.
+func (j *JobWrapper) RequestAndLimit(r corev1.ResourceName, v string) *JobWrapper {
+	return j.Request(r, v).Limit(r, v)
+}
+
 func (j *JobWrapper) Image(image string, args []string) *JobWrapper {
 	j.Spec.Template.Spec.Containers[0].Image = image
 	j.Spec.Template.Spec.Containers[0].Args = args

--- a/pkg/util/testingjobs/jobset/wrappers.go
+++ b/pkg/util/testingjobs/jobset/wrappers.go
@@ -154,6 +154,11 @@ func (j *JobSetWrapper) Limit(replicatedJobName string, r corev1.ResourceName, v
 	return j
 }
 
+// RequestAndLimit adds a resource request and limit to the first container of the target replicatedJob.
+func (j *JobSetWrapper) RequestAndLimit(replicatedJobName string, r corev1.ResourceName, v string) *JobSetWrapper {
+	return j.Request(replicatedJobName, r, v).Limit(replicatedJobName, r, v)
+}
+
 // PriorityClass updates JobSet priorityclass.
 func (j *JobSetWrapper) PriorityClass(pc string) *JobSetWrapper {
 	for i := range j.Spec.ReplicatedJobs {

--- a/pkg/util/testingjobs/leaderworkerset/wrappers.go
+++ b/pkg/util/testingjobs/leaderworkerset/wrappers.go
@@ -186,6 +186,11 @@ func (w *LeaderWorkerSetWrapper) Limit(r corev1.ResourceName, v string) *LeaderW
 	return w
 }
 
+// RequestAndLimit adds a resource request and limit to the default container.
+func (w *LeaderWorkerSetWrapper) RequestAndLimit(r corev1.ResourceName, v string) *LeaderWorkerSetWrapper {
+	return w.Request(r, v).Limit(r, v)
+}
+
 // LeaderTemplate sets the leader template of the LeaderWorkerSet.
 func (w *LeaderWorkerSetWrapper) LeaderTemplate(leader corev1.PodTemplateSpec) *LeaderWorkerSetWrapper {
 	w.Spec.LeaderWorkerTemplate.LeaderTemplate = &leader

--- a/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
+++ b/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
@@ -178,6 +178,11 @@ func (j *MPIJobWrapper) Limit(replicaType kfmpi.MPIReplicaType, r corev1.Resourc
 	return j
 }
 
+// RequestAndLimit adds a resource request and limit to the default container.
+func (j *MPIJobWrapper) RequestAndLimit(replicaType kfmpi.MPIReplicaType, r corev1.ResourceName, v string) *MPIJobWrapper {
+	return j.Request(replicaType, r, v).Limit(replicaType, r, v)
+}
+
 // Parallelism updates job parallelism.
 func (j *MPIJobWrapper) Parallelism(p int32) *MPIJobWrapper {
 	j.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Replicas = ptr.To(p)

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -221,6 +221,11 @@ func (p *PodWrapper) Request(r corev1.ResourceName, v string) *PodWrapper {
 	return p
 }
 
+// RequestAndLimit adds a resource request and limit to the default container.
+func (p *PodWrapper) RequestAndLimit(r corev1.ResourceName, v string) *PodWrapper {
+	return p.Request(r, v).Limit(r, v)
+}
+
 func (p *PodWrapper) ServiceAccountName(serviceAccountName string) *PodWrapper {
 	p.Spec.ServiceAccountName = serviceAccountName
 	return p

--- a/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
+++ b/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
@@ -179,6 +179,11 @@ func (j *PyTorchJobWrapper) Limit(replicaType kftraining.ReplicaType, r corev1.R
 	return j
 }
 
+// RequestAndLimit adds a resource request and limit to the default container.
+func (j *PyTorchJobWrapper) RequestAndLimit(replicaType kftraining.ReplicaType, r corev1.ResourceName, v string) *PyTorchJobWrapper {
+	return j.Request(replicaType, r, v).Limit(replicaType, r, v)
+}
+
 // Parallelism updates job parallelism.
 func (j *PyTorchJobWrapper) Parallelism(p int32) *PyTorchJobWrapper {
 	j.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeWorker].Replicas = ptr.To(p)

--- a/pkg/util/testingjobs/raycluster/wrappers.go
+++ b/pkg/util/testingjobs/raycluster/wrappers.go
@@ -210,6 +210,21 @@ func (j *ClusterWrapper) Request(rayType rayv1.RayNodeType, r corev1.ResourceNam
 	return j
 }
 
+// Limit adds a resource limit to the default container.
+func (j *ClusterWrapper) Limit(rayType rayv1.RayNodeType, r corev1.ResourceName, v string) *ClusterWrapper {
+	if rayType == rayv1.HeadNode {
+		j.Spec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits[r] = resource.MustParse(v)
+	} else if rayType == rayv1.WorkerNode {
+		j.Spec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Limits[r] = resource.MustParse(v)
+	}
+	return j
+}
+
+// RequestAndLimit adds a resource request and limit to the default container.
+func (j *ClusterWrapper) RequestAndLimit(rayType rayv1.RayNodeType, r corev1.ResourceName, v string) *ClusterWrapper {
+	return j.Request(rayType, r, v).Limit(rayType, r, v)
+}
+
 func (j *ClusterWrapper) Image(rayType rayv1.RayNodeType, image string, args []string) *ClusterWrapper {
 	if rayType == rayv1.HeadNode {
 		j.Spec.HeadGroupSpec.Template.Spec.Containers[0].Image = image

--- a/pkg/util/testingjobs/rayjob/wrappers.go
+++ b/pkg/util/testingjobs/rayjob/wrappers.go
@@ -227,6 +227,21 @@ func (j *JobWrapper) Request(rayType rayv1.RayNodeType, r corev1.ResourceName, v
 	return j
 }
 
+// Limit adds a resource request to the default container.
+func (j *JobWrapper) Limit(rayType rayv1.RayNodeType, r corev1.ResourceName, v string) *JobWrapper {
+	if rayType == rayv1.HeadNode {
+		j.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Resources.Limits[r] = resource.MustParse(v)
+	} else if rayType == rayv1.WorkerNode {
+		j.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.Containers[0].Resources.Limits[r] = resource.MustParse(v)
+	}
+	return j
+}
+
+// RequestAndLimit adds a resource request and limit to the default container.
+func (j *JobWrapper) RequestAndLimit(rayType rayv1.RayNodeType, r corev1.ResourceName, v string) *JobWrapper {
+	return j.Request(rayType, r, v).Limit(rayType, r, v)
+}
+
 func (j *JobWrapper) Image(rayType rayv1.RayNodeType, image string, args ...string) *JobWrapper {
 	if rayType == rayv1.HeadNode {
 		j.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.Containers[0].Image = image

--- a/pkg/util/testingjobs/statefulset/wrappers.go
+++ b/pkg/util/testingjobs/statefulset/wrappers.go
@@ -210,3 +210,8 @@ func (ss *StatefulSetWrapper) Limit(r corev1.ResourceName, v string) *StatefulSe
 	ss.Spec.Template.Spec.Containers[0].Resources.Limits[r] = resource.MustParse(v)
 	return ss
 }
+
+// RequestAndLimit adds a resource request and limit to the default container.
+func (ss *StatefulSetWrapper) RequestAndLimit(r corev1.ResourceName, v string) *StatefulSetWrapper {
+	return ss.Request(r, v).Limit(r, v)
+}

--- a/test/e2e/customconfigs/skipjobswithoutqueuename_test.go
+++ b/test/e2e/customconfigs/skipjobswithoutqueuename_test.go
@@ -131,7 +131,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 			numPods := 2
 			aw := awtesting.MakeAppWrapper("aw-child", ns.Name).
 				Component(testingjob.MakeJob("job-0", ns.Name).
-					Request(corev1.ResourceCPU, "100m").
+					RequestAndLimit(corev1.ResourceCPU, "200m").
 					Parallelism(int32(numPods)).
 					Completions(int32(numPods)).
 					Suspend(false).
@@ -194,7 +194,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 					).
 					SetTypeMeta().
 					Suspend(false).
-					Request("replicated-job-1", corev1.ResourceCPU, "100m").
+					RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "200m").
 					Obj()).
 				Suspend(false).
 				Obj()
@@ -266,8 +266,8 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 			ginkgo.By("creating a pod without a queue name", func() {
 				testPod = testingpod.MakePod("test-pod", "kube-system").
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-					Request(corev1.ResourceCPU, "1").
-					Request(corev1.ResourceMemory, "2Gi").
+					RequestAndLimit(corev1.ResourceCPU, "1").
+					RequestAndLimit(corev1.ResourceMemory, "2Gi").
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, testPod)).Should(gomega.Succeed())
 			})
@@ -294,8 +294,8 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 			ginkgo.By("creating a deployment without a queue name", func() {
 				testDeploy = testingdeploy.MakeDeployment("test-deploy", ns.Name).
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-					Request(corev1.ResourceCPU, "1").
-					Request(corev1.ResourceMemory, "2Gi").
+					RequestAndLimit(corev1.ResourceCPU, "1").
+					RequestAndLimit(corev1.ResourceMemory, "2Gi").
 					Replicas(2).
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, testDeploy)).Should(gomega.Succeed())
@@ -323,8 +323,8 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 			ginkgo.By("creating a deployment without a queue name in the kube-system namespace", func() {
 				testDeploy = testingdeploy.MakeDeployment("test-deploy", "kube-system").
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-					Request(corev1.ResourceCPU, "1").
-					Request(corev1.ResourceMemory, "2Gi").
+					RequestAndLimit(corev1.ResourceCPU, "1").
+					RequestAndLimit(corev1.ResourceMemory, "2Gi").
 					Replicas(2).
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, testDeploy)).Should(gomega.Succeed())
@@ -358,8 +358,8 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 			ginkgo.By("creating a StatefulSet without a queue name", func() {
 				testSts = testingsts.MakeStatefulSet("test-sts", ns.Name).
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-					Request(corev1.ResourceCPU, "1").
-					Request(corev1.ResourceMemory, "2Gi").
+					RequestAndLimit(corev1.ResourceCPU, "1").
+					RequestAndLimit(corev1.ResourceMemory, "2Gi").
 					Replicas(2).
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, testSts)).Should(gomega.Succeed())
@@ -388,8 +388,8 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 			ginkgo.By("creating a StatefulSet without a queue name in the kube-system namespace", func() {
 				testSts = testingsts.MakeStatefulSet("test-sts", "kube-system").
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-					Request(corev1.ResourceCPU, "1").
-					Request(corev1.ResourceMemory, "2Gi").
+					RequestAndLimit(corev1.ResourceCPU, "1").
+					RequestAndLimit(corev1.ResourceMemory, "2Gi").
 					Replicas(2).
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, testSts)).Should(gomega.Succeed())

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -209,8 +209,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		ginkgo.It("Should create a pod on worker if admitted", func() {
 			pod := testingpod.MakePod("pod", managerNs.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
-				Request("cpu", "1").
-				Request("memory", "2G").
+				RequestAndLimit("cpu", "1").
+				RequestAndLimit("memory", "2G").
 				Queue(managerLq.Name).
 				Obj()
 			// Since it requires 2G of memory, this pod can only be admitted in worker 2.
@@ -396,8 +396,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			// Since it requires 2G of memory, this job can only be admitted in worker 2.
 			job := testingjob.MakeJob("job", managerNs.Name).
 				Queue(managerLq.Name).
-				Request("cpu", "1").
-				Request("memory", "2G").
+				RequestAndLimit("cpu", "1").
+				RequestAndLimit("memory", "2G").
 				// Give it the time to be observed Active in the live status update step.
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 				Obj()
@@ -492,8 +492,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 						Args: util.BehaviorWaitForDeletion,
 					},
 				).
-				Request("replicated-job-1", "cpu", "500m").
-				Request("replicated-job-1", "memory", "200M").
+				RequestAndLimit("replicated-job-1", "cpu", "500m").
+				RequestAndLimit("replicated-job-1", "memory", "200M").
 				Obj()
 
 			ginkgo.By("Creating the jobSet", func() {
@@ -586,7 +586,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					Suspend(false).
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion). // Give it the time to be observed Active in the live status update step.
 					Parallelism(2).
-					Request(corev1.ResourceCPU, "1").
+					RequestAndLimit(corev1.ResourceCPU, "1").
 					SetTypeMeta().Obj()).
 				Obj()
 
@@ -659,10 +659,10 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 						RestartPolicy: "OnFailure",
 					},
 				).
-				Request(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "0.2").
-				Request(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceMemory, "800M").
-				Request(kftraining.PyTorchJobReplicaTypeWorker, corev1.ResourceCPU, "0.5").
-				Request(kftraining.PyTorchJobReplicaTypeWorker, corev1.ResourceMemory, "800M").
+				RequestAndLimit(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "0.2").
+				RequestAndLimit(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceMemory, "800M").
+				RequestAndLimit(kftraining.PyTorchJobReplicaTypeWorker, corev1.ResourceCPU, "0.5").
+				RequestAndLimit(kftraining.PyTorchJobReplicaTypeWorker, corev1.ResourceMemory, "800M").
 				Image(kftraining.PyTorchJobReplicaTypeMaster, util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Image(kftraining.PyTorchJobReplicaTypeWorker, util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Obj()
@@ -722,10 +722,10 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 						RestartPolicy: "OnFailure",
 					},
 				).
-				Request(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "1").
-				Request(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceMemory, "200M").
-				Request(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "0.5").
-				Request(kfmpi.MPIReplicaTypeWorker, corev1.ResourceMemory, "100M").
+				RequestAndLimit(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "1").
+				RequestAndLimit(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceMemory, "200M").
+				RequestAndLimit(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "0.5").
+				RequestAndLimit(kfmpi.MPIReplicaTypeWorker, corev1.ResourceMemory, "100M").
 				Image(kfmpi.MPIReplicaTypeLauncher, util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Image(kfmpi.MPIReplicaTypeWorker, util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Obj()
@@ -774,8 +774,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				Suspend(true).
 				Queue(managerLq.Name).
 				WithSubmissionMode(rayv1.K8sJobMode).
-				Request(rayv1.HeadNode, corev1.ResourceCPU, "1").
-				Request(rayv1.WorkerNode, corev1.ResourceCPU, "0.5").
+				RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
+				RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "0.5").
 				Entrypoint("python -c \"import ray; ray.init(); print(ray.cluster_resources())\"").
 				Image(rayv1.HeadNode, kuberayTestImage).
 				Image(rayv1.WorkerNode, kuberayTestImage).
@@ -817,8 +817,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			raycluster := testingraycluster.MakeCluster("raycluster1", managerNs.Name).
 				Suspend(true).
 				Queue(managerLq.Name).
-				Request(rayv1.HeadNode, corev1.ResourceCPU, "1").
-				Request(rayv1.WorkerNode, corev1.ResourceCPU, "0.5").
+				RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
+				RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "0.5").
 				Image(rayv1.HeadNode, kuberayTestImage, []string{}).
 				Image(rayv1.WorkerNode, kuberayTestImage, []string{}).
 				Obj()

--- a/test/e2e/singlecluster/appwrapper_test.go
+++ b/test/e2e/singlecluster/appwrapper_test.go
@@ -84,7 +84,7 @@ var _ = ginkgo.Describe("AppWrapper", func() {
 		numPods := 2
 		aw := awtesting.MakeAppWrapper("appwrapper", ns.Name).
 			Component(utiltestingjob.MakeJob("job-0", ns.Name).
-				Request(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Parallelism(int32(numPods)).
 				Completions(int32(numPods)).
 				Suspend(false).

--- a/test/e2e/singlecluster/deployment_test.go
+++ b/test/e2e/singlecluster/deployment_test.go
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("Deployment", func() {
 	ginkgo.It("should admit workloads that fits", func() {
 		deployment := deploymenttesting.MakeDeployment("deployment", ns.Name).
 			Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-			Request(corev1.ResourceCPU, "100m").
+			RequestAndLimit(corev1.ResourceCPU, "200m").
 			Replicas(3).
 			Queue(lq.Name).
 			Obj()
@@ -136,7 +136,7 @@ var _ = ginkgo.Describe("Deployment", func() {
 	ginkgo.It("should admit workloads after change queue-name if AvailableReplicas = 0", func() {
 		deployment := deploymenttesting.MakeDeployment("deployment", ns.Name).
 			Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-			Request(corev1.ResourceCPU, "100m").
+			RequestAndLimit(corev1.ResourceCPU, "200m").
 			Replicas(3).
 			Queue("invalid-queue-name").
 			Obj()

--- a/test/e2e/singlecluster/e2e_test.go
+++ b/test/e2e/singlecluster/e2e_test.go
@@ -51,8 +51,8 @@ var _ = ginkgo.Describe("Kueue", func() {
 		gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 		sampleJob = testingjob.MakeJob("test-job", ns.Name).
 			Queue("main").
-			Request("cpu", "1").
-			Request("memory", "20Mi").
+			RequestAndLimit("cpu", "1").
+			RequestAndLimit("memory", "20Mi").
 			Obj()
 		jobKey = client.ObjectKeyFromObject(sampleJob)
 	})
@@ -234,7 +234,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 				job := testingjob.MakeJob("high", ns.Name).
 					Queue("main").
 					PriorityClass("high").
-					Request(corev1.ResourceCPU, "1").
+					RequestAndLimit(corev1.ResourceCPU, "1").
 					NodeSelector("instance-type", "on-demand"). // target the same flavor to cause preemption
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
@@ -270,7 +270,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 				job := testingjob.MakeJob("high-with-wpc", ns.Name).
 					Queue("main").
 					WorkloadPriorityClass("high-workload").
-					Request(corev1.ResourceCPU, "1").
+					RequestAndLimit(corev1.ResourceCPU, "1").
 					NodeSelector("instance-type", "on-demand"). // target the same flavor to cause preemption
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
@@ -291,7 +291,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 			job := testingjob.MakeJob("job", ns.Name).
 				Queue("main").
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
-				Request("cpu", "500m").
+				RequestAndLimit("cpu", "500m").
 				Parallelism(3).
 				Completions(4).
 				SetAnnotation(workloadjob.JobMinParallelismAnnotation, "1").

--- a/test/e2e/singlecluster/fair_sharing_test.go
+++ b/test/e2e/singlecluster/fair_sharing_test.go
@@ -101,8 +101,8 @@ var _ = ginkgo.Describe("Fair Sharing", ginkgo.Ordered, ginkgo.ContinueOnFailure
 					Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 					Parallelism(3).
 					Completions(3).
-					Request("cpu", "1").
-					Request("memory", "200Mi").
+					RequestAndLimit("cpu", "1").
+					RequestAndLimit("memory", "200Mi").
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, job)).To(gomega.Succeed())
 			}

--- a/test/e2e/singlecluster/jobset_test.go
+++ b/test/e2e/singlecluster/jobset_test.go
@@ -90,8 +90,8 @@ var _ = ginkgo.Describe("JobSet", func() {
 						Completions: 2,
 					},
 				).
-				Request("replicated-job-1", "cpu", "500m").
-				Request("replicated-job-1", "memory", "200M").
+				RequestAndLimit("replicated-job-1", "cpu", "500m").
+				RequestAndLimit("replicated-job-1", "memory", "200M").
 				Obj()
 
 			ginkgo.By("Creating the jobSet", func() {
@@ -172,8 +172,8 @@ var _ = ginkgo.Describe("JobSet", func() {
 						Completions: 1,
 					},
 				).
-				Request("replicated-job-1", "cpu", "500m").
-				Request("replicated-job-1", "memory", "200M").
+				RequestAndLimit("replicated-job-1", "cpu", "500m").
+				RequestAndLimit("replicated-job-1", "memory", "200M").
 				Obj()
 
 			ginkgo.By("Creating the jobSet", func() {

--- a/test/e2e/singlecluster/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/leaderworkerset_test.go
@@ -88,7 +88,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 				Size(1).
 				Replicas(1).
-				Request(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Queue(lq.Name).
 				Obj()
 
@@ -146,7 +146,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 				Size(3).
 				Replicas(1).
-				Request(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Queue(lq.Name).
 				Obj()
 			ginkgo.By("Create a LeaderWorkerSet", func() {
@@ -200,7 +200,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 				Size(3).
 				Replicas(2).
-				Request(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Queue(lq.Name).
 				Obj()
 
@@ -263,7 +263,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 					Size(3).
 					Replicas(1).
-					Request(corev1.ResourceCPU, "100m").
+					RequestAndLimit(corev1.ResourceCPU, "200m").
 					Queue(lq.Name).
 					StartupPolicy(startupPolicyType).
 					Obj()
@@ -357,7 +357,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 					Size(3).
 					Replicas(2).
-					Request(corev1.ResourceCPU, "100m").
+					RequestAndLimit(corev1.ResourceCPU, "200m").
 					Queue(lq.Name).
 					StartupPolicy(startupPolicyType).
 					Obj()
@@ -454,7 +454,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 					Size(3).
 					Replicas(2).
-					Request(corev1.ResourceCPU, "100m").
+					RequestAndLimit(corev1.ResourceCPU, "200m").
 					Queue(lq.Name).
 					LeaderTemplate(corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
@@ -537,7 +537,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				Image(util.E2eTestAgnHostImageOld, util.BehaviorWaitForDeletion).
 				Size(3).
 				Replicas(2).
-				Request(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Queue(lq.Name).
 				LeaderTemplate(corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{

--- a/test/e2e/singlecluster/metrics_test.go
+++ b/test/e2e/singlecluster/metrics_test.go
@@ -136,7 +136,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 				PodSets(
 					*utiltesting.MakePodSet("ps1", 1).Obj(),
 				).
-				Request(corev1.ResourceCPU, "1").
+				RequestAndLimit(corev1.ResourceCPU, "1").
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, workload)).To(gomega.Succeed())
 		})
@@ -268,7 +268,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 
 			createdJob = testingjob.MakeJob("admission-checked-job", ns.Name).
 				Queue(localQueue.Name).
-				Request("cpu", "1").
+				RequestAndLimit("cpu", "1").
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, createdJob)).To(gomega.Succeed())
 
@@ -412,7 +412,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 
 			lowerJob1 = testingjob.MakeJob("lower-job-1", ns.Name).
 				Queue(localQueue1.Name).
-				Request("cpu", "1").
+				RequestAndLimit("cpu", "1").
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, lowerJob1)).To(gomega.Succeed())
 
@@ -431,7 +431,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 
 			lowerJob2 = testingjob.MakeJob("lower-job-2", ns.Name).
 				Queue(localQueue1.Name).
-				Request("cpu", "1").
+				RequestAndLimit("cpu", "1").
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, lowerJob2)).To(gomega.Succeed())
 
@@ -451,7 +451,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 			blockerJob = testingjob.MakeJob("blocker", ns.Name).
 				Queue(localQueue2.Name).
 				PriorityClass(highPriorityClass.Name).
-				Request(corev1.ResourceCPU, "3").
+				RequestAndLimit(corev1.ResourceCPU, "3").
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, blockerJob)).Should(gomega.Succeed())
 
@@ -471,14 +471,14 @@ var _ = ginkgo.Describe("Metrics", func() {
 			higherJob1 = testingjob.MakeJob("high-large-1", ns.Name).
 				Queue(localQueue1.Name).
 				PriorityClass(highPriorityClass.Name).
-				Request(corev1.ResourceCPU, "4").
+				RequestAndLimit(corev1.ResourceCPU, "4").
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, higherJob1)).Should(gomega.Succeed())
 
 			higherJob2 = testingjob.MakeJob("high-large-2", ns.Name).
 				Queue(localQueue2.Name).
 				PriorityClass(highPriorityClass.Name).
-				Request(corev1.ResourceCPU, "4").
+				RequestAndLimit(corev1.ResourceCPU, "4").
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, higherJob2)).Should(gomega.Succeed())
 		})

--- a/test/e2e/singlecluster/pod_test.go
+++ b/test/e2e/singlecluster/pod_test.go
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 			group := podtesting.MakePod("group", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Queue(lq.Name).
-				Request(corev1.ResourceCPU, "1").
+				RequestAndLimit(corev1.ResourceCPU, "1").
 				MakeGroup(2)
 			gKey := client.ObjectKey{Namespace: ns.Name, Name: "group"}
 			for _, p := range group {
@@ -130,7 +130,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 			group := podtesting.MakePod("group", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Queue(lq.Name).
-				Request(corev1.ResourceCPU, "1").
+				RequestAndLimit(corev1.ResourceCPU, "1").
 				MakeGroup(3)
 
 			ginkgo.By("Incomplete group should not start", func() {
@@ -182,7 +182,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				TerminationGracePeriod(1).
 				Queue(lq.Name).
-				Request(corev1.ResourceCPU, "1").
+				RequestAndLimit(corev1.ResourceCPU, "1").
 				MakeGroup(3)
 
 			// First pod runs for much longer, so that there is time to terminate it.
@@ -296,7 +296,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 			group := podtesting.MakePod("group", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Queue(lq.Name).
-				Request(corev1.ResourceCPU, "1").
+				RequestAndLimit(corev1.ResourceCPU, "1").
 				MakeGroup(2)
 
 			// The first pod has a node selector for a missing node.
@@ -367,7 +367,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 			group := podtesting.MakePod("group", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Queue(lq.Name).
-				Request(corev1.ResourceCPU, "3").
+				RequestAndLimit(corev1.ResourceCPU, "3").
 				MakeGroup(2)
 			gKey := client.ObjectKey{Namespace: ns.Name, Name: "group"}
 
@@ -425,7 +425,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletionFailOnExit).
 				TerminationGracePeriod(1).
 				Queue(lq.Name).
-				Request(corev1.ResourceCPU, "2").
+				RequestAndLimit(corev1.ResourceCPU, "2").
 				MakeGroup(2)
 			defaultGroupKey := client.ObjectKey{Namespace: ns.Name, Name: "default-priority-group"}
 			defaultGroupPods := sets.New(
@@ -450,7 +450,7 @@ var _ = ginkgo.Describe("Pod groups", func() {
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 				Queue(lq.Name).
 				PriorityClass("high").
-				Request(corev1.ResourceCPU, "1").
+				RequestAndLimit(corev1.ResourceCPU, "1").
 				MakeGroup(2)
 			highGroupKey := client.ObjectKey{Namespace: ns.Name, Name: "high-priority-group"}
 

--- a/test/e2e/singlecluster/statefulset_test.go
+++ b/test/e2e/singlecluster/statefulset_test.go
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("StatefulSet integration", func() {
 		ginkgo.It("should admit group that fits", func() {
 			statefulSet := statefulsettesting.MakeStatefulSet("sts", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-				Request(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Replicas(3).
 				Queue(lq.Name).
 				Obj()
@@ -108,7 +108,7 @@ var _ = ginkgo.Describe("StatefulSet integration", func() {
 			ginkgo.By("Creating potentially conflicting stateful-set", func() {
 				conflictingStatefulSet := statefulsettesting.MakeStatefulSet("sts-conflict", ns.Name).
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-					Request(corev1.ResourceCPU, "100m").
+					RequestAndLimit(corev1.ResourceCPU, "200m").
 					Replicas(1).
 					Queue(lq.Name).
 					Obj()
@@ -145,7 +145,7 @@ var _ = ginkgo.Describe("StatefulSet integration", func() {
 		ginkgo.It("should allow to update the PodTemplate in StatefulSet", func() {
 			statefulSet := statefulsettesting.MakeStatefulSet("sts", ns.Name).
 				Image(util.E2eTestAgnHostImageOld, util.BehaviorWaitForDeletion).
-				Request(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Replicas(3).
 				Queue(lq.Name).
 				Obj()
@@ -195,7 +195,7 @@ var _ = ginkgo.Describe("StatefulSet integration", func() {
 		ginkgo.It("should delete all pods on scale down to zero", func() {
 			statefulSet := statefulsettesting.MakeStatefulSet("sts", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-				Request(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Replicas(3).
 				Queue(lq.Name).
 				Obj()
@@ -243,7 +243,7 @@ var _ = ginkgo.Describe("StatefulSet integration", func() {
 		ginkgo.It("should create pods after scale up from zero", func() {
 			statefulSet := statefulsettesting.MakeStatefulSet("sts", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-				Request(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Replicas(0).
 				Queue(lq.Name).
 				Obj()
@@ -279,7 +279,7 @@ var _ = ginkgo.Describe("StatefulSet integration", func() {
 		ginkgo.It("should allow to scale up after scale down to zero", func() {
 			statefulSet := statefulsettesting.MakeStatefulSet("sts", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-				Request(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Replicas(3).
 				Queue(lq.Name).
 				Obj()
@@ -341,7 +341,7 @@ var _ = ginkgo.Describe("StatefulSet integration", func() {
 		ginkgo.It("should allow to change queue name if ReadyReplicas=0", func() {
 			statefulSet := statefulsettesting.MakeStatefulSet("sts", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-				Request(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Replicas(3).
 				Queue(fmt.Sprintf("%s-invalid", localQueueName)).
 				Obj()
@@ -385,7 +385,7 @@ var _ = ginkgo.Describe("StatefulSet integration", func() {
 		ginkgo.It("should delete all Pods if StatefulSet was deleted after being partially ready", func() {
 			statefulSet := statefulsettesting.MakeStatefulSet("sts", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-				Request(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
 				Replicas(3).
 				Queue(localQueueName).
 				Obj()

--- a/test/e2e/singlecluster/tas_test.go
+++ b/test/e2e/singlecluster/tas_test.go
@@ -98,8 +98,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 		ginkgo.It("should admit a Job via TAS", func() {
 			sampleJob := testingjob.MakeJob("test-job", ns.Name).
 				Queue(localQueue.Name).
-				Request("cpu", "700m").
-				Request("memory", "20Mi").
+				RequestAndLimit("cpu", "700m").
+				RequestAndLimit("memory", "20Mi").
 				Obj()
 			jobKey := client.ObjectKeyFromObject(sampleJob)
 			sampleJob = (&testingjob.JobWrapper{Job: *sampleJob}).
@@ -218,10 +218,10 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 						},
 					},
 				).
-				Request("rj1", "cpu", "200m").
-				Request("rj1", "memory", "20Mi").
-				Request("rj2", "cpu", "200m").
-				Request("rj2", "memory", "20Mi").
+				RequestAndLimit("rj1", "cpu", "200m").
+				RequestAndLimit("rj1", "memory", "20Mi").
+				RequestAndLimit("rj2", "cpu", "200m").
+				RequestAndLimit("rj2", "memory", "20Mi").
 				Obj()
 
 			ginkgo.By("Creating the JobSet", func() {
@@ -331,8 +331,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 				Queue(localQueue.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
-				Request("cpu", "100m").
-				Request("memory", "100Mi").
+				RequestAndLimit("cpu", "200m").
+				RequestAndLimit("memory", "200Mi").
 				Obj()
 
 			ginkgo.By("Creating the Pod", func() {
@@ -390,8 +390,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 				Queue(localQueue.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
-				Request("cpu", "100m").
-				Request("memory", "100Mi").
+				RequestAndLimit("cpu", "200m").
+				RequestAndLimit("memory", "200Mi").
 				MakeGroup(2)
 
 			ginkgo.By("Creating the Pod group", func() {

--- a/test/e2e/singlecluster/visibility_test.go
+++ b/test/e2e/singlecluster/visibility_test.go
@@ -114,7 +114,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 				blockingJob = testingjob.MakeJob("test-job-1", nsA.Name).
 					Queue(localQueueA.Name).
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-					Request(corev1.ResourceCPU, "1").
+					RequestAndLimit(corev1.ResourceCPU, "1").
 					TerminationGracePeriod(1).
 					BackoffLimit(0).
 					PriorityClass(highPriorityClass.Name).
@@ -154,7 +154,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 				sampleJob2 = testingjob.MakeJob("test-job-2", nsA.Name).
 					Queue(localQueueA.Name).
 					Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
-					Request(corev1.ResourceCPU, "1").
+					RequestAndLimit(corev1.ResourceCPU, "1").
 					PriorityClass(lowPriorityClass.Name).
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, sampleJob2)).Should(gomega.Succeed())
@@ -216,7 +216,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 					job := testingjob.MakeJob(jobCase.JobName, nsA.Name).
 						Queue(jobCase.LocalQueueName).
 						Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
-						Request(corev1.ResourceCPU, "1").
+						RequestAndLimit(corev1.ResourceCPU, "1").
 						PriorityClass(jobCase.JobPrioClassName).
 						Obj()
 					gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
@@ -275,7 +275,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 				sampleJob2 = testingjob.MakeJob("test-job-2", nsA.Name).
 					Queue(localQueueA.Name).
 					Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
-					Request(corev1.ResourceCPU, "1").
+					RequestAndLimit(corev1.ResourceCPU, "1").
 					PriorityClass(lowPriorityClass.Name).
 					Obj()
 				gomega.Expect(k8sClient.Create(ctx, sampleJob2)).Should(gomega.Succeed())
@@ -337,7 +337,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 					job := testingjob.MakeJob(jobCase.JobName, nsA.Name).
 						Queue(jobCase.LocalQueueName).
 						Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
-						Request(corev1.ResourceCPU, "1").
+						RequestAndLimit(corev1.ResourceCPU, "1").
 						PriorityClass(jobCase.JobPrioClassName).
 						Obj()
 					gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
@@ -430,7 +430,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 					job := testingjob.MakeJob(jobCase.JobName, jobCase.nsName).
 						Queue(jobCase.LocalQueueName).
 						Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
-						Request(corev1.ResourceCPU, "1").
+						RequestAndLimit(corev1.ResourceCPU, "1").
 						PriorityClass(jobCase.JobPrioClassName).
 						Obj()
 					gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())

--- a/test/e2e/tas/appwrapper_test.go
+++ b/test/e2e/tas/appwrapper_test.go
@@ -92,10 +92,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 				Component(utiltestingjob.MakeJob("job-0", ns.Name).
 					Parallelism(int32(numPods)).
 					Completions(int32(numPods)).
-					Request(corev1.ResourceCPU, "100m").
-					Limit(corev1.ResourceCPU, "100m").
-					Request(extraResource, "1").
-					Limit(extraResource, "1").
+					RequestAndLimit(corev1.ResourceCPU, "200m").
+					RequestAndLimit(extraResource, "1").
 					Suspend(false).
 					Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 					PodAnnotation(kueuealpha.PodSetPreferredTopologyAnnotation, testing.DefaultRackTopologyLevel).
@@ -138,8 +136,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 				Completions(int32(numPods)).
 				Indexed(true).
 				Suspend(false).
-				Request(extraResource, "1").
-				Limit(extraResource, "1").
+				RequestAndLimit(extraResource, "1").
 				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, testing.DefaultBlockTopologyLevel).
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				SetTypeMeta().

--- a/test/e2e/tas/job_test.go
+++ b/test/e2e/tas/job_test.go
@@ -102,8 +102,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 				Queue(localQueue.Name).
 				Parallelism(3).
 				Completions(3).
-				Request(extraResource, "1").
-				Limit(extraResource, "1").
+				RequestAndLimit(extraResource, "1").
 				Obj()
 			sampleJob = (&testingjob.JobWrapper{Job: *sampleJob}).
 				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, testing.DefaultRackTopologyLevel).
@@ -126,8 +125,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 				Queue(localQueue.Name).
 				Parallelism(3).
 				Completions(3).
-				Request(extraResource, "1").
-				Limit(extraResource, "1").
+				RequestAndLimit(extraResource, "1").
 				Obj()
 			sampleJob = (&testingjob.JobWrapper{Job: *sampleJob}).
 				PodAnnotation(kueuealpha.PodSetPreferredTopologyAnnotation, testing.DefaultRackTopologyLevel).
@@ -179,8 +177,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 				Queue(localQueue.Name).
 				Parallelism(3).
 				Completions(3).
-				Request(extraResource, "1").
-				Limit(extraResource, "1").
+				RequestAndLimit(extraResource, "1").
 				Obj()
 			sampleJob = (&testingjob.JobWrapper{Job: *sampleJob}).
 				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, testing.DefaultBlockTopologyLevel).
@@ -233,8 +230,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 				Queue(localQueue.Name).
 				Parallelism(2).
 				Completions(3).
-				Request(extraResource, "1").
-				Limit(extraResource, "1").
+				RequestAndLimit(extraResource, "1").
 				Obj()
 			sampleJob = (&testingjob.JobWrapper{Job: *sampleJob}).
 				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, testing.DefaultBlockTopologyLevel).
@@ -262,8 +258,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 				Parallelism(int32(numPods)).
 				Completions(int32(numPods)).
 				Indexed(true).
-				Request(extraResource, "1").
-				Limit(extraResource, "1").
+				RequestAndLimit(extraResource, "1").
 				Obj()
 			sampleJob = (&testingjob.JobWrapper{Job: *sampleJob}).
 				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, testing.DefaultBlockTopologyLevel).

--- a/test/e2e/tas/jobset_test.go
+++ b/test/e2e/tas/jobset_test.go
@@ -108,8 +108,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", func() {
 						},
 					},
 				).
-				Request("replicated-job-1", extraResource, "1").
-				Limit("replicated-job-1", extraResource, "1").
+				RequestAndLimit("replicated-job-1", extraResource, "1").
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, sampleJob)).Should(gomega.Succeed())
 

--- a/test/e2e/tas/mpijob_test.go
+++ b/test/e2e/tas/mpijob_test.go
@@ -117,10 +117,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for MPIJob", func() {
 				).
 				Image(kfmpi.MPIReplicaTypeLauncher, util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Image(kfmpi.MPIReplicaTypeWorker, util.E2eTestAgnHostImage, util.BehaviorExitFast).
-				Request(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "100m").
-				Limit(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "100m").
-				Request(kfmpi.MPIReplicaTypeWorker, extraResource, "1").
-				Limit(kfmpi.MPIReplicaTypeWorker, extraResource, "1").
+				RequestAndLimit(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "200m").
+				RequestAndLimit(kfmpi.MPIReplicaTypeWorker, extraResource, "1").
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, mpijob)).Should(gomega.Succeed())
 

--- a/test/e2e/tas/pod_group_test.go
+++ b/test/e2e/tas/pod_group_test.go
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Pod group", func() {
 			numPods := 4
 			basePod := testingpod.MakePod("test-pod", ns.Name).
 				Queue("test-queue").
-				Request(extraResource, "1").
+				RequestAndLimit(extraResource, "1").
 				Limit(extraResource, "1").
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, testing.DefaultBlockTopologyLevel)

--- a/test/e2e/tas/pytorch_test.go
+++ b/test/e2e/tas/pytorch_test.go
@@ -116,10 +116,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for PyTorchJob", func() {
 				).
 				Image(kftraining.PyTorchJobReplicaTypeMaster, util.E2eTestAgnHostImage, util.BehaviorExitFast).
 				Image(kftraining.PyTorchJobReplicaTypeWorker, util.E2eTestAgnHostImage, util.BehaviorExitFast).
-				Request(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "100m").
-				Limit(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "100m").
-				Request(kftraining.PyTorchJobReplicaTypeWorker, extraResource, "1").
-				Limit(kftraining.PyTorchJobReplicaTypeWorker, extraResource, "1").
+				RequestAndLimit(kftraining.PyTorchJobReplicaTypeMaster, corev1.ResourceCPU, "200m").
+				RequestAndLimit(kftraining.PyTorchJobReplicaTypeWorker, extraResource, "1").
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, pytorchjob)).Should(gomega.Succeed())
 

--- a/test/e2e/tas/rayjob_test.go
+++ b/test/e2e/tas/rayjob_test.go
@@ -110,10 +110,10 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, fu
 										Name: "head-container",
 										Resources: corev1.ResourceRequirements{
 											Requests: corev1.ResourceList{
-												corev1.ResourceCPU: resource.MustParse("100m"),
+												corev1.ResourceCPU: resource.MustParse("200m"),
 											},
 											Limits: corev1.ResourceList{
-												corev1.ResourceCPU: resource.MustParse("100m"),
+												corev1.ResourceCPU: resource.MustParse("200m"),
 											},
 										},
 									},

--- a/test/e2e/tas/statefulset_test.go
+++ b/test/e2e/tas/statefulset_test.go
@@ -80,8 +80,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for StatefulSet", func() {
 			const replicas = 3
 			sts := statefulset.MakeStatefulSet("sts", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-				Request(extraResource, "1").
-				Limit(extraResource, "1").
+				RequestAndLimit(extraResource, "1").
 				Replicas(replicas).
 				Queue(localQueue.Name).
 				PodTemplateSpecAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, testing.DefaultBlockTopologyLevel).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
As we discuss [here](https://github.com/kubernetes-sigs/kueue/issues/4520#issuecomment-2724124038) to prevent flakiness we need use RequestAndLimit instead of just Request. And also increase CPU resources from 100m to 200m.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #4520

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```