### PR TITLE
Automated cherry pick of #4973: Handle request value with zero in CountIn

### DIFF
--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"maps"
+	"math"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -107,11 +108,16 @@ func (req Requests) CountIn(capacity Requests) int32 {
 	var result *int32
 	for rName, rValue := range req {
 		capacity, found := capacity[rName]
-		if !found {
+		if !found && rValue != 0 {
 			return 0
 		}
 		// find the minimum count matching all the resource quota.
-		count := int32(capacity / rValue)
+		var count int32
+		if rValue == 0 {
+			count = int32(math.MaxInt32)
+		} else {
+			count = int32(capacity / rValue)
+		}
 		if result == nil || count < *result {
 			result = ptr.To(count)
 		}

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"math"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -79,6 +80,36 @@ func TestCountIn(t *testing.T) {
 				corev1.ResourceCPU: 5,
 			},
 			wantResult: 2,
+		},
+		"requests amount of zero": {
+			requests: Requests{
+				corev1.ResourceCPU: 0,
+			},
+			capacity: Requests{
+				corev1.ResourceCPU: 5,
+			},
+			wantResult: int32(math.MaxInt32),
+		},
+		"has one resource with request amount of zero": {
+			requests: Requests{
+				corev1.ResourceCPU:    0,
+				corev1.ResourceMemory: 1,
+			},
+			capacity: Requests{
+				corev1.ResourceCPU:    5,
+				corev1.ResourceMemory: 5,
+			},
+			wantResult: 5,
+		},
+		"requests amount of zero for extra resource": {
+			requests: Requests{
+				corev1.ResourceCPU:    1,
+				corev1.ResourceMemory: 0,
+			},
+			capacity: Requests{
+				corev1.ResourceCPU: 5,
+			},
+			wantResult: 5,
 		},
 	}
 	for name, tc := range cases {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -5091,6 +5091,51 @@ func TestScheduleForTAS(t *testing.T) {
 				},
 			},
 		},
+		"workload with zero value request gets scheduled": {
+			nodes:           defaultSingleNode,
+			topologies:      []kueuealpha.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
+			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueue},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("foo", "default").
+					Queue("tas-main").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "0").
+						Request(corev1.ResourceMemory, "10Mi").
+						Obj()).
+					Obj(),
+			},
+			wantNewAssignments: map[string]kueue.Admission{
+				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
+					Assignment(corev1.ResourceCPU, "tas-default", "0").
+					Assignment(corev1.ResourceMemory, "tas-default", "10Mi").
+					AssignmentPodCount(1).
+					TopologyAssignment(&kueue.TopologyAssignment{
+						Levels: utiltas.Levels(&defaultSingleLevelTopology),
+						Domains: []kueue.TopologyDomainAssignment{
+							{
+								Count: 1,
+								Values: []string{
+									"x1",
+								},
+							},
+						},
+					}).Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Namespace: "default", Name: "foo"},
+					Reason:    "QuotaReserved",
+					EventType: corev1.EventTypeNormal,
+				},
+				{
+					Key:       types.NamespacedName{Namespace: "default", Name: "foo"},
+					Reason:    "Admitted",
+					EventType: corev1.EventTypeNormal,
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -5100,6 +5100,7 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("foo", "default").
 					Queue("tas-main").
 					PodSets(*utiltesting.MakePodSet("one", 1).
+						PreferredTopologyRequest(corev1.LabelHostname).
 						Request(corev1.ResourceCPU, "0").
 						Request(corev1.ResourceMemory, "10Mi").
 						Obj()).


### PR DESCRIPTION
Cherry pick of #4973 on release-0.10.

#4973: [release-0.11] Handle request value with zero in CountIn

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
TAS: Fix bug where scheduling panics when the workload using TopologyAwareScheduling has container request value specified as zero.
```