### PR TITLE
Add support for node selectors based filtering in TAS

### DIFF
--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -295,6 +295,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 		topologyRequest    *kueue.PodSetTopologyRequest
 		levels             []string
 		nodeLabels         map[string]string
+		nodeSelector       map[string]string
 		nodes              []corev1.Node
 		pods               []corev1.Pod
 		requests           resources.Requests
@@ -1944,6 +1945,116 @@ func TestFindTopologyAssignment(t *testing.T) {
 			wantReason:         `topology "default" doesn't allow to fit any of 1 pod(s)`,
 			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
+		"skip node which doesn't match node selector, missing label; BestFit": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("zone", "zone-a").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourcePods:   resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Required: ptr.To(corev1.LabelHostname),
+			},
+			nodeLabels: map[string]string{
+				"zone": "zone-a",
+			},
+			levels: defaultOneLevel,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 300,
+			},
+			nodeSelector: map[string]string{
+				"custom-label-1": "custom-value-1",
+			},
+			count:      1,
+			wantReason: `topology "default" doesn't allow to fit any of 1 pod(s)`,
+		},
+		"skip node which doesn't match node selector, label exists, value doesn't match; BestFit": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("zone", "zone-a").
+					Label(corev1.LabelHostname, "x1").
+					Label("custom-label-1", "value-1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourcePods:   resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Required: ptr.To(corev1.LabelHostname),
+			},
+			nodeLabels: map[string]string{
+				"zone": "zone-a",
+			},
+			nodeSelector: map[string]string{
+				"custom-label-1": "custom-value-1",
+			},
+			levels: defaultOneLevel,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 300,
+			},
+			count:      1,
+			wantReason: `topology "default" doesn't allow to fit any of 1 pod(s)`,
+		},
+		"allow to schedule on node which matches node; BestFit": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-r1-x1").
+					Label("zone", "zone-a").
+					Label(corev1.LabelHostname, "x1").
+					Label("custom-label-1", "value-1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourcePods:   resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("b1-r1-x2").
+					Label("zone", "zone-a").
+					Label(corev1.LabelHostname, "x2").
+					Label("custom-label-1", "value-2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourcePods:   resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Required: ptr.To(corev1.LabelHostname),
+			},
+			nodeLabels: map[string]string{
+				"zone": "zone-a",
+			},
+			nodeSelector: map[string]string{
+				"custom-label-1": "value-2",
+			},
+			levels: defaultOneLevel,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 1,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultOneLevel,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 1,
+						Values: []string{
+							"x2",
+						},
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -1979,6 +2090,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Tolerations: tc.tolerations,
+							NodeSelector: tc.nodeSelector,
 						},
 					},
 				},

--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -1995,7 +1995,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 				"zone": "zone-a",
 			},
 			nodeSelector: map[string]string{
-				"custom-label-1": "custom-value-1",
+				"custom-label-1": "value-2",
 			},
 			levels: defaultOneLevel,
 			requests: resources.Requests{

--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -2089,7 +2089,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					TopologyRequest: tc.topologyRequest,
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
-							Tolerations: tc.tolerations,
+							Tolerations:  tc.tolerations,
 							NodeSelector: tc.nodeSelector,
 						},
 					},

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -680,7 +680,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests,
 		// 2. Check Node Labels against Compiled Selector
 		var nodeLabelSet labels.Set
 		if leaf.nodeLabels != nil {
-			nodeLabelSet = labels.Set(leaf.nodeLabels)
+			nodeLabelSet = leaf.nodeLabels
 		}
 		if !compiledSelector.Matches(nodeLabelSet) {
 			s.log.V(2).Info("excluding node that doesn't match nodeSelectors", "domainID", leaf.id, "nodeLabels", nodeLabelSet)

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -725,10 +725,6 @@ func (s *TASFlavorSnapshot) notFitMessage(fitCount, totalCount int32) string {
 // Returns labels.Everything() if no selectors are provided.
 // Returns labels.Nothing() if selectors are invalid.
 func (s *TASFlavorSnapshot) compileNodeSelector(nodeSelectors map[string]string) labels.Selector {
-	// If there are no node selectors match everything.
-	if len(nodeSelectors) == 0 {
-		return labels.Everything()
-	}
 	selector, err := labels.ValidatedSelectorFromSet(nodeSelectors)
 	if err != nil {
 		s.log.Error(err, "invalid node selectors provided, no nodes will be matched", "selectors", nodeSelectors)

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -674,7 +674,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests,
 			return t.Effect == corev1.TaintEffectNoSchedule || t.Effect == corev1.TaintEffectNoExecute
 		})
 		if untolerated {
-			s.log.V(5).Info("excluding node with untolerated taint", "domainID", leaf.id, "taint", taint)
+			s.log.V(2).Info("excluding node with untolerated taint", "domainID", leaf.id, "taint", taint)
 			continue
 		}
 		// 2. Check Node Labels against Compiled Selector
@@ -683,7 +683,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests,
 			nodeLabelSet = labels.Set(leaf.nodeLabels)
 		}
 		if !compiledSelector.Matches(nodeLabelSet) {
-			s.log.V(5).Info("excluding node that doesn't match nodeSelectors", "domainID", leaf.id, "nodeLabels", nodeLabelSet)
+			s.log.V(2).Info("excluding node that doesn't match nodeSelectors", "domainID", leaf.id, "nodeLabels", nodeLabelSet)
 			continue
 		}
 		remainingCapacity := leaf.freeCapacity.Clone()

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/utils/ptr"
 
@@ -83,6 +84,10 @@ type leafDomain struct {
 	// nodeTaints contains the list of taints for the node, only applies for
 	// lowest level of topology, if the lowest level is node
 	nodeTaints []corev1.Taint
+
+	// nodeLabels contains the list of labels on the node, only applies for
+	// lowest level of topology, if the lowest level is node
+	nodeLabels map[string]string
 }
 
 type domainByID map[utiltas.TopologyDomainID]*domain
@@ -150,6 +155,7 @@ func (s *TASFlavorSnapshot) addNode(node corev1.Node) utiltas.TopologyDomainID {
 		}
 		if s.isLowestLevelNode() {
 			leafDomain.nodeTaints = slices.Clone(node.Spec.Taints)
+			leafDomain.nodeLabels = node.GetLabels()
 		}
 		s.leaves[domainID] = &leafDomain
 	}
@@ -410,6 +416,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	requests := tasPodSetRequests.SinglePodRequests.Clone()
 	requests.Add(resources.Requests{corev1.ResourcePods: 1})
 	podSetTolerations := tasPodSetRequests.PodSet.Template.Spec.Tolerations
+	podSetNodeSelectors := tasPodSetRequests.PodSet.Template.Spec.NodeSelector
 	count := tasPodSetRequests.Count
 	required := isRequired(tasPodSetRequests.PodSet.TopologyRequest)
 	key := s.levelKeyWithImpliedFallback(&tasPodSetRequests)
@@ -422,7 +429,13 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		return nil, fmt.Sprintf("no requested topology level: %s", *key)
 	}
 	// phase 1 - determine the number of pods which can fit in each topology domain
-	s.fillInCounts(requests, assumedUsage, simulateEmpty, append(podSetTolerations, s.tolerations...))
+	s.fillInCounts(
+		requests,
+		assumedUsage,
+		simulateEmpty,
+		append(podSetTolerations, s.tolerations...),
+		podSetNodeSelectors,
+	)
 
 	// phase 2a: determine the level at which the assignment is done along with
 	// the domains which can accommodate all pods
@@ -647,18 +660,30 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool)
 func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests,
 	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
 	simulateEmpty bool,
-	tolerations []corev1.Toleration) {
+	tolerations []corev1.Toleration,
+	nodeSelectors map[string]string) {
 	for _, domain := range s.domains {
 		// cleanup the state in case some remaining values are present from computing
 		// assignments for previous PodSets.
 		domain.state = 0
 	}
+	compiledSelector := s.compileNodeSelector(nodeSelectors)
 	for _, leaf := range s.leaves {
+		// 1. Check Tolerations against Node Taints
 		taint, untolerated := corev1helpers.FindMatchingUntoleratedTaint(leaf.nodeTaints, tolerations, func(t *corev1.Taint) bool {
 			return t.Effect == corev1.TaintEffectNoSchedule || t.Effect == corev1.TaintEffectNoExecute
 		})
 		if untolerated {
-			s.log.V(2).Info("excluding node with untolerated taint", "domainID", leaf.id, "taint", taint)
+			s.log.V(5).Info("excluding node with untolerated taint", "domainID", leaf.id, "taint", taint)
+			continue
+		}
+		// 2. Check Node Labels against Compiled Selector
+		var nodeLabelSet labels.Set
+		if leaf.nodeLabels != nil {
+			nodeLabelSet = labels.Set(leaf.nodeLabels)
+		}
+		if !compiledSelector.Matches(nodeLabelSet) {
+			s.log.V(5).Info("excluding node that doesn't match nodeSelectors", "domainID", leaf.id, "nodeLabels", nodeLabelSet)
 			continue
 		}
 		remainingCapacity := leaf.freeCapacity.Clone()
@@ -694,4 +719,20 @@ func (s *TASFlavorSnapshot) notFitMessage(fitCount, totalCount int32) string {
 		return fmt.Sprintf("topology %q doesn't allow to fit any of %v pod(s)", s.topologyName, totalCount)
 	}
 	return fmt.Sprintf("topology %q allows to fit only %v out of %v pod(s)", s.topologyName, fitCount, totalCount)
+}
+
+// compileNodeSelector validates and compiles node selectors, returning a selector.
+// Returns labels.Everything() if no selectors are provided.
+// Returns labels.Nothing() if selectors are invalid.
+func (s *TASFlavorSnapshot) compileNodeSelector(nodeSelectors map[string]string) labels.Selector {
+	// If there are no node selectors match everything.
+	if len(nodeSelectors) == 0 {
+		return labels.Everything()
+	}
+	selector, err := labels.ValidatedSelectorFromSet(labels.Set(nodeSelectors))
+	if err != nil {
+		s.log.Error(err, "invalid node selectors provided, no nodes will be matched", "selectors", nodeSelectors)
+		return labels.Nothing()
+	}
+	return selector
 }

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -428,17 +428,24 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	if !found {
 		return nil, fmt.Sprintf("no requested topology level: %s", *key)
 	}
+	var selector labels.Selector
+	if s.isLowestLevelNode() {
+		sel, err := labels.ValidatedSelectorFromSet(podSetNodeSelectors)
+		if err != nil {
+			return nil, fmt.Sprintf("invalid node selectors: %s, reason: %s", podSetNodeSelectors, err)
+		}
+		selector = sel
+	} else {
+		selector = labels.Everything()
+	}
 	// phase 1 - determine the number of pods which can fit in each topology domain
-	err := s.fillInCounts(
+	s.fillInCounts(
 		requests,
 		assumedUsage,
 		simulateEmpty,
 		append(podSetTolerations, s.tolerations...),
-		podSetNodeSelectors,
+		selector,
 	)
-	if err != nil {
-		return nil, fmt.Sprintf("invalid node selectors: %s, reason: %s", podSetNodeSelectors, err)
-	}
 
 	// phase 2a: determine the level at which the assignment is done along with
 	// the domains which can accommodate all pods
@@ -664,15 +671,11 @@ func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests,
 	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
 	simulateEmpty bool,
 	tolerations []corev1.Toleration,
-	nodeSelectors map[string]string) error {
+	selector labels.Selector) {
 	for _, domain := range s.domains {
 		// cleanup the state in case some remaining values are present from computing
 		// assignments for previous PodSets.
 		domain.state = 0
-	}
-	selector, err := labels.ValidatedSelectorFromSet(nodeSelectors)
-	if err != nil {
-		return err
 	}
 	for _, leaf := range s.leaves {
 		// 1. Check Tolerations against Node Taints
@@ -706,7 +709,6 @@ func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests,
 	for _, root := range s.roots {
 		root.state = s.fillInCountsHelper(root)
 	}
-	return nil
 }
 
 func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain) int32 {

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -729,7 +729,7 @@ func (s *TASFlavorSnapshot) compileNodeSelector(nodeSelectors map[string]string)
 	if len(nodeSelectors) == 0 {
 		return labels.Everything()
 	}
-	selector, err := labels.ValidatedSelectorFromSet(labels.Set(nodeSelectors))
+	selector, err := labels.ValidatedSelectorFromSet(nodeSelectors)
 	if err != nil {
 		s.log.Error(err, "invalid node selectors provided, no nodes will be matched", "selectors", nodeSelectors)
 		return labels.Nothing()

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1292,7 +1292,8 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					wl1 *kueue.Workload
 				)
 				customLabelKey := "custom-label-key-1"
-				customLabelValue := "value-1"
+				customLabelCorrectValue := "value-1"
+				customLabelWrongValue := "value-2"
 
 				ginkgo.By("creating a node missing the required label", func() {
 					nodes = []corev1.Node{
@@ -1316,7 +1317,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					wl1 = testing.MakeWorkload("wl-needs-label", ns.Name).
 						Queue(localQueue.Name).
 						PodSets(*testing.MakePodSet("main", 1).
-							NodeSelector(map[string]string{customLabelKey: customLabelValue}).
+							NodeSelector(map[string]string{customLabelKey: customLabelCorrectValue}).
 							Request(corev1.ResourceCPU, "1").
 							Obj()).
 						Obj()
@@ -1328,77 +1329,26 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
 				})
 
-				ginkgo.By("Add the required label to the node", func() {
+				ginkgo.By("Add a label to the node with correct key but wrong value", func() {
 					nodeToUpdate := &corev1.Node{}
 					gomega.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: nodes[0].Name}, nodeToUpdate)).Should(gomega.Succeed())
-					if nodeToUpdate.Labels == nil {
-						nodeToUpdate.Labels = make(map[string]string)
-					}
-					nodeToUpdate.Labels[customLabelKey] = customLabelValue
+					nodeToUpdate.Labels[customLabelKey] = customLabelWrongValue
 					gomega.Expect(k8sClient.Update(ctx, nodeToUpdate)).Should(gomega.Succeed())
-					nodes[0] = *nodeToUpdate
 				})
 
-				ginkgo.By("verify the workload gets admitted after label is added", func() {
-					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
-					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
-					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)
-				})
-			})
-
-			ginkgo.It("should admit workload when node label value is corrected", func() {
-				var (
-					wl1 *kueue.Workload
-				)
-				customLabelKey := "custom-label-key-2"
-				wrongValue := "wrong-value"
-				correctValue := "correct-value"
-
-				ginkgo.By("creating a node with the wrong label value", func() {
-					nodes = []corev1.Node{
-						*testingnode.MakeNode("node-wrong-label-value").
-							Label("node-group", "tas").
-							Label(customLabelKey, wrongValue).
-							Label(testing.DefaultBlockTopologyLevel, "b1").
-							Label(testing.DefaultRackTopologyLevel, "r1").
-							Label(corev1.LabelHostname, "node-wrong-label-value").
-							StatusAllocatable(corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("1"),
-								corev1.ResourceMemory: resource.MustParse("1Gi"),
-								corev1.ResourcePods:   resource.MustParse("10"),
-							}).
-							Ready().
-							Obj(),
-					}
-					util.CreateNodesWithStatus(ctx, k8sClient, nodes)
-				})
-
-				ginkgo.By("creating a workload requiring the correct label value via NodeSelector", func() {
-					wl1 = testing.MakeWorkload("wl-needs-correct-label", ns.Name).
-						Queue(localQueue.Name).
-						PodSets(*testing.MakePodSet("main", 1).
-							NodeSelector(map[string]string{customLabelKey: correctValue}).
-							Request(corev1.ResourceCPU, "1").
-							Obj()).
-						Obj()
-					util.MustCreate(ctx, k8sClient, wl1)
-				})
-
-				ginkgo.By("verify the workload is inadmissible due to wrong label value", func() {
+				ginkgo.By("verify the workload is inadmissible due to wrong value in the label", func() {
 					util.ExpectWorkloadsToBePending(ctx, k8sClient, wl1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
 				})
 
-				ginkgo.By("Correct the label value on the node", func() {
+				ginkgo.By("Add the correct label to the node", func() {
 					nodeToUpdate := &corev1.Node{}
 					gomega.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: nodes[0].Name}, nodeToUpdate)).Should(gomega.Succeed())
-					gomega.Expect(nodeToUpdate.Labels).Should(gomega.HaveKeyWithValue(customLabelKey, wrongValue))
-					nodeToUpdate.Labels[customLabelKey] = correctValue
+					nodeToUpdate.Labels[customLabelKey] = customLabelCorrectValue
 					gomega.Expect(k8sClient.Update(ctx, nodeToUpdate)).Should(gomega.Succeed())
-					nodes[0] = *nodeToUpdate
 				})
 
-				ginkgo.By("verify the workload gets admitted after label is corrected", func() {
+				ginkgo.By("verify the workload gets admitted after label is added", func() {
 					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
 					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
 					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 0)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR adds support for node selectors in TAS. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4571 

#### Special notes for your reviewer:
The PR has the following changes:

1. Getting node selectors from nodes and using them to filter out non matching nodes.
2. 2 new integrations tests for cases when a node label is either added or updated.
3. Added additional check of `ExpectClusterQueuesToBeActive` for test suite `Node is mutated during test cases` which seemed to be missing compare to the other suites.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for Node Selectors in TAS Workloads.
```