### PR TITLE
Filter Inadmissible Workloads before Scheduling Cycle

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -196,7 +196,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	logSnapshotIfVerbose(log, snapshot)
 
 	// 3. Calculate requirements (resource flavors, borrowing) for admitting workloads.
-	entries := s.nominate(ctx, headWorkloads, snapshot)
+	entries, inadmissibleEntries := s.nominate(ctx, headWorkloads, snapshot)
 
 	// 4. Create iterator which returns ordered entries.
 	iterator := makeIterator(ctx, entries, s.workloadOrdering, s.fairSharing.Enable)
@@ -213,7 +213,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 
 		cq := snapshot.ClusterQueue(e.ClusterQueue)
 		log := log.WithValues("workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", string(e.ClusterQueue)))
-		if cq != nil && cq.HasParent() {
+		if cq.HasParent() {
 			log = log.WithValues("parentCohort", klog.KRef("", string(cq.Parent().GetName())), "rootCohort", klog.KRef("", string(cq.Parent().Root().GetName())))
 		}
 		ctx := ctrl.LoggerInto(ctx, log)
@@ -301,6 +301,11 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 			result = metrics.AdmissionResultSuccess
 		}
 	}
+	for _, e := range inadmissibleEntries {
+		logAdmissionAttemptIfVerbose(log, &e)
+		s.requeueAndUpdate(ctx, e)
+	}
+
 	reportSkippedPreemptions(skippedPreemptions)
 	metrics.AdmissionAttempt(result, s.clock.Since(startTime))
 	if result != metrics.AdmissionResultSuccess {
@@ -342,10 +347,12 @@ func (e *entry) assignmentUsage() workload.Usage {
 }
 
 // nominate returns the workloads with their requirements (resource flavors, borrowing) if
-// they were admitted by the clusterQueues in the snapshot.
-func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, snap *cache.Snapshot) []entry {
+// they were admitted by the clusterQueues in the snapshot. The second return value
+// is the list of inadmissibleEntries.
+func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, snap *cache.Snapshot) ([]entry, []entry) {
 	log := ctrl.LoggerFrom(ctx)
 	entries := make([]entry, 0, len(workloads))
+	var inadmissibleEntries []entry
 	for _, w := range workloads {
 		log := log.WithValues("workload", klog.KObj(w.Obj), "clusterQueue", klog.KRef("", string(w.ClusterQueue)))
 		ns := corev1.Namespace{}
@@ -373,10 +380,12 @@ func (s *Scheduler) nominate(ctx context.Context, workloads []workload.Info, sna
 			e.assignment, e.preemptionTargets = s.getAssignments(log, &e.Info, snap)
 			e.inadmissibleMsg = e.assignment.Message()
 			e.LastAssignment = &e.assignment.LastState
+			entries = append(entries, e)
+			continue
 		}
-		entries = append(entries, e)
+		inadmissibleEntries = append(inadmissibleEntries, e)
 	}
-	return entries
+	return entries, inadmissibleEntries
 }
 
 func fits(cq *cache.ClusterQueueSnapshot, usage *workload.Usage, preemptedWorkloads preemption.PreemptedWorkloads, newTargets []*preemption.Target) bool {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We were running inadmissible workloads through the normal scheduling logic. As we already know these are inadmissible, these should only be logged and requeued. This is a follow-up to https://github.com/kubernetes-sigs/kueue/pull/5138

#### Which issue(s) this PR fixes:
Fixes #5291

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix race condition where deleted ClusterQueue could cause crash during scheduling cycle
```