### PR TITLE
Automated cherry pick of #5185: Update changelog about corrupted 0.11.x (x<=2)

### DIFF
--- a/CHANGELOG/CHANGELOG-0.11.md
+++ b/CHANGELOG/CHANGELOG-0.11.md
@@ -44,6 +44,9 @@ Changes since `v0.11.2`:
 
 ## v0.11.2
 
+IMPORTANT: Avoid using this release due to the corrupted [Topology CRD specification](https://github.com/kubernetes-sigs/kueue/issues/4850).
+When upgrading to the newer version please reinstall Kueue. If you are not using TopologyAwareScheduling the upgrading is not urgent.
+
 Changes since `v0.11.1`:
 
 ## Changes by Kind
@@ -58,7 +61,10 @@ Changes since `v0.11.1`:
 
 ## v0.11.1
 
-Changes since `0.11.1`:
+IMPORTANT: Avoid using this release due to the corrupted [Topology CRD specification](https://github.com/kubernetes-sigs/kueue/issues/4850).
+When upgrading to the newer version please reinstall Kueue. If you are not using TopologyAwareScheduling the upgrading is not urgent.
+
+Changes since `v0.11.0`:
 
 ## Changes by Kind
 
@@ -68,6 +74,9 @@ Changes since `0.11.1`:
 - Fixed bug that doesn't allow to use WorkloadPriorityClass on LeaderWorkerSet. (#4725, @mbobrovskyi)
 
 ## v0.11.0
+
+IMPORTANT: Avoid using this release due to the corrupted [Topology CRD specification](https://github.com/kubernetes-sigs/kueue/issues/4850).
+When upgrading to the newer version please reinstall Kueue. If you are not using TopologyAwareScheduling the upgrading is not urgent.
 
 Changes since `0.10.0`:
 


### PR DESCRIPTION
Cherry pick of #5185 on release-0.11.

#5185: Update changelog about corrupted 0.11.x (x<=2)

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```