### PR TITLE
chore: use 'any' instead of 'interface{}' for consistency

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -57,6 +57,7 @@ linters-settings:
       - name: increment-decrement
       - name: var-naming
       - name: redundant-import-alias
+      - name: use-any
 
 # Settings for enabling and disabling linters
 linters:

--- a/client-go/applyconfiguration/utils.go
+++ b/client-go/applyconfiguration/utils.go
@@ -32,7 +32,7 @@ import (
 
 // ForKind returns an apply configuration type for the given GroupVersionKind, or nil if no
 // apply configuration type exists for the given GroupVersionKind.
-func ForKind(kind schema.GroupVersionKind) interface{} {
+func ForKind(kind schema.GroupVersionKind) any {
 	switch kind {
 	// Group=kueue.x-k8s.io, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithKind("Topology"):

--- a/client-go/applyconfiguration/utils.go
+++ b/client-go/applyconfiguration/utils.go
@@ -32,7 +32,7 @@ import (
 
 // ForKind returns an apply configuration type for the given GroupVersionKind, or nil if no
 // apply configuration type exists for the given GroupVersionKind.
-func ForKind(kind schema.GroupVersionKind) any {
+func ForKind(kind schema.GroupVersionKind) interface{} {
 	switch kind {
 	// Group=kueue.x-k8s.io, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithKind("Topology"):

--- a/cmd/kueuectl/app/list/list_pods_test.go
+++ b/cmd/kueuectl/app/list/list_pods_test.go
@@ -724,7 +724,7 @@ func podTableObjBody(codec runtime.Codec, pods ...corev1.Pod) io.ReadCloser {
 		_ = codec.Encode(&pods[i], b)
 		table.Rows = append(table.Rows, metav1.TableRow{
 			Object: runtime.RawExtension{Raw: b.Bytes()},
-			Cells:  []interface{}{pods[i].Name, "1/1", "Running", int64(0), "<unknown>", "<none>", "<none>", "<none>", "<none>"},
+			Cells:  []any{pods[i].Name, "1/1", "Running", int64(0), "<unknown>", "<none>", "<none>", "<none>", "<none>"},
 		})
 	}
 

--- a/cmd/kueueviz/backend/handlers/local_queue_workloads.go
+++ b/cmd/kueueviz/backend/handlers/local_queue_workloads.go
@@ -29,13 +29,13 @@ func LocalQueueWorkloadsWebSocketHandler(dynamicClient dynamic.Interface) gin.Ha
 	return func(c *gin.Context) {
 		namespace := c.Param("namespace")
 		queueName := c.Param("queue_name")
-		GenericWebSocketHandler(func() (interface{}, error) {
+		GenericWebSocketHandler(func() (any, error) {
 			return fetchLocalQueueWorkloads(dynamicClient, namespace, queueName)
 		})(c)
 	}
 }
 
-func fetchLocalQueueWorkloads(dynamicClient dynamic.Interface, namespace, queueName string) (interface{}, error) {
+func fetchLocalQueueWorkloads(dynamicClient dynamic.Interface, namespace, queueName string) (any, error) {
 	result, err := dynamicClient.Resource(WorkloadsGVR()).Namespace(namespace).List(context.TODO(), metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("spec.queueName=%s", queueName),
 	})
@@ -43,7 +43,7 @@ func fetchLocalQueueWorkloads(dynamicClient dynamic.Interface, namespace, queueN
 		return nil, fmt.Errorf("error fetching workloads for local queue %s: %v", queueName, err)
 	}
 
-	var workloads []map[string]interface{}
+	var workloads []map[string]any
 	for _, item := range result.Items {
 		workloads = append(workloads, item.Object)
 	}

--- a/cmd/kueueviz/backend/handlers/local_queues.go
+++ b/cmd/kueueviz/backend/handlers/local_queues.go
@@ -27,7 +27,7 @@ import (
 
 // LocalQueuesWebSocketHandler streams all local queues
 func LocalQueuesWebSocketHandler(dynamicClient dynamic.Interface) gin.HandlerFunc {
-	return GenericWebSocketHandler(func() (interface{}, error) {
+	return GenericWebSocketHandler(func() (any, error) {
 		return fetchLocalQueues(dynamicClient)
 	})
 }
@@ -37,25 +37,25 @@ func LocalQueueDetailsWebSocketHandler(dynamicClient dynamic.Interface) gin.Hand
 	return func(c *gin.Context) {
 		namespace := c.Param("namespace")
 		queueName := c.Param("queue_name")
-		GenericWebSocketHandler(func() (interface{}, error) {
+		GenericWebSocketHandler(func() (any, error) {
 			return fetchLocalQueueDetails(dynamicClient, namespace, queueName)
 		})(c)
 	}
 }
 
 // Fetch all local queues
-func fetchLocalQueues(dynamicClient dynamic.Interface) (interface{}, error) {
+func fetchLocalQueues(dynamicClient dynamic.Interface) (any, error) {
 	result, err := dynamicClient.Resource(LocalQueuesGVR()).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("error fetching local queues: %v", err)
 	}
 
-	var queues []map[string]interface{}
+	var queues []map[string]any
 	for _, item := range result.Items {
 		queue := item.Object
 		queue["namespace"] = item.GetNamespace()
 		queue["name"] = item.GetName()
-		status, statusExists := item.Object["status"].(map[string]interface{})
+		status, statusExists := item.Object["status"].(map[string]any)
 		// Include the status if it exists
 		if statusExists {
 			queue["status"] = status
@@ -66,7 +66,7 @@ func fetchLocalQueues(dynamicClient dynamic.Interface) (interface{}, error) {
 }
 
 // Fetch details for a specific local queue
-func fetchLocalQueueDetails(dynamicClient dynamic.Interface, namespace, queueName string) (interface{}, error) {
+func fetchLocalQueueDetails(dynamicClient dynamic.Interface, namespace, queueName string) (any, error) {
 
 	result, err := dynamicClient.Resource(LocalQueuesGVR()).Namespace(namespace).Get(context.TODO(), queueName, metav1.GetOptions{})
 	if err != nil {

--- a/cmd/kueueviz/backend/handlers/websocket_handler.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler.go
@@ -34,7 +34,7 @@ var upgrader = websocket.Upgrader{
 }
 
 // GenericWebSocketHandler creates a WebSocket endpoint with periodic data updates
-func GenericWebSocketHandler(dataFetcher func() (interface{}, error)) gin.HandlerFunc {
+func GenericWebSocketHandler(dataFetcher func() (any, error)) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		startTime := time.Now()
 		log.Debug("WebSocket handler started")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1049,7 +1049,7 @@ func TestEncode(t *testing.T) {
 			if err != nil {
 				t.Errorf("Unexpected error:%s", err)
 			}
-			gotMap := map[string]interface{}{}
+			gotMap := map[string]any{}
 			err = yaml.Unmarshal([]byte(got), &gotMap)
 			if err != nil {
 				t.Errorf("Unable to unmarshal result:%s", err)

--- a/pkg/controller/jobframework/integrationmanager_test.go
+++ b/pkg/controller/jobframework/integrationmanager_test.go
@@ -226,7 +226,7 @@ func TestRegister(t *testing.T) {
 			}
 
 			if gotCallbacks, found := tc.manager.get(tc.integrationName); found {
-				if diff := cmp.Diff(tc.wantCallbacks, gotCallbacks, cmp.FilterValues(func(_, _ interface{}) bool { return true }, cmp.Comparer(compareCallbacks))); diff != "" {
+				if diff := cmp.Diff(tc.wantCallbacks, gotCallbacks, cmp.FilterValues(func(_, _ any) bool { return true }, cmp.Comparer(compareCallbacks))); diff != "" {
 					t.Errorf("Unexpected callbacks (-want +got):\n%s", diff)
 				}
 			}
@@ -234,7 +234,7 @@ func TestRegister(t *testing.T) {
 	}
 }
 
-func compareCallbacks(x, y interface{}) bool {
+func compareCallbacks(x, y any) bool {
 	xcb := x.(IntegrationCallbacks)
 	ycb := y.(IntegrationCallbacks)
 

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -172,7 +172,7 @@ func ValidateImmutablePodGroupPodSpec(newPodSpec *corev1.PodSpec, oldPodSpec *co
 	return validateImmutablePodGroupPodSpecPath(utilpod.SpecShape(newPodSpec), utilpod.SpecShape(oldPodSpec), fieldPath)
 }
 
-func validateImmutablePodGroupPodSpecPath(newShape, oldShape map[string]interface{}, fieldPath *field.Path) field.ErrorList {
+func validateImmutablePodGroupPodSpecPath(newShape, oldShape map[string]any, fieldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	fields := sets.New[string]()
@@ -183,8 +183,8 @@ func validateImmutablePodGroupPodSpecPath(newShape, oldShape map[string]interfac
 		childFieldPath := fieldPath.Child(fieldName)
 
 		switch newValue := newShape[fieldName].(type) {
-		case []map[string]interface{}:
-			oldValue := oldShape[fieldName].([]map[string]interface{})
+		case []map[string]any:
+			oldValue := oldShape[fieldName].([]map[string]any)
 
 			if len(newValue) != len(oldValue) {
 				allErrs = append(allErrs, apivalidation.ValidateImmutableField(newValue, oldValue, childFieldPath)...)
@@ -194,8 +194,8 @@ func validateImmutablePodGroupPodSpecPath(newShape, oldShape map[string]interfac
 			for i := range newValue {
 				allErrs = append(allErrs, validateImmutablePodGroupPodSpecPath(newValue[i], oldValue[i], childFieldPath.Index(i))...)
 			}
-		case map[string]interface{}:
-			oldValue := oldShape[fieldName].(map[string]interface{})
+		case map[string]any:
+			oldValue := oldShape[fieldName].(map[string]any)
 			allErrs = append(allErrs, validateImmutablePodGroupPodSpecPath(newValue, oldValue, childFieldPath)...)
 		default:
 			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newShape[fieldName], oldShape[fieldName], childFieldPath)...)

--- a/pkg/util/heap/heap.go
+++ b/pkg/util/heap/heap.go
@@ -82,7 +82,7 @@ func (h *data[T]) Swap(i, j int) {
 }
 
 // Push is supposed to be called by heap.Push only.
-func (h *data[T]) Push(kv interface{}) {
+func (h *data[T]) Push(kv any) {
 	keyValue := kv.(itemKeyValue[T])
 	h.items[keyValue.key] = &heapItem[T]{
 		obj:   keyValue.obj,
@@ -92,7 +92,7 @@ func (h *data[T]) Push(kv interface{}) {
 }
 
 // Pop is supposed to be called by heap.Pop only.
-func (h *data[T]) Pop() interface{} {
+func (h *data[T]) Pop() any {
 	key := h.keys[len(h.keys)-1]
 	h.keys = h.keys[:len(h.keys)-1]
 	item, ok := h.items[key]

--- a/pkg/util/pod/pod.go
+++ b/pkg/util/pod/pod.go
@@ -103,7 +103,7 @@ func readUIntFromStringBelowBound(value string, bound int) (*int, error) {
 }
 
 func GenerateRoleHash(podSpec *corev1.PodSpec) (string, error) {
-	shape := map[string]interface{}{
+	shape := map[string]any{
 		"spec": SpecShape(podSpec),
 	}
 
@@ -116,8 +116,8 @@ func GenerateRoleHash(podSpec *corev1.PodSpec) (string, error) {
 	return fmt.Sprintf("%x", sha256.Sum256(shapeJSON))[:8], nil
 }
 
-func SpecShape(podSpec *corev1.PodSpec) (result map[string]interface{}) {
-	return map[string]interface{}{
+func SpecShape(podSpec *corev1.PodSpec) (result map[string]any) {
+	return map[string]any{
 		"initContainers":            ContainersShape(podSpec.InitContainers),
 		"containers":                ContainersShape(podSpec.Containers),
 		"nodeSelector":              podSpec.NodeSelector,
@@ -131,10 +131,10 @@ func SpecShape(podSpec *corev1.PodSpec) (result map[string]interface{}) {
 	}
 }
 
-func ContainersShape(containers []corev1.Container) (result []map[string]interface{}) {
+func ContainersShape(containers []corev1.Container) (result []map[string]any) {
 	for _, c := range containers {
-		result = append(result, map[string]interface{}{
-			"resources": map[string]interface{}{
+		result = append(result, map[string]any{
+			"resources": map[string]any{
 				"requests": c.Resources.Requests,
 			},
 			"ports": c.Ports,

--- a/pkg/util/testing/client.go
+++ b/pkg/util/testing/client.go
@@ -107,11 +107,11 @@ func (tr *EventRecorder) Event(object runtime.Object, eventType, reason, message
 	tr.generateEvent(object, eventType, reason, message)
 }
 
-func (tr *EventRecorder) Eventf(object runtime.Object, eventType, reason, messageFmt string, args ...interface{}) {
+func (tr *EventRecorder) Eventf(object runtime.Object, eventType, reason, messageFmt string, args ...any) {
 	tr.AnnotatedEventf(object, nil, eventType, reason, messageFmt, args...)
 }
 
-func (tr *EventRecorder) AnnotatedEventf(targetObject runtime.Object, _ map[string]string, eventType, reason, messageFmt string, args ...interface{}) {
+func (tr *EventRecorder) AnnotatedEventf(targetObject runtime.Object, _ map[string]string, eventType, reason, messageFmt string, args ...any) {
 	tr.generateEvent(targetObject, eventType, reason, fmt.Sprintf(messageFmt, args...))
 }
 

--- a/pkg/util/testing/condition_matchers.go
+++ b/pkg/util/testing/condition_matchers.go
@@ -52,7 +52,7 @@ type conditionMatcher struct {
 	status        metav1.ConditionStatus
 }
 
-func (matcher *conditionMatcher) Match(actual interface{}) (bool, error) {
+func (matcher *conditionMatcher) Match(actual any) (bool, error) {
 	conditions, ok := actual.([]metav1.Condition)
 	if !ok {
 		return false, fmt.Errorf("Condition matcher expects a []metav1.Condition. Got:\n%s", format.Object(actual, 1))
@@ -70,15 +70,15 @@ func (matcher *conditionMatcher) Match(actual interface{}) (bool, error) {
 	return found.Status == matcher.status, nil
 }
 
-func (matcher *conditionMatcher) FailureMessage(actual interface{}) string {
+func (matcher *conditionMatcher) FailureMessage(actual any) string {
 	return matcher.buildErrorMessage(actual, false)
 }
 
-func (matcher *conditionMatcher) NegatedFailureMessage(actual interface{}) string {
+func (matcher *conditionMatcher) NegatedFailureMessage(actual any) string {
 	return matcher.buildErrorMessage(actual, true)
 }
 
-func (matcher *conditionMatcher) buildErrorMessage(actual interface{}, negated bool) string {
+func (matcher *conditionMatcher) buildErrorMessage(actual any, negated bool) string {
 	b := strings.Builder{}
 	b.WriteString("Expected\n")
 	b.WriteString(format.Object(actual, 1))

--- a/pkg/util/testing/error_matchers.go
+++ b/pkg/util/testing/error_matchers.go
@@ -64,7 +64,7 @@ func BeError(errorType ErrorType) types.GomegaMatcher {
 	}
 }
 
-func (matcher *errorMatcher) Match(actual interface{}) (success bool, err error) {
+func (matcher *errorMatcher) Match(actual any) (success bool, err error) {
 	err, ok := actual.(error)
 	if !ok {
 		return false, fmt.Errorf("Error matcher expects an error.  Got:\n%s", format.Object(actual, 1))
@@ -73,10 +73,10 @@ func (matcher *errorMatcher) Match(actual interface{}) (success bool, err error)
 	return err != nil && matcher.errorType.IsError(err), nil
 }
 
-func (matcher *errorMatcher) FailureMessage(actual interface{}) (message string) {
+func (matcher *errorMatcher) FailureMessage(actual any) (message string) {
 	return fmt.Sprintf("Expected %s, but got:\n%s", matcher.errorType.String(), format.Object(actual, 1))
 }
 
-func (matcher *errorMatcher) NegatedFailureMessage(interface{}) (message string) {
+func (matcher *errorMatcher) NegatedFailureMessage(any) (message string) {
 	return fmt.Sprintf("Expected not to be %s", matcher.errorType.String())
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replace `interface{}` with `any` for consistency. Enable `revive.use-any` to enforce that.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```