### PR TITLE
Add Topology rbac templates in chart

### DIFF
--- a/charts/kueue/templates/rbac/topology_editor_role.yaml
+++ b/charts/kueue/templates/rbac/topology_editor_role.yaml
@@ -1,0 +1,21 @@
+# permissions for end users to edit topologies.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: '{{ include "kueue.fullname" . }}-topology-editor-role'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+rules:
+  - apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - topologies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/charts/kueue/templates/rbac/topology_viewer_role.yaml
+++ b/charts/kueue/templates/rbac/topology_viewer_role.yaml
@@ -1,0 +1,17 @@
+# permissions for end users to view resourceflavors.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: '{{ include "kueue.fullname" . }}-topology-viewer-role'
+  labels:
+  {{- include "kueue.labels" . | nindent 4 }}
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+rules:
+  - apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - topologies
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Topology should have same cluster role configured as ResourceFlavor.

#### Which issue(s) this PR fixes:

Fixes #4831

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add cluster role for Topology in chart
```