### PR TITLE
Add git hub action to automatically bump hugo version on dependabot commit

### DIFF
--- a/.github/workflows/sync-dependabot.yaml
+++ b/.github/workflows/sync-dependabot.yaml
@@ -1,0 +1,35 @@
+# This workflow syncs dependency versions for Dependabot PRs
+name: Dependabot Version Sync
+
+on:
+  pull_request_target:
+    branches: [ main ]
+
+jobs:
+    run-sync-hugo-version:
+        if: ${{ github.actor == 'dependabot[bot]' }}
+        runs-on: ubuntu-latest
+
+        # Permission required to edit a PR
+        permissions:
+          contents: write
+
+        steps:
+            - uses: actions/checkout@v4
+              with: 
+                ref: ${{github.head_ref}}
+            - name: sync hugo version
+              if: ${{ contains(github.event.pull_request.title, 'hugo') }}
+              run: |
+                  make sync-hugo-version
+            - name: commit and push the changes
+              run: |
+                if ! git diff --exit-code; then
+                      git config user.name "$(git log -1 --pretty=%an)"
+                      git config user.email "$(git log -1 --pretty=%ae)"
+                      git add .
+                      git commit -m "Sync hugo version"
+                      git push
+                else
+                      echo "No changes to commit"
+                fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR will automate the hugo version bumping and it will alter dependabot's commits to bump the version where dependabot can't.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4811

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```