### PR TITLE
make iterable function for traversing to root

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -732,12 +732,12 @@ func (c *Cache) ClusterQueueAncestors(cqObj *kueue.ClusterQueue) ([]kueue.Cohort
 	}
 
 	var ancestors []kueue.CohortReference
-	for cohort != nil && cohort.HasParent() {
-		ancestors = append(ancestors, cohort.Name)
-		cohort = cohort.Parent()
+
+	for ancestor := range cohort.PathSelfToRoot() {
+		ancestors = append(ancestors, ancestor.Name)
 	}
 
-	return ancestors, nil
+	return ancestors[:len(ancestors)-1], nil
 }
 
 func getUsage(frq resources.FlavorResourceQuantities, cq *clusterQueue) []kueue.FlavorUsage {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3845,7 +3845,8 @@ func TestClusterQueueAncestors(t *testing.T) {
 			cohorts: []*kueuealpha.Cohort{
 				utiltesting.MakeCohort("root").Obj(),
 			},
-			cq: utiltesting.MakeClusterQueue("cq").Cohort("root").Obj(),
+			cq:            utiltesting.MakeClusterQueue("cq").Cohort("root").Obj(),
+			wantAncestors: []kueue.CohortReference{},
 		},
 		"two level": {
 			cohorts: []*kueuealpha.Cohort{

--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cache
 
 import (
+	"iter"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
@@ -220,4 +222,17 @@ func (c *ClusterQueueSnapshot) FindTopologyAssignmentsForWorkload(
 
 func (c *ClusterQueueSnapshot) IsTASOnly() bool {
 	return c.tasOnly
+}
+
+// Returns all ancestors starting with parent and ending with root
+func (c *ClusterQueueSnapshot) PathParentToRoot() iter.Seq[*CohortSnapshot] {
+	return func(yield func(*CohortSnapshot) bool) {
+		a := c.Parent()
+		for a != nil {
+			if !yield(a) {
+				return
+			}
+			a = a.Parent()
+		}
+	}
 }

--- a/pkg/cache/cohort.go
+++ b/pkg/cache/cohort.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cache
 
 import (
+	"iter"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
@@ -84,4 +86,17 @@ func (c *cohort) CCParent() hierarchy.CycleCheckable {
 
 func (c *cohort) fairWeight() *resource.Quantity {
 	return &c.FairWeight
+}
+
+// Returns all ancestors starting with self and ending with root
+func (c *cohort) PathSelfToRoot() iter.Seq[*cohort] {
+	return func(yield func(*cohort) bool) {
+		cohort := c
+		for cohort != nil {
+			if !yield(cohort) {
+				return
+			}
+			cohort = cohort.Parent()
+		}
+	}
 }

--- a/pkg/scheduler/fair_sharing_iterator.go
+++ b/pkg/scheduler/fair_sharing_iterator.go
@@ -205,15 +205,12 @@ func (e *entryComparer) computeDRS(rootCohort *cache.CohortSnapshot, cqToEntry m
 
 		// calculate DRS, with workload, for CQ.
 		dominantResourceShare := cq.DominantResourceShare()
-		e.drsValues[drsKey{parentCohort: cq.Parent().GetName(), workloadKey: workload.Key(entry.Obj)}] = dominantResourceShare
 
 		// calculate DRS, with workload, for all Cohorts on
 		// path to root.
-		cohort := cq.Parent()
-		for cohort.HasParent() {
-			dominantResourceShare := cohort.DominantResourceShare()
-			e.drsValues[drsKey{parentCohort: cohort.Parent().GetName(), workloadKey: workload.Key(entry.Obj)}] = dominantResourceShare
-			cohort = cohort.Parent()
+		for ancestor := range cq.PathParentToRoot() {
+			e.drsValues[drsKey{parentCohort: ancestor.GetName(), workloadKey: workload.Key(entry.Obj)}] = dominantResourceShare
+			dominantResourceShare = ancestor.DominantResourceShare()
 		}
 
 		cq.RemoveUsage(entry.assignmentUsage())

--- a/pkg/scheduler/preemption/fairsharing/least_common_ancestor.go
+++ b/pkg/scheduler/preemption/fairsharing/least_common_ancestor.go
@@ -33,27 +33,24 @@ func getAlmostLCAs(t *TargetClusterQueue) (almostLCA, almostLCA) {
 // returning the first Cohort which contains the preemptor
 // ClusterQueue in its subtree.
 func getLCA(t *TargetClusterQueue) *cache.CohortSnapshot {
-	cohort := t.targetCq.Parent()
-	for {
-		if t.ordering.onPathFromRootToPreemptorCQ(cohort) {
-			return cohort
+	for ancestor := range t.targetCq.PathParentToRoot() {
+		if t.ordering.onPathFromRootToPreemptorCQ(ancestor) {
+			return ancestor
 		}
-		cohort = cohort.Parent()
 	}
+	return nil
 }
 
 // getAlmostLCA traverses from a ClusterQueue towards the root,
 // returning the first Cohort or ClusterQueue that has the
 // LeastCommonAncestor as its parent.
 func getAlmostLCA(cq *cache.ClusterQueueSnapshot, lca *cache.CohortSnapshot) almostLCA {
-	if cq.Parent() == lca {
-		return cq
-	}
-	cohort := cq.Parent()
-	for {
-		if cohort.Parent() == lca {
-			return cohort
+	var aLca almostLCA = cq
+	for ancestor := range cq.PathParentToRoot() {
+		if ancestor == lca {
+			return aLca
 		}
-		cohort = cohort.Parent()
+		aLca = ancestor
 	}
+	panic("Could not find least common ancestor.")
 }

--- a/pkg/scheduler/preemption/fairsharing/ordering.go
+++ b/pkg/scheduler/preemption/fairsharing/ordering.go
@@ -67,10 +67,8 @@ func MakeClusterQueueOrdering(cq *cache.ClusterQueueSnapshot, candidates []*work
 		prunedCohorts:       sets.New[*cache.CohortSnapshot](),
 	}
 
-	cohort := cq.Parent()
-	for cohort != nil {
-		t.preemptorAncestors.Insert(cohort)
-		cohort = cohort.Parent()
+	for ancestor := range cq.PathParentToRoot() {
+		t.preemptorAncestors.Insert(ancestor)
 	}
 
 	for _, candidate := range candidates {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4644 

#### Special notes for your reviewer:
~Let me know if this was the approach that was expected or if there's a way to make this generic so that the iterator doesn't have to be implemented twice~

**Solved** I was able to implement this in the generic ClusterQueue and Cohort structs

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```