### PR TITLE
TAS: account for TAS usage after reboot  (cherry-pick to 0.11)

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -147,6 +147,8 @@ func (c *Cache) newClusterQueue(log logr.Logger, cq *kueue.ClusterQueue) (*clust
 		AdmittedUsage:       make(resources.FlavorResourceQuantities),
 		resourceNode:        NewResourceNode(),
 		tasCache:            &c.tasCache,
+
+		workloadsNotAccountedForTAS: sets.New[string](),
 	}
 	c.hm.AddClusterQueue(cqImpl)
 	c.hm.UpdateClusterQueueEdge(kueue.ClusterQueueReference(cq.Name), cq.Spec.Cohort)
@@ -262,12 +264,15 @@ func (c *Cache) DeleteResourceFlavor(log logr.Logger, rf *kueue.ResourceFlavor) 
 	return c.updateClusterQueues(log)
 }
 
-func (c *Cache) AddOrUpdateTopologyForFlavor(log logr.Logger, topology *kueuealpha.Topology, flv *kueue.ResourceFlavor) sets.Set[kueue.ClusterQueueReference] {
+func (c *Cache) AddTopologyForFlavor(log logr.Logger, topology *kueuealpha.Topology, flv *kueue.ResourceFlavor) sets.Set[kueue.ClusterQueueReference] {
 	c.Lock()
 	defer c.Unlock()
 	levels := utiltas.Levels(topology)
-	tasInfo := c.tasCache.NewTASFlavorCache(kueue.TopologyReference(topology.Name), levels, flv.Spec.NodeLabels, flv.Spec.Tolerations)
-	c.tasCache.Set(kueue.ResourceFlavorReference(flv.Name), tasInfo)
+	tasFlavor := kueue.ResourceFlavorReference(flv.Name)
+	if c.tasCache.Get(tasFlavor) == nil {
+		tasInfo := c.tasCache.NewTASFlavorCache(kueue.TopologyReference(topology.Name), levels, flv.Spec.NodeLabels, flv.Spec.Tolerations)
+		c.tasCache.Set(tasFlavor, tasInfo)
+	}
 	return c.updateClusterQueues(log)
 }
 
@@ -586,7 +591,7 @@ func (c *Cache) DeleteWorkload(log logr.Logger, w *kueue.Workload) error {
 
 	c.cleanupAssumedState(log, w)
 
-	cq.deleteWorkload(log, w)
+	cq.forgetWorkload(log, w)
 	if c.podsReadyTracking {
 		c.podsReadyCond.Broadcast()
 	}
@@ -652,7 +657,7 @@ func (c *Cache) ForgetWorkload(log logr.Logger, w *kueue.Workload) error {
 	if cq == nil {
 		return ErrCqNotFound
 	}
-	cq.deleteWorkload(log, w)
+	cq.forgetWorkload(log, w)
 	if c.podsReadyTracking {
 		c.podsReadyCond.Broadcast()
 	}

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -87,6 +87,8 @@ type clusterQueue struct {
 	hierarchy.ClusterQueue[*cohort]
 
 	tasCache *TASCache
+
+	workloadsNotAccountedForTAS sets.Set[string]
 }
 
 func (c *clusterQueue) GetName() kueue.ClusterQueueReference {
@@ -205,6 +207,20 @@ func (c *clusterQueue) updateQuotasAndResourceGroups(in []kueue.ResourceGroup) b
 }
 
 func (c *clusterQueue) updateQueueStatus(log logr.Logger) {
+	if features.Enabled(features.TopologyAwareScheduling) &&
+		len(c.tasFlavors) > 0 &&
+		len(c.workloadsNotAccountedForTAS) > 0 &&
+		c.isTASSynced() {
+		log.V(2).Info("Delayed accounting for TAS usage for workloads", "count", len(c.workloadsNotAccountedForTAS))
+		// There are some workloads which are not accounted yet for TAS.
+		// We re-add them as not the tasCache is initialized (synced).
+		for k, w := range c.Workloads {
+			if c.workloadsNotAccountedForTAS.Has(k) {
+				c.addOrUpdateWorkload(log, w.Obj)
+				c.workloadsNotAccountedForTAS.Delete(k)
+			}
+		}
+	}
 	status := active
 	if c.isStopped ||
 		len(c.missingFlavors) > 0 ||
@@ -226,6 +242,15 @@ func (c *clusterQueue) updateQueueStatus(log logr.Logger) {
 		c.Status = status
 		metrics.ReportClusterQueueStatus(c.Name, c.Status)
 	}
+}
+
+func (c *clusterQueue) isTASSynced() bool {
+	for tasFlavor := range c.tasFlavors {
+		if c.tasCache.Get(tasFlavor) == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *clusterQueue) inactiveReason() (string, string) {
@@ -305,10 +330,8 @@ func (c *clusterQueue) isTASViolated() bool {
 	if !features.Enabled(features.TopologyAwareScheduling) || len(c.tasFlavors) == 0 {
 		return false
 	}
-	for tasFlavor := range c.tasFlavors {
-		if c.tasCache.Get(tasFlavor) == nil {
-			return true
-		}
+	if !c.isTASSynced() {
+		return true
 	}
 	return len(c.multiKueueAdmissionChecks) > 0 || len(c.provisioningAdmissionChecks) > 0
 }
@@ -468,6 +491,11 @@ func (c *clusterQueue) addWorkload(log logr.Logger, w *kueue.Workload) error {
 	return nil
 }
 
+func (c *clusterQueue) forgetWorkload(log logr.Logger, w *kueue.Workload) {
+	c.deleteWorkload(log, w)
+	delete(c.workloadsNotAccountedForTAS, workload.Key(w))
+}
+
 func (c *clusterQueue) deleteWorkload(log logr.Logger, w *kueue.Workload) {
 	k := workload.Key(w)
 	wi, exist := c.Workloads[k]
@@ -510,20 +538,7 @@ func (c *clusterQueue) updateWorkloadUsage(log logr.Logger, wi *workload.Info, m
 			removeUsage(c, fr, q)
 		}
 	}
-	if features.Enabled(features.TopologyAwareScheduling) && wi.IsUsingTAS() {
-		for tasFlavor, tasUsage := range wi.TASUsage() {
-			if tasFlvCache := c.tasFlavorCache(tasFlavor); tasFlvCache != nil {
-				if m == 1 {
-					tasFlvCache.addUsage(tasUsage)
-				}
-				if m == -1 {
-					tasFlvCache.removeUsage(tasUsage)
-				}
-			} else {
-				log.V(2).Info("TAS flavor used by workload not found in cache", "tasFlavor", tasFlavor)
-			}
-		}
-	}
+	c.updateWorkloadTASUsage(log, wi, m)
 	if admitted {
 		updateFlavorUsage(frUsage, c.AdmittedUsage, m)
 		c.admittedWorkloadsCount += int(m)
@@ -542,14 +557,37 @@ func (c *clusterQueue) updateWorkloadUsage(log logr.Logger, wi *workload.Info, m
 	}
 }
 
-func (c *clusterQueue) tasFlavorCache(flvName kueue.ResourceFlavorReference) *TASFlavorCache {
-	if !features.Enabled(features.TopologyAwareScheduling) {
-		return nil
+func (c *clusterQueue) updateWorkloadTASUsage(log logr.Logger, wi *workload.Info, m int64) {
+	if !features.Enabled(features.TopologyAwareScheduling) || !wi.IsUsingTAS() {
+		return
 	}
-	if c.tasCache == nil {
-		return nil
+	key := workload.Key(wi.Obj)
+	log = log.WithValues("workload", key)
+	if !c.isTASSynced() {
+		log.V(2).Info("Delaying accounting of the TAS usage, because TAS cache is not synced yet")
+		// TAS cache is not synced yet so we defer accounting for TAS usage.
+		c.workloadsNotAccountedForTAS.Insert(key)
+		return
 	}
-	return c.tasCache.Get(flvName)
+	for tasFlavor, tasUsage := range wi.TASUsage() {
+		tasFlvCache := c.tasCache.Get(tasFlavor)
+		switch {
+		case tasFlvCache == nil:
+			log.V(2).Info("TAS flavor used by workload not found in cache", "tasFlavor", tasFlavor)
+		case m == 1:
+			tasFlvCache.addUsage(tasUsage)
+		case m == -1:
+			// If the workload is not accounted for TAS, we haven't called
+			// addUsage on startup, and so we don't subtract the capacity now.
+			if c.workloadsNotAccountedForTAS.Has(key) {
+				log.V(2).Info("Skip subtracting TAS usage because we've never accounted for it")
+			} else {
+				tasFlvCache.removeUsage(tasUsage)
+			}
+		}
+	}
+	// We just accounted for TAS usage so drop it from the set.
+	c.workloadsNotAccountedForTAS.Delete(key)
 }
 
 func updateFlavorUsage(newUsage resources.FlavorResourceQuantities, oldUsage resources.FlavorResourceQuantities, m int64) {

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -481,6 +481,15 @@ func (c *clusterQueue) addWorkload(log logr.Logger, w *kueue.Workload) error {
 	if _, exist := c.Workloads[k]; exist {
 		return errors.New("workload already exists in ClusterQueue")
 	}
+	c.addOrUpdateWorkload(log, w)
+	return nil
+}
+
+func (c *clusterQueue) addOrUpdateWorkload(log logr.Logger, w *kueue.Workload) {
+	k := workload.Key(w)
+	if _, exist := c.Workloads[k]; exist {
+		c.deleteWorkload(log, w)
+	}
 	wi := workload.NewInfo(w, c.workloadInfoOptions...)
 	c.Workloads[k] = wi
 	c.updateWorkloadUsage(log, wi, 1)
@@ -488,7 +497,6 @@ func (c *clusterQueue) addWorkload(log logr.Logger, w *kueue.Workload) error {
 		c.WorkloadsNotReady.Insert(k)
 	}
 	c.reportActiveWorkloads()
-	return nil
 }
 
 func (c *clusterQueue) forgetWorkload(log logr.Logger, w *kueue.Workload) {

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -750,7 +750,7 @@ func TestClusterQueueReadinessWithTAS(t *testing.T) {
 			cqCache.AddOrUpdateResourceFlavor(log, rf)
 
 			if !tc.skipTopology {
-				cqCache.AddOrUpdateTopologyForFlavor(log, topology, rf)
+				cqCache.AddTopologyForFlavor(log, topology, rf)
 			}
 
 			mkAC := utiltesting.MakeAdmissionCheck("mk-check").ControllerName(kueue.MultiKueueControllerName).Active(metav1.ConditionTrue).Obj()

--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -154,7 +154,7 @@ func (r *rfReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 				return reconcile.Result{}, client.IgnoreNotFound(err)
 			}
 			log.V(3).Info("Adding topology to cache for flavor", "flavorName", flv.Name)
-			r.cache.AddOrUpdateTopologyForFlavor(log, &topology, flv)
+			r.cache.AddTopologyForFlavor(log, &topology, flv)
 		} else {
 			log.V(3).Info("Skip topology update to cache as already present for flavor", "flavorName", flv.Name)
 		}

--- a/pkg/controller/tas/topology_controller.go
+++ b/pkg/controller/tas/topology_controller.go
@@ -153,7 +153,7 @@ func (r *topologyReconciler) Create(e event.TypedCreateEvent[*kueuealpha.Topolog
 		}
 		if *flv.Spec.TopologyName == kueue.TopologyReference(e.Object.Name) {
 			log.V(3).Info("Updating Topology cache for flavor", "flavor", flv.Name)
-			r.cache.AddOrUpdateTopologyForFlavor(log, e.Object, &flv)
+			r.cache.AddTopologyForFlavor(log, e.Object, &flv)
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This is cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/5276 on top of the logger cherry-pick https://github.com/kubernetes-sigs/kueue/pull/5329

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fix the bug where TAS workloads may be admitted after restart of the Kueue controller.
```