### PR TITLE
[release-0.10] cherry-pick #4813

### DIFF
--- a/pkg/scheduler/preemption/policy.go
+++ b/pkg/scheduler/preemption/policy.go
@@ -1,0 +1,29 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preemption
+
+import (
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/cache"
+)
+
+// CanAlwaysReclaim indicates that the CQ is guaranteed to
+// be able to reclaim the capacity of workloads borrowing
+// its capacity.
+func CanAlwaysReclaim(cq *cache.ClusterQueueSnapshot) bool {
+	return cq.Preemption.ReclaimWithinCohort == kueue.PreemptionPolicyAny
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -225,10 +225,18 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 
 		if mode == flavorassigner.Preempt && len(e.preemptionTargets) == 0 {
 			log.V(2).Info("Workload requires preemption, but there are no candidate workloads allowed for preemption", "preemption", cq.Preemption)
-			// we use resourcesToReserve to block capacity up to either the nominal capacity,
-			// or the borrowing limit when borrowing, so that a lower priority workload cannot
-			// admit before us.
-			cq.AddUsage(resourcesToReserve(e, cq))
+			// we reserve capacity if we are uncertain
+			// whether we can reclaim the capacity
+			// later. Otherwise, we allow other workloads
+			// in the Cohort to borrow this capacity,
+			// confident we can reclaim it later.
+			if !preemption.CanAlwaysReclaim(cq) {
+				// reserve capacity up to the
+				// borrowing limit, so that
+				// lower-priority workloads in another
+				// Cohort cannot admit before us.
+				cq.AddUsage(resourcesToReserve(e, cq))
+			}
 			continue
 		}
 

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -75,6 +75,14 @@ func MakeWorkload(name, ns string) *WorkloadWrapper {
 	}}
 }
 
+// MakeWorkloadWithGeneratedName creates a wrapper for a Workload with a single pod
+// with a single container.
+func MakeWorkloadWithGeneratedName(namePrefix, ns string) *WorkloadWrapper {
+	wl := MakeWorkload("", ns)
+	wl.GenerateName = namePrefix
+	return wl
+}
+
 func (w *WorkloadWrapper) Obj() *kueue.Workload {
 	return &w.Workload
 }

--- a/test/util/util_scheduling.go
+++ b/test/util/util_scheduling.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func FinishRunningWorkloadsInCQ(ctx context.Context, k8sClient client.Client, cq *kueue.ClusterQueue, n int) {
+	var wList kueue.WorkloadList
+	gomega.ExpectWithOffset(1, k8sClient.List(ctx, &wList)).To(gomega.Succeed())
+	finished := 0
+	for i := 0; i < len(wList.Items) && finished < n; i++ {
+		wl := wList.Items[i]
+		if wl.Status.Admission != nil && string(wl.Status.Admission.ClusterQueue) == cq.Name && !meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadFinished) {
+			FinishWorkloads(ctx, k8sClient, &wl)
+			finished++
+		}
+	}
+	gomega.ExpectWithOffset(1, finished).To(gomega.Equal(n), "Not enough workloads finished")
+}
+
+func FinishEvictionOfWorkloadsInCQ(ctx context.Context, k8sClient client.Client, cq *kueue.ClusterQueue, n int) {
+	finished := sets.New[types.UID]()
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+		var wList kueue.WorkloadList
+		g.Expect(k8sClient.List(ctx, &wList)).To(gomega.Succeed())
+		for i := 0; i < len(wList.Items) && finished.Len() < n; i++ {
+			wl := wList.Items[i]
+			if wl.Status.Admission == nil || string(wl.Status.Admission.ClusterQueue) != cq.Name {
+				continue
+			}
+			evicted := meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted)
+			quotaReserved := meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
+			if evicted && quotaReserved {
+				workload.UnsetQuotaReservationWithCondition(&wl, "Pending", "Eviction finished by test", time.Now())
+				g.Expect(workload.ApplyAdmissionStatus(ctx, k8sClient, &wl, true)).To(gomega.Succeed())
+				finished.Insert(wl.UID)
+			}
+		}
+		g.Expect(finished.Len()).Should(gomega.Equal(n), "Not enough workloads evicted")
+	}, Timeout, Interval).Should(gomega.Succeed())
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Cherry-pick #4813. We additionally cherry-pick #4813, #4812, and copy some code from #4695

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Merge conflicts:
- e2e Metrics test file doesn't exist in 0.10
- TestScheduleForTASPreemption doesn't exist in 0.10
- TestScheduleForTASCohorts doesn't exist in 0.10
- FS Integration test "using hierarchical cohorts" doesn't exist in 0.10
- Dependency of FinishEvictionOfWorkloadsInCQ, workload.ApplyAdmissionStatus, takes one fewer parameter
- Needed to add function MakeWorkloadWithGeneratedName, which new tests depend on

#### Does this PR introduce a user-facing change?
```release-note
Fix bug which resulted in under-utilization of the resources in a Cohort.
Now, when a ClusterQueue is configured with `preemption.reclaimWithinCohort: Any`,
its resources can be lent out more freely, as we are certain that we can reclaim
them later. Please see PR #4813 for detailed description of scenario.
```