### PR TITLE
Reconcile Cohort when FairSharing Weight Updated

### DIFF
--- a/pkg/controller/core/cohort_controller.go
+++ b/pkg/controller/core/cohort_controller.go
@@ -110,8 +110,7 @@ func (r *CohortReconciler) Create(event.TypedCreateEvent[*kueue.Cohort]) bool {
 
 func (r *CohortReconciler) Update(e event.TypedUpdateEvent[*kueue.Cohort]) bool {
 	log := r.log.WithValues("cohort", klog.KObj(e.ObjectNew))
-	if equality.Semantic.DeepEqual(e.ObjectOld.Spec.ResourceGroups, e.ObjectNew.Spec.ResourceGroups) &&
-		e.ObjectOld.Spec.Parent == e.ObjectNew.Spec.Parent {
+	if equality.Semantic.DeepEqual(e.ObjectOld.Spec, e.ObjectNew.Spec) {
 		log.V(2).Info("Skip Cohort update event as Cohort unchanged")
 		return false
 	}

--- a/pkg/controller/core/cohort_controller_test.go
+++ b/pkg/controller/core/cohort_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -338,6 +339,21 @@ func TestCohortReconcilerFilters(t *testing.T) {
 		"deleting parent returns true": {
 			old:  utiltesting.MakeCohort("cohort").Parent("parent").Obj(),
 			new:  utiltesting.MakeCohort("cohort").Obj(),
+			want: true,
+		},
+		"adding weight returns true": {
+			old:  utiltesting.MakeCohort("cohort").Obj(),
+			new:  utiltesting.MakeCohort("cohort").FairWeight(resource.MustParse("1")).Obj(),
+			want: true,
+		},
+		"deleting weight returns true": {
+			old:  utiltesting.MakeCohort("cohort").FairWeight(resource.MustParse("1")).Obj(),
+			new:  utiltesting.MakeCohort("cohort").Obj(),
+			want: true,
+		},
+		"updating weight returns true": {
+			old:  utiltesting.MakeCohort("cohort").FairWeight(resource.MustParse("1")).Obj(),
+			new:  utiltesting.MakeCohort("cohort").FairWeight(resource.MustParse("2")).Obj(),
 			want: true,
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We were filtering Cohort reconciles when only FairSharing weight updated. This meant that our internal representation of Cohort was not matching the API representation.

#### Which issue(s) this PR fixes:
Fixes #4960

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix bug where update to Cohort.FairSharing didn't trigger a reconcile. This bug resulted in the new weight not being used until the Cohort was modified in another way.
```