### PR TITLE
Remove unused FlavorIndependentAdmissionCheck constant.

### DIFF
--- a/apis/kueue/v1beta1/admissioncheck_types.go
+++ b/apis/kueue/v1beta1/admissioncheck_types.go
@@ -97,9 +97,6 @@ const (
 	// AdmissionCheckActive indicates that the controller of the admission check is
 	// ready to evaluate the checks states
 	AdmissionCheckActive string = "Active"
-
-	// FlavorIndependentAdmissionCheck indicates if the AdmissionCheck cannot be applied at ResourceFlavor level.
-	FlavorIndependentAdmissionCheck string = "FlavorIndependent"
 )
 
 // +genclient

--- a/pkg/cache/admissioncheck.go
+++ b/pkg/cache/admissioncheck.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cache
 
 type AdmissionCheck struct {
-	Active                       bool
-	Controller                   string
-	SingleInstanceInClusterQueue bool
-	FlavorIndependent            bool
+	Active     bool
+	Controller string
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -286,10 +286,6 @@ func (c *Cache) AddOrUpdateAdmissionCheck(ac *kueue.AdmissionCheck) sets.Set[kue
 		Active:     apimeta.IsStatusConditionTrue(ac.Status.Conditions, kueue.AdmissionCheckActive),
 		Controller: ac.Spec.ControllerName,
 	}
-	if ac.Spec.ControllerName == kueue.MultiKueueControllerName {
-		newAC.SingleInstanceInClusterQueue = true
-		newAC.FlavorIndependent = true
-	}
 	c.admissionChecks[ac.Name] = newAC
 
 	return c.updateClusterQueues()

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -333,7 +333,6 @@ func (c *clusterQueue) updateWithAdmissionChecks(checks map[string]AdmissionChec
 	provisioningAdmissionChecks := sets.New[string]()
 	var missing []string
 	var inactive []string
-	var flavorIndependentCheckOnFlavors []string
 	var perFlavorMultiKueueChecks []string
 	for acName, flavors := range c.AdmissionChecks {
 		if ac, found := checks[acName]; !found {
@@ -343,13 +342,6 @@ func (c *clusterQueue) updateWithAdmissionChecks(checks map[string]AdmissionChec
 				inactive = append(inactive, acName)
 			}
 			checksPerController[ac.Controller] = append(checksPerController[ac.Controller], acName)
-			if ac.SingleInstanceInClusterQueue {
-				singleInstanceControllers.Insert(ac.Controller)
-			}
-			if ac.FlavorIndependent && flavors.Len() != 0 {
-				flavorIndependentCheckOnFlavors = append(flavorIndependentCheckOnFlavors, acName)
-			}
-
 			if ac.Controller == kueue.ProvisioningRequestControllerName {
 				provisioningAdmissionChecks.Insert(acName)
 			}
@@ -368,7 +360,6 @@ func (c *clusterQueue) updateWithAdmissionChecks(checks map[string]AdmissionChec
 	// sort the lists since c.AdmissionChecks is a map
 	slices.Sort(missing)
 	slices.Sort(inactive)
-	slices.Sort(flavorIndependentCheckOnFlavors)
 	slices.Sort(perFlavorMultiKueueChecks)
 	multiKueueChecks := sets.List(multiKueueAdmissionChecks)
 	provisioningChecks := sets.List(provisioningAdmissionChecks)

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -188,12 +188,6 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			*utiltesting.MakeAdmissionCheckStrategyRule("check3").Obj()).
 		Obj()
 
-	cqWithACPerFlavor := utiltesting.MakeClusterQueue("cq3").
-		AdmissionCheckStrategy(
-			*utiltesting.MakeAdmissionCheckStrategyRule("check1", "flavor1", "flavor2", "flavor3").Obj(),
-		).
-		Obj()
-
 	testcases := []struct {
 		name            string
 		cq              *kueue.ClusterQueue
@@ -350,21 +344,6 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			wantMessage: `Can't admit new workloads: Cannot use multiple MultiKueue AdmissionChecks on the same ClusterQueue, found: check1,check3.`,
 		},
 		{
-			name:     "Pending clusterQueue with a FlavorIndependent AC applied per ResourceFlavor",
-			cq:       cqWithACPerFlavor,
-			cqStatus: pending,
-			admissionChecks: map[string]AdmissionCheck{
-				"check1": {
-					Active:            true,
-					Controller:        "controller1",
-					FlavorIndependent: true,
-				},
-			},
-			wantStatus:  active,
-			wantReason:  "Ready",
-			wantMessage: "Can admit new workloads",
-		},
-		{
 			name:     "Terminating clusterQueue updated with valid AC list",
 			cq:       cqWithAC,
 			cqStatus: terminating,
@@ -450,38 +429,21 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			cqStatus: active,
 			admissionChecks: map[string]AdmissionCheck{
 				"check1": {
-					Active:                       true,
-					Controller:                   "controller1",
-					SingleInstanceInClusterQueue: true,
+					Active:     true,
+					Controller: "controller1",
 				},
 				"check2": {
 					Active:     true,
 					Controller: "controller2",
 				},
 				"check3": {
-					Active:                       true,
-					Controller:                   "controller2",
-					SingleInstanceInClusterQueue: true,
+					Active:     true,
+					Controller: "controller2",
 				},
 			},
 			wantStatus:  active,
 			wantReason:  "Ready",
 			wantMessage: "Can admit new workloads",
-		},
-		{
-			name:     "Active clusterQueue with a FlavorIndependent MultiKueue AC applied per ResourceFlavor",
-			cq:       cqWithACPerFlavor,
-			cqStatus: pending,
-			admissionChecks: map[string]AdmissionCheck{
-				"check1": {
-					Active:            true,
-					Controller:        kueue.MultiKueueControllerName,
-					FlavorIndependent: true,
-				},
-			},
-			wantStatus:  pending,
-			wantReason:  "MultiKueueAdmissionCheckAppliedPerFlavor",
-			wantMessage: `Can't admit new workloads: Cannot specify MultiKueue AdmissionCheck per flavor, found: check1.`,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Remove unused FlavorIndependentAdmissionCheck.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
It was missed and not removed in https://github.com/kubernetes-sigs/kueue/pull/4995.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```