### PR TITLE
Two level TAS scheduling / PodSet chunk topology

### DIFF
--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -2305,74 +2305,6 @@ func TestFindTopologyAssignment(t *testing.T) {
 				},
 			},
 		},
-		"block required for podset; host required for slices; MostFreeCapacity": {
-			//        b1
-			//         |
-			//        r1
-			//    /    |    \
-			// x1:6, x2:4, x3:2
-			//
-			nodes: []corev1.Node{
-				*testingnode.MakeNode("b1-r1-x1").
-					Label(tasBlockLabel, "b1").
-					Label(tasRackLabel, "r1").
-					Label(corev1.LabelHostname, "x1").
-					StatusAllocatable(corev1.ResourceList{
-						corev1.ResourceCPU:  resource.MustParse("6"),
-						corev1.ResourcePods: resource.MustParse("10"),
-					}).
-					Ready().
-					Obj(),
-				*testingnode.MakeNode("b1-r1-x2").
-					Label(tasBlockLabel, "b1").
-					Label(tasRackLabel, "r1").
-					Label(corev1.LabelHostname, "x2").
-					StatusAllocatable(corev1.ResourceList{
-						corev1.ResourceCPU:  resource.MustParse("4"),
-						corev1.ResourcePods: resource.MustParse("10"),
-					}).
-					Ready().
-					Obj(),
-				*testingnode.MakeNode("b1-r1-x3").
-					Label(tasBlockLabel, "b1").
-					Label(tasRackLabel, "r1").
-					Label(corev1.LabelHostname, "x3").
-					StatusAllocatable(corev1.ResourceList{
-						corev1.ResourceCPU:  resource.MustParse("2"),
-						corev1.ResourcePods: resource.MustParse("10"),
-					}).
-					Ready().
-					Obj(),
-			},
-			topologyRequest: &kueue.PodSetTopologyRequest{
-				Required:                    ptr.To(tasBlockLabel),
-				PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
-				PodSetSliceSize:             ptr.To(int32(2)),
-			},
-			levels: defaultThreeLevels,
-			requests: resources.Requests{
-				corev1.ResourceCPU: 1000,
-			},
-			count: 8,
-			wantAssignment: &kueue.TopologyAssignment{
-				Levels: defaultOneLevel,
-				Domains: []kueue.TopologyDomainAssignment{
-					{
-						Count: 6,
-						Values: []string{
-							"x1",
-						},
-					},
-					{
-						Count: 2,
-						Values: []string{
-							"x2",
-						},
-					},
-				},
-			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
-		},
 		"block required for podset; host required for slices; LeastFreeCapacity": {
 			//        b1
 			//         |
@@ -2637,9 +2569,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 			requests: resources.Requests{
 				corev1.ResourceCPU: 1000,
 			},
-			count:              1,
-			wantReason:         "podset slice topology cloud.com/topology-block is above the podset topology kubernetes.io/hostname",
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			count:      1,
+			wantReason: "podset slice topology cloud.com/topology-block is above the podset topology kubernetes.io/hostname",
 		},
 		"slice size is required when slice topology is requested": {
 			nodes: defaultNodes,
@@ -2651,9 +2582,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 			requests: resources.Requests{
 				corev1.ResourceCPU: 1000,
 			},
-			count:              1,
-			wantReason:         "slice topology requested, but slice size not provided",
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			count:      1,
+			wantReason: "slice topology requested, but slice size not provided",
 		},
 		"cannot request not existing slice topology": {
 			nodes: defaultNodes,
@@ -2666,9 +2596,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 			requests: resources.Requests{
 				corev1.ResourceCPU: 1000,
 			},
-			count:              1,
-			wantReason:         "no requested topology level: not-existing-topology-level",
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			count:      1,
+			wantReason: "no requested topology level: not-existing-topology-level",
 		},
 	}
 	for name, tc := range cases {

--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -2796,7 +2796,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 				corev1.ResourceCPU: 1000,
 			},
 			count:      1,
-			wantReason: "no requested topology level: not-existing-topology-level",
+			wantReason: "no requested topology level for slices: not-existing-topology-level",
 		},
 	}
 	for name, tc := range cases {

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -994,6 +994,7 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	// logic for a leaf
 	if len(domain.children) == 0 {
 		if level == sliceLevelIdx {
+			// initialize the sliceState if leaf is the request slice level
 			domain.sliceState = domain.state / sliceSize
 		}
 		return domain.state, domain.sliceState
@@ -1009,10 +1010,10 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	}
 	domain.state = childrenCapacity
 	if level == sliceLevelIdx {
+		// initialize the sliceState for the requested slice level.
 		sliceCapacity = domain.state / sliceSize
 	}
 	domain.sliceState = sliceCapacity
-
 	return childrenCapacity, sliceCapacity
 }
 

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -69,6 +69,15 @@ type domain struct {
 	// assigned to the given domain.
 	state int32
 
+	// sliceState is a temporary state of the topology domains during the
+	// assignment algorithm that denotes the number of slices that can fit within
+	// that domain.
+	//
+	// For domains that are below the requested topology level the algorithm
+	// assigns 0 to that field as this field makes no sense for lower level
+	// domains.
+	sliceState int32
+
 	// levelValues stores the mapping from domain ID back to the
 	// ordered list of values
 	levelValues []string
@@ -516,15 +525,16 @@ func deleteDomain(currentTopologyAssignment *kueue.TopologyAssignment, nodeToRep
 // Algorithm overview:
 // Phase 1:
 //
-//	determine pod counts for each topology domain. Start at the lowest level
+//	determine pod counts and slice count for each topology domain. Start at the lowest level
 //	and bubble up the numbers to the top level
 //
 // Phase 2:
 //
-//	a) select the domain at requested level with count >= requestedCount
-//	b) traverse the structure down level-by-level optimizing the number of used
-//	  domains at each level
-//	c) build the assignment for the lowest level in the hierarchy
+//	a) sort domains using chosen strategy (i.e. starting from the highest free capacity)
+//	b) select consecutive domains at requested level that can fit the workload
+//	c) traverse the structure down level-by-level optimizing the number of used
+//	domains at each level
+//	d) build the assignment for the lowest level in the hierarchy
 func (s *TASFlavorSnapshot) findTopologyAssignment(
 	tasPodSetRequests TASPodSetRequests,
 	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
@@ -540,9 +550,21 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	podSetTolerations := info.Tolerations
 	podSetNodeSelectors := info.NodeSelector
 	count := tasPodSetRequests.Count
+
+	// If slice topology is not requested then we can assume that slice is a single pod
+	sliceSize, reason := getSliceSizeWithSinglePodAsDefault(tasPodSetRequests.PodSet.TopologyRequest)
+	if len(reason) > 0 {
+		return nil, reason
+	}
+
 	required := isRequired(tasPodSetRequests.PodSet.TopologyRequest)
+
 	topologyKey := s.levelKeyWithImpliedFallback(&tasPodSetRequests)
+	sliceTopologyKey := s.sliceLevelKeyWithDefault(&tasPodSetRequests, ptr.To(s.lowestLevel()))
+
 	unconstrained := isUnconstrained(tasPodSetRequests.PodSet.TopologyRequest, &tasPodSetRequests)
+
+	// TODO Consider moving those validations to an earlier stage (possibly webhook)
 	if topologyKey == nil {
 		return nil, "topology level not specified"
 	}
@@ -550,6 +572,16 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	if !found {
 		return nil, fmt.Sprintf("no requested topology level: %s", *topologyKey)
 	}
+
+	sliceLevelIdx, found := s.resolveLevelIdx(*sliceTopologyKey)
+	if !found {
+		return nil, fmt.Sprintf("no requested topology level: %s", *sliceTopologyKey)
+	}
+
+	if levelIdx > sliceLevelIdx {
+		return nil, fmt.Sprintf("podset slice topology %s is above the podset topology %s", *sliceTopologyKey, *topologyKey)
+	}
+
 	var selector labels.Selector
 	if s.isLowestLevelNode() {
 		sel, err := labels.ValidatedSelectorFromSet(podSetNodeSelectors)
@@ -560,10 +592,12 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	} else {
 		selector = labels.Everything()
 	}
-	// phase 1 - determine the number of pods which can fit in each topology domain
+	// phase 1 - determine the number of pods and slices which can fit in each topology domain
 	s.fillInCounts(
 		requests,
 		assumedUsage,
+		sliceSize,
+		sliceLevelIdx,
 		simulateEmpty,
 		append(podSetTolerations, s.tolerations...),
 		selector,
@@ -571,8 +605,8 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	)
 
 	// phase 2a: determine the level at which the assignment is done along with
-	// the domains which can accommodate all pods
-	fitLevelIdx, currFitDomain, reason := s.findLevelWithFitDomains(levelIdx, required, count, unconstrained)
+	// the domains which can accommodate all pods/slices
+	fitLevelIdx, currFitDomain, reason := s.findLevelWithFitDomains(levelIdx, required, count, sliceSize, unconstrained)
 	if len(reason) > 0 {
 		return nil, reason
 	}
@@ -580,13 +614,40 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	// phase 2b: traverse the tree down level-by-level optimizing the number of
 	// topology domains at each level
 	// if unconstrained is set, we'll only do it once
-	currFitDomain = s.updateCountsToMinimum(currFitDomain, count, unconstrained)
+	currFitDomain = s.updateSliceCountsToMinimum(currFitDomain, count, sliceSize, unconstrained)
 	for levelIdx := fitLevelIdx; levelIdx+1 < len(s.domainsPerLevel); levelIdx++ {
-		lowerFitDomains := s.lowerLevelDomains(currFitDomain)
-		sortedLowerDomains := s.sortedDomains(lowerFitDomains, unconstrained)
-		currFitDomain = s.updateCountsToMinimum(sortedLowerDomains, count, unconstrained)
+		if levelIdx < sliceLevelIdx {
+			// If we are "above" the requested slice topology level, we're greedily assigning pods/slices to
+			// all domains without checking what we've assigned to parent domains.
+			sortedLowerDomains := s.sortedDomains(s.lowerLevelDomains(currFitDomain), unconstrained)
+			currFitDomain = s.updateSliceCountsToMinimum(sortedLowerDomains, count, sliceSize, unconstrained)
+		} else {
+			// If we are "at" or "below" the requested slice topology level, we have to carefully assign pods
+			// to domains based on what we've assigned to parent domains, that's why we're iterating through
+			// each parent domain and assigning `domain.state` amount of pods its child domains.
+			newCurrFitDomain := make([]*domain, 0)
+			for _, domain := range currFitDomain {
+				sortedLowerDomains := s.sortedDomains(domain.children, unconstrained)
+
+				addCurrFitDomain := s.updateCountsToMinimum(sortedLowerDomains, domain.state, unconstrained)
+				newCurrFitDomain = append(newCurrFitDomain, addCurrFitDomain...)
+			}
+			currFitDomain = newCurrFitDomain
+		}
 	}
 	return s.buildAssignment(currFitDomain), ""
+}
+
+func getSliceSizeWithSinglePodAsDefault(podSetTopologyRequest *kueue.PodSetTopologyRequest) (int32, string) {
+	if podSetTopologyRequest != nil && podSetTopologyRequest.PodSetSliceRequiredTopology != nil {
+		if podSetTopologyRequest.PodSetSliceSize != nil {
+			return *podSetTopologyRequest.PodSetSliceSize, ""
+		} else {
+			return 0, "slice topology requested, but slice size not provided"
+		}
+	}
+
+	return 1, ""
 }
 
 // Merges two topology assignments keeping the lexicographical order of levelValues
@@ -669,6 +730,13 @@ func (s *TASFlavorSnapshot) levelKey(topologyRequest *kueue.PodSetTopologyReques
 	}
 }
 
+func (s *TASFlavorSnapshot) sliceLevelKeyWithDefault(tasRequests *TASPodSetRequests, defaultSliceLevelKey *string) *string {
+	if tasRequests.PodSet.TopologyRequest != nil && tasRequests.PodSet.TopologyRequest.PodSetSliceRequiredTopology != nil {
+		return tasRequests.PodSet.TopologyRequest.PodSetSliceRequiredTopology
+	}
+	return defaultSliceLevelKey
+}
+
 func isUnconstrained(tr *kueue.PodSetTopologyRequest, tasRequests *TASPodSetRequests) bool {
 	return (tr != nil && tr.Unconstrained != nil && *tr.Unconstrained) || tasRequests.Implied
 }
@@ -677,7 +745,7 @@ func isUnconstrained(tr *kueue.PodSetTopologyRequest, tasRequests *TASPodSetRequ
 // value of state, higher or equal than count.
 // If such a domain doesn't exist, it returns 0 as it's an index of the domain with the
 // most available resources
-func findBestFitDomainIdx(domains []*domain, count int32) int {
+func findBestFitDomainIdx(domains []*domain, count int32) *domain {
 	bestFitIdx := 0
 	for i, domain := range domains {
 		if domain.state >= count && domain.state < domains[bestFitIdx].state {
@@ -686,10 +754,22 @@ func findBestFitDomainIdx(domains []*domain, count int32) int {
 			bestFitIdx = i
 		}
 	}
-	return bestFitIdx
+	return domains[bestFitIdx]
 }
 
-func (s *TASFlavorSnapshot) findLevelWithFitDomains(levelIdx int, required bool, podSetSize int32, unconstrained bool) (int, []*domain, string) {
+func findBestFitDomainIdxForSlices(domains []*domain, sliceCount int32) *domain {
+	bestFitIdx := 0
+	for i, domain := range domains {
+		if domain.sliceState >= sliceCount && domain.sliceState < domains[bestFitIdx].sliceState {
+			// choose the first occurrence of fitting domains
+			// to make it consecutive with other podSet's
+			bestFitIdx = i
+		}
+	}
+	return domains[bestFitIdx]
+}
+
+func (s *TASFlavorSnapshot) findLevelWithFitDomains(levelIdx int, required bool, podSetSize int32, sliceSize int32, unconstrained bool) (int, []*domain, string) {
 	domains := s.domainsPerLevel[levelIdx]
 	if len(domains) == 0 {
 		return 0, nil, fmt.Sprintf("no topology domains at level: %s", s.levelKeys[levelIdx])
@@ -697,30 +777,34 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(levelIdx int, required bool,
 	levelDomains := slices.Collect(maps.Values(domains))
 	sortedDomain := s.sortedDomains(levelDomains, unconstrained)
 	topDomain := sortedDomain[0]
-	if useBestFitAlgorithm(unconstrained) && topDomain.state >= podSetSize {
+
+	sliceCount := podSetSize / sliceSize
+	if useBestFitAlgorithm(unconstrained) && topDomain.sliceState >= sliceCount {
 		// optimize the potentially last domain
-		topDomain = sortedDomain[findBestFitDomainIdx(sortedDomain, podSetSize)]
+		topDomain = findBestFitDomainIdxForSlices(sortedDomain, sliceCount)
 	}
-	if topDomain.state < podSetSize {
+	if topDomain.sliceState < sliceCount {
 		if required {
-			return 0, nil, s.notFitMessage(topDomain.state, podSetSize)
+			return 0, nil, s.notFitMessage(topDomain.sliceState, sliceCount, sliceSize)
 		}
 		if levelIdx > 0 && !unconstrained {
-			return s.findLevelWithFitDomains(levelIdx-1, required, podSetSize, unconstrained)
+			return s.findLevelWithFitDomains(levelIdx-1, required, podSetSize, sliceSize, unconstrained)
 		}
 		results := []*domain{}
-		remainingCount := podSetSize
-		for idx := 0; remainingCount > 0 && idx < len(sortedDomain) && sortedDomain[idx].state > 0; idx++ {
-			offset := 0
-			if useBestFitAlgorithm(unconstrained) && sortedDomain[idx].state >= remainingCount {
+		remainingSliceCount := podSetSize / sliceSize
+		for idx := 0; remainingSliceCount > 0 && idx < len(sortedDomain) && sortedDomain[idx].sliceState > 0; idx++ {
+			domain := sortedDomain[idx]
+			if useBestFitAlgorithm(unconstrained) && sortedDomain[idx].sliceState >= remainingSliceCount {
 				// optimize the last domain
-				offset = findBestFitDomainIdx(sortedDomain[idx:], remainingCount)
+				domain = findBestFitDomainIdxForSlices(sortedDomain[idx:], remainingSliceCount)
 			}
-			results = append(results, sortedDomain[idx+offset])
-			remainingCount -= sortedDomain[idx+offset].state
+			results = append(results, domain)
+
+			remainingSliceCount -= domain.sliceState
 		}
-		if remainingCount > 0 {
-			return 0, nil, s.notFitMessage(podSetSize-remainingCount, podSetSize)
+		if remainingSliceCount > 0 {
+			requiredSliceCount := podSetSize / sliceSize
+			return 0, nil, s.notFitMessage(requiredSliceCount-remainingSliceCount, requiredSliceCount, sliceSize)
 		}
 		return levelIdx, results, ""
 	}
@@ -738,14 +822,39 @@ func useLeastFreeCapacityAlgorithm(unconstrained bool) bool {
 		(unconstrained && features.Enabled(features.TASProfileMixed))
 }
 
+func (s *TASFlavorSnapshot) updateSliceCountsToMinimum(domains []*domain, count int32, sliceSize int32, unconstrained bool) []*domain {
+	result := make([]*domain, 0)
+	remainingSlices := count / sliceSize
+	for i, domain := range domains {
+		if useBestFitAlgorithm(unconstrained) && domain.sliceState >= remainingSlices {
+			// optimize the last domain
+			domain = findBestFitDomainIdxForSlices(domains[i:], remainingSlices)
+		}
+
+		if domain.sliceState >= remainingSlices {
+			domain.state = remainingSlices * sliceSize
+			domain.sliceState = remainingSlices
+			result = append(result, domain)
+			return result
+		}
+		domain.state = domain.sliceState * sliceSize
+		remainingSlices -= domain.sliceState
+		result = append(result, domain)
+	}
+	s.log.Error(errCodeAssumptionsViolated, "unexpected remainingCount",
+		"remainingSlices", remainingSlices,
+		"count", count,
+		"leaves", s.leaves)
+	return nil
+}
+
 func (s *TASFlavorSnapshot) updateCountsToMinimum(domains []*domain, count int32, unconstrained bool) []*domain {
 	result := make([]*domain, 0)
 	remainingCount := count
 	for i, domain := range domains {
 		if useBestFitAlgorithm(unconstrained) && domain.state >= remainingCount {
 			// optimize the last domain
-			mostAllocatedIdx := findBestFitDomainIdx(domains[i:], remainingCount)
-			domain = domains[i+mostAllocatedIdx]
+			domain = findBestFitDomainIdx(domains[i:], remainingCount)
 		}
 
 		if domain.state >= remainingCount {
@@ -803,22 +912,29 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool)
 	isLeastFreeCapacity := useLeastFreeCapacityAlgorithm(unconstrained)
 	result := slices.Clone(domains)
 	slices.SortFunc(result, func(a, b *domain) int {
-		if a.state == b.state {
-			return slices.Compare(a.levelValues, b.levelValues)
+		if a.sliceState != b.sliceState {
+			if isLeastFreeCapacity {
+				// Start from the domain with the least amount of free resources.
+				// Ascending order.
+				return cmp.Compare(a.sliceState, b.sliceState)
+			}
+			return cmp.Compare(b.sliceState, a.sliceState)
 		}
-		if isLeastFreeCapacity {
-			// Start from the domain with the least amount of free resources.
-			// Ascending order.
+
+		if a.state != b.state {
 			return cmp.Compare(a.state, b.state)
 		}
-		// Descending order.
-		return cmp.Compare(b.state, a.state)
+
+		return slices.Compare(a.levelValues, b.levelValues)
 	})
+
 	return result
 }
 
 func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests,
 	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	sliceSize int32,
+	sliceLevelIdx int,
 	simulateEmpty bool,
 	tolerations []corev1.Toleration,
 	selector labels.Selector,
@@ -827,6 +943,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests,
 		// cleanup the state in case some remaining values are present from computing
 		// assignments for previous PodSets.
 		domain.state = 0
+		domain.sliceState = 0
 	}
 	for _, leaf := range s.leaves {
 		// 1. Check Tolerations against Node Taints
@@ -863,9 +980,17 @@ func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests,
 			remainingCapacity.Sub(leafAssumedUsage)
 		}
 		leaf.state = requests.CountIn(remainingCapacity)
+
+		// if this is where slices topology is requested then we calculate the number of slices
+		// that can fit. Otherwise we assign 0 and this value won't be used.
+		if (len(s.levelKeys) - 1) == sliceLevelIdx {
+			leaf.sliceState = leaf.state / sliceSize
+		} else {
+			leaf.sliceState = 0
+		}
 	}
 	for _, root := range s.roots {
-		root.state = s.fillInCountsHelper(root)
+		root.state, root.sliceState = s.fillInCountsHelper(root, sliceSize, sliceLevelIdx, 0)
 	}
 }
 
@@ -878,23 +1003,40 @@ func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas
 	return strings.HasPrefix(string(utiltas.DomainID(leaf.levelValues)), string(requiredReplacementDomain))
 }
 
-func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain) int32 {
+func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int) (int32, int32) {
 	// logic for a leaf
 	if len(domain.children) == 0 {
-		return domain.state
+		return domain.state, domain.sliceState
 	}
 	// logic for a parent
 	childrenCapacity := int32(0)
+	sliceCapacity := int32(0)
+
 	for _, child := range domain.children {
-		childrenCapacity += s.fillInCountsHelper(child)
+		addChildrenCapacity, addChildrenSliceCapacity := s.fillInCountsHelper(child, sliceSize, sliceLevelIdx, level+1)
+		childrenCapacity += addChildrenCapacity
+		sliceCapacity += addChildrenSliceCapacity
 	}
 	domain.state = childrenCapacity
-	return childrenCapacity
+	if level == sliceLevelIdx {
+		sliceCapacity = domain.state / sliceSize
+	}
+	domain.sliceState = sliceCapacity
+
+	return childrenCapacity, sliceCapacity
 }
 
-func (s *TASFlavorSnapshot) notFitMessage(fitCount, totalCount int32) string {
-	if fitCount == 0 {
-		return fmt.Sprintf("topology %q doesn't allow to fit any of %v pod(s)", s.topologyName, totalCount)
+func (s *TASFlavorSnapshot) notFitMessage(slicesFitCount, totalRequestesSlicesCount, sliceSize int32) string {
+	if sliceSize == 1 {
+		// slices are a single pods, so let's refer to them as pods
+		if slicesFitCount == 0 {
+			return fmt.Sprintf("topology %q doesn't allow to fit any of %v pod(s)", s.topologyName, totalRequestesSlicesCount)
+		}
+		return fmt.Sprintf("topology %q allows to fit only %v out of %v pod(s)", s.topologyName, slicesFitCount, totalRequestesSlicesCount)
+	} else {
+		if slicesFitCount == 0 {
+			return fmt.Sprintf("topology %q doesn't allow to fit any of %v slice(s)", s.topologyName, totalRequestesSlicesCount)
+		}
+		return fmt.Sprintf("topology %q allows to fit only %v out of %v slice(s)", s.topologyName, slicesFitCount, totalRequestesSlicesCount)
 	}
-	return fmt.Sprintf("topology %q allows to fit only %v out of %v pod(s)", s.topologyName, fitCount, totalCount)
 }

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -975,12 +975,6 @@ func (s *TASFlavorSnapshot) fillInCounts(requests resources.Requests,
 			remainingCapacity.Sub(leafAssumedUsage)
 		}
 		leaf.state = requests.CountIn(remainingCapacity)
-
-		// if this is where slices topology is requested then we calculate the number of slices
-		// that can fit. Otherwise we assign 0 and this value won't be used.
-		if (len(s.levelKeys) - 1) == sliceLevelIdx {
-			leaf.sliceState = leaf.state / sliceSize
-		}
 	}
 	for _, root := range s.roots {
 		root.state, root.sliceState = s.fillInCountsHelper(root, sliceSize, sliceLevelIdx, 0)
@@ -999,6 +993,9 @@ func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas
 func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int) (int32, int32) {
 	// logic for a leaf
 	if len(domain.children) == 0 {
+		if level == sliceLevelIdx {
+			domain.sliceState = domain.state / sliceSize
+		}
 		return domain.state, domain.sliceState
 	}
 	// logic for a parent

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -1026,7 +1026,7 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 
 func (s *TASFlavorSnapshot) notFitMessage(slicesFitCount, totalRequestesSlicesCount, sliceSize int32) string {
 	if sliceSize == 1 {
-		// slices are a single pods, so let's refer to them as pods
+		// each slice is a single pod, so let's refer to them as pods
 		if slicesFitCount == 0 {
 			return fmt.Sprintf("topology %q doesn't allow to fit any of %v pod(s)", s.topologyName, totalRequestesSlicesCount)
 		}

--- a/pkg/controller/jobframework/tas.go
+++ b/pkg/controller/jobframework/tas.go
@@ -73,7 +73,7 @@ func NewPodSetTopologyRequest(meta *metav1.ObjectMeta) *podSetTopologyRequestBui
 	if sliceRequiredTopologyFound && sliceSizeFound {
 		sliceSizeIntValue, err := strconv.ParseInt(sliceSizeValue, 10, 32)
 		if err != nil {
-			// silently ignore as it should not happen, due to earlier validation in a webhook
+			// silently ignore as it should not happen due to earlier validation in a webhook
 		} else {
 			psTopologyReq.PodSetSliceRequiredTopology = &sliceRequiredTopologyValue
 			psTopologyReq.PodSetSliceSize = ptr.To(int32(sliceSizeIntValue))

--- a/pkg/controller/jobframework/tas.go
+++ b/pkg/controller/jobframework/tas.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -53,6 +54,10 @@ func NewPodSetTopologyRequest(meta *metav1.ObjectMeta) *podSetTopologyRequestBui
 	requiredValue, requiredFound := meta.Annotations[kueuealpha.PodSetRequiredTopologyAnnotation]
 	preferredValue, preferredFound := meta.Annotations[kueuealpha.PodSetPreferredTopologyAnnotation]
 	unconstrained, unconstrainedFound := meta.Annotations[kueuealpha.PodSetUnconstrainedTopologyAnnotation]
+
+	sliceRequiredTopologyValue, sliceRequiredTopologyFound := meta.Annotations[kueuealpha.PodSetSliceRequiredTopologyAnnotation]
+	sliceSizeValue, sliceSizeFound := meta.Annotations[kueuealpha.PodSetSliceSizeAnnotation]
+
 	switch {
 	case requiredFound:
 		psTopologyReq.Required = &requiredValue
@@ -63,6 +68,13 @@ func NewPodSetTopologyRequest(meta *metav1.ObjectMeta) *podSetTopologyRequestBui
 		psTopologyReq.Unconstrained = &unconstrained
 	default:
 		psTopologyReq = nil
+	}
+
+	if sliceRequiredTopologyFound && sliceSizeFound {
+		psTopologyReq.PodSetSliceRequiredTopology = &sliceRequiredTopologyValue
+		sliceSizeIntValue, _ := strconv.ParseInt(sliceSizeValue, 10, 32)
+		// TODO Error handling. For simplicity of reviewing a PR, it will be implemented in a follow-up
+		psTopologyReq.PodSetSliceSize = ptr.To(int32(sliceSizeIntValue))
 	}
 
 	builder := &podSetTopologyRequestBuilder{request: psTopologyReq}

--- a/pkg/controller/jobframework/tas.go
+++ b/pkg/controller/jobframework/tas.go
@@ -71,10 +71,13 @@ func NewPodSetTopologyRequest(meta *metav1.ObjectMeta) *podSetTopologyRequestBui
 	}
 
 	if sliceRequiredTopologyFound && sliceSizeFound {
-		psTopologyReq.PodSetSliceRequiredTopology = &sliceRequiredTopologyValue
-		sliceSizeIntValue, _ := strconv.ParseInt(sliceSizeValue, 10, 32)
-		// TODO Error handling. For simplicity of reviewing a PR, it will be implemented in a follow-up
-		psTopologyReq.PodSetSliceSize = ptr.To(int32(sliceSizeIntValue))
+		sliceSizeIntValue, err := strconv.ParseInt(sliceSizeValue, 10, 32)
+		if err != nil {
+			// silently ignore as it should not happen, due to earlier validation in a webhook
+		} else {
+			psTopologyReq.PodSetSliceRequiredTopology = &sliceRequiredTopologyValue
+			psTopologyReq.PodSetSliceSize = ptr.To(int32(sliceSizeIntValue))
+		}
 	}
 
 	builder := &podSetTopologyRequestBuilder{request: psTopologyReq}

--- a/pkg/controller/jobframework/tas_validation.go
+++ b/pkg/controller/jobframework/tas_validation.go
@@ -66,10 +66,10 @@ func ValidateTASPodSetRequest(replicaPath *field.Path, replicaMetadata *metav1.O
 
 	// validate slice size annotation
 	if sliceSizeFound {
-		val, err := strconv.Atoi(sliceSizeValue)
+		val, err := strconv.ParseInt(sliceSizeValue, 10, 32)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(annotationsPath.Key(kueuealpha.PodSetSliceSizeAnnotation), sliceSizeValue, "must be a numeric value"))
-		} else if val < 1 {
+		} else if int32(val) < 1 {
 			allErrs = append(allErrs, field.Invalid(annotationsPath.Key(kueuealpha.PodSetSliceSizeAnnotation), sliceSizeValue, "must be greater than or equal to 1"))
 		}
 	}

--- a/test/e2e/tas/jobset_test.go
+++ b/test/e2e/tas/jobset_test.go
@@ -183,7 +183,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
 					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
-				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("ensure all pods are scheduled", func() {
@@ -193,7 +193,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), listOpts)).To(gomega.Succeed())
 					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
-				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("verify the assignment of pods are as expected with rank-based ordering", func() {

--- a/test/e2e/tas/jobset_test.go
+++ b/test/e2e/tas/jobset_test.go
@@ -145,6 +145,71 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", func() {
 				gomega.Expect(wantAssignment).Should(gomega.BeComparableTo(gotAssignment))
 			})
 		})
+
+		ginkgo.It("Should place pods in podset slices based on the ranks-ordering", func() {
+			replicas := 2
+			parallelism := 3
+			numPods := replicas * parallelism
+			sampleJob := testingjobset.MakeJobSet("ranks-jobset", ns.Name).
+				Queue(localQueue.Name).
+				ReplicatedJobs(
+					testingjobset.ReplicatedJobRequirements{
+						Name:        "replicated-job-1",
+						Image:       util.E2eTestAgnHostImage,
+						Args:        util.BehaviorExitFast,
+						Replicas:    int32(replicas),
+						Parallelism: int32(parallelism),
+						Completions: int32(parallelism),
+						PodAnnotations: map[string]string{
+							kueuealpha.PodSetPreferredTopologyAnnotation:     testing.DefaultBlockTopologyLevel,
+							kueuealpha.PodSetSliceRequiredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
+							kueuealpha.PodSetSliceSizeAnnotation:             "3",
+						},
+					},
+				).
+				RequestAndLimit("replicated-job-1", extraResource, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, sampleJob)
+
+			ginkgo.By("JobSet is unsuspended", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sampleJob), sampleJob)).To(gomega.Succeed())
+					g.Expect(sampleJob.Spec.Suspend).Should(gomega.Equal(ptr.To(false)))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			pods := &corev1.PodList{}
+			ginkgo.By("ensure all pods are created", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
+				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("ensure all pods are scheduled", func() {
+				listOpts := &client.ListOptions{
+					FieldSelector: fields.OneTermNotEqualSelector("spec.nodeName", ""),
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), listOpts)).To(gomega.Succeed())
+					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
+				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verify the assignment of pods are as expected with rank-based ordering", func() {
+				gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+				gotAssignment := readRankAssignmentsFromJobSetPods(pods.Items)
+				wantAssignment := map[string]string{
+					"0/0": "kind-worker",
+					"0/1": "kind-worker2",
+					"0/2": "kind-worker3",
+					"1/0": "kind-worker5",
+					"1/1": "kind-worker6",
+					"1/2": "kind-worker7",
+				}
+				gomega.Expect(wantAssignment).Should(gomega.BeComparableTo(gotAssignment))
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Currently Topology-Aware Scheduling considers the whole PodSet as a single unit for which we look for a matching domain. However, there are use-cases in which we would like to allow user to define a sub-podset topology and two-level topologies (schedule the whole podset in one higher-level topology and schedule each subset of the podset in other, lower-level topology).

An example is a JobSet in which user can define topology for all Jobs resulting from a single ReplicatedJob. We want to allow user to define topology for each such Job and possibly co-locate all such Jobs in higher-level topology.

This PR introduces two-level scheduling allowing user to define required topology for PodSet chunks and required or preferred topology for the whole PodSet. We are also allowing user to define the size of the chunk.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5439

#### Special notes for your reviewer:
There are follow-up PRs planned:
- Introduce PodSet chunk TAS scheduling only (without expectations of the topology for the whole PodSet)
- Robust validation and corner cases

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduce two-level TAS scheduling
```