### PR TITLE
Fix getAncestorWorkload if integration disabled.

### DIFF
--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -164,6 +164,14 @@ type JobWithManagedBy interface {
 	SetManagedBy(*string)
 }
 
+// TopLevelJob interface is an optional interface used to indicate
+// that the Job owns/manages the Workload object, regardless of the Job
+// owner references.
+type TopLevelJob interface {
+	// IsTopLevel returns true if the Job owns/manages the Workload.
+	IsTopLevel() bool
+}
+
 func QueueName(job GenericJob) string {
 	return QueueNameForObject(job.Object())
 }

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -67,7 +67,7 @@ const (
 )
 
 var (
-	ErrUnknownWorkloadOwner     = errors.New("workload owner is unknown")
+	ErrCyclicOwnership          = errors.New("cyclic ownership")
 	ErrWorkloadOwnerNotFound    = errors.New("workload owner not found")
 	ErrNoMatchingWorkloads      = errors.New("no matching workloads")
 	ErrExtraWorkloads           = errors.New("extra workloads")
@@ -292,27 +292,31 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	isTopLevelJob := true
-	objectOwner := metav1.GetControllerOf(object)
-	if objectOwner != nil && IsOwnerManagedByKueue(objectOwner) {
-		isTopLevelJob = false
+	var (
+		ancestorJob   client.Object
+		isTopLevelJob bool
+	)
+
+	if topLevelJob, ok := job.(TopLevelJob); ok && topLevelJob.IsTopLevel() {
+		// Skipping traversal to top-level ancestor job because this is already a top-level job.
+		isTopLevelJob = true
+	} else {
+		ancestorJob, err = GetAncestorJobManagedByKueue(ctx, r.client, r.record, object)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		isTopLevelJob = ancestorJob == nil
 	}
 
 	// when manageJobsWithoutQueueName is disabled we only reconcile jobs that either
 	// have a queue-name label or have a kueue-managed ancestor that has a queue-name label.
 	if !r.manageJobsWithoutQueueName && QueueName(job) == "" {
 		if isTopLevelJob {
-			log.V(3).Info("queue-name label is not set, ignoring the job", "queueName", QueueName(job))
+			log.V(3).Info("queue-name label is not set, ignoring the job")
 			return ctrl.Result{}, nil
 		}
-		isAncestorJobManaged, err := r.IsAncestorJobManaged(ctx, job.Object())
-		if err != nil {
-			log.Error(err, "couldn't check whether an ancestor job is managed by kueue")
-			return ctrl.Result{}, err
-		}
-		if !isAncestorJobManaged {
-			log.V(3).Info("No kueue-managed ancestors have a queue-name label, ignoring the job",
-				"parentJob", objectOwner.Name)
+		if QueueNameForObject(ancestorJob) == "" {
+			log.V(3).Info("No kueue-managed ancestors have a queue-name label, ignoring the job")
 			return ctrl.Result{}, nil
 		}
 	}
@@ -321,7 +325,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 	if !isTopLevelJob {
 		_, _, finished := job.Finished()
 		if !finished && !job.IsSuspended() {
-			if ancestorWorkload, err := r.getAncestorWorkload(ctx, object); err != nil {
+			if ancestorWorkload, err := r.getAncestorWorkload(ctx, ancestorJob); err != nil {
 				log.Error(err, "couldn't get an ancestor job workload")
 				return ctrl.Result{}, err
 			} else if ancestorWorkload == nil || !workload.IsAdmitted(ancestorWorkload) {
@@ -572,20 +576,10 @@ func (r *JobReconciler) recordAdmissionCheckUpdate(wl *kueue.Workload, job Gener
 	}
 }
 
-// IsAncestorJobManaged checks whether an ancestor job is managed by kueue.
-func (r *JobReconciler) IsAncestorJobManaged(ctx context.Context, jobObj client.Object) (bool, error) {
-	ancestor, err := r.getAncestorJobManagedByKueue(ctx, jobObj)
-	if err != nil {
-		return false, err
-	}
-	return ancestor != nil, nil
-}
-
 // getAncestorWorkload returns the Workload object of the Kueue-managed ancestor job.
-func (r *JobReconciler) getAncestorWorkload(ctx context.Context, jobObj client.Object) (*kueue.Workload, error) {
-	ancestor, err := r.getAncestorJobManagedByKueue(ctx, jobObj)
-	if err != nil || ancestor == nil {
-		return nil, err
+func (r *JobReconciler) getAncestorWorkload(ctx context.Context, ancestor client.Object) (*kueue.Workload, error) {
+	if QueueNameForObject(ancestor) == "" {
+		return nil, nil
 	}
 	wlList := kueue.WorkloadList{}
 	if err := r.client.List(ctx, &wlList, client.InNamespace(ancestor.GetNamespace()), client.MatchingFields{indexer.OwnerReferenceUID: string(ancestor.GetUID())}); client.IgnoreNotFound(err) != nil {
@@ -593,45 +587,67 @@ func (r *JobReconciler) getAncestorWorkload(ctx context.Context, jobObj client.O
 	}
 	if len(wlList.Items) > 0 {
 		// In theory the job can own multiple Workloads, we cannot do too much about it, maybe log it.
+		ctrl.LoggerFrom(ctx).V(2).Info(
+			"WARNING: The job has multiple associated Workloads.",
+			"job", ancestor.GetName(),
+			"workloads", klog.KObjSlice(wlList.Items),
+		)
 		return &wlList.Items[0], nil
 	}
 	return nil, nil
 }
 
-// getAncestorJobManagedByKueue traverses controllerRefs to find an ancestor job that is manged by Kueue (ie, it has a queue-name label).
-func (r *JobReconciler) getAncestorJobManagedByKueue(ctx context.Context, jobObj client.Object) (client.Object, error) {
+// GetAncestorJobManagedByKueue traverses controllerRefs to find a top-level ancestor Job
+// that is managed by Kueue (i.e., it has a queue-name label). If a Job with a queue-name
+// is not found, it will return the top-level ancestor with an enabled integration.
+func GetAncestorJobManagedByKueue(ctx context.Context, c client.Client, record record.EventRecorder, jobObj client.Object) (client.Object, error) {
+	log := ctrl.LoggerFrom(ctx)
 	seen := sets.New[types.UID]()
-	currentJob := jobObj
-	for {
-		if seen.Has(currentJob.GetUID()) {
-			return nil, nil
-		}
-		seen.Insert(currentJob.GetUID())
+	currentObj := jobObj
 
-		owner := metav1.GetControllerOf(currentJob)
-		if owner == nil || !IsOwnerManagedByKueue(owner) {
-			return nil, nil
+	var topLevelJob client.Object
+	for {
+		if seen.Has(currentObj.GetUID()) {
+			log.Error(ErrCyclicOwnership,
+				"Terminated search for Kueue-managed Job because of cyclic ownership",
+				"owner", currentObj,
+			)
+			return nil, ErrCyclicOwnership
 		}
-		parentJob := GetEmptyOwnerObject(owner)
-		if parentJob == nil {
-			return nil, fmt.Errorf("workload owner %v: %w", owner, ErrUnknownWorkloadOwner)
+		seen.Insert(currentObj.GetUID())
+
+		owner := metav1.GetControllerOf(currentObj)
+		if owner == nil {
+			return topLevelJob, nil
 		}
-		if err := r.client.Get(ctx, client.ObjectKey{Name: owner.Name, Namespace: jobObj.GetNamespace()}, parentJob); err != nil {
+
+		parentObj := GetEmptyOwnerObject(owner)
+		managed := parentObj != nil
+		if parentObj == nil {
+			parentObj = &metav1.PartialObjectMetadata{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: owner.APIVersion,
+					Kind:       owner.Kind,
+				},
+			}
+		}
+		if err := c.Get(ctx, client.ObjectKey{Name: owner.Name, Namespace: jobObj.GetNamespace()}, parentObj); err != nil {
 			return nil, errors.Join(ErrWorkloadOwnerNotFound, err)
 		}
-		if QueueNameForObject(parentJob) != "" {
-			return parentJob, nil
+		if managed && (topLevelJob == nil || QueueNameForObject(topLevelJob) == "" || QueueNameForObject(parentObj) != "") {
+			topLevelJob = parentObj
 		}
-		currentJob = parentJob
+		currentObj = parentObj
 		if len(seen) > managedOwnersChainLimit {
-			r.record.Eventf(jobObj, corev1.EventTypeWarning, ReasonJobNestingTooDeep,
-				"Terminated search for Kueue-managed Job because ancestor depth exceeded limit of %d", managedOwnersChainLimit)
-			ctrl.LoggerFrom(ctx).V(2).Info(
-				"Terminated search for Kueue-managed Job because ancestor depth exceeded managedOwnersChainlimit",
-				"limit ", managedOwnersChainLimit,
-				"lastParentReached", parentJob,
+			record.Eventf(jobObj, corev1.EventTypeWarning, ReasonJobNestingTooDeep,
+				"Terminated search for Kueue-managed Job because ancestor depth exceeded limit of %d", managedOwnersChainLimit,
 			)
-			return nil, nil
+			log.V(2).Info(
+				"WARNING: Terminated search for Kueue-managed Job because ancestor depth exceeded managedOwnersChainLimit",
+				"limit ", managedOwnersChainLimit,
+				"lastParentReached", parentObj,
+			)
+			return topLevelJob, nil
 		}
 	}
 }

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -47,7 +47,7 @@ import (
 	. "sigs.k8s.io/kueue/pkg/controller/jobframework"
 )
 
-func TestGetAncestorJobManagedByKueue(t *testing.T) {
+func TestFindAncestorJobManagedByKueue(t *testing.T) {
 	grandparentJobName := "test-job-grandparent"
 	parentJobName := "test-job-parent"
 	childJobName := "test-job-child"
@@ -335,7 +335,7 @@ func TestGetAncestorJobManagedByKueue(t *testing.T) {
 				builder = builder.WithObjects(tc.job)
 			}
 			cl := builder.Build()
-			gotManaged, gotErr := GetAncestorJobManagedByKueue(ctx, cl, recorder, tc.job, tc.manageJobsWithoutQueueName)
+			gotManaged, gotErr := FindAncestorJobManagedByKueue(ctx, cl, recorder, tc.job, tc.manageJobsWithoutQueueName)
 			if diff := cmp.Diff(tc.wantManaged, gotManaged, cmp.Options{
 				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
 				cmpopts.EquateEmpty(),

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -31,12 +31,14 @@ import (
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingaw "sigs.k8s.io/kueue/pkg/util/testingjobs/appwrapper"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	"sigs.k8s.io/kueue/pkg/util/testingjobs/jobset"
 	testingmpijob "sigs.k8s.io/kueue/pkg/util/testingjobs/mpijob"
 
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
@@ -44,34 +46,38 @@ import (
 	. "sigs.k8s.io/kueue/pkg/controller/jobframework"
 )
 
-func TestIsAncestorJobManaged(t *testing.T) {
+func TestGetAncestorJobManagedByKueue(t *testing.T) {
 	grandparentJobName := "test-job-grandparent"
 	parentJobName := "test-job-parent"
 	childJobName := "test-job-child"
 	jobNamespace := "default"
 	cases := map[string]struct {
-		ancestors   []client.Object
-		job         client.Object
-		wantManaged bool
-		wantErr     error
-		wantEvents  []utiltesting.EventRecord
+		integrations []string
+		ancestors    []client.Object
+		job          client.Object
+		wantManaged  client.Object
+		wantErr      error
+		wantEvents   []utiltesting.EventRecord
 	}{
 		"child job has ownerReference with unmanaged workload owner": {
+			integrations: []string{"kubeflow.org/mpijob", "workload.codeflare.dev/appwrapper", "batch/job"},
 			ancestors: []client.Object{
 				testingjob.MakeJob(parentJobName, jobNamespace).UID(parentJobName).Obj(),
 			},
 			job: testingjob.MakeJob(childJobName, jobNamespace).
 				OwnerReference(parentJobName, batchv1.SchemeGroupVersion.WithKind("CronJob")).
 				Obj(),
-			wantManaged: false,
+			wantErr: ErrWorkloadOwnerNotFound,
 		},
 		"child job has ownerReference with known non-existing workload owner": {
+			integrations: []string{"kubeflow.org/mpijob", "workload.codeflare.dev/appwrapper", "batch/job"},
 			job: testingjob.MakeJob(childJobName, jobNamespace).
 				OwnerReference(parentJobName, kfmpi.SchemeGroupVersionKind).
 				Obj(),
 			wantErr: ErrWorkloadOwnerNotFound,
 		},
 		"child job has ownerReference with known existing workload owner, and the parent job has queue-name label": {
+			integrations: []string{"kubeflow.org/mpijob", "workload.codeflare.dev/appwrapper", "batch/job"},
 			ancestors: []client.Object{
 				testingmpijob.MakeMPIJob(parentJobName, jobNamespace).
 					UID(parentJobName).
@@ -81,9 +87,13 @@ func TestIsAncestorJobManaged(t *testing.T) {
 			job: testingjob.MakeJob(childJobName, jobNamespace).
 				OwnerReference(parentJobName, kfmpi.SchemeGroupVersionKind).
 				Obj(),
-			wantManaged: true,
+			wantManaged: testingmpijob.MakeMPIJob(parentJobName, jobNamespace).
+				UID(parentJobName).
+				Queue("test-q").
+				Obj(),
 		},
 		"child job has ownerReference with known existing workload owner, and the parent job doesn't has queue-name label": {
+			integrations: []string{"kubeflow.org/mpijob", "workload.codeflare.dev/appwrapper", "batch/job"},
 			ancestors: []client.Object{
 				testingmpijob.MakeMPIJob(parentJobName, jobNamespace).
 					UID(parentJobName).
@@ -91,9 +101,13 @@ func TestIsAncestorJobManaged(t *testing.T) {
 			},
 			job: testingjob.MakeJob(childJobName, jobNamespace).
 				OwnerReference(parentJobName, kfmpi.SchemeGroupVersionKind).
+				Obj(),
+			wantManaged: testingmpijob.MakeMPIJob(parentJobName, jobNamespace).
+				UID(parentJobName).
 				Obj(),
 		},
 		"child job has managed parent and grandparent and grandparent has a queue-name label": {
+			integrations: []string{"kubeflow.org/mpijob", "workload.codeflare.dev/appwrapper", "batch/job"},
 			ancestors: []client.Object{
 				testingaw.MakeAppWrapper(grandparentJobName, jobNamespace).
 					UID(grandparentJobName).
@@ -107,9 +121,13 @@ func TestIsAncestorJobManaged(t *testing.T) {
 			job: testingjob.MakeJob(childJobName, jobNamespace).
 				OwnerReference(parentJobName, kfmpi.SchemeGroupVersionKind).
 				Obj(),
-			wantManaged: true,
+			wantManaged: testingaw.MakeAppWrapper(grandparentJobName, jobNamespace).
+				UID(grandparentJobName).
+				Queue("test-q").
+				Obj(),
 		},
 		"child job has managed parent and grandparent and grandparent doesn't have a queue-name label": {
+			integrations: []string{"kubeflow.org/mpijob", "workload.codeflare.dev/appwrapper", "batch/job"},
 			ancestors: []client.Object{
 				testingaw.MakeAppWrapper(grandparentJobName, jobNamespace).
 					UID(grandparentJobName).
@@ -122,9 +140,12 @@ func TestIsAncestorJobManaged(t *testing.T) {
 			job: testingjob.MakeJob(childJobName, jobNamespace).
 				OwnerReference(parentJobName, kfmpi.SchemeGroupVersionKind).
 				Obj(),
-			wantManaged: false,
+			wantManaged: testingaw.MakeAppWrapper(grandparentJobName, jobNamespace).
+				UID(grandparentJobName).
+				Obj(),
 		},
 		"cyclic ownership links are properly handled": {
+			integrations: []string{"kubeflow.org/mpijob", "workload.codeflare.dev/appwrapper", "batch/job"},
 			ancestors: []client.Object{
 				testingaw.MakeAppWrapper(grandparentJobName, jobNamespace).
 					UID(grandparentJobName).
@@ -138,9 +159,10 @@ func TestIsAncestorJobManaged(t *testing.T) {
 			job: testingjob.MakeJob(childJobName, jobNamespace).
 				OwnerReference(parentJobName, kfmpi.SchemeGroupVersionKind).
 				Obj(),
-			wantManaged: false,
+			wantErr: ErrCyclicOwnership,
 		},
 		"cuts off ancestor traversal at the limit and generates an appropriate event": {
+			integrations: []string{"kubeflow.org/mpijob", "workload.codeflare.dev/appwrapper", "batch/job"},
 			ancestors: []client.Object{
 				testingjob.MakeJob("ancestor-0", jobNamespace).UID("ancestor-0").Queue("test-q").Obj(),
 				testingjob.MakeJob("ancestor-1", jobNamespace).UID("ancestor-1").OwnerReference("ancestor-0", batchv1.SchemeGroupVersion.WithKind("Job")).Obj(),
@@ -158,7 +180,6 @@ func TestIsAncestorJobManaged(t *testing.T) {
 			job: testingjob.MakeJob(childJobName, jobNamespace).
 				OwnerReference("ancestor-11", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
-			wantManaged: false,
 			wantEvents: []utiltesting.EventRecord{
 				{
 					Key:       types.NamespacedName{Namespace: jobNamespace, Name: childJobName},
@@ -167,29 +188,49 @@ func TestIsAncestorJobManaged(t *testing.T) {
 					Message:   "Terminated search for Kueue-managed Job because ancestor depth exceeded limit of 10",
 				},
 			},
+			wantManaged: testingjob.MakeJob("ancestor-1", jobNamespace).UID("ancestor-1").OwnerReference("ancestor-0", batchv1.SchemeGroupVersion.WithKind("Job")).Obj(),
+		},
+		"child Job has an unmanaged parent but a managed grandparent, and the grandparent has a queue-name label": {
+			integrations: []string{"batch/job", "workload.codeflare.dev/appwrapper"},
+			ancestors: []client.Object{
+				testingaw.MakeAppWrapper("aw", jobNamespace).UID("aw").
+					Queue("test-q").
+					Obj(),
+				jobset.MakeJobSet("jobset", jobNamespace).UID("jobset").
+					OwnerReference("aw", awv1beta2.GroupVersion.WithKind(awv1beta2.AppWrapperKind)).
+					Obj(),
+			},
+			job: testingjob.MakeJob("job", jobNamespace).UID("job").
+				OwnerReference("jobset", v1alpha2.SchemeGroupVersion.WithKind("JobSet")).
+				Obj(),
+			wantManaged: testingaw.MakeAppWrapper("aw", jobNamespace).UID("aw").
+				Queue("test-q").
+				Obj(),
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Cleanup(EnableIntegrationsForTest(t, "kubeflow.org/mpijob", "workload.codeflare.dev/appwrapper", "batch/job"))
+			t.Cleanup(EnableIntegrationsForTest(t, tc.integrations...))
 			ctx, _ := utiltesting.ContextWithLog(t)
 			recorder := &utiltesting.EventRecorder{}
-			builder := utiltesting.NewClientBuilder(kfmpi.AddToScheme, awv1beta2.AddToScheme)
+			builder := utiltesting.NewClientBuilder(kfmpi.AddToScheme, awv1beta2.AddToScheme, v1alpha2.AddToScheme)
 			builder = builder.WithObjects(tc.ancestors...)
 			if tc.job != nil {
 				builder = builder.WithObjects(tc.job)
 			}
 			cl := builder.Build()
-			r := NewReconciler(cl, recorder)
-			got, gotErr := r.IsAncestorJobManaged(ctx, tc.job)
-			if tc.wantManaged != got {
-				t.Errorf("Unexpected response from IsAncestorJobManaged want: %v,got: %v", tc.wantManaged, got)
+			gotManaged, gotErr := GetAncestorJobManagedByKueue(ctx, cl, recorder, tc.job)
+			if diff := cmp.Diff(tc.wantManaged, gotManaged, cmp.Options{
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+				cmpopts.EquateEmpty(),
+			}); len(diff) != 0 {
+				t.Errorf("Unexpected managed job (-want,+got):\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents); diff != "" {
-				t.Errorf("unexpected events (-want/+got):\n%s", diff)
+				t.Errorf("Unexpected events (-want/+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -2207,6 +2207,7 @@ func TestReconciler(t *testing.T) {
 				Obj(),
 			otherJobs: []batchv1.Job{
 				*utiltestingjob.MakeJob("parent", "ns").
+					UID("parent").
 					Queue("queue").
 					Obj(),
 			},

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -161,6 +161,7 @@ var (
 	_ jobframework.JobWithFinalize                 = (*Pod)(nil)
 	_ jobframework.ComposableJob                   = (*Pod)(nil)
 	_ jobframework.JobWithCustomWorkloadConditions = (*Pod)(nil)
+	_ jobframework.TopLevelJob                     = (*Pod)(nil)
 )
 
 type options struct {
@@ -318,6 +319,10 @@ func (p *Pod) Run(ctx context.Context, c client.Client, podSetsInfo []podset.Pod
 		}
 		return nil
 	})
+}
+
+func (p *Pod) IsTopLevel() bool {
+	return true
 }
 
 // RunWithPodSetsInfo will inject the node affinity and podSet counts extracting from workload to job and unsuspend it.

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -321,12 +321,12 @@ func (w *WorkloadWrapper) Conditions(conditions ...metav1.Condition) *WorkloadWr
 }
 
 func (w *WorkloadWrapper) ControllerReference(gvk schema.GroupVersionKind, name, uid string) *WorkloadWrapper {
-	appendOwnerReference(&w.Workload, gvk, name, uid, ptr.To(true), ptr.To(true))
+	AppendOwnerReference(&w.Workload, gvk, name, uid, ptr.To(true), ptr.To(true))
 	return w
 }
 
 func (w *WorkloadWrapper) OwnerReference(gvk schema.GroupVersionKind, name, uid string) *WorkloadWrapper {
-	appendOwnerReference(&w.Workload, gvk, name, uid, nil, nil)
+	AppendOwnerReference(&w.Workload, gvk, name, uid, nil, nil)
 	return w
 }
 
@@ -1528,7 +1528,7 @@ func (w *PodTemplateWrapper) Toleration(toleration corev1.Toleration) *PodTempla
 }
 
 func (w *PodTemplateWrapper) ControllerReference(gvk schema.GroupVersionKind, name, uid string) *PodTemplateWrapper {
-	appendOwnerReference(&w.PodTemplate, gvk, name, uid, ptr.To(true), ptr.To(true))
+	AppendOwnerReference(&w.PodTemplate, gvk, name, uid, ptr.To(true), ptr.To(true))
 	return w
 }
 
@@ -1563,7 +1563,7 @@ func (w *NamespaceWrapper) Label(k, v string) *NamespaceWrapper {
 	return w
 }
 
-func appendOwnerReference(obj client.Object, gvk schema.GroupVersionKind, name, uid string, controller, blockDeletion *bool) {
+func AppendOwnerReference(obj client.Object, gvk schema.GroupVersionKind, name, uid string, controller, blockDeletion *bool) {
 	obj.SetOwnerReferences(append(obj.GetOwnerReferences(), metav1.OwnerReference{
 		APIVersion:         gvk.GroupVersion().String(),
 		Kind:               gvk.Kind,

--- a/pkg/util/testingjobs/jobset/wrappers.go
+++ b/pkg/util/testingjobs/jobset/wrappers.go
@@ -21,11 +21,14 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 	jobsetutil "sigs.k8s.io/jobset/pkg/util/testing"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/util/testing"
 )
 
 // JobSetWrapper wraps a JobSet.
@@ -93,6 +96,11 @@ func (j *JobSetWrapper) ReplicatedJobs(replicatedJobs ...ReplicatedJobRequiremen
 		}
 		j.Spec.ReplicatedJobs[index] = jobsetutil.MakeReplicatedJob(req.Name).Job(jt).Replicas(req.Replicas).Obj()
 	}
+	return j
+}
+
+func (j *JobSetWrapper) UID(uid string) *JobSetWrapper {
+	j.ObjectMeta.UID = types.UID(uid)
 	return j
 }
 
@@ -191,5 +199,11 @@ func (j *JobSetWrapper) Condition(c metav1.Condition) *JobSetWrapper {
 // ManagedBy adds a managedby.
 func (j *JobSetWrapper) ManagedBy(c string) *JobSetWrapper {
 	j.Spec.ManagedBy = &c
+	return j
+}
+
+// OwnerReference adds a ownerReference to the default container.
+func (j *JobSetWrapper) OwnerReference(ownerName string, ownerGVK schema.GroupVersionKind) *JobSetWrapper {
+	testing.AppendOwnerReference(j, ownerGVK, ownerName, ownerName, ptr.To(true), nil)
 	return j
 }

--- a/pkg/util/testingjobs/jobset/wrappers.go
+++ b/pkg/util/testingjobs/jobset/wrappers.go
@@ -50,6 +50,7 @@ type ReplicatedJobRequirements struct {
 	Replicas       int32
 	Parallelism    int32
 	Completions    int32
+	Labels         map[string]string
 	Annotations    map[string]string
 	PodAnnotations map[string]string
 	Image          string
@@ -77,6 +78,7 @@ func (j *JobSetWrapper) ReplicatedJobs(replicatedJobs ...ReplicatedJobRequiremen
 	j.Spec.ReplicatedJobs = make([]jobsetapi.ReplicatedJob, len(replicatedJobs))
 	for index, req := range replicatedJobs {
 		jt := jobsetutil.MakeJobTemplate("", "").PodSpec(TestPodSpec).Obj()
+		jt.Labels = req.Labels
 		jt.Annotations = req.Annotations
 		jt.Spec.Parallelism = ptr.To(req.Parallelism)
 		jt.Spec.Completions = ptr.To(req.Completions)

--- a/test/e2e/customconfigs/managejobswithoutqueuename_test.go
+++ b/test/e2e/customconfigs/managejobswithoutqueuename_test.go
@@ -291,8 +291,8 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 
 			ginkgo.By("Checking that the AppWrapper is unsuspended", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(aw), aw)).To(gomega.Succeed())
-					g.Expect(aw.Spec.Suspend).Should(gomega.BeFalse())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(aw), createdAppWrapper)).To(gomega.Succeed())
+					g.Expect(createdAppWrapper.Spec.Suspend).Should(gomega.BeFalse())
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -697,9 +697,10 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName without JobSet integration",
 			})
 
 			ginkgo.By("Checking that the AppWrapper is unsuspended", func() {
+				createdAppWrapper := &awv1beta2.AppWrapper{}
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(aw), aw)).To(gomega.Succeed())
-					g.Expect(aw.Spec.Suspend).Should(gomega.BeFalse())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(aw), createdAppWrapper)).To(gomega.Succeed())
+					g.Expect(createdAppWrapper.Spec.Suspend).Should(gomega.BeFalse())
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix `getAncestorWorkload` when one of middle owner object disabled or not managed by Kueue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #4860

#### Special notes for your reviewer:
In case

```
Job -> JobSet(disabled) -> AppWrapper (with queue name)
```
or

```
Job -> CustomResource -> AppWrapper (with queue name)
```

we should traverse to root object and get Workload for AppWrapper even if one of middle resources not managed by Kueue.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a bug that caused Kueue to create redundant workloads for each Job when manageJobsWithoutQueueName was enabled, JobSet integration was disabled, and AppWrapper was used for JobSet.
```