### PR TITLE
Fix assumedUsage calculation in TAS

### DIFF
--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -2207,7 +2207,7 @@ func TestFindTopologyAssignmentForTwoPodSets(t *testing.T) {
 		wantResult["podset1"] = buildWantedResult(wantAssignment1)
 		wantResult["podset2"] = buildWantedResult(wantAssignment2)
 
-		gotResult := snapshot.FindTopologyAssignmentsForFlavor(flavorTASRequests, false)
+		gotResult := snapshot.FindTopologyAssignmentsForFlavor(flavorTASRequests, false, nil)
 		if diff := cmp.Diff(wantResult, gotResult); diff != "" {
 			t.Errorf("unexpected topology assignment (-want,+got): %s", diff)
 		}

--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"context"
 	"sort"
 	"testing"
 
@@ -2118,4 +2119,141 @@ func TestFindTopologyAssignment(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFindTopologyAssignmentForTwoPodSets(t *testing.T) {
+	const (
+		tasBlockLabel = "cloud.com/topology-block"
+	)
+
+	t.Run("find topology assignment for two podsets with overlapping domain", func(t *testing.T) {
+		ctx, _ := utiltesting.ContextWithLog(t)
+		nodes := []corev1.Node{
+			*testingnode.MakeNode("b1").
+				Label(tasBlockLabel, "b1").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("2"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}).
+				Ready().
+				Obj(),
+			*testingnode.MakeNode("b2").
+				Label(tasBlockLabel, "b2").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("2"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}).
+				Ready().
+				Obj(),
+			*testingnode.MakeNode("b3").
+				Label(tasBlockLabel, "b3").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("2"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}).
+				Ready().
+				Obj(),
+		}
+		levels := []string{tasBlockLabel}
+		requests := resources.Requests{
+			corev1.ResourceCPU: 1000,
+		}
+		topologyRequest := &kueue.PodSetTopologyRequest{
+			Preferred: ptr.To(tasBlockLabel),
+		}
+		wantAssignment1 := &kueue.TopologyAssignment{
+			Levels: []string{tasBlockLabel},
+			Domains: []kueue.TopologyDomainAssignment{
+				{
+					Count: 2,
+					Values: []string{
+						"b1",
+					},
+				},
+				{
+					Count: 1,
+					Values: []string{
+						"b2",
+					},
+				},
+			},
+		}
+		wantAssignment2 := &kueue.TopologyAssignment{
+			Levels: []string{tasBlockLabel},
+			Domains: []kueue.TopologyDomainAssignment{
+				{
+					Count: 1,
+					Values: []string{
+						"b2",
+					},
+				},
+				{
+					Count: 2,
+					Values: []string{
+						"b3",
+					},
+				},
+			},
+		}
+
+		snapshot := buildSnapshot(ctx, t, nodes, levels)
+
+		tasInput1 := buildTASInput("podset1", topologyRequest, requests, 3)
+		tasInput2 := buildTASInput("podset2", topologyRequest, requests, 3)
+
+		flavorTASRequests := []TASPodSetRequests{tasInput1, tasInput2}
+
+		wantResult := make(TASAssignmentsResult)
+		wantResult["podset1"] = buildWantedResult(wantAssignment1)
+		wantResult["podset2"] = buildWantedResult(wantAssignment2)
+
+		gotResult := snapshot.FindTopologyAssignmentsForFlavor(flavorTASRequests, false)
+		if diff := cmp.Diff(wantResult, gotResult); diff != "" {
+			t.Errorf("unexpected topology assignment (-want,+got): %s", diff)
+		}
+	})
+}
+
+func buildSnapshot(ctx context.Context, t *testing.T, nodes []corev1.Node, levels []string) *TASFlavorSnapshot {
+	initialObjects := make([]client.Object, 0)
+	for i := range nodes {
+		initialObjects = append(initialObjects, &nodes[i])
+	}
+	clientBuilder := utiltesting.NewClientBuilder()
+	clientBuilder.WithObjects(initialObjects...)
+	_ = tasindexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder))
+	client := clientBuilder.Build()
+
+	tasCache := NewTASCache(client)
+	tasFlavorCache := tasCache.NewTASFlavorCache("default", levels, map[string]string{}, []corev1.Toleration{})
+
+	snapshot, err := tasFlavorCache.snapshot(ctx)
+	if err != nil {
+		t.Fatalf("failed to build the snapshot: %v", err)
+	}
+	return snapshot
+}
+
+func buildTASInput(podsetName kueue.PodSetReference, topologyRequest *kueue.PodSetTopologyRequest, requests resources.Requests, podCount int32) TASPodSetRequests {
+	return TASPodSetRequests{
+		PodSet: &kueue.PodSet{
+			Name:            podsetName,
+			TopologyRequest: topologyRequest,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Tolerations:  []corev1.Toleration{},
+					NodeSelector: map[string]string{},
+				},
+			},
+		},
+		SinglePodRequests: requests,
+		Count:             podCount,
+	}
+}
+func buildWantedResult(wantAssignment *kueue.TopologyAssignment) tasPodSetAssignmentResult {
+	wantPodSetResult := tasPodSetAssignmentResult{
+		FailureReason: "",
+	}
+	wantPodSetResult.TopologyAssignment = wantAssignment
+	return wantPodSetResult
 }

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -437,7 +437,7 @@ func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.Request
 		if assumedUsage[domainID] == nil {
 			assumedUsage[domainID] = resources.Requests{}
 		}
-		assumedUsage[domainID].Add(tr.TotalRequests())
+		assumedUsage[domainID].Add(tr.SinglePodRequests.ScaledUp(int64(domain.Count)))
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
This PR fixes assumedUsage calculation in TAS

Before this change, for each domain present in podset assignment algorithm was adding total requested resources for the whole podset instead of resources actually used by the pods assigned to that domain. This resulted in some workloads with more than 1 podset not fitting in the topology which should have enough resources to accomodate that workload.

This PR fixes that by replacing `TotalRequests` with `SinglePodRequests` scaled by the number of pods actually assigned to that domain.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: fix accounting of TAS usage for workloads with multiple PodSets. This bug could prevent admitting workloads which otherwise could fit.
```