### PR TITLE
Automated cherry pick of #5362: Update main after v0.11.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ LD_FLAGS += -X '$(version_pkg).GitCommit=$(shell git rev-parse HEAD)'
 
 # Update these variables when preparing a new release or a release branch.
 # Then run `make prepare-release-branch`
-RELEASE_VERSION=v0.11.4
+RELEASE_VERSION=v0.11.5
 RELEASE_BRANCH=main
 # Version used form Helm which is not using the leading "v"
 CHART_VERSION := $(shell echo $(RELEASE_VERSION) | cut -c2-)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) and watch the Kueu
 To install the latest release of Kueue in your cluster, run the following command:
 
 ```shell
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.11.4/manifests.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.11.5/manifests.yaml
 ```
 
 The controller runs in the `kueue-system` namespace.

--- a/SECURITY-INSIGHTS.yaml
+++ b/SECURITY-INSIGHTS.yaml
@@ -1,11 +1,11 @@
 header:
   schema-version: 1.0.0
   expiration-date: '2024-09-28T01:00:00.000Z'
-  last-updated: '2025-04-24'
-  last-reviewed: '2025-04-24'
-  commit-hash: 74a9dfc91cc1caf7a0ddb283e2972cd49de32e02
+  last-updated: '2025-05-26'
+  last-reviewed: '2025-05-26'
+  commit-hash: 7a3498f047900c8a66ac3f86fb4248cbca1edc5c
   project-url: 'https://github.com/kubernetes-sigs/kueue'
-  project-release: 0.11.4
+  project-release: 0.11.5
   changelog: 'https://github.com/kubernetes-sigs/kueue/tree/main/CHANGELOG'
   license: 'https://github.com/kubernetes-sigs/kueue/blob/main/LICENSE'
 project-lifecycle:
@@ -28,7 +28,7 @@ documentation:
   - 'https://kueue.sigs.k8s.io/docs/'
 distribution-points:
   - >-
-    https://github.com/kubernetes-sigs/kueue/releases/download/v0.11.4/manifests.yaml
+    https://github.com/kubernetes-sigs/kueue/releases/download/v0.11.5/manifests.yaml
 security-artifacts:
   threat-model:
     threat-model-created: false
@@ -62,5 +62,5 @@ dependencies:
   dependencies-lists:
     - 'https://github.com/kubernetes-sigs/kueue/blob/main/go.mod'
   sbom:
-    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.11.4/kueue-v0.11.4.spdx.json
+    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.11.5/kueue-v0.11.5.spdx.json
       sbom-format: SPDX

--- a/charts/kueue/Chart.yaml
+++ b/charts/kueue/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.11.4"
+appVersion: "v0.11.5"

--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -37,7 +37,7 @@ $ helm install kueue kueue/ --create-namespace --namespace kueue-system
 Or use the charts pushed to `oci://registry.k8s.io/kueue/charts/kueue`:
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.11.4" --create-namespace --namespace=kueue-system
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.11.5" --create-namespace --namespace=kueue-system
 ```
 
 ##### Verify that controller pods are running properly.

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -90,10 +90,10 @@ ignoreFiles = []
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
   # version number for this doc set.
-  version = "v0.11.4"
+  version = "v0.11.5"
 
   # Version of Kueue without the leading "v", as used for Helm charts.
-  chart_version = "0.11.4"
+  chart_version = "0.11.5"
 
   # Flag used in the "version-banner" partial to decide whether to display a
   # banner on every page indicating that this is an archived version of the docs.


### PR DESCRIPTION
Cherry pick of #5362 on website.

#5362: Update main after v0.11.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```