### PR TITLE
Use logger in cache (cherry-pick to release-0.10)

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -134,7 +134,7 @@ func New(client client.Client, opts ...Option) *Cache {
 	return c
 }
 
-func (c *Cache) newClusterQueue(cq *kueue.ClusterQueue) (*clusterQueue, error) {
+func (c *Cache) newClusterQueue(log logr.Logger, cq *kueue.ClusterQueue) (*clusterQueue, error) {
 	cqImpl := &clusterQueue{
 		Name:                cq.Name,
 		Workloads:           make(map[string]*workload.Info),
@@ -148,7 +148,7 @@ func (c *Cache) newClusterQueue(cq *kueue.ClusterQueue) (*clusterQueue, error) {
 	}
 	c.hm.AddClusterQueue(cqImpl)
 	c.hm.UpdateClusterQueueEdge(cq.Name, cq.Spec.Cohort)
-	if err := cqImpl.updateClusterQueue(c.hm.CycleChecker, cq, c.resourceFlavors, c.admissionChecks, nil); err != nil {
+	if err := cqImpl.updateClusterQueue(log, c.hm.CycleChecker, cq, c.resourceFlavors, c.admissionChecks, nil); err != nil {
 		return nil, err
 	}
 
@@ -212,7 +212,7 @@ func (c *Cache) CleanUpOnContext(ctx context.Context) {
 	c.podsReadyCond.Broadcast()
 }
 
-func (c *Cache) updateClusterQueues() sets.Set[string] {
+func (c *Cache) updateClusterQueues(log logr.Logger) sets.Set[string] {
 	cqs := sets.New[string]()
 
 	for _, cq := range c.hm.ClusterQueues {
@@ -220,8 +220,8 @@ func (c *Cache) updateClusterQueues() sets.Set[string] {
 		// We call update on all ClusterQueues irrespective of which CQ actually use this flavor
 		// because it is not expensive to do so, and is not worth tracking which ClusterQueues use
 		// which flavors.
-		cq.UpdateWithFlavors(c.resourceFlavors)
-		cq.updateWithAdmissionChecks(c.admissionChecks)
+		cq.UpdateWithFlavors(log, c.resourceFlavors)
+		cq.updateWithAdmissionChecks(log, c.admissionChecks)
 		curStatus := cq.Status
 		if prevStatus == pending && curStatus == active {
 			cqs.Insert(cq.Name)
@@ -246,37 +246,37 @@ func (c *Cache) TASCache() *TASCache {
 	return &c.tasCache
 }
 
-func (c *Cache) AddOrUpdateResourceFlavor(rf *kueue.ResourceFlavor) sets.Set[string] {
+func (c *Cache) AddOrUpdateResourceFlavor(log logr.Logger, rf *kueue.ResourceFlavor) sets.Set[string] {
 	c.Lock()
 	defer c.Unlock()
 	c.resourceFlavors[kueue.ResourceFlavorReference(rf.Name)] = rf
-	return c.updateClusterQueues()
+	return c.updateClusterQueues(log)
 }
 
-func (c *Cache) DeleteResourceFlavor(rf *kueue.ResourceFlavor) sets.Set[string] {
+func (c *Cache) DeleteResourceFlavor(log logr.Logger, rf *kueue.ResourceFlavor) sets.Set[string] {
 	c.Lock()
 	defer c.Unlock()
 	delete(c.resourceFlavors, kueue.ResourceFlavorReference(rf.Name))
-	return c.updateClusterQueues()
+	return c.updateClusterQueues(log)
 }
 
-func (c *Cache) AddOrUpdateTopologyForFlavor(topology *kueuealpha.Topology, flv *kueue.ResourceFlavor) sets.Set[string] {
+func (c *Cache) AddOrUpdateTopologyForFlavor(log logr.Logger, topology *kueuealpha.Topology, flv *kueue.ResourceFlavor) sets.Set[string] {
 	c.Lock()
 	defer c.Unlock()
 	levels := utiltas.Levels(topology)
 	tasInfo := c.tasCache.NewTASFlavorCache(kueue.TopologyReference(topology.Name), levels, flv.Spec.NodeLabels, flv.Spec.Tolerations)
 	c.tasCache.Set(kueue.ResourceFlavorReference(flv.Name), tasInfo)
-	return c.updateClusterQueues()
+	return c.updateClusterQueues(log)
 }
 
-func (c *Cache) DeleteTopologyForFlavor(flv kueue.ResourceFlavorReference) sets.Set[string] {
+func (c *Cache) DeleteTopologyForFlavor(log logr.Logger, flv kueue.ResourceFlavorReference) sets.Set[string] {
 	c.Lock()
 	defer c.Unlock()
 	c.tasCache.Delete(flv)
-	return c.updateClusterQueues()
+	return c.updateClusterQueues(log)
 }
 
-func (c *Cache) AddOrUpdateAdmissionCheck(ac *kueue.AdmissionCheck) sets.Set[string] {
+func (c *Cache) AddOrUpdateAdmissionCheck(log logr.Logger, ac *kueue.AdmissionCheck) sets.Set[string] {
 	c.Lock()
 	defer c.Unlock()
 
@@ -293,14 +293,14 @@ func (c *Cache) AddOrUpdateAdmissionCheck(ac *kueue.AdmissionCheck) sets.Set[str
 	}
 	c.admissionChecks[ac.Name] = newAC
 
-	return c.updateClusterQueues()
+	return c.updateClusterQueues(log)
 }
 
-func (c *Cache) DeleteAdmissionCheck(ac *kueue.AdmissionCheck) sets.Set[string] {
+func (c *Cache) DeleteAdmissionCheck(log logr.Logger, ac *kueue.AdmissionCheck) sets.Set[string] {
 	c.Lock()
 	defer c.Unlock()
 	delete(c.admissionChecks, ac.Name)
-	return c.updateClusterQueues()
+	return c.updateClusterQueues(log)
 }
 
 func (c *Cache) AdmissionChecksForClusterQueue(cqName string) []AdmissionCheck {
@@ -381,7 +381,8 @@ func (c *Cache) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) err
 	if _, ok := c.hm.ClusterQueues[cq.Name]; ok {
 		return errors.New("ClusterQueue already exists")
 	}
-	cqImpl, err := c.newClusterQueue(cq)
+	log := ctrl.LoggerFrom(ctx)
+	cqImpl, err := c.newClusterQueue(log, cq)
 	if err != nil {
 		return err
 	}
@@ -410,7 +411,6 @@ func (c *Cache) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) err
 	if err := c.client.List(ctx, &workloads, client.MatchingFields{utilindexer.WorkloadClusterQueueKey: cq.Name}); err != nil {
 		return fmt.Errorf("listing workloads that match the queue: %w", err)
 	}
-	log := ctrl.LoggerFrom(ctx)
 	for i, w := range workloads.Items {
 		log := log.WithValues("workload", workload.Key(&w))
 		if !workload.HasQuotaReservation(&w) || workload.IsFinished(&w) {
@@ -422,7 +422,7 @@ func (c *Cache) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) err
 	return nil
 }
 
-func (c *Cache) UpdateClusterQueue(cq *kueue.ClusterQueue) error {
+func (c *Cache) UpdateClusterQueue(log logr.Logger, cq *kueue.ClusterQueue) error {
 	c.Lock()
 	defer c.Unlock()
 	cqImpl, ok := c.hm.ClusterQueues[cq.Name]
@@ -431,7 +431,7 @@ func (c *Cache) UpdateClusterQueue(cq *kueue.ClusterQueue) error {
 	}
 	oldParent := cqImpl.Parent()
 	c.hm.UpdateClusterQueueEdge(cq.Name, cq.Spec.Cohort)
-	if err := cqImpl.updateClusterQueue(c.hm.CycleChecker, cq, c.resourceFlavors, c.admissionChecks, oldParent); err != nil {
+	if err := cqImpl.updateClusterQueue(log, c.hm.CycleChecker, cq, c.resourceFlavors, c.admissionChecks, oldParent); err != nil {
 		return err
 	}
 	for _, qImpl := range cqImpl.localQueues {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
@@ -81,7 +82,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			}).
 			Obj(),
 	}
-	setup := func(cache *Cache) error {
+	setup := func(log logr.Logger, cache *Cache) error {
 		cache.AddOrUpdateResourceFlavor(
 			utiltesting.MakeResourceFlavor("default").
 				NodeLabel("cpuType", "default").
@@ -95,7 +96,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 	}
 	cases := []struct {
 		name                string
-		operation           func(*Cache) error
+		operation           func(log logr.Logger, cache *Cache) error
 		clientObjects       []client.Object
 		wantClusterQueues   map[string]*clusterQueue
 		wantCohorts         map[string]sets.Set[string]
@@ -103,8 +104,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 	}{
 		{
 			name: "add",
-			operation: func(cache *Cache) error {
-				return setup(cache)
+			operation: func(log logr.Logger, cache *Cache) error {
+				return setup(log, cache)
 			},
 			wantClusterQueues: map[string]*clusterQueue{
 				"a": {
@@ -172,7 +173,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "add ClusterQueue with preemption policies",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				cq := utiltesting.MakeClusterQueue("foo").Preemption(kueue.ClusterQueuePreemption{
 					ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
@@ -199,7 +200,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "add ClusterQueue with fair sharing weight",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				cq := utiltesting.MakeClusterQueue("foo").FairWeight(resource.MustParse("2")).Obj()
 				if err := cache.AddClusterQueue(context.Background(), cq); err != nil {
 					return fmt.Errorf("failed to add ClusterQueue: %w", err)
@@ -220,7 +221,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "add flavors after queue capacities",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				for _, c := range initialClusterQueues {
 					if err := cache.AddClusterQueue(context.Background(), &c); err != nil {
 						return fmt.Errorf("failed adding ClusterQueue: %w", err)
@@ -298,8 +299,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "update",
-			operation: func(cache *Cache) error {
-				err := setup(cache)
+			operation: func(log logr.Logger, cache *Cache) error {
+				err := setup(log, cache)
 				if err != nil {
 					return err
 				}
@@ -399,7 +400,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "shouldn't delete usage resources on update ClusterQueue",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				cache.AddOrUpdateResourceFlavor(
 					utiltesting.MakeResourceFlavor("default").
 						NodeLabel("cpuType", "default").
@@ -425,7 +426,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					Condition(metav1.Condition{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue}).
 					Obj()
 
-				cache.AddOrUpdateWorkload(wl)
+				cache.AddOrUpdateWorkload(log, wl)
 
 				cq = utiltesting.MakeClusterQueue("a").
 					ResourceGroup(*utiltesting.MakeFlavorQuotas("default").Obj()).
@@ -487,8 +488,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			// to another Cohort (or no Cohort). Cohort two
 			// is deleted as all of its members are deleted.
 			name: "implicit Cohorts created and deleted",
-			operation: func(cache *Cache) error {
-				_ = setup(cache)
+			operation: func(log logr.Logger, cache *Cache) error {
+				_ = setup(log, cache)
 				updateCqs := []kueue.ClusterQueue{
 					utiltesting.MakeClusterQueue("a").NamespaceSelector(nil).Cohort("three").ClusterQueue,
 					utiltesting.MakeClusterQueue("b").NamespaceSelector(nil).ClusterQueue,
@@ -542,8 +543,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "delete",
-			operation: func(cache *Cache) error {
-				err := setup(cache)
+			operation: func(log logr.Logger, cache *Cache) error {
+				err := setup(log, cache)
 				if err != nil {
 					return err
 				}
@@ -604,8 +605,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "add resource flavors",
-			operation: func(cache *Cache) error {
-				err := setup(cache)
+			operation: func(log logr.Logger, cache *Cache) error {
+				err := setup(log, cache)
 				if err != nil {
 					return err
 				}
@@ -678,8 +679,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "Add ClusterQueue with multiple resource groups",
-			operation: func(cache *Cache) error {
-				err := cache.AddClusterQueue(context.Background(),
+			operation: func(log logr.Logger, cache *Cache) error {
+				err := cache.AddClusterQueue(t.Context(),
 					utiltesting.MakeClusterQueue("foo").
 						ResourceGroup(
 							*utiltesting.MakeFlavorQuotas("foo").
@@ -715,8 +716,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "add cluster queue with missing check",
-			operation: func(cache *Cache) error {
-				err := cache.AddClusterQueue(context.Background(),
+			operation: func(log logr.Logger, cache *Cache) error {
+				err := cache.AddClusterQueue(t.Context(),
 					utiltesting.MakeClusterQueue("foo").
 						AdmissionChecks("check1", "check2").
 						Obj())
@@ -744,8 +745,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "add check after queue creation",
-			operation: func(cache *Cache) error {
-				err := cache.AddClusterQueue(context.Background(),
+			operation: func(log logr.Logger, cache *Cache) error {
+				err := cache.AddClusterQueue(t.Context(),
 					utiltesting.MakeClusterQueue("foo").
 						AdmissionChecks("check1", "check2").
 						Obj())
@@ -776,7 +777,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "remove check after queue creation",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check1").Active(metav1.ConditionTrue).Obj())
 				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionTrue).Obj())
 				err := cache.AddClusterQueue(context.Background(),
@@ -809,7 +810,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "inactivate check after queue creation",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check1").Active(metav1.ConditionTrue).Obj())
 				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionTrue).Obj())
 				err := cache.AddClusterQueue(context.Background(),
@@ -855,7 +856,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					utiltesting.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj(),
 				).Admitted(true).Finished().Obj(),
 			},
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("f1").Obj())
 				err := cache.AddClusterQueue(context.Background(),
 					utiltesting.MakeClusterQueue("cq1").
@@ -925,7 +926,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "add CQ with multiple resource groups and flavors",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				cq := utiltesting.MakeClusterQueue("foo").
 					ResourceGroup(
 						kueue.FlavorQuotas{
@@ -989,7 +990,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		{
 			name:                "should not populate the fields with lendingLimit when feature disabled",
 			disableLendingLimit: true,
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				cq := utiltesting.MakeClusterQueue("foo").
 					ResourceGroup(
 						kueue.FlavorQuotas{
@@ -1052,7 +1053,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "create cohort",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				cohort := utiltesting.MakeCohort("cohort").Obj()
 				return cache.AddOrUpdateCohort(cohort)
 			},
@@ -1062,7 +1063,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "create and delete cohort",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				cohort := utiltesting.MakeCohort("cohort").Obj()
 				_ = cache.AddOrUpdateCohort(cohort)
 				cache.DeleteCohort(cohort.Name)
@@ -1072,7 +1073,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		},
 		{
 			name: "cohort remains after deletion when child exists",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				cohort := utiltesting.MakeCohort("cohort").Obj()
 				_ = cache.AddOrUpdateCohort(cohort)
 
@@ -1100,11 +1101,12 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			if tc.disableLendingLimit {
 				features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
 			}
 			cache := New(utiltesting.NewFakeClient(tc.clientObjects...))
-			if err := tc.operation(cache); err != nil {
+			if err := tc.operation(log, cache); err != nil {
 				t.Errorf("Unexpected error during test operation: %s", err)
 			}
 			if diff := cmp.Diff(tc.wantClusterQueues, cache.hm.ClusterQueues,
@@ -1194,15 +1196,16 @@ func TestCacheWorkloadOperations(t *testing.T) {
 	}
 
 	steps := []struct {
-		name                 string
-		operation            func(cache *Cache) error
+		name string
+
+		operation            func(log logr.Logger, cache *Cache) error
 		wantResults          map[string]result
 		wantAssumedWorkloads map[string]string
 		wantError            string
 	}{
 		{
 			name: "add",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				workloads := []*kueue.Workload{
 					utiltesting.MakeWorkload("a", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 						ClusterQueue:      "one",
@@ -1214,7 +1217,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 					utiltesting.MakeWorkload("pending", "").Obj(),
 				}
 				for i := range workloads {
-					cache.AddOrUpdateWorkload(workloads[i])
+					cache.AddOrUpdateWorkload(log, workloads[i])
 				}
 				return nil
 			},
@@ -1233,11 +1236,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "add error clusterQueue doesn't exist",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				w := utiltesting.MakeWorkload("d", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "three",
 				}).Obj()
-				if !cache.AddOrUpdateWorkload(w) {
+				if !cache.AddOrUpdateWorkload(log, w) {
 					return errors.New("failed to add workload")
 				}
 				return nil
@@ -1258,11 +1261,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "add already exists",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				w := utiltesting.MakeWorkload("b", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Obj()
-				if !cache.AddOrUpdateWorkload(w) {
+				if !cache.AddOrUpdateWorkload(log, w) {
 					return errors.New("failed to add workload")
 				}
 				return nil
@@ -1282,7 +1285,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "update cluster queue for a workload",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				old := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Obj()
@@ -1290,7 +1293,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 					ClusterQueue:      "two",
 					PodSetAssignments: podSetFlavors,
 				}).Obj()
-				return cache.UpdateWorkload(old, latest)
+				return cache.UpdateWorkload(log, old, latest)
 			},
 			wantResults: map[string]result{
 				"one": {
@@ -1311,14 +1314,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "update error old clusterQueue doesn't exist",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				old := utiltesting.MakeWorkload("d", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "three",
 				}).Obj()
 				latest := utiltesting.MakeWorkload("d", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Obj()
-				return cache.UpdateWorkload(old, latest)
+				return cache.UpdateWorkload(log, old, latest)
 			},
 			wantError: "old ClusterQueue doesn't exist",
 			wantResults: map[string]result{
@@ -1336,14 +1339,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "update error new clusterQueue doesn't exist",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				old := utiltesting.MakeWorkload("d", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Obj()
 				latest := utiltesting.MakeWorkload("d", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "three",
 				}).Obj()
-				return cache.UpdateWorkload(old, latest)
+				return cache.UpdateWorkload(log, old, latest)
 			},
 			wantError: "new ClusterQueue doesn't exist",
 			wantResults: map[string]result{
@@ -1361,14 +1364,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "update workload which doesn't exist.",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				old := utiltesting.MakeWorkload("d", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Obj()
 				latest := utiltesting.MakeWorkload("d", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "two",
 				}).Obj()
-				return cache.UpdateWorkload(old, latest)
+				return cache.UpdateWorkload(log, old, latest)
 			},
 			wantResults: map[string]result{
 				"one": {
@@ -1385,11 +1388,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "delete",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				w := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Obj()
-				return cache.DeleteWorkload(w)
+				return cache.DeleteWorkload(log, w)
 			},
 			wantResults: map[string]result{
 				"one": {
@@ -1406,9 +1409,9 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "delete workload with cancelled admission",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				w := utiltesting.MakeWorkload("a", "").Obj()
-				return cache.DeleteWorkload(w)
+				return cache.DeleteWorkload(log, w)
 			},
 			wantResults: map[string]result{
 				"one": {
@@ -1425,9 +1428,9 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "attempt deleting non-existing workload with cancelled admission",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				w := utiltesting.MakeWorkload("d", "").Obj()
-				return cache.DeleteWorkload(w)
+				return cache.DeleteWorkload(log, w)
 			},
 			wantError: "cluster queue not found",
 			wantResults: map[string]result{
@@ -1445,11 +1448,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "delete error clusterQueue doesn't exist",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				w := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "three",
 				}).Obj()
-				return cache.DeleteWorkload(w)
+				return cache.DeleteWorkload(log, w)
 			},
 			wantError: "cluster queue not found",
 			wantResults: map[string]result{
@@ -1467,11 +1470,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "delete workload which doesn't exist",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				w := utiltesting.MakeWorkload("d", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Obj()
-				return cache.DeleteWorkload(w)
+				return cache.DeleteWorkload(log, w)
 			},
 			wantResults: map[string]result{
 				"one": {
@@ -1488,7 +1491,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "assume",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				workloads := []*kueue.Workload{
 					utiltesting.MakeWorkload("d", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 						ClusterQueue:      "one",
@@ -1500,7 +1503,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 					}).Obj(),
 				}
 				for i := range workloads {
-					if err := cache.AssumeWorkload(workloads[i]); err != nil {
+					if err := cache.AssumeWorkload(log, workloads[i]); err != nil {
 						return err
 					}
 				}
@@ -1529,11 +1532,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "assume error clusterQueue doesn't exist",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				w := utiltesting.MakeWorkload("d", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 					ClusterQueue: "three",
 				}).Obj()
-				if err := cache.AssumeWorkload(w); err != nil {
+				if err := cache.AssumeWorkload(log, w); err != nil {
 					return err
 				}
 				return nil
@@ -1555,7 +1558,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "forget",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				workloads := []*kueue.Workload{
 					utiltesting.MakeWorkload("d", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 						ClusterQueue:      "one",
@@ -1567,13 +1570,13 @@ func TestCacheWorkloadOperations(t *testing.T) {
 					}).Obj(),
 				}
 				for i := range workloads {
-					if err := cache.AssumeWorkload(workloads[i]); err != nil {
+					if err := cache.AssumeWorkload(log, workloads[i]); err != nil {
 						return err
 					}
 				}
 
 				w := workloads[0]
-				return cache.ForgetWorkload(w)
+				return cache.ForgetWorkload(log, w)
 			},
 			wantResults: map[string]result{
 				"one": {
@@ -1597,11 +1600,11 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "forget error workload is not assumed",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				w := utiltesting.MakeWorkload("b", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Obj()
-				if err := cache.ForgetWorkload(w); err != nil {
+				if err := cache.ForgetWorkload(log, w); err != nil {
 					return err
 				}
 				return nil
@@ -1622,7 +1625,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		},
 		{
 			name: "add assumed workload",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				workloads := []*kueue.Workload{
 					utiltesting.MakeWorkload("d", "").PodSets(podSets...).ReserveQuota(&kueue.Admission{
 						ClusterQueue:      "one",
@@ -1634,13 +1637,13 @@ func TestCacheWorkloadOperations(t *testing.T) {
 					}).Obj(),
 				}
 				for i := range workloads {
-					if err := cache.AssumeWorkload(workloads[i]); err != nil {
+					if err := cache.AssumeWorkload(log, workloads[i]); err != nil {
 						return err
 					}
 				}
 
 				w := workloads[0]
-				if !cache.AddOrUpdateWorkload(w) {
+				if !cache.AddOrUpdateWorkload(log, w) {
 					return errors.New("failed to add workload")
 				}
 				return nil
@@ -1669,6 +1672,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 	for _, step := range steps {
 		t.Run(step.name, func(t *testing.T) {
 			cache := New(cl)
+			_, log := utiltesting.ContextWithLog(t)
 
 			for _, c := range clusterQueues {
 				if err := cache.AddClusterQueue(context.Background(), &c); err != nil {
@@ -1676,7 +1680,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				}
 			}
 
-			gotError := step.operation(cache)
+			gotError := step.operation(log, cache)
 			if diff := cmp.Diff(step.wantError, messageOrEmpty(gotError)); diff != "" {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}
@@ -2028,14 +2032,14 @@ func TestClusterQueueUsage(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			cache := New(utiltesting.NewFakeClient())
-			ctx := context.Background()
+			ctx, log := utiltesting.ContextWithLog(t)
 			err := cache.AddClusterQueue(ctx, tc.clusterQueue)
 			if err != nil {
 				t.Fatalf("Adding ClusterQueue: %v", err)
 			}
 			for i := range tc.workloads {
 				w := &tc.workloads[i]
-				if added := cache.AddOrUpdateWorkload(w); !added {
+				if added := cache.AddOrUpdateWorkload(log, w); !added {
 					t.Fatalf("Workload %s was not added", workload.Key(w))
 				}
 			}
@@ -2259,7 +2263,7 @@ func TestLocalQueueUsage(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			cache := New(utiltesting.NewFakeClient())
-			ctx := context.Background()
+			ctx, log := utiltesting.ContextWithLog(t)
 			if tc.cq != nil {
 				if err := cache.AddClusterQueue(ctx, tc.cq); err != nil {
 					t.Fatalf("Adding ClusterQueue: %v", err)
@@ -2269,7 +2273,7 @@ func TestLocalQueueUsage(t *testing.T) {
 				t.Fatalf("Adding LocalQueue: %v", err)
 			}
 			for _, w := range tc.wls {
-				if added := cache.AddOrUpdateWorkload(&w); !added && !tc.inAdmissibleWl.Has(w.Name) {
+				if added := cache.AddOrUpdateWorkload(log, &w); !added && !tc.inAdmissibleWl.Has(w.Name) {
 					t.Fatalf("Workload %s was not added", workload.Key(&w))
 				}
 			}
@@ -2373,12 +2377,13 @@ func TestCacheQueueOperations(t *testing.T) {
 		return nil
 	}
 	insertAllWorkloads := func(ctx context.Context, cl client.Client, cache *Cache) error {
+		log := ctrl.LoggerFrom(ctx)
 		for _, wl := range workloads {
 			wl := wl.DeepCopy()
 			if err := cl.Create(ctx, wl); err != nil {
 				return err
 			}
-			cache.AddOrUpdateWorkload(wl)
+			cache.AddOrUpdateWorkload(log, wl)
 		}
 		return nil
 	}
@@ -2537,11 +2542,12 @@ func TestCacheQueueOperations(t *testing.T) {
 				insertAllClusterQueues,
 				insertAllQueues,
 				func(ctx context.Context, cl client.Client, cache *Cache) error {
+					log := ctrl.LoggerFrom(ctx)
 					wl := workloads[0].DeepCopy()
 					if err := cl.Create(ctx, wl); err != nil {
 						return err
 					}
-					return cache.AssumeWorkload(wl)
+					return cache.AssumeWorkload(log, wl)
 				},
 			},
 			wantLocalQueues: map[string]*queue{
@@ -2575,14 +2581,15 @@ func TestCacheQueueOperations(t *testing.T) {
 				insertAllClusterQueues,
 				insertAllQueues,
 				func(ctx context.Context, cl client.Client, cache *Cache) error {
+					log := ctrl.LoggerFrom(ctx)
 					wl := workloads[0].DeepCopy()
 					if err := cl.Create(ctx, wl); err != nil {
 						return err
 					}
-					if err := cache.AssumeWorkload(wl); err != nil {
+					if err := cache.AssumeWorkload(log, wl); err != nil {
 						return err
 					}
-					return cache.ForgetWorkload(wl)
+					return cache.ForgetWorkload(log, wl)
 				},
 			},
 			wantLocalQueues: map[string]*queue{
@@ -2617,7 +2624,8 @@ func TestCacheQueueOperations(t *testing.T) {
 				insertAllQueues,
 				insertAllWorkloads,
 				func(ctx context.Context, cl client.Client, cache *Cache) error {
-					return cache.DeleteWorkload(workloads[0])
+					log := ctrl.LoggerFrom(ctx)
+					return cache.DeleteWorkload(log, workloads[0])
 				},
 			},
 			wantLocalQueues: map[string]*queue{
@@ -2856,7 +2864,7 @@ func TestWaitForPodsReadyCancelled(t *testing.T) {
 	wl := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 		ClusterQueue: "one",
 	}).Obj()
-	if err := cache.AssumeWorkload(wl); err != nil {
+	if err := cache.AssumeWorkload(log, wl); err != nil {
 		t.Fatalf("Failed assuming the workload to block the further admission: %v", err)
 	}
 
@@ -2885,212 +2893,212 @@ func TestCachePodsReadyForAllAdmittedWorkloads(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		setup     func(cache *Cache) error
-		operation func(cache *Cache) error
+		setup     func(log logr.Logger, cache *Cache) error
+		operation func(log logr.Logger, cache *Cache) error
 		wantReady bool
 	}{
 		{
 			name:      "empty cache",
-			operation: func(cache *Cache) error { return nil },
+			operation: func(log logr.Logger, cache *Cache) error { return nil },
 			wantReady: true,
 		},
 		{
 			name: "add Workload without PodsReady condition",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				wl := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Obj()
-				cache.AddOrUpdateWorkload(wl)
+				cache.AddOrUpdateWorkload(log, wl)
 				return nil
 			},
 			wantReady: false,
 		},
 		{
 			name: "add Workload with PodsReady=False",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				wl := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Condition(metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
 					Status: metav1.ConditionFalse,
 				}).Obj()
-				cache.AddOrUpdateWorkload(wl)
+				cache.AddOrUpdateWorkload(log, wl)
 				return nil
 			},
 			wantReady: false,
 		},
 		{
 			name: "add Workload with PodsReady=True",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				wl := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Condition(metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
 					Status: metav1.ConditionTrue,
 				}).Obj()
-				cache.AddOrUpdateWorkload(wl)
+				cache.AddOrUpdateWorkload(log, wl)
 				return nil
 			},
 			wantReady: true,
 		},
 		{
 			name: "assume Workload without PodsReady condition",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				wl := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Obj()
-				return cache.AssumeWorkload(wl)
+				return cache.AssumeWorkload(log, wl)
 			},
 			wantReady: false,
 		},
 		{
 			name: "assume Workload with PodsReady=False",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				wl := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Condition(metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
 					Status: metav1.ConditionFalse,
 				}).Obj()
-				return cache.AssumeWorkload(wl)
+				return cache.AssumeWorkload(log, wl)
 			},
 			wantReady: false,
 		},
 		{
 			name: "assume Workload with PodsReady=True",
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				wl := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Condition(metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
 					Status: metav1.ConditionTrue,
 				}).Obj()
-				return cache.AssumeWorkload(wl)
+				return cache.AssumeWorkload(log, wl)
 			},
 			wantReady: true,
 		},
 		{
 			name: "update workload to have PodsReady=True",
-			setup: func(cache *Cache) error {
+			setup: func(log logr.Logger, cache *Cache) error {
 				wl := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Obj()
-				cache.AddOrUpdateWorkload(wl)
+				cache.AddOrUpdateWorkload(log, wl)
 				return nil
 			},
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				wl := cache.hm.ClusterQueues["one"].Workloads["/a"].Obj
 				newWl := wl.DeepCopy()
 				apimeta.SetStatusCondition(&newWl.Status.Conditions, metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
 					Status: metav1.ConditionTrue,
 				})
-				return cache.UpdateWorkload(wl, newWl)
+				return cache.UpdateWorkload(log, wl, newWl)
 			},
 			wantReady: true,
 		},
 		{
 			name: "update workload to have PodsReady=False",
-			setup: func(cache *Cache) error {
+			setup: func(log logr.Logger, cache *Cache) error {
 				wl := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Condition(metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
 					Status: metav1.ConditionTrue,
 				}).Obj()
-				cache.AddOrUpdateWorkload(wl)
+				cache.AddOrUpdateWorkload(log, wl)
 				return nil
 			},
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				wl := cache.hm.ClusterQueues["one"].Workloads["/a"].Obj
 				newWl := wl.DeepCopy()
 				apimeta.SetStatusCondition(&newWl.Status.Conditions, metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
 					Status: metav1.ConditionFalse,
 				})
-				return cache.UpdateWorkload(wl, newWl)
+				return cache.UpdateWorkload(log, wl, newWl)
 			},
 			wantReady: false,
 		},
 		{
 			name: "assume second workload without PodsReady",
-			setup: func(cache *Cache) error {
+			setup: func(log logr.Logger, cache *Cache) error {
 				wl1 := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Condition(metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
 					Status: metav1.ConditionTrue,
 				}).Obj()
-				cache.AddOrUpdateWorkload(wl1)
+				cache.AddOrUpdateWorkload(log, wl1)
 				return nil
 			},
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				wl2 := utiltesting.MakeWorkload("b", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "two",
 				}).Obj()
-				return cache.AssumeWorkload(wl2)
+				return cache.AssumeWorkload(log, wl2)
 			},
 			wantReady: false,
 		},
 		{
 			name: "update second workload to have PodsReady=True",
-			setup: func(cache *Cache) error {
+			setup: func(log logr.Logger, cache *Cache) error {
 				wl1 := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Condition(metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
 					Status: metav1.ConditionTrue,
 				}).Obj()
-				cache.AddOrUpdateWorkload(wl1)
+				cache.AddOrUpdateWorkload(log, wl1)
 				wl2 := utiltesting.MakeWorkload("b", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "two",
 				}).Obj()
-				cache.AddOrUpdateWorkload(wl2)
+				cache.AddOrUpdateWorkload(log, wl2)
 				return nil
 			},
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				wl2 := cache.hm.ClusterQueues["two"].Workloads["/b"].Obj
 				newWl2 := wl2.DeepCopy()
 				apimeta.SetStatusCondition(&newWl2.Status.Conditions, metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
 					Status: metav1.ConditionTrue,
 				})
-				return cache.UpdateWorkload(wl2, newWl2)
+				return cache.UpdateWorkload(log, wl2, newWl2)
 			},
 			wantReady: true,
 		},
 		{
 			name: "delete workload with PodsReady=False",
-			setup: func(cache *Cache) error {
+			setup: func(log logr.Logger, cache *Cache) error {
 				wl := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Condition(metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
 					Status: metav1.ConditionFalse,
 				}).Obj()
-				cache.AddOrUpdateWorkload(wl)
+				cache.AddOrUpdateWorkload(log, wl)
 				return nil
 			},
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				wl := cache.hm.ClusterQueues["one"].Workloads["/a"].Obj
-				return cache.DeleteWorkload(wl)
+				return cache.DeleteWorkload(log, wl)
 			},
 			wantReady: true,
 		},
 		{
 			name: "forget workload with PodsReady=False",
-			setup: func(cache *Cache) error {
+			setup: func(log logr.Logger, cache *Cache) error {
 				wl := utiltesting.MakeWorkload("a", "").ReserveQuota(&kueue.Admission{
 					ClusterQueue: "one",
 				}).Condition(metav1.Condition{
 					Type:   kueue.WorkloadPodsReady,
 					Status: metav1.ConditionFalse,
 				}).Obj()
-				return cache.AssumeWorkload(wl)
+				return cache.AssumeWorkload(log, wl)
 			},
-			operation: func(cache *Cache) error {
+			operation: func(log logr.Logger, cache *Cache) error {
 				wl := cache.hm.ClusterQueues["one"].Workloads["/a"].Obj
-				return cache.ForgetWorkload(wl)
+				return cache.ForgetWorkload(log, wl)
 			},
 			wantReady: true,
 		},
@@ -3107,11 +3115,11 @@ func TestCachePodsReadyForAllAdmittedWorkloads(t *testing.T) {
 				}
 			}
 			if tc.setup != nil {
-				if err := tc.setup(cache); err != nil {
+				if err := tc.setup(log, cache); err != nil {
 					t.Errorf("Unexpected error during setup: %q", err)
 				}
 			}
-			if err := tc.operation(cache); err != nil {
+			if err := tc.operation(log, cache); err != nil {
 				t.Errorf("Unexpected error during operation: %q", err)
 			}
 			gotReady := cache.PodsReadyForAllAdmittedWorkloads(log)

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -83,7 +83,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			Obj(),
 	}
 	setup := func(log logr.Logger, cache *Cache) error {
-		cache.AddOrUpdateResourceFlavor(
+		cache.AddOrUpdateResourceFlavor(log,
 			utiltesting.MakeResourceFlavor("default").
 				NodeLabel("cpuType", "default").
 				Obj())
@@ -227,7 +227,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 						return fmt.Errorf("failed adding ClusterQueue: %w", err)
 					}
 				}
-				cache.AddOrUpdateResourceFlavor(
+				cache.AddOrUpdateResourceFlavor(log,
 					utiltesting.MakeResourceFlavor("default").
 						NodeLabel("cpuType", "default").
 						Obj())
@@ -323,11 +323,11 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 						Obj(),
 				}
 				for _, c := range clusterQueues {
-					if err := cache.UpdateClusterQueue(&c); err != nil {
+					if err := cache.UpdateClusterQueue(log, &c); err != nil {
 						return fmt.Errorf("failed updating ClusterQueue: %w", err)
 					}
 				}
-				cache.AddOrUpdateResourceFlavor(
+				cache.AddOrUpdateResourceFlavor(log,
 					utiltesting.MakeResourceFlavor("default").
 						NodeLabel("cpuType", "default").
 						NodeLabel("region", "central").
@@ -401,7 +401,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		{
 			name: "shouldn't delete usage resources on update ClusterQueue",
 			operation: func(log logr.Logger, cache *Cache) error {
-				cache.AddOrUpdateResourceFlavor(
+				cache.AddOrUpdateResourceFlavor(log,
 					utiltesting.MakeResourceFlavor("default").
 						NodeLabel("cpuType", "default").
 						Obj())
@@ -434,7 +434,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					NamespaceSelector(nil).
 					Obj()
 
-				if err := cache.UpdateClusterQueue(cq); err != nil {
+				if err := cache.UpdateClusterQueue(log, cq); err != nil {
 					return fmt.Errorf("failed updating ClusterQueue: %w", err)
 				}
 
@@ -496,7 +496,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					utiltesting.MakeClusterQueue("c").NamespaceSelector(nil).Cohort("three").ClusterQueue,
 				}
 				for _, c := range updateCqs {
-					_ = cache.UpdateClusterQueue(&c)
+					_ = cache.UpdateClusterQueue(log, &c)
 				}
 				deleteCqs := []kueue.ClusterQueue{
 					utiltesting.MakeClusterQueue("d").Cohort("two").ClusterQueue,
@@ -610,7 +610,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("nonexistent-flavor").Obj())
+				cache.AddOrUpdateResourceFlavor(log, utiltesting.MakeResourceFlavor("nonexistent-flavor").Obj())
 				return nil
 			},
 			wantClusterQueues: map[string]*clusterQueue{
@@ -680,7 +680,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		{
 			name: "Add ClusterQueue with multiple resource groups",
 			operation: func(log logr.Logger, cache *Cache) error {
-				err := cache.AddClusterQueue(t.Context(),
+				err := cache.AddClusterQueue(context.Background(),
 					utiltesting.MakeClusterQueue("foo").
 						ResourceGroup(
 							*utiltesting.MakeFlavorQuotas("foo").
@@ -717,7 +717,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		{
 			name: "add cluster queue with missing check",
 			operation: func(log logr.Logger, cache *Cache) error {
-				err := cache.AddClusterQueue(t.Context(),
+				err := cache.AddClusterQueue(context.Background(),
 					utiltesting.MakeClusterQueue("foo").
 						AdmissionChecks("check1", "check2").
 						Obj())
@@ -746,7 +746,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		{
 			name: "add check after queue creation",
 			operation: func(log logr.Logger, cache *Cache) error {
-				err := cache.AddClusterQueue(t.Context(),
+				err := cache.AddClusterQueue(context.Background(),
 					utiltesting.MakeClusterQueue("foo").
 						AdmissionChecks("check1", "check2").
 						Obj())
@@ -754,8 +754,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					return fmt.Errorf("adding ClusterQueue: %w", err)
 				}
 
-				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check1").Active(metav1.ConditionTrue).Obj())
-				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionTrue).Obj())
+				cache.AddOrUpdateAdmissionCheck(log, utiltesting.MakeAdmissionCheck("check1").Active(metav1.ConditionTrue).Obj())
+				cache.AddOrUpdateAdmissionCheck(log, utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionTrue).Obj())
 				return nil
 			},
 			wantClusterQueues: map[string]*clusterQueue{
@@ -778,8 +778,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		{
 			name: "remove check after queue creation",
 			operation: func(log logr.Logger, cache *Cache) error {
-				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check1").Active(metav1.ConditionTrue).Obj())
-				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionTrue).Obj())
+				cache.AddOrUpdateAdmissionCheck(log, utiltesting.MakeAdmissionCheck("check1").Active(metav1.ConditionTrue).Obj())
+				cache.AddOrUpdateAdmissionCheck(log, utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionTrue).Obj())
 				err := cache.AddClusterQueue(context.Background(),
 					utiltesting.MakeClusterQueue("foo").
 						AdmissionChecks("check1", "check2").
@@ -788,7 +788,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					return fmt.Errorf("adding ClusterQueue: %w", err)
 				}
 
-				cache.DeleteAdmissionCheck(utiltesting.MakeAdmissionCheck("check2").Obj())
+				cache.DeleteAdmissionCheck(log, utiltesting.MakeAdmissionCheck("check2").Obj())
 				return nil
 			},
 			wantClusterQueues: map[string]*clusterQueue{
@@ -811,8 +811,8 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 		{
 			name: "inactivate check after queue creation",
 			operation: func(log logr.Logger, cache *Cache) error {
-				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check1").Active(metav1.ConditionTrue).Obj())
-				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionTrue).Obj())
+				cache.AddOrUpdateAdmissionCheck(log, utiltesting.MakeAdmissionCheck("check1").Active(metav1.ConditionTrue).Obj())
+				cache.AddOrUpdateAdmissionCheck(log, utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionTrue).Obj())
 				err := cache.AddClusterQueue(context.Background(),
 					utiltesting.MakeClusterQueue("foo").
 						AdmissionChecks("check1", "check2").
@@ -821,7 +821,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					return fmt.Errorf("adding ClusterQueue: %w", err)
 				}
 
-				cache.AddOrUpdateAdmissionCheck(utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionFalse).Obj())
+				cache.AddOrUpdateAdmissionCheck(log, utiltesting.MakeAdmissionCheck("check2").Active(metav1.ConditionFalse).Obj())
 				return nil
 			},
 			wantClusterQueues: map[string]*clusterQueue{
@@ -857,7 +857,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				).Admitted(true).Finished().Obj(),
 			},
 			operation: func(log logr.Logger, cache *Cache) error {
-				cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("f1").Obj())
+				cache.AddOrUpdateResourceFlavor(log, utiltesting.MakeResourceFlavor("f1").Obj())
 				err := cache.AddClusterQueue(context.Background(),
 					utiltesting.MakeClusterQueue("cq1").
 						ResourceGroup(kueue.FlavorQuotas{
@@ -2793,9 +2793,10 @@ func TestClusterQueuesUsingFlavor(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			cache := New(utiltesting.NewFakeClient())
-			cache.AddOrUpdateResourceFlavor(x86Rf)
-			cache.AddOrUpdateResourceFlavor(aarch64Rf)
+			cache.AddOrUpdateResourceFlavor(log, x86Rf)
+			cache.AddOrUpdateResourceFlavor(log, aarch64Rf)
 
 			for _, cq := range tc.clusterQueues {
 				if err := cache.AddClusterQueue(context.Background(), cq); err != nil {
@@ -3106,8 +3107,7 @@ func TestCachePodsReadyForAllAdmittedWorkloads(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cache := New(cl, WithPodsReadyTracking(true))
-			ctx := context.Background()
-			log := ctrl.LoggerFrom(ctx)
+			ctx, log := utiltesting.ContextWithLog(t)
 
 			for _, c := range clusterQueues {
 				if err := cache.AddClusterQueue(ctx, &c); err != nil {
@@ -3307,9 +3307,10 @@ func TestClusterQueuesUsingAdmissionChecks(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			cache := New(utiltesting.NewFakeClient())
 			for _, check := range checks {
-				cache.AddOrUpdateAdmissionCheck(check)
+				cache.AddOrUpdateAdmissionCheck(log, check)
 			}
 
 			for _, cq := range tc.clusterQueues {
@@ -3420,12 +3421,13 @@ func TestClusterQueueReadiness(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
 			cache := New(utiltesting.NewFakeClient())
 			for _, rf := range tc.resourceFlavors {
-				cache.AddOrUpdateResourceFlavor(rf)
+				cache.AddOrUpdateResourceFlavor(log, rf)
 			}
 			for _, ac := range tc.admissionChecks {
-				cache.AddOrUpdateAdmissionCheck(ac)
+				cache.AddOrUpdateAdmissionCheck(log, ac)
 			}
 			for _, cq := range tc.clusterQueues {
 				if err := cache.AddClusterQueue(context.Background(), cq); err != nil {
@@ -3485,7 +3487,7 @@ func TestCohortCycles(t *testing.T) {
 	})
 	t.Run("clusterqueue add and update return error when cohort has cycle", func(t *testing.T) {
 		cache := New(utiltesting.NewFakeClient())
-		ctx := context.Background()
+		ctx, log := utiltesting.ContextWithLog(t)
 		cohortA := utiltesting.MakeCohort("cohort-a").Parent("cohort-b").Obj()
 		if err := cache.AddOrUpdateCohort(cohortA); err != nil {
 			t.Fatal("Expected success as no cycle yet")
@@ -3507,7 +3509,7 @@ func TestCohortCycles(t *testing.T) {
 
 		// Error when updating CQ with parent Cohort-B
 		cq = utiltesting.MakeClusterQueue("cq").Cohort("cohort-b").Obj()
-		if err := cache.UpdateClusterQueue(cq); err == nil {
+		if err := cache.UpdateClusterQueue(log, cq); err == nil {
 			t.Fatal("Expected failure when updating cq to cohort with cycle")
 		}
 
@@ -3516,14 +3518,14 @@ func TestCohortCycles(t *testing.T) {
 
 		// Update succeeds
 		cq = utiltesting.MakeClusterQueue("cq").Cohort("cohort-b").Obj()
-		if err := cache.UpdateClusterQueue(cq); err != nil {
+		if err := cache.UpdateClusterQueue(log, cq); err != nil {
 			t.Fatal("Expected success")
 		}
 	})
 
 	t.Run("clusterqueue leaving cohort with cycle successfully updates new cohort", func(t *testing.T) {
 		cache := New(utiltesting.NewFakeClient())
-		ctx := context.Background()
+		ctx, log := utiltesting.ContextWithLog(t)
 		cycleCohort := utiltesting.MakeCohort("cycle").Parent("cycle").Obj()
 		if err := cache.AddOrUpdateCohort(cycleCohort); err == nil {
 			t.Fatal("Expected failure")
@@ -3545,7 +3547,7 @@ func TestCohortCycles(t *testing.T) {
 
 		// Successfully updated to cohort without cycle
 		cq.Spec.Cohort = "cohort"
-		if err := cache.UpdateClusterQueue(cq); err != nil {
+		if err := cache.UpdateClusterQueue(log, cq); err != nil {
 			t.Fatal("Expected success")
 		}
 
@@ -3567,7 +3569,7 @@ func TestCohortCycles(t *testing.T) {
 
 	t.Run("clusterqueue joining cohort with cycle successfully updates old cohort", func(t *testing.T) {
 		cache := New(utiltesting.NewFakeClient())
-		ctx := context.Background()
+		ctx, log := utiltesting.ContextWithLog(t)
 		cycleCohort := utiltesting.MakeCohort("cycle").Parent("cycle").Obj()
 		if err := cache.AddOrUpdateCohort(cycleCohort); err == nil {
 			t.Fatal("Expected failure")
@@ -3603,7 +3605,7 @@ func TestCohortCycles(t *testing.T) {
 
 		// Updated to cycle
 		cq.Spec.Cohort = "cycle"
-		if err := cache.UpdateClusterQueue(cq); err == nil {
+		if err := cache.UpdateClusterQueue(log, cq); err == nil {
 			t.Fatal("Expected failure")
 		}
 
@@ -3778,7 +3780,7 @@ func TestSnapshotError(t *testing.T) {
 		connectionRefusedErr = errors.New("connection refused")
 	)
 	features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, true)
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 
 	topology := *utiltesting.MakeDefaultOneLevelTopology("default")
 	flavor := *utiltesting.MakeResourceFlavor("tas-default").
@@ -3811,7 +3813,7 @@ func TestSnapshotError(t *testing.T) {
 	kcBuilder.WithObjects(&flavor)
 	client := kcBuilder.Build()
 	cache := New(client)
-	cache.AddOrUpdateResourceFlavor(&flavor)
+	cache.AddOrUpdateResourceFlavor(log, &flavor)
 	if flavor.Spec.TopologyName != nil {
 		tasFlavorCache := cache.tasCache.NewTASFlavorCache(*flavor.Spec.TopologyName, []string{corev1.LabelHostname}, flavor.Spec.NodeLabels, flavor.Spec.Tolerations)
 		cache.tasCache.Set(kueue.ResourceFlavorReference(flavor.Name), tasFlavorCache)

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -133,7 +133,7 @@ var defaultPreemption = kueue.ClusterQueuePreemption{
 
 var defaultFlavorFungibility = kueue.FlavorFungibility{WhenCanBorrow: kueue.Borrow, WhenCanPreempt: kueue.TryNextFlavor}
 
-func (c *clusterQueue) updateClusterQueue(cycleChecker hierarchy.CycleChecker, in *kueue.ClusterQueue, resourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor, admissionChecks map[string]AdmissionCheck, oldParent *cohort) error {
+func (c *clusterQueue) updateClusterQueue(log logr.Logger, cycleChecker hierarchy.CycleChecker, in *kueue.ClusterQueue, resourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor, admissionChecks map[string]AdmissionCheck, oldParent *cohort) error {
 	if c.updateQuotasAndResourceGroups(in.Spec.ResourceGroups) || oldParent != c.Parent() {
 		if oldParent != nil && oldParent != c.Parent() {
 			// ignore error when old Cohort has cycle.
@@ -167,8 +167,8 @@ func (c *clusterQueue) updateClusterQueue(cycleChecker hierarchy.CycleChecker, i
 		c.Preemption = defaultPreemption
 	}
 
-	c.UpdateWithFlavors(resourceFlavors)
-	c.updateWithAdmissionChecks(admissionChecks)
+	c.UpdateWithFlavors(log, resourceFlavors)
+	c.updateWithAdmissionChecks(log, admissionChecks)
 
 	if in.Spec.FlavorFungibility != nil {
 		c.FlavorFungibility = *in.Spec.FlavorFungibility
@@ -218,7 +218,7 @@ func (c *clusterQueue) updateQuotasAndResourceGroups(in []kueue.ResourceGroup) b
 		!equality.Semantic.DeepEqual(oldQuotas, c.resourceNode.Quotas)
 }
 
-func (c *clusterQueue) updateQueueStatus() {
+func (c *clusterQueue) updateQueueStatus(log logr.Logger) {
 	status := active
 	if c.isStopped ||
 		len(c.missingFlavors) > 0 ||
@@ -236,6 +236,7 @@ func (c *clusterQueue) updateQueueStatus() {
 		status = terminating
 	}
 	if status != c.Status {
+		log.V(3).Info("Updating status in cache", "clusterQueue", c.Name, "newStatus", status, "oldStatus", c.Status)
 		c.Status = status
 		metrics.ReportClusterQueueStatus(c.Name, c.Status)
 	}
@@ -339,9 +340,9 @@ func (c *clusterQueue) isTASViolated() bool {
 
 // UpdateWithFlavors updates a ClusterQueue based on the passed ResourceFlavors set.
 // Exported only for testing.
-func (c *clusterQueue) UpdateWithFlavors(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
+func (c *clusterQueue) UpdateWithFlavors(log logr.Logger, flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
 	c.updateLabelKeys(flavors)
-	c.updateQueueStatus()
+	c.updateQueueStatus(log)
 }
 
 func (c *clusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
@@ -377,7 +378,7 @@ func (c *clusterQueue) updateLabelKeys(flavors map[kueue.ResourceFlavorReference
 }
 
 // updateWithAdmissionChecks updates a ClusterQueue based on the passed AdmissionChecks set.
-func (c *clusterQueue) updateWithAdmissionChecks(checks map[string]AdmissionCheck) {
+func (c *clusterQueue) updateWithAdmissionChecks(log logr.Logger, checks map[string]AdmissionCheck) {
 	checksPerController := make(map[string][]string, len(c.AdmissionChecks))
 	singleInstanceControllers := sets.New[string]()
 	multiKueueAdmissionChecks := sets.New[string]()
@@ -473,7 +474,7 @@ func (c *clusterQueue) updateWithAdmissionChecks(checks map[string]AdmissionChec
 	}
 
 	if update {
-		c.updateQueueStatus()
+		c.updateQueueStatus(log)
 	}
 }
 

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -886,7 +886,7 @@ func TestDominantResourceShare(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 			cache := New(utiltesting.NewFakeClient())
 			cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("default").Obj())
 			cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("on-demand").Obj())
@@ -911,7 +911,7 @@ func TestDominantResourceShare(t *testing.T) {
 
 				wl := utiltesting.MakeWorkload(fmt.Sprintf("workload-%d", i), "default-namespace").ReserveQuota(admission.Obj()).Obj()
 
-				cache.AddOrUpdateWorkload(wl)
+				cache.AddOrUpdateWorkload(log, wl)
 				snapshot.AddWorkload(workload.NewInfo(wl))
 				i += 1
 			}

--- a/pkg/cache/resource_test.go
+++ b/pkg/cache/resource_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cache
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -361,10 +360,10 @@ func TestAvailable(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx, log := utiltesting.ContextWithLog(t)
 			cache := New(utiltesting.NewFakeClient())
-			cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("red").Obj())
-			cache.AddOrUpdateResourceFlavor(utiltesting.MakeResourceFlavor("blue").Obj())
+			cache.AddOrUpdateResourceFlavor(log, utiltesting.MakeResourceFlavor("red").Obj())
+			cache.AddOrUpdateResourceFlavor(log, utiltesting.MakeResourceFlavor("blue").Obj())
 			for _, cq := range tc.clusterQueues {
 				_ = cache.AddClusterQueue(ctx, &cq)
 			}

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cache
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -894,7 +893,7 @@ func TestSnapshot(t *testing.T) {
 				_ = cache.AddOrUpdateCohort(cohort)
 			}
 			for _, rf := range tc.rfs {
-				cache.AddOrUpdateResourceFlavor(rf)
+				cache.AddOrUpdateResourceFlavor(log, rf)
 			}
 			for _, wl := range tc.wls {
 				cache.AddOrUpdateWorkload(log, wl)
@@ -967,12 +966,12 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 			Obj(),
 	}
 
-	ctx := context.Background()
+	ctx, log := utiltesting.ContextWithLog(t)
 	cl := utiltesting.NewClientBuilder().WithLists(&kueue.WorkloadList{Items: workloads}).Build()
 
 	cqCache := New(cl)
 	for _, flv := range flavors {
-		cqCache.AddOrUpdateResourceFlavor(flv)
+		cqCache.AddOrUpdateResourceFlavor(log, flv)
 	}
 	for _, cq := range clusterQueues {
 		if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
@@ -1261,12 +1260,12 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			Obj(),
 	}
 
-	ctx := context.Background()
+	ctx, log := utiltesting.ContextWithLog(t)
 	cl := utiltesting.NewClientBuilder().WithLists(&kueue.WorkloadList{Items: workloads}).Build()
 
 	cqCache := New(cl)
 	for _, flv := range flavors {
-		cqCache.AddOrUpdateResourceFlavor(flv)
+		cqCache.AddOrUpdateResourceFlavor(log, flv)
 	}
 	for _, cq := range clusterQueues {
 		if err := cqCache.AddClusterQueue(ctx, cq); err != nil {

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -878,7 +878,7 @@ func TestSnapshot(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 			if tc.disableLendingLimit {
 				features.SetFeatureGateDuringTest(t, features.LendingLimit, false)
 			}
@@ -897,7 +897,7 @@ func TestSnapshot(t *testing.T) {
 				cache.AddOrUpdateResourceFlavor(rf)
 			}
 			for _, wl := range tc.wls {
-				cache.AddOrUpdateWorkload(wl)
+				cache.AddOrUpdateWorkload(log, wl)
 			}
 			snapshot, err := cache.Snapshot(ctx)
 			if err != nil {

--- a/pkg/controller/core/admissioncheck_controller.go
+++ b/pkg/controller/core/admissioncheck_controller.go
@@ -124,7 +124,7 @@ func (r *AdmissionCheckReconciler) Create(e event.CreateEvent) bool {
 	}
 	defer r.notifyWatchers(nil, ac)
 	r.log.WithValues("admissionCheck", klog.KObj(ac)).V(5).Info("Create event")
-	if cqNames := r.cache.AddOrUpdateAdmissionCheck(ac); len(cqNames) > 0 {
+	if cqNames := r.cache.AddOrUpdateAdmissionCheck(r.log, ac); len(cqNames) > 0 {
 		r.qManager.QueueInadmissibleWorkloads(context.Background(), cqNames)
 	}
 	return true
@@ -144,7 +144,7 @@ func (r *AdmissionCheckReconciler) Update(e event.UpdateEvent) bool {
 	if !newAc.DeletionTimestamp.IsZero() {
 		return true
 	}
-	if cqNames := r.cache.AddOrUpdateAdmissionCheck(newAc); len(cqNames) > 0 {
+	if cqNames := r.cache.AddOrUpdateAdmissionCheck(r.log, newAc); len(cqNames) > 0 {
 		r.qManager.QueueInadmissibleWorkloads(context.Background(), cqNames)
 	}
 	return false
@@ -158,7 +158,7 @@ func (r *AdmissionCheckReconciler) Delete(e event.DeleteEvent) bool {
 	defer r.notifyWatchers(ac, nil)
 	r.log.WithValues("admissionCheck", klog.KObj(ac)).V(5).Info("Delete event")
 
-	if cqNames := r.cache.DeleteAdmissionCheck(ac); len(cqNames) > 0 {
+	if cqNames := r.cache.DeleteAdmissionCheck(r.log, ac); len(cqNames) > 0 {
 		r.qManager.QueueInadmissibleWorkloads(context.Background(), cqNames)
 	}
 	return true

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -346,7 +346,7 @@ func (r *ClusterQueueReconciler) Update(e event.UpdateEvent) bool {
 	defer r.notifyWatchers(oldCq, newCq)
 	specUpdated := !equality.Semantic.DeepEqual(oldCq.Spec, newCq.Spec)
 
-	if err := r.cache.UpdateClusterQueue(newCq); err != nil {
+	if err := r.cache.UpdateClusterQueue(r.log, newCq); err != nil {
 		log.Error(err, "Failed to update clusterQueue in cache")
 	}
 	if err := r.qManager.UpdateClusterQueue(context.Background(), newCq, specUpdated); err != nil {

--- a/pkg/controller/core/clusterqueue_controller_test.go
+++ b/pkg/controller/core/clusterqueue_controller_test.go
@@ -220,7 +220,7 @@ func TestUpdateCqStatusIfChanged(t *testing.T) {
 				t.Fatalf("Inserting localQueue in manager: %v", err)
 			}
 			for _, wl := range defaultWls.Items {
-				cqCache.AddOrUpdateWorkload(&wl)
+				cqCache.AddOrUpdateWorkload(log, &wl)
 			}
 			r := &ClusterQueueReconciler{
 				client:   cl,

--- a/pkg/controller/core/resourceflavor_controller.go
+++ b/pkg/controller/core/resourceflavor_controller.go
@@ -132,7 +132,7 @@ func (r *ResourceFlavorReconciler) Create(e event.CreateEvent) bool {
 
 	// As long as one clusterQueue becomes active,
 	// we should inform clusterQueue controller to broadcast the event.
-	if cqNames := r.cache.AddOrUpdateResourceFlavor(flv.DeepCopy()); len(cqNames) > 0 {
+	if cqNames := r.cache.AddOrUpdateResourceFlavor(r.log, flv.DeepCopy()); len(cqNames) > 0 {
 		r.qManager.QueueInadmissibleWorkloads(context.Background(), cqNames)
 		// If at least one CQ becomes active, then those CQs should now get evaluated by the scheduler;
 		// note that the workloads in those CQs are not necessarily "inadmissible", and hence we trigger a
@@ -152,7 +152,7 @@ func (r *ResourceFlavorReconciler) Delete(e event.DeleteEvent) bool {
 	log := r.log.WithValues("resourceFlavor", klog.KObj(flv))
 	log.V(2).Info("ResourceFlavor delete event")
 
-	if cqNames := r.cache.DeleteResourceFlavor(flv); len(cqNames) > 0 {
+	if cqNames := r.cache.DeleteResourceFlavor(r.log, flv); len(cqNames) > 0 {
 		r.qManager.QueueInadmissibleWorkloads(context.Background(), cqNames)
 	}
 	return false
@@ -176,7 +176,7 @@ func (r *ResourceFlavorReconciler) Update(e event.UpdateEvent) bool {
 		return true
 	}
 
-	if cqNames := r.cache.AddOrUpdateResourceFlavor(newFlv.DeepCopy()); len(cqNames) > 0 {
+	if cqNames := r.cache.AddOrUpdateResourceFlavor(r.log, newFlv.DeepCopy()); len(cqNames) > 0 {
 		r.qManager.QueueInadmissibleWorkloads(context.Background(), cqNames)
 	}
 	return false

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -670,7 +670,7 @@ func TestDefault(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.MultiKueueBatchJobWithManagedBy, tc.multiKueueBatchJobWithManagedByEnabled)
 			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 
 			clientBuilder := utiltesting.NewClientBuilder().
 				WithObjects(
@@ -696,7 +696,7 @@ func TestDefault(t *testing.T) {
 					t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
 				}
 				if tc.admissionCheck != nil {
-					cqCache.AddOrUpdateAdmissionCheck(tc.admissionCheck)
+					cqCache.AddOrUpdateAdmissionCheck(log, tc.admissionCheck)
 					if err := queueManager.AddClusterQueue(ctx, &cq); err != nil {
 						t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
 					}

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -393,7 +393,7 @@ func TestDefault(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
 			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 
 			clientBuilder := utiltesting.NewClientBuilder().
 				WithObjects(
@@ -420,7 +420,7 @@ func TestDefault(t *testing.T) {
 					t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
 				}
 				if tc.admissionCheck != nil {
-					cqCache.AddOrUpdateAdmissionCheck(tc.admissionCheck)
+					cqCache.AddOrUpdateAdmissionCheck(log, tc.admissionCheck)
 					if err := queueManager.AddClusterQueue(ctx, &cq); err != nil {
 						t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
 					}

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -368,7 +368,7 @@ func TestDefault(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.MultiKueue, tc.multiKueueEnabled)
 			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 
 			clientBuilder := utiltesting.NewClientBuilder().
 				WithObjects(
@@ -395,7 +395,7 @@ func TestDefault(t *testing.T) {
 					t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
 				}
 				if tc.admissionCheck != nil {
-					cqCache.AddOrUpdateAdmissionCheck(tc.admissionCheck)
+					cqCache.AddOrUpdateAdmissionCheck(log, tc.admissionCheck)
 					if err := queueManager.AddClusterQueue(ctx, &cq); err != nil {
 						t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
 					}

--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -174,7 +174,7 @@ func (h *topologyHandler) Create(ctx context.Context, e event.CreateEvent, q wor
 		}
 		if *flv.Spec.TopologyName == kueue.TopologyReference(topology.Name) {
 			log.V(3).Info("Updating Topology cache for flavor", "flavor", flv.Name)
-			h.cache.AddOrUpdateTopologyForFlavor(topology, &flv)
+			h.cache.AddOrUpdateTopologyForFlavor(log, topology, &flv)
 			q.AddAfter(reconcile.Request{NamespacedName: types.NamespacedName{Name: flv.Name}}, nodeBatchPeriod)
 		}
 	}
@@ -208,7 +208,7 @@ func (r *rfReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 				return reconcile.Result{}, client.IgnoreNotFound(err)
 			}
 			log.V(3).Info("Adding topology to cache for flavor", "flavorName", flv.Name)
-			r.cache.AddOrUpdateTopologyForFlavor(&topology, flv)
+			r.cache.AddOrUpdateTopologyForFlavor(log, &topology, flv)
 		} else {
 			log.V(3).Info("Skip topology update to cache as already present for flavor", "flavorName", flv.Name)
 		}

--- a/pkg/controller/tas/topology_controller.go
+++ b/pkg/controller/tas/topology_controller.go
@@ -147,7 +147,7 @@ func (r *topologyReconciler) Delete(e event.DeleteEvent) bool {
 	for flName, flCache := range r.tasCache.Clone() {
 		if kueue.TopologyReference(topology.Name) == flCache.TopologyName {
 			log.V(3).Info("Deleting topology from cache for flavor", "flavorName", flName)
-			r.cache.DeleteTopologyForFlavor(flName)
+			r.cache.DeleteTopologyForFlavor(log, flName)
 		}
 	}
 	return true

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -1989,7 +1989,7 @@ func TestAssignFlavors(t *testing.T) {
 				}
 			}
 			for _, rf := range resourceFlavors {
-				cache.AddOrUpdateResourceFlavor(rf)
+				cache.AddOrUpdateResourceFlavor(log, rf)
 			}
 
 			if err := cache.AddOrUpdateCohort(utiltesting.MakeCohort(tc.clusterQueue.Spec.Cohort).Obj()); err != nil {
@@ -2155,8 +2155,9 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 			if err := cache.AddClusterQueue(ctx, &otherCq); err != nil {
 				t.Fatalf("Failed to add CQ to cache")
 			}
+			log := testr.NewWithOptions(t, testr.Options{Verbosity: 2})
 			for _, rf := range resourceFlavors {
-				cache.AddOrUpdateResourceFlavor(rf)
+				cache.AddOrUpdateResourceFlavor(log, rf)
 			}
 
 			snapshot, err := cache.Snapshot(ctx)
@@ -2170,7 +2171,6 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 			testClusterQueue.AddUsage(tc.testClusterQueueUsage)
 
 			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{})
-			log := testr.NewWithOptions(t, testr.Options{Verbosity: 2})
 			assignment := flvAssigner.Assign(log, nil)
 			if gotRepMode := assignment.RepresentativeMode(); gotRepMode != tc.wantMode {
 				t.Errorf("Unexpected RepresentativeMode. got %s, want %s", gotRepMode, tc.wantMode)
@@ -2285,7 +2285,7 @@ func TestDeletedFlavors(t *testing.T) {
 			// we have to add the deleted flavor to the cache before snapshot,
 			// or else snapshot will fail
 			for _, flavor := range flavorMap {
-				cache.AddOrUpdateResourceFlavor(flavor)
+				cache.AddOrUpdateResourceFlavor(log, flavor)
 			}
 			snapshot, err := cache.Snapshot(ctx)
 			if err != nil {
@@ -2297,7 +2297,7 @@ func TestDeletedFlavors(t *testing.T) {
 			}
 
 			// and we delete it
-			cache.DeleteResourceFlavor(flavorMap["deleted-flavor"])
+			cache.DeleteResourceFlavor(log, flavorMap["deleted-flavor"])
 			delete(flavorMap, "deleted-flavor")
 
 			flvAssigner := New(wlInfo, clusterQueue, flavorMap, false, &testOracle{})

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -1820,7 +1820,7 @@ func TestPreemption(t *testing.T) {
 
 			cqCache := cache.New(cl)
 			for _, flv := range flavors {
-				cqCache.AddOrUpdateResourceFlavor(flv)
+				cqCache.AddOrUpdateResourceFlavor(log, flv)
 			}
 			for _, cq := range tc.clusterQueues {
 				if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
@@ -2352,7 +2352,7 @@ func TestFairPreemptions(t *testing.T) {
 				Build()
 			cqCache := cache.New(cl)
 			for _, flv := range flavors {
-				cqCache.AddOrUpdateResourceFlavor(flv)
+				cqCache.AddOrUpdateResourceFlavor(log, flv)
 			}
 			for _, cq := range tc.clusterQueues {
 				if err := cqCache.AddClusterQueue(ctx, cq); err != nil {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -493,7 +493,7 @@ func (s *Scheduler) admit(ctx context.Context, e *entry, cq *cache.ClusterQueueS
 		// sync Admitted, ignore the result since an API update is always done.
 		_ = workload.SyncAdmittedCondition(newWorkload, s.clock.Now())
 	}
-	if err := s.cache.AssumeWorkload(newWorkload); err != nil {
+	if err := s.cache.AssumeWorkload(log, newWorkload); err != nil {
 		return err
 	}
 	e.status = assumed
@@ -526,7 +526,7 @@ func (s *Scheduler) admit(ctx context.Context, e *entry, cq *cache.ClusterQueueS
 		}
 		// Ignore errors because the workload or clusterQueue could have been deleted
 		// by an event.
-		_ = s.cache.ForgetWorkload(newWorkload)
+		_ = s.cache.ForgetWorkload(log, newWorkload)
 		if apierrors.IsNotFound(err) {
 			log.V(2).Info("Workload not admitted because it was deleted")
 			return

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -3470,7 +3470,7 @@ func TestLastSchedulingContext(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 			scheme := runtime.NewScheme()
 
 			clientBuilder := utiltesting.NewClientBuilder().
@@ -3545,7 +3545,7 @@ func TestLastSchedulingContext(t *testing.T) {
 				if err != nil {
 					t.Errorf("Delete workload failed: %v", err)
 				}
-				err = cqCache.DeleteWorkload(&wl)
+				err = cqCache.DeleteWorkload(log, &wl)
 				if err != nil {
 					t.Errorf("Delete workload failed: %v", err)
 				}
@@ -3919,7 +3919,7 @@ func TestResourcesToReserve(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 			assignment := flavorassigner.Assignment{
 				PodSets: []flavorassigner.PodSetAssignment{{
 					Name:    "memory",
@@ -3953,7 +3953,7 @@ func TestResourcesToReserve(t *testing.T) {
 				quantity := resources.ResourceQuantity(fr.Resource, v)
 				admission := utiltesting.MakeAdmission("cq").Assignment(fr.Resource, fr.Flavor, quantity.String())
 				wl := utiltesting.MakeWorkload(fmt.Sprintf("workload-%d", i), "default-namespace").ReserveQuota(admission.Obj()).Obj()
-				cqCache.AddOrUpdateWorkload(wl)
+				cqCache.AddOrUpdateWorkload(log, wl)
 				i += 1
 			}
 			snapshot, err := cqCache.Snapshot(ctx)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2666,7 +2666,7 @@ func TestSchedule(t *testing.T) {
 			if tc.disablePartialAdmission {
 				features.SetFeatureGateDuringTest(t, features.PartialAdmission, false)
 			}
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 
 			allQueues := append(queues, tc.additionalLocalQueues...)
 			allClusterQueues := append(clusterQueues, tc.additionalClusterQueues...)
@@ -2693,7 +2693,7 @@ func TestSchedule(t *testing.T) {
 				}
 			}
 			for i := range resourceFlavors {
-				cqCache.AddOrUpdateResourceFlavor(resourceFlavors[i])
+				cqCache.AddOrUpdateResourceFlavor(log, resourceFlavors[i])
 			}
 			for _, cq := range allClusterQueues {
 				if err := cqCache.AddClusterQueue(ctx, &cq); err != nil {
@@ -3494,7 +3494,7 @@ func TestLastSchedulingContext(t *testing.T) {
 				}
 			}
 			for i := range resourceFlavors {
-				cqCache.AddOrUpdateResourceFlavor(resourceFlavors[i])
+				cqCache.AddOrUpdateResourceFlavor(log, resourceFlavors[i])
 			}
 			for _, cq := range tc.cqs {
 				if err := cqCache.AddClusterQueue(ctx, &cq); err != nil {
@@ -3941,7 +3941,7 @@ func TestResourcesToReserve(t *testing.T) {
 				Build()
 			cqCache := cache.New(cl)
 			for _, flavor := range resourceFlavors {
-				cqCache.AddOrUpdateResourceFlavor(flavor)
+				cqCache.AddOrUpdateResourceFlavor(log, flavor)
 			}
 			err := cqCache.AddClusterQueue(ctx, cq)
 			if err != nil {
@@ -5141,7 +5141,7 @@ func TestScheduleForTAS(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, true)
-			ctx, _ := utiltesting.ContextWithLog(t)
+			ctx, log := utiltesting.ContextWithLog(t)
 
 			clientBuilder := utiltesting.NewClientBuilder().
 				WithLists(
@@ -5162,7 +5162,7 @@ func TestScheduleForTAS(t *testing.T) {
 				return kueue.TopologyReference(tc.topologies[i].Name), tc.topologies[i]
 			})
 			for _, flavor := range tc.resourceFlavors {
-				cqCache.AddOrUpdateResourceFlavor(&flavor)
+				cqCache.AddOrUpdateResourceFlavor(log, &flavor)
 				if flavor.Spec.TopologyName != nil {
 					t := topologyByName[*flavor.Spec.TopologyName]
 					tasCache := cqCache.TASCache()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/5324 and https://github.com/kubernetes-sigs/kueue/pull/5326

This is preparatory cherry-pick before cherry-pick for https://github.com/kubernetes-sigs/kueue/pull/5276

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```