### PR TITLE
Use testing.TB.Context() instead of context.Background()

### DIFF
--- a/cmd/importer/pod/check_test.go
+++ b/cmd/importer/pod/check_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pod
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -156,7 +155,7 @@ func TestCheckNamespace(t *testing.T) {
 			builder = builder.WithLists(&podsList, &cqList, &lqList, &rfList)
 
 			client := builder.Build()
-			ctx := context.Background()
+			ctx := t.Context()
 
 			mpc, _ := util.LoadImportCache(ctx, client, []string{testingNamespace}, tc.mapping, nil)
 			gotErr := Check(ctx, client, mpc, 8)

--- a/cmd/importer/pod/import_test.go
+++ b/cmd/importer/pod/import_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pod
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -178,7 +177,7 @@ func TestImportNamespace(t *testing.T) {
 				WithLists(&podsList, &cqList, &lqList)
 
 			client := builder.Build()
-			ctx := context.Background()
+			ctx := t.Context()
 
 			mpc, _ := util.LoadImportCache(ctx, client, []string{testingNamespace}, tc.mapping, tc.addLabels)
 			gotErr := Import(ctx, client, mpc, 8)

--- a/cmd/kueuectl/app/create/create_resourceflavor_test.go
+++ b/cmd/kueuectl/app/create/create_resourceflavor_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package create
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -358,7 +357,7 @@ func TestResourceFlavorCmd(t *testing.T) {
 				t.Errorf("Unexpected output (-want/+got)\n%s", diff)
 			}
 
-			gotRf, err := clientset.KueueV1beta1().ResourceFlavors().Get(context.Background(), tc.rfName, metav1.GetOptions{})
+			gotRf, err := clientset.KueueV1beta1().ResourceFlavors().Get(t.Context(), tc.rfName, metav1.GetOptions{})
 			if client.IgnoreNotFound(err) != nil {
 				t.Error(err)
 				return

--- a/cmd/kueuectl/app/delete/delete_workload_test.go
+++ b/cmd/kueuectl/app/delete/delete_workload_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package delete
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -353,7 +352,7 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 				t.Errorf("Unexpected error output (-want/+got)\n%s", diff)
 			}
 
-			gotWorkloadList, err := clientset.KueueV1beta1().Workloads(tc.ns).List(context.Background(), metav1.ListOptions{})
+			gotWorkloadList, err := clientset.KueueV1beta1().Workloads(tc.ns).List(t.Context(), metav1.ListOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -366,7 +365,7 @@ Do you want to proceed (y/n)? jobs.batch/j1 deleted
 			}
 
 			unstructured, err := dynamicClient.Resource(mapping.Resource).Namespace(metav1.NamespaceDefault).
-				List(context.Background(), metav1.ListOptions{})
+				List(t.Context(), metav1.ListOptions{})
 			if err != nil {
 				t.Error(err)
 				return

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -88,7 +88,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				NodeLabel("cpuType", "default").
 				Obj())
 		for _, c := range initialClusterQueues {
-			if err := cache.AddClusterQueue(context.Background(), &c); err != nil {
+			if err := cache.AddClusterQueue(t.Context(), &c); err != nil {
 				return fmt.Errorf("failed adding ClusterQueue: %w", err)
 			}
 		}
@@ -178,7 +178,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
 				}).Obj()
-				if err := cache.AddClusterQueue(context.Background(), cq); err != nil {
+				if err := cache.AddClusterQueue(t.Context(), cq); err != nil {
 					return fmt.Errorf("failed to add ClusterQueue: %w", err)
 				}
 				return nil
@@ -202,7 +202,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			name: "add ClusterQueue with fair sharing weight",
 			operation: func(cache *Cache) error {
 				cq := utiltesting.MakeClusterQueue("foo").FairWeight(resource.MustParse("2")).Obj()
-				if err := cache.AddClusterQueue(context.Background(), cq); err != nil {
+				if err := cache.AddClusterQueue(t.Context(), cq); err != nil {
 					return fmt.Errorf("failed to add ClusterQueue: %w", err)
 				}
 				return nil
@@ -223,7 +223,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			name: "add flavors after queue capacities",
 			operation: func(cache *Cache) error {
 				for _, c := range initialClusterQueues {
-					if err := cache.AddClusterQueue(context.Background(), &c); err != nil {
+					if err := cache.AddClusterQueue(t.Context(), &c); err != nil {
 						return fmt.Errorf("failed adding ClusterQueue: %w", err)
 					}
 				}
@@ -414,7 +414,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector(nil).
 					Obj()
 
-				if err := cache.AddClusterQueue(context.Background(), cq); err != nil {
+				if err := cache.AddClusterQueue(t.Context(), cq); err != nil {
 					return fmt.Errorf("failed adding ClusterQueue: %w", err)
 				}
 
@@ -680,7 +680,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		{
 			name: "Add ClusterQueue with multiple resource groups",
 			operation: func(cache *Cache) error {
-				err := cache.AddClusterQueue(context.Background(),
+				err := cache.AddClusterQueue(t.Context(),
 					utiltesting.MakeClusterQueue("foo").
 						ResourceGroup(
 							*utiltesting.MakeFlavorQuotas("foo").
@@ -717,7 +717,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		{
 			name: "add cluster queue with missing check",
 			operation: func(cache *Cache) error {
-				err := cache.AddClusterQueue(context.Background(),
+				err := cache.AddClusterQueue(t.Context(),
 					utiltesting.MakeClusterQueue("foo").
 						AdmissionChecks("check1", "check2").
 						Obj())
@@ -746,7 +746,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		{
 			name: "add check after queue creation",
 			operation: func(cache *Cache) error {
-				err := cache.AddClusterQueue(context.Background(),
+				err := cache.AddClusterQueue(t.Context(),
 					utiltesting.MakeClusterQueue("foo").
 						AdmissionChecks("check1", "check2").
 						Obj())
@@ -780,7 +780,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			operation: func(cache *Cache) error {
 				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check1").Active(metav1.ConditionTrue).Obj())
 				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionTrue).Obj())
-				err := cache.AddClusterQueue(context.Background(),
+				err := cache.AddClusterQueue(t.Context(),
 					utiltesting.MakeClusterQueue("foo").
 						AdmissionChecks("check1", "check2").
 						Obj())
@@ -813,7 +813,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			operation: func(cache *Cache) error {
 				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check1").Active(metav1.ConditionTrue).Obj())
 				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionTrue).Obj())
-				err := cache.AddClusterQueue(context.Background(),
+				err := cache.AddClusterQueue(t.Context(),
 					utiltesting.MakeClusterQueue("foo").
 						AdmissionChecks("check1", "check2").
 						Obj())
@@ -858,7 +858,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			},
 			operation: func(cache *Cache) error {
 				cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("f1").Obj())
-				err := cache.AddClusterQueue(context.Background(),
+				err := cache.AddClusterQueue(t.Context(),
 					utiltesting.MakeClusterQueue("cq1").
 						ResourceGroup(kueue.FlavorQuotas{
 							Name: "f1",
@@ -973,7 +973,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 						},
 					).
 					Obj()
-				return cache.AddClusterQueue(context.Background(), cq)
+				return cache.AddClusterQueue(t.Context(), cq)
 			},
 			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"foo": {
@@ -1037,7 +1037,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 						},
 					).
 					Obj()
-				return cache.AddClusterQueue(context.Background(), cq)
+				return cache.AddClusterQueue(t.Context(), cq)
 			},
 			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"foo": {
@@ -1077,7 +1077,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				cohort := utiltesting.MakeCohort("cohort").Obj()
 				_ = cache.AddOrUpdateCohort(cohort)
 
-				_ = cache.AddClusterQueue(context.Background(),
+				_ = cache.AddClusterQueue(t.Context(),
 					utiltesting.MakeClusterQueue("cq").Cohort("cohort").Obj())
 				cache.DeleteCohort(kueue.CohortReference(cohort.Name))
 				return nil
@@ -1673,7 +1673,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			cache := New(cl)
 
 			for _, c := range clusterQueues {
-				if err := cache.AddClusterQueue(context.Background(), &c); err != nil {
+				if err := cache.AddClusterQueue(t.Context(), &c); err != nil {
 					t.Fatalf("Failed adding clusterQueue: %v", err)
 				}
 			}
@@ -2030,7 +2030,7 @@ func TestClusterQueueUsage(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			cache := New(utiltesting.NewFakeClient())
-			ctx := context.Background()
+			ctx := t.Context()
 			err := cache.AddClusterQueue(ctx, tc.clusterQueue)
 			if err != nil {
 				t.Fatalf("Adding ClusterQueue: %v", err)
@@ -2261,7 +2261,7 @@ func TestLocalQueueUsage(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			cache := New(utiltesting.NewFakeClient())
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.cq != nil {
 				if err := cache.AddClusterQueue(ctx, tc.cq); err != nil {
 					t.Fatalf("Adding ClusterQueue: %v", err)
@@ -2720,7 +2720,7 @@ func TestCacheQueueOperations(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cl := utiltesting.NewFakeClient()
 			cache := New(cl)
-			ctx := context.Background()
+			ctx := t.Context()
 			for i, op := range tc.ops {
 				if err := op(ctx, cl, cache); err != nil {
 					t.Fatalf("Running op %d: %v", i, err)
@@ -2795,7 +2795,7 @@ func TestClusterQueuesUsingFlavor(t *testing.T) {
 			cache.AddOrUpdateResourceFlavor(aarch64Rf)
 
 			for _, cq := range tc.clusterQueues {
-				if err := cache.AddClusterQueue(context.Background(), cq); err != nil {
+				if err := cache.AddClusterQueue(t.Context(), cq); err != nil {
 					t.Errorf("failed to add clusterQueue %s", cq.Name)
 				}
 			}
@@ -2831,7 +2831,7 @@ func TestMatchingClusterQueues(t *testing.T) {
 
 	cache := New(utiltesting.NewFakeClient())
 	for _, cq := range clusterQueues {
-		if err := cache.AddClusterQueue(context.Background(), cq); err != nil {
+		if err := cache.AddClusterQueue(t.Context(), cq); err != nil {
 			t.Errorf("failed to add clusterQueue %s", cq.Name)
 		}
 	}
@@ -2845,7 +2845,7 @@ func TestMatchingClusterQueues(t *testing.T) {
 // TestWaitForPodsReadyCancelled ensures that the WaitForPodsReady call does not block when the context is closed.
 func TestWaitForPodsReadyCancelled(t *testing.T) {
 	cache := New(utiltesting.NewFakeClient(), WithPodsReadyTracking(true))
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	log := ctrl.LoggerFrom(ctx)
 
@@ -3103,7 +3103,7 @@ func TestCachePodsReadyForAllAdmittedWorkloads(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cache := New(cl, WithPodsReadyTracking(true))
-			ctx := context.Background()
+			ctx := t.Context()
 			log := ctrl.LoggerFrom(ctx)
 
 			for _, c := range clusterQueues {
@@ -3316,7 +3316,7 @@ func TestClusterQueuesUsingAdmissionChecks(t *testing.T) {
 			}
 
 			for _, cq := range tc.clusterQueues {
-				if err := cache.AddClusterQueue(context.Background(), cq); err != nil {
+				if err := cache.AddClusterQueue(t.Context(), cq); err != nil {
 					t.Errorf("failed to add clusterQueue %s", cq.Name)
 				}
 			}
@@ -3431,7 +3431,7 @@ func TestClusterQueueReadiness(t *testing.T) {
 				cache.AddOrUpdateAdmissionCheck(ac)
 			}
 			for _, cq := range tc.clusterQueues {
-				if err := cache.AddClusterQueue(context.Background(), cq); err != nil {
+				if err := cache.AddClusterQueue(t.Context(), cq); err != nil {
 					t.Errorf("failed to add clusterQueue %q: %v", cq.Name, err)
 				}
 			}
@@ -3488,7 +3488,7 @@ func TestCohortCycles(t *testing.T) {
 	})
 	t.Run("clusterqueue add and update return error when cohort has cycle", func(t *testing.T) {
 		cache := New(utiltesting.NewFakeClient())
-		ctx := context.Background()
+		ctx := t.Context()
 		cohortA := utiltesting.MakeCohort("cohort-a").Parent("cohort-b").Obj()
 		if err := cache.AddOrUpdateCohort(cohortA); err != nil {
 			t.Fatal("Expected success as no cycle yet")
@@ -3526,7 +3526,7 @@ func TestCohortCycles(t *testing.T) {
 
 	t.Run("clusterqueue leaving cohort with cycle successfully updates new cohort", func(t *testing.T) {
 		cache := New(utiltesting.NewFakeClient())
-		ctx := context.Background()
+		ctx := t.Context()
 		cycleCohort := utiltesting.MakeCohort("cycle").Parent("cycle").Obj()
 		if err := cache.AddOrUpdateCohort(cycleCohort); err == nil {
 			t.Fatal("Expected failure")
@@ -3570,7 +3570,7 @@ func TestCohortCycles(t *testing.T) {
 
 	t.Run("clusterqueue joining cohort with cycle successfully updates old cohort", func(t *testing.T) {
 		cache := New(utiltesting.NewFakeClient())
-		ctx := context.Background()
+		ctx := t.Context()
 		cycleCohort := utiltesting.MakeCohort("cycle").Parent("cycle").Obj()
 		if err := cache.AddOrUpdateCohort(cycleCohort); err == nil {
 			t.Fatal("Expected failure")

--- a/pkg/cache/resource_node_test.go
+++ b/pkg/cache/resource_node_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cache
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -46,10 +45,10 @@ func TestCohortLendable(t *testing.T) {
 		).Cohort("test-cohort").
 		ClusterQueue
 
-	if err := cache.AddClusterQueue(context.Background(), &cq1); err != nil {
+	if err := cache.AddClusterQueue(t.Context(), &cq1); err != nil {
 		t.Fatal("Failed to add CQ to cache", err)
 	}
-	if err := cache.AddClusterQueue(context.Background(), &cq2); err != nil {
+	if err := cache.AddClusterQueue(t.Context(), &cq2); err != nil {
 		t.Fatal("Failed to add CQ to cache", err)
 	}
 

--- a/pkg/cache/resource_test.go
+++ b/pkg/cache/resource_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cache
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -362,7 +361,7 @@ func TestAvailable(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			cache := New(utiltesting.NewFakeClient())
 			cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("red").Obj())
 			cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("blue").Obj())

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cache
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -988,7 +987,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 			Obj(),
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cl := utiltesting.NewClientBuilder().WithLists(&kueue.WorkloadList{Items: workloads}).Build()
 
 	cqCache := New(cl)
@@ -1282,7 +1281,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			Obj(),
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cl := utiltesting.NewClientBuilder().WithLists(&kueue.WorkloadList{Items: workloads}).Build()
 
 	cqCache := New(cl)

--- a/pkg/controller/admissionchecks/multikueue/admissioncheck_test.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck_test.go
@@ -280,7 +280,7 @@ func TestReconcile(t *testing.T) {
 			if tc.acValidationRulesEnabled {
 				features.SetFeatureGateDuringTest(t, features.AdmissionCheckValidationRules, true)
 			}
-			builder, ctx := getClientBuilder()
+			builder := getClientBuilder(t.Context())
 
 			builder = builder.WithLists(
 				&kueue.AdmissionCheckList{Items: tc.checks},
@@ -297,13 +297,13 @@ func TestReconcile(t *testing.T) {
 			helper, _ := newMultiKueueStoreHelper(c)
 			reconciler := newACReconciler(c, helper)
 
-			_, gotErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.reconcileFor}})
+			_, gotErr := reconciler.Reconcile(t.Context(), reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.reconcileFor}})
 			if diff := cmp.Diff(tc.wantError, gotErr); diff != "" {
 				t.Errorf("unexpected error (-want/+got):\n%s", diff)
 			}
 
 			checks := &kueue.AdmissionCheckList{}
-			listErr := c.List(ctx, checks)
+			listErr := c.List(t.Context(), checks)
 
 			if listErr != nil {
 				t.Errorf("unexpected list checks error: %s", listErr)

--- a/pkg/controller/admissionchecks/multikueue/fswatch_test.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch_test.go
@@ -143,7 +143,7 @@ func TestFSWatch(t *testing.T) {
 					t.Fatalf("unexpected prepare error: %s", err)
 				}
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
 			watcher := newKubeConfigFSWatcher()
 
 			// start the recorder
@@ -193,7 +193,7 @@ func TestFSWatch(t *testing.T) {
 }
 
 func TestFSWatchAddRm(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	basePath := t.TempDir()
 	f1Path := filepath.Join(basePath, "file.one")

--- a/pkg/controller/admissionchecks/provisioning/admissioncheck_reconciler_test.go
+++ b/pkg/controller/admissionchecks/provisioning/admissioncheck_reconciler_test.go
@@ -114,7 +114,7 @@ func TestReconcileAdmissionCheck(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			builder, ctx := getClientBuilder()
+			builder, ctx := getClientBuilder(t.Context())
 
 			builder = builder.WithObjects(tc.check)
 			builder = builder.WithStatusSubresource(tc.check)

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -1256,7 +1256,7 @@ func TestReconcile(t *testing.T) {
 				interceptorFuncs.Create = tc.interceptorFuncsCreate
 			}
 
-			builder, ctx := getClientBuilder()
+			builder, ctx := getClientBuilder(t.Context())
 			builder = builder.WithInterceptorFuncs(interceptorFuncs)
 			builder = builder.WithObjects(tc.workload)
 			builder = builder.WithStatusSubresource(tc.workload)
@@ -1441,7 +1441,7 @@ func TestActiveOrLastPRForChecks(t *testing.T) {
 				baseCheck.Name: baseConfig.DeepCopy(),
 			}
 
-			builder, ctx := getClientBuilder()
+			builder, ctx := getClientBuilder(t.Context())
 
 			builder = builder.WithObjects(workload)
 			builder = builder.WithStatusSubresource(workload)

--- a/pkg/controller/admissionchecks/provisioning/indexer_test.go
+++ b/pkg/controller/admissionchecks/provisioning/indexer_test.go
@@ -39,13 +39,12 @@ const (
 	TestNamespace = "ns"
 )
 
-func getClientBuilder() (*fake.ClientBuilder, context.Context) {
+func getClientBuilder(ctx context.Context) (*fake.ClientBuilder, context.Context) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(kueue.AddToScheme(scheme))
 	utilruntime.Must(autoscaling.AddToScheme(scheme))
 
-	ctx := context.Background()
 	builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(utiltesting.MakeNamespace(TestNamespace))
 	_ = SetupIndexer(ctx, utiltesting.AsIndexer(builder))
 	return builder, ctx
@@ -132,7 +131,7 @@ func TestIndexProvisioningRequests(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			builder, ctx := getClientBuilder()
+			builder, ctx := getClientBuilder(t.Context())
 			k8sclient := builder.Build()
 			for _, req := range tc.requests {
 				if err := k8sclient.Create(ctx, req); err != nil {
@@ -242,7 +241,7 @@ func TestIndexWorkload(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			builder, ctx := getClientBuilder()
+			builder, ctx := getClientBuilder(t.Context())
 			k8sclient := builder.Build()
 			for _, wl := range tc.workloads {
 				if err := k8sclient.Create(ctx, wl); err != nil {
@@ -338,7 +337,7 @@ func TestIndexAdmissionChecks(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			builder, ctx := getClientBuilder()
+			builder, ctx := getClientBuilder(t.Context())
 			k8sclient := builder.Build()
 			for _, req := range tc.checks {
 				if err := k8sclient.Create(ctx, req); err != nil {

--- a/pkg/controller/core/clusterqueue_controller_test.go
+++ b/pkg/controller/core/clusterqueue_controller_test.go
@@ -568,7 +568,7 @@ func TestClusterQueuePendingWorkloadsStatus(t *testing.T) {
 				QueueingStrategy(kueue.StrictFIFO).Obj()
 			lq := utiltesting.MakeLocalQueue(lqName, "").
 				ClusterQueue(cqName).Obj()
-			ctx := context.Background()
+			ctx := t.Context()
 
 			cl := utiltesting.NewClientBuilder().WithLists(defaultWls).WithObjects(lq, cq).WithStatusSubresource(lq, cq).
 				Build()

--- a/pkg/controller/core/cohort_controller_test.go
+++ b/pkg/controller/core/cohort_controller_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestCohortReconcileCohortNotFoundDelete(t *testing.T) {
 	cl := utiltesting.NewClientBuilder().Build()
-	ctx := context.Background()
+	ctx := t.Context()
 	cache := cache.New(cl)
 	qManager := queue.NewManager(cl, cache)
 	reconciler := NewCohortReconciler(cl, cache, qManager)
@@ -71,7 +71,7 @@ func TestCohortReconcileCohortNotFoundDelete(t *testing.T) {
 func TestCohortReconcileCohortNotFoundIdempotentDelete(t *testing.T) {
 	cl := utiltesting.NewClientBuilder().
 		Build()
-	ctx := context.Background()
+	ctx := t.Context()
 	cache := cache.New(cl)
 	qManager := queue.NewManager(cl, cache)
 	reconciler := NewCohortReconciler(cl, cache, qManager)
@@ -108,7 +108,7 @@ func TestCohortReconcileCycleNoError(t *testing.T) {
 		WithObjects(cohortA, cohortB).
 		WithStatusSubresource(&kueue.Cohort{}).
 		Build()
-	ctx := context.Background()
+	ctx := t.Context()
 	cache := cache.New(cl)
 	qManager := queue.NewManager(cl, cache)
 	reconciler := NewCohortReconciler(cl, cache, qManager)
@@ -146,7 +146,7 @@ func TestCohortReconcileCycleNoError(t *testing.T) {
 }
 
 func TestCohortReconcileErrorOtherThanNotFoundNotDeleted(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	funcs := interceptor.Funcs{
 		Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			return errors.New("error")
@@ -185,7 +185,7 @@ func TestCohortReconcileErrorOtherThanNotFoundNotDeleted(t *testing.T) {
 }
 
 func TestCohortReconcileLifecycle(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	cohort := utiltesting.MakeCohort("cohort").ResourceGroup(
 		utiltesting.MakeFlavorQuotas("red").Resource("cpu", "10").FlavorQuotas,
 	).Obj()

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package jobframework_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -289,7 +288,7 @@ func TestBaseWebhookDefault(t *testing.T) {
 				Queues:                     queueManager,
 				Cache:                      cqCache,
 			}
-			if err := w.Default(context.Background(), tc.job); err != nil {
+			if err := w.Default(t.Context(), tc.job); err != nil {
 				t.Errorf("set defaults by base webhook")
 			}
 			if diff := cmp.Diff(tc.want, tc.job); len(diff) != 0 {
@@ -350,7 +349,7 @@ func TestValidateOnCreate(t *testing.T) {
 			w := &jobframework.BaseWebhook{
 				FromObject: makeTestGenericJob().withValidateOnCreate(tc.validateOnCreate).fromObject,
 			}
-			gotWarn, gotErr := w.ValidateCreate(context.Background(), tc.job)
+			gotWarn, gotErr := w.ValidateCreate(t.Context(), tc.job)
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("validate create err mismatch (-want +got):\n%s", diff)
 			}
@@ -427,7 +426,7 @@ func TestValidateOnUpdate(t *testing.T) {
 			w := &jobframework.BaseWebhook{
 				FromObject: makeTestGenericJob().withValidateOnUpdate(tc.validateOnUpdate).fromObject,
 			}
-			gotWarn, gotErr := w.ValidateUpdate(context.Background(), tc.oldJob, tc.job)
+			gotWarn, gotErr := w.ValidateUpdate(t.Context(), tc.oldJob, tc.job)
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("validate create err mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/controller/jobframework/setup_test.go
+++ b/pkg/controller/jobframework/setup_test.go
@@ -259,7 +259,7 @@ func TestSetupIndexes(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			builder := utiltesting.NewClientBuilder().WithObjects(utiltesting.MakeNamespace(testNamespace))

--- a/pkg/controller/jobframework/webhook/defaulter_test.go
+++ b/pkg/controller/jobframework/webhook/defaulter_test.go
@@ -82,7 +82,7 @@ func TestLossLessDefaulter(t *testing.T) {
 			},
 		},
 	}
-	resp := handler.Handle(context.Background(), req)
+	resp := handler.Handle(t.Context(), req)
 	if !resp.Allowed {
 		t.Errorf("Response not allowed")
 	}

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package jobset
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -105,7 +104,7 @@ func TestValidateCreate(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			jsw := &JobSetWebhook{}
-			_, gotErr := jsw.ValidateCreate(context.Background(), tc.job)
+			_, gotErr := jsw.ValidateCreate(t.Context(), tc.job)
 
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("validateCreate() mismatch (-want +got):\n%s", diff)

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package leaderworkerset
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -660,7 +659,7 @@ func TestValidateUpdate(t *testing.T) {
 				jobframework.EnableIntegrationsForTest(t, integration)
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			wh := &Webhook{}
 

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package mpijob
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -123,7 +122,7 @@ func TestValidateCreate(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			jsw := &MpiJobWebhook{}
-			_, gotErr := jsw.ValidateCreate(context.Background(), tc.job)
+			_, gotErr := jsw.ValidateCreate(t.Context(), tc.job)
 
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("validateCreate() mismatch (-want +got):\n%s", diff)

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package raycluster
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -125,7 +124,7 @@ func TestValidateDefault(t *testing.T) {
 				cache:                      cqCache,
 			}
 			result := tc.oldJob.DeepCopy()
-			if err := wh.Default(context.Background(), result); err != nil {
+			if err := wh.Default(t.Context(), result); err != nil {
 				t.Errorf("unexpected Default() error: %s", err)
 			}
 			if diff := cmp.Diff(tc.newJob, result); diff != "" {
@@ -257,7 +256,7 @@ func TestValidateCreate(t *testing.T) {
 			wh := &RayClusterWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
 			}
-			_, result := wh.ValidateCreate(context.Background(), tc.job)
+			_, result := wh.ValidateCreate(t.Context(), tc.job)
 			if diff := cmp.Diff(tc.wantErr, result); diff != "" {
 				t.Errorf("ValidateCreate() mismatch (-want +got):\n%s", diff)
 			}
@@ -323,7 +322,7 @@ func TestValidateUpdate(t *testing.T) {
 			wh := &RayClusterWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
 			}
-			_, result := wh.ValidateUpdate(context.Background(), tc.oldJob, tc.newJob)
+			_, result := wh.ValidateUpdate(t.Context(), tc.oldJob, tc.newJob)
 			if diff := cmp.Diff(tc.wantErr, result); diff != "" {
 				t.Errorf("ValidateUpdate() mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package rayjob
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -124,7 +123,7 @@ func TestValidateDefault(t *testing.T) {
 				cache:                      cqCache,
 			}
 			result := tc.oldJob.DeepCopy()
-			if err := wh.Default(context.Background(), result); err != nil {
+			if err := wh.Default(t.Context(), result); err != nil {
 				t.Errorf("unexpected Default() error: %s", err)
 			}
 			if diff := cmp.Diff(tc.newJob, result); diff != "" {
@@ -284,7 +283,7 @@ func TestValidateCreate(t *testing.T) {
 			wh := &RayJobWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
 			}
-			_, result := wh.ValidateCreate(context.Background(), tc.job)
+			_, result := wh.ValidateCreate(t.Context(), tc.job)
 			if diff := cmp.Diff(tc.wantErr, result); diff != "" {
 				t.Errorf("ValidateCreate() mismatch (-want +got):\n%s", diff)
 			}
@@ -381,7 +380,7 @@ func TestValidateUpdate(t *testing.T) {
 			wh := &RayJobWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
 			}
-			_, result := wh.ValidateUpdate(context.Background(), tc.oldJob, tc.newJob)
+			_, result := wh.ValidateUpdate(t.Context(), tc.oldJob, tc.newJob)
 			if diff := cmp.Diff(tc.wantErr, result); diff != "" {
 				t.Errorf("ValidateUpdate() mismatch (-want +got):\n%s", diff)
 			}

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package statefulset
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -611,7 +610,7 @@ func TestValidateUpdate(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.integrations...))
-			ctx := context.Background()
+			ctx := t.Context()
 
 			wh := &Webhook{}
 

--- a/pkg/queue/cluster_queue_test.go
+++ b/pkg/queue/cluster_queue_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package queue
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -443,7 +442,7 @@ func TestClusterQueueImpl(t *testing.T) {
 
 			if test.queueInadmissibleWorkloads {
 				if diff := cmp.Diff(test.wantInadmissibleWorkloadsRequeued,
-					cq.QueueInadmissibleWorkloads(context.Background(), cl)); diff != "" {
+					cq.QueueInadmissibleWorkloads(t.Context(), cl)); diff != "" {
 					t.Errorf("Unexpected requeuing of inadmissible workloads (-want,+got):\n%s", diff)
 				}
 			}
@@ -464,7 +463,7 @@ func TestQueueInadmissibleWorkloadsDuringScheduling(t *testing.T) {
 	cq.namespaceSelector = labels.Everything()
 	wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 	cl := utiltesting.NewFakeClient(wl, utiltesting.MakeNamespace(defaultNamespace))
-	ctx := context.Background()
+	ctx := t.Context()
 	cq.PushOrUpdate(workload.NewInfo(wl))
 
 	wantActiveWorkloads := []string{workload.Key(wl)}

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -57,7 +57,7 @@ func TestAddLocalQueueOrphans(t *testing.T) {
 	)
 	manager := NewManager(kClient, nil)
 	q := utiltesting.MakeLocalQueue("foo", "earth").Obj()
-	if err := manager.AddLocalQueue(context.Background(), q); err != nil {
+	if err := manager.AddLocalQueue(t.Context(), q); err != nil {
 		t.Fatalf("Failed adding queue: %v", err)
 	}
 	qImpl := manager.localQueues[Key(q)]
@@ -88,7 +88,7 @@ func TestAddClusterQueueOrphans(t *testing.T) {
 		queues[0],
 		queues[1],
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 	manager := NewManager(kClient, nil)
 	cq := utiltesting.MakeClusterQueue("cq").Obj()
 	if err := manager.AddClusterQueue(ctx, cq); err != nil {
@@ -141,7 +141,7 @@ func TestUpdateClusterQueue(t *testing.T) {
 		utiltesting.MakeWorkload("b", defaultNamespace).Queue("bar").Creation(now).Obj(),
 	}
 	// Setup.
-	ctx := context.Background()
+	ctx := t.Context()
 	cl := utiltesting.NewFakeClient(utiltesting.MakeNamespace(defaultNamespace))
 	manager := NewManager(cl, nil)
 	for _, cq := range clusterQueues {
@@ -223,7 +223,7 @@ func TestRequeueWorkloadsCohortCycle(t *testing.T) {
 	lq := utiltesting.MakeLocalQueue("foo", defaultNamespace).ClusterQueue("cq1").Obj()
 	wl := utiltesting.MakeWorkload("a", defaultNamespace).Queue("foo").Creation(time.Now()).Obj()
 	// Setup.
-	ctx := context.Background()
+	ctx := t.Context()
 	cl := utiltesting.NewFakeClient(utiltesting.MakeNamespace(defaultNamespace))
 	manager := NewManager(cl, nil)
 	for _, cohort := range cohorts {
@@ -254,7 +254,7 @@ func TestRequeueWorkloadsCohortCycle(t *testing.T) {
 func TestClusterQueueToActive(t *testing.T) {
 	stoppedCq := utiltesting.MakeClusterQueue("cq1").Cohort("alpha").Condition(kueue.ClusterQueueActive, metav1.ConditionFalse, "ByTest", "by test").Obj()
 	runningCq := utiltesting.MakeClusterQueue("cq1").Cohort("alpha").Condition(kueue.ClusterQueueActive, metav1.ConditionTrue, "ByTest", "by test").Obj()
-	ctx := context.Background()
+	ctx := t.Context()
 	cl := utiltesting.NewFakeClient(utiltesting.MakeNamespace(defaultNamespace))
 	manager := NewManager(cl, nil)
 
@@ -326,7 +326,7 @@ func TestUpdateLocalQueue(t *testing.T) {
 	if err := kueue.AddToScheme(scheme); err != nil {
 		t.Fatalf("Failed adding kueue scheme: %s", err)
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	manager := NewManager(utiltesting.NewFakeClient(), nil)
 	for _, cq := range clusterQueues {
 		if err := manager.AddClusterQueue(ctx, cq); err != nil {
@@ -371,7 +371,7 @@ func TestDeleteLocalQueue(t *testing.T) {
 	q := utiltesting.MakeLocalQueue("foo", "").ClusterQueue("cq").Obj()
 	wl := utiltesting.MakeWorkload("a", "").Queue("foo").Obj()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cl := utiltesting.NewFakeClient(wl)
 	manager := NewManager(cl, nil)
 
@@ -399,7 +399,7 @@ func TestDeleteLocalQueue(t *testing.T) {
 func TestAddWorkload(t *testing.T) {
 	manager := NewManager(utiltesting.NewFakeClient(), nil)
 	cq := utiltesting.MakeClusterQueue("cq").Obj()
-	if err := manager.AddClusterQueue(context.Background(), cq); err != nil {
+	if err := manager.AddClusterQueue(t.Context(), cq); err != nil {
 		t.Fatalf("Failed adding clusterQueue %s: %v", cq.Name, err)
 	}
 	queues := []*kueue.LocalQueue{
@@ -407,7 +407,7 @@ func TestAddWorkload(t *testing.T) {
 		utiltesting.MakeLocalQueue("bar", "mars").Obj(),
 	}
 	for _, q := range queues {
-		if err := manager.AddLocalQueue(context.Background(), q); err != nil {
+		if err := manager.AddLocalQueue(t.Context(), q); err != nil {
 			t.Fatalf("Failed adding queue %s: %v", q.Name, err)
 		}
 	}
@@ -466,7 +466,7 @@ func TestAddWorkload(t *testing.T) {
 }
 
 func TestStatus(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	scheme := runtime.NewScheme()
 	if err := kueue.AddToScheme(scheme); err != nil {
 		t.Fatalf("Failed adding kueue scheme: %s", err)
@@ -632,7 +632,7 @@ func TestRequeueWorkloadStrictFIFO(t *testing.T) {
 		t.Run(tc.workload.Name, func(t *testing.T) {
 			cl := utiltesting.NewFakeClient()
 			manager := NewManager(cl, nil)
-			ctx := context.Background()
+			ctx := t.Context()
 			if err := manager.AddClusterQueue(ctx, cq); err != nil {
 				t.Fatalf("Failed adding cluster queue %s: %v", cq.Name, err)
 			}
@@ -791,7 +791,7 @@ func TestUpdateWorkload(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			manager := NewManager(utiltesting.NewFakeClient(), nil)
-			ctx := context.Background()
+			ctx := t.Context()
 			for _, cq := range tc.clusterQueues {
 				if err := manager.AddClusterQueue(ctx, cq); err != nil {
 					t.Fatalf("Adding cluster queue %s: %v", cq.Name, err)
@@ -904,7 +904,7 @@ func TestHeads(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), headsTimeout)
+			ctx, cancel := context.WithTimeout(t.Context(), headsTimeout)
 			defer cancel()
 			fakeC := &fakeStatusChecker{}
 			manager := NewManager(utiltesting.NewFakeClient(), fakeC)
@@ -1145,7 +1145,7 @@ func TestHeadsAsync(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), headsTimeout)
+			ctx, cancel := context.WithTimeout(t.Context(), headsTimeout)
 			defer cancel()
 			client := utiltesting.NewFakeClient(tc.initialObjs...)
 			manager := NewManager(client, nil)
@@ -1162,7 +1162,7 @@ func TestHeadsAsync(t *testing.T) {
 // TestHeadsCancelled ensures that the Heads call returns when the context is closed.
 func TestHeadsCancelled(t *testing.T) {
 	manager := NewManager(utiltesting.NewFakeClient(), nil)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
 		cancel()
 	}()
@@ -1217,7 +1217,7 @@ func TestGetPendingWorkloadsInfo(t *testing.T) {
 	if err := kueue.AddToScheme(scheme); err != nil {
 		t.Fatalf("Failed adding kueue scheme: %s", err)
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	manager := NewManager(utiltesting.NewFakeClient(), nil)
 	for _, cq := range clusterQueues {
 		if err := manager.AddClusterQueue(ctx, cq); err != nil {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -3359,7 +3359,7 @@ func TestEntryOrdering(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.PrioritySortingWithinCohort, tc.prioritySorting)
-			iter := makeIterator(context.Background(), tc.input, tc.workloadOrdering, false)
+			iter := makeIterator(t.Context(), tc.input, tc.workloadOrdering, false)
 			order := make([]string, len(tc.input))
 			for i := range tc.input {
 				order[i] = iter.pop().Obj.Name

--- a/pkg/util/admissioncheck/admissioncheck_test.go
+++ b/pkg/util/admissioncheck/admissioncheck_test.go
@@ -104,7 +104,7 @@ func TestConfigHelper(t *testing.T) {
 				builder = builder.WithObjects(tc.config)
 			}
 			client := builder.Build()
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			helper, err := NewConfigHelper[*kueue.ProvisioningRequestConfig](client)
@@ -208,7 +208,7 @@ func TestFilterCheckStates(t *testing.T) {
 				builder = builder.WithLists(&kueue.AdmissionCheckList{Items: tc.admissionchecks})
 			}
 			client := builder.Build()
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			gotResult, _ := FilterForController(ctx, client, tc.states, "test-controller")

--- a/pkg/util/parallelize/parallelize_test.go
+++ b/pkg/util/parallelize/parallelize_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package parallelize
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -54,7 +53,7 @@ func TestUntil(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			result = make([]int, 5)
-			err := Until(context.Background(), len(result), tc.op)
+			err := Until(t.Context(), len(result), tc.op)
 			if !errors.Is(err, tc.wantErr) {
 				t.Errorf("Got error %q, want %q", err, tc.wantErr)
 			}

--- a/pkg/util/priority/priority_test.go
+++ b/pkg/util/priority/priority_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package priority
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -141,7 +140,7 @@ func TestGetPriorityFromPriorityClass(t *testing.T) {
 			builder := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.priorityClassList)
 			client := builder.Build()
 
-			name, source, value, err := GetPriorityFromPriorityClass(context.Background(), client, tt.priorityClassName)
+			name, source, value, err := GetPriorityFromPriorityClass(t.Context(), client, tt.priorityClassName)
 			if diff := cmp.Diff(tt.wantErr, err); diff != "" {
 				t.Errorf("unexpected error (-want,+got):\n%s", diff)
 			}
@@ -205,7 +204,7 @@ func TestGetPriorityFromWorkloadPriorityClass(t *testing.T) {
 			builder := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.workloadPriorityClassList)
 			client := builder.Build()
 
-			name, source, value, err := GetPriorityFromWorkloadPriorityClass(context.Background(), client, tt.workloadPriorityClassName)
+			name, source, value, err := GetPriorityFromWorkloadPriorityClass(t.Context(), client, tt.workloadPriorityClassName)
 			if diff := cmp.Diff(tt.wantErr, err); diff != "" {
 				t.Errorf("unexpected error (-want,+got):\n%s", diff)
 			}

--- a/pkg/util/routine/error_channel_test.go
+++ b/pkg/util/routine/error_channel_test.go
@@ -35,7 +35,7 @@ func TestErrorChannel(t *testing.T) {
 		t.Errorf("expect %v from err channel, but got %v", err, actualErr)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	errCh.SendErrorWithCancel(err, cancel)
 	if actualErr := errCh.ReceiveError(); !errors.Is(actualErr, err) {
 		t.Errorf("expect %v from err channel, but got %v", err, actualErr)

--- a/pkg/util/testing/context.go
+++ b/pkg/util/testing/context.go
@@ -29,5 +29,5 @@ func ContextWithLog(t *testing.T) (context.Context, logr.Logger) {
 	logger := testr.NewWithOptions(t, testr.Options{
 		Verbosity: 2,
 	})
-	return ctrl.LoggerInto(context.Background(), logger), logger
+	return ctrl.LoggerInto(t.Context(), logger), logger
 }

--- a/pkg/util/wait/backoff_test.go
+++ b/pkg/util/wait/backoff_test.go
@@ -88,7 +88,7 @@ func TestUntilWithBackoff(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			timer := makeSpyTimer()
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			i := 0

--- a/pkg/visibility/api/v1beta1/pending_workloads_cq_test.go
+++ b/pkg/visibility/api/v1beta1/pending_workloads_cq_test.go
@@ -322,7 +322,7 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			manager := queue.NewManager(utiltesting.NewFakeClient(), nil)
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 			go manager.CleanUpOnContext(ctx)
 			pendingWorkloadsInCqRest := NewPendingWorkloadsInCqREST(manager)

--- a/pkg/visibility/api/v1beta1/pending_workloads_lq_test.go
+++ b/pkg/visibility/api/v1beta1/pending_workloads_lq_test.go
@@ -439,7 +439,7 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			manager := queue.NewManager(utiltesting.NewFakeClient(), nil)
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 			go manager.CleanUpOnContext(ctx)
 			pendingWorkloadsInLqRest := NewPendingWorkloadsInLqREST(manager)

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package workload
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -423,7 +422,7 @@ func TestUpdateWorkloadStatus(t *testing.T) {
 			workload := utiltesting.MakeWorkload("foo", "bar").Generation(1).Obj()
 			workload.Status = tc.oldStatus
 			cl := utiltesting.NewFakeClientSSAAsSM(workload)
-			ctx := context.Background()
+			ctx := t.Context()
 			err := UpdateStatus(ctx, cl, workload, tc.condType, tc.condStatus, tc.reason, tc.message, "manager-prefix", fakeClock)
 			if err != nil {
 				t.Fatalf("Failed updating status: %v", err)

--- a/test/e2e/certmanager/suite_test.go
+++ b/test/e2e/certmanager/suite_test.go
@@ -53,7 +53,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	ctrl.SetLogger(util.NewTestingLogger(ginkgo.GinkgoWriter, -3))
 
 	k8sClient, _ = util.CreateClientUsingCluster("")
-	ctx = ginkgo.GinkgoTB().Context()
+	ctx = ginkgo.GinkgoT().Context()
 
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)

--- a/test/e2e/certmanager/suite_test.go
+++ b/test/e2e/certmanager/suite_test.go
@@ -53,7 +53,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	ctrl.SetLogger(util.NewTestingLogger(ginkgo.GinkgoWriter, -3))
 
 	k8sClient, _ = util.CreateClientUsingCluster("")
-	ctx = context.Background()
+	ctx = ginkgo.GinkgoTB().Context()
 
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)

--- a/test/e2e/customconfigs/suite_test.go
+++ b/test/e2e/customconfigs/suite_test.go
@@ -52,7 +52,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	util.SetupLogger()
 
 	k8sClient, _ = util.CreateClientUsingCluster("")
-	ctx = ginkgo.GinkgoTB().Context()
+	ctx = ginkgo.GinkgoT().Context()
 
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)

--- a/test/e2e/customconfigs/suite_test.go
+++ b/test/e2e/customconfigs/suite_test.go
@@ -52,7 +52,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	util.SetupLogger()
 
 	k8sClient, _ = util.CreateClientUsingCluster("")
-	ctx = context.Background()
+	ctx = ginkgo.GinkgoTB().Context()
 
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)

--- a/test/e2e/multikueue/suite_test.go
+++ b/test/e2e/multikueue/suite_test.go
@@ -267,7 +267,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	worker1RestClient = util.CreateRestClient(worker1Cfg)
 	worker2RestClient = util.CreateRestClient(worker2Cfg)
 
-	ctx = context.Background()
+	ctx = ginkgo.GinkgoTB().Context()
 
 	worker1Kconfig, err := kubeconfigForMultiKueueSA(ctx, k8sWorker1Client, worker1Cfg, "kueue-system", "mksa", worker1ClusterName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/multikueue/suite_test.go
+++ b/test/e2e/multikueue/suite_test.go
@@ -267,7 +267,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	worker1RestClient = util.CreateRestClient(worker1Cfg)
 	worker2RestClient = util.CreateRestClient(worker2Cfg)
 
-	ctx = ginkgo.GinkgoTB().Context()
+	ctx = ginkgo.GinkgoT().Context()
 
 	worker1Kconfig, err := kubeconfigForMultiKueueSA(ctx, k8sWorker1Client, worker1Cfg, "kueue-system", "mksa", worker1ClusterName)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/singlecluster/suite_test.go
+++ b/test/e2e/singlecluster/suite_test.go
@@ -63,7 +63,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	restClient = util.CreateRestClient(cfg)
 	visibilityClient = util.CreateVisibilityClient("")
 	impersonatedVisibilityClient = util.CreateVisibilityClient("system:serviceaccount:kueue-system:default")
-	ctx = context.Background()
+	ctx = ginkgo.GinkgoTB().Context()
 
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)

--- a/test/e2e/singlecluster/suite_test.go
+++ b/test/e2e/singlecluster/suite_test.go
@@ -63,7 +63,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	restClient = util.CreateRestClient(cfg)
 	visibilityClient = util.CreateVisibilityClient("")
 	impersonatedVisibilityClient = util.CreateVisibilityClient("system:serviceaccount:kueue-system:default")
-	ctx = ginkgo.GinkgoTB().Context()
+	ctx = ginkgo.GinkgoT().Context()
 
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)

--- a/test/e2e/tas/suite_test.go
+++ b/test/e2e/tas/suite_test.go
@@ -53,7 +53,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	util.SetupLogger()
 
 	k8sClient, _ = util.CreateClientUsingCluster("")
-	ctx = context.Background()
+	ctx = ginkgo.GinkgoTB().Context()
 
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)

--- a/test/e2e/tas/suite_test.go
+++ b/test/e2e/tas/suite_test.go
@@ -53,7 +53,7 @@ var _ = ginkgo.BeforeSuite(func() {
 	util.SetupLogger()
 
 	k8sClient, _ = util.CreateClientUsingCluster("")
-	ctx = ginkgo.GinkgoTB().Context()
+	ctx = ginkgo.GinkgoT().Context()
 
 	waitForAvailableStart := time.Now()
 	util.WaitForKueueAvailability(ctx, k8sClient)

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -133,7 +133,7 @@ func (f *Framework) SetupClient(cfg *rest.Config) (context.Context, client.Clien
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 	gomega.ExpectWithOffset(1, k8sClient).NotTo(gomega.BeNil())
 
-	ctx, cancel := context.WithCancel(ginkgo.GinkgoTB().Context())
+	ctx, cancel := context.WithCancel(ginkgo.GinkgoT().Context())
 	f.cancel = cancel
 
 	return ctx, k8sClient

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -133,7 +133,7 @@ func (f *Framework) SetupClient(cfg *rest.Config) (context.Context, client.Clien
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 	gomega.ExpectWithOffset(1, k8sClient).NotTo(gomega.BeNil())
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ginkgo.GinkgoTB().Context())
 	f.cancel = cancel
 
 	return ctx, k8sClient

--- a/test/performance/scheduler/minimalkueue/main.go
+++ b/test/performance/scheduler/minimalkueue/main.go
@@ -25,6 +25,7 @@ import (
 	"runtime/pprof"
 	"syscall"
 
+	"github.com/onsi/ginkgo/v2"
 	zaplog "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -137,7 +138,7 @@ func mainWithExitCode() int {
 		return 1
 	}
 
-	ctx, cancel := context.WithCancel(ctrl.LoggerInto(context.Background(), log))
+	ctx, cancel := context.WithCancel(ctrl.LoggerInto(ginkgo.GinkgoTB().Context(), log))
 	defer cancel()
 	go func() {
 		done := make(chan os.Signal, 2)

--- a/test/performance/scheduler/minimalkueue/main.go
+++ b/test/performance/scheduler/minimalkueue/main.go
@@ -25,7 +25,6 @@ import (
 	"runtime/pprof"
 	"syscall"
 
-	"github.com/onsi/ginkgo/v2"
 	zaplog "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -138,7 +137,7 @@ func mainWithExitCode() int {
 		return 1
 	}
 
-	ctx, cancel := context.WithCancel(ctrl.LoggerInto(ginkgo.GinkgoTB().Context(), log))
+	ctx, cancel := context.WithCancel(ctrl.LoggerInto(context.Background(), log))
 	defer cancel()
 	go func() {
 		done := make(chan os.Signal, 2)

--- a/test/performance/scheduler/runner/main.go
+++ b/test/performance/scheduler/runner/main.go
@@ -45,6 +45,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/yaml"
 
+	"github.com/onsi/ginkgo/v2"
+
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -103,7 +105,7 @@ func main() {
 	log.Info("Start runner", "outputDir", outputDir, "crdsPath", crdsPath)
 	errCh := make(chan error, 3)
 	wg := &sync.WaitGroup{}
-	ctx, ctxCancel := context.WithCancel(ctrl.LoggerInto(context.Background(), log))
+	ctx, ctxCancel := context.WithCancel(ctrl.LoggerInto(ginkgo.GinkgoTB().Context(), log))
 	var cfg *rest.Config
 
 	if *minimalKueuePath != "" {
@@ -239,7 +241,7 @@ func main() {
 		if err != nil {
 			log.Error(err, "Create cleanup client")
 		} else {
-			generator.Cleanup(context.Background(), c)
+			generator.Cleanup(ginkgo.GinkgoTB().Context(), c)
 		}
 	}
 }

--- a/test/performance/scheduler/runner/main.go
+++ b/test/performance/scheduler/runner/main.go
@@ -45,8 +45,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/yaml"
 
-	"github.com/onsi/ginkgo/v2"
-
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -105,7 +103,7 @@ func main() {
 	log.Info("Start runner", "outputDir", outputDir, "crdsPath", crdsPath)
 	errCh := make(chan error, 3)
 	wg := &sync.WaitGroup{}
-	ctx, ctxCancel := context.WithCancel(ctrl.LoggerInto(ginkgo.GinkgoTB().Context(), log))
+	ctx, ctxCancel := context.WithCancel(ctrl.LoggerInto(context.Background(), log))
 	var cfg *rest.Config
 
 	if *minimalKueuePath != "" {
@@ -241,7 +239,7 @@ func main() {
 		if err != nil {
 			log.Error(err, "Create cleanup client")
 		} else {
-			generator.Cleanup(ginkgo.GinkgoTB().Context(), c)
+			generator.Cleanup(context.Background(), c)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Go 1.24, testing.TB.Context(t) is supported, allowing us to replace all instances of context.Background() in tests

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/4655#event-16929191363

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```