### PR TITLE
Add appwrappers permissions to multikueue service account example.

### DIFF
--- a/site/static/examples/multikueue/create-multikueue-kubeconfig.sh
+++ b/site/static/examples/multikueue/create-multikueue-kubeconfig.sh
@@ -207,6 +207,22 @@ rules:
   - rayclusters/status
   verbs:
   - get
+- apiGroups:
+  - workload.codeflare.dev
+  resources:
+  - appwrappers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - workload.codeflare.dev
+  resources:
+  - appwrappers/status
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds missing `appwrappers` and `appwrappers/status` permissions for the `multikueue-sa` ServiceAccount in the example script `create-multikueue-kubeconfig.sh`.

Without these permissions, `MultiKueueCluster` resources referencing clusters with `AppWrapper` workloads will remain inactive due to permission errors such as:

```
❯ kubectl --context kind-management-kueue-cluster get clusterqueues cluster-queue -o jsonpath="{range .status.conditions[?(@.type == \"Active\")]}CQ - Active: {@.status} Reason: {@.reason} Message: {@.message}{'\n'}{end}"
kubectl  --context kind-management-kueue-cluster get admissionchecks sample-multikueue -o jsonpath="{range .status.conditions[?(@.type == \"Active\")]}AC - Active: {@.status} Reason: {@.reason} Message: {@.message}{'\n'}{end}"
kubectl  --context kind-management-kueue-cluster get multikueuecluster multikueue-test-worker -o jsonpath="{range .status.conditions[?(@.type == \"Active\")]}MC - Active: {@.status} Reason: {@.reason} Message: {@.message}{'\n'}{end}"
CQ - Active: False Reason: AdmissionCheckInactive Message: Can't admit new workloads: references inactive AdmissionCheck(s): [sample-multikueue].
AC - Active: False Reason: NoUsableClusters Message: Inactive clusters: [multikueue-test-worker]
MC - Active: False Reason: ClientConnectionFailed Message: appwrappers.workload.codeflare.dev is forbidden: User "system:serviceaccount:kueue-system:multikueue-sa" cannot watch resource "appwrappers" in API group "workload.codeflare.dev" at the cluster scope
```

This change is required to allow `multikueue` to properly watch and manage `AppWrapper` resources across clusters.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

To reproduce the permission error, follow these steps:

1. Clone the example repository and set up the management and worker clusters using Kind:
   ```bash
   git clone git@github.com:yoshikawa/sandbox.git
   cd sandbox/kueue/multi-clusters/management
   kind create cluster --config kind-management-cluster.yaml
   cd ../worker
   kind create cluster --config kind-worker-cluster.yaml
   ```
2. Apply Kueue resources to each cluster:
   ```bash
   cd ../management
   kubectl --context kind-management-kueue-cluster apply --server-side -k . 

   cd ../worker
   kubectl --context kind-worker-kueue-cluster apply --server-side -k . 
   ```
3. Deploy ClusterQueue and MultiKueue:
   ```bash
   cd ../management
   kubectl --context kind-management-kueue-cluster apply -f multi-queue.yaml

   cd ../worker
   kubectl --context kind-worker-kueue-cluster apply -f cluster-queue.yaml
   ```
4. Set up the worker cluster kubeconfig for multikueue:
   ```bash
   cd ../worker
   # Please refer to the example shell script provided in the documentation.
   # The correct script is shown below.
   ./create-multikueue-kubeconfig.sh worker.kubeconfig
   # If the server in the config is set to https://127.0.0.1/, please update it to the control plane node IP address.
   kubectl --context kind-management-kueue-cluster create secret generic worker-cluster-kubeconfig --from-file=kubeconfig=worker.kubeconfig -n kueue-system
   ```
5. Check status of related resources:
   ```bash
   kubectl --context kind-management-kueue-cluster get clusterqueues cluster-queue -o jsonpath="{range .status.conditions[?(@.type == \"Active\")]}CQ - Active: {@.status} Reason: {@.reason} Message: {@.message}{'\n'}{end}"
   kubectl --context kind-management-kueue-cluster get admissionchecks sample-multikueue -o jsonpath="{range .status.conditions[?(@.type == \"Active\")]}AC - Active: {@.status} Reason: {@.reason} Message: {@.message}{'\n'}{end}"
   kubectl --context kind-management-kueue-cluster get multikueuecluster multikueue-test-worker -o jsonpath="{range .status.conditions[?(@.type == \"Active\")]}MC - Active: {@.status} Reason: {@.reason} Message: {@.message}{'\n'}{end}"
   ```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```