### PR TITLE
[chore][log] Remove `fmt.Sprintf` from `log.info`

### DIFF
--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -322,6 +322,6 @@ func CreateNamespaceFromPrefixWithLog(ctx context.Context, k8sClient client.Clie
 
 func CreateNamespaceFromObjectWithLog(ctx context.Context, k8sClient client.Client, ns *corev1.Namespace) *corev1.Namespace {
 	MustCreate(ctx, k8sClient, ns)
-	ginkgo.GinkgoLogr.Info(fmt.Sprintf("Created namespace: %s", ns.Name))
+	ginkgo.GinkgoLogr.Info("Created namespace", "namespace", ns.Name)
 	return ns
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

It's common practice to avoid using `fmt.Sprintf` in logs and instead use key-value pairs to make logs more structured. The only place where using `log.info(fmt.Sprintf(...))` is acceptable is in a test utility, and it's fine to use it there. I just opened this PR to follow common practice. This is purely a coding style issue, and I'm fine with closing this PR if the Kueue maintainers prefer the current approach.


Screenshot for running e2e tests with this PR:
<img width="902" alt="Screenshot 2025-04-17 at 12 36 39 AM" src="https://github.com/user-attachments/assets/db4190c6-ede5-4887-be96-16c3a5dee146" />


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```