### PR TITLE
Document waitForPodsReady.recoveryTimeout

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_wait_for_pods_ready.md
+++ b/site/content/en/docs/tasks/manage/setup_wait_for_pods_ready.md
@@ -43,6 +43,7 @@ fields:
     waitForPodsReady:
       enable: true
       timeout: 10m
+      recoveryTimeout: 3m
       blockAdmission: true
       requeuingStrategy:
         timestamp: Eviction | Creation
@@ -68,6 +69,14 @@ When the `timeout` expires for an admitted Workload, and the workload's
 pods are not all scheduled yet (i.e., the Workload condition remains
 `PodsReady=False`), then the Workload's admission is
 cancelled, the corresponding job is suspended and the Workload is re-queued.
+
+`recoveryTimeout` is an optional parameter used for
+workloads that are already running but have one or more Pods in a not-ready state
+(e.g., due to Pod failure). If a Pod is not ready, the workload often cannot
+progress, leading to wasted resources. To prevent this, users can configure
+a timeout period they are willing to wait for a recovery Pod. If the
+`recoveryTimeout` expires, similar to the regular timeout, the workload is evicted and requeued.
+It has no default value, so it must be set explicitly.
 
 The `blockAdmission` (`waitForPodsReady.blockAdmission`) is an optional parameter.
 When enabled, then the workloads are admitted sequentially to prevent deadlock


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```