### PR TITLE
Preserve the Workload's DeactivationTarget condition after deactivation.

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -510,7 +510,6 @@ const (
 	WorkloadRequeued = "Requeued"
 
 	// WorkloadDeactivationTarget means that the Workload should be deactivated.
-	// This condition is temporary, so it should be removed after deactivation.
 	WorkloadDeactivationTarget = "DeactivationTarget"
 )
 

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -197,7 +197,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		message := "The workload is deactivated"
 		dtCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadDeactivationTarget)
 		if !apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted) {
-			if dtCond != nil {
+			if dtCond != nil && dtCond.Status == metav1.ConditionTrue {
 				reason = fmt.Sprintf("%sDueTo%s", reason, dtCond.Reason)
 				message = fmt.Sprintf("%s due to %s", message, dtCond.Message)
 			}
@@ -206,7 +206,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			evicted = true
 		}
 		if dtCond != nil {
-			apimeta.RemoveStatusCondition(&wl.Status.Conditions, kueue.WorkloadDeactivationTarget)
+			dtCond.Status = metav1.ConditionFalse
+			apimeta.SetStatusCondition(&wl.Status.Conditions, *dtCond)
 		}
 		if wl.Status.RequeueState != nil {
 			wl.Status.RequeueState = nil

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -664,10 +664,9 @@ func TestReconcile(t *testing.T) {
 						Reason:  "DeactivatedDueToAdmissionCheck",
 						Message: "The workload is deactivated due to Admission check(s): check-1, were rejected",
 					},
-					// In a real cluster this condition would be removed but it cant be in the fake cluster
 					metav1.Condition{
 						Type:    kueue.WorkloadDeactivationTarget,
-						Status:  metav1.ConditionTrue,
+						Status:  metav1.ConditionFalse,
 						Reason:  kueue.WorkloadEvictedByAdmissionCheck,
 						Message: "Admission check(s): check-1, were rejected",
 					},
@@ -1177,10 +1176,9 @@ func TestReconcile(t *testing.T) {
 					Reason:  "DeactivatedDueToRequeuingLimitExceeded",
 					Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
 				}).
-				// DeactivationTarget condition should be deleted in the real cluster, but the fake client doesn't allow us to do it.
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadDeactivationTarget,
-					Status:  metav1.ConditionTrue,
+					Status:  metav1.ConditionFalse,
 					Reason:  kueue.WorkloadRequeuingLimitExceeded,
 					Message: "exceeding the maximum number of re-queuing retries",
 				}).
@@ -1237,10 +1235,9 @@ func TestReconcile(t *testing.T) {
 					Reason:  "DeactivatedDueToRequeuingLimitExceeded",
 					Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
 				}).
-				// DeactivationTarget condition should be deleted in the real cluster, but the fake client doesn't allow us to do it.
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadDeactivationTarget,
-					Status:  metav1.ConditionTrue,
+					Status:  metav1.ConditionFalse,
 					Reason:  kueue.WorkloadRequeuingLimitExceeded,
 					Message: "exceeding the maximum number of re-queuing retries",
 				}).
@@ -1298,10 +1295,9 @@ func TestReconcile(t *testing.T) {
 					Reason:  "DeactivatedDueToRequeuingLimitExceeded",
 					Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
 				}).
-				// DeactivationTarget condition should be deleted in the real cluster, but the fake client doesn't allow us to do it.
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadDeactivationTarget,
-					Status:  metav1.ConditionTrue,
+					Status:  metav1.ConditionFalse,
 					Reason:  "RequeuingLimitExceeded",
 					Message: "exceeding the maximum number of re-queuing retries",
 				}).
@@ -1361,10 +1357,9 @@ func TestReconcile(t *testing.T) {
 					Reason:  "DeactivatedDueToRequeuingLimitExceeded",
 					Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
 				}).
-				// DeactivationTarget condition should be deleted in the real cluster, but the fake client doesn't allow us to do it.
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadDeactivationTarget,
-					Status:  metav1.ConditionTrue,
+					Status:  metav1.ConditionFalse,
 					Reason:  "RequeuingLimitExceeded",
 					Message: "exceeding the maximum number of re-queuing retries",
 				}).

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -2489,8 +2489,13 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 						Reason:  "DeactivatedDueToRequeuingLimitExceeded",
 						Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
 					}, util.IgnoreConditionTimestampsAndObservedGeneration),
+					gomega.BeComparableTo(metav1.Condition{
+						Type:    kueue.WorkloadDeactivationTarget,
+						Status:  metav1.ConditionFalse,
+						Reason:  "RequeuingLimitExceeded",
+						Message: "exceeding the maximum number of re-queuing retries",
+					}, util.IgnoreConditionTimestampsAndObservedGeneration),
 				))
-				g.Expect(apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadDeactivationTarget)).Should(gomega.BeNil())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -2108,8 +2108,13 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 						Reason:  "DeactivatedDueToRequeuingLimitExceeded",
 						Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",
 					}, util.IgnoreConditionTimestampsAndObservedGeneration),
+					gomega.BeComparableTo(metav1.Condition{
+						Type:    kueue.WorkloadDeactivationTarget,
+						Status:  metav1.ConditionFalse,
+						Reason:  "RequeuingLimitExceeded",
+						Message: "exceeding the maximum number of re-queuing retries",
+					}, util.IgnoreConditionTimestampsAndObservedGeneration),
 				))
-				g.Expect(wl.Status.Conditions).ShouldNot(testing.HaveCondition(kueue.WorkloadDeactivationTarget))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Preserve the Workload's DeactivationTarget condition after deactivation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #4471

#### Special notes for your reviewer:
Follow up for https://github.com/kubernetes-sigs/kueue/pull/5177#discussion_r2081236526.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added the DeactivationTarget condition to the Workload status to indicate that the workload was deactivated by Kueue, along with the reason for the deactivation.
```