### PR TITLE
tas: Wait for TAS reconciliation before starting the scheduling cycles

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -559,6 +559,19 @@ func (c *Cache) addOrUpdateWorkload(w *kueue.Workload) bool {
 	return clusterQueue.addWorkload(w) == nil
 }
 
+func (c *Cache) GetWorkloads() []*workload.Info {
+	c.RLock()
+	defer c.RUnlock()
+
+	workloads := make([]*workload.Info, 0)
+	for _, cq := range c.hm.ClusterQueues() {
+		for _, wl := range cq.Workloads {
+			workloads = append(workloads, wl)
+		}
+	}
+	return workloads
+}
+
 func (c *Cache) UpdateWorkload(oldWl, newWl *kueue.Workload) error {
 	c.Lock()
 	defer c.Unlock()

--- a/pkg/cache/tas_cache.go
+++ b/pkg/cache/tas_cache.go
@@ -27,8 +27,9 @@ import (
 
 type TASCache struct {
 	sync.RWMutex
-	client  client.Client
-	flavors map[kueue.ResourceFlavorReference]*TASFlavorCache
+	client        client.Client
+	flavors       map[kueue.ResourceFlavorReference]*TASFlavorCache
+	syncedFlavors bool
 }
 
 func NewTASCache(client client.Client) TASCache {
@@ -61,4 +62,16 @@ func (t *TASCache) Delete(name kueue.ResourceFlavorReference) {
 	t.Lock()
 	defer t.Unlock()
 	delete(t.flavors, name)
+}
+
+func (t *TASCache) SetSyncedFlavors(synced bool) {
+	t.Lock()
+	defer t.Unlock()
+	t.syncedFlavors = synced
+}
+
+func (t *TASCache) SyncedFlavors() bool {
+	t.RLock()
+	defer t.RUnlock()
+	return t.syncedFlavors
 }

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -159,6 +159,15 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, nil
 	}
 
+	if features.Enabled(features.TopologyAwareScheduling) {
+		if !r.cache.TASCache().SyncedFlavors() {
+			log.V(2).Info("Waiting for TAS cache to be synced")
+			return ctrl.Result{
+				RequeueAfter: 1 * time.Second,
+			}, nil
+		}
+	}
+
 	if workload.IsActive(&wl) {
 		if apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadDeactivationTarget) {
 			wl.Spec.Active = ptr.To(false)

--- a/pkg/controller/tas/controllers.go
+++ b/pkg/controller/tas/controllers.go
@@ -17,9 +17,14 @@ limitations under the License.
 package tas
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/queue"
 )
@@ -38,5 +43,57 @@ func SetupControllers(mgr ctrl.Manager, queues *queue.Manager, cache *cache.Cach
 	if ctrlName, err := topologyUngater.setupWithManager(mgr, cfg); err != nil {
 		return ctrlName, err
 	}
+
+	// Set up the TAS flavor cache in the background. This is because mgr is configured to list from a cache
+	// and the cache is not populated until the controller is started.
+	go func() {
+		err := syncTasCache(mgr, cache)
+		if err != nil {
+			panic(fmt.Sprintf("failed to populate TAS cache: %v", err))
+		}
+	}()
+
 	return "", nil
+}
+
+func syncTasCache(mgr ctrl.Manager, cCache *cache.Cache) error {
+	// Wait for the cache to be synced before listing resources. Else it will fail.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	if ok := mgr.GetCache().WaitForCacheSync(ctx); !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	var flvs kueue.ResourceFlavorList
+	// Wait for the flavors to be populated in the cache. We suppose that we are down when we are
+	// in sync with the catched list fetched above. We also suppose that the flavors are not
+	// created/recreated in the meantime.
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for flavors to be populated in the cache: %w", ctx.Err())
+		default:
+		}
+		if err := mgr.GetClient().List(ctx, &flvs); err != nil {
+			return fmt.Errorf("unable to list resource flavors: %w", err)
+		}
+		allFound := true
+		for _, flv := range flvs.Items {
+			if flv.Spec.TopologyName != nil {
+				for {
+					if cCache.TASCache().Get(kueue.ResourceFlavorReference(flv.Name)) != nil {
+						break
+					}
+					allFound = false
+					time.Sleep(1 * time.Second)
+					break
+				}
+			}
+		}
+		if allFound {
+			cCache.TASCache().SetSyncedFlavors(true)
+			return nil
+		}
+	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -23,12 +23,14 @@ import (
 	"slices"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -71,6 +73,7 @@ type Scheduler struct {
 	workloadOrdering        workload.Ordering
 	fairSharing             config.FairSharing
 	clock                   clock.Clock
+	doneTas                 bool
 
 	// schedulingCycle identifies the number of scheduling
 	// attempts since the last restart.
@@ -173,10 +176,79 @@ func reportSkippedPreemptions(p map[kueue.ClusterQueueReference]int) {
 	}
 }
 
+func (s *Scheduler) waitForTas(ctx context.Context, log logr.Logger) wait.SpeedSignal {
+	for !s.cache.TASCache().SyncedFlavors() {
+		log.V(2).Info("Waiting for the TAS cache to be synced")
+		time.Sleep(1 * time.Second)
+	}
+
+	// All the listed workloads that have reservation should have been added to the cache to ensure
+	// the TAS usage is as correct as possible.
+	var wlsList kueue.WorkloadList
+	err := s.client.List(ctx, &wlsList)
+	if err != nil {
+		return wait.SlowDown
+	}
+	wlsIn := s.cache.GetWorkloads()
+	wls := sets.Set[string]{}
+	for _, wl := range wlsIn {
+		key := fmt.Sprintf("%s/%s", wl.Obj.Namespace, wl.Obj.Name)
+		wls.Insert(key)
+	}
+	wlsListSet := sets.Set[string]{}
+	for _, wl := range wlsList.Items {
+		wlsListSet.Insert(wl.Name)
+	}
+	for _, wl := range wlsList.Items {
+		if !workload.HasQuotaReservation(&wl) || workload.IsFinished(&wl) {
+			continue
+		}
+		key := fmt.Sprintf("%s/%s", wl.Namespace, wl.Name)
+		if !wls.Has(key) {
+			log.V(2).Info("Workload has not received the topology update", "workload", wl)
+			return wait.SlowDown
+		}
+	}
+	log.V(2).Info("TAS cache is synced, proceeding with scheduling")
+	return wait.KeepGoing
+}
+
 func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	s.schedulingCycle++
 	log := ctrl.LoggerFrom(ctx).WithValues("schedulingCycle", s.schedulingCycle)
 	ctx = ctrl.LoggerInto(ctx, log)
+
+	if ctx.Err() != nil {
+		log.V(2).Info("Scheduler context cancelled, stopping scheduling")
+		return wait.KeepGoing
+	}
+
+	log.V(2).Info("Starting scheduling cycle")
+	if features.Enabled(features.TopologyAwareScheduling) && !s.doneTas {
+		timer := time.NewTimer(5 * time.Second)
+		defer timer.Stop()
+	retry:
+		for {
+			select {
+			case <-ctx.Done():
+				log.V(2).Info("Scheduler context cancelled, stopping scheduling")
+				return wait.KeepGoing
+			case <-timer.C:
+				err := fmt.Errorf("TAS cache not synced after 5 seconds")
+				log.Error(err, "TAS usage may be wrong")
+				break retry
+			default:
+				if s.waitForTas(ctx, log) == wait.SlowDown {
+					log.V(2).Info("Waiting for the TAS cache to be synced")
+					time.Sleep(1 * time.Second)
+					continue
+				} else {
+					break retry
+				}
+			}
+		}
+		s.doneTas = true
+	}
 
 	// 1. Get the heads from the queues, including their desired clusterQueue.
 	// This operation blocks while the queues are empty.
@@ -209,6 +281,10 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	preemptedWorkloads := make(preemption.PreemptedWorkloads)
 	skippedPreemptions := make(map[kueue.ClusterQueueReference]int)
 	for iterator.hasNext() {
+		if ctx.Err() != nil {
+			log.V(2).Info("Scheduler context cancelled, stopping scheduling")
+			return wait.KeepGoing
+		}
 		e := iterator.pop()
 
 		cq := snapshot.ClusterQueue(e.ClusterQueue)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When TAS is enabled and the kueue pod restarts, the TAS usage in the cache must be correctly initialized before scheduling and other workload-related reconciliations can happen. Currently, such a synchronization does not happen resulting in workloads being scheduled to incorrect nodes after a kueue reboot.

This PR is similar to #5104. However, it seems that in that PR we were trying to access the manager cache before the controller starts which does not work. Hence, we have to synchronize the TAS flavor cache in the background after the controllers are started. This also implies that we have to wait in certain controllers and the scheduler before making any scheduling/reconciliation decision. I also added two integration tests that reproduce the reboot without this fix and that pass with the changes in this PR. I ran the >50 times in my machine and I did not notice any flakiness.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```