### PR TITLE
LocalQueueReference

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -37,6 +37,13 @@ const (
 	ClusterQueueActiveReasonReady                                    = "Ready"
 )
 
+// ClusterQueueReference is the name of the ClusterQueue.
+// It must be a DNS (RFC 1123) and has the maximum length of 253 characters.
+//
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+type ClusterQueueReference string
+
 // CohortReference is the name of the Cohort.
 //
 // Validation of a cohort name is equivalent to that of object names:

--- a/apis/kueue/v1beta1/localqueue_types.go
+++ b/apis/kueue/v1beta1/localqueue_types.go
@@ -17,9 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"fmt"
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,29 +28,6 @@ import (
 // +kubebuilder:validation:MaxLength=253
 // +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
 type LocalQueueName string
-
-// LocalQueueReference is the full reference to LocalQueue formed as <namespace>/< LocalQueueName >.
-type LocalQueueReference string
-
-func NewLocalQueueReference(namespace string, name LocalQueueName) LocalQueueReference {
-	return LocalQueueReference(namespace + "/" + string(name))
-}
-
-func ParseLocalQueueReference(ref LocalQueueReference) (string, LocalQueueName, error) {
-	parts := strings.Split(string(ref), "/")
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid LocalQueueReference %s", ref)
-	}
-	return parts[0], LocalQueueName(parts[1]), nil
-}
-
-func MustParseLocalQueueReference(ref LocalQueueReference) (string, LocalQueueName) {
-	namespace, name, err := ParseLocalQueueReference(ref)
-	if err != nil {
-		panic(err)
-	}
-	return namespace, name
-}
 
 // LocalQueueSpec defines the desired state of LocalQueue
 type LocalQueueSpec struct {

--- a/apis/kueue/v1beta1/localqueue_types.go
+++ b/apis/kueue/v1beta1/localqueue_types.go
@@ -17,10 +17,43 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// LocalQueueName is the name of the LocalQueue.
+// It must be a DNS (RFC 1123) and has the maximum length of 253 characters.
+//
+// +kubebuilder:validation:MaxLength=253
+// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+type LocalQueueName string
+
+// LocalQueueReference is the full reference to LocalQueue formed as <namespace>/< LocalQueueName >.
+type LocalQueueReference string
+
+func NewLocalQueueReference(namespace string, name LocalQueueName) LocalQueueReference {
+	return LocalQueueReference(namespace + "/" + string(name))
+}
+
+func ParseLocalQueueReference(ref LocalQueueReference) (string, LocalQueueName, error) {
+	parts := strings.Split(string(ref), "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid LocalQueueReference %s", ref)
+	}
+	return parts[0], LocalQueueName(parts[1]), nil
+}
+
+func MustParseLocalQueueReference(ref LocalQueueReference) (string, LocalQueueName) {
+	namespace, name, err := ParseLocalQueueReference(ref)
+	if err != nil {
+		panic(err)
+	}
+	return namespace, name
+}
 
 // LocalQueueSpec defines the desired state of LocalQueue
 type LocalQueueSpec struct {
@@ -42,11 +75,6 @@ type LocalQueueSpec struct {
 	// +kubebuilder:default="None"
 	StopPolicy *StopPolicy `json:"stopPolicy,omitempty"`
 }
-
-// ClusterQueueReference is the name of the ClusterQueue.
-// +kubebuilder:validation:MaxLength=253
-// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-type ClusterQueueReference string
 
 type LocalQueueFlavorStatus struct {
 	// name of the flavor.

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -39,9 +39,7 @@ type WorkloadSpec struct {
 
 	// queueName is the name of the LocalQueue the Workload is associated with.
 	// queueName cannot be changed while .status.admission is not null.
-	// +kubebuilder:validation:MaxLength=253
-	// +kubebuilder:validation:Pattern="^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
-	QueueName string `json:"queueName,omitempty"`
+	QueueName LocalQueueName `json:"queueName,omitempty"`
 
 	// If specified, indicates the workload's priority.
 	// "system-node-critical" and "system-cluster-critical" are two special

--- a/apis/visibility/v1beta1/types.go
+++ b/apis/visibility/v1beta1/types.go
@@ -18,6 +18,8 @@ package v1beta1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 // +genclient
@@ -68,7 +70,7 @@ type PendingWorkload struct {
 	Priority int32 `json:"priority"`
 
 	// LocalQueueName indicates the name of the LocalQueue the workload is submitted to
-	LocalQueueName string `json:"localQueueName"`
+	LocalQueueName v1beta1.LocalQueueName `json:"localQueueName"`
 
 	// PositionInClusterQueue indicates the workload's position in the ClusterQueue, starting from 0
 	PositionInClusterQueue int32 `json:"positionInClusterQueue"`

--- a/client-go/applyconfiguration/kueue/v1beta1/workloadspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/workloadspec.go
@@ -17,16 +17,20 @@ limitations under the License.
 
 package v1beta1
 
+import (
+	kueuev1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+)
+
 // WorkloadSpecApplyConfiguration represents a declarative configuration of the WorkloadSpec type for use
 // with apply.
 type WorkloadSpecApplyConfiguration struct {
-	PodSets                     []PodSetApplyConfiguration `json:"podSets,omitempty"`
-	QueueName                   *string                    `json:"queueName,omitempty"`
-	PriorityClassName           *string                    `json:"priorityClassName,omitempty"`
-	Priority                    *int32                     `json:"priority,omitempty"`
-	PriorityClassSource         *string                    `json:"priorityClassSource,omitempty"`
-	Active                      *bool                      `json:"active,omitempty"`
-	MaximumExecutionTimeSeconds *int32                     `json:"maximumExecutionTimeSeconds,omitempty"`
+	PodSets                     []PodSetApplyConfiguration   `json:"podSets,omitempty"`
+	QueueName                   *kueuev1beta1.LocalQueueName `json:"queueName,omitempty"`
+	PriorityClassName           *string                      `json:"priorityClassName,omitempty"`
+	Priority                    *int32                       `json:"priority,omitempty"`
+	PriorityClassSource         *string                      `json:"priorityClassSource,omitempty"`
+	Active                      *bool                        `json:"active,omitempty"`
+	MaximumExecutionTimeSeconds *int32                       `json:"maximumExecutionTimeSeconds,omitempty"`
 }
 
 // WorkloadSpecApplyConfiguration constructs a declarative configuration of the WorkloadSpec type for use with
@@ -51,7 +55,7 @@ func (b *WorkloadSpecApplyConfiguration) WithPodSets(values ...*PodSetApplyConfi
 // WithQueueName sets the QueueName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the QueueName field is set to the value of the last call.
-func (b *WorkloadSpecApplyConfiguration) WithQueueName(value string) *WorkloadSpecApplyConfiguration {
+func (b *WorkloadSpecApplyConfiguration) WithQueueName(value kueuev1beta1.LocalQueueName) *WorkloadSpecApplyConfiguration {
 	b.QueueName = &value
 	return b
 }

--- a/client-go/applyconfiguration/visibility/v1beta1/pendingworkload.go
+++ b/client-go/applyconfiguration/visibility/v1beta1/pendingworkload.go
@@ -21,16 +21,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	kueuev1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 // PendingWorkloadApplyConfiguration represents a declarative configuration of the PendingWorkload type for use
 // with apply.
 type PendingWorkloadApplyConfiguration struct {
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Priority                         *int32  `json:"priority,omitempty"`
-	LocalQueueName                   *string `json:"localQueueName,omitempty"`
-	PositionInClusterQueue           *int32  `json:"positionInClusterQueue,omitempty"`
-	PositionInLocalQueue             *int32  `json:"positionInLocalQueue,omitempty"`
+	Priority                         *int32                       `json:"priority,omitempty"`
+	LocalQueueName                   *kueuev1beta1.LocalQueueName `json:"localQueueName,omitempty"`
+	PositionInClusterQueue           *int32                       `json:"positionInClusterQueue,omitempty"`
+	PositionInLocalQueue             *int32                       `json:"positionInLocalQueue,omitempty"`
 }
 
 // PendingWorkloadApplyConfiguration constructs a declarative configuration of the PendingWorkload type for use with
@@ -192,7 +193,7 @@ func (b *PendingWorkloadApplyConfiguration) WithPriority(value int32) *PendingWo
 // WithLocalQueueName sets the LocalQueueName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the LocalQueueName field is set to the value of the last call.
-func (b *PendingWorkloadApplyConfiguration) WithLocalQueueName(value string) *PendingWorkloadApplyConfiguration {
+func (b *PendingWorkloadApplyConfiguration) WithLocalQueueName(value kueuev1beta1.LocalQueueName) *PendingWorkloadApplyConfiguration {
 	b.LocalQueueName = &value
 	return b
 }

--- a/cmd/kueuectl/app/list/list_workload.go
+++ b/cmd/kueuectl/app/list/list_workload.go
@@ -361,7 +361,7 @@ func (o *WorkloadOptions) filterList(list *v1beta1.WorkloadList, enableOwnerRefe
 }
 
 func (o *WorkloadOptions) filterByLocalQueue(wl *v1beta1.Workload) bool {
-	return len(o.LocalQueueFilter) == 0 || wl.Spec.QueueName == o.LocalQueueFilter
+	return len(o.LocalQueueFilter) == 0 || string(wl.Spec.QueueName) == o.LocalQueueFilter
 }
 
 func (o *WorkloadOptions) filterByClusterQueue(wl *v1beta1.Workload) bool {
@@ -417,7 +417,7 @@ func (o *WorkloadOptions) localQueues(ctx context.Context, list *v1beta1.Workloa
 			continue
 		}
 		if _, ok := localQueues[localQueueKeyForWorkload(&wl)]; !ok {
-			lq, err := o.ClientSet.KueueV1beta1().LocalQueues(wl.Namespace).Get(ctx, wl.Spec.QueueName, metav1.GetOptions{})
+			lq, err := o.ClientSet.KueueV1beta1().LocalQueues(wl.Namespace).Get(ctx, string(wl.Spec.QueueName), metav1.GetOptions{})
 			if client.IgnoreNotFound(err) != nil {
 				return nil, err
 			}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 	"sigs.k8s.io/kueue/pkg/metrics"
+	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/resources"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -141,7 +142,7 @@ func (c *Cache) newClusterQueue(cq *kueue.ClusterQueue) (*clusterQueue, error) {
 		Name:                kueue.ClusterQueueReference(cq.Name),
 		Workloads:           make(map[string]*workload.Info),
 		WorkloadsNotReady:   sets.New[string](),
-		localQueues:         make(map[kueue.LocalQueueReference]*LocalQueue),
+		localQueues:         make(map[queue.LocalQueueReference]*LocalQueue),
 		podsReadyTracking:   c.podsReadyTracking,
 		workloadInfoOptions: c.workloadInfoOptions,
 		AdmittedUsage:       make(resources.FlavorResourceQuantities),
@@ -445,7 +446,11 @@ func (c *Cache) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 	}
 	if features.Enabled(features.LocalQueueMetrics) {
 		for _, q := range c.hm.ClusterQueue(cqName).localQueues {
-			metrics.ClearLocalQueueCacheMetrics(metrics.LQRefFromLocalQueueKey(q.key))
+			namespace, lqName := queue.MustParseLocalQueueReference(q.key)
+			metrics.ClearLocalQueueCacheMetrics(metrics.LocalQueueReference{
+				Name:      lqName,
+				Namespace: namespace,
+			})
 		}
 	}
 	c.hm.DeleteClusterQueue(cqName)
@@ -942,6 +947,6 @@ func (c *Cache) MatchingClusterQueues(nsLabels map[string]string) sets.Set[kueue
 }
 
 // Key is the key used to index the queue.
-func queueKey(q *kueue.LocalQueue) kueue.LocalQueueReference {
-	return kueue.NewLocalQueueReference(q.Namespace, kueue.LocalQueueName(q.Name))
+func queueKey(q *kueue.LocalQueue) queue.LocalQueueReference {
+	return queue.NewLocalQueueReference(q.Namespace, kueue.LocalQueueName(q.Name))
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -141,7 +141,7 @@ func (c *Cache) newClusterQueue(cq *kueue.ClusterQueue) (*clusterQueue, error) {
 		Name:                kueue.ClusterQueueReference(cq.Name),
 		Workloads:           make(map[string]*workload.Info),
 		WorkloadsNotReady:   sets.New[string](),
-		localQueues:         make(map[string]*LocalQueue),
+		localQueues:         make(map[kueue.LocalQueueReference]*LocalQueue),
 		podsReadyTracking:   c.podsReadyTracking,
 		workloadInfoOptions: c.workloadInfoOptions,
 		AdmittedUsage:       make(resources.FlavorResourceQuantities),
@@ -942,6 +942,6 @@ func (c *Cache) MatchingClusterQueues(nsLabels map[string]string) sets.Set[kueue
 }
 
 // Key is the key used to index the queue.
-func queueKey(q *kueue.LocalQueue) string {
-	return fmt.Sprintf("%s/%s", q.Namespace, q.Name)
+func queueKey(q *kueue.LocalQueue) kueue.LocalQueueReference {
+	return kueue.NewLocalQueueReference(q.Namespace, kueue.LocalQueueName(q.Name))
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -2386,7 +2386,7 @@ func TestCacheQueueOperations(t *testing.T) {
 	}
 	cases := map[string]struct {
 		ops             []func(context.Context, client.Client, *Cache) error
-		wantLocalQueues map[string]*LocalQueue
+		wantLocalQueues map[kueue.LocalQueueReference]*LocalQueue
 	}{
 		"insert cqs, queues, workloads": {
 			ops: []func(ctx context.Context, cl client.Client, cache *Cache) error{
@@ -2394,7 +2394,7 @@ func TestCacheQueueOperations(t *testing.T) {
 				insertAllQueues,
 				insertAllWorkloads,
 			},
-			wantLocalQueues: map[string]*LocalQueue{
+			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
 				"ns1/alpha": {
 					key:                "ns1/alpha",
 					reservingWorkloads: 1,
@@ -2435,14 +2435,14 @@ func TestCacheQueueOperations(t *testing.T) {
 				insertAllClusterQueues,
 				insertAllWorkloads,
 			},
-			wantLocalQueues: map[string]*LocalQueue{},
+			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{},
 		},
 		"insert queues, workloads but no cqs": {
 			ops: []func(context.Context, client.Client, *Cache) error{
 				insertAllQueues,
 				insertAllWorkloads,
 			},
-			wantLocalQueues: map[string]*LocalQueue{},
+			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{},
 		},
 		"insert queues last": {
 			ops: []func(context.Context, client.Client, *Cache) error{
@@ -2450,7 +2450,7 @@ func TestCacheQueueOperations(t *testing.T) {
 				insertAllWorkloads,
 				insertAllQueues,
 			},
-			wantLocalQueues: map[string]*LocalQueue{
+			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
 				"ns1/alpha": {
 					key:                "ns1/alpha",
 					reservingWorkloads: 1,
@@ -2498,7 +2498,7 @@ func TestCacheQueueOperations(t *testing.T) {
 				insertAllWorkloads,
 				insertAllClusterQueues,
 			},
-			wantLocalQueues: map[string]*LocalQueue{
+			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
 				"ns1/alpha": {
 					key:                "ns1/alpha",
 					reservingWorkloads: 1,
@@ -2546,7 +2546,7 @@ func TestCacheQueueOperations(t *testing.T) {
 					return cache.AssumeWorkload(wl)
 				},
 			},
-			wantLocalQueues: map[string]*LocalQueue{
+			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
 				"ns1/alpha": {
 					key:                "ns1/alpha",
 					reservingWorkloads: 1,
@@ -2587,7 +2587,7 @@ func TestCacheQueueOperations(t *testing.T) {
 					return cache.ForgetWorkload(wl)
 				},
 			},
-			wantLocalQueues: map[string]*LocalQueue{
+			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
 				"ns1/alpha": {
 					key:                "ns1/alpha",
 					reservingWorkloads: 0,
@@ -2622,7 +2622,7 @@ func TestCacheQueueOperations(t *testing.T) {
 					return cache.DeleteWorkload(workloads[0])
 				},
 			},
-			wantLocalQueues: map[string]*LocalQueue{
+			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
 				"ns1/alpha": {
 					key:                "ns1/alpha",
 					reservingWorkloads: 0,
@@ -2668,7 +2668,7 @@ func TestCacheQueueOperations(t *testing.T) {
 					return nil
 				},
 			},
-			wantLocalQueues: map[string]*LocalQueue{
+			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
 				"ns1/gamma": {
 					key:                "ns1/gamma",
 					reservingWorkloads: 1,
@@ -2690,7 +2690,7 @@ func TestCacheQueueOperations(t *testing.T) {
 					return nil
 				},
 			},
-			wantLocalQueues: map[string]*LocalQueue{
+			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
 				"ns2/beta": {
 					key:                "ns2/beta",
 					reservingWorkloads: 2,
@@ -2726,7 +2726,7 @@ func TestCacheQueueOperations(t *testing.T) {
 					t.Fatalf("Running op %d: %v", i, err)
 				}
 			}
-			cacheQueues := make(map[string]*LocalQueue)
+			cacheQueues := make(map[kueue.LocalQueueReference]*LocalQueue)
 			for _, cacheCQ := range cache.hm.ClusterQueues() {
 				for qKey, cacheQ := range cacheCQ.localQueues {
 					if _, ok := cacheQueues[qKey]; ok {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -39,6 +39,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
+	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -2386,7 +2387,7 @@ func TestCacheQueueOperations(t *testing.T) {
 	}
 	cases := map[string]struct {
 		ops             []func(context.Context, client.Client, *Cache) error
-		wantLocalQueues map[kueue.LocalQueueReference]*LocalQueue
+		wantLocalQueues map[queue.LocalQueueReference]*LocalQueue
 	}{
 		"insert cqs, queues, workloads": {
 			ops: []func(ctx context.Context, cl client.Client, cache *Cache) error{
@@ -2394,7 +2395,7 @@ func TestCacheQueueOperations(t *testing.T) {
 				insertAllQueues,
 				insertAllWorkloads,
 			},
-			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
+			wantLocalQueues: map[queue.LocalQueueReference]*LocalQueue{
 				"ns1/alpha": {
 					key:                "ns1/alpha",
 					reservingWorkloads: 1,
@@ -2435,14 +2436,14 @@ func TestCacheQueueOperations(t *testing.T) {
 				insertAllClusterQueues,
 				insertAllWorkloads,
 			},
-			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{},
+			wantLocalQueues: map[queue.LocalQueueReference]*LocalQueue{},
 		},
 		"insert queues, workloads but no cqs": {
 			ops: []func(context.Context, client.Client, *Cache) error{
 				insertAllQueues,
 				insertAllWorkloads,
 			},
-			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{},
+			wantLocalQueues: map[queue.LocalQueueReference]*LocalQueue{},
 		},
 		"insert queues last": {
 			ops: []func(context.Context, client.Client, *Cache) error{
@@ -2450,7 +2451,7 @@ func TestCacheQueueOperations(t *testing.T) {
 				insertAllWorkloads,
 				insertAllQueues,
 			},
-			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
+			wantLocalQueues: map[queue.LocalQueueReference]*LocalQueue{
 				"ns1/alpha": {
 					key:                "ns1/alpha",
 					reservingWorkloads: 1,
@@ -2498,7 +2499,7 @@ func TestCacheQueueOperations(t *testing.T) {
 				insertAllWorkloads,
 				insertAllClusterQueues,
 			},
-			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
+			wantLocalQueues: map[queue.LocalQueueReference]*LocalQueue{
 				"ns1/alpha": {
 					key:                "ns1/alpha",
 					reservingWorkloads: 1,
@@ -2546,7 +2547,7 @@ func TestCacheQueueOperations(t *testing.T) {
 					return cache.AssumeWorkload(wl)
 				},
 			},
-			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
+			wantLocalQueues: map[queue.LocalQueueReference]*LocalQueue{
 				"ns1/alpha": {
 					key:                "ns1/alpha",
 					reservingWorkloads: 1,
@@ -2587,7 +2588,7 @@ func TestCacheQueueOperations(t *testing.T) {
 					return cache.ForgetWorkload(wl)
 				},
 			},
-			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
+			wantLocalQueues: map[queue.LocalQueueReference]*LocalQueue{
 				"ns1/alpha": {
 					key:                "ns1/alpha",
 					reservingWorkloads: 0,
@@ -2622,7 +2623,7 @@ func TestCacheQueueOperations(t *testing.T) {
 					return cache.DeleteWorkload(workloads[0])
 				},
 			},
-			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
+			wantLocalQueues: map[queue.LocalQueueReference]*LocalQueue{
 				"ns1/alpha": {
 					key:                "ns1/alpha",
 					reservingWorkloads: 0,
@@ -2668,7 +2669,7 @@ func TestCacheQueueOperations(t *testing.T) {
 					return nil
 				},
 			},
-			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
+			wantLocalQueues: map[queue.LocalQueueReference]*LocalQueue{
 				"ns1/gamma": {
 					key:                "ns1/gamma",
 					reservingWorkloads: 1,
@@ -2690,7 +2691,7 @@ func TestCacheQueueOperations(t *testing.T) {
 					return nil
 				},
 			},
-			wantLocalQueues: map[kueue.LocalQueueReference]*LocalQueue{
+			wantLocalQueues: map[queue.LocalQueueReference]*LocalQueue{
 				"ns2/beta": {
 					key:                "ns2/beta",
 					reservingWorkloads: 2,
@@ -2726,7 +2727,7 @@ func TestCacheQueueOperations(t *testing.T) {
 					t.Fatalf("Running op %d: %v", i, err)
 				}
 			}
-			cacheQueues := make(map[kueue.LocalQueueReference]*LocalQueue)
+			cacheQueues := make(map[queue.LocalQueueReference]*LocalQueue)
 			for _, cacheCQ := range cache.hm.ClusterQueues() {
 				for qKey, cacheQ := range cacheCQ.localQueues {
 					if _, ok := cacheQueues[qKey]; ok {

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 	"sigs.k8s.io/kueue/pkg/metrics"
+	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	"sigs.k8s.io/kueue/pkg/util/api"
@@ -68,7 +69,7 @@ type clusterQueue struct {
 
 	AdmittedUsage resources.FlavorResourceQuantities
 	// localQueues by (namespace/name).
-	localQueues                        map[kueue.LocalQueueReference]*LocalQueue
+	localQueues                        map[queue.LocalQueueReference]*LocalQueue
 	podsReadyTracking                  bool
 	missingFlavors                     []kueue.ResourceFlavorReference
 	missingAdmissionChecks             []kueue.AdmissionCheckReference
@@ -445,7 +446,7 @@ func (c *clusterQueue) reportActiveWorkloads() {
 }
 
 func (q *LocalQueue) reportActiveWorkloads() {
-	namespace, name := kueue.MustParseLocalQueueReference(q.key)
+	namespace, name := queue.MustParseLocalQueueReference(q.key)
 	metrics.LocalQueueAdmittedActiveWorkloads.WithLabelValues(string(name), namespace).Set(float64(q.admittedWorkloads))
 	metrics.LocalQueueReservingActiveWorkloads.WithLabelValues(string(name), namespace).Set(float64(q.reservingWorkloads))
 }
@@ -479,7 +480,7 @@ func (c *clusterQueue) updateWorkloadUsage(wi *workload.Info, m int64) {
 		updateFlavorUsage(frUsage, c.AdmittedUsage, m)
 		c.admittedWorkloadsCount += int(m)
 	}
-	qKey := workload.QueueKey(wi.Obj)
+	qKey := queue.KeyFromWorkload(wi.Obj)
 	if lq, ok := c.localQueues[qKey]; ok {
 		updateFlavorUsage(frUsage, lq.totalReserved, m)
 		lq.reservingWorkloads += int(m)
@@ -543,7 +544,11 @@ func (c *clusterQueue) addLocalQueue(q *kueue.LocalQueue) error {
 func (c *clusterQueue) deleteLocalQueue(q *kueue.LocalQueue) {
 	qKey := queueKey(q)
 	if features.Enabled(features.LocalQueueMetrics) {
-		metrics.ClearLocalQueueCacheMetrics(metrics.LQRefFromLocalQueueKey(qKey))
+		namespace, lqName := queue.MustParseLocalQueueReference(qKey)
+		metrics.ClearLocalQueueCacheMetrics(metrics.LocalQueueReference{
+			Name:      lqName,
+			Namespace: namespace,
+		})
 	}
 	delete(c.localQueues, qKey)
 }

--- a/pkg/cache/localqueue.go
+++ b/pkg/cache/localqueue.go
@@ -17,11 +17,12 @@ limitations under the License.
 package cache
 
 import (
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/resources"
 )
 
 type LocalQueue struct {
-	key                string
+	key                kueue.LocalQueueReference
 	reservingWorkloads int
 	admittedWorkloads  int
 	totalReserved      resources.FlavorResourceQuantities

--- a/pkg/cache/localqueue.go
+++ b/pkg/cache/localqueue.go
@@ -17,12 +17,12 @@ limitations under the License.
 package cache
 
 import (
-	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/resources"
 )
 
 type LocalQueue struct {
-	key                kueue.LocalQueueReference
+	key                queue.LocalQueueReference
 	reservingWorkloads int
 	admittedWorkloads  int
 	totalReserved      resources.FlavorResourceQuantities

--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -16,13 +16,15 @@ limitations under the License.
 
 package constants
 
+import kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+
 const (
 	// QueueLabel is the label key in the workload that holds the queue name.
 	QueueLabel = "kueue.x-k8s.io/queue-name"
 
 	// DefaultLocalQueueName is the name for default LocalQueue that is applied
 	// if the feature LocalQueueDefaulting is enabled and QueueLabel is not specified.
-	DefaultLocalQueueName = "default"
+	DefaultLocalQueueName kueue.LocalQueueName = "default"
 
 	// QueueAnnotation is the annotation key in the workload that holds the queue name.
 	//

--- a/pkg/controller/core/clusterqueue_controller_test.go
+++ b/pkg/controller/core/clusterqueue_controller_test.go
@@ -43,8 +43,8 @@ func TestUpdateCqStatusIfChanged(t *testing.T) {
 	lqName := "test-lq"
 	defaultWls := &kueue.WorkloadList{
 		Items: []kueue.Workload{
-			*utiltesting.MakeWorkload("alpha", "").Queue(lqName).Obj(),
-			*utiltesting.MakeWorkload("beta", "").Queue(lqName).Obj(),
+			*utiltesting.MakeWorkload("alpha", "").Queue(kueue.LocalQueueName(lqName)).Obj(),
+			*utiltesting.MakeWorkload("beta", "").Queue(kueue.LocalQueueName(lqName)).Obj(),
 		},
 	}
 
@@ -167,7 +167,7 @@ func TestUpdateCqStatusIfChanged(t *testing.T) {
 					Message: "Can admit new workloads",
 				}},
 			},
-			newWl:              utiltesting.MakeWorkload("gamma", "").Queue(lqName).Obj(),
+			newWl:              utiltesting.MakeWorkload("gamma", "").Queue(kueue.LocalQueueName(lqName)).Obj(),
 			newConditionStatus: metav1.ConditionTrue,
 			newReason:          "Ready",
 			newMessage:         "Can admit new workloads",
@@ -525,8 +525,8 @@ func TestClusterQueuePendingWorkloadsStatus(t *testing.T) {
 	const lowPrio, highPrio = 0, 100
 	defaultWls := &kueue.WorkloadList{
 		Items: []kueue.Workload{
-			*utiltesting.MakeWorkload("one", "").Queue(lqName).Priority(highPrio).Obj(),
-			*utiltesting.MakeWorkload("two", "").Queue(lqName).Priority(lowPrio).Obj(),
+			*utiltesting.MakeWorkload("one", "").Queue(kueue.LocalQueueName(lqName)).Priority(highPrio).Obj(),
+			*utiltesting.MakeWorkload("two", "").Queue(kueue.LocalQueueName(lqName)).Priority(lowPrio).Obj(),
 		},
 	}
 	testCases := map[string]struct {

--- a/pkg/controller/core/indexer/indexer.go
+++ b/pkg/controller/core/indexer/indexer.go
@@ -53,7 +53,7 @@ func IndexWorkloadQueue(obj client.Object) []string {
 	if !ok {
 		return nil
 	}
-	return []string{wl.Spec.QueueName}
+	return []string{string(wl.Spec.QueueName)}
 }
 
 func IndexWorkloadClusterQueue(obj client.Object) []string {

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -206,7 +206,7 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 
 func localQueueReferenceFromLocalQueue(lq *kueue.LocalQueue) metrics.LocalQueueReference {
 	return metrics.LocalQueueReference{
-		Name:      lq.Name,
+		Name:      kueue.LocalQueueName(lq.Name),
 		Namespace: lq.Namespace,
 	}
 }
@@ -256,7 +256,7 @@ func (h *qWorkloadHandler) Generic(_ context.Context, e event.GenericEvent, q wo
 	}
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
-			Name:      w.Spec.QueueName,
+			Name:      string(w.Spec.QueueName),
 			Namespace: w.Namespace,
 		},
 	}
@@ -378,7 +378,7 @@ func (r *LocalQueueReconciler) UpdateStatusIfChanged(
 		})
 		if features.Enabled(features.LocalQueueMetrics) {
 			metrics.ReportLocalQueueStatus(metrics.LocalQueueReference{
-				Name:      queue.Name,
+				Name:      kueue.LocalQueueName(queue.Name),
 				Namespace: queue.Namespace,
 			}, conditionStatus)
 		}

--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -90,7 +90,7 @@ func ApplyDefaultLocalQueue(jobObj client.Object, defaultQueueExist func(string)
 		if labels == nil {
 			labels = make(map[string]string, 1)
 		}
-		labels[constants.QueueLabel] = constants.DefaultLocalQueueName
+		labels[constants.QueueLabel] = string(constants.DefaultLocalQueueName)
 		jobObj.SetLabels(labels)
 	}
 }
@@ -102,7 +102,7 @@ func ApplyDefaultForManagedBy(job GenericJob, queues *queue.Manager, cache *cach
 			if !found {
 				return
 			}
-			clusterQueueName, ok := queues.ClusterQueueFromLocalQueue(queue.QueueKey(job.Object().GetNamespace(), localQueueName))
+			clusterQueueName, ok := queues.ClusterQueueFromLocalQueue(kueue.NewLocalQueueReference(job.Object().GetNamespace(), kueue.LocalQueueName(localQueueName)))
 			if !ok {
 				log.V(5).Info("Cluster queue for local queue not found", "localQueueName", localQueueName)
 				return

--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -102,7 +102,7 @@ func ApplyDefaultForManagedBy(job GenericJob, queues *queue.Manager, cache *cach
 			if !found {
 				return
 			}
-			clusterQueueName, ok := queues.ClusterQueueFromLocalQueue(kueue.NewLocalQueueReference(job.Object().GetNamespace(), kueue.LocalQueueName(localQueueName)))
+			clusterQueueName, ok := queues.ClusterQueueFromLocalQueue(queue.NewLocalQueueReference(job.Object().GetNamespace(), kueue.LocalQueueName(localQueueName)))
 			if !ok {
 				log.V(5).Info("Cluster queue for local queue not found", "localQueueName", localQueueName)
 				return

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -172,16 +172,16 @@ type TopLevelJob interface {
 	IsTopLevel() bool
 }
 
-func QueueName(job GenericJob) string {
+func QueueName(job GenericJob) kueue.LocalQueueName {
 	return QueueNameForObject(job.Object())
 }
 
-func QueueNameForObject(object client.Object) string {
+func QueueNameForObject(object client.Object) kueue.LocalQueueName {
 	if queueLabel := object.GetLabels()[constants.QueueLabel]; queueLabel != "" {
-		return queueLabel
+		return kueue.LocalQueueName(queueLabel)
 	}
 	// fallback to the annotation (deprecated)
-	return object.GetAnnotations()[constants.QueueAnnotation]
+	return kueue.LocalQueueName(object.GetAnnotations()[constants.QueueAnnotation])
 }
 
 func MaximumExecutionTimeSeconds(job GenericJob) *int32 {

--- a/pkg/controller/jobs/deployment/deployment_webhook.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook.go
@@ -85,7 +85,7 @@ func (wh *Webhook) Default(ctx context.Context, obj runtime.Object) error {
 		deployment.Spec.Template.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
 		queueName := jobframework.QueueNameForObject(deployment.Object())
 		if queueName != "" {
-			deployment.Spec.Template.Labels[controllerconstants.QueueLabel] = queueName
+			deployment.Spec.Template.Labels[controllerconstants.QueueLabel] = string(queueName)
 		}
 		if priorityClass := jobframework.WorkloadPriorityClassName(deployment.Object()); priorityClass != "" {
 			deployment.Spec.Template.Labels[controllerconstants.WorkloadPriorityClassLabel] = priorityClass

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -310,7 +310,7 @@ func TestValidateUpdate(t *testing.T) {
 			oldJob: testingutil.MakeJob("job", "default").Obj(),
 			newJob: testingutil.MakeJob("job", "default").Queue("queue").Suspend(false).Obj(),
 			wantErr: field.ErrorList{
-				field.Invalid(queueNameLabelPath, "queue", apivalidation.FieldImmutableErrorMsg),
+				field.Invalid(queueNameLabelPath, kueue.LocalQueueName("queue"), apivalidation.FieldImmutableErrorMsg),
 			},
 		},
 		{
@@ -324,7 +324,7 @@ func TestValidateUpdate(t *testing.T) {
 			oldJob: testingutil.MakeJob("job", "default").Queue("queue").Obj(),
 			newJob: testingutil.MakeJob("job", "default").Queue("queue2").Suspend(false).Obj(),
 			wantErr: field.ErrorList{
-				field.Invalid(queueNameLabelPath, "queue2", apivalidation.FieldImmutableErrorMsg),
+				field.Invalid(queueNameLabelPath, kueue.LocalQueueName("queue2"), apivalidation.FieldImmutableErrorMsg),
 			},
 		},
 		{
@@ -436,7 +436,7 @@ func TestValidateUpdate(t *testing.T) {
 				Suspend(false).
 				Label(constants.QueueLabel, "new-queue").
 				Obj(),
-			wantErr: apivalidation.ValidateImmutableField("new-queue", "old-queue", queueNameLabelPath),
+			wantErr: apivalidation.ValidateImmutableField(kueue.LocalQueueName("new-queue"), "old-queue", queueNameLabelPath),
 		},
 		{
 			name: "queue name can changes when it is  suspend",

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_pod_reconciler.go
@@ -126,7 +126,7 @@ func (r *PodReconciler) setDefault(ctx context.Context, pod *corev1.Pod) (bool, 
 	wlName := GetWorkloadName(lws.UID, lws.Name, pod.Labels[leaderworkersetv1.GroupIndexLabelKey])
 
 	pod.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
-	pod.Labels[controllerconstants.QueueLabel] = queueName
+	pod.Labels[controllerconstants.QueueLabel] = string(queueName)
 	pod.Labels[podconstants.GroupNameLabel] = wlName
 	pod.Labels[controllerconstants.PrebuiltWorkloadLabel] = wlName
 	pod.Annotations[podconstants.GroupTotalCountAnnotation] = fmt.Sprint(ptr.Deref(lws.Spec.LeaderWorkerTemplate.Size, 1))

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -175,7 +175,7 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 			if pod.pod.Labels == nil {
 				pod.pod.Labels = make(map[string]string)
 			}
-			pod.pod.Labels[ctrlconstants.QueueLabel] = ctrlconstants.DefaultLocalQueueName
+			pod.pod.Labels[ctrlconstants.QueueLabel] = string(ctrlconstants.DefaultLocalQueueName)
 		}
 
 		suspend = jobframework.QueueNameForObject(pod.Object()) != "" || w.manageJobsWithoutQueueName

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -288,7 +289,7 @@ func TestValidateUpdate(t *testing.T) {
 				Suspend(false).
 				Obj(),
 			wantErr: field.ErrorList{
-				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), "queue2", apivalidation.FieldImmutableErrorMsg),
+				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), kueue.LocalQueueName("queue2"), apivalidation.FieldImmutableErrorMsg),
 			}.ToAggregate(),
 		},
 		"managed - queue name can change while suspended": {

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -344,7 +345,7 @@ func TestValidateUpdate(t *testing.T) {
 				ShutdownAfterJobFinishes(true).
 				Obj(),
 			wantErr: field.ErrorList{
-				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), "queue2", apivalidation.FieldImmutableErrorMsg),
+				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), kueue.LocalQueueName("queue2"), apivalidation.FieldImmutableErrorMsg),
 			}.ToAggregate(),
 		},
 		"managed - queue name can change while suspended": {

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -86,7 +86,7 @@ func (wh *Webhook) Default(ctx context.Context, obj runtime.Object) error {
 		ss.Spec.Template.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
 		queueName := jobframework.QueueNameForObject(ss.Object())
 		if queueName != "" {
-			ss.Spec.Template.Labels[controllerconstants.QueueLabel] = queueName
+			ss.Spec.Template.Labels[controllerconstants.QueueLabel] = string(queueName)
 			ss.Spec.Template.Labels[podconstants.GroupNameLabel] = GetWorkloadName(ss.Name)
 			ss.Spec.Template.Annotations[podconstants.GroupTotalCountAnnotation] = fmt.Sprint(ptr.Deref(ss.Spec.Replicas, 1))
 			ss.Spec.Template.Annotations[podconstants.GroupFastAdmissionAnnotationKey] = podconstants.GroupFastAdmissionAnnotationValue

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -17,7 +17,6 @@ limitations under the License.
 package metrics
 
 import (
-	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -33,7 +32,7 @@ type AdmissionResult string
 type ClusterQueueStatus string
 
 type LocalQueueReference struct {
-	Name      string
+	Name      kueue.LocalQueueName
 	Namespace string
 }
 
@@ -399,8 +398,8 @@ func QuotaReservedWorkload(cqName kueue.ClusterQueueReference, waitTime time.Dur
 }
 
 func LocalQueueQuotaReservedWorkload(lq LocalQueueReference, waitTime time.Duration) {
-	LocalQueueQuotaReservedWorkloadsTotal.WithLabelValues(lq.Name, lq.Namespace).Inc()
-	localQueueQuotaReservedWaitTime.WithLabelValues(lq.Name, lq.Namespace).Observe(waitTime.Seconds())
+	LocalQueueQuotaReservedWorkloadsTotal.WithLabelValues(string(lq.Name), lq.Namespace).Inc()
+	localQueueQuotaReservedWaitTime.WithLabelValues(string(lq.Name), lq.Namespace).Observe(waitTime.Seconds())
 }
 
 func AdmittedWorkload(cqName kueue.ClusterQueueReference, waitTime time.Duration) {
@@ -409,8 +408,8 @@ func AdmittedWorkload(cqName kueue.ClusterQueueReference, waitTime time.Duration
 }
 
 func LocalQueueAdmittedWorkload(lq LocalQueueReference, waitTime time.Duration) {
-	LocalQueueAdmittedWorkloadsTotal.WithLabelValues(lq.Name, lq.Namespace).Inc()
-	localQueueAdmissionWaitTime.WithLabelValues(lq.Name, lq.Namespace).Observe(waitTime.Seconds())
+	LocalQueueAdmittedWorkloadsTotal.WithLabelValues(string(lq.Name), lq.Namespace).Inc()
+	localQueueAdmissionWaitTime.WithLabelValues(string(lq.Name), lq.Namespace).Observe(waitTime.Seconds())
 }
 
 func AdmissionChecksWaitTime(cqName kueue.ClusterQueueReference, waitTime time.Duration) {
@@ -418,7 +417,7 @@ func AdmissionChecksWaitTime(cqName kueue.ClusterQueueReference, waitTime time.D
 }
 
 func LocalQueueAdmissionChecksWaitTime(lq LocalQueueReference, waitTime time.Duration) {
-	localQueueAdmissionChecksWaitTime.WithLabelValues(lq.Name, lq.Namespace).Observe(waitTime.Seconds())
+	localQueueAdmissionChecksWaitTime.WithLabelValues(string(lq.Name), lq.Namespace).Observe(waitTime.Seconds())
 }
 
 func ReportPendingWorkloads(cqName kueue.ClusterQueueReference, active, inadmissible int) {
@@ -427,8 +426,8 @@ func ReportPendingWorkloads(cqName kueue.ClusterQueueReference, active, inadmiss
 }
 
 func ReportLocalQueuePendingWorkloads(lq LocalQueueReference, active, inadmissible int) {
-	LocalQueuePendingWorkloads.WithLabelValues(lq.Name, lq.Namespace, PendingStatusActive).Set(float64(active))
-	LocalQueuePendingWorkloads.WithLabelValues(lq.Name, lq.Namespace, PendingStatusInadmissible).Set(float64(inadmissible))
+	LocalQueuePendingWorkloads.WithLabelValues(string(lq.Name), lq.Namespace, PendingStatusActive).Set(float64(active))
+	LocalQueuePendingWorkloads.WithLabelValues(string(lq.Name), lq.Namespace, PendingStatusInadmissible).Set(float64(inadmissible))
 }
 
 func ReportEvictedWorkloads(cqName kueue.ClusterQueueReference, reason string) {
@@ -436,7 +435,7 @@ func ReportEvictedWorkloads(cqName kueue.ClusterQueueReference, reason string) {
 }
 
 func ReportLocalQueueEvictedWorkloads(lq LocalQueueReference, reason string) {
-	LocalQueueEvictedWorkloadsTotal.WithLabelValues(lq.Name, lq.Namespace, reason).Inc()
+	LocalQueueEvictedWorkloadsTotal.WithLabelValues(string(lq.Name), lq.Namespace, reason).Inc()
 }
 
 func ReportPreemption(preemptingCqName kueue.ClusterQueueReference, preemptingReason string, targetCqName kueue.ClusterQueueReference) {
@@ -451,11 +450,11 @@ func LQRefFromWorkload(wl *kueue.Workload) LocalQueueReference {
 	}
 }
 
-func LQRefFromLocalQueueKey(lqKey string) LocalQueueReference {
-	split := strings.Split(lqKey, "/")
+func LQRefFromLocalQueueKey(ref kueue.LocalQueueReference) LocalQueueReference {
+	namespace, lqName := kueue.MustParseLocalQueueReference(ref)
 	return LocalQueueReference{
-		Name:      split[1],
-		Namespace: split[0],
+		Name:      lqName,
+		Namespace: namespace,
 	}
 }
 
@@ -473,14 +472,14 @@ func ClearClusterQueueMetrics(cqName string) {
 }
 
 func ClearLocalQueueMetrics(lq LocalQueueReference) {
-	LocalQueuePendingWorkloads.DeleteLabelValues(lq.Name, lq.Namespace, PendingStatusActive)
-	LocalQueuePendingWorkloads.DeleteLabelValues(lq.Name, lq.Namespace, PendingStatusInadmissible)
-	LocalQueueQuotaReservedWorkloadsTotal.DeleteLabelValues(lq.Name, lq.Namespace)
-	localQueueQuotaReservedWaitTime.DeleteLabelValues(lq.Name, lq.Namespace)
-	LocalQueueAdmittedWorkloadsTotal.DeleteLabelValues(lq.Name, lq.Namespace)
-	localQueueAdmissionWaitTime.DeleteLabelValues(lq.Name, lq.Namespace)
-	localQueueAdmissionChecksWaitTime.DeleteLabelValues(lq.Name, lq.Namespace)
-	LocalQueueEvictedWorkloadsTotal.DeletePartialMatch(prometheus.Labels{"name": lq.Name, "namespace": lq.Namespace})
+	LocalQueuePendingWorkloads.DeleteLabelValues(string(lq.Name), lq.Namespace, PendingStatusActive)
+	LocalQueuePendingWorkloads.DeleteLabelValues(string(lq.Name), lq.Namespace, PendingStatusInadmissible)
+	LocalQueueQuotaReservedWorkloadsTotal.DeleteLabelValues(string(lq.Name), lq.Namespace)
+	localQueueQuotaReservedWaitTime.DeleteLabelValues(string(lq.Name), lq.Namespace)
+	LocalQueueAdmittedWorkloadsTotal.DeleteLabelValues(string(lq.Name), lq.Namespace)
+	localQueueAdmissionWaitTime.DeleteLabelValues(string(lq.Name), lq.Namespace)
+	localQueueAdmissionChecksWaitTime.DeleteLabelValues(string(lq.Name), lq.Namespace)
+	LocalQueueEvictedWorkloadsTotal.DeletePartialMatch(prometheus.Labels{"name": string(lq.Name), "namespace": lq.Namespace})
 }
 
 func ReportClusterQueueStatus(cqName kueue.ClusterQueueReference, cqStatus ClusterQueueStatus) {
@@ -503,7 +502,7 @@ func ReportLocalQueueStatus(lq LocalQueueReference, conditionStatus metav1.Condi
 		if status == conditionStatus {
 			v = 1
 		}
-		LocalQueueByStatus.WithLabelValues(lq.Name, lq.Namespace, string(status)).Set(v)
+		LocalQueueByStatus.WithLabelValues(string(lq.Name), lq.Namespace, string(status)).Set(v)
 	}
 }
 
@@ -516,10 +515,10 @@ func ClearCacheMetrics(cqName string) {
 }
 
 func ClearLocalQueueCacheMetrics(lq LocalQueueReference) {
-	LocalQueueReservingActiveWorkloads.DeleteLabelValues(lq.Name, lq.Namespace)
-	LocalQueueAdmittedActiveWorkloads.DeleteLabelValues(lq.Name, lq.Namespace)
+	LocalQueueReservingActiveWorkloads.DeleteLabelValues(string(lq.Name), lq.Namespace)
+	LocalQueueAdmittedActiveWorkloads.DeleteLabelValues(string(lq.Name), lq.Namespace)
 	for _, status := range ConditionStatusValues {
-		LocalQueueByStatus.DeleteLabelValues(lq.Name, lq.Namespace, string(status))
+		LocalQueueByStatus.DeleteLabelValues(string(lq.Name), lq.Namespace, string(status))
 	}
 }
 
@@ -536,7 +535,7 @@ func ReportClusterQueueResourceReservations(cohort kueue.CohortReference, queue,
 }
 
 func ReportLocalQueueResourceReservations(lq LocalQueueReference, flavor, resource string, usage float64) {
-	LocalQueueResourceReservations.WithLabelValues(lq.Name, lq.Namespace, flavor, resource).Set(usage)
+	LocalQueueResourceReservations.WithLabelValues(string(lq.Name), lq.Namespace, flavor, resource).Set(usage)
 }
 
 func ReportClusterQueueResourceUsage(cohort kueue.CohortReference, queue, flavor, resource string, usage float64) {
@@ -544,7 +543,7 @@ func ReportClusterQueueResourceUsage(cohort kueue.CohortReference, queue, flavor
 }
 
 func ReportLocalQueueResourceUsage(lq LocalQueueReference, flavor, resource string, usage float64) {
-	LocalQueueResourceUsage.WithLabelValues(lq.Name, lq.Namespace, flavor, resource).Set(usage)
+	LocalQueueResourceUsage.WithLabelValues(string(lq.Name), lq.Namespace, flavor, resource).Set(usage)
 }
 
 func ReportClusterQueueWeightedShare(cq string, weightedShare int64) {
@@ -570,7 +569,7 @@ func ClearClusterQueueResourceMetrics(cqName string) {
 
 func ClearLocalQueueResourceMetrics(lq LocalQueueReference) {
 	lbls := prometheus.Labels{
-		"name":      lq.Name,
+		"name":      string(lq.Name),
 		"namespace": lq.Namespace,
 	}
 	LocalQueueResourceReservations.DeletePartialMatch(lbls)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -450,14 +450,6 @@ func LQRefFromWorkload(wl *kueue.Workload) LocalQueueReference {
 	}
 }
 
-func LQRefFromLocalQueueKey(ref kueue.LocalQueueReference) LocalQueueReference {
-	namespace, lqName := kueue.MustParseLocalQueueReference(ref)
-	return LocalQueueReference{
-		Name:      lqName,
-		Namespace: namespace,
-	}
-}
-
 func ClearClusterQueueMetrics(cqName string) {
 	AdmissionCyclePreemptionSkips.DeleteLabelValues(cqName)
 	PendingWorkloads.DeleteLabelValues(cqName, PendingStatusActive)

--- a/pkg/queue/cluster_queue_test.go
+++ b/pkg/queue/cluster_queue_test.go
@@ -254,10 +254,10 @@ func Test_DeleteFromLocalQueue(t *testing.T) {
 	cq := newClusterQueueImpl(defaultOrdering, testingclock.NewFakeClock(time.Now()))
 	q := utiltesting.MakeLocalQueue("foo", "").ClusterQueue("cq").Obj()
 	qImpl := newLocalQueue(q)
-	wl1 := utiltesting.MakeWorkload("wl1", "").Queue(q.Name).Obj()
-	wl2 := utiltesting.MakeWorkload("wl2", "").Queue(q.Name).Obj()
-	wl3 := utiltesting.MakeWorkload("wl3", "").Queue(q.Name).Obj()
-	wl4 := utiltesting.MakeWorkload("wl4", "").Queue(q.Name).Obj()
+	wl1 := utiltesting.MakeWorkload("wl1", "").Queue(kueue.LocalQueueName(q.Name)).Obj()
+	wl2 := utiltesting.MakeWorkload("wl2", "").Queue(kueue.LocalQueueName(q.Name)).Obj()
+	wl3 := utiltesting.MakeWorkload("wl3", "").Queue(kueue.LocalQueueName(q.Name)).Obj()
+	wl4 := utiltesting.MakeWorkload("wl4", "").Queue(kueue.LocalQueueName(q.Name)).Obj()
 	admissibleworkloads := []*kueue.Workload{wl1, wl2}
 	inadmissibleWorkloads := []*kueue.Workload{wl3, wl4}
 

--- a/pkg/queue/local_queue.go
+++ b/pkg/queue/local_queue.go
@@ -17,25 +17,23 @@ limitations under the License.
 package queue
 
 import (
-	"fmt"
-
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 // Key is the key used to index the queue.
-func Key(q *kueue.LocalQueue) string {
-	return fmt.Sprintf("%s/%s", q.Namespace, q.Name)
+func Key(q *kueue.LocalQueue) kueue.LocalQueueReference {
+	return kueue.NewLocalQueueReference(q.Namespace, kueue.LocalQueueName(q.Name))
 }
 
-func DefaultQueueKey(namespace string) string {
-	return fmt.Sprintf("%s/%s", namespace, constants.DefaultLocalQueueName)
+func DefaultQueueKey(namespace string) kueue.LocalQueueReference {
+	return kueue.NewLocalQueueReference(namespace, constants.DefaultLocalQueueName)
 }
 
 // LocalQueue is the internal implementation of kueue.LocalQueue.
 type LocalQueue struct {
-	Key          string
+	Key          kueue.LocalQueueReference
 	ClusterQueue kueue.ClusterQueueReference
 
 	items map[string]*workload.Info
@@ -71,7 +69,7 @@ func (m *Manager) PendingActiveInLocalQueue(lq *LocalQueue) int {
 			result++
 		}
 	}
-	if c.inflight != nil && workloadKey(c.inflight) == lq.Key {
+	if c.inflight != nil && workloadKey(c.inflight) == string(lq.Key) {
 		result++
 	}
 	return result

--- a/pkg/queue/local_queue.go
+++ b/pkg/queue/local_queue.go
@@ -17,23 +17,53 @@ limitations under the License.
 package queue
 
 import (
+	"fmt"
+	"strings"
+
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
-// Key is the key used to index the queue.
-func Key(q *kueue.LocalQueue) kueue.LocalQueueReference {
-	return kueue.NewLocalQueueReference(q.Namespace, kueue.LocalQueueName(q.Name))
+// LocalQueueReference is the full reference to LocalQueue formed as <namespace>/< kueue.LocalQueueName >.
+type LocalQueueReference string
+
+func NewLocalQueueReference(namespace string, name kueue.LocalQueueName) LocalQueueReference {
+	return LocalQueueReference(namespace + "/" + string(name))
 }
 
-func DefaultQueueKey(namespace string) kueue.LocalQueueReference {
-	return kueue.NewLocalQueueReference(namespace, constants.DefaultLocalQueueName)
+func ParseLocalQueueReference(ref LocalQueueReference) (string, kueue.LocalQueueName, error) {
+	parts := strings.Split(string(ref), "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid LocalQueueReference %s", ref)
+	}
+	return parts[0], kueue.LocalQueueName(parts[1]), nil
+}
+
+func MustParseLocalQueueReference(ref LocalQueueReference) (string, kueue.LocalQueueName) {
+	namespace, name, err := ParseLocalQueueReference(ref)
+	if err != nil {
+		panic(err)
+	}
+	return namespace, name
+}
+
+// Key is the key used to index the queue.
+func Key(q *kueue.LocalQueue) LocalQueueReference {
+	return NewLocalQueueReference(q.Namespace, kueue.LocalQueueName(q.Name))
+}
+
+func KeyFromWorkload(w *kueue.Workload) LocalQueueReference {
+	return NewLocalQueueReference(w.Namespace, w.Spec.QueueName)
+}
+
+func DefaultQueueKey(namespace string) LocalQueueReference {
+	return NewLocalQueueReference(namespace, constants.DefaultLocalQueueName)
 }
 
 // LocalQueue is the internal implementation of kueue.LocalQueue.
 type LocalQueue struct {
-	Key          kueue.LocalQueueReference
+	Key          LocalQueueReference
 	ClusterQueue kueue.ClusterQueueReference
 
 	items map[string]*workload.Info
@@ -64,7 +94,7 @@ func (m *Manager) PendingActiveInLocalQueue(lq *LocalQueue) int {
 		return 0
 	}
 	for _, wl := range c.heap.List() {
-		wlLqKey := workload.QueueKey(wl.Obj)
+		wlLqKey := KeyFromWorkload(wl.Obj)
 		if wlLqKey == lq.Key {
 			result++
 		}
@@ -82,7 +112,7 @@ func (m *Manager) PendingInadmissibleInLocalQueue(lq *LocalQueue) int {
 	}
 	result := 0
 	for _, wl := range c.inadmissibleWorkloads {
-		wlLqKey := workload.QueueKey(wl.Obj)
+		wlLqKey := KeyFromWorkload(wl.Obj)
 		if wlLqKey == lq.Key {
 			result++
 		}

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -89,7 +89,7 @@ type Manager struct {
 
 	client        client.Client
 	statusChecker StatusChecker
-	localQueues   map[kueue.LocalQueueReference]*LocalQueue
+	localQueues   map[LocalQueueReference]*LocalQueue
 
 	snapshotsMutex sync.RWMutex
 	snapshots      map[kueue.ClusterQueueReference][]kueue.ClusterQueuePendingWorkload
@@ -111,7 +111,7 @@ func NewManager(client client.Client, checker StatusChecker, opts ...Option) *Ma
 	m := &Manager{
 		client:         client,
 		statusChecker:  checker,
-		localQueues:    make(map[kueue.LocalQueueReference]*LocalQueue),
+		localQueues:    make(map[LocalQueueReference]*LocalQueue),
 		snapshotsMutex: sync.RWMutex{},
 		snapshots:      make(map[kueue.ClusterQueueReference][]kueue.ClusterQueuePendingWorkload, 0),
 		workloadOrdering: workload.Ordering{
@@ -319,7 +319,11 @@ func (m *Manager) DeleteLocalQueue(q *kueue.LocalQueue) {
 		cq.DeleteFromLocalQueue(qImpl)
 	}
 	if features.Enabled(features.LocalQueueMetrics) {
-		metrics.ClearLocalQueueMetrics(metrics.LQRefFromLocalQueueKey(key))
+		namespace, lqName := MustParseLocalQueueReference(key)
+		metrics.ClearLocalQueueMetrics(metrics.LocalQueueReference{
+			Name:      lqName,
+			Namespace: namespace,
+		})
 	}
 	delete(m.localQueues, key)
 }
@@ -351,7 +355,7 @@ func (m *Manager) Pending(cq *kueue.ClusterQueue) (int, error) {
 func (m *Manager) QueueForWorkloadExists(wl *kueue.Workload) bool {
 	m.RLock()
 	defer m.RUnlock()
-	_, ok := m.localQueues[workload.QueueKey(wl)]
+	_, ok := m.localQueues[KeyFromWorkload(wl)]
 	return ok
 }
 
@@ -361,7 +365,7 @@ func (m *Manager) QueueForWorkloadExists(wl *kueue.Workload) bool {
 func (m *Manager) ClusterQueueForWorkload(wl *kueue.Workload) (kueue.ClusterQueueReference, bool) {
 	m.RLock()
 	defer m.RUnlock()
-	q, ok := m.localQueues[workload.QueueKey(wl)]
+	q, ok := m.localQueues[KeyFromWorkload(wl)]
 	if !ok {
 		return "", false
 	}
@@ -378,7 +382,7 @@ func (m *Manager) AddOrUpdateWorkload(w *kueue.Workload) error {
 }
 
 func (m *Manager) AddOrUpdateWorkloadWithoutLock(w *kueue.Workload) error {
-	qKey := workload.QueueKey(w)
+	qKey := KeyFromWorkload(w)
 	q := m.localQueues[qKey]
 	if q == nil {
 		return ErrLocalQueueDoesNotExistOrInactive
@@ -413,7 +417,7 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 		return false
 	}
 
-	q := m.localQueues[workload.QueueKey(&w)]
+	q := m.localQueues[KeyFromWorkload(&w)]
 	if q == nil {
 		return false
 	}
@@ -437,11 +441,11 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 
 func (m *Manager) DeleteWorkload(w *kueue.Workload) {
 	m.Lock()
-	m.deleteWorkloadFromQueueAndClusterQueue(w, workload.QueueKey(w))
+	m.deleteWorkloadFromQueueAndClusterQueue(w, KeyFromWorkload(w))
 	m.Unlock()
 }
 
-func (m *Manager) deleteWorkloadFromQueueAndClusterQueue(w *kueue.Workload, qKey kueue.LocalQueueReference) {
+func (m *Manager) deleteWorkloadFromQueueAndClusterQueue(w *kueue.Workload, qKey LocalQueueReference) {
 	q := m.localQueues[qKey]
 	if q == nil {
 		return
@@ -470,7 +474,7 @@ func (m *Manager) QueueAssociatedInadmissibleWorkloadsAfter(ctx context.Context,
 		action()
 	}
 
-	q := m.localQueues[workload.QueueKey(w)]
+	q := m.localQueues[KeyFromWorkload(w)]
 	if q == nil {
 		return
 	}
@@ -568,7 +572,7 @@ func (m *Manager) UpdateWorkload(oldW, w *kueue.Workload) error {
 	m.Lock()
 	defer m.Unlock()
 	if oldW.Spec.QueueName != w.Spec.QueueName {
-		m.deleteWorkloadFromQueueAndClusterQueue(w, workload.QueueKey(oldW))
+		m.deleteWorkloadFromQueueAndClusterQueue(w, KeyFromWorkload(oldW))
 	}
 	return m.AddOrUpdateWorkloadWithoutLock(w)
 }
@@ -617,7 +621,7 @@ func (m *Manager) heads() []workload.Info {
 		wlCopy := *wl
 		wlCopy.ClusterQueue = cqName
 		workloads = append(workloads, wlCopy)
-		q := m.localQueues[workload.QueueKey(wl.Obj)]
+		q := m.localQueues[KeyFromWorkload(wl.Obj)]
 		delete(q.items, workload.Key(wl.Obj))
 		if features.Enabled(features.LocalQueueMetrics) {
 			m.reportLQPendingWorkloads(q)
@@ -637,7 +641,11 @@ func (m *Manager) reportLQPendingWorkloads(lq *LocalQueue) {
 		inadmissible += active
 		active = 0
 	}
-	metrics.ReportLocalQueuePendingWorkloads(metrics.LQRefFromLocalQueueKey(lq.Key), active, inadmissible)
+	namespace, lqName := MustParseLocalQueueReference(lq.Key)
+	metrics.ReportLocalQueuePendingWorkloads(metrics.LocalQueueReference{
+		Name:      lqName,
+		Namespace: namespace,
+	}, active, inadmissible)
 }
 
 func (m *Manager) reportPendingWorkloads(cqName kueue.ClusterQueueReference, cq *ClusterQueue) {
@@ -677,7 +685,7 @@ func (m *Manager) PendingWorkloadsInfo(cqName kueue.ClusterQueueReference) []*wo
 
 // ClusterQueueFromLocalQueue returns ClusterQueue name and whether it's found,
 // given a QueueKey(namespace/localQueueName) as the parameter
-func (m *Manager) ClusterQueueFromLocalQueue(localQueueKey kueue.LocalQueueReference) (kueue.ClusterQueueReference, bool) {
+func (m *Manager) ClusterQueueFromLocalQueue(localQueueKey LocalQueueReference) (kueue.ClusterQueueReference, bool) {
 	m.RLock()
 	defer m.RUnlock()
 	if lq, ok := m.localQueues[localQueueKey]; ok {

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -672,7 +672,7 @@ func TestUpdateWorkload(t *testing.T) {
 		update           func(*kueue.Workload)
 		wantUpdated      bool
 		wantQueueOrder   map[kueue.ClusterQueueReference][]string
-		wantQueueMembers map[string]sets.Set[string]
+		wantQueueMembers map[kueue.LocalQueueReference]sets.Set[string]
 		wantErr          error
 	}{
 		"in queue": {
@@ -693,7 +693,7 @@ func TestUpdateWorkload(t *testing.T) {
 			wantQueueOrder: map[kueue.ClusterQueueReference][]string{
 				"cq": {"/b", "/a"},
 			},
-			wantQueueMembers: map[string]sets.Set[string]{
+			wantQueueMembers: map[kueue.LocalQueueReference]sets.Set[string]{
 				"/foo": sets.New("/a", "/b"),
 			},
 		},
@@ -715,7 +715,7 @@ func TestUpdateWorkload(t *testing.T) {
 			wantQueueOrder: map[kueue.ClusterQueueReference][]string{
 				"cq": {"/a"},
 			},
-			wantQueueMembers: map[string]sets.Set[string]{
+			wantQueueMembers: map[kueue.LocalQueueReference]sets.Set[string]{
 				"/foo": nil,
 				"/bar": sets.New("/a"),
 			},
@@ -740,7 +740,7 @@ func TestUpdateWorkload(t *testing.T) {
 				"cq1": nil,
 				"cq2": {"/a"},
 			},
-			wantQueueMembers: map[string]sets.Set[string]{
+			wantQueueMembers: map[kueue.LocalQueueReference]sets.Set[string]{
 				"/foo": nil,
 				"/bar": sets.New("/a"),
 			},
@@ -761,7 +761,7 @@ func TestUpdateWorkload(t *testing.T) {
 			wantQueueOrder: map[kueue.ClusterQueueReference][]string{
 				"cq": nil,
 			},
-			wantQueueMembers: map[string]sets.Set[string]{
+			wantQueueMembers: map[kueue.LocalQueueReference]sets.Set[string]{
 				"/foo": nil,
 			},
 			wantErr: ErrLocalQueueDoesNotExistOrInactive,
@@ -783,7 +783,7 @@ func TestUpdateWorkload(t *testing.T) {
 			wantQueueOrder: map[kueue.ClusterQueueReference][]string{
 				"cq": {"/a"},
 			},
-			wantQueueMembers: map[string]sets.Set[string]{
+			wantQueueMembers: map[kueue.LocalQueueReference]sets.Set[string]{
 				"/foo": sets.New("/a"),
 			},
 		},
@@ -837,7 +837,7 @@ func TestUpdateWorkload(t *testing.T) {
 			if diff := cmp.Diff(tc.wantQueueOrder, queueOrder); diff != "" {
 				t.Errorf("Elements popped in the wrong order from clusterQueues (-want,+got):\n%s", diff)
 			}
-			queueMembers := make(map[string]sets.Set[string])
+			queueMembers := make(map[kueue.LocalQueueReference]sets.Set[string])
 			for name, q := range manager.localQueues {
 				queueMembers[name] = workloadNamesFromLQ(q)
 			}

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -672,7 +672,7 @@ func TestUpdateWorkload(t *testing.T) {
 		update           func(*kueue.Workload)
 		wantUpdated      bool
 		wantQueueOrder   map[kueue.ClusterQueueReference][]string
-		wantQueueMembers map[kueue.LocalQueueReference]sets.Set[string]
+		wantQueueMembers map[LocalQueueReference]sets.Set[string]
 		wantErr          error
 	}{
 		"in queue": {
@@ -693,7 +693,7 @@ func TestUpdateWorkload(t *testing.T) {
 			wantQueueOrder: map[kueue.ClusterQueueReference][]string{
 				"cq": {"/b", "/a"},
 			},
-			wantQueueMembers: map[kueue.LocalQueueReference]sets.Set[string]{
+			wantQueueMembers: map[LocalQueueReference]sets.Set[string]{
 				"/foo": sets.New("/a", "/b"),
 			},
 		},
@@ -715,7 +715,7 @@ func TestUpdateWorkload(t *testing.T) {
 			wantQueueOrder: map[kueue.ClusterQueueReference][]string{
 				"cq": {"/a"},
 			},
-			wantQueueMembers: map[kueue.LocalQueueReference]sets.Set[string]{
+			wantQueueMembers: map[LocalQueueReference]sets.Set[string]{
 				"/foo": nil,
 				"/bar": sets.New("/a"),
 			},
@@ -740,7 +740,7 @@ func TestUpdateWorkload(t *testing.T) {
 				"cq1": nil,
 				"cq2": {"/a"},
 			},
-			wantQueueMembers: map[kueue.LocalQueueReference]sets.Set[string]{
+			wantQueueMembers: map[LocalQueueReference]sets.Set[string]{
 				"/foo": nil,
 				"/bar": sets.New("/a"),
 			},
@@ -761,7 +761,7 @@ func TestUpdateWorkload(t *testing.T) {
 			wantQueueOrder: map[kueue.ClusterQueueReference][]string{
 				"cq": nil,
 			},
-			wantQueueMembers: map[kueue.LocalQueueReference]sets.Set[string]{
+			wantQueueMembers: map[LocalQueueReference]sets.Set[string]{
 				"/foo": nil,
 			},
 			wantErr: ErrLocalQueueDoesNotExistOrInactive,
@@ -783,7 +783,7 @@ func TestUpdateWorkload(t *testing.T) {
 			wantQueueOrder: map[kueue.ClusterQueueReference][]string{
 				"cq": {"/a"},
 			},
-			wantQueueMembers: map[kueue.LocalQueueReference]sets.Set[string]{
+			wantQueueMembers: map[LocalQueueReference]sets.Set[string]{
 				"/foo": sets.New("/a"),
 			},
 		},
@@ -811,7 +811,7 @@ func TestUpdateWorkload(t *testing.T) {
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected UpdatedWorkload returned error (-want,+got):\n%s", diff)
 			}
-			q := manager.localQueues[workload.QueueKey(wl)]
+			q := manager.localQueues[KeyFromWorkload(wl)]
 			if q != nil {
 				key := workload.Key(wl)
 				item := q.items[key]
@@ -837,7 +837,7 @@ func TestUpdateWorkload(t *testing.T) {
 			if diff := cmp.Diff(tc.wantQueueOrder, queueOrder); diff != "" {
 				t.Errorf("Elements popped in the wrong order from clusterQueues (-want,+got):\n%s", diff)
 			}
-			queueMembers := make(map[kueue.LocalQueueReference]sets.Set[string])
+			queueMembers := make(map[LocalQueueReference]sets.Set[string])
 			for name, q := range manager.localQueues {
 				queueMembers[name] = workloadNamesFromLQ(q)
 			}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -648,7 +648,7 @@ func (s *Scheduler) requeueAndUpdate(ctx context.Context, e entry) {
 		e.requeueReason = queue.RequeueReasonFailedAfterNomination
 	}
 	added := s.queues.RequeueWorkload(ctx, &e.Info, e.requeueReason)
-	log.V(2).Info("Workload re-queued", "workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", string(e.ClusterQueue)), "queue", klog.KRef(e.Obj.Namespace, e.Obj.Spec.QueueName), "requeueReason", e.requeueReason, "added", added, "status", e.status)
+	log.V(2).Info("Workload re-queued", "workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", string(e.ClusterQueue)), "queue", klog.KRef(e.Obj.Namespace, string(e.Obj.Spec.QueueName)), "requeueReason", e.requeueReason, "added", added, "status", e.status)
 
 	if e.status == notNominated || e.status == skipped {
 		patch := workload.PrepareWorkloadPatch(e.Obj, true, s.clock)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4059,7 +4059,7 @@ var ignoreConditionTimestamps = cmpopts.IgnoreFields(metav1.Condition{}, "LastTr
 func TestRequeueAndUpdate(t *testing.T) {
 	cq := utiltesting.MakeClusterQueue("cq").Obj()
 	q1 := utiltesting.MakeLocalQueue("q1", "ns1").ClusterQueue(cq.Name).Obj()
-	w1 := utiltesting.MakeWorkload("w1", "ns1").Queue(q1.Name).Obj()
+	w1 := utiltesting.MakeWorkload("w1", "ns1").Queue(kueue.LocalQueueName(q1.Name)).Obj()
 
 	cases := []struct {
 		name              string

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -134,7 +134,7 @@ func (w *WorkloadWrapper) RequestAndLimit(r corev1.ResourceName, q string) *Work
 	return w.Request(r, q).Limit(r, q)
 }
 
-func (w *WorkloadWrapper) Queue(q string) *WorkloadWrapper {
+func (w *WorkloadWrapper) Queue(q kueue.LocalQueueName) *WorkloadWrapper {
 	w.Spec.QueueName = q
 	return w
 }

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/testing"
 )
@@ -132,8 +133,8 @@ func (j *JobWrapper) WorkloadPriorityClass(wpc string) *JobWrapper {
 }
 
 // Queue updates the queue name of the job
-func (j *JobWrapper) Queue(queue string) *JobWrapper {
-	return j.Label(constants.QueueLabel, queue)
+func (j *JobWrapper) Queue(queue kueue.LocalQueueName) *JobWrapper {
+	return j.Label(constants.QueueLabel, string(queue))
 }
 
 // Label sets the label key and value

--- a/pkg/visibility/api/v1beta1/pending_workloads_cq.go
+++ b/pkg/visibility/api/v1beta1/pending_workloads_cq.go
@@ -74,7 +74,7 @@ func (m *pendingWorkloadsInCqREST) Get(_ context.Context, name string, opts runt
 		return nil, errors.NewNotFound(visibility.Resource("clusterqueue"), name)
 	}
 
-	localQueuePositions := make(map[string]int32, 0)
+	localQueuePositions := make(map[kueue.LocalQueueName]int32, 0)
 
 	for index := 0; index < int(offset+limit) && index < len(pendingWorkloadsInfo); index++ {
 		// Update positions in LocalQueue

--- a/pkg/visibility/api/v1beta1/pending_workloads_lq.go
+++ b/pkg/visibility/api/v1beta1/pending_workloads_lq.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	visibility "sigs.k8s.io/kueue/apis/visibility/v1beta1"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/queue"
@@ -69,7 +70,8 @@ func (m *pendingWorkloadsInLqREST) Get(ctx context.Context, name string, opts ru
 	offset := pendingWorkloadOpts.Offset
 
 	namespace := genericapirequest.NamespaceValue(ctx)
-	cqName, ok := m.queueMgr.ClusterQueueFromLocalQueue(queue.QueueKey(namespace, name))
+	lqName := kueue.LocalQueueName(name)
+	cqName, ok := m.queueMgr.ClusterQueueFromLocalQueue(kueue.NewLocalQueueReference(namespace, lqName))
 	if !ok {
 		return nil, errors.NewNotFound(visibility.Resource("localqueue"), name)
 	}
@@ -80,7 +82,7 @@ func (m *pendingWorkloadsInLqREST) Get(ctx context.Context, name string, opts ru
 		if len(wls) >= int(limit) {
 			break
 		}
-		if wlInfo.Obj.Spec.QueueName == name {
+		if wlInfo.Obj.Spec.QueueName == lqName {
 			if skippedWls < int(offset) {
 				skippedWls++
 			} else {

--- a/pkg/visibility/api/v1beta1/pending_workloads_lq.go
+++ b/pkg/visibility/api/v1beta1/pending_workloads_lq.go
@@ -71,7 +71,7 @@ func (m *pendingWorkloadsInLqREST) Get(ctx context.Context, name string, opts ru
 
 	namespace := genericapirequest.NamespaceValue(ctx)
 	lqName := kueue.LocalQueueName(name)
-	cqName, ok := m.queueMgr.ClusterQueueFromLocalQueue(kueue.NewLocalQueueReference(namespace, lqName))
+	cqName, ok := m.queueMgr.ClusterQueueFromLocalQueue(queue.NewLocalQueueReference(namespace, lqName))
 	if !ok {
 		return nil, errors.NewNotFound(visibility.Resource("localqueue"), name)
 	}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -363,8 +363,8 @@ func Key(w *kueue.Workload) string {
 	return fmt.Sprintf("%s/%s", w.Namespace, w.Name)
 }
 
-func QueueKey(w *kueue.Workload) string {
-	return fmt.Sprintf("%s/%s", w.Namespace, w.Spec.QueueName)
+func QueueKey(w *kueue.Workload) kueue.LocalQueueReference {
+	return kueue.NewLocalQueueReference(w.Namespace, w.Spec.QueueName)
 }
 
 func reclaimableCounts(wl *kueue.Workload) map[kueue.PodSetReference]int32 {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -363,10 +363,6 @@ func Key(w *kueue.Workload) string {
 	return fmt.Sprintf("%s/%s", w.Namespace, w.Name)
 }
 
-func QueueKey(w *kueue.Workload) kueue.LocalQueueReference {
-	return kueue.NewLocalQueueReference(w.Namespace, w.Spec.QueueName)
-}
-
 func reclaimableCounts(wl *kueue.Workload) map[kueue.PodSetReference]int32 {
 	return utilslices.ToMap(wl.Status.ReclaimablePods, func(i int) (kueue.PodSetReference, int32) {
 		return wl.Status.ReclaimablePods[i].Name, wl.Status.ReclaimablePods[i].Count

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -806,7 +806,8 @@ and are newer than the pending workload.</li>
 - [LocalQueueSpec](#kueue-x-k8s-io-v1beta1-LocalQueueSpec)
 
 
-<p>ClusterQueueReference is the name of the ClusterQueue.</p>
+<p>ClusterQueueReference is the name of the ClusterQueue.
+It must be a DNS (RFC 1123) and has the maximum length of 253 characters.</p>
 
 
 
@@ -1355,6 +1356,21 @@ feature gate.</p>
 </tr>
 </tbody>
 </table>
+
+## `LocalQueueName`     {#kueue-x-k8s-io-v1beta1-LocalQueueName}
+    
+(Alias of `string`)
+
+**Appears in:**
+
+- [WorkloadSpec](#kueue-x-k8s-io-v1beta1-WorkloadSpec)
+
+
+<p>LocalQueueName is the name of the LocalQueue.
+It must be a DNS (RFC 1123) and has the maximum length of 253 characters.</p>
+
+
+
 
 ## `LocalQueueResourceUsage`     {#kueue-x-k8s-io-v1beta1-LocalQueueResourceUsage}
     
@@ -2552,7 +2568,7 @@ podSets cannot be changed.</p>
 </td>
 </tr>
 <tr><td><code>queueName</code> <B>[Required]</B><br/>
-<code>string</code>
+<a href="#kueue-x-k8s-io-v1beta1-LocalQueueName"><code>LocalQueueName</code></a>
 </td>
 <td>
    <p>queueName is the name of the LocalQueue the Workload is associated with.

--- a/test/e2e/certmanager/metrics_test.go
+++ b/test/e2e/certmanager/metrics_test.go
@@ -156,7 +156,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Ordered, func() {
 			gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
 
 			workload = utiltesting.MakeWorkload("test-workload", ns.Name).
-				Queue(localQueue.Name).
+				Queue(v1beta1.LocalQueueName(localQueue.Name)).
 				PodSets(
 					*utiltesting.MakePodSet("ps1", 1).Obj(),
 				).

--- a/test/e2e/customconfigs/waitforpodsready_test.go
+++ b/test/e2e/customconfigs/waitforpodsready_test.go
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("WaitForPodsReady Job Controller E2E", func() {
 		ginkgo.It("should evict and requeue workload when pods readiness timeout is surpassed", func() {
 			ginkgo.By("creating a suspended job so its pods never report Ready", func() {
 				job = testingjob.MakeJob("job-timeout", ns.Name).
-					Queue(lq.Name).
+					Queue(kueue.LocalQueueName(lq.Name)).
 					Request(corev1.ResourceCPU, "2").
 					Parallelism(1).
 					Obj()
@@ -173,7 +173,7 @@ var _ = ginkgo.Describe("WaitForPodsReady Job Controller E2E", func() {
 			ginkgo.By("creating a job", func() {
 				job = testingjob.MakeJob("job-recovery-timeout", ns.Name).
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-					Queue(lq.Name).
+					Queue(kueue.LocalQueueName(lq.Name)).
 					Request(corev1.ResourceCPU, "2").
 					Parallelism(1).
 					BackoffLimitPerIndex(2).
@@ -243,7 +243,7 @@ var _ = ginkgo.Describe("WaitForPodsReady Job Controller E2E", func() {
 			ginkgo.By("creating a job", func() {
 				job = testingjob.MakeJob("job-recovery-timeout", ns.Name).
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-					Queue(lq.Name).
+					Queue(kueue.LocalQueueName(lq.Name)).
 					Request(corev1.ResourceCPU, "2").
 					Parallelism(1).
 					BackoffLimitPerIndex(2).

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -439,7 +439,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			}
 			// Since it requires 2G of memory, this job can only be admitted in worker 2.
 			job := testingjob.MakeJob("job", managerNs.Name).
-				Queue(managerLq.Name).
+				Queue(kueue.LocalQueueName(managerLq.Name)).
 				RequestAndLimit("cpu", "1").
 				RequestAndLimit("memory", "2G").
 				TerminationGracePeriod(1).

--- a/test/e2e/singlecluster/e2e_test.go
+++ b/test/e2e/singlecluster/e2e_test.go
@@ -150,7 +150,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 
 				wl = testing.MakeWorkload("prebuilt-wl", ns.Name).
 					Finalizers(kueue.ResourceInUseFinalizerName).
-					Queue(localQueue.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
 					PodSets(
 						*testing.MakePodSet(kueue.DefaultPodSetName, 1).Containers(sampleJob.Spec.Template.Spec.Containers[0]).Obj(),
 					).

--- a/test/e2e/singlecluster/fair_sharing_test.go
+++ b/test/e2e/singlecluster/fair_sharing_test.go
@@ -95,7 +95,7 @@ var _ = ginkgo.Describe("Fair Sharing", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			ginkgo.By("create jobs")
 			for i := 0; i < 4; i++ {
 				job := jobtesting.MakeJob(fmt.Sprintf("j%d", i+1), ns.Name).
-					Queue(lq1.Name).
+					Queue(v1beta1.LocalQueueName(lq1.Name)).
 					Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 					Parallelism(3).
 					Completions(3).

--- a/test/e2e/singlecluster/metrics_test.go
+++ b/test/e2e/singlecluster/metrics_test.go
@@ -132,7 +132,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 			util.MustCreate(ctx, k8sClient, localQueue)
 
 			workload = utiltesting.MakeWorkload("test-workload", ns.Name).
-				Queue(localQueue.Name).
+				Queue(v1beta1.LocalQueueName(localQueue.Name)).
 				PodSets(
 					*utiltesting.MakePodSet("ps1", 1).Obj(),
 				).
@@ -267,7 +267,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 			util.MustCreate(ctx, k8sClient, localQueue)
 
 			createdJob = testingjob.MakeJob("admission-checked-job", ns.Name).
-				Queue(localQueue.Name).
+				Queue(v1beta1.LocalQueueName(localQueue.Name)).
 				RequestAndLimit("cpu", "1").
 				Obj()
 			util.MustCreate(ctx, k8sClient, createdJob)
@@ -411,7 +411,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 			util.MustCreate(ctx, k8sClient, highPriorityClass)
 
 			lowerJob1 = testingjob.MakeJob("lower-job-1", ns.Name).
-				Queue(localQueue1.Name).
+				Queue(v1beta1.LocalQueueName(localQueue1.Name)).
 				RequestAndLimit("cpu", "1").
 				Obj()
 			util.MustCreate(ctx, k8sClient, lowerJob1)
@@ -430,7 +430,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, lowerWorkload1)
 
 			lowerJob2 = testingjob.MakeJob("lower-job-2", ns.Name).
-				Queue(localQueue1.Name).
+				Queue(v1beta1.LocalQueueName(localQueue1.Name)).
 				RequestAndLimit("cpu", "1").
 				Obj()
 			util.MustCreate(ctx, k8sClient, lowerJob2)
@@ -449,7 +449,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, lowerWorkload2)
 
 			blockerJob = testingjob.MakeJob("blocker", ns.Name).
-				Queue(localQueue2.Name).
+				Queue(v1beta1.LocalQueueName(localQueue2.Name)).
 				PriorityClass(highPriorityClass.Name).
 				RequestAndLimit(corev1.ResourceCPU, "3").
 				Obj()
@@ -469,14 +469,14 @@ var _ = ginkgo.Describe("Metrics", func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, blockerWorkload)
 
 			higherJob1 = testingjob.MakeJob("high-large-1", ns.Name).
-				Queue(localQueue1.Name).
+				Queue(v1beta1.LocalQueueName(localQueue1.Name)).
 				PriorityClass(highPriorityClass.Name).
 				RequestAndLimit(corev1.ResourceCPU, "4").
 				Obj()
 			util.MustCreate(ctx, k8sClient, higherJob1)
 
 			higherJob2 = testingjob.MakeJob("high-large-2", ns.Name).
-				Queue(localQueue2.Name).
+				Queue(v1beta1.LocalQueueName(localQueue2.Name)).
 				PriorityClass(highPriorityClass.Name).
 				RequestAndLimit(corev1.ResourceCPU, "4").
 				Obj()

--- a/test/e2e/singlecluster/tas_test.go
+++ b/test/e2e/singlecluster/tas_test.go
@@ -91,7 +91,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 
 		ginkgo.It("should admit a Job via TAS", func() {
 			sampleJob := testingjob.MakeJob("test-job", ns.Name).
-				Queue(localQueue.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
 				RequestAndLimit("cpu", "700m").
 				RequestAndLimit("memory", "20Mi").
 				Obj()

--- a/test/e2e/singlecluster/visibility_test.go
+++ b/test/e2e/singlecluster/visibility_test.go
@@ -102,7 +102,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 
 			ginkgo.By("Schedule a job that when admitted workload blocks the queue", func() {
 				blockingJob = testingjob.MakeJob("test-job-1", nsA.Name).
-					Queue(localQueueA.Name).
+					Queue(kueue.LocalQueueName(localQueueA.Name)).
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 					RequestAndLimit(corev1.ResourceCPU, "1").
 					TerminationGracePeriod(1).
@@ -142,7 +142,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 
 			ginkgo.By("Schedule a job which is pending due to lower priority", func() {
 				sampleJob2 = testingjob.MakeJob("test-job-2", nsA.Name).
-					Queue(localQueueA.Name).
+					Queue(kueue.LocalQueueName(localQueueA.Name)).
 					Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 					RequestAndLimit(corev1.ResourceCPU, "1").
 					PriorityClass(lowPriorityClass.Name).
@@ -204,7 +204,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 				}
 				for _, jobCase := range jobCases {
 					job := testingjob.MakeJob(jobCase.JobName, nsA.Name).
-						Queue(jobCase.LocalQueueName).
+						Queue(kueue.LocalQueueName(jobCase.LocalQueueName)).
 						Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 						RequestAndLimit(corev1.ResourceCPU, "1").
 						PriorityClass(jobCase.JobPrioClassName).
@@ -223,7 +223,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 						Priority:               highPriorityClass.Value,
 						PositionInLocalQueue:   0,
 						PositionInClusterQueue: 0,
-						LocalQueueName:         localQueueA.Name,
+						LocalQueueName:         kueue.LocalQueueName(localQueueA.Name),
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{
@@ -233,7 +233,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 						Priority:               midPriorityClass.Value,
 						PositionInLocalQueue:   0,
 						PositionInClusterQueue: 1,
-						LocalQueueName:         localQueueB.Name,
+						LocalQueueName:         kueue.LocalQueueName(localQueueB.Name),
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{
@@ -243,7 +243,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 						Priority:               lowPriorityClass.Value,
 						PositionInLocalQueue:   1,
 						PositionInClusterQueue: 2,
-						LocalQueueName:         localQueueB.Name,
+						LocalQueueName:         kueue.LocalQueueName(localQueueB.Name),
 					},
 				}
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -263,7 +263,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 
 			ginkgo.By("Schedule a job which is pending due to lower priority", func() {
 				sampleJob2 = testingjob.MakeJob("test-job-2", nsA.Name).
-					Queue(localQueueA.Name).
+					Queue(kueue.LocalQueueName(localQueueA.Name)).
 					Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 					RequestAndLimit(corev1.ResourceCPU, "1").
 					PriorityClass(lowPriorityClass.Name).
@@ -325,7 +325,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 				}
 				for _, jobCase := range jobCases {
 					job := testingjob.MakeJob(jobCase.JobName, nsA.Name).
-						Queue(jobCase.LocalQueueName).
+						Queue(kueue.LocalQueueName(jobCase.LocalQueueName)).
 						Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 						RequestAndLimit(corev1.ResourceCPU, "1").
 						PriorityClass(jobCase.JobPrioClassName).
@@ -344,7 +344,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 						Priority:               highPriorityClass.Value,
 						PositionInLocalQueue:   0,
 						PositionInClusterQueue: 0,
-						LocalQueueName:         localQueueA.Name,
+						LocalQueueName:         kueue.LocalQueueName(localQueueA.Name),
 					},
 				}
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -364,7 +364,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 						Priority:               midPriorityClass.Value,
 						PositionInLocalQueue:   0,
 						PositionInClusterQueue: 1,
-						LocalQueueName:         localQueueB.Name,
+						LocalQueueName:         kueue.LocalQueueName(localQueueB.Name),
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{
@@ -374,7 +374,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 						Priority:               lowPriorityClass.Value,
 						PositionInLocalQueue:   1,
 						PositionInClusterQueue: 2,
-						LocalQueueName:         localQueueB.Name,
+						LocalQueueName:         kueue.LocalQueueName(localQueueB.Name),
 					},
 				}
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -418,7 +418,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 				}
 				for _, jobCase := range jobCases {
 					job := testingjob.MakeJob(jobCase.JobName, jobCase.nsName).
-						Queue(jobCase.LocalQueueName).
+						Queue(kueue.LocalQueueName(jobCase.LocalQueueName)).
 						Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
 						RequestAndLimit(corev1.ResourceCPU, "1").
 						PriorityClass(jobCase.JobPrioClassName).
@@ -437,7 +437,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 						Priority:               highPriorityClass.Value,
 						PositionInLocalQueue:   0,
 						PositionInClusterQueue: 0,
-						LocalQueueName:         localQueueA.Name,
+						LocalQueueName:         kueue.LocalQueueName(localQueueA.Name),
 					},
 				}
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -457,7 +457,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 						Priority:               midPriorityClass.Value,
 						PositionInLocalQueue:   0,
 						PositionInClusterQueue: 1,
-						LocalQueueName:         localQueueB.Name,
+						LocalQueueName:         kueue.LocalQueueName(localQueueB.Name),
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{
@@ -467,7 +467,7 @@ var _ = ginkgo.Describe("Kueue visibility server", func() {
 						Priority:               lowPriorityClass.Value,
 						PositionInLocalQueue:   1,
 						PositionInClusterQueue: 2,
-						LocalQueueName:         localQueueB.Name,
+						LocalQueueName:         kueue.LocalQueueName(localQueueB.Name),
 					},
 				}
 				gomega.Eventually(func(g gomega.Gomega) {

--- a/test/e2e/tas/job_test.go
+++ b/test/e2e/tas/job_test.go
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 
 		ginkgo.It("Should not admit a Job if Rack required", func() {
 			sampleJob := testingjob.MakeJob("test-job", ns.Name).
-				Queue(localQueue.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
 				Parallelism(3).
 				Completions(3).
 				RequestAndLimit(extraResource, "1").
@@ -116,7 +116,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 
 		ginkgo.It("should admit a Job to TAS Block if Rack preferred", func() {
 			sampleJob := testingjob.MakeJob("test-job", ns.Name).
-				Queue(localQueue.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
 				Parallelism(3).
 				Completions(3).
 				RequestAndLimit(extraResource, "1").
@@ -168,7 +168,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 
 		ginkgo.It("Should admit a Job to TAS Block if Block required", func() {
 			sampleJob := testingjob.MakeJob("test-job", ns.Name).
-				Queue(localQueue.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
 				Parallelism(3).
 				Completions(3).
 				RequestAndLimit(extraResource, "1").
@@ -221,7 +221,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 
 		ginkgo.It("Should allow to run a Job with parallelism < completions", func() {
 			sampleJob := testingjob.MakeJob("test-job", ns.Name).
-				Queue(localQueue.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
 				Parallelism(2).
 				Completions(3).
 				RequestAndLimit(extraResource, "1").
@@ -248,7 +248,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", func() {
 		ginkgo.It("Should place pods based on the ranks-ordering", func() {
 			numPods := 4
 			sampleJob := testingjob.MakeJob("ranks-job", ns.Name).
-				Queue(localQueue.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
 				Parallelism(int32(numPods)).
 				Completions(int32(numPods)).
 				Indexed(true).

--- a/test/integration/multikueue/enabled_integration_test.go
+++ b/test/integration/multikueue/enabled_integration_test.go
@@ -137,7 +137,7 @@ var _ = ginkgo.Describe("MultiKueue when not all integrations are enabled", gink
 
 	ginkgo.It("Should create a Job workload, when batch/Job adapter is enabled", func() {
 		job := testingjob.MakeJob("job", managerNs.Name).
-			Queue(managerLq.Name).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
 			Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).Should(gomega.Succeed())
 

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -201,7 +201,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 
 	ginkgo.It("Should run a job on worker if admitted", func() {
 		job := testingjob.MakeJob("job", managerNs.Name).
-			Queue(managerLq.Name).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
 
@@ -295,7 +295,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueBatchJobWithManagedBy, true)
 		job := testingjob.MakeJob("job", managerNs.Name).
 			ManagedBy(kueue.MultiKueueControllerName).
-			Queue(managerLq.Name).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
 
@@ -1215,7 +1215,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 
 	ginkgo.It("Should remove the worker's workload and job after reconnect when the managers job and workload are deleted", func() {
 		job := testingjob.MakeJob("job", managerNs.Name).
-			Queue(managerLq.Name).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
 		jobLookupKey := client.ObjectKeyFromObject(job)

--- a/test/integration/multikueue/no_gc_test.go
+++ b/test/integration/multikueue/no_gc_test.go
@@ -166,7 +166,7 @@ var _ = ginkgo.Describe("MultiKueue no GC", ginkgo.Ordered, ginkgo.ContinueOnFai
 
 	ginkgo.It("Should remove the worker's workload and job when managers job is deleted", framework.SlowSpec, func() {
 		job := testingjob.MakeJob("job", managerNs.Name).
-			Queue(managerLq.Name).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
 			Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).Should(gomega.Succeed())
 
@@ -227,7 +227,7 @@ var _ = ginkgo.Describe("MultiKueue no GC", ginkgo.Ordered, ginkgo.ContinueOnFai
 		}
 		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueBatchJobWithManagedBy, true)
 		job := testingjob.MakeJob("job", managerNs.Name).
-			Queue(managerLq.Name).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
 			ManagedBy(kueue.MultiKueueControllerName).
 			Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).Should(gomega.Succeed())

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -120,7 +120,7 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			wl := testing.MakeWorkload("wl", ns.Name).
-				Queue(lq.Name).
+				Queue(kueue.LocalQueueName(lq.Name)).
 				PodSets(
 					*testing.MakePodSet("ps1", 3).
 						Request(corev1.ResourceCPU, "1").
@@ -937,7 +937,7 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			lq = testing.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
 			util.MustCreate(ctx, k8sClient, lq)
 			wl := testing.MakeWorkload("wl", ns.Name).
-				Queue(lq.Name).
+				Queue(kueue.LocalQueueName(lq.Name)).
 				PodSets(
 					*testing.MakePodSet("ps1", 3).
 						Request(corev1.ResourceCPU, "1").

--- a/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
@@ -148,17 +148,17 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 
 		ginkgo.It("Should update status and report metrics when workloads are assigned and finish", framework.SlowSpec, func() {
 			workloads := []*kueue.Workload{
-				testing.MakeWorkload("one", ns.Name).Queue(localQueue.Name).
+				testing.MakeWorkload("one", ns.Name).Queue(kueue.LocalQueueName(localQueue.Name)).
 					Request(corev1.ResourceCPU, "2").Request(resourceGPU, "2").Obj(),
-				testing.MakeWorkload("two", ns.Name).Queue(localQueue.Name).
+				testing.MakeWorkload("two", ns.Name).Queue(kueue.LocalQueueName(localQueue.Name)).
 					Request(corev1.ResourceCPU, "3").Request(resourceGPU, "3").Obj(),
-				testing.MakeWorkload("three", ns.Name).Queue(localQueue.Name).
+				testing.MakeWorkload("three", ns.Name).Queue(kueue.LocalQueueName(localQueue.Name)).
 					Request(corev1.ResourceCPU, "1").Request(resourceGPU, "1").Obj(),
-				testing.MakeWorkload("four", ns.Name).Queue(localQueue.Name).
+				testing.MakeWorkload("four", ns.Name).Queue(kueue.LocalQueueName(localQueue.Name)).
 					Request(corev1.ResourceCPU, "1").Request(resourceGPU, "1").Obj(),
 				testing.MakeWorkload("five", ns.Name).Queue("other").
 					Request(corev1.ResourceCPU, "1").Request(resourceGPU, "1").Obj(),
-				testing.MakeWorkload("six", ns.Name).Queue(localQueue.Name).
+				testing.MakeWorkload("six", ns.Name).Queue(kueue.LocalQueueName(localQueue.Name)).
 					Request(corev1.ResourceCPU, "1").Request(resourceGPU, "1").Obj(),
 			}
 
@@ -364,7 +364,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 		})
 
 		ginkgo.It("Should update status and report metrics when a pending workload is deleted", func() {
-			workload := testing.MakeWorkload("one", ns.Name).Queue(localQueue.Name).
+			workload := testing.MakeWorkload("one", ns.Name).Queue(kueue.LocalQueueName(localQueue.Name)).
 				Request(corev1.ResourceCPU, "5").Obj()
 
 			ginkgo.By("Creating a workload", func() {
@@ -437,7 +437,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 			})
 
 			wl := testing.MakeWorkload("one", ns.Name).
-				Queue(localQueue.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
 				PodSets(
 					*testing.MakePodSet("driver", 2).
 						Request(corev1.ResourceCPU, "1").
@@ -630,7 +630,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 			util.MustCreate(ctx, k8sClient, cq)
 			lq = testing.MakeLocalQueue("bar-lq", ns.Name).ClusterQueue(cq.Name).Obj()
 			util.MustCreate(ctx, k8sClient, lq)
-			wl = testing.MakeWorkload("bar-wl", ns.Name).Queue(lq.Name).Obj()
+			wl = testing.MakeWorkload("bar-wl", ns.Name).Queue(kueue.LocalQueueName(lq.Name)).Obj()
 			util.MustCreate(ctx, k8sClient, wl)
 		})
 
@@ -889,7 +889,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 			util.ExpectLQByStatusMetric(lq, metav1.ConditionTrue)
 
 			ginkgo.By("Admit workload")
-			wl := testing.MakeWorkload("workload", ns.Name).Queue(lq.Name).Obj()
+			wl := testing.MakeWorkload("workload", ns.Name).Queue(kueue.LocalQueueName(lq.Name)).Obj()
 			util.MustCreate(ctx, k8sClient, wl)
 			gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, testing.MakeAdmission(cq.Name).Obj())).To(gomega.Succeed())
 			util.SetWorkloadsAdmissionCheck(ctx, k8sClient, wl, kueue.AdmissionCheckReference(check.Name), kueue.CheckStateReady, true)
@@ -924,7 +924,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 			util.ExpectLQByStatusMetric(lq, metav1.ConditionTrue)
 
 			ginkgo.By("Setting quota reservation")
-			wl := testing.MakeWorkload("workload", ns.Name).Queue(lq.Name).Obj()
+			wl := testing.MakeWorkload("workload", ns.Name).Queue(kueue.LocalQueueName(lq.Name)).Obj()
 			util.MustCreate(ctx, k8sClient, wl)
 			gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, testing.MakeAdmission(cq.Name).Obj())).To(gomega.Succeed())
 
@@ -986,9 +986,9 @@ var _ = ginkgo.Describe("ClusterQueue controller with queue visibility is enable
 		ginkgo.It("Should update of the pending workloads when a new workload is scheduled", framework.SlowSpec, func() {
 			const lowPrio, midLowerPrio, midHigherPrio, highPrio = 0, 10, 20, 100
 			workloadsFirstBatch := []*kueue.Workload{
-				testing.MakeWorkload("one", ns.Name).Queue(localQueue.Name).Priority(highPrio).
+				testing.MakeWorkload("one", ns.Name).Queue(kueue.LocalQueueName(localQueue.Name)).Priority(highPrio).
 					Request(corev1.ResourceCPU, "2").Request(resourceGPU, "2").Obj(),
-				testing.MakeWorkload("two", ns.Name).Queue(localQueue.Name).Priority(midHigherPrio).
+				testing.MakeWorkload("two", ns.Name).Queue(kueue.LocalQueueName(localQueue.Name)).Priority(midHigherPrio).
 					Request(corev1.ResourceCPU, "3").Request(resourceGPU, "3").Obj(),
 			}
 
@@ -1024,9 +1024,9 @@ var _ = ginkgo.Describe("ClusterQueue controller with queue visibility is enable
 
 			ginkgo.By("Creating new workloads to so that the number of workloads exceeds the MaxCount")
 			workloadsSecondBatch := []*kueue.Workload{
-				testing.MakeWorkload("three", ns.Name).Queue(localQueue.Name).Priority(midLowerPrio).
+				testing.MakeWorkload("three", ns.Name).Queue(kueue.LocalQueueName(localQueue.Name)).Priority(midLowerPrio).
 					Request(corev1.ResourceCPU, "2").Request(resourceGPU, "2").Obj(),
-				testing.MakeWorkload("four", ns.Name).Queue(localQueue.Name).Priority(lowPrio).
+				testing.MakeWorkload("four", ns.Name).Queue(kueue.LocalQueueName(localQueue.Name)).Priority(lowPrio).
 					Request(corev1.ResourceCPU, "3").Request(resourceGPU, "3").Obj(),
 			}
 			for _, w := range workloadsSecondBatch {

--- a/test/integration/singlecluster/controller/core/localqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/localqueue_controller_test.go
@@ -228,15 +228,15 @@ var _ = ginkgo.Describe("Queue controller", ginkgo.Ordered, ginkgo.ContinueOnFai
 		util.ExpectLQPendingWorkloadsMetric(queue, 0, 0)
 		workloads := []*kueue.Workload{
 			testing.MakeWorkload("one", ns.Name).
-				Queue(queue.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
 				Request(resourceGPU, "2").
 				Obj(),
 			testing.MakeWorkload("two", ns.Name).
-				Queue(queue.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
 				Request(resourceGPU, "3").
 				Obj(),
 			testing.MakeWorkload("three", ns.Name).
-				Queue(queue.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
 				Request(resourceGPU, "1").
 				Obj(),
 		}
@@ -462,15 +462,15 @@ var _ = ginkgo.Describe("Queue controller", ginkgo.Ordered, ginkgo.ContinueOnFai
 
 		workloads := []*kueue.Workload{
 			testing.MakeWorkload("one", ns.Name).
-				Queue(queue.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
 				Request(resourceGPU, "2").
 				Obj(),
 			testing.MakeWorkload("two", ns.Name).
-				Queue(queue.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
 				Request(resourceGPU, "3").
 				Obj(),
 			testing.MakeWorkload("three", ns.Name).
-				Queue(queue.Name).
+				Queue(kueue.LocalQueueName(queue.Name)).
 				Request(resourceGPU, "1").
 				Obj(),
 		}

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -124,7 +124,7 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Ordered, ginkgo.ContinueOn
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		})
 		ginkgo.It("Should update status when workloads are created", func() {
-			wl = testing.MakeWorkload("three", ns.Name).Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+			wl = testing.MakeWorkload("three", ns.Name).Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			message = fmt.Sprintf("ClusterQueue %s doesn't exist", "fooclusterqueue")
 			util.MustCreate(ctx, k8sClient, wl)
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
@@ -140,7 +140,7 @@ var _ = ginkgo.Describe("AppWrapper controller", ginkgo.Ordered, ginkgo.Continue
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(""), "The Workload shouldn't have .spec.queueName set")
+			gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(kueue.LocalQueueName("")), "The Workload shouldn't have .spec.queueName set")
 			gomega.Expect(metav1.IsControlledBy(createdWorkload, createdAppWrapper)).To(gomega.BeTrue(), "The Workload should be owned by the AppWrapper")
 
 			ginkgo.By("checking the workload is created with priority and priorityName")
@@ -153,7 +153,7 @@ var _ = ginkgo.Describe("AppWrapper controller", ginkgo.Ordered, ginkgo.Continue
 			gomega.Expect(k8sClient.Update(ctx, createdAppWrapper)).Should(gomega.Succeed())
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-				g.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(awQueueName))
+				g.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(kueue.LocalQueueName(awQueueName)))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("checking a second non-matching workload is deleted")

--- a/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
@@ -144,7 +144,7 @@ var _ = ginkgo.Describe("JobSet controller", ginkgo.Ordered, ginkgo.ContinueOnFa
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(""), "The Workload shouldn't have .spec.queueName set")
+			gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(kueue.LocalQueueName("")), "The Workload shouldn't have .spec.queueName set")
 			gomega.Expect(metav1.IsControlledBy(createdWorkload, createdJobSet)).To(gomega.BeTrue(), "The Workload should be owned by the JobSet")
 
 			ginkgo.By("checking the workload is created with priority and priorityName")
@@ -152,8 +152,8 @@ var _ = ginkgo.Describe("JobSet controller", ginkgo.Ordered, ginkgo.ContinueOnFa
 			gomega.Expect(*createdWorkload.Spec.Priority).Should(gomega.Equal(priorityValue))
 
 			ginkgo.By("checking the workload is updated with queue name when the JobSet does")
-			jobSetQueueName := "test-queue"
-			createdJobSet.Annotations = map[string]string{constants.QueueLabel: jobSetQueueName}
+			var jobSetQueueName kueue.LocalQueueName = "test-queue"
+			createdJobSet.Annotations = map[string]string{constants.QueueLabel: string(jobSetQueueName)}
 			gomega.Expect(k8sClient.Update(ctx, createdJobSet)).Should(gomega.Succeed())
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())

--- a/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
@@ -102,7 +102,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(""), "The Workload shouldn't have .spec.queueName set")
+		gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(kueue.LocalQueueName("")), "The Workload shouldn't have .spec.queueName set")
 		gomega.Expect(metav1.IsControlledBy(createdWorkload, createdJob)).To(gomega.BeTrue(), "The Workload should be owned by the Job")
 
 		ginkgo.By("checking the workload is created with priority and priorityName")
@@ -110,8 +110,8 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 		gomega.Expect(*createdWorkload.Spec.Priority).Should(gomega.Equal(int32(priorityValue)))
 
 		ginkgo.By("checking the workload is updated with queue name when the job does")
-		jobQueueName := "test-queue"
-		createdJob.Annotations = map[string]string{constants.QueueAnnotation: jobQueueName}
+		var jobQueueName kueue.LocalQueueName = "test-queue"
+		createdJob.Annotations = map[string]string{constants.QueueAnnotation: string(jobQueueName)}
 		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -170,7 +170,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(1))
 
-				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"),
+				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName("test-queue")),
 					"The Workload should have .spec.queueName set")
 
 				ginkgo.By("checking that workload has ProvisioningRequest annotations")
@@ -296,7 +296,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 					gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(1))
 
-					gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
+					gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName("test-queue")), "The Workload should have .spec.queueName set")
 
 					ginkgo.By("checking that pod is unsuspended when workload is admitted")
 					clusterQueue := testing.MakeClusterQueue("cluster-queue").
@@ -350,7 +350,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 			ginkgo.When("Pod owner is managed by Kueue", func() {
 				ginkgo.It("Should skip the pod", func() {
-					job := testingjob.MakeJob("parent-job", ns.Name).Queue(lq.Name).Obj()
+					job := testingjob.MakeJob("parent-job", ns.Name).Queue(kueue.LocalQueueName(lq.Name)).Obj()
 					util.MustCreate(ctx, k8sClient, job)
 
 					pod := testingpod.MakePod(podName, ns.Name).Queue(lq.Name).Obj()
@@ -518,7 +518,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				})
 
 				wl := testing.MakeWorkload(workloadName, ns.Name).
-					Queue(lq.Name).
+					Queue(kueue.LocalQueueName(lq.Name)).
 					PodSets(*testing.MakePodSet(kueue.DefaultPodSetName, 1).PodSpec(pod.Spec).Obj()).
 					Obj()
 				wlLookupKey := types.NamespacedName{Name: workloadName, Namespace: ns.Name}
@@ -605,7 +605,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdWorkload.Spec.PodSets[0].Count).To(gomega.Equal(int32(1)))
 				gomega.Expect(createdWorkload.Spec.PodSets[1].Count).To(gomega.Equal(int32(1)))
 
-				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
+				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName("test-queue")), "The Workload should have .spec.queueName set")
 
 				ginkgo.By("checking that all pods in group are unsuspended when workload is admitted", func() {
 					admission := testing.MakeAdmission(clusterQueue.Name).PodSets(
@@ -679,7 +679,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(1))
 				gomega.Expect(createdWorkload.Spec.PodSets[0].Count).To(gomega.Equal(int32(2)))
 
-				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
+				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName("test-queue")), "The Workload should have .spec.queueName set")
 
 				ginkgo.By("checking that all pods in group are unsuspended when workload is admitted", func() {
 					admission := testing.MakeAdmission(clusterQueue.Name).PodSets(
@@ -755,7 +755,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(1))
 				gomega.Expect(createdWorkload.Spec.PodSets[0].Count).To(gomega.Equal(int32(2)))
-				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
+				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName("test-queue")), "The Workload should have .spec.queueName set")
 				originalWorkloadUID := createdWorkload.UID
 
 				admission := testing.MakeAdmission(clusterQueue.Name, "bf90803c").
@@ -905,7 +905,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(1))
 				gomega.Expect(createdWorkload.Spec.PodSets[0].Count).To(gomega.Equal(int32(1)))
-				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
+				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName("test-queue")), "The Workload should have .spec.queueName set")
 
 				ginkgo.By("checking that pod is unsuspended when workload is admitted")
 				admission := testing.MakeAdmission(clusterQueue.Name, "bf90803c").
@@ -1055,7 +1055,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(2))
 				gomega.Expect(createdWorkload.Spec.PodSets[0].Count).To(gomega.Equal(int32(1)))
 				gomega.Expect(createdWorkload.Spec.PodSets[1].Count).To(gomega.Equal(int32(1)))
-				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
+				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName("test-queue")), "The Workload should have .spec.queueName set")
 
 				createdPod := &corev1.Pod{}
 				ginkgo.By("checking that all pods in group are unsuspended when workload is admitted", func() {
@@ -1174,7 +1174,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(2))
 				gomega.Expect(createdWorkload.Spec.PodSets[0].Count).To(gomega.Equal(int32(1)))
 				gomega.Expect(createdWorkload.Spec.PodSets[1].Count).To(gomega.Equal(int32(1)))
-				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
+				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName("test-queue")), "The Workload should have .spec.queueName set")
 
 				ginkgo.By("checking that excess pod is deleted before admission", func() {
 					excessPod := excessBasePod.Clone().Obj()
@@ -1314,7 +1314,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(2))
 				gomega.Expect(createdWorkload.Spec.PodSets[0].Count).To(gomega.Equal(int32(1)))
 				gomega.Expect(createdWorkload.Spec.PodSets[1].Count).To(gomega.Equal(int32(1)))
-				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal("test-queue"), "The Workload should have .spec.queueName set")
+				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName("test-queue")), "The Workload should have .spec.queueName set")
 				gomega.Expect(createdWorkload.ObjectMeta.Finalizers).To(gomega.ContainElement("kueue.x-k8s.io/resource-in-use"),
 					"The Workload should have the finalizer")
 
@@ -1587,7 +1587,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				})
 
 				wl := testing.MakeWorkload(workloadName, ns.Name).
-					Queue(lq.Name).
+					Queue(kueue.LocalQueueName(lq.Name)).
 					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
 					PodSets(
 						*testing.MakePodSet("leader", 1).PodSpec(pod1.Spec).Obj(),

--- a/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
@@ -97,7 +97,7 @@ var _ = ginkgo.Describe("RayCluster controller", ginkgo.Ordered, ginkgo.Continue
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(""), "The Workload shouldn't have .spec.queueName set")
+		gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(kueue.LocalQueueName("")), "The Workload shouldn't have .spec.queueName set")
 		gomega.Expect(metav1.IsControlledBy(createdWorkload, createdJob)).To(gomega.BeTrue(), "The Workload should be owned by the Job")
 
 		ginkgo.By("checking the workload is created with priority and priorityName")
@@ -105,8 +105,8 @@ var _ = ginkgo.Describe("RayCluster controller", ginkgo.Ordered, ginkgo.Continue
 		gomega.Expect(*createdWorkload.Spec.Priority).Should(gomega.Equal(priorityValue))
 
 		ginkgo.By("checking the workload is updated with queue name when the job does")
-		jobQueueName := "test-queue"
-		createdJob.Annotations = map[string]string{constants.QueueAnnotation: jobQueueName}
+		var jobQueueName kueue.LocalQueueName = "test-queue"
+		createdJob.Annotations = map[string]string{constants.QueueAnnotation: string(jobQueueName)}
 		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -108,7 +108,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(""), "The Workload shouldn't have .spec.queueName set")
+		gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(kueue.LocalQueueName("")), "The Workload shouldn't have .spec.queueName set")
 		gomega.Expect(metav1.IsControlledBy(createdWorkload, createdJob)).To(gomega.BeTrue(), "The Workload should be owned by the Job")
 
 		ginkgo.By("checking the workload is created with priority and priorityName")
@@ -116,8 +116,8 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 		gomega.Expect(*createdWorkload.Spec.Priority).Should(gomega.Equal(priorityValue))
 
 		ginkgo.By("checking the workload is updated with queue name when the job does")
-		jobQueueName := "test-queue"
-		createdJob.Annotations = map[string]string{constants.QueueAnnotation: jobQueueName}
+		var jobQueueName kueue.LocalQueueName = "test-queue"
+		createdJob.Annotations = map[string]string{constants.QueueAnnotation: string(jobQueueName)}
 		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -60,7 +60,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		return cq
 	}
 
-	var createWorkloadWithPriority = func(queue string, cpuRequests string, priority int32) *kueue.Workload {
+	var createWorkloadWithPriority = func(queue kueue.LocalQueueName, cpuRequests string, priority int32) *kueue.Workload {
 		wl := testing.MakeWorkloadWithGeneratedName("workload-", ns.Name).
 			Priority(priority).
 			Queue(queue).
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		return wl
 	}
 
-	var createWorkload = func(queue string, cpuRequests string) *kueue.Workload {
+	var createWorkload = func(queue kueue.LocalQueueName, cpuRequests string) *kueue.Workload {
 		return createWorkloadWithPriority(queue, cpuRequests, 0)
 	}
 
@@ -357,8 +357,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("all capacity used")
 			for range 6 {
-				createWorkloadWithPriority(bestEffortQueue.GetName(), "1", -1)
-				createWorkloadWithPriority(physicsQueue.GetName(), "1", -1)
+				createWorkloadWithPriority(kueue.LocalQueueName(bestEffortQueue.GetName()), "1", -1)
+				createWorkloadWithPriority(kueue.LocalQueueName(physicsQueue.GetName()), "1", -1)
 			}
 			expectCohortWeightedShare("best-effort", 1000)
 			expectCohortWeightedShare("physics", 500)
@@ -368,7 +368,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("create high priority workloads")
 			for range 6 {
 				for _, cq := range cqs {
-					createWorkloadWithPriority(cq.GetName(), "1", 100)
+					createWorkloadWithPriority(kueue.LocalQueueName(cq.GetName()), "1", 100)
 				}
 			}
 

--- a/test/integration/singlecluster/scheduler/podsready/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/podsready/scheduler_test.go
@@ -128,9 +128,9 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 
 		ginkgo.It("Should unblock admission of new workloads in other ClusterQueues once the admitted workload exceeds timeout", func() {
 			ginkgo.By("checking the first prod workload gets admitted while the second is waiting")
-			prodWl := testing.MakeWorkload("prod-wl", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+			prodWl := testing.MakeWorkload("prod-wl", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl)
-			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(devQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, devWl)
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, prodWl)
 			util.ExpectWorkloadsToBeWaiting(ctx, k8sClient, devWl)
@@ -150,9 +150,9 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 
 		ginkgo.It("Should unblock admission of new workloads in other ClusterQueues once the admitted workload exceeds timeout", func() {
 			ginkgo.By("checking the first prod workload gets admitted while the second is waiting")
-			prodWl := testing.MakeWorkload("prod-wl", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+			prodWl := testing.MakeWorkload("prod-wl", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl)
-			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(devQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, devWl)
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, prodWl)
 			util.ExpectWorkloadsToBeWaiting(ctx, k8sClient, devWl)
@@ -172,11 +172,11 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 
 		ginkgo.It("Should unblock admission of new workloads once the admitted workload is deleted", func() {
 			ginkgo.By("checking the first prod workload gets admitted while the second is waiting")
-			prodWl := testing.MakeWorkload("prod-wl", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+			prodWl := testing.MakeWorkload("prod-wl", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl)
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, prodWl)
 
-			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(devQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, devWl)
 			util.ExpectWorkloadsToBeWaiting(ctx, k8sClient, devWl)
 
@@ -187,9 +187,9 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 
 		ginkgo.It("Should block admission of one new workload if two are considered in the same scheduling cycle", framework.SlowSpec, func() {
 			ginkgo.By("creating two workloads but delaying cluster queue creation which has enough capacity")
-			prodWl := testing.MakeWorkload("prod-wl", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "11").Obj()
+			prodWl := testing.MakeWorkload("prod-wl", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "11").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl)
-			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(devQueue.Name).Request(corev1.ResourceCPU, "11").Obj()
+			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "11").Obj()
 			util.WaitForNextSecondAfterCreation(prodWl)
 			util.MustCreate(ctx, k8sClient, devWl)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, prodWl, devWl)
@@ -224,11 +224,11 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			const lowPrio, highPrio = 0, 100
 
 			ginkgo.By("create the 'prod1' workload")
-			prodWl1 := testing.MakeWorkload("prod1", ns.Name).Queue(prodQueue.Name).Priority(highPrio).Request(corev1.ResourceCPU, "2").Obj()
+			prodWl1 := testing.MakeWorkload("prod1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Priority(highPrio).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl1)
 
 			ginkgo.By("create the 'prod2' workload")
-			prodWl2 := testing.MakeWorkload("prod2", ns.Name).Queue(prodQueue.Name).Priority(lowPrio).Request(corev1.ResourceCPU, "2").Obj()
+			prodWl2 := testing.MakeWorkload("prod2", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Priority(lowPrio).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl2)
 
 			ginkgo.By("checking the 'prod1' workload is admitted and the 'prod2' workload is waiting")
@@ -263,7 +263,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 
 		ginkgo.It("Should re-admit a timed out workload and deactivate a workload exceeded the re-queue count limit. After that re-activating a workload", framework.SlowSpec, func() {
 			ginkgo.By("create the 'prod' workload")
-			prodWl := testing.MakeWorkload("prod", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+			prodWl := testing.MakeWorkload("prod", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl)
 
 			ginkgo.By("checking the 'prod' workload is admitted")
@@ -335,10 +335,10 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 
 		ginkgo.It("Should unblock admission of new workloads in other ClusterQueues once the admitted workload exceeds timeout", func() {
 			ginkgo.By("create the 'prod' workload")
-			prodWl := testing.MakeWorkload("prod", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+			prodWl := testing.MakeWorkload("prod", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl)
 			util.WaitForNextSecondAfterCreation(prodWl)
-			devWl := testing.MakeWorkload("dev", ns.Name).Queue(devQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+			devWl := testing.MakeWorkload("dev", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, devWl)
 
 			ginkgo.By("wait for the 'prod' workload to be admitted and the 'dev' to be waiting")
@@ -429,9 +429,9 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 
 		// the workloads are created with a 5 cpu resource requirement to ensure only one can fit at a given time,
 		// letting them all to time out, we should see a circular buffer admission pattern
-		wl1 := testing.MakeWorkload("prod1", ns.Name).Queue(localQueueName).Request(corev1.ResourceCPU, "5").Obj()
-		wl2 := testing.MakeWorkload("prod2", ns.Name).Queue(localQueueName).Request(corev1.ResourceCPU, "5").Obj()
-		wl3 := testing.MakeWorkload("prod3", ns.Name).Queue(localQueueName).Request(corev1.ResourceCPU, "5").Obj()
+		wl1 := testing.MakeWorkload("prod1", ns.Name).Queue(kueue.LocalQueueName(localQueueName)).Request(corev1.ResourceCPU, "5").Obj()
+		wl2 := testing.MakeWorkload("prod2", ns.Name).Queue(kueue.LocalQueueName(localQueueName)).Request(corev1.ResourceCPU, "5").Obj()
+		wl3 := testing.MakeWorkload("prod3", ns.Name).Queue(kueue.LocalQueueName(localQueueName)).Request(corev1.ResourceCPU, "5").Obj()
 
 		ginkgo.By("create the workloads", func() {
 			util.MustCreate(ctx, k8sClient, wl1)
@@ -514,9 +514,9 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 
 		ginkgo.It("Should prioritize workloads submitted earlier", framework.SlowSpec, func() {
 			// the workloads are created with a 1 cpu resource requirement to ensure only one can fit at a given time
-			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(standaloneQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
-			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(standaloneQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
-			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(standaloneQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(kueue.LocalQueueName(standaloneQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
+			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(kueue.LocalQueueName(standaloneQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
+			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(kueue.LocalQueueName(standaloneQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 
 			ginkgo.By("create the workloads", func() {
 				util.MustCreate(ctx, k8sClient, wl1)
@@ -630,9 +630,9 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 
 		ginkgo.It("Should not block admission of one new workload if two are considered in the same scheduling cycle", func() {
 			ginkgo.By("creating two workloads but delaying cluster queue creation which has enough capacity")
-			prodWl := testing.MakeWorkload("prod-wl", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "11").Obj()
+			prodWl := testing.MakeWorkload("prod-wl", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "11").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl)
-			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(devQueue.Name).Request(corev1.ResourceCPU, "11").Obj()
+			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "11").Obj()
 			util.MustCreate(ctx, k8sClient, devWl)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, prodWl, devWl)
 
@@ -661,7 +661,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 
 		ginkgo.It("Should re-admit a timed out workload", func() {
 			ginkgo.By("create the 'prod' workload")
-			prodWl := testing.MakeWorkload("prod", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+			prodWl := testing.MakeWorkload("prod", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl)
 			ginkgo.By("checking the 'prod' workload is admitted")
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodClusterQ.Name, prodWl)
@@ -716,9 +716,9 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 
 		ginkgo.It("Should keep the evicted workload at the front of the queue", framework.SlowSpec, func() {
 			// the workloads are created with a 1 cpu resource requirement to ensure only one can fit at a given time
-			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(standaloneQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
-			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(standaloneQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
-			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(standaloneQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(kueue.LocalQueueName(standaloneQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
+			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(kueue.LocalQueueName(standaloneQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
+			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(kueue.LocalQueueName(standaloneQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 
 			ginkgo.By("create the workloads", func() {
 				util.MustCreate(ctx, k8sClient, wl1)

--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -88,22 +88,22 @@ var _ = ginkgo.Describe("Preemption", func() {
 		ginkgo.It("Should preempt Workloads with lower priority when there is not enough quota", func() {
 			ginkgo.By("Creating initial Workloads with different priorities")
 			lowWl1 := testing.MakeWorkload("low-wl-1", ns.Name).
-				Queue(q.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
 				Priority(lowPriority).
 				Request(corev1.ResourceCPU, "1").
 				Obj()
 			lowWl2 := testing.MakeWorkload("low-wl-2", ns.Name).
-				Queue(q.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
 				Priority(lowPriority).
 				Request(corev1.ResourceCPU, "1").
 				Obj()
 			midWl := testing.MakeWorkload("mid-wl", ns.Name).
-				Queue(q.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
 				Priority(midPriority).
 				Request(corev1.ResourceCPU, "1").
 				Obj()
 			highWl1 := testing.MakeWorkload("high-wl-1", ns.Name).
-				Queue(q.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
 				Priority(highPriority).
 				Request(corev1.ResourceCPU, "1").
 				Obj()
@@ -116,7 +116,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Creating a low priority Workload")
 			lowWl3 := testing.MakeWorkload("low-wl-3", ns.Name).
-				Queue(q.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
 				Priority(lowPriority).
 				Request(corev1.ResourceCPU, "1").
 				Obj()
@@ -126,7 +126,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Creating a high priority Workload")
 			highWl2 := testing.MakeWorkload("high-wl-2", ns.Name).
-				Queue(q.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
 				Priority(highPriority).
 				Request(corev1.ResourceCPU, "2").
 				Obj()
@@ -143,17 +143,17 @@ var _ = ginkgo.Describe("Preemption", func() {
 		ginkgo.It("Should preempt newer Workloads with the same priority when there is not enough quota", func() {
 			ginkgo.By("Creating initial Workloads")
 			wl1 := testing.MakeWorkload("wl-1", ns.Name).
-				Queue(q.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
 				Priority(lowPriority).
 				Request(corev1.ResourceCPU, "1").
 				Obj()
 			wl2 := testing.MakeWorkload("wl-2", ns.Name).
-				Queue(q.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
 				Priority(lowPriority).
 				Request(corev1.ResourceCPU, "1").
 				Obj()
 			wl3 := testing.MakeWorkload("wl-3", ns.Name).
-				Queue(q.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
 				Priority(lowPriority).
 				Request(corev1.ResourceCPU, "3").
 				Obj()
@@ -166,7 +166,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 			util.WaitForNextSecondAfterCreation(wl3)
 			ginkgo.By("Creating a new Workload")
 			wl4 := testing.MakeWorkload("wl-4", ns.Name).
-				Queue(q.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
 				Priority(lowPriority).
 				Request(corev1.ResourceCPU, "1").
 				Obj()
@@ -188,7 +188,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 		ginkgo.It("Should include job UID in preemption condition when the label is set", func() {
 			ginkgo.By("Creating a low priority Workload")
 			lowWl := testing.MakeWorkload("low", ns.Name).
-				Queue(q.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
 				Priority(lowPriority).
 				Request(corev1.ResourceCPU, "4").
 				Obj()
@@ -199,7 +199,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 			ginkgo.By("Creating a high priority Workload with JobUID label")
 			highWl := testing.MakeWorkload("high", ns.Name).
 				Label(constants.JobUIDLabel, "job-uid").
-				Queue(q.Name).
+				Queue(kueue.LocalQueueName(q.Name)).
 				Priority(highPriority).
 				Request(corev1.ResourceCPU, "4").
 				Obj()
@@ -260,20 +260,20 @@ var _ = ginkgo.Describe("Preemption", func() {
 			ginkgo.By("Creating workloads in beta-cq that borrow quota")
 
 			alphaLowWl := testing.MakeWorkload("alpha-low", ns.Name).
-				Queue(alphaLQ.Name).
+				Queue(kueue.LocalQueueName(alphaLQ.Name)).
 				Priority(lowPriority).
 				Request(corev1.ResourceCPU, "1").
 				Obj()
 			util.MustCreate(ctx, k8sClient, alphaLowWl)
 
 			betaMidWl := testing.MakeWorkload("beta-mid", ns.Name).
-				Queue(betaLQ.Name).
+				Queue(kueue.LocalQueueName(betaLQ.Name)).
 				Priority(midPriority).
 				Request(corev1.ResourceCPU, "1").
 				Obj()
 			util.MustCreate(ctx, k8sClient, betaMidWl)
 			betaHighWl := testing.MakeWorkload("beta-high", ns.Name).
-				Queue(betaLQ.Name).
+				Queue(kueue.LocalQueueName(betaLQ.Name)).
 				Priority(highPriority).
 				Request(corev1.ResourceCPU, "4").
 				Obj()
@@ -284,7 +284,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Creating workload in alpha-cq to preempt workloads in both ClusterQueues")
 			alphaMidWl := testing.MakeWorkload("alpha-mid", ns.Name).
-				Queue(alphaLQ.Name).
+				Queue(kueue.LocalQueueName(alphaLQ.Name)).
 				Priority(midPriority).
 				Request(corev1.ResourceCPU, "2").
 				Obj()
@@ -337,13 +337,13 @@ var _ = ginkgo.Describe("Preemption", func() {
 			ginkgo.By("Creating workloads in beta-cq that borrow quota")
 
 			alphaHighWl1 := testing.MakeWorkload("alpha-high-1", ns.Name).
-				Queue(alphaLQ.Name).
+				Queue(kueue.LocalQueueName(alphaLQ.Name)).
 				Priority(highPriority).
 				Request(corev1.ResourceCPU, "2").
 				Obj()
 			util.MustCreate(ctx, k8sClient, alphaHighWl1)
 			betaLowWl := testing.MakeWorkload("beta-low", ns.Name).
-				Queue(betaLQ.Name).
+				Queue(kueue.LocalQueueName(betaLQ.Name)).
 				Priority(lowPriority).
 				Request(corev1.ResourceCPU, "4").
 				Obj()
@@ -354,7 +354,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Creating high priority workload in alpha-cq that doesn't fit without borrowing")
 			alphaHighWl2 := testing.MakeWorkload("alpha-high-2", ns.Name).
-				Queue(alphaLQ.Name).
+				Queue(kueue.LocalQueueName(alphaLQ.Name)).
 				Priority(highPriority).
 				Request(corev1.ResourceCPU, "2").
 				Obj()
@@ -370,13 +370,13 @@ var _ = ginkgo.Describe("Preemption", func() {
 			ginkgo.By("Creating workloads in beta-cq that borrow quota")
 
 			betaMidWl := testing.MakeWorkload("beta-mid", ns.Name).
-				Queue(betaLQ.Name).
+				Queue(kueue.LocalQueueName(betaLQ.Name)).
 				Priority(midPriority).
 				Request(corev1.ResourceCPU, "3").
 				Obj()
 			util.MustCreate(ctx, k8sClient, betaMidWl)
 			betaHighWl := testing.MakeWorkload("beta-high", ns.Name).
-				Queue(betaLQ.Name).
+				Queue(kueue.LocalQueueName(betaLQ.Name)).
 				Priority(highPriority).
 				Request(corev1.ResourceCPU, "3").
 				Obj()
@@ -386,13 +386,13 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Creating workload in alpha-cq and gamma-cq that need to preempt")
 			alphaMidWl := testing.MakeWorkload("alpha-mid", ns.Name).
-				Queue(alphaLQ.Name).
+				Queue(kueue.LocalQueueName(alphaLQ.Name)).
 				Priority(midPriority).
 				Request(corev1.ResourceCPU, "2").
 				Obj()
 
 			gammaMidWl := testing.MakeWorkload("gamma-mid", ns.Name).
-				Queue(gammaLQ.Name).
+				Queue(kueue.LocalQueueName(gammaLQ.Name)).
 				Priority(midPriority).
 				Request(corev1.ResourceCPU, "2").
 				Obj()
@@ -421,7 +421,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 			var betaWls []*kueue.Workload
 			for i := 0; i < 3; i++ {
 				wl := testing.MakeWorkload(fmt.Sprintf("beta-%d", i), ns.Name).
-					Queue(betaLQ.Name).
+					Queue(kueue.LocalQueueName(betaLQ.Name)).
 					Request(corev1.ResourceCPU, "2").
 					Obj()
 				util.MustCreate(ctx, k8sClient, wl)
@@ -432,13 +432,13 @@ var _ = ginkgo.Describe("Preemption", func() {
 			ginkgo.By("Creating preempting pods")
 
 			alphaWl := testing.MakeWorkload("alpha", ns.Name).
-				Queue(alphaLQ.Name).
+				Queue(kueue.LocalQueueName(alphaLQ.Name)).
 				Request(corev1.ResourceCPU, "2").
 				Obj()
 			util.MustCreate(ctx, k8sClient, alphaWl)
 
 			gammaWl := testing.MakeWorkload("gamma", ns.Name).
-				Queue(gammaLQ.Name).
+				Queue(kueue.LocalQueueName(gammaLQ.Name)).
 				Request(corev1.ResourceCPU, "2").
 				Obj()
 			util.MustCreate(ctx, k8sClient, gammaWl)
@@ -664,7 +664,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 		ginkgo.It("should allow preempting workloads while borrowing", func() {
 			ginkgo.By("Create a low priority workload which requires borrowing")
 			aBestEffortLowWl := testing.MakeWorkload("a-best-effort-low", ns.Name).
-				Queue(aBestEffortLQ.Name).
+				Queue(kueue.LocalQueueName(aBestEffortLQ.Name)).
 				Priority(lowPriority).
 				Request(corev1.ResourceCPU, "5").
 				Obj()
@@ -677,7 +677,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Create a low priority workload which is not borrowing")
 			bBestEffortLowWl := testing.MakeWorkload("b-best-effort-low", ns.Name).
-				Queue(bBestEffortLQ.Name).
+				Queue(kueue.LocalQueueName(bBestEffortLQ.Name)).
 				Priority(lowPriority).
 				Request(corev1.ResourceCPU, "1").
 				Obj()
@@ -690,7 +690,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Create a high priority workload (above MaxPriorityThreshold) which requires borrowing")
 			bStandardWl := testing.MakeWorkload("b-standard-high", ns.Name).
-				Queue(bStandardLQ.Name).
+				Queue(kueue.LocalQueueName(bStandardLQ.Name)).
 				Priority(highPriority).
 				Request(corev1.ResourceCPU, "5").
 				Obj()
@@ -703,7 +703,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Create the a-standard-very-high workload")
 			aStandardVeryHighWl := testing.MakeWorkload("a-standard-very-high", ns.Name).
-				Queue(aStandardLQ.Name).
+				Queue(kueue.LocalQueueName(aStandardLQ.Name)).
 				Priority(veryHighPriority).
 				Request(corev1.ResourceCPU, "7").
 				Obj()
@@ -777,14 +777,14 @@ var _ = ginkgo.Describe("Preemption", func() {
 			util.MustCreate(ctx, k8sClient, devQueue)
 
 			ginkgo.By("Creating two workloads")
-			wl1 := testing.MakeWorkload("wl-1", ns.Name).Priority(0).Queue(devQueue.Name).Request(corev1.ResourceCPU, "4").Obj()
-			wl2 := testing.MakeWorkload("wl-2", ns.Name).Priority(1).Queue(devQueue.Name).Request(corev1.ResourceCPU, "5").Obj()
+			wl1 := testing.MakeWorkload("wl-1", ns.Name).Priority(0).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "4").Obj()
+			wl2 := testing.MakeWorkload("wl-2", ns.Name).Priority(1).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 			util.MustCreate(ctx, k8sClient, wl2)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
 
 			ginkgo.By("Creating another workload")
-			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "4").Obj()
+			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "4").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
 			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, wl1)
 
@@ -877,7 +877,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Create a mid priority workload in aCQ and await for admission", func() {
 				aWl = testing.MakeWorkload("a-low", ns.Name).
-					Queue(aLQ.Name).
+					Queue(kueue.LocalQueueName(aLQ.Name)).
 					Priority(midPriority).
 					Request(corev1.ResourceCPU, "4").
 					Obj()
@@ -887,7 +887,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Create a high priority workload b1 in bCQ and await for admission", func() {
 				b1Wl = testing.MakeWorkload("b1-high", ns.Name).
-					Queue(bLQ.Name).
+					Queue(kueue.LocalQueueName(bLQ.Name)).
 					Priority(highPriority).
 					Request(corev1.ResourceCPU, "4").
 					Obj()
@@ -897,7 +897,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Create a high priority workload b2 in bCQ", func() {
 				b2Wl = testing.MakeWorkload("b2-high", ns.Name).
-					Queue(bLQ.Name).
+					Queue(kueue.LocalQueueName(bLQ.Name)).
 					Priority(highPriority).
 					Request(corev1.ResourceCPU, "4").
 					Obj()
@@ -963,7 +963,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Create a workload in bestEffortCQ and await for admission", func() {
 				bestEffortWl = testing.MakeWorkload("best-effort-wl", ns.Name).
-					Queue(bestEffortLQ.Name).
+					Queue(kueue.LocalQueueName(bestEffortLQ.Name)).
 					Priority(highPriority).
 					Request(corev1.ResourceCPU, "3").
 					Obj()
@@ -973,7 +973,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Create a workload in guaranteedCQ", func() {
 				guaranteedWl = testing.MakeWorkload("guaranteed-wl", ns.Name).
-					Queue(guaranteedLQ.Name).
+					Queue(kueue.LocalQueueName(guaranteedLQ.Name)).
 					Priority(midPriority).
 					Request(corev1.ResourceCPU, "3").
 					Obj()

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -226,7 +226,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.It("Should admit workloads as they fit in their ClusterQueue", framework.SlowSpec, func() {
 			ginkgo.By("checking the first prod workload gets admitted")
-			prodWl1 := testing.MakeWorkload("prod-wl1", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+			prodWl1 := testing.MakeWorkload("prod-wl1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl1)
 			prodWl1Admission := testing.MakeAdmission(prodClusterQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "2").Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, prodWl1, prodWl1Admission)
@@ -236,14 +236,14 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 1)
 
 			ginkgo.By("checking a second no-fit workload does not get admitted")
-			prodWl2 := testing.MakeWorkload("prod-wl2", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "5").Obj()
+			prodWl2 := testing.MakeWorkload("prod-wl2", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl2)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, prodWl2)
 			util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 1)
 
 			ginkgo.By("checking a workload with replica count 0 gets admitted")
 			emptyWl := testing.MakeWorkload("empty-wl", ns.Name).
-				Queue(prodQueue.Name).
+				Queue(kueue.LocalQueueName(prodQueue.Name)).
 				PodSets(*testing.MakePodSet(kueue.DefaultPodSetName, 0).
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
@@ -276,7 +276,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			})
 
 			ginkgo.By("checking a dev workload gets admitted")
-			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(devQueue.Name).Request(corev1.ResourceCPU, "5").Obj()
+			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 			util.MustCreate(ctx, k8sClient, devWl)
 			spotUntaintedFlavorAdmission := testing.MakeAdmission(devClusterQ.Name).Assignment(corev1.ResourceCPU, "spot-untainted", "5").Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, devWl, spotUntaintedFlavorAdmission)
@@ -297,7 +297,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.It("Should admit workloads as number of pods allows it", func() {
 			wl1 := testing.MakeWorkload("wl1", ns.Name).
-				Queue(podsCountQueue.Name).
+				Queue(kueue.LocalQueueName(podsCountQueue.Name)).
 				PodSets(*testing.MakePodSet(kueue.DefaultPodSetName, 3).
 					Request(corev1.ResourceCPU, "2").
 					Obj()).
@@ -318,14 +318,14 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			})
 
 			wl2 := testing.MakeWorkload("wl2", ns.Name).
-				Queue(podsCountQueue.Name).
+				Queue(kueue.LocalQueueName(podsCountQueue.Name)).
 				PodSets(*testing.MakePodSet(kueue.DefaultPodSetName, 3).
 					Request(corev1.ResourceCPU, "2").
 					Obj()).
 				Obj()
 
 			wl3 := testing.MakeWorkload("wl3", ns.Name).
-				Queue(podsCountQueue.Name).
+				Queue(kueue.LocalQueueName(podsCountQueue.Name)).
 				PodSets(*testing.MakePodSet(kueue.DefaultPodSetName, 2).
 					Request(corev1.ResourceCPU, "2").
 					Obj()).
@@ -360,7 +360,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.It("Should admit workloads as the number of pods (only) allows it", func() {
 			wl1 := testing.MakeWorkload("wl1", ns.Name).
-				Queue(podsCountOnlyQueue.Name).
+				Queue(kueue.LocalQueueName(podsCountOnlyQueue.Name)).
 				PodSets(*testing.MakePodSet(kueue.DefaultPodSetName, 3).
 					Obj()).
 				Obj()
@@ -379,13 +379,13 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			})
 
 			wl2 := testing.MakeWorkload("wl2", ns.Name).
-				Queue(podsCountOnlyQueue.Name).
+				Queue(kueue.LocalQueueName(podsCountOnlyQueue.Name)).
 				PodSets(*testing.MakePodSet(kueue.DefaultPodSetName, 3).
 					Obj()).
 				Obj()
 
 			wl3 := testing.MakeWorkload("wl3", ns.Name).
-				Queue(podsCountOnlyQueue.Name).
+				Queue(kueue.LocalQueueName(podsCountOnlyQueue.Name)).
 				PodSets(*testing.MakePodSet(kueue.DefaultPodSetName, 2).
 					Obj()).
 				Obj()
@@ -418,7 +418,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		})
 
 		ginkgo.It("Should admit workloads when resources are dynamically reclaimed", func() {
-			firstWl := testing.MakeWorkload("first-wl", ns.Name).Queue(preemptionQueue.Name).
+			firstWl := testing.MakeWorkload("first-wl", ns.Name).Queue(kueue.LocalQueueName(preemptionQueue.Name)).
 				PodSets(
 					*testing.MakePodSet("first", 1).Request(corev1.ResourceCPU, "1").Obj(),
 					*testing.MakePodSet("second", 1).Request(corev1.ResourceCPU, "1").Obj(),
@@ -440,7 +440,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.ExpectReservingActiveWorkloadsMetric(preemptionClusterQ, 1)
 			})
 
-			secondWl := testing.MakeWorkload("second-wl", ns.Name).Queue(preemptionQueue.Name).
+			secondWl := testing.MakeWorkload("second-wl", ns.Name).Queue(kueue.LocalQueueName(preemptionQueue.Name)).
 				PodSets(
 					*testing.MakePodSet("first", 1).Request(corev1.ResourceCPU, "1").Obj(),
 					*testing.MakePodSet("second", 1).Request(corev1.ResourceCPU, "1").Obj(),
@@ -468,7 +468,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.It("Should admit workloads with admission checks", func() {
 			wl1 := testing.MakeWorkload("admission-check-wl1", ns.Name).
-				Queue(admissionCheckQueue.Name).
+				Queue(kueue.LocalQueueName(admissionCheckQueue.Name)).
 				Request(corev1.ResourceCPU, "2").
 				Obj()
 
@@ -492,15 +492,15 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.It("Should admit workloads according to their priorities", func() {
 				const lowPrio, midPrio, highPrio = 0, 10, 100
 
-				wlLow := testing.MakeWorkload("wl-low-priority", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Priority(lowPrio).Obj()
+				wlLow := testing.MakeWorkload("wl-low-priority", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(lowPrio).Obj()
 				util.MustCreate(ctx, k8sClient, wlLow)
-				wlMid1 := testing.MakeWorkload("wl-mid-priority-1", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Priority(midPrio).Obj()
+				wlMid1 := testing.MakeWorkload("wl-mid-priority-1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(midPrio).Obj()
 				util.MustCreate(ctx, k8sClient, wlMid1)
-				wlMid2 := testing.MakeWorkload("wl-mid-priority-2", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Priority(midPrio).Obj()
+				wlMid2 := testing.MakeWorkload("wl-mid-priority-2", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(midPrio).Obj()
 				util.MustCreate(ctx, k8sClient, wlMid2)
-				wlHigh1 := testing.MakeWorkload("wl-high-priority-1", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Priority(highPrio).Obj()
+				wlHigh1 := testing.MakeWorkload("wl-high-priority-1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(highPrio).Obj()
 				util.MustCreate(ctx, k8sClient, wlHigh1)
-				wlHigh2 := testing.MakeWorkload("wl-high-priority-2", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Priority(highPrio).Obj()
+				wlHigh2 := testing.MakeWorkload("wl-high-priority-2", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(highPrio).Obj()
 				util.MustCreate(ctx, k8sClient, wlHigh2)
 
 				util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 5)
@@ -540,15 +540,15 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.It("Should admit workloads according to their priorities", func() {
 				const lowPrio, midPrio, highPrio = 0, 10, 100
 
-				wlLow := testing.MakeWorkload("wl-low-priority", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Priority(lowPrio).Obj()
+				wlLow := testing.MakeWorkload("wl-low-priority", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(lowPrio).Obj()
 				util.MustCreate(ctx, k8sClient, wlLow)
-				wlMid1 := testing.MakeWorkload("wl-mid-priority-1", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Priority(midPrio).Obj()
+				wlMid1 := testing.MakeWorkload("wl-mid-priority-1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(midPrio).Obj()
 				util.MustCreate(ctx, k8sClient, wlMid1)
-				wlMid2 := testing.MakeWorkload("wl-mid-priority-2", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Priority(midPrio).Obj()
+				wlMid2 := testing.MakeWorkload("wl-mid-priority-2", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(midPrio).Obj()
 				util.MustCreate(ctx, k8sClient, wlMid2)
-				wlHigh1 := testing.MakeWorkload("wl-high-priority-1", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Priority(highPrio).Obj()
+				wlHigh1 := testing.MakeWorkload("wl-high-priority-1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(highPrio).Obj()
 				util.MustCreate(ctx, k8sClient, wlHigh1)
-				wlHigh2 := testing.MakeWorkload("wl-high-priority-2", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Priority(highPrio).Obj()
+				wlHigh2 := testing.MakeWorkload("wl-high-priority-2", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(highPrio).Obj()
 				util.MustCreate(ctx, k8sClient, wlHigh2)
 
 				util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
@@ -579,7 +579,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		})
 
 		ginkgo.It("Should admit two small workloads after a big one finishes", func() {
-			bigWl := testing.MakeWorkload("big-wl", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "5").Obj()
+			bigWl := testing.MakeWorkload("big-wl", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 			ginkgo.By("Creating big workload")
 			util.MustCreate(ctx, k8sClient, bigWl)
 
@@ -589,8 +589,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectQuotaReservedWorkloadsTotalMetric(prodClusterQ, 1)
 			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 1)
 
-			smallWl1 := testing.MakeWorkload("small-wl-1", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2.5").Obj()
-			smallWl2 := testing.MakeWorkload("small-wl-2", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2.5").Obj()
+			smallWl1 := testing.MakeWorkload("small-wl-1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2.5").Obj()
+			smallWl2 := testing.MakeWorkload("small-wl-2", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2.5").Obj()
 			ginkgo.By("Creating two small workloads")
 			util.MustCreate(ctx, k8sClient, smallWl1)
 			util.MustCreate(ctx, k8sClient, smallWl2)
@@ -610,7 +610,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		})
 
 		ginkgo.It("Reclaimed resources are not accounted during admission", func() {
-			wl := testing.MakeWorkload("first-wl", ns.Name).Queue(prodQueue.Name).
+			wl := testing.MakeWorkload("first-wl", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).
 				PodSets(*testing.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "3").Obj()).
 				Obj()
 			ginkgo.By("Creating the workload", func() {
@@ -664,7 +664,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.It("Should re-enqueue by the delete event of workload belonging to the same ClusterQueue", func() {
 			ginkgo.By("First big workload starts")
-			wl1 := testing.MakeWorkload("on-demand-wl1", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "4").Obj()
+			wl1 := testing.MakeWorkload("on-demand-wl1", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "4").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 			expectWl1Admission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "4").Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectWl1Admission)
@@ -674,7 +674,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 
 			ginkgo.By("Second big workload is pending")
-			wl2 := testing.MakeWorkload("on-demand-wl2", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "4").Obj()
+			wl2 := testing.MakeWorkload("on-demand-wl2", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "4").Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
@@ -683,7 +683,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 
 			ginkgo.By("Third small workload starts")
-			wl3 := testing.MakeWorkload("on-demand-wl3", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "1").Obj()
+			wl3 := testing.MakeWorkload("on-demand-wl3", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
 			expectWl3Admission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3, expectWl3Admission)
@@ -716,7 +716,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, fooQ)
 
 			ginkgo.By("First big workload starts")
-			wl1 := testing.MakeWorkload("on-demand-wl1", ns.Name).Queue(fooQ.Name).Request(corev1.ResourceCPU, "8").Obj()
+			wl1 := testing.MakeWorkload("on-demand-wl1", ns.Name).Queue(kueue.LocalQueueName(fooQ.Name)).Request(corev1.ResourceCPU, "8").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 			expectAdmission := testing.MakeAdmission(fooCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "8").Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectAdmission)
@@ -726,7 +726,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectAdmittedWorkloadsTotalMetric(fooCQ, 1)
 
 			ginkgo.By("Second big workload is pending")
-			wl2 := testing.MakeWorkload("on-demand-wl2", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "8").Obj()
+			wl2 := testing.MakeWorkload("on-demand-wl2", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "8").Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
@@ -735,7 +735,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, 0)
 
 			ginkgo.By("Third small workload starts")
-			wl3 := testing.MakeWorkload("on-demand-wl3", ns.Name).Queue(fooQ.Name).Request(corev1.ResourceCPU, "2").Obj()
+			wl3 := testing.MakeWorkload("on-demand-wl3", ns.Name).Queue(kueue.LocalQueueName(fooQ.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
 			expectAdmission = testing.MakeAdmission(fooCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "2").Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3, expectAdmission)
@@ -779,7 +779,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		})
 		ginkgo.It("Should re-enqueue by the update event of ClusterQueue", func() {
 			metrics.AdmissionAttemptsTotal.Reset()
-			wl := testing.MakeWorkload("on-demand-wl", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "6").Obj()
+			wl := testing.MakeWorkload("on-demand-wl", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "6").Obj()
 			util.MustCreate(ctx, k8sClient, wl)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
@@ -853,9 +853,9 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.It("Should admit workloads from the selected namespaces", func() {
 			ginkgo.By("checking the workloads don't get admitted at first")
-			wl1 := testing.MakeWorkload("wl1", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "1").Obj()
+			wl1 := testing.MakeWorkload("wl1", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
-			wl2 := testing.MakeWorkload("wl2", nsFoo.Name).Queue(queueFoo.Name).Request(corev1.ResourceCPU, "1").Obj()
+			wl2 := testing.MakeWorkload("wl2", nsFoo.Name).Queue(kueue.LocalQueueName(queueFoo.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl1, wl2)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 2)
@@ -898,7 +898,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		ginkgo.It("Should be inactive until the flavor is created", func() {
 			ginkgo.By("Creating one workload")
 			util.ExpectClusterQueueStatusMetric(fooCQ, metrics.CQStatusPending)
-			wl := testing.MakeWorkload("workload", ns.Name).Queue(fooQ.Name).Request(corev1.ResourceCPU, "1").Obj()
+			wl := testing.MakeWorkload("workload", ns.Name).Queue(kueue.LocalQueueName(fooQ.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl)
 			util.ExpectWorkloadsToBeFrozen(ctx, k8sClient, fooCQ.Name, wl)
 			util.ExpectPendingWorkloadsMetric(fooCQ, 0, 1)
@@ -954,7 +954,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.It("Should schedule workloads on tolerated flavors", func() {
 			ginkgo.By("checking a workload without toleration starts on the non-tainted flavor")
-			wl1 := testing.MakeWorkload("on-demand-wl1", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "5").Obj()
+			wl1 := testing.MakeWorkload("on-demand-wl1", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 
 			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj()
@@ -965,7 +965,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 
 			ginkgo.By("checking a second workload without toleration doesn't start")
-			wl2 := testing.MakeWorkload("on-demand-wl2", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "5").Obj()
+			wl2 := testing.MakeWorkload("on-demand-wl2", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
@@ -974,7 +974,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
 
 			ginkgo.By("checking a third workload with toleration starts")
-			wl3 := testing.MakeWorkload("on-demand-wl3", ns.Name).Queue(queue.Name).Toleration(spotToleration).Request(corev1.ResourceCPU, "5").Obj()
+			wl3 := testing.MakeWorkload("on-demand-wl3", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Toleration(spotToleration).Request(corev1.ResourceCPU, "5").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
 
 			expectAdmission = testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "spot-tainted", "5").Obj()
@@ -1016,7 +1016,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.It("Should admit workloads with affinity to specific flavor", func() {
 			ginkgo.By("checking a workload without affinity gets admitted on the first flavor")
-			wl1 := testing.MakeWorkload("no-affinity-workload", ns.Name).Queue(queue.Name).Request(corev1.ResourceCPU, "1").Obj()
+			wl1 := testing.MakeWorkload("no-affinity-workload", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "spot-untainted", "1").Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectAdmission)
@@ -1026,7 +1026,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 
 			ginkgo.By("checking a second workload with affinity to on-demand gets admitted")
-			wl2 := testing.MakeWorkload("affinity-wl", ns.Name).Queue(queue.Name).
+			wl2 := testing.MakeWorkload("affinity-wl", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
 				NodeSelector(map[string]string{instanceKey: onDemandFlavor.Name, "foo": "bar"}).
 				Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
@@ -1052,7 +1052,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				ResourceGroup(*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj()).
 				Obj()
 			q = testing.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
-			w = testing.MakeWorkload("workload", ns.Name).Queue(q.Name).Request(corev1.ResourceCPU, "2").Obj()
+			w = testing.MakeWorkload("workload", ns.Name).Queue(kueue.LocalQueueName(q.Name)).Request(corev1.ResourceCPU, "2").Obj()
 		})
 
 		ginkgo.AfterEach(func() {
@@ -1130,7 +1130,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, queue)
 
 			ginkgo.By("checking a no-fit workload does not get admitted")
-			wl := testing.MakeWorkload("wl", ns.Name).Queue(queue.Name).
+			wl := testing.MakeWorkload("wl", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
 				Request(corev1.ResourceCPU, "10").Toleration(spotToleration).Obj()
 			util.MustCreate(ctx, k8sClient, wl)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
@@ -1177,8 +1177,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			devQueue := testing.MakeLocalQueue("dev-queue", ns.Name).ClusterQueue(devCQ.Name).Obj()
 			util.MustCreate(ctx, k8sClient, devQueue)
-			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "11").Obj()
-			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(devQueue.Name).Request(corev1.ResourceCPU, "11").Obj()
+			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "11").Obj()
+			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "11").Obj()
 
 			ginkgo.By("Creating two workloads")
 			util.MustCreate(ctx, k8sClient, wl1)
@@ -1238,13 +1238,13 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, devQueue)
 
 			ginkgo.By("Creating the first workload for the prod ClusterQueue")
-			pWl1 := testing.MakeWorkload("p-wl-1", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+			pWl1 := testing.MakeWorkload("p-wl-1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, pWl1)
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodCQ.Name, pWl1)
 
 			ginkgo.By("Creating a workload for each ClusterQueue")
-			dWl1 := testing.MakeWorkload("d-wl-1", ns.Name).Queue(devQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
-			pWl2 := testing.MakeWorkload("p-wl-2", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+			dWl1 := testing.MakeWorkload("d-wl-1", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
+			pWl2 := testing.MakeWorkload("p-wl-2", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, dWl1)
 			util.WaitForNextSecondAfterCreation(dWl1)
 			util.MustCreate(ctx, k8sClient, pWl2)
@@ -1283,8 +1283,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, prodQueue)
 
 			ginkgo.By("Creating 2 workloads and ensuring they are admitted")
-			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
-			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
+			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 			util.MustCreate(ctx, k8sClient, wl2)
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1,
@@ -1293,7 +1293,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj())
 
 			ginkgo.By("Creating an additional workload that can't fit in the first flavor")
-			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3,
 				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "spot-untainted", "1").Obj())
@@ -1326,7 +1326,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, devQueue)
 
 			ginkgo.By("Creating one workload")
-			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "9").Obj()
+			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "9").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 			prodWl1Admission := testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "9").Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, prodWl1Admission)
@@ -1336,7 +1336,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectAdmittedWorkloadsTotalMetric(prodCQ, 1)
 
 			ginkgo.By("Creating another workload")
-			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(devQueue.Name).Request(corev1.ResourceCPU, "11").Toleration(spotToleration).Obj()
+			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "11").Toleration(spotToleration).Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
 			prodWl2Admission := testing.MakeAdmission(devCQ.Name).Assignment(corev1.ResourceCPU, "spot-tainted", "11").Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, prodWl2Admission)
@@ -1373,14 +1373,14 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, devQueue)
 
 			ginkgo.By("Creating two workloads")
-			wl1 := testing.MakeWorkload("wl-1", ns.Name).Priority(0).Queue(devQueue.Name).Request(corev1.ResourceCPU, "9").Obj()
-			wl2 := testing.MakeWorkload("wl-2", ns.Name).Priority(1).Queue(devQueue.Name).Request(corev1.ResourceCPU, "9").Obj()
+			wl1 := testing.MakeWorkload("wl-1", ns.Name).Priority(0).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "9").Obj()
+			wl2 := testing.MakeWorkload("wl-2", ns.Name).Priority(1).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "9").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 			util.MustCreate(ctx, k8sClient, wl2)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl2)
 
 			ginkgo.By("Creating another workload")
-			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "5").Obj()
+			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
 			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, wl1)
 
@@ -1421,7 +1421,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, queue)
 
 			ginkgo.By("workload not admitted when Cohort doesn't provide any resources")
-			wl = testing.MakeWorkload("wl", ns.Name).Queue(queue.Name).
+			wl = testing.MakeWorkload("wl", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
 				Request(corev1.ResourceCPU, "10").Obj()
 			util.MustCreate(ctx, k8sClient, wl)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
@@ -1459,7 +1459,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, queue)
 
 			ginkgo.By("workload not admitted")
-			wl = testing.MakeWorkload("wl", ns.Name).Queue(queue.Name).
+			wl = testing.MakeWorkload("wl", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
 				Request(corev1.ResourceCPU, "10").Obj()
 			util.MustCreate(ctx, k8sClient, wl)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
@@ -1503,7 +1503,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			//     /
 			//    cq
 			ginkgo.By("workload not admitted")
-			wl = testing.MakeWorkload("wl", ns.Name).Queue(queue.Name).
+			wl = testing.MakeWorkload("wl", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
 				Request(corev1.ResourceCPU, "10").Obj()
 			util.MustCreate(ctx, k8sClient, wl)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
@@ -1558,7 +1558,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, queue)
 
 			ginkgo.By("checking a no-fit workload does not get admitted")
-			wl := testing.MakeWorkload("wl", ns.Name).Queue(queue.Name).
+			wl := testing.MakeWorkload("wl", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
 				Request(corev1.ResourceCPU, "9").Obj()
 			util.MustCreate(ctx, k8sClient, wl)
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
@@ -1605,8 +1605,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			devQueue := testing.MakeLocalQueue("dev-queue", ns.Name).ClusterQueue(devCQ.Name).Obj()
 			util.MustCreate(ctx, k8sClient, devQueue)
 
-			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "5").Obj()
-			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(prodQueue.Name).Request(corev1.ResourceCPU, "5").Obj()
+			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "5").Obj()
+			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 
 			ginkgo.By("Creating two workloads")
 			util.MustCreate(ctx, k8sClient, wl1)
@@ -1684,15 +1684,15 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			strictFIFOQueue := testing.MakeLocalQueue("strict-fifo-q", matchingNS.Name).ClusterQueue(strictFIFOClusterQ.Name).Obj()
 
 			ginkgo.By("Creating workloads")
-			wl1 := testing.MakeWorkload("wl1", matchingNS.Name).Queue(strictFIFOQueue.
-				Name).Request(corev1.ResourceCPU, "2").Priority(100).Obj()
+			wl1 := testing.MakeWorkload("wl1", matchingNS.Name).
+				Queue(kueue.LocalQueueName(strictFIFOQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(100).Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
-			wl2 := testing.MakeWorkload("wl2", matchingNS.Name).Queue(strictFIFOQueue.
-				Name).Request(corev1.ResourceCPU, "5").Priority(10).Obj()
+			wl2 := testing.MakeWorkload("wl2", matchingNS.Name).
+				Queue(kueue.LocalQueueName(strictFIFOQueue.Name)).Request(corev1.ResourceCPU, "5").Priority(10).Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
 			// wl3 can't be scheduled before wl2 even though there is enough quota.
-			wl3 := testing.MakeWorkload("wl3", matchingNS.Name).Queue(strictFIFOQueue.
-				Name).Request(corev1.ResourceCPU, "1").Priority(1).Obj()
+			wl3 := testing.MakeWorkload("wl3", matchingNS.Name).
+				Queue(kueue.LocalQueueName(strictFIFOQueue.Name)).Request(corev1.ResourceCPU, "1").Priority(1).Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
 
 			util.MustCreate(ctx, k8sClient, strictFIFOQueue)
@@ -1718,15 +1718,15 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, matchingQueue)
 
 			ginkgo.By("Creating workloads")
-			wl1 := testing.MakeWorkload("wl1", matchingNS.Name).Queue(matchingQueue.
-				Name).Request(corev1.ResourceCPU, "2").Priority(100).Obj()
+			wl1 := testing.MakeWorkload("wl1", matchingNS.Name).
+				Queue(kueue.LocalQueueName(matchingQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(100).Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
-			wl2 := testing.MakeWorkload("wl2", ns.Name).Queue(notMatchingQueue.
-				Name).Request(corev1.ResourceCPU, "5").Priority(10).Obj()
+			wl2 := testing.MakeWorkload("wl2", ns.Name).
+				Queue(kueue.LocalQueueName(notMatchingQueue.Name)).Request(corev1.ResourceCPU, "5").Priority(10).Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
 			// wl2 can't block wl3 from getting scheduled.
-			wl3 := testing.MakeWorkload("wl3", matchingNS.Name).Queue(matchingQueue.
-				Name).Request(corev1.ResourceCPU, "1").Priority(1).Obj()
+			wl3 := testing.MakeWorkload("wl3", matchingNS.Name).
+				Queue(kueue.LocalQueueName(matchingQueue.Name)).Request(corev1.ResourceCPU, "1").Priority(1).Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
 
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, strictFIFOClusterQ.Name, wl1, wl3)
@@ -1764,12 +1764,12 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			}()
 
 			ginkgo.By("Creating workloads")
-			admittedWl1 := testing.MakeWorkload("wl", matchingNS.Name).Queue(strictFIFOLocalQueue.
-				Name).Request(corev1.ResourceCPU, "3").Priority(10).Obj()
+			admittedWl1 := testing.MakeWorkload("wl", matchingNS.Name).
+				Queue(kueue.LocalQueueName(strictFIFOLocalQueue.Name)).Request(corev1.ResourceCPU, "3").Priority(10).Obj()
 			util.MustCreate(ctx, k8sClient, admittedWl1)
 
-			admittedWl2 := testing.MakeWorkload("player1-a", matchingNS.Name).Queue(lqTeamA.
-				Name).Request(corev1.ResourceCPU, "5").Priority(1).Obj()
+			admittedWl2 := testing.MakeWorkload("player1-a", matchingNS.Name).
+				Queue(kueue.LocalQueueName(lqTeamA.Name)).Request(corev1.ResourceCPU, "5").Priority(1).Obj()
 			util.MustCreate(ctx, k8sClient, admittedWl2)
 
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, admittedWl1, admittedWl2)
@@ -1782,20 +1782,20 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			// pendingWl exceed nominal+borrowing quota and cannot preempt as priority based
 			// premption within CQ is disabled.
-			pendingWl := testing.MakeWorkload("pending-wl", matchingNS.Name).Queue(strictFIFOLocalQueue.
-				Name).Request(corev1.ResourceCPU, "3").Priority(99).Obj()
+			pendingWl := testing.MakeWorkload("pending-wl", matchingNS.Name).
+				Queue(kueue.LocalQueueName(strictFIFOLocalQueue.Name)).Request(corev1.ResourceCPU, "3").Priority(99).Obj()
 			util.MustCreate(ctx, k8sClient, pendingWl)
 
 			// borrowingWL can borrow shared resources, so it should be scheduled even if workloads
 			// in other cluster queues are waiting to reclaim nominal resources.
-			borrowingWl := testing.MakeWorkload("player2-a", matchingNS.Name).Queue(lqTeamA.
-				Name).Request(corev1.ResourceCPU, "5").Priority(11).Obj()
+			borrowingWl := testing.MakeWorkload("player2-a", matchingNS.Name).
+				Queue(kueue.LocalQueueName(lqTeamA.Name)).Request(corev1.ResourceCPU, "5").Priority(11).Obj()
 			util.MustCreate(ctx, k8sClient, borrowingWl)
 
 			// blockedWL wants to borrow resources from strictFIFO CQ, but should be blocked
 			// from borrowing because there is a pending workload in strictFIFO CQ.
-			blockedWl := testing.MakeWorkload("player3-a", matchingNS.Name).Queue(lqTeamA.
-				Name).Request(corev1.ResourceCPU, "1").Priority(10).Obj()
+			blockedWl := testing.MakeWorkload("player3-a", matchingNS.Name).
+				Queue(kueue.LocalQueueName(lqTeamA.Name)).Request(corev1.ResourceCPU, "1").Priority(10).Obj()
 			util.MustCreate(ctx, k8sClient, blockedWl)
 
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1829,7 +1829,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, queue)
 
 			ginkgo.By("New created workloads should be admitted")
-			wl1 := testing.MakeWorkload("workload1", ns.Name).Queue(queue.Name).Obj()
+			wl1 := testing.MakeWorkload("workload1", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 			defer func() {
 				gomega.Expect(util.DeleteObject(ctx, k8sClient, wl1)).To(gomega.Succeed())
@@ -1847,7 +1847,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("New created workloads should be frozen")
-			wl2 := testing.MakeWorkload("workload2", ns.Name).Queue(queue.Name).Obj()
+			wl2 := testing.MakeWorkload("workload2", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
 			defer func() {
 				gomega.Expect(util.DeleteObject(ctx, k8sClient, wl2)).To(gomega.Succeed())
@@ -1907,7 +1907,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			lr := lrBuilder.Obj()
 			util.MustCreate(ctx, k8sClient, lr)
 
-			wlBuilder := testing.MakeWorkload("workload", ns.Name).Queue(queue.Name)
+			wlBuilder := testing.MakeWorkload("workload", ns.Name).Queue(kueue.LocalQueueName(queue.Name))
 
 			if tp.reqCPU != "" {
 				wlBuilder.Request(corev1.ResourceCPU, tp.reqCPU)
@@ -1969,7 +1969,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.It("Should evict workloads when stop policy is drain", func() {
 			ginkgo.By("Creating first workload")
-			wl1 := testing.MakeWorkload("one", ns.Name).Queue(queue.Name).Obj()
+			wl1 := testing.MakeWorkload("one", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
@@ -2004,7 +2004,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.FinishEvictionForWorkloads(ctx, k8sClient, wl1)
 
 			ginkgo.By("Creating another workload")
-			wl2 := testing.MakeWorkload("two", ns.Name).Queue(queue.Name).Obj()
+			wl2 := testing.MakeWorkload("two", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
 
 			util.ExpectPendingWorkloadsMetric(cq, 0, 2)
@@ -2054,7 +2054,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.It("Should evict workloads when stop policy is drain", func() {
 			ginkgo.By("Creating first workload")
-			wl1 := testing.MakeWorkload("wl1", ns.Name).Queue(lq.Name).Obj()
+			wl1 := testing.MakeWorkload("wl1", ns.Name).Queue(kueue.LocalQueueName(lq.Name)).Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
@@ -2121,7 +2121,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.FinishEvictionForWorkloads(ctx, k8sClient, wl1)
 
 			ginkgo.By("Creating second workload")
-			wl2 := testing.MakeWorkload("wl2", ns.Name).Queue(lq.Name).Obj()
+			wl2 := testing.MakeWorkload("wl2", ns.Name).Queue(kueue.LocalQueueName(lq.Name)).Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
 
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
@@ -2183,11 +2183,11 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		ginkgo.It("Should report pending workloads properly when blocked", func() {
 			var wl1, wl2, wl3 *kueue.Workload
 			ginkgo.By("Create two workloads", func() {
-				wl1 = testing.MakeWorkload("wl1", ns.Name).Queue(localQueue.
-					Name).Request(corev1.ResourceCPU, "2").Priority(100).Obj()
+				wl1 = testing.MakeWorkload("wl1", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(100).Obj()
 				util.MustCreate(ctx, k8sClient, wl1)
-				wl2 = testing.MakeWorkload("wl2", ns.Name).Queue(localQueue.
-					Name).Request(corev1.ResourceCPU, "5").Priority(10).Obj()
+				wl2 = testing.MakeWorkload("wl2", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "5").Priority(10).Obj()
 				util.MustCreate(ctx, k8sClient, wl2)
 
 				util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
@@ -2199,8 +2199,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			})
 
 			ginkgo.By("Create wl3 which is now also pending", func() {
-				wl3 = testing.MakeWorkload("wl3", ns.Name).Queue(localQueue.
-					Name).Request(corev1.ResourceCPU, "1").Priority(1).Obj()
+				wl3 = testing.MakeWorkload("wl3", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Priority(1).Obj()
 				util.MustCreate(ctx, k8sClient, wl3)
 
 				util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
@@ -2237,14 +2237,14 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		ginkgo.It("Should allow mutating the requeueingStrategy", func() {
 			var wl1, wl2, wl3 *kueue.Workload
 			ginkgo.By("Create initial set of workloads, verify counters", func() {
-				wl1 = testing.MakeWorkload("wl1", ns.Name).Queue(localQueue.
-					Name).Request(corev1.ResourceCPU, "2").Priority(100).Obj()
+				wl1 = testing.MakeWorkload("wl1", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "2").Priority(100).Obj()
 				util.MustCreate(ctx, k8sClient, wl1)
-				wl2 = testing.MakeWorkload("wl2", ns.Name).Queue(localQueue.
-					Name).Request(corev1.ResourceCPU, "5").Priority(10).Obj()
+				wl2 = testing.MakeWorkload("wl2", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "5").Priority(10).Obj()
 				util.MustCreate(ctx, k8sClient, wl2)
-				wl3 = testing.MakeWorkload("wl3", ns.Name).Queue(localQueue.
-					Name).Request(corev1.ResourceCPU, "1").Priority(1).Obj()
+				wl3 = testing.MakeWorkload("wl3", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Priority(1).Obj()
 				util.MustCreate(ctx, k8sClient, wl3)
 
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
@@ -2297,8 +2297,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			var wl4 *kueue.Workload
 			ginkgo.By("Creating workload wl4, verify the counter of pending workloads is incremented", func() {
-				wl4 = testing.MakeWorkload("wl4", ns.Name).Queue(localQueue.
-					Name).Request(corev1.ResourceCPU, "1").Priority(1).Obj()
+				wl4 = testing.MakeWorkload("wl4", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Priority(1).Obj()
 				util.MustCreate(ctx, k8sClient, wl4)
 
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1, wl3)
@@ -2363,7 +2363,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		ginkgo.It("shouldn't admit second workload on over admission", func() {
 			ginkgo.By("creating first workload")
 			wl1 := testing.MakeWorkload("wl1", ns.Name).
-				Queue(lq1.Name).
+				Queue(kueue.LocalQueueName(lq1.Name)).
 				Request(corev1.ResourceCPU, "2").
 				Request(corev1.ResourceMemory, "2Gi").
 				Obj()
@@ -2371,7 +2371,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("creating second workload")
 			wl2 := testing.MakeWorkload("wl2", ns.Name).
-				Queue(lq2.Name).
+				Queue(kueue.LocalQueueName(lq2.Name)).
 				Request(corev1.ResourceCPU, "1").
 				Request(corev1.ResourceMemory, "1Gi").
 				Obj()
@@ -2466,7 +2466,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			return cq
 		}
 
-		var createWorkloadWithPriority = func(queue string, cpuRequests string, priority int32) *kueue.Workload {
+		var createWorkloadWithPriority = func(queue kueue.LocalQueueName, cpuRequests string, priority int32) *kueue.Workload {
 			wl := testing.MakeWorkloadWithGeneratedName("workload-", ns.Name).
 				Priority(priority).
 				Queue(queue).

--- a/test/integration/singlecluster/scheduler/workload_controller_test.go
+++ b/test/integration/singlecluster/scheduler/workload_controller_test.go
@@ -207,7 +207,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 		ginkgo.It("Should accumulate RuntimeClass's overhead", func() {
 			ginkgo.By("Create and wait for workload admission", func() {
 				wl = testing.MakeWorkload("one", ns.Name).
-					Queue(localQueue.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
 					Request(corev1.ResourceCPU, "1").
 					RuntimeClass("kata").
 					Obj()
@@ -261,7 +261,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 		ginkgo.It("Should not accumulate RuntimeClass's overhead", func() {
 			ginkgo.By("Create and wait for workload admission", func() {
 				wl = testing.MakeWorkload("one", ns.Name).
-					Queue(localQueue.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
 					Request(corev1.ResourceCPU, "1").
 					RuntimeClass("kata").
 					Obj()
@@ -316,7 +316,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 		ginkgo.It("Should use the range defined default requests, if provided", func() {
 			ginkgo.By("Create and wait for workload admission", func() {
 				wl = testing.MakeWorkload("one", ns.Name).
-					Queue(localQueue.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
 					Obj()
 				util.MustCreate(ctx, k8sClient, wl)
 
@@ -355,7 +355,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 		ginkgo.It("Should not use the range defined requests, if provided by the workload", func() {
 			ginkgo.By("Create and wait for workload admission", func() {
 				wl = testing.MakeWorkload("one", ns.Name).
-					Queue(localQueue.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
 					Request(corev1.ResourceCPU, "1").
 					Obj()
 				util.MustCreate(ctx, k8sClient, wl)
@@ -414,7 +414,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 		ginkgo.It("The limits should be used as request values", func() {
 			ginkgo.By("Create and wait for workload admission", func() {
 				wl = testing.MakeWorkload("one", ns.Name).
-					Queue(localQueue.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
 					Limit(corev1.ResourceCPU, "1").
 					Obj()
 				util.MustCreate(ctx, k8sClient, wl)
@@ -476,7 +476,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			ginkgo.By("Create and wait for workload admission", func() {
 				util.MustCreate(ctx, k8sClient, localQueue)
 				wl = testing.MakeWorkload("one", ns.Name).
-					Queue(localQueue.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
 					Request(pseudoCPU, "1").
 					Obj()
 				util.MustCreate(ctx, k8sClient, wl)
@@ -508,7 +508,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 
 			ginkgo.By("Create a pending workload and validate its resourceRequests", func() {
 				wl2 = testing.MakeWorkload("two", ns.Name).
-					Queue(localQueue.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
 					Request(pseudoCPU, "2").
 					Obj()
 				util.MustCreate(ctx, k8sClient, wl2)
@@ -574,7 +574,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			ginkgo.By("Create inadmissable workload", func() {
 				util.MustCreate(ctx, k8sClient, localQueue)
 				wl = testing.MakeWorkload("one", ns.Name).
-					Queue(localQueue.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
 					Request(pseudoCPU, "1").
 					Obj()
 				util.MustCreate(ctx, k8sClient, wl)
@@ -624,7 +624,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 		ginkgo.It("Should sync the resource requests with the new overhead", func() {
 			ginkgo.By("Create and wait for the first workload admission", func() {
 				wl = testing.MakeWorkload("one", ns.Name).
-					Queue(localQueue.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
 					Request(corev1.ResourceCPU, "1").
 					RuntimeClass("kata").
 					Obj()
@@ -640,7 +640,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			var wl2 *kueue.Workload
 			ginkgo.By("Create a second workload, should stay pending", func() {
 				wl2 = testing.MakeWorkload("two", ns.Name).
-					Queue(localQueue.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
 					Request(corev1.ResourceCPU, "1").
 					RuntimeClass("kata").
 					Obj()
@@ -713,7 +713,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 		ginkgo.It("Should sync the resource requests with the limit", func() {
 			ginkgo.By("Create and wait for the first workload admission", func() {
 				wl = testing.MakeWorkload("one", ns.Name).
-					Queue(localQueue.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
 					Obj()
 				util.MustCreate(ctx, k8sClient, wl)
 
@@ -727,7 +727,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			var wl2 *kueue.Workload
 			ginkgo.By("Create a second workload, should stay pending", func() {
 				wl2 = testing.MakeWorkload("two", ns.Name).
-					Queue(localQueue.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
 					Obj()
 				util.MustCreate(ctx, k8sClient, wl2)
 
@@ -817,7 +817,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 				var wl *kueue.Workload
 				ginkgo.By("Create the workload", func() {
 					wl = testing.MakeWorkload("one", ns.Name).
-						Queue(localQueue.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).
 						Request(corev1.ResourceCPU, "1").
 						Obj()
 					util.MustCreate(ctx, k8sClient, wl)
@@ -840,7 +840,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 				var wl *kueue.Workload
 				ginkgo.By("Create the workload", func() {
 					wl = testing.MakeWorkload("one", ns.Name).
-						Queue(localQueue.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).
 						Request(corev1.ResourceCPU, "7").
 						Obj()
 					util.MustCreate(ctx, k8sClient, wl)

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -146,7 +146,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 		ginkgo.It("should not allow to update topologyName", func() {
 			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
-			tasFlavor.Spec.TopologyName = ptr.To(kueue.TopologyReference("invalid"))
+			tasFlavor.Spec.TopologyName = ptr.To[kueue.TopologyReference]("invalid")
 			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
 		})
 
@@ -365,7 +365,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			ginkgo.It("should not admit workload which does not fit to the required topology domain", func() {
 				ginkgo.By("creating a workload which requires rack, but does not fit in any", func() {
 					wl1 := testing.MakeWorkload("wl1-inadmissible", ns.Name).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
 						Required: ptr.To(testing.DefaultRackTopologyLevel),
 					}
@@ -381,7 +381,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				var wl1, wl2, wl3, wl4 *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {
 					wl1 = testing.MakeWorkload("wl1", ns.Name).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl1.Spec.PodSets[0].Count = 2
 					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
 						Required: ptr.To(testing.DefaultBlockTopologyLevel),
@@ -424,7 +424,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("creating the second workload to see it lands on another rack", func() {
 					wl2 = testing.MakeWorkload("wl2", ns.Name).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl2.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
 						Required: ptr.To(testing.DefaultRackTopologyLevel),
 					}
@@ -459,7 +459,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("creating the wl3", func() {
 					wl3 = testing.MakeWorkload("wl3", ns.Name).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl3.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
 						Required: ptr.To(testing.DefaultRackTopologyLevel),
 					}
@@ -494,7 +494,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("creating wl4", func() {
 					wl4 = testing.MakeWorkload("wl4", ns.Name).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl4.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
 						Required: ptr.To(testing.DefaultRackTopologyLevel),
 					}
@@ -578,7 +578,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				var wl *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {
 					wl = testing.MakeWorkload("wl", ns.Name).
-						Queue(localQueue.Name).PodSets(*testing.MakePodSet("worker", 2).
+						Queue(kueue.LocalQueueName(localQueue.Name)).PodSets(*testing.MakePodSet("worker", 2).
 						RequiredTopologyRequest(testing.DefaultBlockTopologyLevel).
 						Obj()).Request(corev1.ResourceCPU, "1").Obj()
 					util.MustCreate(ctx, k8sClient, wl)
@@ -645,7 +645,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				var wl *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {
 					wl = testing.MakeWorkload("wl", ns.Name).
-						Queue(localQueue.Name).PodSets(*testing.MakePodSet("worker", 2).
+						Queue(kueue.LocalQueueName(localQueue.Name)).PodSets(*testing.MakePodSet("worker", 2).
 						RequiredTopologyRequest(testing.DefaultBlockTopologyLevel).
 						Obj()).Request(corev1.ResourceCPU, "1").Obj()
 					util.MustCreate(ctx, k8sClient, wl)
@@ -776,7 +776,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						PodSets(*testing.MakePodSet("worker", 4).
 							PreferredTopologyRequest(testing.DefaultRackTopologyLevel).
 							Obj()).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "2").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 					util.MustCreate(ctx, k8sClient, wl1)
 				})
 
@@ -792,7 +792,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						PodSets(*testing.MakePodSet("worker", 1).
 							PreferredTopologyRequest(testing.DefaultBlockTopologyLevel).
 							Obj()).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					util.MustCreate(ctx, k8sClient, wl1)
 				})
 
@@ -806,7 +806,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						PodSets(*testing.MakePodSet("worker-2", 4).
 							PreferredTopologyRequest(testing.DefaultBlockTopologyLevel).
 							Obj()).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					util.MustCreate(ctx, k8sClient, wl2)
 				})
 
@@ -822,7 +822,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					wl1 = testing.MakeWorkload("wl1", ns.Name).
 						PodSets(*testing.MakePodSet("worker", 2).
 							Obj()).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					util.MustCreate(ctx, k8sClient, wl1)
 				})
 
@@ -844,7 +844,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					wl2 = testing.MakeWorkload("wl2", ns.Name).
 						PodSets(*testing.MakePodSet("worker-2", 3).
 							Obj()).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					util.MustCreate(ctx, k8sClient, wl2)
 				})
 
@@ -938,7 +938,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						PodSets(*testing.MakePodSet("worker", 1).
 							PreferredTopologyRequest(testing.DefaultBlockTopologyLevel).
 							Obj()).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "5").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 					util.MustCreate(ctx, k8sClient, wl1)
 				})
 
@@ -953,7 +953,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						PodSets(*testing.MakePodSet("worker", 1).
 							PreferredTopologyRequest(testing.DefaultBlockTopologyLevel).
 							Obj()).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "5").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 					util.MustCreate(ctx, k8sClient, wl2)
 				})
 
@@ -968,7 +968,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						PodSets(*testing.MakePodSet("worker", 2).
 							PreferredTopologyRequest(testing.DefaultBlockTopologyLevel).
 							Obj()).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "5").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 					util.MustCreate(ctx, k8sClient, wl3)
 				})
 
@@ -1079,7 +1079,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						PodSets(*testing.MakePodSet("worker", 2).
 							PreferredTopologyRequest(testing.DefaultBlockTopologyLevel).
 							Obj()).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "4").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "4").Obj()
 					util.MustCreate(ctx, k8sClient, wl1)
 				})
 
@@ -1098,7 +1098,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						PodSets(*testing.MakePodSet("worker", 1).
 							PreferredTopologyRequest(testing.DefaultBlockTopologyLevel).
 							Obj()).
-						Queue(localQueueB.Name).Request(corev1.ResourceCPU, "2").Obj()
+						Queue(kueue.LocalQueueName(localQueueB.Name)).Request(corev1.ResourceCPU, "2").Obj()
 					util.MustCreate(ctx, k8sClient, wl2)
 				})
 
@@ -1157,7 +1157,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("creating a workload which requires rack, but does not fit in any", func() {
 					wl1 = testing.MakeWorkload("wl1", ns.Name).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
 						Required: ptr.To(testing.DefaultRackTopologyLevel),
 					}
@@ -1262,7 +1262,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("creating a workload which does not tolerate the taint", func() {
 					wl1 = testing.MakeWorkload("wl1", ns.Name).
-						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
 						Required: ptr.To(testing.DefaultRackTopologyLevel),
 					}
@@ -1315,7 +1315,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 				ginkgo.By("creating a workload requiring the missing label via NodeSelector", func() {
 					wl1 = testing.MakeWorkload("wl-needs-label", ns.Name).
-						Queue(localQueue.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).
 						PodSets(*testing.MakePodSet("main", 1).
 							NodeSelector(map[string]string{customLabelKey: customLabelCorrectValue}).
 							Request(corev1.ResourceCPU, "1").
@@ -1454,7 +1454,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				var wl1 *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {
 					wl1 = testing.MakeWorkload("wl1", ns.Name).
-						Queue(localQueue.Name).Obj()
+						Queue(kueue.LocalQueueName(localQueue.Name)).Obj()
 					ps1 := *testing.MakePodSet("manager", 1).NodeSelector(
 						map[string]string{corev1.LabelInstanceTypeStable: "cpu-node"},
 					).Request(corev1.ResourceCPU, "5").Obj()

--- a/test/performance/scheduler/runner/generator/generator.go
+++ b/test/performance/scheduler/runner/generator/generator.go
@@ -106,7 +106,7 @@ func concurrent[T any](set T, count func(T) int, call func(int) error) error {
 	close(errCh)
 	return errors.Join(errs...)
 }
-func generateWlSet(ctx context.Context, c client.Client, wlSet WorkloadsSet, namespace string, localQueue string, wlSetIdx int) error {
+func generateWlSet(ctx context.Context, c client.Client, wlSet WorkloadsSet, namespace string, localQueue kueue.LocalQueueName, wlSetIdx int) error {
 	delay := time.Duration(wlSet.CreationIntervalMs) * time.Millisecond
 	log := ctrl.LoggerFrom(ctx).WithName("generate workload group").WithValues("namespace", namespace, "localQueue", localQueue, "delay", delay)
 	log.Info("Start generation")
@@ -166,7 +166,7 @@ func generateQueue(ctx context.Context, c client.Client, qSet QueuesSet, cohortN
 	}
 
 	return concurrent(qSet.WorkloadsSets, func(wlSets []WorkloadsSet) int { return len(wlSets) }, func(wlSetIdx int) error {
-		return generateWlSet(ctx, c, qSet.WorkloadsSets[wlSetIdx], ns.Name, lq.Name, wlSetIdx)
+		return generateWlSet(ctx, c, qSet.WorkloadsSets[wlSetIdx], ns.Name, kueue.LocalQueueName(lq.Name), wlSetIdx)
 	})
 }
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -734,7 +734,7 @@ func SetWorkloadsAdmissionCheck(ctx context.Context, k8sClient client.Client, wl
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
-func AwaitAndVerifyWorkloadQueueName(ctx context.Context, client client.Client, createdWorkload *kueue.Workload, wlLookupKey types.NamespacedName, jobQueueName string) {
+func AwaitAndVerifyWorkloadQueueName(ctx context.Context, client client.Client, createdWorkload *kueue.Workload, wlLookupKey types.NamespacedName, jobQueueName kueue.LocalQueueName) {
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
 		g.Expect(client.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 		g.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(jobQueueName))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
To improve readability of the code

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4530

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```