### PR TITLE
Implement generic strings Join util

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3366,7 +3366,7 @@ func TestClusterQueueReadiness(t *testing.T) {
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
 			wantReason:       "FlavorNotFound",
-			wantMessage:      "Can't admit new workloads: references missing ResourceFlavor(s): [flavor1].",
+			wantMessage:      "Can't admit new workloads: references missing ResourceFlavor(s): flavor1.",
 		},
 		"check not found": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
@@ -3374,7 +3374,7 @@ func TestClusterQueueReadiness(t *testing.T) {
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
 			wantReason:       "AdmissionCheckNotFound",
-			wantMessage:      "Can't admit new workloads: references missing AdmissionCheck(s): [check1].",
+			wantMessage:      "Can't admit new workloads: references missing AdmissionCheck(s): check1.",
 		},
 		"check inactive": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
@@ -3383,14 +3383,14 @@ func TestClusterQueueReadiness(t *testing.T) {
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
 			wantReason:       "AdmissionCheckInactive",
-			wantMessage:      "Can't admit new workloads: references inactive AdmissionCheck(s): [check1].",
+			wantMessage:      "Can't admit new workloads: references inactive AdmissionCheck(s): check1.",
 		},
 		"flavor and check not found": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},
 			clusterQueueName: "queue1",
 			wantStatus:       metav1.ConditionFalse,
 			wantReason:       "FlavorNotFound",
-			wantMessage:      "Can't admit new workloads: references missing ResourceFlavor(s): [flavor1], references missing AdmissionCheck(s): [check1].",
+			wantMessage:      "Can't admit new workloads: references missing ResourceFlavor(s): flavor1, references missing AdmissionCheck(s): check1.",
 		},
 		"terminating": {
 			clusterQueues:    []*kueue.ClusterQueue{baseQueue},

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -229,15 +229,15 @@ func (c *clusterQueue) inactiveReason() (string, string) {
 		}
 		if len(c.missingFlavors) > 0 {
 			reasons = append(reasons, kueue.ClusterQueueActiveReasonFlavorNotFound)
-			messages = append(messages, fmt.Sprintf("references missing ResourceFlavor(s): %v", c.missingFlavors))
+			messages = append(messages, fmt.Sprintf("references missing ResourceFlavor(s): %v", stringsutils.Join(c.missingFlavors, ",")))
 		}
 		if len(c.missingAdmissionChecks) > 0 {
 			reasons = append(reasons, kueue.ClusterQueueActiveReasonAdmissionCheckNotFound)
-			messages = append(messages, fmt.Sprintf("references missing AdmissionCheck(s): %v", c.missingAdmissionChecks))
+			messages = append(messages, fmt.Sprintf("references missing AdmissionCheck(s): %v", stringsutils.Join(c.missingAdmissionChecks, ",")))
 		}
 		if len(c.inactiveAdmissionChecks) > 0 {
 			reasons = append(reasons, kueue.ClusterQueueActiveReasonAdmissionCheckInactive)
-			messages = append(messages, fmt.Sprintf("references inactive AdmissionCheck(s): %v", c.inactiveAdmissionChecks))
+			messages = append(messages, fmt.Sprintf("references inactive AdmissionCheck(s): %v", stringsutils.Join(c.inactiveAdmissionChecks, ",")))
 		}
 
 		if len(c.multiKueueAdmissionChecks) > 1 {
@@ -271,7 +271,7 @@ func (c *clusterQueue) inactiveReason() (string, string) {
 			return kueue.ClusterQueueActiveReasonUnknown, "Can't admit new workloads."
 		}
 
-		return reasons[0], api.TruncateConditionMessage(strings.Join([]string{"Can't admit new workloads: ", strings.Join(messages, ", "), "."}, ""))
+		return reasons[0], api.TruncateConditionMessage(fmt.Sprintf("Can't admit new workloads: %v.", strings.Join(messages, ", ")))
 	}
 	return kueue.ClusterQueueActiveReasonReady, "Can admit new workloads"
 }

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -257,7 +257,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "AdmissionCheckNotFound",
-			wantMessage: "Can't admit new workloads: references missing AdmissionCheck(s): [check3].",
+			wantMessage: "Can't admit new workloads: references missing AdmissionCheck(s): check3.",
 		},
 		{
 			name:     "Active clusterQueue with an AC strategy updated with not found AC",
@@ -275,7 +275,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "AdmissionCheckNotFound",
-			wantMessage: "Can't admit new workloads: references missing AdmissionCheck(s): [check3].",
+			wantMessage: "Can't admit new workloads: references missing AdmissionCheck(s): check3.",
 		},
 		{
 			name:     "Active clusterQueue updated with inactive AC",
@@ -297,7 +297,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "AdmissionCheckInactive",
-			wantMessage: "Can't admit new workloads: references inactive AdmissionCheck(s): [check3].",
+			wantMessage: "Can't admit new workloads: references inactive AdmissionCheck(s): check3.",
 		},
 		{
 			name:     "Active clusterQueue with an AC strategy updated with inactive AC",
@@ -319,7 +319,7 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			},
 			wantStatus:  pending,
 			wantReason:  "AdmissionCheckInactive",
-			wantMessage: "Can't admit new workloads: references inactive AdmissionCheck(s): [check3].",
+			wantMessage: "Can't admit new workloads: references inactive AdmissionCheck(s): check3.",
 		},
 		{
 			name:     "Active clusterQueue with an MultiKueue AC strategy updated with duplicate single instance AC Controller",

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"unsafe"
 
 	corev1 "k8s.io/api/core/v1"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -40,6 +39,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	podworkload "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	"sigs.k8s.io/kueue/pkg/features"
+	stringsutils "sigs.k8s.io/kueue/pkg/util/strings"
 )
 
 const (
@@ -272,9 +272,7 @@ var (
 	validStrategySetsStr = func() []string {
 		var ss []string
 		for _, s := range validStrategySets {
-			// Casting because strings.Join requires a slice of strings
-			strategies := *(*[]string)(unsafe.Pointer(&s))
-			ss = append(ss, strings.Join(strategies, ","))
+			ss = append(ss, stringsutils.Join(s, ","))
 		}
 		return ss
 	}()

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -56,6 +56,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
+	stringsutils "sigs.k8s.io/kueue/pkg/util/strings"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -385,7 +386,7 @@ func (r *WorkloadReconciler) reconcileCheckBasedEviction(ctx context.Context, wl
 		for _, check := range workload.RejectedChecks(wl) {
 			rejectedCheckNames = append(rejectedCheckNames, check.Name)
 		}
-		workload.SetDeactivationTarget(wl, kueue.WorkloadEvictedByAdmissionCheck, fmt.Sprintf("Admission check(s): %v, were rejected", rejectedCheckNames))
+		workload.SetDeactivationTarget(wl, kueue.WorkloadEvictedByAdmissionCheck, fmt.Sprintf("Admission check(s): %v, were rejected", stringsutils.Join(rejectedCheckNames, ",")))
 		if err := workload.ApplyAdmissionStatus(ctx, r.client, wl, true, r.clock); err != nil {
 			return false, client.IgnoreNotFound(err)
 		}

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -556,7 +556,7 @@ func TestReconcile(t *testing.T) {
 						Type:    kueue.WorkloadDeactivationTarget,
 						Status:  metav1.ConditionTrue,
 						Reason:  "AdmissionCheck",
-						Message: "Admission check(s): [check], were rejected",
+						Message: "Admission check(s): check, were rejected",
 					},
 				).
 				Obj(),
@@ -604,7 +604,7 @@ func TestReconcile(t *testing.T) {
 						Type:    kueue.WorkloadDeactivationTarget,
 						Status:  metav1.ConditionTrue,
 						Reason:  "AdmissionCheck",
-						Message: "Admission check(s): [check], were rejected",
+						Message: "Admission check(s): check, were rejected",
 					},
 				).
 				Obj(),
@@ -637,7 +637,7 @@ func TestReconcile(t *testing.T) {
 					Type:    kueue.WorkloadDeactivationTarget,
 					Status:  metav1.ConditionTrue,
 					Reason:  kueue.WorkloadEvictedByAdmissionCheck,
-					Message: "Admission check(s): [check-1], were rejected",
+					Message: "Admission check(s): check-1, were rejected",
 				}).
 				Obj(),
 			wantWorkload: utiltesting.MakeWorkload("wl", "ns").
@@ -662,14 +662,14 @@ func TestReconcile(t *testing.T) {
 						Type:    kueue.WorkloadEvicted,
 						Status:  metav1.ConditionTrue,
 						Reason:  "DeactivatedDueToAdmissionCheck",
-						Message: "The workload is deactivated due to Admission check(s): [check-1], were rejected",
+						Message: "The workload is deactivated due to Admission check(s): check-1, were rejected",
 					},
 					// In a real cluster this condition would be removed but it cant be in the fake cluster
 					metav1.Condition{
 						Type:    kueue.WorkloadDeactivationTarget,
 						Status:  metav1.ConditionTrue,
 						Reason:  kueue.WorkloadEvictedByAdmissionCheck,
-						Message: "Admission check(s): [check-1], were rejected",
+						Message: "Admission check(s): check-1, were rejected",
 					},
 				).
 				Obj(),
@@ -678,7 +678,7 @@ func TestReconcile(t *testing.T) {
 					Key:       types.NamespacedName{Namespace: "ns", Name: "wl"},
 					EventType: "Normal",
 					Reason:    "EvictedDueToDeactivatedDueToAdmissionCheck",
-					Message:   "The workload is deactivated due to Admission check(s): [check-1], were rejected",
+					Message:   "The workload is deactivated due to Admission check(s): check-1, were rejected",
 				},
 			},
 		},

--- a/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
@@ -195,7 +195,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 							Type:    kueue.ClusterQueueActive,
 							Status:  metav1.ConditionFalse,
 							Reason:  "FlavorNotFound",
-							Message: "Can't admit new workloads: references missing ResourceFlavor(s): [on-demand spot model-a model-b].",
+							Message: "Can't admit new workloads: references missing ResourceFlavor(s): on-demand,spot,model-a,model-b.",
 						},
 					},
 				}, util.IgnoreConditionTimestampsAndObservedGeneration, ignorePendingWorkloadsStatus))
@@ -385,7 +385,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 							Type:    kueue.ClusterQueueActive,
 							Status:  metav1.ConditionFalse,
 							Reason:  "FlavorNotFound",
-							Message: "Can't admit new workloads: references missing ResourceFlavor(s): [on-demand spot model-a model-b].",
+							Message: "Can't admit new workloads: references missing ResourceFlavor(s): on-demand,spot,model-a,model-b.",
 						},
 					},
 				}, util.IgnoreConditionTimestampsAndObservedGeneration, ignorePendingWorkloadsStatus))
@@ -413,7 +413,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 							Type:    kueue.ClusterQueueActive,
 							Status:  metav1.ConditionFalse,
 							Reason:  "FlavorNotFound",
-							Message: "Can't admit new workloads: references missing ResourceFlavor(s): [on-demand spot model-a model-b].",
+							Message: "Can't admit new workloads: references missing ResourceFlavor(s): on-demand,spot,model-a,model-b.",
 						},
 					},
 				}, util.IgnoreConditionTimestampsAndObservedGeneration, ignorePendingWorkloadsStatus))
@@ -663,7 +663,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 						Type:    kueue.ClusterQueueActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "FlavorNotFound",
-						Message: "Can't admit new workloads: references missing ResourceFlavor(s): [arch-a arch-b].",
+						Message: "Can't admit new workloads: references missing ResourceFlavor(s): arch-a,arch-b.",
 					},
 				}, util.IgnoreConditionTimestampsAndObservedGeneration))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -679,7 +679,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 						Type:    kueue.ClusterQueueActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "FlavorNotFound",
-						Message: "Can't admit new workloads: references missing ResourceFlavor(s): [arch-b].",
+						Message: "Can't admit new workloads: references missing ResourceFlavor(s): arch-b.",
 					},
 				}, util.IgnoreConditionTimestampsAndObservedGeneration))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -718,7 +718,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 						Type:    kueue.ClusterQueueActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "AdmissionCheckNotFound",
-						Message: "Can't admit new workloads: references missing AdmissionCheck(s): [check1 check2].",
+						Message: "Can't admit new workloads: references missing AdmissionCheck(s): check1,check2.",
 					},
 				}, util.IgnoreConditionTimestampsAndObservedGeneration))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -735,7 +735,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 						Type:    kueue.ClusterQueueActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "AdmissionCheckNotFound",
-						Message: "Can't admit new workloads: references missing AdmissionCheck(s): [check2].",
+						Message: "Can't admit new workloads: references missing AdmissionCheck(s): check2.",
 					},
 				}, util.IgnoreConditionTimestampsAndObservedGeneration))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -751,7 +751,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 						Type:    kueue.ClusterQueueActive,
 						Status:  metav1.ConditionFalse,
 						Reason:  "AdmissionCheckInactive",
-						Message: "Can't admit new workloads: references inactive AdmissionCheck(s): [check2].",
+						Message: "Can't admit new workloads: references inactive AdmissionCheck(s): check2.",
 					},
 				}, util.IgnoreConditionTimestampsAndObservedGeneration))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -636,7 +636,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 								Type:    kueue.ClusterQueueActive,
 								Status:  metav1.ConditionFalse,
 								Reason:  "FlavorNotFound",
-								Message: `Can't admit new workloads: references missing ResourceFlavor(s): [tas-flavor].`,
+								Message: `Can't admit new workloads: references missing ResourceFlavor(s): tas-flavor.`,
 							},
 						}, util.IgnoreConditionTimestampsAndObservedGeneration))
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
To generalise a lot of strings type alias and join those

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4983

#### Special notes for your reviewer:
If you see any other potential places where this can be used, let me know

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```