### PR TITLE
Adjust setting the appVersion for charts in makefile script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ prepare-release-branch: yq kustomize ## Prepare the release branch with the rele
 	$(SED) -r 's/v[0-9]+\.[0-9]+\.[0-9]+/$(RELEASE_VERSION)/g' -i README.md -i site/hugo.toml
 	$(SED) -r 's/chart_version = "[0-9]+\.[0-9]+\.[0-9]+/chart_version = "$(CHART_VERSION)/g' -i site/hugo.toml
 	$(SED) -r 's/--version="v?[0-9]+\.[0-9]+\.[0-9]+/--version="$(CHART_VERSION)/g' -i charts/kueue/README.md
-	$(YQ) e '.appVersion = "$(CHART_VERSION)"' -i charts/kueue/Chart.yaml
+	$(YQ) e '.appVersion = "$(RELEASE_VERSION)"' -i charts/kueue/Chart.yaml
 	@$(call clean-manifests)
 
 .PHONY: update-security-insights

--- a/charts/kueue/Chart.yaml
+++ b/charts/kueue/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.11.0"
+appVersion: "v0.11.0"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

This is just a cleanup without user-facing implications, because the charts published actually have the leading "v":

```
> helm list -nkueue-system       
NAME 	NAMESPACE   	REVISION	UPDATED                                	STATUS  	CHART        	APP VERSION
kueue	kueue-system	1       	2025-03-20 14:04:01.522860323 +0100 CET	deployed	kueue-v0.11.0	v0.11.0 
```
This is because the value is actually overwritten in `hack/push-chart.sh`

I will also cherry-pick to 0.10.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```