### PR TITLE
Fix tagging for helm charts

### DIFF
--- a/hack/push-chart.sh
+++ b/hack/push-chart.sh
@@ -32,12 +32,11 @@ HELM=${HELM:-./bin/helm}
 YQ=${YQ:-./bin/yq}
 
 readonly k8s_registry="registry.k8s.io/kueue"
-# Regex taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string, but with "v" prefix
-readonly semver_regex='^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
+readonly semver_regex='^v([0-9]+)(\.[0-9]+){1,2}(-rc\.[0-9]+)?$'
 
 image_repository=${IMAGE_REPO}
 app_version=${GIT_TAG}
-if echo "${EXTRA_TAG}" | grep -Pq "${semver_regex}";
+if [[ ${EXTRA_TAG} =~ ${semver_regex} ]]
 then
 	image_repository=${k8s_registry}/kueue
 	app_version=${EXTRA_TAG}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This PR reverts the generic approach attempted in https://github.com/kubernetes-sigs/kueue/pull/5280

This is not working because the "grep" on busybox does not recognize "-P".

```
https://storage.googleapis.com/kubernetes-ci-logs/logs/post-kueue-push-images/1924436373746487296/artifacts/build.log
[9:02](https://kubernetes.slack.com/archives/D05KY8M2MRQ/p1747767751405919)
Installed plugin: unittest
EXTRA_TAG="v0.12.0-rc.1" GIT_TAG="v20250519-v0.12.0-rc.1" IMAGE_REGISTRY="us-central1-docker.pkg.dev/k8s-staging-images/kueue" HELM_CHART_REPO="us-central1-docker.pkg.dev/k8s-staging-images/kueue/charts" IMAGE_REPO="us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue" HELM="/workspace/bin/helm" YQ="/workspace/bin/yq" ./hack/push-chart.sh
grep: unrecognized option: P
BusyBox v1.36.1 (2024-06-10 07:11:47 UTC) multi-call binary.

Usage: grep [-HhnlLoqvsrRiwFE] [-m N] [-A|B|C N] { PATTERN | -e PATTERN... | -f FILE... } [FILE]...

Search for PATTERN in FILEs (or stdin)

	-H	Add 'filename:' prefix
	-h	Do not add 'filename:' prefix
	-n	Add 'line_no:' prefix
	-l	Show only names of files that match
	-L	Show only names of files that don't match
	-c	Show only count of matching lines
	-o	Show only the matching part of line
	-q	Quiet. Return 0 if PATTERN is found, 1 otherwise
	-v	Select non-matching lines
	-s	Suppress open and read errors
	-r	Recurse
```
Also, I wasn't able to use "-E" because `(?:` is not supported.

In this case I decided it is quicker to revert and make it custom. Note that it was custom in the past too.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```