### PR TITLE
drop workload state from kueueviz as its always unknown

### DIFF
--- a/cmd/kueueviz/frontend/src/LocalQueueDetail.jsx
+++ b/cmd/kueueviz/frontend/src/LocalQueueDetail.jsx
@@ -107,7 +107,6 @@ const LocalQueueDetail = () => {
             {workloads.map((workload) => (
               <TableRow key={workload.metadata.name}>
                 <TableCell><Link to={`/workload/${namespace}/${workload.metadata.name}`}>{workload.metadata.name}</Link></TableCell>
-                <TableCell>{workload.status?.state || "Unknown"}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/cmd/kueueviz/frontend/src/WorkloadDetail.jsx
+++ b/cmd/kueueviz/frontend/src/WorkloadDetail.jsx
@@ -52,7 +52,6 @@ const WorkloadDetail = () => {
             {" → "}
             <Link to={`/cluster-queue/${workload.clusterQueueName}`}>{workload.clusterQueueName}</Link>
           </Typography>
-          <Typography variant="body1"><strong>Status:</strong> {workload.status?.state || 'Unknown'}</Typography>
           <Typography variant="body1"><strong>Priority:</strong> {workload.spec?.priority || 'N/A'}</Typography>
           <Typography variant="body1"><strong>Priority Class Name:</strong> {workload.spec?.priorityClassName || 'N/A'}</Typography>
         </Grid>

--- a/cmd/kueueviz/frontend/src/Workloads.jsx
+++ b/cmd/kueueviz/frontend/src/Workloads.jsx
@@ -92,7 +92,6 @@ const Workloads = () => {
                       </Tooltip>
                     </TableCell>
                     <TableCell><Link to={`/local-queue/${workload.metadata.namespace}/${workload.spec.queueName}`}>{workload.spec.queueName}</Link></TableCell>
-                    <TableCell>{workload.status?.state || "Unknown"}</TableCell>
                     <TableCell>{workload.preemption?.preempted ? "Yes" : "No"}</TableCell>
                     <TableCell>{workload.preemption?.reason || "N/A"}</TableCell>
                     <TableCell>{workload.spec.priority}</TableCell>

--- a/cmd/kueueviz/frontend/src/WorkloadsList.jsx
+++ b/cmd/kueueviz/frontend/src/WorkloadsList.jsx
@@ -68,7 +68,6 @@ const WorkloadsList = ({ workloads, error }) => {
                   'N/A'
                 )}
               </TableCell>
-              <TableCell>{workload.status?.state || "Unknown"}</TableCell>
               <TableCell>{workload.preemption?.preempted ? "Yes" : "No"}</TableCell>
               <TableCell>{workload.preemption?.reason || "N/A"}</TableCell>
               <TableCell>{workload.spec?.priority || "N/A"}</TableCell>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kueueViz is displaying "Unknown" for workload status. This is sloppy and confusing.

It turns out that kueueViz was trying to find a non existent value in the workload API. It was trying to display workload.status.state which does not exist.

Removing this column.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5139 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```