### PR TITLE
[helm] Disable conversion of the v1alpha1 Topology CRD

### DIFF
--- a/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
@@ -12,15 +12,7 @@ metadata:
   name: topologies.kueue.x-k8s.io
 spec:
   conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: {{ include "kueue.fullname" . }}-webhook-service
-          namespace: '{{ .Release.Namespace }}'
-          path: /convert
-      conversionReviewVersions:
-      - v1
+    strategy: None
   group: kueue.x-k8s.io
   names:
     kind: Topology


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/kueue/issues/4850. There's no webhook for converting Topolgy into v1beta1 and supposedly, the v1beta1 should not be public facing yet

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes https://github.com/kubernetes-sigs/kueue/issues/4850. There's no webhook for converting Topolgy into v1beta1 and supposedly, the v1beta1 should not be public facing yet

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4850

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```