### PR TITLE
Automated cherry pick of #4950: Set the E2E_KIND_VERSION mk variable based on the E2E_K8S_VERSION

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -55,9 +55,12 @@ endif
 
 # Folder where the e2e tests are located.
 E2E_TARGET ?= ./test/e2e/...
-E2E_KIND_VERSION ?= kindest/node:v1.32.0
-# E2E_K8S_VERSIONS sets the list of k8s versions included in test-e2e-all
-E2E_K8S_VERSIONS ?= 1.29.13 1.30.9 1.31.5 1.32.1
+E2E_K8S_VERSIONS ?= 1.30.10 1.31.6 1.32.3
+E2E_K8S_VERSION ?= 1.32
+E2E_K8S_FULL_VERSION ?= $(filter $(E2E_K8S_VERSION).%,$(E2E_K8S_VERSIONS))
+# Default to E2E_K8S_VERSION.0 if no match is found
+E2E_K8S_FULL_VERSION := $(or $(E2E_K8S_FULL_VERSION),$(E2E_K8S_VERSION).0)
+E2E_KIND_VERSION ?= kindest/node:v$(E2E_K8S_FULL_VERSION)
 
 # For local testing, we should allow user to use different kind cluster name
 # Default will delete default kind cluster

--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -71,9 +71,9 @@ make test-e2e-customconfigs
 make test-multikueue-e2e
 ```
 
-You can also change `kind` version by modifying `E2E_KIND_VERSION` variable:
+You can specify the Kubernetes version used for running the e2e tests by setting the `E2E_K8S_FULL_VERSION` variable:
 ```shell
-E2E_KIND_VERSION=kindest/node:v1.32.0 make test-e2e
+E2E_K8S_FULL_VERSION=1.32.2 make test-e2e
 ```
 
 For running a subset of tests, see [Running subset of tests](#running-subset-of-integration-or-e2e-tests).


### PR DESCRIPTION
Cherry pick of #4950 on release-0.11.

#4950: Set the E2E_KIND_VERSION mk variable based on the E2E_K8S_VERSION

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```