### PR TITLE
Use usageOp consistently to express usage add/subtract in cache

### DIFF
--- a/pkg/cache/localqueue.go
+++ b/pkg/cache/localqueue.go
@@ -40,7 +40,7 @@ func (lq *LocalQueue) GetAdmittedUsage() corev1.ResourceList {
 	return lq.admittedUsage.FlattenFlavors().ToResourceList()
 }
 
-func (lq *LocalQueue) updateAdmittedUsage(usage resources.FlavorResourceQuantities, op int64) {
+func (lq *LocalQueue) updateAdmittedUsage(usage resources.FlavorResourceQuantities, op usageOp) {
 	lq.Lock()
 	defer lq.Unlock()
 	updateFlavorUsage(usage, lq.admittedUsage, op)

--- a/pkg/cache/tas_flavor.go
+++ b/pkg/cache/tas_flavor.go
@@ -50,6 +50,13 @@ const (
 	subtract
 )
 
+func (u usageOp) asSignedOne() int {
+	if u == add {
+		return 1
+	}
+	return -1
+}
+
 type TASFlavorCache struct {
 	sync.RWMutex
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

To make the code more readable and consistent. Follow up to https://github.com/kubernetes-sigs/kueue/pull/5335#discussion_r2106539779

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```