### PR TITLE
KEP-973: Mutable PriorityClassName for suspended Workloads

### DIFF
--- a/keps/973-workload-priority/README.md
+++ b/keps/973-workload-priority/README.md
@@ -9,6 +9,8 @@
   - [User Stories](#user-stories)
     - [Story 1](#story-1)
     - [Story 2](#story-2)
+  - [Notes/Constraints/Caveats (Optional)](#notesconstraintscaveats-optional)
+    - [Workload's priority values are always mutable](#workloads-priority-values-are-always-mutable)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [Kueue WorkloadPriorityClass API](#kueue-workloadpriorityclass-api)
@@ -22,7 +24,6 @@
     - [5. A jobFramework specifies only <code>workload's priority</code>](#5-a-jobframework-specifies-only-workloads-priority)
     - [6. A jobFramework specifies only <code>priorityClass</code>](#6-a-jobframework-specifies-only-priorityclass)
   - [Where workload's Priority is used](#where-workloads-priority-is-used)
-  - [Workload's priority values are always mutable](#workloads-priority-values-are-always-mutable)
   - [What happens when a user changes the priority of <code>workloadPriorityClass</code>?](#what-happens-when-a-user-changes-the-priority-of-workloadpriorityclass)
   - [Validation webhook](#validation-webhook)
   - [Future works](#future-works)
@@ -97,6 +98,18 @@ In such cases, they create two `WorkloadPriorityClass` and apply each one to the
 
 An organization desires to modify the priority of workloads that remain inactive for a specific duration.
 By developing a custom controller to manage Priority value of `Workload` spec, this expectation can be met.
+
+### Notes/Constraints/Caveats (Optional)
+
+#### Workload's priority values are always mutable
+
+Workload's `Priority` field is always mutable because it might be useful for the preemption.
+On the other hand, Workload's `PriorityClassSource` and `PriorityClassName` fields are always immutable for simplicity until Kueue v0.11.
+Since Kueue v0.12, the only Workload's `PriorityClassName` is made mutable only when the Workload is suspended. 
+However, the `PriorityClassName` can not be replaced with an empty name when updating to prevent switching to `scheduling.k8s.io/v1` PriorityClass.
+
+Side Note: The `scheduling.k8s.io/v1` PriorityClass is immutable although the sig-scheduling discussed mutable PriorityClass in 
+[Kubernetes Enhancement 4133](https://github.com/kubernetes/enhancements/issues/4133).
 
 ### Risks and Mitigations
 
@@ -439,12 +452,6 @@ spec:
 The priority of workloads is utilized in queuing, preemption, and other scheduling processes in Kueue.
 With the introduction of `workloadPriorityClass`, there is no change in the places where priority is used in Kueue.
 It just enables the usage of `workloadPriorityClass` as the priority.
-
-### Workload's priority values are always mutable
-
-Workload's `Priority` field is always mutable because it might be useful for the preemption.  
-Workload's `PriorityClassSource` and `PriorityClassName` fields are immutable for simplicity.  
-By the way, there is an [open KEP](https://github.com/kubernetes/enhancements/pull/4129) to make `PriorityClass` mutable in k8s. This `workload`'s design aligns with the direction of k8s `PriorityClass`.
 
 ### What happens when a user changes the priority of `workloadPriorityClass`?
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Since https://github.com/kubernetes-sigs/kueue/issues/5004, we allow them to replace the PriorityClassName with a non-empty name in Workloads.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```