### PR TITLE
Doc: Fix the outdated deployment queue-name label section

### DIFF
--- a/site/content/en/docs/tasks/run/deployment.md
+++ b/site/content/en/docs/tasks/run/deployment.md
@@ -34,16 +34,12 @@ When running Deployment on Kueue, take into consideration the following aspects:
 
 ### a. Queue selection
 
-The target [local queue](/docs/concepts/local_queue) should be specified in the `spec.template.metadata.labels` section of the Deployment configuration. 
-Since Kueue's scheduling and resource management will be applied to the individual Pods of the Deployment,
-the queue name should be specified at the Pod level.
+The target [local queue](/docs/concepts/local_queue) should be specified in the `metadata.labels` section of the Deployment configuration.
 
 ```yaml
-spec:
-   template:
-      metadata:
-         labels:
-            kueue.x-k8s.io/queue-name: user-queue
+metadata:
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
 ```
 
 ### b. Configure the resource needs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

The queue-name label will be propagated from `.metadata.label` to `.spec.template.metadata.labels` in the admission webhook controller: https://github.com/kubernetes-sigs/kueue/blob/f9cb97fdb04309358e2a042478dab2fb4ccb8d3d/pkg/controller/jobs/deployment/deployment_webhook.go#L86-L89

So, I refined the deployment queue-name label description to align with other Pods' dependent workload documentations:

- StatefulSet queue-name label section: https://kueue.sigs.k8s.io/docs/tasks/run/statefulset/#a-queue-selection
- LeaderworkerSet queue-name label section: https://kueue.sigs.k8s.io/docs/tasks/run/leaderworkerset/

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```