### PR TITLE
Use Component struct on AppWrapper.

### DIFF
--- a/pkg/controller/jobs/appwrapper/appwrapper_controller_test.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller_test.go
@@ -95,8 +95,8 @@ func TestPodSets(t *testing.T) {
 	}{
 		"no annotations": {
 			job: testingappwrapper.MakeAppWrapper("aw", "ns").
-				Component(pytorchJob).
-				Component(batchJob).
+				Component(testingappwrapper.Component{Template: pytorchJob}).
+				Component(testingappwrapper.Component{Template: batchJob}).
 				Obj(),
 			wantPodSets: []kueue.PodSet{
 				*utiltesting.MakePodSet("aw-0", 1).
@@ -113,7 +113,7 @@ func TestPodSets(t *testing.T) {
 		},
 		"with required and preferred topology annotation": {
 			job: testingappwrapper.MakeAppWrapper("aw", "ns").
-				Component(pytorchJobTAS).
+				Component(testingappwrapper.Component{Template: pytorchJobTAS}).
 				Obj(),
 
 			wantPodSets: []kueue.PodSet{
@@ -135,7 +135,7 @@ func TestPodSets(t *testing.T) {
 		},
 		"without required and preferred topology annotation if TAS is disabled": {
 			job: testingappwrapper.MakeAppWrapper("aw", "ns").
-				Component(pytorchJobTAS).
+				Component(testingappwrapper.Component{Template: pytorchJobTAS}).
 				Obj(),
 
 			wantPodSets: []kueue.PodSet{
@@ -198,10 +198,14 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
 			job: testingappwrapper.MakeAppWrapper("aw", "ns").
-				Component(utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj()).
+				Component(testingappwrapper.Component{
+					Template: utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj(),
+				}).
 				Obj(),
 			wantJob: testingappwrapper.MakeAppWrapper("aw", "ns").
-				Component(utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj()).
+				Component(testingappwrapper.Component{
+					Template: utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj(),
+				}).
 				Obj(),
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("aw", "ns").
@@ -218,14 +222,18 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
 			job: testingappwrapper.MakeAppWrapper("aw", "ns").
-				Component(utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj()).
+				Component(testingappwrapper.Component{
+					Template: utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj(),
+				}).
 				Annotations(map[string]string{
 					controllerconsts.ProvReqAnnotationPrefix + "test-annotation": "test-val",
 					"invalid-provreq-prefix/test-annotation-2":                   "test-val-2",
 				}).
 				Obj(),
 			wantJob: testingappwrapper.MakeAppWrapper("aw", "ns").
-				Component(utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj()).
+				Component(testingappwrapper.Component{
+					Template: utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj(),
+				}).
 				Annotations(map[string]string{
 					controllerconsts.ProvReqAnnotationPrefix + "test-annotation": "test-val",
 					"invalid-provreq-prefix/test-annotation-2":                   "test-val-2",
@@ -246,10 +254,14 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManageJobsWithoutQueueName(false),
 			},
 			job: testingappwrapper.MakeAppWrapper("aw", "ns").
-				Component(utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj()).
+				Component(testingappwrapper.Component{
+					Template: utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj(),
+				}).
 				Obj(),
 			wantJob: testingappwrapper.MakeAppWrapper("aw", "ns").
-				Component(utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj()).
+				Component(testingappwrapper.Component{
+					Template: utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj(),
+				}).
 				Obj(),
 			wantWorkloads: []kueue.Workload{},
 		},
@@ -354,12 +366,16 @@ func TestReconciler(t *testing.T) {
 
 		"workload shouldn't be recreated for completed job": {
 			job: testingappwrapper.MakeAppWrapper("aw", "ns").
-				Component(utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj()).
+				Component(testingappwrapper.Component{
+					Template: utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj(),
+				}).
 				Queue("foo").
 				SetPhase(awv1beta2.AppWrapperSucceeded).
 				Obj(),
 			wantJob: testingappwrapper.MakeAppWrapper("aw", "ns").
-				Component(utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj()).
+				Component(testingappwrapper.Component{
+					Template: utiltestingjob.MakeJob("job", "ns").Parallelism(2).SetTypeMeta().Obj(),
+				}).
 				Queue("foo").
 				SetPhase(awv1beta2.AppWrapperSucceeded).
 				Obj(),

--- a/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter_test.go
@@ -49,7 +49,9 @@ func TestMultiKueueAdapter(t *testing.T) {
 	}
 
 	baseAppWrapperBuilder := utiltestingaw.MakeAppWrapper("aw1", TestNamespace).
-		Component(utiltestingjob.MakeJob("job", "ns").SetTypeMeta().Parallelism(2).Obj())
+		Component(utiltestingaw.Component{
+			Template: utiltestingjob.MakeJob("job", "ns").SetTypeMeta().Parallelism(2).Obj(),
+		})
 	baseAppWrapperManagedByKueueBuilder := baseAppWrapperBuilder.DeepCopy().ManagedBy(kueue.MultiKueueControllerName)
 
 	cases := map[string]struct {

--- a/pkg/util/testingjobs/appwrapper/wrappers.go
+++ b/pkg/util/testingjobs/appwrapper/wrappers.go
@@ -96,39 +96,26 @@ func (aw *AppWrapperWrapper) UID(uid string) *AppWrapperWrapper {
 }
 
 // OwnerReference adds a ownerReference to the default container.
-func (j *AppWrapperWrapper) OwnerReference(ownerName string, ownerGVK schema.GroupVersionKind) *AppWrapperWrapper {
-	j.ObjectMeta.OwnerReferences = append(j.ObjectMeta.OwnerReferences, metav1.OwnerReference{
+func (aw *AppWrapperWrapper) OwnerReference(ownerName string, ownerGVK schema.GroupVersionKind) *AppWrapperWrapper {
+	aw.ObjectMeta.OwnerReferences = append(aw.ObjectMeta.OwnerReferences, metav1.OwnerReference{
 		APIVersion: ownerGVK.GroupVersion().String(),
 		Kind:       ownerGVK.Kind,
 		Name:       ownerName,
 		UID:        types.UID(ownerName),
 		Controller: ptr.To(true),
 	})
-	return j
-}
-
-// Component adds a component to the AppWrapper
-func (aw *AppWrapperWrapper) Component(comp runtime.Object) *AppWrapperWrapper {
-	data, err := json.Marshal(comp)
-	if err == nil {
-		// See https://github.com/project-codeflare/codeflare-operator/pull/630
-		// The root cause is that the Kubernetes API defines creationTimestamp as a struct instead of a pointer
-		patchedData := strings.ReplaceAll(string(data), `"metadata":{"creationTimestamp":null},`, "")
-		patchedData = strings.ReplaceAll(patchedData, `"metadata":{"creationTimestamp":null,`, `"metadata":{`)
-		patchedData = strings.ReplaceAll(patchedData, `"creationTimestamp":null,`, "")
-		awc := awv1beta2.AppWrapperComponent{
-			Template: runtime.RawExtension{
-				Raw: []byte(patchedData),
-			},
-		}
-		aw.AppWrapper.Spec.Components = append(aw.AppWrapper.Spec.Components, awc)
-	}
 	return aw
 }
 
-// ComponentWithInfos adds a component to the AppWrapper
-func (aw *AppWrapperWrapper) ComponentWithInfos(comp runtime.Object, infos ...awv1beta2.AppWrapperPodSetInfo) *AppWrapperWrapper {
-	data, err := json.Marshal(comp)
+type Component struct {
+	DeclaredPodSets []awv1beta2.AppWrapperPodSet
+	Template        runtime.Object
+	PodSetInfos     []awv1beta2.AppWrapperPodSetInfo
+}
+
+// Component adds a component to the AppWrapper
+func (aw *AppWrapperWrapper) Component(component Component) *AppWrapperWrapper {
+	data, err := json.Marshal(component.Template)
 	if err == nil {
 		// See https://github.com/project-codeflare/codeflare-operator/pull/630
 		// The root cause is that the Kubernetes API defines creationTimestamp as a struct instead of a pointer
@@ -136,10 +123,11 @@ func (aw *AppWrapperWrapper) ComponentWithInfos(comp runtime.Object, infos ...aw
 		patchedData = strings.ReplaceAll(patchedData, `"metadata":{"creationTimestamp":null,`, `"metadata":{`)
 		patchedData = strings.ReplaceAll(patchedData, `"creationTimestamp":null,`, "")
 		awc := awv1beta2.AppWrapperComponent{
+			DeclaredPodSets: component.DeclaredPodSets,
+			PodSetInfos:     component.PodSetInfos,
 			Template: runtime.RawExtension{
 				Raw: []byte(patchedData),
 			},
-			PodSetInfos: infos,
 		}
 		aw.AppWrapper.Spec.Components = append(aw.AppWrapper.Spec.Components, awc)
 	}

--- a/test/e2e/customconfigs/skipjobswithoutqueuename_test.go
+++ b/test/e2e/customconfigs/skipjobswithoutqueuename_test.go
@@ -123,13 +123,15 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 		ginkgo.It("should not suspend child jobs of admitted jobs", func() {
 			numPods := 2
 			aw := awtesting.MakeAppWrapper("aw-child", ns.Name).
-				Component(testingjob.MakeJob("job-0", ns.Name).
-					RequestAndLimit(corev1.ResourceCPU, "200m").
-					Parallelism(int32(numPods)).
-					Completions(int32(numPods)).
-					Suspend(false).
-					Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
-					SetTypeMeta().Obj()).
+				Component(awtesting.Component{
+					Template: testingjob.MakeJob("job-0", ns.Name).
+						RequestAndLimit(corev1.ResourceCPU, "200m").
+						Parallelism(int32(numPods)).
+						Completions(int32(numPods)).
+						Suspend(false).
+						Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
+						SetTypeMeta().Obj(),
+				}).
 				Suspend(false).
 				Obj()
 
@@ -174,21 +176,23 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Ordered, func() {
 
 		ginkgo.It("should not suspend grandchildren jobs of admitted jobs", func() {
 			aw := awtesting.MakeAppWrapper("aw-grandchild", ns.Name).
-				Component(testingjobset.MakeJobSet("job-set", ns.Name).
-					ReplicatedJobs(
-						testingjobset.ReplicatedJobRequirements{
-							Name:        "replicated-job-1",
-							Replicas:    2,
-							Parallelism: 2,
-							Completions: 2,
-							Image:       util.E2eTestAgnHostImage,
-							Args:        util.BehaviorExitFast,
-						},
-					).
-					SetTypeMeta().
-					Suspend(false).
-					RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "200m").
-					Obj()).
+				Component(awtesting.Component{
+					Template: testingjobset.MakeJobSet("job-set", ns.Name).
+						ReplicatedJobs(
+							testingjobset.ReplicatedJobRequirements{
+								Name:        "replicated-job-1",
+								Replicas:    2,
+								Parallelism: 2,
+								Completions: 2,
+								Image:       util.E2eTestAgnHostImage,
+								Args:        util.BehaviorExitFast,
+							},
+						).
+						SetTypeMeta().
+						Suspend(false).
+						RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "200m").
+						Obj(),
+				}).
 				Suspend(false).
 				Obj()
 

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -568,14 +568,16 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			jobName := "job-1"
 			aw := testingaw.MakeAppWrapper("aw", managerNs.Name).
 				Queue(managerLq.Name).
-				Component(testingjob.MakeJob(jobName, managerNs.Name).
-					SetTypeMeta().
-					Suspend(false).
-					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion). // Give it the time to be observed Active in the live status update step.
-					Parallelism(2).
-					RequestAndLimit(corev1.ResourceCPU, "1").
-					TerminationGracePeriod(1).
-					SetTypeMeta().Obj()).
+				Component(testingaw.Component{
+					Template: testingjob.MakeJob(jobName, managerNs.Name).
+						SetTypeMeta().
+						Suspend(false).
+						Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion). // Give it the time to be observed Active in the live status update step.
+						Parallelism(2).
+						RequestAndLimit(corev1.ResourceCPU, "1").
+						TerminationGracePeriod(1).
+						SetTypeMeta().Obj(),
+				}).
 				Obj()
 
 			ginkgo.By("Creating the appwrapper", func() {

--- a/test/e2e/singlecluster/appwrapper_test.go
+++ b/test/e2e/singlecluster/appwrapper_test.go
@@ -77,13 +77,15 @@ var _ = ginkgo.Describe("AppWrapper", func() {
 	ginkgo.It("Should admit workloads that fit", func() {
 		numPods := 2
 		aw := awtesting.MakeAppWrapper("appwrapper", ns.Name).
-			Component(utiltestingjob.MakeJob("job-0", ns.Name).
-				RequestAndLimit(corev1.ResourceCPU, "200m").
-				Parallelism(int32(numPods)).
-				Completions(int32(numPods)).
-				Suspend(false).
-				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
-				SetTypeMeta().Obj()).
+			Component(awtesting.Component{
+				Template: utiltestingjob.MakeJob("job-0", ns.Name).
+					RequestAndLimit(corev1.ResourceCPU, "200m").
+					Parallelism(int32(numPods)).
+					Completions(int32(numPods)).
+					Suspend(false).
+					Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
+					SetTypeMeta().Obj(),
+			}).
 			Queue(localQueueName).
 			Obj()
 

--- a/test/e2e/tas/appwrapper_test.go
+++ b/test/e2e/tas/appwrapper_test.go
@@ -83,15 +83,17 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 			numPods := 4
 
 			aw := awtesting.MakeAppWrapper("appwrapper", ns.Name).
-				Component(utiltestingjob.MakeJob("job-0", ns.Name).
-					Parallelism(int32(numPods)).
-					Completions(int32(numPods)).
-					RequestAndLimit(corev1.ResourceCPU, "200m").
-					RequestAndLimit(extraResource, "1").
-					Suspend(false).
-					Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
-					PodAnnotation(kueuealpha.PodSetPreferredTopologyAnnotation, testing.DefaultRackTopologyLevel).
-					SetTypeMeta().Obj()).
+				Component(awtesting.Component{
+					Template: utiltestingjob.MakeJob("job-0", ns.Name).
+						Parallelism(int32(numPods)).
+						Completions(int32(numPods)).
+						RequestAndLimit(corev1.ResourceCPU, "200m").
+						RequestAndLimit(extraResource, "1").
+						Suspend(false).
+						Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
+						PodAnnotation(kueuealpha.PodSetPreferredTopologyAnnotation, testing.DefaultRackTopologyLevel).
+						SetTypeMeta().Obj(),
+				}).
 				Queue(localQueue.Name).
 				Obj()
 
@@ -136,7 +138,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for AppWrapper", func() {
 				SetTypeMeta().
 				Obj()
 			aw := awtesting.MakeAppWrapper("aw-ranks-job", ns.Name).
-				Component(wrappedJob).
+				Component(awtesting.Component{Template: wrappedJob}).
 				Queue(localQueue.Name).
 				Obj()
 

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -837,7 +837,9 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 
 	ginkgo.It("Should run an appwrapper on worker if admitted", func() {
 		aw := testingaw.MakeAppWrapper("aw", managerNs.Name).
-			Component(testingjob.MakeJob("job-1", managerNs.Name).SetTypeMeta().Parallelism(1).Obj()).
+			Component(testingaw.Component{
+				Template: testingjob.MakeJob("job-1", managerNs.Name).SetTypeMeta().Parallelism(1).Obj(),
+			}).
 			Queue(managerLq.Name).
 			ManagedBy(kueue.MultiKueueControllerName).
 			Obj()

--- a/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
@@ -117,8 +117,12 @@ var _ = ginkgo.Describe("AppWrapper controller", ginkgo.Ordered, ginkgo.Continue
 			gomega.Expect(k8sClient.Create(ctx, priorityClass)).Should(gomega.Succeed())
 
 			aw := testingaw.MakeAppWrapper(awName, ns.Name).
-				Component(utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().PriorityClass(priorityClassName).Obj()).
-				Component(utiltestingjob.MakeJob("job-1", ns.Name).SetTypeMeta().PriorityClass(priorityClassName).Obj()).
+				Component(testingaw.Component{
+					Template: utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().PriorityClass(priorityClassName).Obj(),
+				}).
+				Component(testingaw.Component{
+					Template: utiltestingjob.MakeJob("job-1", ns.Name).SetTypeMeta().PriorityClass(priorityClassName).Obj(),
+				}).
 				Suspend(false).
 				Obj()
 
@@ -209,8 +213,12 @@ var _ = ginkgo.Describe("AppWrapper controller", ginkgo.Ordered, ginkgo.Continue
 		ginkgo.It("An appwrapper created in an unmanaged namespace is not suspended and a workload is not created", func() {
 			ginkgo.By("Creating an unsuspended job without a queue-name in unmanaged-ns")
 			aw := testingaw.MakeAppWrapper(awName, "unmanaged-ns").
-				Component(utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().PriorityClass(priorityClassName).Obj()).
-				Component(utiltestingjob.MakeJob("job-1", ns.Name).SetTypeMeta().PriorityClass(priorityClassName).Obj()).
+				Component(testingaw.Component{
+					Template: utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().PriorityClass(priorityClassName).Obj(),
+				}).
+				Component(testingaw.Component{
+					Template: utiltestingjob.MakeJob("job-1", ns.Name).SetTypeMeta().PriorityClass(priorityClassName).Obj(),
+				}).
 				Suspend(false).
 				Obj()
 
@@ -228,7 +236,9 @@ var _ = ginkgo.Describe("AppWrapper controller", ginkgo.Ordered, ginkgo.Continue
 
 		ginkgo.It("Should finish the preemption when the appwrapper no longer has resources deployed", func() {
 			aw := testingaw.MakeAppWrapper(awName, ns.Name).
-				Component(utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().PriorityClass(priorityClassName).Obj()).
+				Component(testingaw.Component{
+					Template: utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().PriorityClass(priorityClassName).Obj(),
+				}).
 				Suspend(false).
 				Queue(localQueue.Name).
 				Obj()
@@ -349,12 +359,16 @@ var _ = ginkgo.Describe("AppWrapper controller", ginkgo.Ordered, ginkgo.Continue
 			createdAppWrapper := &awv1beta2.AppWrapper{}
 			createdWorkload := &kueue.Workload{}
 			aw := testingaw.MakeAppWrapper(awName, ns.Name).
-				Component(utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().
-					Request(corev1.ResourceCPU, "1").
-					Obj()).
-				Component(utiltestingjob.MakeJob("job-1", ns.Name).SetTypeMeta().
-					Request(corev1.ResourceCPU, "1").
-					Obj()).
+				Component(testingaw.Component{
+					Template: utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().
+						Request(corev1.ResourceCPU, "1").
+						Obj(),
+				}).
+				Component(testingaw.Component{
+					Template: utiltestingjob.MakeJob("job-1", ns.Name).SetTypeMeta().
+						Request(corev1.ResourceCPU, "1").
+						Obj(),
+				}).
 				Queue("queue").
 				Obj()
 
@@ -520,8 +534,12 @@ var _ = ginkgo.Describe("AppWrapper controller for workloads when only jobs with
 	ginkgo.It("Should reconcile jobs only when queue is set", func() {
 		ginkgo.By("checking the workload is not created when queue name is not set")
 		aw := testingaw.MakeAppWrapper(awName, ns.Name).
-			Component(utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().Obj()).
-			Component(utiltestingjob.MakeJob("job-1", ns.Name).SetTypeMeta().Obj()).
+			Component(testingaw.Component{
+				Template: utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().Obj(),
+			}).
+			Component(testingaw.Component{
+				Template: utiltestingjob.MakeJob("job-1", ns.Name).SetTypeMeta().Obj(),
+			}).
 			Suspend(false).
 			Obj()
 
@@ -588,8 +606,12 @@ var _ = ginkgo.Describe("AppWrapper controller when waitForPodsReady enabled", g
 			ginkgo.By("Create a job")
 			awQueueName := "test-queue"
 			aw := testingaw.MakeAppWrapper(awName, ns.Name).
-				Component(utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().Obj()).
-				Component(utiltestingjob.MakeJob("job-1", ns.Name).SetTypeMeta().Obj()).
+				Component(testingaw.Component{
+					Template: utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().Obj(),
+				}).
+				Component(testingaw.Component{
+					Template: utiltestingjob.MakeJob("job-1", ns.Name).SetTypeMeta().Obj(),
+				}).
 				Queue(awQueueName).
 				Obj()
 
@@ -792,13 +814,17 @@ var _ = ginkgo.Describe("AppWrapper controller interacting with scheduler", gink
 
 		ginkgo.By("checking a dev job starts")
 		aw := testingaw.MakeAppWrapper(awName, ns.Name).
-			Component(utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().
-				Request(corev1.ResourceCPU, "1").
-				Obj()).
-			Component(utiltestingjob.MakeJob("job-1", ns.Name).SetTypeMeta().
-				Request(corev1.ResourceCPU, "1").
-				Parallelism(3).
-				Obj()).
+			Component(testingaw.Component{
+				Template: utiltestingjob.MakeJob("job-0", ns.Name).SetTypeMeta().
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+			}).
+			Component(testingaw.Component{
+				Template: utiltestingjob.MakeJob("job-1", ns.Name).SetTypeMeta().
+					Request(corev1.ResourceCPU, "1").
+					Parallelism(3).
+					Obj(),
+			}).
 			Queue(localQueue.Name).
 			Obj()
 		gomega.Expect(k8sClient.Create(ctx, aw)).Should(gomega.Succeed())
@@ -889,11 +915,13 @@ var _ = ginkgo.Describe("AppWrapper controller when TopologyAwareScheduling enab
 
 	ginkgo.It("should admit workload which fits in a required topology domain", func() {
 		aw := testingaw.MakeAppWrapper(awName, ns.Name).
-			Component(utiltestingjob.MakeJob("job", ns.Name).
-				PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, tasBlockLabel).
-				Request(corev1.ResourceCPU, "1").
-				SetTypeMeta().
-				Obj()).
+			Component(testingaw.Component{
+				Template: utiltestingjob.MakeJob("job", ns.Name).
+					PodAnnotation(kueuealpha.PodSetRequiredTopologyAnnotation, tasBlockLabel).
+					Request(corev1.ResourceCPU, "1").
+					SetTypeMeta().
+					Obj(),
+			}).
 			Queue(localQueue.Name).
 			Suspend(false).
 			Obj()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Use the Component struct in AppWrapper to allow to set additional fields such as DeclaredPodSets and PodSetInfos with component template.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Prepare for #4860

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```