### PR TITLE
Automated cherry pick of #4854: Pod groups MultiKueue adapter

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -283,6 +283,11 @@ func (w *wlReconciler) adapter(local *kueue.Workload) (jobframework.MultiKueueAd
 	if controller := metav1.GetControllerOf(local); controller != nil {
 		adapterKey := schema.FromAPIVersionAndKind(controller.APIVersion, controller.Kind).String()
 		return w.adapters[adapterKey], controller
+	} else if refs := local.GetOwnerReferences(); len(refs) > 0 {
+		// For workloads without a controller but with owner references,
+		// use the first owner reference to find the adapter. This supports composable workloads.
+		adapterKey := schema.FromAPIVersionAndKind(refs[0].APIVersion, refs[0].Kind).String()
+		return w.adapters[adapterKey], &refs[0]
 	}
 	return nil, nil
 }

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -167,13 +167,10 @@ func syncLocalPodWithRemote(
 		}
 
 		// Patch the status of the local pod to match the remote pod
-		if err := clientutil.PatchStatus(ctx, localClient, localPod, func() (bool, error) {
+		return clientutil.PatchStatus(ctx, localClient, localPod, func() (bool, error) {
 			localPod.Status = remotePod.Status
 			return true, nil
-		}); err != nil {
-			return err
-		}
-		return nil
+		})
 	}
 
 	// If the remote pod does not exist, create it

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -32,6 +33,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 )
@@ -49,39 +51,12 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 		return err
 	}
 
-	remotePod := corev1.Pod{}
-	err = remoteClient.Get(ctx, key, &remotePod)
-	if client.IgnoreNotFound(err) != nil {
-		return err
+	if !isPodAPartOfGroup(localPod) {
+		return syncLocalPodWithRemote(ctx, localClient, remoteClient, &localPod, workloadName, origin, &log)
 	}
 
-	// the remote pod exists
-	if err == nil {
-		if localPod.DeletionTimestamp != nil {
-			// Ensure the local pod is not terminating before updating its status; otherwise, it will fail when patching the status.
-			log.V(2).Info("Skipping the sync since the local pod is terminating")
-			return nil
-		}
-		// Patch the status of the local pod to match the remote pod
-		return clientutil.PatchStatus(ctx, localClient, &localPod, func() (bool, error) {
-			localPod.Status = remotePod.Status
-			return true, nil
-		})
-	}
-
-	remotePod = corev1.Pod{
-		ObjectMeta: api.CloneObjectMetaForCreation(&localPod.ObjectMeta),
-		Spec:       *localPod.Spec.DeepCopy(),
-	}
-
-	// add the prebuilt workload
-	if remotePod.Labels == nil {
-		remotePod.Labels = map[string]string{}
-	}
-	remotePod.Labels[constants.PrebuiltWorkloadLabel] = workloadName
-	remotePod.Labels[kueue.MultiKueueOriginLabel] = origin
-
-	return remoteClient.Create(ctx, &remotePod)
+	groupName := podGroupName(localPod)
+	return syncPodGroup(ctx, localClient, remoteClient, key, workloadName, origin, groupName)
 }
 
 func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient client.Client, key types.NamespacedName) error {
@@ -90,7 +65,25 @@ func (b *multiKueueAdapter) DeleteRemoteObject(ctx context.Context, remoteClient
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
-	return client.IgnoreNotFound(remoteClient.Delete(ctx, &pod))
+
+	if !isPodAPartOfGroup(pod) {
+		return client.IgnoreNotFound(remoteClient.Delete(ctx, &pod))
+	}
+
+	groupName := podGroupName(pod)
+	podGroup := &corev1.PodList{}
+	err = remoteClient.List(ctx, podGroup, client.InNamespace(key.Namespace), client.MatchingLabels{podconstants.GroupNameLabel: groupName})
+	if err != nil {
+		return err
+	}
+
+	for _, remotePod := range podGroup.Items {
+		if err = client.IgnoreNotFound(remoteClient.Delete(ctx, &remotePod)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (b *multiKueueAdapter) KeepAdmissionCheckPending() bool {
@@ -123,4 +116,83 @@ func (*multiKueueAdapter) WorkloadKeyFor(o runtime.Object) (types.NamespacedName
 	}
 
 	return types.NamespacedName{Name: prebuiltWl, Namespace: pod.Namespace}, nil
+}
+
+// isPodAPartOfGroup checks if a pod belongs to a group by verifying the presence of a group name label.
+func isPodAPartOfGroup(p corev1.Pod) bool {
+	return podGroupName(p) != ""
+}
+
+func syncPodGroup(ctx context.Context, localClient client.Client, remoteClient client.Client, key types.NamespacedName, workloadName, origin, groupName string) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	localPodGroup := &corev1.PodList{}
+	err := localClient.List(ctx, localPodGroup, client.InNamespace(key.Namespace), client.MatchingLabels{podconstants.GroupNameLabel: groupName})
+	if err != nil {
+		return err
+	}
+
+	for _, localPod := range localPodGroup.Items {
+		if err = syncLocalPodWithRemote(ctx, localClient, remoteClient, &localPod, workloadName, origin, &log); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func syncLocalPodWithRemote(
+	ctx context.Context,
+	localClient client.Client,
+	remoteClient client.Client,
+	localPod *corev1.Pod,
+	workloadName, origin string,
+	log *logr.Logger,
+) error {
+	key := types.NamespacedName{Name: localPod.Name, Namespace: localPod.Namespace}
+	remotePod := corev1.Pod{}
+
+	// Try to fetch the corresponding remote pod
+	err := remoteClient.Get(ctx, key, &remotePod)
+	if client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	// If the remote pod exists
+	if err == nil {
+		// Skip syncing if the local pod is terminating
+		if localPod.DeletionTimestamp != nil {
+			log.V(2).Info("Skipping sync since the local pod is terminating", "podName", localPod.Name)
+			return nil
+		}
+
+		// Patch the status of the local pod to match the remote pod
+		if err := clientutil.PatchStatus(ctx, localClient, localPod, func() (bool, error) {
+			localPod.Status = remotePod.Status
+			return true, nil
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// If the remote pod does not exist, create it
+	remotePod = corev1.Pod{
+		ObjectMeta: api.CloneObjectMetaForCreation(&localPod.ObjectMeta),
+		Spec:       *localPod.Spec.DeepCopy(),
+	}
+
+	// add the prebuilt workload
+	if remotePod.Labels == nil {
+		remotePod.Labels = map[string]string{}
+	}
+	remotePod.Labels[constants.PrebuiltWorkloadLabel] = workloadName
+	remotePod.Labels[kueue.MultiKueueOriginLabel] = origin
+
+	if err = remoteClient.Create(ctx, &remotePod); err != nil {
+		log.Error(err, "Failed to create remote pod", "podName", remotePod.Name)
+		return err
+	}
+
+	return nil
 }

--- a/pkg/util/testingjobs/pod/wrappers.go
+++ b/pkg/util/testingjobs/pod/wrappers.go
@@ -77,6 +77,16 @@ func (p *PodWrapper) MakeGroup(count int) []*corev1.Pod {
 	return pods
 }
 
+func (p *PodWrapper) MakePodGroupWrappers(count int) []*PodWrapper {
+	var pods []*PodWrapper
+	for i := 0; i < count; i++ {
+		pod := p.Clone().Group(p.Pod.Name).GroupTotalCount(strconv.Itoa(count))
+		pod.Pod.Name += fmt.Sprintf("-%d", i)
+		pods = append(pods, pod)
+	}
+	return pods
+}
+
 // MakeIndexedGroup returns multiple indexed pods that form a pod group, based on the original wrapper.
 func (p *PodWrapper) MakeIndexedGroup(count int) []*corev1.Pod {
 	var pods []*corev1.Pod

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -423,38 +423,12 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 			})
-			finishReason := "PodCompleted"
-			finishPodConditions := []corev1.PodCondition{
-				{
-					Type:   corev1.PodReadyToStartContainers,
-					Status: corev1.ConditionFalse,
-					Reason: "",
-				},
-				{
-					Type:   corev1.PodInitialized,
-					Status: corev1.ConditionTrue,
-					Reason: finishReason},
-				{
-					Type:   corev1.PodReady,
-					Status: corev1.ConditionFalse,
-					Reason: finishReason,
-				},
-				{
-					Type:   corev1.ContainersReady,
-					Status: corev1.ConditionFalse,
-					Reason: finishReason},
-				{
-					Type:   corev1.PodScheduled,
-					Status: corev1.ConditionTrue,
-					Reason: "",
-				},
-			}
+
 			ginkgo.By("Waiting for the group to get status updates", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.List(ctx, pods, client.InNamespace(managerNs.Name))).To(gomega.Succeed())
 					for _, p := range pods.Items {
 						g.Expect(p.Status.Phase).To(gomega.Equal(corev1.PodSucceeded))
-						g.Expect(p.Status.Conditions).To(gomega.BeComparableTo(finishPodConditions, cmpopts.IgnoreFields(corev1.PodCondition{}, "LastTransitionTime")))
 					}
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -372,6 +372,93 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				}
 			})
 		})
+		ginkgo.It("Should create a pod group on worker if admitted", func() {
+			numPods := 2
+			groupName := "test-group"
+			group := testingpod.MakePod(groupName, managerNs.Name).
+				Queue(managerLq.Name).
+				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				RequestAndLimit(corev1.ResourceMemory, "1G").
+				MakeGroup(numPods)
+
+			ginkgo.By("Creating the Pod group", func() {
+				for _, p := range group {
+					gomega.Expect(k8sManagerClient.Create(ctx, p)).To(gomega.Succeed())
+					gomega.Expect(p.Spec.SchedulingGates).To(gomega.ContainElements(
+						corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName},
+					))
+				}
+			})
+
+			// Since it requires 2G of memory, this pod group can only be admitted in worker 2.
+			pods := &corev1.PodList{}
+			ginkgo.By("ensure all pods are created", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sManagerClient.List(ctx, pods, client.InNamespace(managerNs.Name))).To(gomega.Succeed())
+					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			createdLeaderWorkload := &kueue.Workload{}
+			wlLookupKey := types.NamespacedName{Name: groupName, Namespace: managerNs.Name}
+
+			// the execution should be given to worker2
+			ginkgo.By("Waiting to be admitted in worker2", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdLeaderWorkload)).To(gomega.Succeed())
+					g.Expect(workload.FindAdmissionCheck(createdLeaderWorkload.Status.AdmissionChecks, multiKueueAc.Name)).To(gomega.BeComparableTo(&kueue.AdmissionCheckState{
+						Name:    multiKueueAc.Name,
+						State:   kueue.CheckStatePending,
+						Message: `The workload got reservation on "worker2"`,
+					}, cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime")))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("ensure all pods are created", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sManagerClient.List(ctx, pods, client.InNamespace(managerNs.Name))).To(gomega.Succeed())
+						for _, p := range pods.Items {
+							g.Expect(utilpod.HasGate(&p, podconstants.SchedulingGateName)).To(gomega.BeTrue())
+						}
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+			finishReason := "PodCompleted"
+			finishPodConditions := []corev1.PodCondition{
+				{
+					Type:   corev1.PodReadyToStartContainers,
+					Status: corev1.ConditionFalse,
+					Reason: "",
+				},
+				{
+					Type:   corev1.PodInitialized,
+					Status: corev1.ConditionTrue,
+					Reason: finishReason},
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionFalse,
+					Reason: finishReason,
+				},
+				{
+					Type:   corev1.ContainersReady,
+					Status: corev1.ConditionFalse,
+					Reason: finishReason},
+				{
+					Type:   corev1.PodScheduled,
+					Status: corev1.ConditionTrue,
+					Reason: "",
+				},
+			}
+			ginkgo.By("Waiting for the group to get status updates", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sManagerClient.List(ctx, pods, client.InNamespace(managerNs.Name))).To(gomega.Succeed())
+					for _, p := range pods.Items {
+						g.Expect(p.Status.Phase).To(gomega.Equal(corev1.PodSucceeded))
+						g.Expect(p.Status.Conditions).To(gomega.BeComparableTo(finishPodConditions, cmpopts.IgnoreFields(corev1.PodCondition{}, "LastTransitionTime")))
+					}
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
 		ginkgo.It("Should run a job on worker if admitted", func() {
 			if managerK8SVersion.LessThan(versionutil.MustParseSemantic("1.30.0")) {
 				ginkgo.Skip("the managers kubernetes version is less then 1.30")

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -1079,6 +1079,129 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 		})
 	})
 
+	ginkgo.It("Should create a pod group on worker if admitted", func() {
+		groupName := "test-group"
+		podgroup := testingpod.MakePod(groupName, managerNs.Name).
+			Queue(managerLq.Name).
+			ManagedByKueueLabel().
+			KueueFinalizer().
+			KueueSchedulingGate().
+			MakeGroup(3)
+
+		for _, p := range podgroup {
+			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, p)).Should(gomega.Succeed())
+		}
+
+		// any pod should give the same workload Key
+		createdWorkload := &kueue.Workload{}
+		wlLookupKey := types.NamespacedName{Name: groupName, Namespace: managerNs.Name}
+		admission := utiltesting.MakeAdmission(managerCq.Name).
+			PodSets(
+				kueue.PodSetAssignment{
+					Name:  "bf90803c",
+					Count: ptr.To[int32](3),
+				},
+			).Obj()
+		ginkgo.By("setting workload reservation in the management cluster", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				gomega.Expect(createdWorkload.Spec.PodSets[0].Count).To(gomega.Equal(int32(3)))
+				g.Expect(util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, createdWorkload, admission)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("checking the workload creation in the worker clusters", func() {
+			managerWl := &kueue.Workload{}
+			gomega.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(createdWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(createdWorkload.Spec).To(gomega.BeComparableTo(managerWl.Spec))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("setting workload reservation in worker1, AC state is updated in manager and worker2 wl is removed", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(util.SetQuotaReservation(worker1TestCluster.ctx, worker1TestCluster.client, createdWorkload, admission)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				acs := workload.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, multikueueAC.Name)
+				g.Expect(acs).NotTo(gomega.BeNil())
+				g.Expect(acs.State).To(gomega.Equal(kueue.CheckStatePending))
+				g.Expect(acs.Message).To(gomega.Equal(`The workload got reservation on "worker1"`))
+				ok, err := utiltesting.HasEventAppeared(managerTestCluster.ctx, managerTestCluster.client, corev1.Event{
+					Reason:  "MultiKueue",
+					Type:    corev1.EventTypeNormal,
+					Message: `The workload got reservation on "worker1"`,
+				})
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(ok).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlLookupKey, createdWorkload)).To(utiltesting.BeNotFoundError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		pods := corev1.PodList{}
+		gomega.Expect(managerTestCluster.client.List(managerTestCluster.ctx, &pods)).To(gomega.Succeed())
+
+		ginkgo.By("finishing the worker pod", func() {
+			pods := corev1.PodList{}
+			gomega.Expect(worker1TestCluster.client.List(worker1TestCluster.ctx, &pods)).To(gomega.Succeed())
+			for _, p := range podgroup {
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdPod := corev1.Pod{}
+					g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(p), &createdPod)).To(gomega.Succeed())
+					createdPod.Status.Phase = corev1.PodSucceeded
+					createdPod.Status.Conditions = append(createdPod.Status.Conditions,
+						corev1.PodCondition{
+							Type:               corev1.PodReadyToStartContainers,
+							Status:             corev1.ConditionFalse,
+							LastProbeTime:      metav1.Now(),
+							LastTransitionTime: metav1.Now(),
+							Reason:             "",
+						},
+						corev1.PodCondition{
+							Type:               corev1.PodInitialized,
+							Status:             corev1.ConditionTrue,
+							LastProbeTime:      metav1.Now(),
+							LastTransitionTime: metav1.Now(),
+							Reason:             string(corev1.PodSucceeded),
+						},
+						corev1.PodCondition{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionFalse,
+							LastProbeTime:      metav1.Now(),
+							LastTransitionTime: metav1.Now(),
+							Reason:             string(corev1.PodSucceeded),
+						},
+						corev1.PodCondition{
+							Type:               corev1.ContainersReady,
+							Status:             corev1.ConditionFalse,
+							LastProbeTime:      metav1.Now(),
+							LastTransitionTime: metav1.Now(),
+							Reason:             string(corev1.PodSucceeded),
+						},
+						corev1.PodCondition{
+							Type:               corev1.PodScheduled,
+							Status:             corev1.ConditionTrue,
+							LastProbeTime:      metav1.Now(),
+							LastTransitionTime: metav1.Now(),
+							Reason:             "",
+						},
+					)
+					g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdPod)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			}
+			waitForWorkloadToFinishAndRemoteWorkloadToBeDeleted(wlLookupKey, "Pods succeeded: 3/3.")
+		})
+	})
+
 	ginkgo.It("Should remove the worker's workload and job after reconnect when the managers job and workload are deleted", func() {
 		job := testingjob.MakeJob("job", managerNs.Name).
 			Queue(managerLq.Name).

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -1129,17 +1129,10 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-				acs := workload.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, multikueueAC.Name)
+				acs := workload.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, multiKueueAC.Name)
 				g.Expect(acs).NotTo(gomega.BeNil())
 				g.Expect(acs.State).To(gomega.Equal(kueue.CheckStatePending))
 				g.Expect(acs.Message).To(gomega.Equal(`The workload got reservation on "worker1"`))
-				ok, err := utiltesting.HasEventAppeared(managerTestCluster.ctx, managerTestCluster.client, corev1.Event{
-					Reason:  "MultiKueue",
-					Type:    corev1.EventTypeNormal,
-					Message: `The workload got reservation on "worker1"`,
-				})
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(ok).To(gomega.BeTrue())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1160,39 +1153,29 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 					createdPod.Status.Phase = corev1.PodSucceeded
 					createdPod.Status.Conditions = append(createdPod.Status.Conditions,
 						corev1.PodCondition{
-							Type:               corev1.PodReadyToStartContainers,
-							Status:             corev1.ConditionFalse,
-							LastProbeTime:      metav1.Now(),
-							LastTransitionTime: metav1.Now(),
-							Reason:             "",
+							Type:   corev1.PodReadyToStartContainers,
+							Status: corev1.ConditionFalse,
+							Reason: "",
 						},
 						corev1.PodCondition{
-							Type:               corev1.PodInitialized,
-							Status:             corev1.ConditionTrue,
-							LastProbeTime:      metav1.Now(),
-							LastTransitionTime: metav1.Now(),
-							Reason:             string(corev1.PodSucceeded),
+							Type:   corev1.PodInitialized,
+							Status: corev1.ConditionTrue,
+							Reason: string(corev1.PodSucceeded),
 						},
 						corev1.PodCondition{
-							Type:               corev1.PodReady,
-							Status:             corev1.ConditionFalse,
-							LastProbeTime:      metav1.Now(),
-							LastTransitionTime: metav1.Now(),
-							Reason:             string(corev1.PodSucceeded),
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionFalse,
+							Reason: string(corev1.PodSucceeded),
 						},
 						corev1.PodCondition{
-							Type:               corev1.ContainersReady,
-							Status:             corev1.ConditionFalse,
-							LastProbeTime:      metav1.Now(),
-							LastTransitionTime: metav1.Now(),
-							Reason:             string(corev1.PodSucceeded),
+							Type:   corev1.ContainersReady,
+							Status: corev1.ConditionFalse,
+							Reason: string(corev1.PodSucceeded),
 						},
 						corev1.PodCondition{
-							Type:               corev1.PodScheduled,
-							Status:             corev1.ConditionTrue,
-							LastProbeTime:      metav1.Now(),
-							LastTransitionTime: metav1.Now(),
-							Reason:             "",
+							Type:   corev1.PodScheduled,
+							Status: corev1.ConditionTrue,
+							Reason: "",
 						},
 					)
 					g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdPod)).To(gomega.Succeed())


### PR DESCRIPTION
Cherry pick of #4854 on release-0.11.

#4854: Pod groups MultiKueue adapter

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix the support for pod groups in MutliKueue.
```