### PR TITLE
Set the E2E_KIND_VERSION mk variable based on the E2E_K8S_VERSION

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -55,9 +55,12 @@ endif
 
 # Folder where the e2e tests are located.
 E2E_TARGET ?= ./test/e2e/...
-E2E_KIND_VERSION ?= kindest/node:v1.32.0
-# E2E_K8S_VERSIONS sets the list of k8s versions included in test-e2e-all
-E2E_K8S_VERSIONS ?= 1.30.9 1.31.5 1.32.1
+E2E_K8S_VERSIONS ?= 1.30.10 1.31.6 1.32.3
+E2E_K8S_VERSION ?= 1.32
+E2E_K8S_FULL_VERSION ?= $(filter $(E2E_K8S_VERSION).%,$(E2E_K8S_VERSIONS))
+# Default to E2E_K8S_VERSION.0 if no match is found
+E2E_K8S_FULL_VERSION := $(or $(E2E_K8S_FULL_VERSION),$(E2E_K8S_VERSION).0)
+E2E_KIND_VERSION ?= kindest/node:v$(E2E_K8S_FULL_VERSION)
 
 # For local testing, we should allow user to use different kind cluster name
 # Default will delete default kind cluster

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -64,9 +64,9 @@ make test-e2e-kueueviz
 make test-multikueue-e2e
 ```
 
-You can also change `kind` version by modifying `E2E_KIND_VERSION` variable:
+You can specify the Kubernetes version used for running the e2e tests by setting the `E2E_K8S_FULL_VERSION` variable:
 ```shell
-E2E_KIND_VERSION=kindest/node:v1.32.0 make test-e2e
+E2E_K8S_FULL_VERSION=1.32.2 make test-e2e
 ```
 
 For running a subset of tests, see [Running subset of tests](#running-subset-of-integration-or-e2e-tests).


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup


#### What this PR does / why we need it:
This PR sets the `E2E_KIND_VERSION` Makefile variable based on the `E2E_K8S_VERSION` variable. This is needed to make `test-infra` jobs pass only the `E2E_K8S_VERSION` variable


#### Which issue(s) this PR fixes:
Part of #4729

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```