### PR TITLE
[doc] Update min K8s version to v1.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) and watch the Kueu
 
 ## Installation
 
-**Requires Kubernetes 1.25 or newer**.
+**Requires Kubernetes 1.29 or newer**.
 
 To install the latest release of Kueue in your cluster, run the following command:
 

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -28,7 +28,7 @@ description: >
 
 Make sure the following conditions are met:
 
-- A Kubernetes cluster with version 1.25 or newer is running. Learn how to [install the Kubernetes tools](https://kubernetes.io/docs/tasks/tools/).
+- A Kubernetes cluster with version 1.29 or newer is running. Learn how to [install the Kubernetes tools](https://kubernetes.io/docs/tasks/tools/).
 - The `SuspendJob` [feature gate][feature_gate] is enabled. In Kubernetes 1.22 or newer, the feature gate is enabled by default.
 - (Optional) The `JobMutableNodeSchedulingDirectives` [feature gate][feature_gate] (available in Kubernetes 1.22 or newer) is enabled.
   In Kubernetes 1.23 or newer, the feature gate is enabled by default.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

https://github.com/kubernetes-sigs/kueue/pull/3983 stops supporting `flowcontrol.apiserver.k8s.io/v1beta3`. K8s starts to support `flowcontrol.apiserver.k8s.io/v1` since v1.29.

* v1.28: `flowcontrol.apiserver.k8s.io/v1beta3`
  <img width="835" alt="Screenshot 2025-04-17 at 5 01 02 PM" src="https://github.com/user-attachments/assets/eeaf5a6b-378e-4af9-90e4-6b233cb5e333" />
* v1.29: `flowcontrol.apiserver.k8s.io/v1`
  <img width="788" alt="Screenshot 2025-04-17 at 5 00 53 PM" src="https://github.com/user-attachments/assets/f2f8c92c-f216-4256-8c95-af88c8f7e09d" />

* With version older than v1.29, the informer will print the following error messages.
   <img width="1727" alt="Screenshot 2025-04-17 at 5 05 04 PM" src="https://github.com/user-attachments/assets/88d8392a-fc89-47e3-8b3b-bd7aa1983969" />


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```