### PR TITLE
Automated cherry pick of #5068: Split integration tests into baseline and extended targets.

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -43,11 +43,6 @@ INTEGRATION_TARGET ?= ./test/integration/...
 # Verbosity level for apiserver logging.
 # The logging is disabled if 0.
 INTEGRATION_API_LOG_LEVEL ?= 0
-# Integration filters
-INTEGRATION_RUN_ALL?=true
-ifneq ($(INTEGRATION_RUN_ALL),true) 
-	INTEGRATION_FILTERS= --label-filter="!slow && !redundant"
-endif
 
 # Folder where the e2e tests are located.
 E2E_TARGET ?= ./test/e2e/...
@@ -89,6 +84,14 @@ test-integration: gomod-download envtest ginkgo dep-crds kueuectl ginkgo-top ## 
 	API_LOG_LEVEL=$(INTEGRATION_API_LOG_LEVEL) \
 	$(GINKGO) $(INTEGRATION_FILTERS) $(GINKGO_ARGS) -procs=$(INTEGRATION_NPROCS) --race --junit-report=junit.xml --json-report=integration.json --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET)
 	$(PROJECT_DIR)/bin/ginkgo-top -i $(ARTIFACTS)/integration.json > $(ARTIFACTS)/integration-top.yaml
+
+.PHONY: test-integration-required
+test-integration-required: INTEGRATION_FILTERS= --label-filter="!slow && !redundant"
+test-integration-required: test-integration ## Run required integration tests for singlecluster suites.
+
+.PHONY: test-integration-slow-and-redundant
+test-integration-slow-and-redundant: INTEGRATION_FILTERS= --label-filter="slow || redundant"
+test-integration-slow-and-redundant: test-integration ## Run slow and redundant integration tests for singlecluster suites.
 
 CREATE_KIND_CLUSTER ?= true
 .PHONY: test-e2e

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -85,13 +85,13 @@ test-integration: gomod-download envtest ginkgo dep-crds kueuectl ginkgo-top ## 
 	$(GINKGO) $(INTEGRATION_FILTERS) $(GINKGO_ARGS) -procs=$(INTEGRATION_NPROCS) --race --junit-report=junit.xml --json-report=integration.json --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET)
 	$(PROJECT_DIR)/bin/ginkgo-top -i $(ARTIFACTS)/integration.json > $(ARTIFACTS)/integration-top.yaml
 
-.PHONY: test-integration-required
-test-integration-required: INTEGRATION_FILTERS= --label-filter="!slow && !redundant"
-test-integration-required: test-integration ## Run required integration tests for singlecluster suites.
+.PHONY: test-integration-baseline
+test-integration-baseline: INTEGRATION_FILTERS= --label-filter="!slow && !redundant"
+test-integration-baseline: test-integration ## Run baseline integration tests for singlecluster suites.
 
-.PHONY: test-integration-slow-and-redundant
-test-integration-slow-and-redundant: INTEGRATION_FILTERS= --label-filter="slow || redundant"
-test-integration-slow-and-redundant: test-integration ## Run slow and redundant integration tests for singlecluster suites.
+.PHONY: test-integration-extended
+test-integration-extended: INTEGRATION_FILTERS= --label-filter="slow || redundant"
+test-integration-extended: test-integration ## Run extended integration tests for singlecluster suites.
 
 CREATE_KIND_CLUSTER ?= true
 .PHONY: test-e2e


### PR DESCRIPTION
Cherry pick of #5068 on release-0.10.

#5068: Split integration tests into baseline and extended targets.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```