### PR TITLE
Use condition matcher with reason.

### DIFF
--- a/pkg/util/testing/condition_matchers_test.go
+++ b/pkg/util/testing/condition_matchers_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHaveConditionStatusAndReason(t *testing.T) {
+	testCases := map[string]struct {
+		conditionType         string
+		status                metav1.ConditionStatus
+		reason                string
+		conditions            any
+		want                  bool
+		wantErr               string
+		wantFailureMsg        string
+		wantNegatedFailureMsg string
+	}{
+		"invalid conditions": {
+			conditionType: "TestCondition",
+			conditions:    "invalid type",
+			want:          false,
+			wantErr:       "Condition matcher expects a []metav1.Condition. Got:\n    <string>: invalid type",
+		},
+		"success": {
+			conditionType: "TestCondition",
+			conditions:    []metav1.Condition{{Type: "TestCondition"}},
+			want:          true,
+		},
+		"success with status": {
+			conditionType: "TestCondition",
+			conditions:    []metav1.Condition{{Type: "TestCondition", Status: metav1.ConditionTrue}},
+			status:        metav1.ConditionTrue,
+			want:          true,
+		},
+		"success with status and reason": {
+			conditionType: "TestCondition",
+			conditions:    []metav1.Condition{{Type: "TestCondition", Status: metav1.ConditionTrue, Reason: "TestReason"}},
+			status:        metav1.ConditionTrue,
+			reason:        "TestReason",
+			want:          true,
+		},
+		"failure": {
+			conditionType: "InvalidTestCondition",
+			conditions:    []metav1.Condition{},
+			want:          false,
+			wantFailureMsg: `Expected
+    <[]v1.Condition | len:0, cap:0>: []
+to have condition type InvalidTestCondition`,
+			wantNegatedFailureMsg: `Expected
+    <[]v1.Condition | len:0, cap:0>: []
+not to have condition type InvalidTestCondition`,
+		},
+		"failure with status": {
+			conditionType: "InvalidTestCondition",
+			status:        metav1.ConditionTrue,
+			conditions:    []metav1.Condition{},
+			want:          false,
+			wantFailureMsg: `Expected
+    <[]v1.Condition | len:0, cap:0>: []
+to have condition type InvalidTestCondition and status True`,
+			wantNegatedFailureMsg: `Expected
+    <[]v1.Condition | len:0, cap:0>: []
+not to have condition type InvalidTestCondition and status True`,
+		},
+		"failure with reason": {
+			conditionType: "InvalidTestCondition",
+			reason:        "TestReason",
+			conditions:    []metav1.Condition{},
+			want:          false,
+			wantFailureMsg: `Expected
+    <[]v1.Condition | len:0, cap:0>: []
+to have condition type InvalidTestCondition and reason TestReason`,
+			wantNegatedFailureMsg: `Expected
+    <[]v1.Condition | len:0, cap:0>: []
+not to have condition type InvalidTestCondition and reason TestReason`,
+		},
+		"failure with status and reason": {
+			conditionType: "InvalidTestCondition",
+			status:        metav1.ConditionTrue,
+			reason:        "TestReason",
+			conditions:    []metav1.Condition{},
+			want:          false,
+			wantFailureMsg: `Expected
+    <[]v1.Condition | len:0, cap:0>: []
+to have condition type InvalidTestCondition, status True and reason TestReason`,
+			wantNegatedFailureMsg: `Expected
+    <[]v1.Condition | len:0, cap:0>: []
+not to have condition type InvalidTestCondition, status True and reason TestReason`,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			matcher := HaveConditionStatusAndReason(tc.conditionType, tc.status, tc.reason)
+			got, gotErr := matcher.Match(tc.conditions)
+
+			var gotErrStr string
+			if gotErr != nil {
+				gotErrStr = gotErr.Error()
+			}
+
+			if diff := cmp.Diff(tc.wantErr, gotErrStr); diff != "" {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Unexpected result (-want,+got):\n%s", diff)
+			}
+
+			if !got && gotErr == nil {
+				gotFailureMsg := matcher.FailureMessage(tc.conditions)
+				if diff := cmp.Diff(tc.wantFailureMsg, gotFailureMsg); diff != "" {
+					t.Errorf("Unexpected failure message (-want,+got):\n%s", diff)
+				}
+
+				gotNegatedFailureMsg := matcher.NegatedFailureMessage(tc.conditions)
+				if diff := cmp.Diff(tc.wantNegatedFailureMsg, gotNegatedFailureMsg); diff != "" {
+					t.Errorf("Unexpected negated failure messge (-want,+got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -495,11 +495,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			ginkgo.By("Waiting for the job to finish", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, createdLeaderWorkload)).To(gomega.Succeed())
-					g.Expect(apimeta.FindStatusCondition(createdLeaderWorkload.Status.Conditions, kueue.WorkloadFinished)).To(gomega.BeComparableTo(&metav1.Condition{
-						Type:   kueue.WorkloadFinished,
-						Status: metav1.ConditionTrue,
-						Reason: kueue.WorkloadFinishedReasonSucceeded,
-					}, util.IgnoreConditionMessage, util.IgnoreConditionTimestampsAndObservedGeneration))
+					g.Expect(createdLeaderWorkload.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadFinished, kueue.WorkloadFinishedReasonSucceeded))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -925,13 +921,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				readClient := &kueue.MultiKueueCluster{}
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, worker1ClusterKey, readClient)).To(gomega.Succeed())
-					g.Expect(readClient.Status.Conditions).To(gomega.ContainElement(gomega.BeComparableTo(
-						metav1.Condition{
-							Type:   kueue.MultiKueueClusterActive,
-							Status: metav1.ConditionFalse,
-							Reason: "ClientConnectionFailed",
-						},
-						util.IgnoreConditionTimestampsAndObservedGeneration, util.IgnoreConditionMessage)))
+					g.Expect(readClient.Status.Conditions).To(utiltesting.HaveConditionStatusFalseAndReason(kueue.MultiKueueClusterActive, "ClientConnectionFailed"))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 

--- a/test/e2e/singlecluster/e2e_test.go
+++ b/test/e2e/singlecluster/e2e_test.go
@@ -195,12 +195,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), createdWorkload)).To(gomega.Succeed())
 					g.Expect(createdWorkload.Finalizers).NotTo(gomega.ContainElement(kueue.ResourceInUseFinalizerName))
-					g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElement(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:   kueue.WorkloadFinished,
-							Status: metav1.ConditionTrue,
-							Reason: kueue.WorkloadFinishedReasonFailed,
-						}, util.IgnoreConditionMessage, util.IgnoreConditionTimestampsAndObservedGeneration)))
+					g.Expect(createdWorkload.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason(kueue.WorkloadFinished, kueue.WorkloadFinishedReasonFailed))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 		})

--- a/test/e2e/singlecluster/jobset_test.go
+++ b/test/e2e/singlecluster/jobset_test.go
@@ -20,12 +20,9 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/jobset/pkg/constants"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	workloadjobset "sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
@@ -99,12 +96,7 @@ var _ = ginkgo.Describe("JobSet", func() {
 			ginkgo.By("Waiting for the jobSet to finish", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdLeaderWorkload)).To(gomega.Succeed())
-					g.Expect(apimeta.FindStatusCondition(createdLeaderWorkload.Status.Conditions, kueue.WorkloadFinished)).To(gomega.BeComparableTo(&metav1.Condition{
-						Type:    kueue.WorkloadFinished,
-						Status:  metav1.ConditionTrue,
-						Reason:  kueue.WorkloadFinishedReasonSucceeded,
-						Message: constants.AllJobsCompletedMessage,
-					}, util.IgnoreConditionTimestampsAndObservedGeneration))
+					g.Expect(createdLeaderWorkload.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason(kueue.WorkloadFinished, kueue.WorkloadFinishedReasonSucceeded))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 		})

--- a/test/e2e/singlecluster/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/leaderworkerset_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -100,14 +99,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
-					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:    "Available",
-							Status:  metav1.ConditionTrue,
-							Reason:  "AllGroupsReady",
-							Message: "All replicas are ready",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration)),
-					)
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -158,14 +150,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
-					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:    "Available",
-							Status:  metav1.ConditionTrue,
-							Reason:  "AllGroupsReady",
-							Message: "All replicas are ready",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration)),
-					)
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -214,14 +199,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(2)))
-					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:    "Available",
-							Status:  metav1.ConditionTrue,
-							Reason:  "AllGroupsReady",
-							Message: "All replicas are ready",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration)),
-					)
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -279,14 +257,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 						g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
-						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-							gomega.BeComparableTo(metav1.Condition{
-								Type:    "Available",
-								Status:  metav1.ConditionTrue,
-								Reason:  "AllGroupsReady",
-								Message: "All replicas are ready",
-							}, util.IgnoreConditionTimestampsAndObservedGeneration)),
-						)
+						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 				})
 
@@ -308,14 +279,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 						g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(2)))
-						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-							gomega.BeComparableTo(metav1.Condition{
-								Type:    "Available",
-								Status:  metav1.ConditionTrue,
-								Reason:  "AllGroupsReady",
-								Message: "All replicas are ready",
-							}, util.IgnoreConditionTimestampsAndObservedGeneration)),
-						)
+						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 				})
 
@@ -374,14 +338,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 						g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(2)))
-						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-							gomega.BeComparableTo(metav1.Condition{
-								Type:    "Available",
-								Status:  metav1.ConditionTrue,
-								Reason:  "AllGroupsReady",
-								Message: "All replicas are ready",
-							}, util.IgnoreConditionTimestampsAndObservedGeneration)),
-						)
+						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 				})
 
@@ -409,14 +366,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 						g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
-						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-							gomega.BeComparableTo(metav1.Condition{
-								Type:    "Available",
-								Status:  metav1.ConditionTrue,
-								Reason:  "AllGroupsReady",
-								Message: "All replicas are ready",
-							}, util.IgnoreConditionTimestampsAndObservedGeneration)),
-						)
+						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 				})
 
@@ -472,13 +422,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 						g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
-						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-							gomega.BeComparableTo(metav1.Condition{
-								Type:   "Available",
-								Status: metav1.ConditionTrue,
-								Reason: "AllGroupsReady",
-							}, util.IgnoreConditionTimestampsAndObservedGeneration, util.IgnoreConditionMessage)),
-						)
+						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 				})
 
@@ -508,13 +452,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 						g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
-						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-							gomega.BeComparableTo(metav1.Condition{
-								Type:   "Available",
-								Status: metav1.ConditionTrue,
-								Reason: "AllGroupsReady",
-							}, util.IgnoreConditionTimestampsAndObservedGeneration, util.IgnoreConditionMessage)),
-						)
+						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 				})
 
@@ -593,14 +531,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 						g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(2)))
-						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-							gomega.BeComparableTo(metav1.Condition{
-								Type:    "Available",
-								Status:  metav1.ConditionTrue,
-								Reason:  "AllGroupsReady",
-								Message: "All replicas are ready",
-							}, util.IgnoreConditionTimestampsAndObservedGeneration)),
-						)
+						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 				})
 
@@ -676,14 +607,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(2)))
-					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:    "Available",
-							Status:  metav1.ConditionTrue,
-							Reason:  "AllGroupsReady",
-							Message: "All replicas are ready",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration)),
-					)
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -716,14 +640,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 					createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(2)))
-					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:    "Available",
-							Status:  metav1.ConditionTrue,
-							Reason:  "AllGroupsReady",
-							Message: "All replicas are ready",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration)),
-					)
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -808,13 +725,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lowPriorityLWS), createdLowPriorityLWS)).To(gomega.Succeed())
 					g.Expect(createdLowPriorityLWS.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
-					g.Expect(createdLowPriorityLWS.Status.Conditions).To(gomega.ContainElement(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:   "Available",
-							Status: metav1.ConditionTrue,
-							Reason: "AllGroupsReady",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration, util.IgnoreConditionMessage),
-					))
+					g.Expect(createdLowPriorityLWS.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -850,13 +761,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(highPriorityLWS), createdHighPriorityLWS)).To(gomega.Succeed())
 					g.Expect(createdHighPriorityLWS.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
-					g.Expect(createdHighPriorityLWS.Status.Conditions).To(gomega.ContainElement(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:   "Available",
-							Status: metav1.ConditionTrue,
-							Reason: "AllGroupsReady",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration, util.IgnoreConditionMessage),
-					))
+					g.Expect(createdHighPriorityLWS.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -865,18 +770,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lowPriorityLWS), createdLowPriorityLWS)).To(gomega.Succeed())
 					g.Expect(createdLowPriorityLWS.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
-					g.Expect(createdLowPriorityLWS.Status.Conditions).To(gomega.ContainElements(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:   "Progressing",
-							Status: metav1.ConditionTrue,
-							Reason: "GroupsProgressing",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration, util.IgnoreConditionMessage),
-						gomega.BeComparableTo(metav1.Condition{
-							Type:   "Available",
-							Status: metav1.ConditionFalse,
-							Reason: "AllGroupsReady",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration, util.IgnoreConditionMessage),
-					))
+					g.Expect(createdLowPriorityLWS.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Progressing", "GroupsProgressing"))
+					g.Expect(createdLowPriorityLWS.Status.Conditions).To(testing.HaveConditionStatusFalseAndReason("Available", "AllGroupsReady"))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -925,13 +820,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
-					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:   "Available",
-							Status: metav1.ConditionTrue,
-							Reason: "AllGroupsReady",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration, util.IgnoreConditionMessage)),
-					)
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -960,13 +849,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
-					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:   "Available",
-							Status: metav1.ConditionFalse,
-							Reason: "AllGroupsReady",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration, util.IgnoreConditionMessage)),
-					)
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusFalseAndReason("Available", "AllGroupsReady"))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -1007,13 +890,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
-					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:   "Available",
-							Status: metav1.ConditionTrue,
-							Reason: "AllGroupsReady",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration, util.IgnoreConditionMessage)),
-					)
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 

--- a/test/e2e/singlecluster/metrics_test.go
+++ b/test/e2e/singlecluster/metrics_test.go
@@ -282,8 +282,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, workloadKey, createdWorkload)).Should(gomega.Succeed())
-				g.Expect(createdWorkload.Status.Conditions).
-					Should(utiltesting.HaveConditionStatusTrue(v1beta1.WorkloadQuotaReserved))
+				g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(v1beta1.WorkloadQuotaReserved))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
@@ -510,17 +509,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, blockerWorkloadKey, blockerWorkload)).To(gomega.Succeed())
-
-				g.Expect(blockerWorkload.Status.Conditions).To(
-					gomega.ContainElements(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:    v1beta1.WorkloadEvicted,
-							Status:  metav1.ConditionTrue,
-							Reason:  "Deactivated",
-							Message: "The workload is deactivated",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration),
-					),
-				)
+				g.Expect(blockerWorkload.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason(v1beta1.WorkloadEvicted, v1beta1.WorkloadDeactivated))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("Expecting at least one of the high-priority jobs to be admitted", func() {

--- a/test/e2e/tas/leaderworkerset_test.go
+++ b/test/e2e/tas/leaderworkerset_test.go
@@ -124,14 +124,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for LeaderWorkerSet", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(replicas))
-					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(gomega.ContainElement(
-						gomega.BeComparableTo(metav1.Condition{
-							Type:    "Available",
-							Status:  metav1.ConditionTrue,
-							Reason:  "AllGroupsReady",
-							Message: "All replicas are ready",
-						}, util.IgnoreConditionTimestampsAndObservedGeneration)),
-					)
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Use condition matcher with reason.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```