### PR TITLE
WIP: Block scheduling until all events for TAS are processed

### DIFF
--- a/pkg/controller/tas/controllers.go
+++ b/pkg/controller/tas/controllers.go
@@ -17,9 +17,13 @@ limitations under the License.
 package tas
 
 import (
+	"context"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
+	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/queue"
@@ -46,4 +50,14 @@ func SetupControllers(mgr ctrl.Manager, queues *queue.Manager, cache *cache.Cach
 		}
 	}
 	return "", nil
+}
+
+func RegisterInformers(ctx context.Context, mgr ctrl.Manager) error {
+	if _, err := mgr.GetCache().GetInformer(ctx, &kueuealpha.Topology{}); err != nil {
+		return err
+	}
+	if _, err := mgr.GetCache().GetInformer(ctx, &kueue.ResourceFlavor{}); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Hold for now, because we may consider alternatives, but early feedback is welcome

/hold

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Block scheduling until all ResourceFlavor and Topology events are processed.
```