### PR TITLE
docs: add object retention page

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_object_retention_policy.md
+++ b/site/content/en/docs/tasks/manage/setup_object_retention_policy.md
@@ -1,0 +1,216 @@
+---
+title: "Setup garbage-collection of workload"
+date: 2025-05-16
+weight: 11
+description: >
+  Configure automatic garbage-collection of finished and deactivated Workloads
+  by defining retention policies.
+---
+
+This guide shows you how to enable and configure optional object retention
+policies in Kueue to automatically delete finished or deactivated Workloads
+after a specified time. By default, Kueue leaves all Workload objects in cluster
+indefinitely; with object retention you can free up etcd storage and reduce
+Kueue’s memory footprint.
+
+## Prerequisites
+
+- A running Kueue installation at **v0.12** or newer.
+- The `ObjectRetentionPolicies` feature-gate enabled in the Kueue controller manager. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
+
+## Set up a retention policy
+
+Follow the instructions described
+[here](/docs/installation#install-a-custom-configured-released-version) to
+install a release version by extending the configuration with the following
+fields:
+
+```yaml
+      objectRetentionPolicies:
+        workloads:
+          afterFinished: "1h"
+          afterDeactivatedByKueue: "1h"
+```
+
+### Workload Retention Policy
+
+The retention policy for Workloads is defined in the
+`.objectRetentionPolicies.workloads` field.
+It contains the following optional fields:
+- `afterFinished`: Duration after which finished Workloads are deleted.
+- `afterDeactivatedByKueue`: Duration after which any Kueue-deactivated Workloads (such as a Job, JobSet, or other custom workload types) are deleted.
+
+
+## Example
+
+### Kueue Configuration
+
+**Configure** Kueue with a 1m retention policy and enable [waitForPodsReady](/docs/tasks/manage/setup_wait_for_pods_ready.md):
+
+```yaml
+  objectRetentionPolicies:
+    workloads:
+      afterFinished: "1m"
+      afterDeactivatedByKueue: "1m"
+  waitForPodsReady:
+    enable: true
+    timeout: 2m
+    recoveryTimeout: 1m
+    blockAdmission: true
+    requeuingStrategy:
+      backoffLimitCount: 0
+```
+
+---
+
+### Scenario A: Successfully finished Workload
+
+1. **Submit** a simple Workload that should finish normally:
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: successful-cq
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+  - coveredResources: [cpu]
+    flavors:
+    - name: objectretention-rf
+      resources:
+      - name: cpu
+        nominalQuota: "2"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  namespace: default
+  name: successful-lq
+spec:
+  clusterQueue: successful-cq
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: successful-job
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: successful-lq
+spec:
+  parallelism: 1
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: c
+          image: registry.k8s.io/e2e-test-images/agnhost:2.53
+          args: ["entrypoint-tester"]
+          resources:
+            requests:
+              cpu: "1"
+```
+
+2. Watch the status transition to `Finished`. After ~1 minute, Kueue will automatically delete it:
+
+```bash
+# ~1m after Finished
+kubectl get workloads -n default
+# <successful-workload not found>
+   
+kubectl get jobs -n default
+# NAME             STATUS     COMPLETIONS   DURATION   AGE
+# successful-job   Complete   1/1                      1m
+```
+
+---
+
+### Scenario B: Evicted Workload via `waitForPodsReady`
+
+1. **Configure** Kueue [deployment](/docs/installation#install-a-custom-configured-released-version) to have more resources available than the node can provide:
+
+```yaml
+        resources:
+          limits:
+            cpu: "100" # or any value greater than the node's capacity
+```
+
+2. **Submit** a Workload that requests more than is available on the node:
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: limited-cq
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+  - coveredResources: ["cpu"]
+    flavors:
+    - name: objectretention-rf
+      resources:
+      - name: cpu
+        nominalQuota: "100" # more than is available on the node
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  namespace: default
+  name: limited-lq
+spec:
+  clusterQueue: limited-cq
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: limited-job
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: limited-lq
+spec:
+  parallelism: 1
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: c
+          image: registry.k8s.io/e2e-test-images/agnhost:2.53
+          args: ["entrypoint-tester"]
+          resources:
+            requests:
+              cpu: "100" # more than is available on the node
+```
+
+3. Without all Pods ready, Kueue evicts and deactivates the Workload:
+
+```bash
+# ~2m after submission
+kubectl get workloads -n default
+# NAME                    QUEUE    RESERVED IN   ADMITTED   FINISHED   AGE
+# limited-workload                               False                 2m
+```
+
+4. ~1 minute after eviction, the deactivated Workload is garbage-collected:
+
+```bash
+# ~1m after eviction
+kubectl get workloads -n default
+# <limited-workload not found>
+   
+kubectl get jobs -n default
+# <limited-job not found>
+```
+
+## Notes
+
+- `afterDeactivatedByKueue` is the duration to wait after *any* Kueue-managed Workload
+  (such as a Job, JobSet, or other custom workload types)
+  has been marked as deactivated by Kueue before automatically deleting it.
+  Deletion of deactivated workloads may cascade to objects not created by Kueue,
+  since deleting the parent Workload owner (e.g. JobSet) can trigger garbage-collection of dependent resources.
+  If you manually / automatically deactivate the Workload by specifying `.spec.active=false`, `afterDeactivatedByKueue` is _NOT_ effective.
+- If a retention duration is mis-configured (invalid duration),
+  the controller will fail to start.
+- Deletion is handled synchronously in the reconciliation loop; in
+  clusters with thousands of expired Workloads it may take time to
+  remove them all on first startup.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add a documentation page for the object retention functionality
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5261 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```