### PR TITLE
Drop test-e2e-all Makefile target

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -127,11 +127,6 @@ test-e2e-customconfigs: kustomize ginkgo yq gomod-download dep-crds kueuectl gin
 .PHONY: test-e2e-certmanager
 test-e2e-certmanager: kustomize ginkgo yq gomod-download dep-crds kueuectl ginkgo-top run-test-e2e-certmanager-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
-E2E_TARGETS := $(addprefix run-test-e2e-,${E2E_K8S_VERSIONS})
-MULTIKUEUE-E2E_TARGETS := $(addprefix run-test-multikueue-e2e-,${E2E_K8S_VERSIONS})
-.PHONY: test-e2e-all
-test-e2e-all: ginkgo ginkgo-top $(E2E_TARGETS) $(MULTIKUEUE-E2E_TARGETS)
-
 FORCE:
 
 run-test-e2e-singlecluster-%: K8S_VERSION = $(@:run-test-e2e-singlecluster-%=%)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR removes the `test-e2e-all` Makefile target since is not used anymore. This is a follow-up from #4950 

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```