### PR TITLE
test: waitforpodsready e2e move curl-pod to test cases

### DIFF
--- a/test/e2e/customconfigs/waitforpodsready_test.go
+++ b/test/e2e/customconfigs/waitforpodsready_test.go
@@ -74,19 +74,6 @@ var _ = ginkgo.Describe("WaitForPodsReady Job Controller E2E", ginkgo.Ordered, f
 			},
 		}
 		util.MustCreate(ctx, k8sClient, metricsReaderClusterRoleBinding)
-
-		curlPod = testingjobspod.MakePod("curl-metrics", configapi.DefaultNamespace).
-			ServiceAccountName(serviceAccountName).
-			Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-			TerminationGracePeriod(1).
-			Obj()
-		util.MustCreate(ctx, k8sClient, curlPod)
-
-		ginkgo.By("Waiting for the curl-metrics pod to run.", func() {
-			util.WaitForPodRunning(ctx, k8sClient, curlPod)
-		})
-
-		curlContainerName = curlPod.Spec.Containers[0].Name
 	})
 
 	ginkgo.BeforeEach(func() {
@@ -113,7 +100,6 @@ var _ = ginkgo.Describe("WaitForPodsReady Job Controller E2E", ginkgo.Ordered, f
 
 	ginkgo.AfterAll(func() {
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, metricsReaderClusterRoleBinding, true)
-		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, curlPod, true, util.LongTimeout)
 	})
 
 	ginkgo.When("WaitForPodsReady has a tiny Timeout and no RecoveryTimeout", func() {
@@ -131,6 +117,23 @@ var _ = ginkgo.Describe("WaitForPodsReady Job Controller E2E", ginkgo.Ordered, f
 					},
 				}
 			})
+
+			curlPod = testingjobspod.MakePod("curl-metrics", configapi.DefaultNamespace).
+				ServiceAccountName(serviceAccountName).
+				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+				TerminationGracePeriod(1).
+				Obj()
+			util.MustCreate(ctx, k8sClient, curlPod)
+
+			ginkgo.By("Waiting for the curl-metrics pod to run.", func() {
+				util.WaitForPodRunning(ctx, k8sClient, curlPod)
+			})
+
+			curlContainerName = curlPod.Spec.Containers[0].Name
+		})
+
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, curlPod, true, util.LongTimeout)
 		})
 
 		ginkgo.It("should evict and requeue workload when pods readiness timeout is surpassed", func() {
@@ -214,6 +217,23 @@ var _ = ginkgo.Describe("WaitForPodsReady Job Controller E2E", ginkgo.Ordered, f
 					},
 				}
 			})
+
+			curlPod = testingjobspod.MakePod("curl-metrics", configapi.DefaultNamespace).
+				ServiceAccountName(serviceAccountName).
+				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+				TerminationGracePeriod(1).
+				Obj()
+			util.MustCreate(ctx, k8sClient, curlPod)
+
+			ginkgo.By("Waiting for the curl-metrics pod to run.", func() {
+				util.WaitForPodRunning(ctx, k8sClient, curlPod)
+			})
+
+			curlContainerName = curlPod.Spec.Containers[0].Name
+		})
+
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, curlPod, true, util.LongTimeout)
 		})
 
 		ginkgo.It("should evict and requeue workload when pod failure causes recovery timeout", func() {
@@ -288,6 +308,23 @@ var _ = ginkgo.Describe("WaitForPodsReady Job Controller E2E", ginkgo.Ordered, f
 					},
 				}
 			})
+
+			curlPod = testingjobspod.MakePod("curl-metrics", configapi.DefaultNamespace).
+				ServiceAccountName(serviceAccountName).
+				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+				TerminationGracePeriod(1).
+				Obj()
+			util.MustCreate(ctx, k8sClient, curlPod)
+
+			ginkgo.By("Waiting for the curl-metrics pod to run.", func() {
+				util.WaitForPodRunning(ctx, k8sClient, curlPod)
+			})
+
+			curlContainerName = curlPod.Spec.Containers[0].Name
+		})
+
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, curlPod, true, util.LongTimeout)
 		})
 
 		ginkgo.It("should continue running workload if pod recovers before recoveryTimeout", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Move curl pod management to test cases to ensure its availability and resolve test flakiness

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5302

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```