### PR TITLE
Update KEP-1282 to support WaitForPodsReady metrics for eviction by reason

### DIFF
--- a/keps/1282-pods-ready-requeue-strategy/README.md
+++ b/keps/1282-pods-ready-requeue-strategy/README.md
@@ -36,7 +36,7 @@
 
 ## Summary
 
-Introduce new options that allow administrators to configure how Workloads are placed back in the queue after being after being evicted due to readiness checks.
+Introduce new options that allow administrators to configure how Workloads are placed back in the queue after being evicted due to readiness checks.
 
 ## Motivation
 
@@ -175,7 +175,7 @@ const (
 
 #### Workload
 
-Add a new field, "requeueState", to the Workload to allow recording the following items: 
+Add a new field, "requeueState", to the WorkloadStatus to allow recording the following items: 
 
 1. the number of times a workload is re-queued
 2. when the workload was re-queued or will be re-queued
@@ -205,6 +205,47 @@ type RequeueState struct {
 	//
 	// +optional
 	RequeueAt *metav1.Time `json:"requeueAt,omitempty"`
+}
+```
+
+Add a new field `evictionStats` to the WorkloadStatus struct to track the number of evictions by type and reason:
+
+```go
+type WorkloadStatus struct {
+	// evictionStats tracks eviction statistics by type and reason.
+    //
+    // +optional
+    // +listType=map
+    // +listMapKey=type
+    // +patchStrategy=merge
+    // +patchMergeKey=type
+    EvictionStats []Eviction `json:"evictionStats,omitempty"`
+}
+
+type Eviction struct {
+    // type identifies the eviction type.
+    //
+    // +required
+    // +kubebuilder:validation:Required
+    // +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
+    // +kubebuilder:validation:MaxLength=316
+    Type string `json:"type"`
+    
+    // reason specifies the programmatic identifier for the eviction cause.
+    //
+    // +required
+    // +kubebuilder:validation:Required
+    // +kubebuilder:validation:MaxLength=1024
+    // +kubebuilder:validation:MinLength=1
+    // +kubebuilder:validation:Pattern=`^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$`
+    Reason string `json:"reason"`
+    
+    // count tracks the number of evictions for this type and reason.
+    //
+    // +required
+    // +kubebuilder:validation:Required
+    // +kubebuilder:validation:Minimum=0
+    Count int32 `json:"count"`
 }
 ```
 

--- a/keps/1282-pods-ready-requeue-strategy/kep.yaml
+++ b/keps/1282-pods-ready-requeue-strategy/kep.yaml
@@ -28,4 +28,5 @@ feature-gates: []
 disable-supported: true
 
 # The following PRR answers are required at beta release
-metrics: []
+metrics:
+  - kueue_wait_for_pods_ready_workload_eviction_total


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Update KEP-1282 to support WaitForPodsReady metrics for eviction by reason.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #5071

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```