### PR TITLE
Protect GuaranteedQuota When FairSharing Weight=0

### DIFF
--- a/apis/kueue/v1beta1/fairsharing_types.go
+++ b/apis/kueue/v1beta1/fairsharing_types.go
@@ -46,7 +46,7 @@ type FairSharingStatus struct {
 	// Cohort, among all the resources provided by the Node, and
 	// divided by the weight.  If zero, it means that the usage of
 	// the Node is below the nominal quota.  If the Node has a
-	// weight of zero, this will return 9223372036854775807, the
-	// maximum possible share value.
+	// weight of zero and is borrowing, this will return
+	// 9223372036854775807, the maximum possible share value.
 	WeightedShare int64 `json:"weightedShare"`
 }

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -594,8 +594,8 @@ spec:
                       Cohort, among all the resources provided by the Node, and
                       divided by the weight.  If zero, it means that the usage of
                       the Node is below the nominal quota.  If the Node has a
-                      weight of zero, this will return 9223372036854775807, the
-                      maximum possible share value.
+                      weight of zero and is borrowing, this will return
+                      9223372036854775807, the maximum possible share value.
                     format: int64
                     type: integer
                 required:

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
@@ -259,8 +259,8 @@ spec:
                       Cohort, among all the resources provided by the Node, and
                       divided by the weight.  If zero, it means that the usage of
                       the Node is below the nominal quota.  If the Node has a
-                      weight of zero, this will return 9223372036854775807, the
-                      maximum possible share value.
+                      weight of zero and is borrowing, this will return
+                      9223372036854775807, the maximum possible share value.
                     format: int64
                     type: integer
                 required:

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -579,8 +579,8 @@ spec:
                       Cohort, among all the resources provided by the Node, and
                       divided by the weight.  If zero, it means that the usage of
                       the Node is below the nominal quota.  If the Node has a
-                      weight of zero, this will return 9223372036854775807, the
-                      maximum possible share value.
+                      weight of zero and is borrowing, this will return
+                      9223372036854775807, the maximum possible share value.
                     format: int64
                     type: integer
                 required:

--- a/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
@@ -244,8 +244,8 @@ spec:
                       Cohort, among all the resources provided by the Node, and
                       divided by the weight.  If zero, it means that the usage of
                       the Node is below the nominal quota.  If the Node has a
-                      weight of zero, this will return 9223372036854775807, the
-                      maximum possible share value.
+                      weight of zero and is borrowing, this will return
+                      9223372036854775807, the maximum possible share value.
                     format: int64
                     type: integer
                 required:

--- a/pkg/cache/fair_sharing_test.go
+++ b/pkg/cache/fair_sharing_test.go
@@ -458,7 +458,7 @@ func TestDominantResourceShare(t *testing.T) {
 				{
 					Name:     "cq",
 					NodeType: nodeTypeCq,
-					DrName:   "",
+					DrName:   "example.com/gpu",
 					DrValue:  math.MaxInt,
 				},
 				{

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -365,7 +365,7 @@ For a LocalQueue, the metric only reports a value of 1 for one of the statuses.`
 quota to the lendable resources in the cohort, among all the resources provided by 
 the ClusterQueue, and divided by the weight.
 If zero, it means that the usage of the ClusterQueue is below the nominal quota.
-If the ClusterQueue has a weight of zero, this will return 9223372036854775807,
+If the ClusterQueue has a weight of zero and is borrowing, this will return 9223372036854775807,
 the maximum possible share value.`,
 		}, []string{"cluster_queue"},
 	)
@@ -378,7 +378,7 @@ the maximum possible share value.`,
 quota to the lendable resources in the Cohort, among all the resources provided by 
 the Cohort, and divided by the weight.
 If zero, it means that the usage of the Cohort is below the nominal quota.
-If the Cohort has a weight of zero, this will return 9223372036854775807,
+If the Cohort has a weight of zero and is borrowing, this will return 9223372036854775807,
 the maximum possible share value.`,
 		}, []string{"cohort"},
 	)

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -2340,6 +2340,40 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: unitWl.Clone().Name("a_incoming").Obj(),
 			targetCQ: "a",
 		},
+		"can't preempt nominal from Cohort with 0 weight": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltesting.MakeClusterQueue("left-cq").
+					Cohort("root").
+					ResourceGroup(*utiltesting.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "0").Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					Obj(),
+				utiltesting.MakeClusterQueue("right-cq").
+					Cohort("right-cohort").
+					ResourceGroup(*utiltesting.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "0").Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					FairWeight(resource.MustParse("0")).
+					Obj(),
+			},
+			cohorts: []*kueuealpha.Cohort{
+				utiltesting.MakeCohort("right-cohort").
+					FairWeight(resource.MustParse("0")).
+					ResourceGroup(*utiltesting.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "1").Obj()).
+					Parent("root").Obj(),
+			},
+			admitted: []kueue.Workload{
+				*unitWl.Clone().Name("right-1").SimpleReserveQuota("right-cq", "default", now).Obj(),
+			},
+			incoming:      unitWl.Clone().Name("left-1").Obj(),
+			wantPreempted: sets.New[string](),
+			targetCQ:      "left-cq",
+		},
 		"can preempt within cluster queue when no cohort": {
 			clusterQueues: []*kueue.ClusterQueue{
 				utiltesting.MakeClusterQueue("a").

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -1087,8 +1087,8 @@ above nominal quota to the lendable resources in the
 Cohort, among all the resources provided by the Node, and
 divided by the weight.  If zero, it means that the usage of
 the Node is below the nominal quota.  If the Node has a
-weight of zero, this will return 9223372036854775807, the
-maximum possible share value.</p>
+weight of zero and is borrowing, this will return
+9223372036854775807, the maximum possible share value.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We protect workloads running under nominal quota from being preempted, even when Cohort has FairWeight of 0. We do this by only returning math.MaxInt score when the Cohort is borrowing. When a Cohort is not borrowing, it gets a FairShare score of 0.

#### Which issue(s) this PR fixes:
Fixes #4961

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix bug where Cohorts with FairWeight set to 0 could have workloads running within Nominal Quota preempted
```