### PR TITLE
Automated cherry pick of #4985: Fix HierarchicalCohorts feature gate

### DIFF
--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -24,6 +24,7 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/queue"
 )
 
@@ -52,9 +53,13 @@ func SetupControllers(mgr ctrl.Manager, qManager *queue.Manager, cc *cache.Cache
 		fairSharingEnabled = cfg.FairSharing.Enable
 	}
 
-	cohortRec := NewCohortReconciler(mgr.GetClient(), cc, qManager, CohortReconcilerWithFairSharing(fairSharingEnabled))
-	if err := cohortRec.SetupWithManager(mgr, cfg); err != nil {
-		return "Cohort", err
+	watchers := []ClusterQueueUpdateWatcher{rfRec, acRec}
+	if features.Enabled(features.HierarchicalCohorts) {
+		cohortRec := NewCohortReconciler(mgr.GetClient(), cc, qManager, CohortReconcilerWithFairSharing(fairSharingEnabled))
+		if err := cohortRec.SetupWithManager(mgr, cfg); err != nil {
+			return "Cohort", err
+		}
+		watchers = append(watchers, cohortRec)
 	}
 
 	cqRec := NewClusterQueueReconciler(
@@ -65,7 +70,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *queue.Manager, cc *cache.Cache
 		WithReportResourceMetrics(cfg.Metrics.EnableClusterQueueResources),
 		WithQueueVisibilityClusterQueuesMaxCount(queueVisibilityClusterQueuesMaxCount(cfg)),
 		WithFairSharing(fairSharingEnabled),
-		WithWatchers(rfRec, acRec, cohortRec),
+		WithWatchers(watchers...),
 	)
 	if err := mgr.Add(cqRec); err != nil {
 		return "Unable to add ClusterQueue to manager", err

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -163,6 +163,12 @@ const (
 	//
 	// Enable to set use LeastAlloactedFit algorithm for TAS
 	TASProfileMixed featuregate.Feature = "TASProfileMixed"
+
+	// owner: @mwielgus
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/79-hierarchical-cohorts
+	//
+	// Enable hierarchical cohorts
+	HierarchicalCohorts featuregate.Feature = "HierarchicalCohorts"
 )
 
 func init() {
@@ -251,6 +257,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	TASProfileMixed: {
 		{Version: version.MustParse("0.11"), Default: false, PreRelease: featuregate.Deprecated},
+	},
+	HierarchicalCohorts: {
+		{Version: version.MustParse("0.7"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.8"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 


### PR DESCRIPTION
Cherry pick of #4985 on release-0.11.

#4985: Fix HierarchicalCohorts feature gate

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```