### PR TITLE
Follow-up: Clean up tests for updating the Workload priority label.

### DIFF
--- a/test/e2e/singlecluster/e2e_test.go
+++ b/test/e2e/singlecluster/e2e_test.go
@@ -48,8 +48,8 @@ var _ = ginkgo.Describe("Kueue", func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-")
 		sampleJob = testingjob.MakeJob("test-job", ns.Name).
 			Queue("main").
-			RequestAndLimit("cpu", "1").
-			RequestAndLimit("memory", "20Mi").
+			RequestAndLimit(corev1.ResourceCPU, "1").
+			RequestAndLimit(corev1.ResourceMemory, "20Mi").
 			Obj()
 		jobKey = client.ObjectKeyFromObject(sampleJob)
 	})
@@ -358,7 +358,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 			job := testingjob.MakeJob("job", ns.Name).
 				Queue("main").
 				Image(util.E2eTestAgnHostImage, util.BehaviorExitFast).
-				RequestAndLimit("cpu", "500m").
+				RequestAndLimit(corev1.ResourceCPU, "500m").
 				Parallelism(3).
 				Completions(4).
 				SetAnnotation(workloadjob.JobMinParallelismAnnotation, "1").
@@ -432,8 +432,8 @@ var _ = ginkgo.Describe("Kueue", func() {
 			ginkgo.By("Create job-two with low priority", func() {
 				sampleJob2 = testingjob.MakeJob("test-job-2", ns.Name).
 					Queue("main").
-					RequestAndLimit("cpu", "1").
-					RequestAndLimit("memory", "20Mi").
+					RequestAndLimit(corev1.ResourceCPU, "1").
+					RequestAndLimit(corev1.ResourceMemory, "20Mi").
 					WorkloadPriorityClass(lowPriority).
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 					NodeSelector("instance-type", "on-demand").
@@ -500,7 +500,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 					WorkloadPriorityClass(samplePriority).
 					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
 					NodeSelector("instance-type", "on-demand").
-					RequestAndLimit("cpu", "2").
+					RequestAndLimit(corev1.ResourceCPU, "2").
 					Obj()
 				util.MustCreate(ctx, k8sClient, sampleJob)
 			})

--- a/test/e2e/singlecluster/e2e_test.go
+++ b/test/e2e/singlecluster/e2e_test.go
@@ -528,7 +528,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, jobKey, createdJob)).Should(gomega.Succeed())
 					createdJob.Labels[constants.WorkloadPriorityClassLabel] = ""
-					g.Expect(k8sClient.Update(ctx, createdJob)).ShouldNot(gomega.Succeed())
+					g.Expect(k8sClient.Update(ctx, createdJob)).Should(testing.BeForbiddenError())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})

--- a/test/e2e/singlecluster/e2e_test.go
+++ b/test/e2e/singlecluster/e2e_test.go
@@ -428,6 +428,16 @@ var _ = ginkgo.Describe("Kueue", func() {
 				})
 			})
 
+			ginkgo.By("Verify priority label is immutable when running", func() {
+				createdJob := &batchv1.Job{}
+				jobKey = client.ObjectKeyFromObject(sampleJob)
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, jobKey, createdJob)).Should(gomega.Succeed())
+					createdJob.Labels[constants.WorkloadPriorityClassLabel] = ""
+					g.Expect(k8sClient.Update(ctx, createdJob)).Should(testing.BeForbiddenError())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
 			var sampleJob2 *batchv1.Job
 			ginkgo.By("Create job-two with low priority", func() {
 				sampleJob2 = testingjob.MakeJob("test-job-2", ns.Name).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Follow-up of #5241.
See: https://github.com/kubernetes-sigs/kueue/pull/5241#pullrequestreview-2844247378

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates to #5241

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```