### PR TITLE
Add ResourceFlavor specificatios for coupling of nodeTaints and tolerations to documentation

### DIFF
--- a/apis/kueue/v1beta1/resourceflavor_types.go
+++ b/apis/kueue/v1beta1/resourceflavor_types.go
@@ -63,6 +63,8 @@ type ResourceFlavorSpec struct {
 	// have.
 	// Workloads' podsets must have tolerations for these nodeTaints in order to
 	// get assigned this ResourceFlavor during admission.
+	// When this ResourceFlavor has also set the matching tolerations (in .spec.tolerations),
+	// then the nodeTaints are not considered during admission.
 	// Only the 'NoSchedule' and 'NoExecute' taint effects are evaluated,
 	// while 'PreferNoSchedule' is ignored.
 	//

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
@@ -81,6 +81,8 @@ spec:
                   have.
                   Workloads' podsets must have tolerations for these nodeTaints in order to
                   get assigned this ResourceFlavor during admission.
+                  When this ResourceFlavor has also set the matching tolerations (in .spec.tolerations),
+                  then the nodeTaints are not considered during admission.
                   Only the 'NoSchedule' and 'NoExecute' taint effects are evaluated,
                   while 'PreferNoSchedule' is ignored.
 

--- a/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
@@ -66,6 +66,8 @@ spec:
                   have.
                   Workloads' podsets must have tolerations for these nodeTaints in order to
                   get assigned this ResourceFlavor during admission.
+                  When this ResourceFlavor has also set the matching tolerations (in .spec.tolerations),
+                  then the nodeTaints are not considered during admission.
                   Only the 'NoSchedule' and 'NoExecute' taint effects are evaluated,
                   while 'PreferNoSchedule' is ignored.
 

--- a/site/content/en/docs/concepts/resource_flavor.md
+++ b/site/content/en/docs/concepts/resource_flavor.md
@@ -69,6 +69,8 @@ Taints on the ResourceFlavor work similarly to [Node taints](https://kubernetes.
 but only support the `NoExecute` and `NoSchedule` effects, while `PreferNoSchedule` is ignored.
 
 For Kueue to [admit](/docs/concepts#admission) a Workload to use the ResourceFlavor, the PodSpecs in the Workload should have a toleration for it.
+On the other hand, when the ResourceFlavor has also set the matching tolerations in `.spec.tolerations`, 
+then the taints are not considered during [admission](/docs/concepts#admission).
 As opposed to the behavior for [ResourceFlavor tolerations for automatic scheduling](#ResourceFlavor-tolerations-for-automatic-scheduling), Kueue does not add tolerations for the flavor taints.
 
 A sample ResourceFlavor looks like the following:

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -2231,6 +2231,8 @@ controller that integrates with the Workload object.</p>
 have.
 Workloads' podsets must have tolerations for these nodeTaints in order to
 get assigned this ResourceFlavor during admission.
+When this ResourceFlavor has also set the matching tolerations (in .spec.tolerations),
+then the nodeTaints are not considered during admission.
 Only the 'NoSchedule' and 'NoExecute' taint effects are evaluated,
 while 'PreferNoSchedule' is ignored.</p>
 <p>An example of a nodeTaint is


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

As we discussed in https://github.com/kubernetes-sigs/kueue/issues/4646, we want to mention what happens if nodeTains and tolerations are specified in the same ResourceFlavor.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/4646

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```