### PR TITLE
[Cleanup] Drop architecture conditions for Ray image env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,7 @@ generate-kueuectl-docs: kueuectl-docs
 .PHONY: ray-project-mini-image-build
 ray-project-mini-image-build:
 	$(IMAGE_BUILD_CMD) \
-		-t $(IMAGE_REGISTRY)/ray-project-mini:$(RAYMINI_VERSION)$(RAY_ARCHITECTURE) \
+		-t $(IMAGE_REGISTRY)/ray-project-mini:$(RAYMINI_VERSION) \
 		--platform=$(PLATFORMS) \
 		--build-arg RAY_VERSION=$(RAY_VERSION) \
 		$(PUSH) \
@@ -414,9 +414,6 @@ ray-project-mini-image-build:
 
 # The step is required for local e2e test run
 .PHONY: kind-ray-project-mini-image-build
-kind-ray-project-mini-image-build:
-	@if [ "$(shell uname -m)" = "arm64" ]; then \
-		$(MAKE) PLATFORMS=linux/arm64  RAY_ARCHITECTURE=-aarch64 PUSH=--load  ray-project-mini-image-build; \
-	else \
-		$(MAKE) PLATFORMS=linux/amd64 PUSH=--load ray-project-mini-image-build; \
-	fi
+kind-ray-project-mini-image-build: PLATFORMS=linux/amd64
+kind-ray-project-mini-image-build: PUSH=--load
+kind-ray-project-mini-image-build: ray-project-mini-image-build

--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -246,27 +246,15 @@ function restore_managers_image {
 
 function determine_kuberay_ray_image {
     local RAY_IMAGE=rayproject/ray:${RAY_VERSION}
-    local RAY_IMAGE_ARM=rayproject/ray:${RAY_VERSION}-aarch64
     local RAYMINI_IMAGE=us-central1-docker.pkg.dev/k8s-staging-images/kueue/ray-project-mini:${RAYMINI_VERSION}
-    local RAYMINI_IMAGE_ARM=us-central1-docker.pkg.dev/k8s-staging-images/kueue/ray-project-mini:${RAYMINI_VERSION}-aarch64
 
     # Extra e2e images required for Kuberay
-    local unamestr=""
     local ray_image_to_use=""
 
-    unamestr=$(uname)
     if [[ "${USE_RAY_FOR_TESTS:-}" == "ray" ]]; then
-        if [[ "$unamestr" == "Linux" ]]; then
-            ray_image_to_use="${RAY_IMAGE}"
-        elif [[ "$unamestr" == "Darwin" ]]; then
-            ray_image_to_use="${RAY_IMAGE_ARM}"
-        fi
+        ray_image_to_use="${RAY_IMAGE}"
     else
-        if [[ "$unamestr" == "Linux" ]]; then
-            ray_image_to_use="${RAYMINI_IMAGE}"
-        elif [[ "$unamestr" == "Darwin" ]]; then
-            ray_image_to_use="${RAYMINI_IMAGE_ARM}"
-        fi
+        ray_image_to_use="${RAYMINI_IMAGE}"
     fi
 
     if [[ -z "$ray_image_to_use" ]]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In CI we only use amd64 architecture. 
The need to specify different architectures for e2e tests is purely for local use.
Remove architecture based conditions in the Makefile and test scripts and
 allow to override PLATFORMS locally for e2e tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5152

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```