### PR TITLE
Fix artifact generation due to wrong alpha-enabled manifests

### DIFF
--- a/config/alpha-enabled/kustomization.yaml
+++ b/config/alpha-enabled/kustomization.yaml
@@ -3,8 +3,6 @@
 # Use default settings as a base.
 resources:
 - ../default
-- topology_editor_role.yaml
-- topology_viewer_role.yaml
 
 patches:
 # Modify feature gates to enable AllAlpha=true


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
To fix artifact generation, as
```
> make artifacts IMAGE_REGISTRY=registry.k8s.io/kueue GIT_TAG=$VERSION
cd config/components/manager && /usr/local/google/home/michalwozniak/go/src/sigs.k8s.io/kueue/bin/kustomize edit set image controller=registry.k8s.io/kueue/kueue:v0.11.3
if [ -d artifacts ]; then rm -rf artifacts; fi
mkdir -p artifacts
/usr/local/google/home/michalwozniak/go/src/sigs.k8s.io/kueue/bin/kustomize build config/default -o artifacts/manifests.yaml
/usr/local/google/home/michalwozniak/go/src/sigs.k8s.io/kueue/bin/kustomize build config/dev -o artifacts/manifests-dev.yaml
/usr/local/google/home/michalwozniak/go/src/sigs.k8s.io/kueue/bin/kustomize build config/alpha-enabled -o artifacts/manifests-alpha-enabled.yaml
Error: accumulating resources: accumulation err='accumulating resources from 'topology_editor_role.yaml': evalsymlink failure on '/usr/local/google/home/michalwozniak/go/src/sigs.k8s.io/kueue/config/alpha-enabled/topology_editor_role.yaml' : lstat /usr/local/google/home/michalwozniak/go/src/sigs.k8s.io/kueue/config/alpha-enabled/topology_editor_role.yaml: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on '/usr/local/google/home/michalwozniak/go/src/sigs.k8s.io/kueue/config/alpha-enabled/topology_editor_role.yaml' : lstat /usr/local/google/home/michalwozniak/go/src/sigs.k8s.io/kueue/config/alpha-enabled/topology_editor_role.yaml: no such file or directory
make: *** [Makefile:269: artifacts] Error 1
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```