### PR TITLE
fix: PropagateResourceRequests map equality check

### DIFF
--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -652,7 +653,7 @@ func PropagateResourceRequests(w *kueue.Workload, info *Info) bool {
 		match := true
 		for idx := range w.Status.ResourceRequests {
 			if w.Status.ResourceRequests[idx].Name != info.TotalRequests[idx].Name ||
-				!maps.Equal(w.Status.ResourceRequests[idx].Resources, info.TotalRequests[idx].Requests.ToResourceList()) {
+				!equality.Semantic.DeepEqual(w.Status.ResourceRequests[idx].Resources, info.TotalRequests[idx].Requests.ToResourceList()) {
 				match = false
 				break
 			}

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -889,3 +889,199 @@ func TestAdmissionCheckStrategy(t *testing.T) {
 		})
 	}
 }
+
+func TestPropagateResourceRequests(t *testing.T) {
+	cases := map[string]struct {
+		wl   *kueue.Workload
+		info *Info
+		want bool
+	}{
+		"one podset, no diff": {
+			wl: &kueue.Workload{
+				Status: kueue.WorkloadStatus{
+					ResourceRequests: []kueue.PodSetRequest{
+						{
+							Name: "ps1",
+							Resources: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10"),
+								corev1.ResourceMemory: resource.MustParse("10Mi"),
+								"nvidia.com/gpu":      resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			info: &Info{
+				TotalRequests: []PodSetResources{{
+					Name: "ps1",
+					Requests: resources.Requests{
+						corev1.ResourceCPU:    10000,
+						corev1.ResourceMemory: 10 * 1024 * 1024,
+						"nvidia.com/gpu":      1,
+					},
+				}},
+			},
+			want: false,
+		},
+		"one podset, memory missing diff": {
+			wl: &kueue.Workload{
+				Status: kueue.WorkloadStatus{
+					ResourceRequests: []kueue.PodSetRequest{
+						{
+							Name: "ps1",
+							Resources: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10"),
+								corev1.ResourceMemory: resource.MustParse("10Mi"),
+								"nvidia.com/gpu":      resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			info: &Info{
+				TotalRequests: []PodSetResources{{
+					Name: "ps1",
+					Requests: resources.Requests{
+						corev1.ResourceCPU: 5000,
+						"nvidia.com/gpu":   1,
+					},
+				}},
+			},
+			want: true,
+		},
+		"one podset, cpu diff": {
+			wl: &kueue.Workload{
+				Status: kueue.WorkloadStatus{
+					ResourceRequests: []kueue.PodSetRequest{
+						{
+							Name: "ps1",
+							Resources: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10"),
+								corev1.ResourceMemory: resource.MustParse("10Mi"),
+								"nvidia.com/gpu":      resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			info: &Info{
+				TotalRequests: []PodSetResources{{
+					Name: "ps1",
+					Requests: resources.Requests{
+						corev1.ResourceCPU:    5000,
+						corev1.ResourceMemory: 10 * 1024 * 1024,
+						"nvidia.com/gpu":      1,
+					},
+				}},
+			},
+			want: true,
+		},
+		"one podset, memory diff": {
+			wl: &kueue.Workload{
+				Status: kueue.WorkloadStatus{
+					ResourceRequests: []kueue.PodSetRequest{
+						{
+							Name: "ps1",
+							Resources: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10"),
+								corev1.ResourceMemory: resource.MustParse("10Gi"),
+								"nvidia.com/gpu":      resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			info: &Info{
+				TotalRequests: []PodSetResources{{
+					Name: "ps1",
+					Requests: resources.Requests{
+						corev1.ResourceCPU:    10000,
+						corev1.ResourceMemory: 10 * 1024 * 1024,
+						"nvidia.com/gpu":      1,
+					},
+				}},
+			},
+			want: true,
+		},
+		"one podset, gpu (extended resource) diff": {
+			wl: &kueue.Workload{
+				Status: kueue.WorkloadStatus{
+					ResourceRequests: []kueue.PodSetRequest{
+						{
+							Name: "ps1",
+							Resources: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10"),
+								corev1.ResourceMemory: resource.MustParse("10Mi"),
+								"nvidia.com/gpu":      resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			info: &Info{
+				TotalRequests: []PodSetResources{{
+					Name: "ps1",
+					Requests: resources.Requests{
+						corev1.ResourceCPU:    10000,
+						corev1.ResourceMemory: 10 * 1024 * 1024,
+						"nvidia.com/gpu":      2,
+					},
+				}},
+			},
+			want: true,
+		},
+		"two podset, no diff ": {
+			wl: &kueue.Workload{
+				Status: kueue.WorkloadStatus{
+					ResourceRequests: []kueue.PodSetRequest{
+						{
+							Name: "ps1",
+							Resources: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("10"),
+								corev1.ResourceMemory: resource.MustParse("10Mi"),
+								"nvidia.com/gpu":      resource.MustParse("1"),
+							},
+						},
+						{
+							Name: "ps2",
+							Resources: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("20"),
+								corev1.ResourceMemory: resource.MustParse("20Mi"),
+								"nvidia.com/gpu":      resource.MustParse("2"),
+							},
+						},
+					},
+				},
+			},
+			info: &Info{
+				TotalRequests: []PodSetResources{
+					{
+						Name: "ps1",
+						Requests: resources.Requests{
+							corev1.ResourceCPU:    10000,
+							corev1.ResourceMemory: 10 * 1024 * 1024,
+							"nvidia.com/gpu":      1,
+						},
+					},
+					{
+						Name: "ps2",
+						Requests: resources.Requests{
+							corev1.ResourceCPU:    20000,
+							corev1.ResourceMemory: 20 * 1024 * 1024,
+							"nvidia.com/gpu":      2,
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := PropagateResourceRequests(tc.wl, tc.info)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Unexpected PropagateResourceRequests() result (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

fix infinite inequality loop for propagate resource requests check

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #5058

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug where PropagateResourceRequests would always trigger an API status patch call.
```