### PR TITLE
Split integration tests into baseline and extended targets.

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -94,13 +94,13 @@ test-integration: gomod-download envtest ginkgo dep-crds kueuectl ginkgo-top ## 
 	$(GINKGO) $(INTEGRATION_FILTERS) $(GINKGO_ARGS) $(GOFLAGS) -procs=$(INTEGRATION_NPROCS) --race --junit-report=junit.xml --json-report=integration.json --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET)
 	$(PROJECT_DIR)/bin/ginkgo-top -i $(ARTIFACTS)/integration.json > $(ARTIFACTS)/integration-top.yaml
 
-.PHONY: test-integration-required
-test-integration-required: INTEGRATION_FILTERS= --label-filter="!slow && !redundant"
-test-integration-required: test-integration ## Run required integration tests for singlecluster suites.
+.PHONY: test-integration-baseline
+test-integration-baseline: INTEGRATION_FILTERS= --label-filter="!slow && !redundant"
+test-integration-baseline: test-integration ## Run baseline integration tests for singlecluster suites.
 
-.PHONY: test-integration-slow-and-redundant
-test-integration-slow-and-redundant: INTEGRATION_FILTERS= --label-filter="slow || redundant"
-test-integration-slow-and-redundant: test-integration ## Run slow and redundant integration tests for singlecluster suites.
+.PHONY: test-integration-extended
+test-integration-extended: INTEGRATION_FILTERS= --label-filter="slow || redundant"
+test-integration-extended: test-integration ## Run extended integration tests for singlecluster suites.
 
 .PHONY: test-multikueue-integration
 test-multikueue-integration: gomod-download envtest ginkgo dep-crds ginkgo-top ## Run integration tests for MultiKueue suite.

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -47,11 +47,6 @@ INTEGRATION_TARGET_MULTIKUEUE ?= ./test/integration/multikueue/...
 # Verbosity level for apiserver logging.
 # The logging is disabled if 0.
 INTEGRATION_API_LOG_LEVEL ?= 0
-# Integration filters
-INTEGRATION_RUN_ALL?=true
-ifneq ($(INTEGRATION_RUN_ALL),true) 
-	INTEGRATION_FILTERS= --label-filter="!slow && !redundant"
-endif
 
 # Folder where the e2e tests are located.
 E2E_TARGET ?= ./test/e2e/...
@@ -99,6 +94,14 @@ test-integration: gomod-download envtest ginkgo dep-crds kueuectl ginkgo-top ## 
 	$(GINKGO) $(INTEGRATION_FILTERS) $(GINKGO_ARGS) $(GOFLAGS) -procs=$(INTEGRATION_NPROCS) --race --junit-report=junit.xml --json-report=integration.json --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET)
 	$(PROJECT_DIR)/bin/ginkgo-top -i $(ARTIFACTS)/integration.json > $(ARTIFACTS)/integration-top.yaml
 
+.PHONY: test-integration-required
+test-integration-required: INTEGRATION_FILTERS= --label-filter="!slow && !redundant"
+test-integration-required: test-integration ## Run required integration tests for singlecluster suites.
+
+.PHONY: test-integration-slow-and-redundant
+test-integration-slow-and-redundant: INTEGRATION_FILTERS= --label-filter="slow || redundant"
+test-integration-slow-and-redundant: test-integration ## Run slow and redundant integration tests for singlecluster suites.
+
 .PHONY: test-multikueue-integration
 test-multikueue-integration: gomod-download envtest ginkgo dep-crds ginkgo-top ## Run integration tests for MultiKueue suite.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
@@ -108,6 +111,14 @@ test-multikueue-integration: gomod-download envtest ginkgo dep-crds ginkgo-top #
 	TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) API_LOG_LEVEL=$(INTEGRATION_API_LOG_LEVEL) \
 	$(GINKGO) $(INTEGRATION_FILTERS) $(GINKGO_ARGS) $(GOFLAGS) -procs=$(INTEGRATION_NPROCS_MULTIKUEUE) --race --junit-report=multikueue-junit.xml --json-report=multikueue-integration.json --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET_MULTIKUEUE)
 	$(PROJECT_DIR)/bin/ginkgo-top -i $(ARTIFACTS)/multikueue-integration.json > $(ARTIFACTS)/multikueue-integration-top.yaml
+
+.PHONY: test-multikueue-integration-required
+test-multikueue-integration-required: INTEGRATION_FILTERS= --label-filter="!slow && !redundant"
+test-multikueue-integration-required: test-multikueue-integration ## Run required integration tests for multikueue suites.
+
+.PHONY: test-multikueue-integration-slow-and-redundant
+test-multikueue-integration-slow-and-redundant: INTEGRATION_FILTERS= --label-filter="slow || redundant"
+test-multikueue-integration-slow-and-redundant: test-multikueue-integration ## Run slow and redundant integration tests for multikueue suite.
 
 CREATE_KIND_CLUSTER ?= true
 

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -112,14 +112,6 @@ test-multikueue-integration: gomod-download envtest ginkgo dep-crds ginkgo-top #
 	$(GINKGO) $(INTEGRATION_FILTERS) $(GINKGO_ARGS) $(GOFLAGS) -procs=$(INTEGRATION_NPROCS_MULTIKUEUE) --race --junit-report=multikueue-junit.xml --json-report=multikueue-integration.json --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET_MULTIKUEUE)
 	$(PROJECT_DIR)/bin/ginkgo-top -i $(ARTIFACTS)/multikueue-integration.json > $(ARTIFACTS)/multikueue-integration-top.yaml
 
-.PHONY: test-multikueue-integration-required
-test-multikueue-integration-required: INTEGRATION_FILTERS= --label-filter="!slow && !redundant"
-test-multikueue-integration-required: test-multikueue-integration ## Run required integration tests for multikueue suites.
-
-.PHONY: test-multikueue-integration-slow-and-redundant
-test-multikueue-integration-slow-and-redundant: INTEGRATION_FILTERS= --label-filter="slow || redundant"
-test-multikueue-integration-slow-and-redundant: test-multikueue-integration ## Run slow and redundant integration tests for multikueue suite.
-
 CREATE_KIND_CLUSTER ?= true
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Split integration tests into baseline and extended targets.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #5062

#### Special notes for your reviewer:
Sometimes we miss testing the slow and redundant integration tests before merging to main, which results in errors in periodic tests. This happens because the presubmit integration tests are filtered by the `INTEGRATION_RUN_ALL` flag.

https://github.com/kubernetes-sigs/kueue/blob/3279d9c05817e465229fac6bdc64250c890ea7dd/Makefile-test.mk#L51-L54

To prevent this, I propose running the slow and redundant tests in parallel with the required tests instead of skipping it in presubmit tests.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```