### PR TITLE
Make HasCycle Stateless

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -148,7 +148,7 @@ func (c *Cache) newClusterQueue(cq *kueue.ClusterQueue) (*clusterQueue, error) {
 	}
 	c.hm.AddClusterQueue(cqImpl)
 	c.hm.UpdateClusterQueueEdge(kueue.ClusterQueueReference(cq.Name), cq.Spec.Cohort)
-	if err := cqImpl.updateClusterQueue(c.hm.CycleChecker, cq, c.resourceFlavors, c.admissionChecks, nil); err != nil {
+	if err := cqImpl.updateClusterQueue(cq, c.resourceFlavors, c.admissionChecks, nil); err != nil {
 		return nil, err
 	}
 
@@ -428,7 +428,7 @@ func (c *Cache) UpdateClusterQueue(cq *kueue.ClusterQueue) error {
 	}
 	oldParent := cqImpl.Parent()
 	c.hm.UpdateClusterQueueEdge(kueue.ClusterQueueReference(cq.Name), cq.Spec.Cohort)
-	if err := cqImpl.updateClusterQueue(c.hm.CycleChecker, cq, c.resourceFlavors, c.admissionChecks, oldParent); err != nil {
+	if err := cqImpl.updateClusterQueue(cq, c.resourceFlavors, c.admissionChecks, oldParent); err != nil {
 		return err
 	}
 	for _, qImpl := range cqImpl.localQueues {
@@ -465,7 +465,7 @@ func (c *Cache) AddOrUpdateCohort(apiCohort *kueuealpha.Cohort) error {
 	cohort := c.hm.Cohort(cohortName)
 	oldParent := cohort.Parent()
 	c.hm.UpdateCohortEdge(cohortName, apiCohort.Spec.Parent)
-	return cohort.updateCohort(c.hm.CycleChecker, apiCohort, oldParent)
+	return cohort.updateCohort(apiCohort, oldParent)
 }
 
 func (c *Cache) DeleteCohort(cohortName kueue.CohortReference) {

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -121,15 +121,15 @@ var defaultPreemption = kueue.ClusterQueuePreemption{
 
 var defaultFlavorFungibility = kueue.FlavorFungibility{WhenCanBorrow: kueue.Borrow, WhenCanPreempt: kueue.TryNextFlavor}
 
-func (c *clusterQueue) updateClusterQueue(cycleChecker hierarchy.CycleChecker, in *kueue.ClusterQueue, resourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor, admissionChecks map[string]AdmissionCheck, oldParent *cohort) error {
+func (c *clusterQueue) updateClusterQueue(in *kueue.ClusterQueue, resourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor, admissionChecks map[string]AdmissionCheck, oldParent *cohort) error {
 	if c.updateQuotasAndResourceGroups(in.Spec.ResourceGroups) || oldParent != c.Parent() {
 		if oldParent != nil && oldParent != c.Parent() {
 			// ignore error when old Cohort has cycle.
-			_ = updateCohortTreeResources(oldParent, cycleChecker)
+			_ = updateCohortTreeResources(oldParent)
 		}
 		if c.HasParent() {
 			// clusterQueue will be updated as part of tree update.
-			if err := updateCohortTreeResources(c.Parent(), cycleChecker); err != nil {
+			if err := updateCohortTreeResources(c.Parent()); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/cache/cohort.go
+++ b/pkg/cache/cohort.go
@@ -42,15 +42,15 @@ func newCohort(name kueue.CohortReference) *cohort {
 	}
 }
 
-func (c *cohort) updateCohort(cycleChecker hierarchy.CycleChecker, apiCohort *kueuealpha.Cohort, oldParent *cohort) error {
+func (c *cohort) updateCohort(apiCohort *kueuealpha.Cohort, oldParent *cohort) error {
 	c.FairWeight = parseFairWeight(apiCohort.Spec.FairSharing)
 
 	c.resourceNode.Quotas = createResourceQuotas(apiCohort.Spec.ResourceGroups)
 	if oldParent != nil && oldParent != c.Parent() {
 		// ignore error when old Cohort has cycle.
-		_ = updateCohortTreeResources(oldParent, cycleChecker)
+		_ = updateCohortTreeResources(oldParent)
 	}
-	return updateCohortTreeResources(c, cycleChecker)
+	return updateCohortTreeResources(c)
 }
 
 func (c *cohort) GetName() kueue.CohortReference {
@@ -76,7 +76,7 @@ func (c *cohort) parentHRN() hierarchicalResourceNode {
 
 // implement hierarchy.CycleCheckable interface
 
-func (c *cohort) CCParent() hierarchy.CycleCheckable[kueue.CohortReference] {
+func (c *cohort) CCParent() hierarchy.CycleCheckable {
 	return c.Parent()
 }
 

--- a/pkg/cache/resource_node.go
+++ b/pkg/cache/resource_node.go
@@ -155,8 +155,8 @@ func updateClusterQueueResourceNode(cq *clusterQueue) {
 // updateCohortTreeResources traverses the Cohort tree from the root
 // to accumulate SubtreeQuota and Usage. It returns an error if the
 // provided Cohort has a cycle.
-func updateCohortTreeResources(cohort *cohort, cycleChecker hierarchy.CycleChecker) error {
-	if cycleChecker.HasCycle(cohort) {
+func updateCohortTreeResources(cohort *cohort) error {
+	if hierarchy.HasCycle(cohort) {
 		return errors.New("cohort has a cycle")
 	}
 	updateCohortResourceNode(cohort.getRootUnsafe())

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -111,7 +111,7 @@ func (c *Cache) Snapshot(ctx context.Context) (*Snapshot, error) {
 		InactiveClusterQueueSets: sets.New[kueue.ClusterQueueReference](),
 	}
 	for _, cohort := range c.hm.Cohorts() {
-		if c.hm.CycleChecker.HasCycle(cohort) {
+		if hierarchy.HasCycle(cohort) {
 			continue
 		}
 		snap.AddCohort(cohort.Name)
@@ -133,7 +133,7 @@ func (c *Cache) Snapshot(ctx context.Context) (*Snapshot, error) {
 		}
 	}
 	for _, cq := range c.hm.ClusterQueues() {
-		if !cq.Active() || (cq.HasParent() && c.hm.CycleChecker.HasCycle(cq.Parent())) {
+		if !cq.Active() || (cq.HasParent() && hierarchy.HasCycle(cq.Parent())) {
 			snap.InactiveClusterQueueSets.Insert(cq.Name)
 			continue
 		}

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -43,7 +43,6 @@ var snapCmpOpts = []cmp.Option{
 	cmpopts.IgnoreUnexported(hierarchy.Cohort[*ClusterQueueSnapshot, *CohortSnapshot]{}),
 	cmpopts.IgnoreUnexported(hierarchy.ClusterQueue[*CohortSnapshot]{}),
 	cmpopts.IgnoreUnexported(hierarchy.Manager[*ClusterQueueSnapshot, *CohortSnapshot]{}),
-	cmpopts.IgnoreUnexported(hierarchy.CycleChecker{}),
 	cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
 }
 

--- a/pkg/queue/cohort.go
+++ b/pkg/queue/cohort.go
@@ -40,7 +40,7 @@ func (c *cohort) GetName() kueue.CohortReference {
 }
 
 // CCParent satisfies the CycleCheckable interface.
-func (c *cohort) CCParent() hierarchy.CycleCheckable[kueue.CohortReference] {
+func (c *cohort) CCParent() hierarchy.CycleCheckable {
 	return c.Parent()
 }
 

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -542,7 +542,7 @@ func (m *Manager) requeueWorkloadsCQ(ctx context.Context, cq *ClusterQueue) bool
 func (m *Manager) requeueWorkloadsCohort(ctx context.Context, cohort *cohort) bool {
 	log := ctrl.LoggerFrom(ctx)
 
-	if m.hm.CycleChecker.HasCycle(cohort) {
+	if hierarchy.HasCycle(cohort) {
 		log.V(2).Info("Attempted to move workloads from Cohort which has cycle", "cohort", cohort.GetName())
 		return false
 	}

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -55,7 +55,6 @@ var snapCmpOpts = []cmp.Option{
 	cmpopts.IgnoreUnexported(hierarchy.Cohort[*cache.ClusterQueueSnapshot, *cache.CohortSnapshot]{}),
 	cmpopts.IgnoreUnexported(hierarchy.ClusterQueue[*cache.CohortSnapshot]{}),
 	cmpopts.IgnoreUnexported(hierarchy.Manager[*cache.ClusterQueueSnapshot, *cache.CohortSnapshot]{}),
-	cmpopts.IgnoreUnexported(hierarchy.CycleChecker{}),
 	cmpopts.IgnoreFields(cache.ClusterQueueSnapshot{}, "AllocatableResourceGeneration"),
 	cmp.Transformer("Cohort.Members", func(s sets.Set[*cache.ClusterQueueSnapshot]) sets.Set[kueue.ClusterQueueReference] {
 		result := make(sets.Set[kueue.ClusterQueueReference], len(s))


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Get rid of memoizing. This isn't a performance critical section, and this is a bug risk.

See https://github.com/kubernetes-sigs/kueue/pull/4561#discussion_r1995727103, where stress testing uncovered (probably harmless) memory race

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```