### PR TITLE
Unexport ResourceNode; Cleanup Preemption Test

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -446,7 +446,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					AllocatableResourceGeneration: 2,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
-					resourceNode: ResourceNode{
+					resourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 5000,
 						},
@@ -887,7 +887,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 						{Flavor: "f1", Resource: corev1.ResourceCPU}: 1000,
 					},
 					FairWeight: oneQuantity,
-					resourceNode: ResourceNode{
+					resourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "f1", Resource: corev1.ResourceCPU}: 2000,
 						},
@@ -3554,7 +3554,7 @@ func TestCohortCycles(t *testing.T) {
 
 		// cohort's SubtreeQuota contains resources from cq.
 		gotResource := cache.hm.Cohort("cohort").getResourceNode()
-		wantResource := ResourceNode{
+		wantResource := resourceNode{
 			Quotas: map[resources.FlavorResource]ResourceQuota{
 				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000},
 			},
@@ -3591,7 +3591,7 @@ func TestCohortCycles(t *testing.T) {
 
 		// cohort's SubtreeQuota contains resources from cq
 		gotResource := cache.hm.Cohort("cohort").getResourceNode()
-		wantResource := ResourceNode{
+		wantResource := resourceNode{
 			Quotas: map[resources.FlavorResource]ResourceQuota{
 				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000},
 			},
@@ -3612,7 +3612,7 @@ func TestCohortCycles(t *testing.T) {
 
 		// Cohort's SubtreeQuota no longer contains resources from CQ.
 		gotResource = cache.hm.Cohort("cohort").getResourceNode()
-		wantResource = ResourceNode{
+		wantResource = resourceNode{
 			Quotas: map[resources.FlavorResource]ResourceQuota{
 				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000},
 			},
@@ -3645,14 +3645,14 @@ func TestCohortCycles(t *testing.T) {
 
 		// before move
 		{
-			wantRoot1 := ResourceNode{
+			wantRoot1 := resourceNode{
 				Quotas: map[resources.FlavorResource]ResourceQuota{},
 				SubtreeQuota: resources.FlavorResourceQuantities{
 					{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
 				},
 				Usage: resources.FlavorResourceQuantities{},
 			}
-			wantRoot2 := ResourceNode{
+			wantRoot2 := resourceNode{
 				Quotas:       map[resources.FlavorResource]ResourceQuota{},
 				SubtreeQuota: resources.FlavorResourceQuantities{},
 				Usage:        resources.FlavorResourceQuantities{},
@@ -3670,12 +3670,12 @@ func TestCohortCycles(t *testing.T) {
 		}
 		// after move
 		{
-			wantRoot1 := ResourceNode{
+			wantRoot1 := resourceNode{
 				Quotas:       map[resources.FlavorResource]ResourceQuota{},
 				SubtreeQuota: resources.FlavorResourceQuantities{},
 				Usage:        resources.FlavorResourceQuantities{},
 			}
-			wantRoot2 := ResourceNode{
+			wantRoot2 := resourceNode{
 				Quotas: map[resources.FlavorResource]ResourceQuota{},
 				SubtreeQuota: resources.FlavorResourceQuantities{
 					{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
@@ -3712,7 +3712,7 @@ func TestCohortCycles(t *testing.T) {
 		if err := cache.AddOrUpdateCohort(cohort); err != nil {
 			t.Fatal("Expected success")
 		}
-		wantRoot := ResourceNode{
+		wantRoot := resourceNode{
 			Quotas: map[resources.FlavorResource]ResourceQuota{},
 			SubtreeQuota: resources.FlavorResourceQuantities{
 				{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
@@ -3743,7 +3743,7 @@ func TestCohortCycles(t *testing.T) {
 
 		// before move
 		{
-			wantRoot := ResourceNode{
+			wantRoot := resourceNode{
 				Quotas: map[resources.FlavorResource]ResourceQuota{},
 				SubtreeQuota: resources.FlavorResourceQuantities{
 					{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
@@ -3762,7 +3762,7 @@ func TestCohortCycles(t *testing.T) {
 
 		// after move
 		{
-			wantRoot := ResourceNode{
+			wantRoot := resourceNode{
 				Quotas:       map[resources.FlavorResource]ResourceQuota{},
 				SubtreeQuota: resources.FlavorResourceQuantities{},
 				Usage:        resources.FlavorResourceQuantities{},

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -82,7 +82,7 @@ type clusterQueue struct {
 	isStopped                                       bool
 	workloadInfoOptions                             []workload.InfoOption
 
-	resourceNode ResourceNode
+	resourceNode resourceNode
 	hierarchy.ClusterQueue[*cohort]
 
 	tasCache *TASCache
@@ -94,7 +94,7 @@ func (c *clusterQueue) GetName() kueue.ClusterQueueReference {
 
 // implements hierarchicalResourceNode interface.
 
-func (c *clusterQueue) getResourceNode() ResourceNode {
+func (c *clusterQueue) getResourceNode() resourceNode {
 	return c.resourceNode
 }
 

--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -49,7 +49,7 @@ type ClusterQueueSnapshot struct {
 	// deleted, or the resource groups are changed.
 	AllocatableResourceGeneration int64
 
-	ResourceNode ResourceNode
+	ResourceNode resourceNode
 	hierarchy.ClusterQueue[*CohortSnapshot]
 
 	TASFlavors map[kueue.ResourceFlavorReference]*TASFlavorSnapshot
@@ -186,7 +186,7 @@ func (c *ClusterQueueSnapshot) fairWeight() *resource.Quantity {
 
 // The methods below implement hierarchicalResourceNode interface.
 
-func (c *ClusterQueueSnapshot) getResourceNode() ResourceNode {
+func (c *ClusterQueueSnapshot) getResourceNode() resourceNode {
 	return c.ResourceNode
 }
 

--- a/pkg/cache/cohort.go
+++ b/pkg/cache/cohort.go
@@ -29,7 +29,7 @@ type cohort struct {
 	Name kueue.CohortReference
 	hierarchy.Cohort[*clusterQueue, *cohort]
 
-	resourceNode ResourceNode
+	resourceNode resourceNode
 
 	FairWeight resource.Quantity
 }
@@ -66,7 +66,7 @@ func (c *cohort) getRootUnsafe() *cohort {
 
 // implements hierarchicalResourceNode interface.
 
-func (c *cohort) getResourceNode() ResourceNode {
+func (c *cohort) getResourceNode() resourceNode {
 	return c.resourceNode
 }
 

--- a/pkg/cache/cohort_snapshot.go
+++ b/pkg/cache/cohort_snapshot.go
@@ -26,7 +26,7 @@ import (
 type CohortSnapshot struct {
 	Name kueue.CohortReference
 
-	ResourceNode ResourceNode
+	ResourceNode resourceNode
 	hierarchy.Cohort[*ClusterQueueSnapshot, *CohortSnapshot]
 
 	FairWeight resource.Quantity
@@ -75,7 +75,7 @@ func (c *CohortSnapshot) DominantResourceShare() int {
 
 // The methods below implement hierarchicalResourceNode interface.
 
-func (c *CohortSnapshot) getResourceNode() ResourceNode {
+func (c *CohortSnapshot) getResourceNode() resourceNode {
 	return c.ResourceNode
 }
 

--- a/pkg/cache/resource_node.go
+++ b/pkg/cache/resource_node.go
@@ -23,9 +23,9 @@ import (
 	"sigs.k8s.io/kueue/pkg/resources"
 )
 
-// ResourceNode is the shared representation of Quotas and Usage, used
+// resourceNode is the shared representation of Quotas and Usage, used
 // by ClusterQueues and Cohorts.
-type ResourceNode struct {
+type resourceNode struct {
 	// Quotas are the ResourceQuotas specified for the current
 	// node.
 	Quotas map[resources.FlavorResource]ResourceQuota
@@ -40,8 +40,8 @@ type ResourceNode struct {
 	Usage resources.FlavorResourceQuantities
 }
 
-func NewResourceNode() ResourceNode {
-	return ResourceNode{
+func NewResourceNode() resourceNode {
+	return resourceNode{
 		Quotas:       make(map[resources.FlavorResource]ResourceQuota),
 		SubtreeQuota: make(resources.FlavorResourceQuantities),
 		Usage:        make(resources.FlavorResourceQuantities),
@@ -50,8 +50,8 @@ func NewResourceNode() ResourceNode {
 
 // Clone clones the mutable field Usage, while returning copies to
 // Quota and SubtreeQuota (these are replaced with new maps upon update).
-func (r ResourceNode) Clone() ResourceNode {
-	return ResourceNode{
+func (r resourceNode) Clone() resourceNode {
+	return resourceNode{
 		Quotas:       r.Quotas,
 		SubtreeQuota: r.SubtreeQuota,
 		Usage:        maps.Clone(r.Usage),
@@ -60,7 +60,7 @@ func (r ResourceNode) Clone() ResourceNode {
 
 // guaranteedQuota is the capacity which will not be lent the node's
 // Cohort.
-func (r ResourceNode) guaranteedQuota(fr resources.FlavorResource) int64 {
+func (r resourceNode) guaranteedQuota(fr resources.FlavorResource) int64 {
 	if lendingLimit := r.Quotas[fr].LendingLimit; lendingLimit != nil {
 		return max(0, r.SubtreeQuota[fr]-*lendingLimit)
 	}
@@ -71,7 +71,7 @@ func (r ResourceNode) guaranteedQuota(fr resources.FlavorResource) int64 {
 // by providing access to the contained ResourceNode, with the ability
 // to navigate to the parent node.
 type hierarchicalResourceNode interface {
-	getResourceNode() ResourceNode
+	getResourceNode() resourceNode
 
 	HasParent() bool
 	parentHRN() hierarchicalResourceNode

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -212,7 +212,7 @@ func TestSnapshot(t *testing.T) {
 			wantSnapshot: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "borrowing",
-					ResourceNode: ResourceNode{
+					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "demand", Resource: corev1.ResourceCPU}: 10_000,
 							{Flavor: "spot", Resource: corev1.ResourceCPU}:   10_000,
@@ -241,7 +241,7 @@ func TestSnapshot(t *testing.T) {
 										LabelKeys:        sets.New("instance"),
 									},
 								},
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Quotas: map[resources.FlavorResource]ResourceQuota{
 										{Flavor: "demand", Resource: corev1.ResourceCPU}: {Nominal: 100_000},
 										{Flavor: "spot", Resource: corev1.ResourceCPU}:   {Nominal: 200_000},
@@ -284,7 +284,7 @@ func TestSnapshot(t *testing.T) {
 										Flavors:          []kueue.ResourceFlavorReference{"default"},
 									},
 								},
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Quotas: map[resources.FlavorResource]ResourceQuota{
 										{Flavor: "spot", Resource: corev1.ResourceCPU}:   {Nominal: 100_000},
 										{Flavor: "default", Resource: "example.com/gpu"}: {Nominal: 50},
@@ -338,7 +338,7 @@ func TestSnapshot(t *testing.T) {
 										Flavors:          []kueue.ResourceFlavorReference{"default"},
 									},
 								},
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Quotas: map[resources.FlavorResource]ResourceQuota{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: {Nominal: 100_000},
 									},
@@ -462,7 +462,7 @@ func TestSnapshot(t *testing.T) {
 			wantSnapshot: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lending",
-					ResourceNode: ResourceNode{
+					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "arm", Resource: corev1.ResourceCPU}: 10_000,
 						},
@@ -488,7 +488,7 @@ func TestSnapshot(t *testing.T) {
 										LabelKeys:        sets.New("arch"),
 									},
 								},
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Quotas: map[resources.FlavorResource]ResourceQuota{
 										{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](5_000)},
 										{Flavor: "x86", Resource: corev1.ResourceCPU}: {Nominal: 20_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](10_000)},
@@ -541,7 +541,7 @@ func TestSnapshot(t *testing.T) {
 										LabelKeys:        sets.New("arch"),
 									},
 								},
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Quotas: map[resources.FlavorResource]ResourceQuota{
 										{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](5_000)},
 										{Flavor: "x86", Resource: corev1.ResourceCPU}: {Nominal: 20_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](10_000)},
@@ -616,7 +616,7 @@ func TestSnapshot(t *testing.T) {
 			wantSnapshot: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lending",
-					ResourceNode: ResourceNode{
+					ResourceNode: resourceNode{
 						SubtreeQuota: resources.FlavorResourceQuantities{
 							{Flavor: "arm", Resource: corev1.ResourceCPU}: 20_000,
 							{Flavor: "x86", Resource: corev1.ResourceCPU}: 40_000,
@@ -643,7 +643,7 @@ func TestSnapshot(t *testing.T) {
 										LabelKeys:        sets.New("arch"),
 									},
 								},
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Quotas: map[resources.FlavorResource]ResourceQuota{
 										{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000, BorrowingLimit: nil, LendingLimit: nil},
 										{Flavor: "x86", Resource: corev1.ResourceCPU}: {Nominal: 20_000, BorrowingLimit: nil, LendingLimit: nil},
@@ -696,7 +696,7 @@ func TestSnapshot(t *testing.T) {
 										LabelKeys:        sets.New("arch"),
 									},
 								},
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Quotas: map[resources.FlavorResource]ResourceQuota{
 										{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 10_000, BorrowingLimit: nil, LendingLimit: nil},
 										{Flavor: "x86", Resource: corev1.ResourceCPU}: {Nominal: 20_000, BorrowingLimit: nil, LendingLimit: nil},
@@ -751,7 +751,7 @@ func TestSnapshot(t *testing.T) {
 					map[kueue.CohortReference]*CohortSnapshot{
 						"cohort": {
 							Name: "cohort",
-							ResourceNode: ResourceNode{
+							ResourceNode: resourceNode{
 								Quotas: map[resources.FlavorResource]ResourceQuota{
 									{Flavor: "arm", Resource: corev1.ResourceCPU}:  {Nominal: 10_000, BorrowingLimit: nil, LendingLimit: nil},
 									{Flavor: "x86", Resource: corev1.ResourceCPU}:  {Nominal: 20_000, BorrowingLimit: nil, LendingLimit: nil},
@@ -776,7 +776,7 @@ func TestSnapshot(t *testing.T) {
 									Flavors:          []kueue.ResourceFlavorReference{"arm", "x86"},
 								},
 							},
-							ResourceNode: ResourceNode{
+							ResourceNode: resourceNode{
 								Quotas: map[resources.FlavorResource]ResourceQuota{
 									{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 7_000, BorrowingLimit: nil, LendingLimit: ptr.To[int64](3_000)},
 									{Flavor: "x86", Resource: corev1.ResourceCPU}: {Nominal: 5_000, BorrowingLimit: nil, LendingLimit: nil},
@@ -838,7 +838,7 @@ func TestSnapshot(t *testing.T) {
 					map[kueue.CohortReference]*CohortSnapshot{
 						"nocycle": {
 							Name: "nocycle",
-							ResourceNode: ResourceNode{
+							ResourceNode: resourceNode{
 								SubtreeQuota: resources.FlavorResourceQuantities{
 									{Flavor: "arm", Resource: corev1.ResourceCPU}: 0,
 								},
@@ -856,7 +856,7 @@ func TestSnapshot(t *testing.T) {
 									Flavors:          []kueue.ResourceFlavorReference{"arm"},
 								},
 							},
-							ResourceNode: ResourceNode{
+							ResourceNode: resourceNode{
 								Quotas: map[resources.FlavorResource]ResourceQuota{
 									{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: 0},
 								},
@@ -1025,7 +1025,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "cohort",
-					ResourceNode: ResourceNode{
+					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}:  0,
 							{Flavor: "alpha", Resource: corev1.ResourceMemory}: 0,
@@ -1046,7 +1046,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								ResourceGroups:    cqCache.hm.ClusterQueue("c1").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}:  0,
 										{Flavor: "alpha", Resource: corev1.ResourceMemory}: 0,
@@ -1066,7 +1066,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
 									},
@@ -1085,7 +1085,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "cohort",
-					ResourceNode: ResourceNode{
+					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}:  2_000,
 							{Flavor: "alpha", Resource: corev1.ResourceMemory}: utiltesting.Gi,
@@ -1109,7 +1109,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								ResourceGroups:    cqCache.hm.ClusterQueue("c1").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}:  0,
 										{Flavor: "alpha", Resource: corev1.ResourceMemory}: utiltesting.Gi,
@@ -1132,7 +1132,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 2_000,
 									},
@@ -1151,7 +1151,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "cohort",
-					ResourceNode: ResourceNode{
+					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}:  3_000,
 							{Flavor: "alpha", Resource: corev1.ResourceMemory}: 0,
@@ -1175,7 +1175,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								ResourceGroups:    cqCache.hm.ClusterQueue("c1").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}:  1_000,
 										{Flavor: "alpha", Resource: corev1.ResourceMemory}: 0,
@@ -1197,7 +1197,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 								ResourceGroups:    cqCache.hm.ClusterQueue("c2").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 2_000,
 									},
@@ -1214,7 +1214,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 	}
 	cmpOpts := append(snapCmpOpts,
 		cmpopts.IgnoreFields(ClusterQueueSnapshot{}, "NamespaceSelector", "Preemption", "Status", "AllocatableResourceGeneration"),
-		cmpopts.IgnoreFields(ResourceNode{}, "Quotas"),
+		cmpopts.IgnoreFields(resourceNode{}, "Quotas"),
 		cmpopts.IgnoreFields(Snapshot{}, "ResourceFlavors"),
 		cmpopts.IgnoreTypes(&workload.Info{}))
 	for name, tc := range cases {
@@ -1319,7 +1319,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
-					ResourceNode: ResourceNode{
+					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
 						},
@@ -1338,7 +1338,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
 									},
@@ -1353,7 +1353,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
 									},
@@ -1372,7 +1372,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
-					ResourceNode: ResourceNode{
+					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
 						},
@@ -1391,7 +1391,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 7_000,
 									},
@@ -1407,7 +1407,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
 									},
@@ -1426,7 +1426,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
-					ResourceNode: ResourceNode{
+					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
 						},
@@ -1445,7 +1445,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 6_000,
 									},
@@ -1461,7 +1461,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
 									},
@@ -1480,7 +1480,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
-					ResourceNode: ResourceNode{
+					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
 						},
@@ -1499,7 +1499,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
 									},
@@ -1515,7 +1515,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
 									},
@@ -1535,7 +1535,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
-					ResourceNode: ResourceNode{
+					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
 						},
@@ -1554,7 +1554,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 1_000,
 									},
@@ -1570,7 +1570,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
 									},
@@ -1590,7 +1590,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
-					ResourceNode: ResourceNode{
+					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
 						},
@@ -1609,7 +1609,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 6_000,
 									},
@@ -1624,7 +1624,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
 									},
@@ -1644,7 +1644,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
-					ResourceNode: ResourceNode{
+					ResourceNode: resourceNode{
 						Usage: resources.FlavorResourceQuantities{
 							{Flavor: "default", Resource: corev1.ResourceCPU}: 3_000,
 						},
@@ -1663,7 +1663,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 9_000,
 									},
@@ -1679,7 +1679,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
 								AllocatableResourceGeneration: 1,
-								ResourceNode: ResourceNode{
+								ResourceNode: resourceNode{
 									Usage: resources.FlavorResourceQuantities{
 										{Flavor: "default", Resource: corev1.ResourceCPU}: 0,
 									},
@@ -1696,7 +1696,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 	}
 	cmpOpts := append(snapCmpOpts,
 		cmpopts.IgnoreFields(ClusterQueueSnapshot{}, "NamespaceSelector", "Preemption", "Status", "AllocatableResourceGeneration"),
-		cmpopts.IgnoreFields(ResourceNode{}, "Quotas"),
+		cmpopts.IgnoreFields(resourceNode{}, "Quotas"),
 		cmpopts.IgnoreFields(Snapshot{}, "ResourceFlavors"),
 		cmpopts.IgnoreTypes(&workload.Info{}))
 	for name, tc := range cases {

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -62,22 +62,6 @@ var snapCmpOpts = cmp.Options{
 	cmpopts.IgnoreFields(cache.ClusterQueueSnapshot{}, "ClusterQueue"),
 }
 
-type nodeKey struct {
-	cohort       kueue.CohortReference
-	clusterQueue kueue.ClusterQueueReference
-}
-
-func resourceNodes(snapshot *cache.Snapshot) map[nodeKey]cache.ResourceNode {
-	nodes := map[nodeKey]cache.ResourceNode{}
-	for _, cohort := range snapshot.Cohorts() {
-		nodes[nodeKey{cohort: cohort.Name}] = cohort.ResourceNode
-	}
-	for _, cq := range snapshot.ClusterQueues() {
-		nodes[nodeKey{clusterQueue: cq.Name}] = cq.ResourceNode
-	}
-	return nodes
-}
-
 func TestPreemption(t *testing.T) {
 	now := time.Now()
 	flavors := []*kueue.ResourceFlavor{
@@ -1888,12 +1872,6 @@ func TestPreemption(t *testing.T) {
 			if diff := cmp.Diff(beforeSnapshot, snapshotWorkingCopy, snapCmpOpts); diff != "" {
 				t.Errorf("Snapshot was modified (-initial,+end):\n%s", diff)
 			}
-
-			beforeResourceNodes := resourceNodes(beforeSnapshot)
-			afterResourceNodes := resourceNodes(snapshotWorkingCopy)
-			if diff := cmp.Diff(beforeResourceNodes, afterResourceNodes, snapCmpOpts); diff != "" {
-				t.Errorf("Snapshot was modified (-initial,+end):\n%s", diff)
-			}
 		})
 	}
 }
@@ -2708,12 +2686,6 @@ func TestFairPreemptions(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(beforeSnapshot, snapshotWorkingCopy, snapCmpOpts); diff != "" {
-				t.Errorf("Snapshot was modified (-initial,+end):\n%s", diff)
-			}
-
-			beforeResourceNodes := resourceNodes(beforeSnapshot)
-			afterResourceNodes := resourceNodes(snapshotWorkingCopy)
-			if diff := cmp.Diff(beforeResourceNodes, afterResourceNodes, snapCmpOpts); diff != "" {
 				t.Errorf("Snapshot was modified (-initial,+end):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Follow up to #4553. After #4635, we can revert #4658 as it is repeating the same assertion. Additionally, we unexport ResourceNode, with the expectation it will only be accessed indirectly behind ClusterQueueSnapshot and CohortSnapshot interfaces.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```