### PR TITLE
fix detection of InternalCertManagement enablement

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -157,7 +157,7 @@ func main() {
 		FilterProvider: filters.WithAuthenticationAndAuthorization,
 	}
 
-	if cfg.InternalCertManagement == nil || !*cfg.InternalCertManagement.Enable {
+	if cfg.InternalCertManagement == nil || *cfg.InternalCertManagement.Enable {
 		metricsCertPath := "/etc/kueue/metrics/certs"
 		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
 			"metrics-cert-path", metricsCertPath)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes the detection of the enablement of the Internal Certificate Manager. 'Enable' should be set to 'true' to enable the InternalCertManagement functionality.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixes the detection of the enablement of the InternalCertManager
```