### PR TITLE
Fix missing namespace selector on webhook manifest

### DIFF
--- a/charts/kueue/templates/webhook/manifests.yaml
+++ b/charts/kueue/templates/webhook/manifests.yaml
@@ -21,6 +21,17 @@ webhooks:
         path: /mutate-workload-codeflare-dev-v1beta2-appwrapper
     failurePolicy: Fail
     name: mappwrapper.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - workload.codeflare.dev
@@ -77,6 +88,17 @@ webhooks:
         path: /mutate-batch-v1-job
     failurePolicy: Fail
     name: mjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - batch
@@ -97,6 +119,17 @@ webhooks:
         path: /mutate-jobset-x-k8s-io-v1alpha2-jobset
     failurePolicy: Fail
     name: mjobset.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - jobset.x-k8s.io
@@ -117,6 +150,17 @@ webhooks:
         path: /mutate-kubeflow-org-v1-jaxjob
     failurePolicy: Fail
     name: mjaxjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -137,6 +181,17 @@ webhooks:
         path: /mutate-kubeflow-org-v1-paddlejob
     failurePolicy: Fail
     name: mpaddlejob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -157,6 +212,17 @@ webhooks:
         path: /mutate-kubeflow-org-v1-pytorchjob
     failurePolicy: Fail
     name: mpytorchjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -177,6 +243,17 @@ webhooks:
         path: /mutate-kubeflow-org-v1-tfjob
     failurePolicy: Fail
     name: mtfjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -197,6 +274,17 @@ webhooks:
         path: /mutate-kubeflow-org-v1-xgboostjob
     failurePolicy: Fail
     name: mxgboostjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -252,6 +340,17 @@ webhooks:
         path: /mutate-leaderworkerset-x-k8s-io-v1-leaderworkerset
     failurePolicy: Fail
     name: mleaderworkerset.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - leaderworkerset.x-k8s.io
@@ -273,6 +372,17 @@ webhooks:
         path: /mutate-kubeflow-org-v2beta1-mpijob
     failurePolicy: Fail
     name: mmpijob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -293,6 +403,17 @@ webhooks:
         path: /mutate-ray-io-v1-raycluster
     failurePolicy: Fail
     name: mraycluster.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - ray.io
@@ -313,6 +434,17 @@ webhooks:
         path: /mutate-ray-io-v1-rayjob
     failurePolicy: Fail
     name: mrayjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - ray.io
@@ -442,6 +574,17 @@ webhooks:
         path: /validate-workload-codeflare-dev-v1beta2-appwrapper
     failurePolicy: Fail
     name: vappwrapper.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - workload.codeflare.dev
@@ -497,6 +640,17 @@ webhooks:
         path: /validate-batch-v1-job
     failurePolicy: Fail
     name: vjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - batch
@@ -517,6 +671,17 @@ webhooks:
         path: /validate-jobset-x-k8s-io-v1alpha2-jobset
     failurePolicy: Fail
     name: vjobset.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - jobset.x-k8s.io
@@ -537,6 +702,17 @@ webhooks:
         path: /validate-kubeflow-org-v1-jaxjob
     failurePolicy: Fail
     name: vjaxjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -557,6 +733,17 @@ webhooks:
         path: /validate-kubeflow-org-v1-paddlejob
     failurePolicy: Fail
     name: vpaddlejob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -577,6 +764,17 @@ webhooks:
         path: /validate-kubeflow-org-v1-pytorchjob
     failurePolicy: Fail
     name: vpytorchjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -597,6 +795,17 @@ webhooks:
         path: /validate-kubeflow-org-v1-tfjob
     failurePolicy: Fail
     name: vtfjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -617,6 +826,17 @@ webhooks:
         path: /validate-kubeflow-org-v1-xgboostjob
     failurePolicy: Fail
     name: vxgboostjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -672,6 +892,17 @@ webhooks:
         path: /validate-leaderworkerset-x-k8s-io-v1-leaderworkerset
     failurePolicy: Fail
     name: vleaderworkerset.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - leaderworkerset.x-k8s.io
@@ -692,6 +923,17 @@ webhooks:
         path: /validate-kubeflow-org-v2beta1-mpijob
     failurePolicy: Fail
     name: vmpijob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -712,6 +954,17 @@ webhooks:
         path: /validate-ray-io-v1-raycluster
     failurePolicy: Fail
     name: vraycluster.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - ray.io
@@ -732,6 +985,17 @@ webhooks:
         path: /validate-ray-io-v1-rayjob
     failurePolicy: Fail
     name: vrayjob.kb.io
+    namespaceSelector:
+      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- else }}
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - '{{ .Release.Namespace }}'
+      {{- end }}
     rules:
       - apiGroups:
           - ray.io

--- a/charts/kueue/templates/webhook/manifests.yaml
+++ b/charts/kueue/templates/webhook/manifests.yaml
@@ -21,17 +21,10 @@ webhooks:
         path: /mutate-workload-codeflare-dev-v1beta2-appwrapper
     failurePolicy: Fail
     name: mappwrapper.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - workload.codeflare.dev
@@ -88,17 +81,10 @@ webhooks:
         path: /mutate-batch-v1-job
     failurePolicy: Fail
     name: mjob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - batch
@@ -119,17 +105,10 @@ webhooks:
         path: /mutate-jobset-x-k8s-io-v1alpha2-jobset
     failurePolicy: Fail
     name: mjobset.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - jobset.x-k8s.io
@@ -150,17 +129,10 @@ webhooks:
         path: /mutate-kubeflow-org-v1-jaxjob
     failurePolicy: Fail
     name: mjaxjob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -181,17 +153,10 @@ webhooks:
         path: /mutate-kubeflow-org-v1-paddlejob
     failurePolicy: Fail
     name: mpaddlejob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -212,17 +177,10 @@ webhooks:
         path: /mutate-kubeflow-org-v1-pytorchjob
     failurePolicy: Fail
     name: mpytorchjob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -243,17 +201,10 @@ webhooks:
         path: /mutate-kubeflow-org-v1-tfjob
     failurePolicy: Fail
     name: mtfjob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -274,17 +225,10 @@ webhooks:
         path: /mutate-kubeflow-org-v1-xgboostjob
     failurePolicy: Fail
     name: mxgboostjob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -340,17 +284,10 @@ webhooks:
         path: /mutate-leaderworkerset-x-k8s-io-v1-leaderworkerset
     failurePolicy: Fail
     name: mleaderworkerset.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - leaderworkerset.x-k8s.io
@@ -372,17 +309,10 @@ webhooks:
         path: /mutate-kubeflow-org-v2beta1-mpijob
     failurePolicy: Fail
     name: mmpijob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -403,17 +333,10 @@ webhooks:
         path: /mutate-ray-io-v1-raycluster
     failurePolicy: Fail
     name: mraycluster.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - ray.io
@@ -434,17 +357,10 @@ webhooks:
         path: /mutate-ray-io-v1-rayjob
     failurePolicy: Fail
     name: mrayjob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - ray.io
@@ -574,17 +490,10 @@ webhooks:
         path: /validate-workload-codeflare-dev-v1beta2-appwrapper
     failurePolicy: Fail
     name: vappwrapper.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - workload.codeflare.dev
@@ -640,17 +549,10 @@ webhooks:
         path: /validate-batch-v1-job
     failurePolicy: Fail
     name: vjob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - batch
@@ -671,17 +573,10 @@ webhooks:
         path: /validate-jobset-x-k8s-io-v1alpha2-jobset
     failurePolicy: Fail
     name: vjobset.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - jobset.x-k8s.io
@@ -702,17 +597,10 @@ webhooks:
         path: /validate-kubeflow-org-v1-jaxjob
     failurePolicy: Fail
     name: vjaxjob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -733,17 +621,10 @@ webhooks:
         path: /validate-kubeflow-org-v1-paddlejob
     failurePolicy: Fail
     name: vpaddlejob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -764,17 +645,10 @@ webhooks:
         path: /validate-kubeflow-org-v1-pytorchjob
     failurePolicy: Fail
     name: vpytorchjob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -795,17 +669,10 @@ webhooks:
         path: /validate-kubeflow-org-v1-tfjob
     failurePolicy: Fail
     name: vtfjob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -826,17 +693,10 @@ webhooks:
         path: /validate-kubeflow-org-v1-xgboostjob
     failurePolicy: Fail
     name: vxgboostjob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -892,17 +752,10 @@ webhooks:
         path: /validate-leaderworkerset-x-k8s-io-v1-leaderworkerset
     failurePolicy: Fail
     name: vleaderworkerset.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - leaderworkerset.x-k8s.io
@@ -923,17 +776,10 @@ webhooks:
         path: /validate-kubeflow-org-v2beta1-mpijob
     failurePolicy: Fail
     name: vmpijob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -954,17 +800,10 @@ webhooks:
         path: /validate-ray-io-v1-raycluster
     failurePolicy: Fail
     name: vraycluster.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - ray.io
@@ -985,17 +824,10 @@ webhooks:
         path: /validate-ray-io-v1-rayjob
     failurePolicy: Fail
     name: vrayjob.kb.io
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
     namespaceSelector:
-      {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
-        {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-      {{- else }}
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - kube-system
-            - '{{ .Release.Namespace }}'
-      {{- end }}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+    {{- end }}
     rules:
       - apiGroups:
           - ray.io

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -323,384 +323,216 @@ files:
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-batch-v1-job"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-jobset-x-k8s-io-v1alpha2-jobset"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-jaxjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-paddlejob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-pytorchjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-tfjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-xgboostjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-leaderworkerset-x-k8s-io-v1-leaderworkerset"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v2beta1-mpijob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-ray-io-v1-raycluster"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-ray-io-v1-rayjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-workload-codeflare-dev-v1beta2-appwrapper"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-batch-v1-job"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-jobset-x-k8s-io-v1alpha2-jobset"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-jaxjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-paddlejob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-pytorchjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-tfjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-xgboostjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-leaderworkerset-x-k8s-io-v1-leaderworkerset"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v2beta1-mpijob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-ray-io-v1-raycluster"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-ray-io-v1-rayjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-          namespaceSelector:
             {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            namespaceSelector:
               {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
-            {{- else }}
-            matchExpressions:
-              - key: kubernetes.io/metadata.name
-                operator: NotIn
-                values:
-                  - kube-system
-                  - '{{ .Release.Namespace }}'
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-workload-codeflare-dev-v1beta2-appwrapper"'

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -320,6 +320,390 @@ files:
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-apps-v1-statefulset"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-batch-v1-job"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-jobset-x-k8s-io-v1alpha2-jobset"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-jaxjob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-paddlejob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-pytorchjob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-tfjob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-xgboostjob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-leaderworkerset-x-k8s-io-v1-leaderworkerset"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v2beta1-mpijob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-ray-io-v1-raycluster"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-ray-io-v1-rayjob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-workload-codeflare-dev-v1beta2-appwrapper"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-batch-v1-job"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-jobset-x-k8s-io-v1alpha2-jobset"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-jaxjob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-paddlejob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-pytorchjob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-tfjob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-xgboostjob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-leaderworkerset-x-k8s-io-v1-leaderworkerset"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v2beta1-mpijob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-ray-io-v1-raycluster"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "MutatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-ray-io-v1-rayjob"'
+      - type: INSERT_TEXT
+        key: .webhooks.[].name
+        value: |
+          namespaceSelector:
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+            {{- else }}
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - '{{ .Release.Namespace }}'
+            {{- end }}
+        onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
+        onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-workload-codeflare-dev-v1beta2-appwrapper"'
   - path: ./config/components/kueueviz/*.yaml
     outputDir: ./charts/kueue/templates/kueueviz
     excludes:


### PR DESCRIPTION
#### What this PR does / why we need it:

Based on the documentation https://kueue.sigs.k8s.io/docs/reference/kueue-config.v1beta1/ :


> ManagedJobsNamespaceSelector provides a namespace-based mechanism to exempt jobs from management by Kueue.

But currently we still catch all jobs creation without respecting this namespace selector.


#### Which issue(s) this PR fixes:

Fixes #5260

#### Special notes for your reviewer:
#### Does this PR introduce a user-facing change?

```release-note
Fix missing namespace selector on webhook manifest. ManagedJobsNamespaceSelector option was only applied to pods/deployment/statefulset, now it is applied to all kind of jobs.
Kube-system and Kueue release namespaces are still not excluded automatically by default.
```

