### PR TITLE
TAS: account for TAS usage after reboot (cherry-pick to 0.10)

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -145,6 +145,8 @@ func (c *Cache) newClusterQueue(log logr.Logger, cq *kueue.ClusterQueue) (*clust
 		AdmittedUsage:       make(resources.FlavorResourceQuantities),
 		resourceNode:        NewResourceNode(),
 		tasCache:            &c.tasCache,
+
+		workloadsNotAccountedForTAS: sets.New[string](),
 	}
 	c.hm.AddClusterQueue(cqImpl)
 	c.hm.UpdateClusterQueueEdge(cq.Name, cq.Spec.Cohort)
@@ -260,12 +262,15 @@ func (c *Cache) DeleteResourceFlavor(log logr.Logger, rf *kueue.ResourceFlavor) 
 	return c.updateClusterQueues(log)
 }
 
-func (c *Cache) AddOrUpdateTopologyForFlavor(log logr.Logger, topology *kueuealpha.Topology, flv *kueue.ResourceFlavor) sets.Set[string] {
+func (c *Cache) AddTopologyForFlavor(log logr.Logger, topology *kueuealpha.Topology, flv *kueue.ResourceFlavor) sets.Set[string] {
 	c.Lock()
 	defer c.Unlock()
 	levels := utiltas.Levels(topology)
-	tasInfo := c.tasCache.NewTASFlavorCache(kueue.TopologyReference(topology.Name), levels, flv.Spec.NodeLabels, flv.Spec.Tolerations)
-	c.tasCache.Set(kueue.ResourceFlavorReference(flv.Name), tasInfo)
+	tasFlavor := kueue.ResourceFlavorReference(flv.Name)
+	if c.tasCache.Get(tasFlavor) == nil {
+		tasInfo := c.tasCache.NewTASFlavorCache(kueue.TopologyReference(topology.Name), levels, flv.Spec.NodeLabels, flv.Spec.Tolerations)
+		c.tasCache.Set(kueue.ResourceFlavorReference(flv.Name), tasInfo)
+	}
 	return c.updateClusterQueues(log)
 }
 
@@ -583,7 +588,7 @@ func (c *Cache) DeleteWorkload(log logr.Logger, w *kueue.Workload) error {
 
 	c.cleanupAssumedState(log, w)
 
-	cq.deleteWorkload(log, w)
+	cq.forgetWorkload(log, w)
 	if c.podsReadyTracking {
 		c.podsReadyCond.Broadcast()
 	}
@@ -649,7 +654,7 @@ func (c *Cache) ForgetWorkload(log logr.Logger, w *kueue.Workload) error {
 	if !ok {
 		return ErrCqNotFound
 	}
-	cq.deleteWorkload(log, w)
+	cq.forgetWorkload(log, w)
 	if c.podsReadyTracking {
 		c.podsReadyCond.Broadcast()
 	}

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -506,6 +506,15 @@ func (c *clusterQueue) addWorkload(log logr.Logger, w *kueue.Workload) error {
 	if _, exist := c.Workloads[k]; exist {
 		return errors.New("workload already exists in ClusterQueue")
 	}
+	c.addOrUpdateWorkload(log, w)
+	return nil
+}
+
+func (c *clusterQueue) addOrUpdateWorkload(log logr.Logger, w *kueue.Workload) {
+	k := workload.Key(w)
+	if _, exist := c.Workloads[k]; exist {
+		c.deleteWorkload(log, w)
+	}
 	wi := workload.NewInfo(w, c.workloadInfoOptions...)
 	c.Workloads[k] = wi
 	c.updateWorkloadUsage(log, wi, 1)
@@ -513,7 +522,6 @@ func (c *clusterQueue) addWorkload(log logr.Logger, w *kueue.Workload) error {
 		c.WorkloadsNotReady.Insert(k)
 	}
 	c.reportActiveWorkloads()
-	return nil
 }
 
 func (c *clusterQueue) forgetWorkload(log logr.Logger, w *kueue.Workload) {

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -91,6 +91,8 @@ type clusterQueue struct {
 	hierarchy.ClusterQueue[*cohort]
 
 	tasCache *TASCache
+
+	workloadsNotAccountedForTAS sets.Set[string]
 }
 
 func (c *clusterQueue) GetName() string {
@@ -219,6 +221,20 @@ func (c *clusterQueue) updateQuotasAndResourceGroups(in []kueue.ResourceGroup) b
 }
 
 func (c *clusterQueue) updateQueueStatus(log logr.Logger) {
+	if features.Enabled(features.TopologyAwareScheduling) &&
+		len(c.tasFlavors) > 0 &&
+		len(c.workloadsNotAccountedForTAS) > 0 &&
+		c.isTASSynced() {
+		log.V(2).Info("Delayed accounting for TAS usage for workloads", "count", len(c.workloadsNotAccountedForTAS))
+		// There are some workloads which are not accounted yet for TAS.
+		// We re-add them as not the tasCache is initialized (synced).
+		for k, w := range c.Workloads {
+			if c.workloadsNotAccountedForTAS.Has(k) {
+				c.addOrUpdateWorkload(log, w.Obj)
+				c.workloadsNotAccountedForTAS.Delete(k)
+			}
+		}
+	}
 	status := active
 	if c.isStopped ||
 		len(c.missingFlavors) > 0 ||
@@ -240,6 +256,15 @@ func (c *clusterQueue) updateQueueStatus(log logr.Logger) {
 		c.Status = status
 		metrics.ReportClusterQueueStatus(c.Name, c.Status)
 	}
+}
+
+func (c *clusterQueue) isTASSynced() bool {
+	for tasFlavor := range c.tasFlavors {
+		if c.tasCache.Get(tasFlavor) == nil {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *clusterQueue) inactiveReason() (string, string) {
@@ -327,10 +352,8 @@ func (c *clusterQueue) isTASViolated() bool {
 	if !features.Enabled(features.TopologyAwareScheduling) || len(c.tasFlavors) == 0 {
 		return false
 	}
-	for tasFlavor := range c.tasFlavors {
-		if c.tasCache.Get(tasFlavor) == nil {
-			return true
-		}
+	if !c.isTASSynced() {
+		return true
 	}
 	return c.HasParent() ||
 		c.Preemption.WithinClusterQueue != kueue.PreemptionPolicyNever ||
@@ -493,6 +516,11 @@ func (c *clusterQueue) addWorkload(log logr.Logger, w *kueue.Workload) error {
 	return nil
 }
 
+func (c *clusterQueue) forgetWorkload(log logr.Logger, w *kueue.Workload) {
+	c.deleteWorkload(log, w)
+	delete(c.workloadsNotAccountedForTAS, workload.Key(w))
+}
+
 func (c *clusterQueue) deleteWorkload(log logr.Logger, w *kueue.Workload) {
 	k := workload.Key(w)
 	wi, exist := c.Workloads[k]
@@ -535,20 +563,7 @@ func (c *clusterQueue) updateWorkloadUsage(log logr.Logger, wi *workload.Info, m
 			removeUsage(c, fr, q)
 		}
 	}
-	if features.Enabled(features.TopologyAwareScheduling) && wi.IsUsingTAS() {
-		for tasFlavor, tasUsage := range wi.TASUsage() {
-			if tasFlvCache := c.tasFlavorCache(tasFlavor); tasFlvCache != nil {
-				if m == 1 {
-					tasFlvCache.addUsage(tasUsage)
-				}
-				if m == -1 {
-					tasFlvCache.removeUsage(tasUsage)
-				}
-			} else {
-				log.V(2).Info("TAS flavor used by workload not found in cache", "tasFlavor", tasFlavor)
-			}
-		}
-	}
+	c.updateWorkloadTASUsage(log, wi, m)
 	if admitted {
 		updateFlavorUsage(frUsage, c.AdmittedUsage, m)
 		c.admittedWorkloadsCount += int(m)
@@ -567,14 +582,37 @@ func (c *clusterQueue) updateWorkloadUsage(log logr.Logger, wi *workload.Info, m
 	}
 }
 
-func (c *clusterQueue) tasFlavorCache(flvName kueue.ResourceFlavorReference) *TASFlavorCache {
-	if !features.Enabled(features.TopologyAwareScheduling) {
-		return nil
+func (c *clusterQueue) updateWorkloadTASUsage(log logr.Logger, wi *workload.Info, m int64) {
+	if !features.Enabled(features.TopologyAwareScheduling) || !wi.IsUsingTAS() {
+		return
 	}
-	if c.tasCache == nil {
-		return nil
+	key := workload.Key(wi.Obj)
+	log = log.WithValues("workload", key)
+	if !c.isTASSynced() {
+		log.V(2).Info("Delaying accounting of the TAS usage, because TAS cache is not synced yet")
+		// TAS cache is not synced yet so we defer accounting for TAS usage.
+		c.workloadsNotAccountedForTAS.Insert(key)
+		return
 	}
-	return c.tasCache.Get(flvName)
+	for tasFlavor, tasUsage := range wi.TASUsage() {
+		tasFlvCache := c.tasCache.Get(tasFlavor)
+		switch {
+		case tasFlvCache == nil:
+			log.V(2).Info("TAS flavor used by workload not found in cache", "tasFlavor", tasFlavor)
+		case m == 1:
+			tasFlvCache.addUsage(tasUsage)
+		case m == -1:
+			// If the workload is not accounted for TAS, we haven't called
+			// addUsage on startup, and so we don't subtract the capacity now.
+			if c.workloadsNotAccountedForTAS.Has(key) {
+				log.V(2).Info("Skip subtracting TAS usage because we've never accounted for it")
+			} else {
+				tasFlvCache.removeUsage(tasUsage)
+			}
+		}
+	}
+	// We just accounted for TAS usage so drop it from the set.
+	c.workloadsNotAccountedForTAS.Delete(key)
 }
 
 func updateFlavorUsage(newUsage resources.FlavorResourceQuantities, oldUsage resources.FlavorResourceQuantities, m int64) {

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -1103,7 +1103,7 @@ func TestClusterQueueReadinessWithTAS(t *testing.T) {
 			cqCache.AddOrUpdateResourceFlavor(log, rf)
 
 			if !tc.skipTopology {
-				cqCache.AddOrUpdateTopologyForFlavor(log, topology, rf)
+				cqCache.AddTopologyForFlavor(log, topology, rf)
 			}
 
 			mkAC := utiltesting.MakeAdmissionCheck("mk-check").ControllerName(kueue.MultiKueueControllerName).Active(metav1.ConditionTrue).Obj()

--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -174,7 +174,7 @@ func (h *topologyHandler) Create(ctx context.Context, e event.CreateEvent, q wor
 		}
 		if *flv.Spec.TopologyName == kueue.TopologyReference(topology.Name) {
 			log.V(3).Info("Updating Topology cache for flavor", "flavor", flv.Name)
-			h.cache.AddOrUpdateTopologyForFlavor(log, topology, &flv)
+			h.cache.AddTopologyForFlavor(log, topology, &flv)
 			q.AddAfter(reconcile.Request{NamespacedName: types.NamespacedName{Name: flv.Name}}, nodeBatchPeriod)
 		}
 	}
@@ -208,7 +208,7 @@ func (r *rfReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 				return reconcile.Result{}, client.IgnoreNotFound(err)
 			}
 			log.V(3).Info("Adding topology to cache for flavor", "flavorName", flv.Name)
-			r.cache.AddOrUpdateTopologyForFlavor(log, &topology, flv)
+			r.cache.AddTopologyForFlavor(log, &topology, flv)
 		} else {
 			log.V(3).Info("Skip topology update to cache as already present for flavor", "flavorName", flv.Name)
 		}

--- a/test/integration/tas/tas_test.go
+++ b/test/integration/tas/tas_test.go
@@ -572,6 +572,66 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				})
 			})
 
+			ginkgo.It("should respect TAS usage by admitted workloads after reboot; second workload created before reboot", func() {
+				var wl1, wl2, wl3 *kueue.Workload
+				ginkgo.By("creating wl1 which consumes the entire TAS capacity", func() {
+					wl1 = testing.MakeWorkload("wl1", ns.Name).
+						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+					wl1.Spec.PodSets[0].Count = 4
+					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Preferred: ptr.To(testing.DefaultBlockTopologyLevel),
+					}
+					gomega.Expect(k8sClient.Create(ctx, wl1)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify wl1 is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					util.ExpectReservingActiveWorkloadsMetric(clusterQueue, 1)
+				})
+
+				ginkgo.By("create wl2 which is blocked by wl1", func() {
+					wl2 = testing.MakeWorkload("wl2", ns.Name).
+						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+					wl2.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Required: ptr.To(testing.DefaultRackTopologyLevel),
+					}
+					gomega.Expect(k8sClient.Create(ctx, wl2)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("very wl2 is not admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+				})
+
+				ginkgo.By("restart controllers", func() {
+					fwk.StopManager(ctx)
+					fwk.StartManager(ctx, cfg, managerSetup)
+				})
+
+				ginkgo.By("verify wl2 is still not admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+				})
+
+				ginkgo.By("finish wl1 to demonstrate there is enough space for wl2", func() {
+					util.FinishWorkloads(ctx, k8sClient, wl1)
+				})
+
+				ginkgo.By("create wl3 to ensure ClusterQueue is reconciled", func() {
+					wl3 = testing.MakeWorkload("wl3", ns.Name).
+						Queue(localQueue.Name).Request(corev1.ResourceCPU, "1").Obj()
+					wl3.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
+						Preferred: ptr.To(testing.DefaultRackTopologyLevel),
+					}
+					gomega.Expect(k8sClient.Create(ctx, wl3)).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("verify wl2 and wl3 get admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2, wl3)
+				})
+			})
+
 			ginkgo.It("should not admit the workload after the topology is deleted but should admit it after the topology is created", func() {
 				var updatedTopology kueuealpha.Topology
 


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

This is cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/5276 on top of the logger cherry-pick https://github.com/kubernetes-sigs/kueue/pull/5333

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix the bug where TAS workloads may be admitted after restart of the Kueue controller.
```