### PR TITLE
Automated cherry pick of #4985: Fix HierarchicalCohorts feature gate

### DIFF
--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -54,7 +54,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *queue.Manager, cc *cache.Cache
 	}
 
 	watchers := []ClusterQueueUpdateWatcher{rfRec, acRec}
-	if features.Enabled(features.HierarchialCohorts) {
+	if features.Enabled(features.HierarchicalCohorts) {
 		cohortRec := NewCohortReconciler(mgr.GetClient(), cc, qManager, CohortReconcilerWithFairSharing(fairSharingEnabled))
 		if err := cohortRec.SetupWithManager(mgr, cfg); err != nil {
 			return "Cohort", err

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -164,11 +164,11 @@ const (
 	// Enable to set use LeastAlloactedFit algorithm for TAS
 	TASProfileMixed featuregate.Feature = "TASProfileMixed"
 
-	// owner: @kannon92
+	// owner: @mwielgus
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/79-hierarchical-cohorts
 	//
-	// Enable hierarchical cohorts controller
-	HierarchialCohorts featuregate.Feature = "HierarchialCohorts"
+	// Enable hierarchical cohorts
+	HierarchicalCohorts featuregate.Feature = "HierarchicalCohorts"
 )
 
 func init() {
@@ -258,7 +258,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	TASProfileMixed: {
 		{Version: version.MustParse("0.11"), Default: false, PreRelease: featuregate.Deprecated},
 	},
-	HierarchialCohorts: {
+	HierarchicalCohorts: {
 		{Version: version.MustParse("0.11"), Default: true, PreRelease: featuregate.Beta},
 	},
 }


### PR DESCRIPTION
Cherry pick of #4985 on release-0.11.

#4985: Fix HierarchicalCohorts feature gate

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```