### PR TITLE
Fix priority-based preemption for target on the 2nd flavor

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -1058,7 +1058,7 @@ func TestAssignFlavors(t *testing.T) {
 					{
 						Name: "launcher",
 						Flavors: ResourceAssignment{
-							corev1.ResourceCPU: {Name: "one", Mode: Preempt, TriedFlavorIdx: -1},
+							corev1.ResourceCPU: {Name: "one", Mode: Preempt, TriedFlavorIdx: 0},
 						},
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("2"),
@@ -1344,8 +1344,8 @@ func TestAssignFlavors(t *testing.T) {
 				PodSets: []PodSetAssignment{{
 					Name: kueue.DefaultPodSetName,
 					Flavors: ResourceAssignment{
-						corev1.ResourceCPU:  {Name: "one", Mode: Fit, TriedFlavorIdx: -1},
-						corev1.ResourcePods: {Name: "one", Mode: Fit, TriedFlavorIdx: -1},
+						corev1.ResourceCPU:  {Name: "one", Mode: Fit, TriedFlavorIdx: 0},
+						corev1.ResourcePods: {Name: "one", Mode: Fit, TriedFlavorIdx: 0},
 					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:  resource.MustParse("9"),
@@ -1759,8 +1759,8 @@ func TestAssignFlavors(t *testing.T) {
 				PodSets: []PodSetAssignment{{
 					Name: kueue.DefaultPodSetName,
 					Flavors: ResourceAssignment{
-						corev1.ResourceCPU:  {Name: "one", Mode: Fit, TriedFlavorIdx: -1},
-						corev1.ResourcePods: {Name: "one", Mode: Fit, TriedFlavorIdx: -1},
+						corev1.ResourceCPU:  {Name: "one", Mode: Fit, TriedFlavorIdx: 0},
+						corev1.ResourcePods: {Name: "one", Mode: Fit, TriedFlavorIdx: 0},
 					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:  resource.MustParse("9"),

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1048,7 +1048,7 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/new-alpha": *utiltesting.MakeAdmission("eng-alpha", "one").Assignment(corev1.ResourceCPU, "on-demand", "1").AssignmentPodCount(1).Obj(),
 			},
 			wantScheduled: []string{"eng-beta/new", "eng-alpha/new-alpha"},
-			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]string{
+			wantLeft: map[kueue.ClusterQueueReference][]string{
 				"eng-gamma": {"eng-gamma/new-gamma"},
 			},
 			wantSkippedPreemptions: map[string]int{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Priority-based preemption doesn't work when there are 2+ ResourceFlavors, and the preempting target is on the 2nd flavor.

Considering the following simple ClusterQueue:
```
spec:
  preemption:
    withinClusterQueue: LowerPriority  # <== enable priority-based preemption
  namespaceSelector: {}
  resourceGroups:
  - coveredResources: ["cpu"]
    flavors:
    - name: rf1
      resources:
      - name: cpu
        nominalQuota: 1
    - name: rf2
      resources:
      - name: cpu
        nominalQuota: 1
```

Firstly let's submit two workloads (each requesting 1 cpu) one by one to this queue: 1) `wl-high` with high priority first. It will be assigned to `rf1`. 2) then `wl-low` with low priority will be assigned to `rf2`.

Now let's submit the third workload `wl-medium` with medium priority. It is expected that it can preempt `wl-low` and be assigned to `rf2`. But it doesn't happen.


#### Which issue(s) this PR fixes:
Fixes #4597

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix priority-based preemption failure when there are 2+ ResourceFlavors and the preempting target is on the 2nd flavor.
```