### PR TITLE
Revert "Do not consider preemption.borrowWithinCohort in FairSharing..."

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -97,6 +97,21 @@ type ClusterQueueSpec struct {
 	// +kubebuilder:default={}
 	FlavorFungibility *FlavorFungibility `json:"flavorFungibility,omitempty"`
 
+	// preemption describes policies to preempt Workloads from this ClusterQueue
+	// or the ClusterQueue's cohort.
+	//
+	// Preemption can happen in two scenarios:
+	//
+	// - When a Workload fits within the nominal quota of the ClusterQueue, but
+	//   the quota is currently borrowed by other ClusterQueues in the cohort.
+	//   Preempting Workloads in other ClusterQueues allows this ClusterQueue to
+	//   reclaim its nominal quota.
+	// - When a Workload doesn't fit within the nominal quota of the ClusterQueue
+	//   and there are admitted Workloads in the ClusterQueue with lower priority.
+	//
+	// The preemption algorithm tries to find a minimal set of Workloads to
+	// preempt to accomomdate the pending Workload, preempting Workloads with
+	// lower priority first.
 	// +kubebuilder:default={}
 	Preemption *ClusterQueuePreemption `json:"preemption,omitempty"`
 
@@ -407,24 +422,6 @@ type FlavorFungibility struct {
 
 // ClusterQueuePreemption contains policies to preempt Workloads from this
 // ClusterQueue or the ClusterQueue's cohort.
-//
-// Preemption may be configured to work in the following scenarios:
-//
-//   - When a Workload fits within the nominal quota of the ClusterQueue, but
-//     the quota is currently borrowed by other ClusterQueues in the cohort.
-//     We preempt workloads in other ClusterQueues to allow this ClusterQueue to
-//     reclaim its nominal quota. Configured using reclaimWithinCohort.
-//   - When a Workload doesn't fit within the nominal quota of the ClusterQueue
-//     and there are admitted Workloads in the ClusterQueue with lower priority.
-//     Configured using withinClusterQueue.
-//   - When a Workload may fit while both borrowing and preempting
-//     low priority workloads in the Cohort. Configured using borrowWithinCohort.
-//   - When FairSharing is enabled, to maintain fair distribution of
-//     unused resources. See FairSharing documentation.
-//
-// The preemption algorithm tries to find a minimal set of Workloads to
-// preempt to accomomdate the pending Workload, preempting Workloads with
-// lower priority first.
 // +kubebuilder:validation:XValidation:rule="!(self.reclaimWithinCohort == 'Never' && has(self.borrowWithinCohort) &&  self.borrowWithinCohort.policy != 'Never')", message="reclaimWithinCohort=Never and borrowWithinCohort.Policy!=Never"
 type ClusterQueuePreemption struct {
 	// reclaimWithinCohort determines whether a pending Workload can preempt
@@ -447,6 +444,8 @@ type ClusterQueuePreemption struct {
 	// +kubebuilder:validation:Enum=Never;LowerPriority;Any
 	ReclaimWithinCohort PreemptionPolicy `json:"reclaimWithinCohort,omitempty"`
 
+	// borrowWithinCohort provides configuration to allow preemption within
+	// cohort while borrowing.
 	// +kubebuilder:default={}
 	BorrowWithinCohort *BorrowWithinCohort `json:"borrowWithinCohort,omitempty"`
 
@@ -474,8 +473,7 @@ const (
 )
 
 // BorrowWithinCohort contains configuration which allows to preempt workloads
-// within cohort while borrowing. It only works with Classical Preemption,
-// __not__ with Fair Sharing.
+// within cohort while borrowing.
 type BorrowWithinCohort struct {
 	// policy determines the policy for preemption to reclaim quota within cohort while borrowing.
 	// Possible values are:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -242,22 +242,17 @@ spec:
               preemption:
                 default: {}
                 description: |-
-                  ClusterQueuePreemption contains policies to preempt Workloads from this
-                  ClusterQueue or the ClusterQueue's cohort.
+                  preemption describes policies to preempt Workloads from this ClusterQueue
+                  or the ClusterQueue's cohort.
 
-                  Preemption may be configured to work in the following scenarios:
+                  Preemption can happen in two scenarios:
 
-                    - When a Workload fits within the nominal quota of the ClusterQueue, but
-                      the quota is currently borrowed by other ClusterQueues in the cohort.
-                      We preempt workloads in other ClusterQueues to allow this ClusterQueue to
-                      reclaim its nominal quota. Configured using reclaimWithinCohort.
-                    - When a Workload doesn't fit within the nominal quota of the ClusterQueue
-                      and there are admitted Workloads in the ClusterQueue with lower priority.
-                      Configured using withinClusterQueue.
-                    - When a Workload may fit while both borrowing and preempting
-                      low priority workloads in the Cohort. Configured using borrowWithinCohort.
-                    - When FairSharing is enabled, to maintain fair distribution of
-                      unused resources. See FairSharing documentation.
+                  - When a Workload fits within the nominal quota of the ClusterQueue, but
+                    the quota is currently borrowed by other ClusterQueues in the cohort.
+                    Preempting Workloads in other ClusterQueues allows this ClusterQueue to
+                    reclaim its nominal quota.
+                  - When a Workload doesn't fit within the nominal quota of the ClusterQueue
+                    and there are admitted Workloads in the ClusterQueue with lower priority.
 
                   The preemption algorithm tries to find a minimal set of Workloads to
                   preempt to accomomdate the pending Workload, preempting Workloads with
@@ -266,9 +261,8 @@ spec:
                   borrowWithinCohort:
                     default: {}
                     description: |-
-                      BorrowWithinCohort contains configuration which allows to preempt workloads
-                      within cohort while borrowing. It only works with Classical Preemption,
-                      __not__ with Fair Sharing.
+                      borrowWithinCohort provides configuration to allow preemption within
+                      cohort while borrowing.
                     properties:
                       maxPriorityThreshold:
                         description: |-

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -227,22 +227,17 @@ spec:
               preemption:
                 default: {}
                 description: |-
-                  ClusterQueuePreemption contains policies to preempt Workloads from this
-                  ClusterQueue or the ClusterQueue's cohort.
+                  preemption describes policies to preempt Workloads from this ClusterQueue
+                  or the ClusterQueue's cohort.
 
-                  Preemption may be configured to work in the following scenarios:
+                  Preemption can happen in two scenarios:
 
-                    - When a Workload fits within the nominal quota of the ClusterQueue, but
-                      the quota is currently borrowed by other ClusterQueues in the cohort.
-                      We preempt workloads in other ClusterQueues to allow this ClusterQueue to
-                      reclaim its nominal quota. Configured using reclaimWithinCohort.
-                    - When a Workload doesn't fit within the nominal quota of the ClusterQueue
-                      and there are admitted Workloads in the ClusterQueue with lower priority.
-                      Configured using withinClusterQueue.
-                    - When a Workload may fit while both borrowing and preempting
-                      low priority workloads in the Cohort. Configured using borrowWithinCohort.
-                    - When FairSharing is enabled, to maintain fair distribution of
-                      unused resources. See FairSharing documentation.
+                  - When a Workload fits within the nominal quota of the ClusterQueue, but
+                    the quota is currently borrowed by other ClusterQueues in the cohort.
+                    Preempting Workloads in other ClusterQueues allows this ClusterQueue to
+                    reclaim its nominal quota.
+                  - When a Workload doesn't fit within the nominal quota of the ClusterQueue
+                    and there are admitted Workloads in the ClusterQueue with lower priority.
 
                   The preemption algorithm tries to find a minimal set of Workloads to
                   preempt to accomomdate the pending Workload, preempting Workloads with
@@ -251,9 +246,8 @@ spec:
                   borrowWithinCohort:
                     default: {}
                     description: |-
-                      BorrowWithinCohort contains configuration which allows to preempt workloads
-                      within cohort while borrowing. It only works with Classical Preemption,
-                      __not__ with Fair Sharing.
+                      borrowWithinCohort provides configuration to allow preemption within
+                      cohort while borrowing.
                     properties:
                       maxPriorityThreshold:
                         description: |-

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -449,9 +449,8 @@ The fields above do the following:
     priority.
 
 - `borrowWithinCohort` determines whether a pending Workload can preempt
-  Workloads from other ClusterQueues if the workload requires borrowing.
-  May only be configured with Classical Preemption, and __not__ with Fair Sharing.
-  This field requires to specify `policy` sub-field with possible values:
+  Workloads from other ClusterQueues if the workload requires borrowing. This
+  field requires to specify `policy` sub-field with possible values:
   - `Never` (default): do not preempt Workloads in the cohort if borrowing is required.
   - `LowerPriority`: if the pending Workload requires borrowing, only preempt
     Workloads in the cohort that have lower priority than the pending Workload.

--- a/site/content/en/docs/concepts/preemption.md
+++ b/site/content/en/docs/concepts/preemption.md
@@ -119,8 +119,8 @@ admitted when accounting back the quota usage of the target Workload.
 
 Fair sharing introduces the concepts of ClusterQueue share values and preemption
 strategies. These work together with the preemption policies set in
-`withinClusterQueue` and `reclaimWithinCohort` (but __not__ `borrowWithinCohort`) to determine if a pending
-Workload can preempt an admitted Workload in Fair sharing. Fair sharing uses preemptions to
+`withinClusterQueue` and `reclaimWithinCohort` to determine if a pending
+Workload can preempt an admitted Workload. Fair sharing uses preemptions to
 achieve an equal or weighted share of the borrowable resources between the
 tenants of a cohort.
 

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -568,8 +568,7 @@ If empty, the AdmissionCheck will run for all workloads submitted to the Cluster
 
 
 <p>BorrowWithinCohort contains configuration which allows to preempt workloads
-within cohort while borrowing. It only works with Classical Preemption,
-<strong>not</strong> with Fair Sharing.</p>
+within cohort while borrowing.</p>
 
 
 <table class="table">
@@ -705,23 +704,6 @@ in the cluster queue.</p>
 
 <p>ClusterQueuePreemption contains policies to preempt Workloads from this
 ClusterQueue or the ClusterQueue's cohort.</p>
-<p>Preemption may be configured to work in the following scenarios:</p>
-<ul>
-<li>When a Workload fits within the nominal quota of the ClusterQueue, but
-the quota is currently borrowed by other ClusterQueues in the cohort.
-We preempt workloads in other ClusterQueues to allow this ClusterQueue to
-reclaim its nominal quota. Configured using reclaimWithinCohort.</li>
-<li>When a Workload doesn't fit within the nominal quota of the ClusterQueue
-and there are admitted Workloads in the ClusterQueue with lower priority.
-Configured using withinClusterQueue.</li>
-<li>When a Workload may fit while both borrowing and preempting
-low priority workloads in the Cohort. Configured using borrowWithinCohort.</li>
-<li>When FairSharing is enabled, to maintain fair distribution of
-unused resources. See FairSharing documentation.</li>
-</ul>
-<p>The preemption algorithm tries to find a minimal set of Workloads to
-preempt to accomomdate the pending Workload, preempting Workloads with
-lower priority first.</p>
 
 
 <table class="table">
@@ -755,7 +737,9 @@ in the cohort that satisfy the fair sharing preemptionStrategies.</li>
 <a href="#kueue-x-k8s-io-v1beta1-BorrowWithinCohort"><code>BorrowWithinCohort</code></a>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span></td>
+   <p>borrowWithinCohort provides configuration to allow preemption within
+cohort while borrowing.</p>
+</td>
 </tr>
 <tr><td><code>withinClusterQueue</code> <B>[Required]</B><br/>
 <a href="#kueue-x-k8s-io-v1beta1-PreemptionPolicy"><code>PreemptionPolicy</code></a>
@@ -878,7 +862,21 @@ before borrowing or preempting in the flavor being evaluated.</p>
 <a href="#kueue-x-k8s-io-v1beta1-ClusterQueuePreemption"><code>ClusterQueuePreemption</code></a>
 </td>
 <td>
-   <span class="text-muted">No description provided.</span></td>
+   <p>preemption describes policies to preempt Workloads from this ClusterQueue
+or the ClusterQueue's cohort.</p>
+<p>Preemption can happen in two scenarios:</p>
+<ul>
+<li>When a Workload fits within the nominal quota of the ClusterQueue, but
+the quota is currently borrowed by other ClusterQueues in the cohort.
+Preempting Workloads in other ClusterQueues allows this ClusterQueue to
+reclaim its nominal quota.</li>
+<li>When a Workload doesn't fit within the nominal quota of the ClusterQueue
+and there are admitted Workloads in the ClusterQueue with lower priority.</li>
+</ul>
+<p>The preemption algorithm tries to find a minimal set of Workloads to
+preempt to accomomdate the pending Workload, preempting Workloads with
+lower priority first.</p>
+</td>
 </tr>
 <tr><td><code>admissionChecks</code><br/>
 <code>[]string</code>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Allows to upgrade to the latest 0.10.x version of Kueue to the users who use FairSharing and ClusterQueue.Preemption.BorrowWithinCohort.

This combination is buggy, but for now we don't have a better replacement, and no mitigation is known.
This will give users time to mitigate or find replacement configurations.

#### Special notes for your reviewer:

The reverting is only applied to 0.10 as 0.11 and main drifted already too much. 

Hopefully, we will have a better replacement for the configuration in the future. 
At the very least we give time to users to figure out a mitigation in the long run.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Revert making ClusterQueue.Preemption.BorrowWithinCohort as no-op when used with FairSharing, by reverting
https://github.com/kubernetes-sigs/kueue/pull/4165, which was done to prevent infinite-preemption loops as
described in https://github.com/kubernetes-sigs/kueue/issues/3779. However, it causes issues with upgrading for
users who use that combination. This configuration remains deprecated and can be removed without any notice
in future releases, so please consider alternatives.
```