### PR TITLE
Drop unnecessary omitempty for ProvisioningRequestConfig fields

### DIFF
--- a/apis/kueue/v1beta1/provisioningrequestconfig_types.go
+++ b/apis/kueue/v1beta1/provisioningrequestconfig_types.go
@@ -93,7 +93,7 @@ type ProvisioningRequestPodSetUpdatesNodeSelector struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=317
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
-	Key string `json:"key,omitempty"`
+	Key string `json:"key"`
 
 	// valueFromProvisioningClassDetail specifies the key of the
 	// ProvisioningRequest.status.provisioningClassDetails from which the value
@@ -102,7 +102,7 @@ type ProvisioningRequestPodSetUpdatesNodeSelector struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=32768
-	ValueFromProvisioningClassDetail string `json:"valueFromProvisioningClassDetail,omitempty"`
+	ValueFromProvisioningClassDetail string `json:"valueFromProvisioningClassDetail"`
 }
 
 type ProvisioningRequestRetryStrategy struct {


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow up to https://github.com/kubernetes-sigs/kueue/pull/5204

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```