### PR TITLE
Fix golangci-lint to allow failing ci on error.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ vet: ## Run go vet against code.
 
 .PHONY: ci-lint
 ci-lint: golangci-lint
-	find . -path ./site -prune -false -o -name go.mod -execdir $(GOLANGCI_LINT) run $(GOLANGCI_LINT_FIX) --timeout 15m0s --config "$(PROJECT_DIR)/.golangci.yaml" \;
+	find . -path ./site -prune -false -o -name go.mod -exec dirname {} \; | xargs -I {} sh -c 'cd "{}" && $(GOLANGCI_LINT) run $(GOLANGCI_LINT_FIX) --timeout 15m0s --config "$(PROJECT_DIR)/.golangci.yaml"'
 
 .PHONY: lint-fix
 lint-fix: GOLANGCI_LINT_FIX=--fix

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -2328,8 +2328,13 @@ func TestGetCacheLQ(t *testing.T) {
 			cl := utiltesting.NewFakeClient()
 			cache := New(cl)
 			ctx := t.Context()
-			cache.AddClusterQueue(ctx, cq)
-			cache.AddLocalQueue(lq)
+
+			if err := cache.AddClusterQueue(ctx, cq); err != nil {
+				t.Fatalf("Adding ClusterQueue: %v", err)
+			}
+			if err := cache.AddLocalQueue(lq); err != nil {
+				t.Fatalf("Adding LocalQueue: %v", err)
+			}
 
 			gotLq, gotErr := cache.GetCacheLocalQueue(tc.getCQReference, tc.getLq)
 			if diff := cmp.Diff(tc.wantLq, gotLq, cmp.AllowUnexported(LocalQueue{}), cmpopts.EquateEmpty(), cmpopts.IgnoreTypes(sync.RWMutex{})); diff != "" {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -628,8 +628,8 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				AdmissionFairSharing: &configapi.AdmissionFairSharing{
-					UsageHalfLifeTime:     metav1.Duration{time.Second},
-					UsageSamplingInterval: metav1.Duration{time.Second},
+					UsageHalfLifeTime:     metav1.Duration{Duration: time.Second},
+					UsageSamplingInterval: metav1.Duration{Duration: time.Second},
 					ResourceWeights: map[corev1.ResourceName]float64{
 						corev1.ResourceCPU:    0.5,
 						corev1.ResourceMemory: 0.5,
@@ -641,8 +641,8 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				AdmissionFairSharing: &configapi.AdmissionFairSharing{
-					UsageHalfLifeTime:     metav1.Duration{-time.Second},
-					UsageSamplingInterval: metav1.Duration{time.Second},
+					UsageHalfLifeTime:     metav1.Duration{Duration: -time.Second},
+					UsageSamplingInterval: metav1.Duration{Duration: time.Second},
 				},
 			},
 			wantErr: field.ErrorList{
@@ -656,7 +656,7 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				AdmissionFairSharing: &configapi.AdmissionFairSharing{
-					UsageSamplingInterval: metav1.Duration{-time.Second},
+					UsageSamplingInterval: metav1.Duration{Duration: -time.Second},
 				},
 			},
 			wantErr: field.ErrorList{
@@ -670,7 +670,7 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				AdmissionFairSharing: &configapi.AdmissionFairSharing{
-					UsageSamplingInterval: metav1.Duration{time.Second},
+					UsageSamplingInterval: metav1.Duration{Duration: time.Second},
 					ResourceWeights: map[corev1.ResourceName]float64{
 						corev1.ResourceCPU: -0.5,
 					},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix golangci-lint to allow failing ci on error.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```