### PR TITLE
WIP: Fix deployment suspend by parent logic.

### DIFF
--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -82,6 +82,7 @@ rules:
   - apiGroups:
       - apps
     resources:
+      - deployments
       - replicasets
       - statefulsets
     verbs:

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -81,6 +81,7 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - deployments
   - replicasets
   - statefulsets
   verbs:

--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -45,8 +45,6 @@ func ApplyDefaultForSuspend(ctx context.Context, job GenericJob, k8sClient clien
 	return nil
 }
 
-// +kubebuilder:rbac:groups="apps",resources=replicasets,verbs=get;list;watch
-
 // WorkloadShouldBeSuspended determines whether jobObj should be default suspended on creation
 func WorkloadShouldBeSuspended(ctx context.Context, jobObj client.Object, k8sClient client.Client,
 	manageJobsWithoutQueueName bool, managedJobsNamespaceSelector labels.Selector) (bool, error) {

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller.go
@@ -205,18 +205,18 @@ func (aw *AppWrapper) PodsReady() bool {
 	return meta.IsStatusConditionTrue(aw.Status.Conditions, string(awv1beta2.PodsReady))
 }
 
-func (j *AppWrapper) CanDefaultManagedBy() bool {
-	jobSpecManagedBy := j.Spec.ManagedBy
+func (aw *AppWrapper) CanDefaultManagedBy() bool {
+	jobSpecManagedBy := aw.Spec.ManagedBy
 	return features.Enabled(features.MultiKueue) &&
 		(jobSpecManagedBy == nil || *jobSpecManagedBy == awv1beta2.AppWrapperControllerName)
 }
 
-func (j *AppWrapper) ManagedBy() *string {
-	return j.Spec.ManagedBy
+func (aw *AppWrapper) ManagedBy() *string {
+	return aw.Spec.ManagedBy
 }
 
-func (j *AppWrapper) SetManagedBy(managedBy *string) {
-	j.Spec.ManagedBy = managedBy
+func (aw *AppWrapper) SetManagedBy(managedBy *string) {
+	aw.Spec.ManagedBy = managedBy
 }
 
 func GetWorkloadNameForAppWrapper(jobName string, jobUID types.UID) string {

--- a/pkg/controller/jobs/deployment/deployment_controller.go
+++ b/pkg/controller/jobs/deployment/deployment_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -38,17 +39,25 @@ const (
 
 func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
-		SetupIndexes:   SetupIndexes,
-		NewReconciler:  jobframework.NewNoopReconcilerFactory(gvk),
-		GVK:            gvk,
-		SetupWebhook:   SetupWebhook,
-		JobType:        &appsv1.Deployment{},
-		AddToScheme:    appsv1.AddToScheme,
-		DependencyList: []string{"pod"},
+		SetupIndexes:           SetupIndexes,
+		NewReconciler:          jobframework.NewNoopReconcilerFactory(gvk),
+		GVK:                    gvk,
+		SetupWebhook:           SetupWebhook,
+		JobType:                &appsv1.Deployment{},
+		AddToScheme:            appsv1.AddToScheme,
+		DependencyList:         []string{"pod"},
+		IsManagingObjectsOwner: isDeployment,
 	}))
 }
 
+// +kubebuilder:rbac:groups="apps",resources=replicasets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;list;watch
+
 type Deployment appsv1.Deployment
+
+func isDeployment(ref *metav1.OwnerReference) bool {
+	return ref.Kind == "Deployment" && ref.APIVersion == "apps/v1"
+}
 
 func fromObject(o runtime.Object) *Deployment {
 	return (*Deployment)(o.(*appsv1.Deployment))

--- a/pkg/util/testingjobs/deployment/wrappers.go
+++ b/pkg/util/testingjobs/deployment/wrappers.go
@@ -160,3 +160,9 @@ func (d *DeploymentWrapper) TerminationGracePeriod(seconds int64) *DeploymentWra
 	d.Spec.Template.Spec.TerminationGracePeriodSeconds = &seconds
 	return d
 }
+
+func (d *DeploymentWrapper) SetTypeMeta() *DeploymentWrapper {
+	d.APIVersion = appsv1.SchemeGroupVersion.String()
+	d.Kind = "Deployment"
+	return d
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix deployment suspend by parent logic.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #4860

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```