### PR TITLE
Cleanup addOrUpdateWorkload in cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -552,7 +552,8 @@ func (c *Cache) addOrUpdateWorkload(w *kueue.Workload) bool {
 	if c.podsReadyTracking {
 		c.podsReadyCond.Broadcast()
 	}
-	return clusterQueue.addOrUpdateWorkload(w) == nil
+	clusterQueue.addOrUpdateWorkload(w)
+	return true
 }
 
 func (c *Cache) UpdateWorkload(oldWl, newWl *kueue.Workload) error {
@@ -577,7 +578,8 @@ func (c *Cache) UpdateWorkload(oldWl, newWl *kueue.Workload) error {
 	if c.podsReadyTracking {
 		c.podsReadyCond.Broadcast()
 	}
-	return cq.addOrUpdateWorkload(newWl)
+	cq.addOrUpdateWorkload(newWl)
+	return nil
 }
 
 func (c *Cache) DeleteWorkload(w *kueue.Workload) error {
@@ -633,9 +635,7 @@ func (c *Cache) AssumeWorkload(w *kueue.Workload) error {
 		return ErrCqNotFound
 	}
 
-	if err := cq.addOrUpdateWorkload(w); err != nil {
-		return err
-	}
+	cq.addOrUpdateWorkload(w)
 	c.assumedWorkloads[k] = w.Status.Admission.ClusterQueue
 	return nil
 }

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -403,7 +403,7 @@ func (c *clusterQueue) updateWithAdmissionChecks(checks map[kueue.AdmissionCheck
 	}
 }
 
-func (c *clusterQueue) addOrUpdateWorkload(w *kueue.Workload) error {
+func (c *clusterQueue) addOrUpdateWorkload(w *kueue.Workload) {
 	k := workload.Key(w)
 	if _, exist := c.Workloads[k]; exist {
 		c.deleteWorkload(w)
@@ -415,7 +415,6 @@ func (c *clusterQueue) addOrUpdateWorkload(w *kueue.Workload) error {
 		c.WorkloadsNotReady.Insert(k)
 	}
 	c.reportActiveWorkloads()
-	return nil
 }
 
 func (c *clusterQueue) deleteWorkload(w *kueue.Workload) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Preparatory PR for: https://github.com/kubernetes-sigs/kueue/pull/5276 and follow up to https://github.com/kubernetes-sigs/kueue/pull/5052, which replaced the use of addWorkload to addOrUpdateWorkload, which does not throw if already exists.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```