### PR TITLE
Automated cherry pick of #5105: Use EXTRA_TAG for Helm App version if it is semantic versioning

### DIFF
--- a/hack/push-chart.sh
+++ b/hack/push-chart.sh
@@ -36,14 +36,13 @@ readonly semver_regex='^v([0-9]+)(\.[0-9]+){1,2}$'
 
 image_repository=${IMAGE_REPO}
 app_version=${GIT_TAG}
-# Strip leading v from version
-chart_version="${app_version/#v/}"
 if [[ ${EXTRA_TAG} =~ ${semver_regex} ]]
 then
 	image_repository=${k8s_registry}/kueue
-	# Strip leading v from version
-	chart_version=${EXTRA_TAG/#v/}
+	app_version=${EXTRA_TAG}
 fi
+# Strip leading v from version
+chart_version="${app_version/#v/}"
 
 default_image_repo=$(${YQ} ".controllerManager.manager.image.repository" charts/kueue/values.yaml)
 readonly default_image_repo


### PR DESCRIPTION
Cherry pick of #5105 on release-0.10.

#5105: Use EXTRA_TAG for Helm App version if it is semantic versioning

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```