### PR TITLE
Use WorkloadReference to improve static code analysis

### DIFF
--- a/cmd/kueuectl/app/list/list_workload.go
+++ b/cmd/kueuectl/app/list/list_workload.go
@@ -430,21 +430,21 @@ func (o *WorkloadOptions) localQueues(ctx context.Context, list *v1beta1.Workloa
 	return localQueues, nil
 }
 
-func (o *WorkloadOptions) pendingWorkloads(ctx context.Context, list *v1beta1.WorkloadList, localQueues map[string]*v1beta1.LocalQueue) (map[string]*visibility.PendingWorkload, error) {
+func (o *WorkloadOptions) pendingWorkloads(ctx context.Context, list *v1beta1.WorkloadList, localQueues map[string]*v1beta1.LocalQueue) (map[workload.WorkloadReference]*visibility.PendingWorkload, error) {
 	var err error
 
-	pendingWorkloads := make(map[string]*visibility.PendingWorkload)
-	pendingWorkloadsSummaries := make(map[string]*visibility.PendingWorkloadsSummary)
+	pendingWorkloads := make(map[workload.WorkloadReference]*visibility.PendingWorkload)
+	pendingWorkloadsSummaries := make(map[v1beta1.ClusterQueueReference]*visibility.PendingWorkloadsSummary)
 
 	for _, wl := range list.Items {
 		if !workloadPending(&wl) {
 			continue
 		}
-		var clusterQueueName string
+		var clusterQueueName v1beta1.ClusterQueueReference
 		if wl.Status.Admission != nil && len(wl.Status.Admission.ClusterQueue) > 0 {
-			clusterQueueName = string(wl.Status.Admission.ClusterQueue)
+			clusterQueueName = wl.Status.Admission.ClusterQueue
 		} else if lq := localQueues[localQueueKeyForWorkload(&wl)]; lq != nil {
-			clusterQueueName = string(lq.Spec.ClusterQueue)
+			clusterQueueName = lq.Spec.ClusterQueue
 		}
 		if len(clusterQueueName) == 0 {
 			continue
@@ -452,7 +452,7 @@ func (o *WorkloadOptions) pendingWorkloads(ctx context.Context, list *v1beta1.Wo
 		pendingWorkloadsSummary, ok := pendingWorkloadsSummaries[clusterQueueName]
 		if !ok {
 			pendingWorkloadsSummary, err = o.ClientSet.VisibilityV1beta1().ClusterQueues().
-				GetPendingWorkloadsSummary(ctx, clusterQueueName, metav1.GetOptions{})
+				GetPendingWorkloadsSummary(ctx, string(clusterQueueName), metav1.GetOptions{})
 			if client.IgnoreNotFound(err) != nil {
 				return nil, err
 			}

--- a/cmd/kueuectl/app/list/list_workload_printer.go
+++ b/cmd/kueuectl/app/list/list_workload_printer.go
@@ -39,14 +39,14 @@ const crdTypeMaxLength = 20
 
 type listWorkloadResources struct {
 	localQueues      map[string]*v1beta1.LocalQueue
-	pendingWorkloads map[string]*visibility.PendingWorkload
+	pendingWorkloads map[workload.WorkloadReference]*visibility.PendingWorkload
 	apiResourceLists map[string]*metav1.APIResourceList
 }
 
 func newListWorkloadResources() *listWorkloadResources {
 	return &listWorkloadResources{
 		localQueues:      make(map[string]*v1beta1.LocalQueue),
-		pendingWorkloads: make(map[string]*visibility.PendingWorkload),
+		pendingWorkloads: make(map[workload.WorkloadReference]*visibility.PendingWorkload),
 		apiResourceLists: make(map[string]*metav1.APIResourceList),
 	}
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -104,7 +104,7 @@ type Cache struct {
 	podsReadyCond sync.Cond
 
 	client              client.Client
-	assumedWorkloads    map[string]kueue.ClusterQueueReference
+	assumedWorkloads    map[workload.WorkloadReference]kueue.ClusterQueueReference
 	resourceFlavors     map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor
 	podsReadyTracking   bool
 	admissionChecks     map[kueue.AdmissionCheckReference]AdmissionCheck
@@ -123,7 +123,7 @@ func New(client client.Client, opts ...Option) *Cache {
 	}
 	c := &Cache{
 		client:              client,
-		assumedWorkloads:    make(map[string]kueue.ClusterQueueReference),
+		assumedWorkloads:    make(map[workload.WorkloadReference]kueue.ClusterQueueReference),
 		resourceFlavors:     make(map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor),
 		admissionChecks:     make(map[kueue.AdmissionCheckReference]AdmissionCheck),
 		podsReadyTracking:   options.podsReadyTracking,
@@ -139,8 +139,8 @@ func New(client client.Client, opts ...Option) *Cache {
 func (c *Cache) newClusterQueue(log logr.Logger, cq *kueue.ClusterQueue) (*clusterQueue, error) {
 	cqImpl := &clusterQueue{
 		Name:                kueue.ClusterQueueReference(cq.Name),
-		Workloads:           make(map[string]*workload.Info),
-		WorkloadsNotReady:   sets.New[string](),
+		Workloads:           make(map[workload.WorkloadReference]*workload.Info),
+		WorkloadsNotReady:   sets.New[workload.WorkloadReference](),
 		localQueues:         make(map[queue.LocalQueueReference]*LocalQueue),
 		podsReadyTracking:   c.podsReadyTracking,
 		workloadInfoOptions: c.workloadInfoOptions,
@@ -148,7 +148,7 @@ func (c *Cache) newClusterQueue(log logr.Logger, cq *kueue.ClusterQueue) (*clust
 		resourceNode:        NewResourceNode(),
 		tasCache:            &c.tasCache,
 
-		workloadsNotAccountedForTAS: sets.New[string](),
+		workloadsNotAccountedForTAS: sets.New[workload.WorkloadReference](),
 	}
 	c.hm.AddClusterQueue(cqImpl)
 	c.hm.UpdateClusterQueueEdge(kueue.ClusterQueueReference(cq.Name), cq.Spec.Cohort)

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -460,7 +460,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 					Status:     active,
 					Preemption: defaultPreemption,
 					FairWeight: oneQuantity,
-					Workloads: map[string]*workload.Info{
+					Workloads: map[workload.WorkloadReference]*workload.Info{
 						"/one": {
 							Obj: utiltesting.MakeWorkload("one", "").
 								Request(corev1.ResourceCPU, "5").
@@ -895,7 +895,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							{Flavor: "f1", Resource: corev1.ResourceCPU}: 2000,
 						},
 					},
-					Workloads: map[string]*workload.Info{
+					Workloads: map[workload.WorkloadReference]*workload.Info{
 						"ns/reserving": {
 							ClusterQueue: "cq1",
 							TotalRequests: []workload.PodSetResources{
@@ -1195,7 +1195,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		}).Obj())
 
 	type result struct {
-		Workloads     sets.Set[string]
+		Workloads     sets.Set[workload.WorkloadReference]
 		UsedResources resources.FlavorResourceQuantities
 	}
 
@@ -1203,7 +1203,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 		name                 string
 		operation            func(log logr.Logger, cache *Cache) error
 		wantResults          map[kueue.ClusterQueueReference]result
-		wantAssumedWorkloads map[string]kueue.ClusterQueueReference
+		wantAssumedWorkloads map[workload.WorkloadReference]kueue.ClusterQueueReference
 		wantError            string
 		wantLocalQueue       queue.LocalQueueReference
 	}{
@@ -1227,14 +1227,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c", "/d"),
+					Workloads: sets.New[workload.WorkloadReference]("/c", "/d"),
 				},
 			},
 		},
@@ -1252,14 +1252,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantError: "failed to add workload",
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c"),
+					Workloads: sets.New[workload.WorkloadReference]("/c"),
 				},
 			},
 		},
@@ -1276,14 +1276,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c"),
+					Workloads: sets.New[workload.WorkloadReference]("/c"),
 				},
 			},
 		},
@@ -1301,14 +1301,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 0,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      0,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/a", "/c"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/c"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
@@ -1330,14 +1330,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantError: "old ClusterQueue doesn't exist",
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c"),
+					Workloads: sets.New[workload.WorkloadReference]("/c"),
 				},
 			},
 		},
@@ -1355,14 +1355,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantError: "new ClusterQueue doesn't exist",
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c"),
+					Workloads: sets.New[workload.WorkloadReference]("/c"),
 				},
 			},
 		},
@@ -1379,14 +1379,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c", "/d"),
+					Workloads: sets.New[workload.WorkloadReference]("/c", "/d"),
 				},
 			},
 		},
@@ -1400,14 +1400,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 0,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      0,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c"),
+					Workloads: sets.New[workload.WorkloadReference]("/c"),
 				},
 			},
 		},
@@ -1419,14 +1419,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 0,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      0,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c"),
+					Workloads: sets.New[workload.WorkloadReference]("/c"),
 				},
 			},
 		},
@@ -1439,14 +1439,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantError: "cluster queue not found",
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c"),
+					Workloads: sets.New[workload.WorkloadReference]("/c"),
 				},
 			},
 		},
@@ -1461,14 +1461,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantError: "cluster queue not found",
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c"),
+					Workloads: sets.New[workload.WorkloadReference]("/c"),
 				},
 			},
 		},
@@ -1482,14 +1482,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c"),
+					Workloads: sets.New[workload.WorkloadReference]("/c"),
 				},
 			},
 		},
@@ -1515,21 +1515,21 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b", "/d"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b", "/d"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 20,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      30,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c", "/e"),
+					Workloads: sets.New[workload.WorkloadReference]("/c", "/e"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 			},
-			wantAssumedWorkloads: map[string]kueue.ClusterQueueReference{
+			wantAssumedWorkloads: map[workload.WorkloadReference]kueue.ClusterQueueReference{
 				"/d": "one",
 				"/e": "two",
 			},
@@ -1548,17 +1548,17 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantError: "cluster queue not found",
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c"),
+					Workloads: sets.New[workload.WorkloadReference]("/c"),
 				},
 			},
-			wantAssumedWorkloads: map[string]kueue.ClusterQueueReference{},
+			wantAssumedWorkloads: map[workload.WorkloadReference]kueue.ClusterQueueReference{},
 		},
 		{
 			name: "forget",
@@ -1584,21 +1584,21 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c", "/e"),
+					Workloads: sets.New[workload.WorkloadReference]("/c", "/e"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 			},
-			wantAssumedWorkloads: map[string]kueue.ClusterQueueReference{
+			wantAssumedWorkloads: map[workload.WorkloadReference]kueue.ClusterQueueReference{
 				"/e": "two",
 			},
 		},
@@ -1616,14 +1616,14 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			wantError: "the workload is not assumed",
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c"),
+					Workloads: sets.New[workload.WorkloadReference]("/c"),
 				},
 			},
 		},
@@ -1654,21 +1654,21 @@ func TestCacheWorkloadOperations(t *testing.T) {
 			},
 			wantResults: map[kueue.ClusterQueueReference]result{
 				"one": {
-					Workloads: sets.New("/a", "/b", "/d"),
+					Workloads: sets.New[workload.WorkloadReference]("/a", "/b", "/d"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 20,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      30,
 					},
 				},
 				"two": {
-					Workloads: sets.New("/c", "/e"),
+					Workloads: sets.New[workload.WorkloadReference]("/c", "/e"),
 					UsedResources: resources.FlavorResourceQuantities{
 						{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10,
 						{Flavor: "spot", Resource: corev1.ResourceCPU}:      15,
 					},
 				},
 			},
-			wantAssumedWorkloads: map[string]kueue.ClusterQueueReference{
+			wantAssumedWorkloads: map[workload.WorkloadReference]kueue.ClusterQueueReference{
 				"/e": "two",
 			},
 		},
@@ -1699,7 +1699,7 @@ func TestCacheWorkloadOperations(t *testing.T) {
 				t.Errorf("Unexpected clusterQueues (-want,+got):\n%s", diff)
 			}
 			if step.wantAssumedWorkloads == nil {
-				step.wantAssumedWorkloads = map[string]kueue.ClusterQueueReference{}
+				step.wantAssumedWorkloads = map[workload.WorkloadReference]kueue.ClusterQueueReference{}
 			}
 			if diff := cmp.Diff(step.wantAssumedWorkloads, cache.assumedWorkloads); diff != "" {
 				t.Errorf("Unexpected assumed workloads (-want,+got):\n%s", diff)
@@ -3204,13 +3204,13 @@ func TestIsAssumedOrAdmittedCheckWorkload(t *testing.T) {
 	tests := []struct {
 		name             string
 		clusterQueues    map[string]*clusterQueue
-		assumedWorkloads map[string]kueue.ClusterQueueReference
+		assumedWorkloads map[workload.WorkloadReference]kueue.ClusterQueueReference
 		workload         workload.Info
 		expected         bool
 	}{
 		{
 			name:             "Workload Is Assumed and not Admitted",
-			assumedWorkloads: map[string]kueue.ClusterQueueReference{"workload_namespace/workload_name": "test", "test2": "test2"},
+			assumedWorkloads: map[workload.WorkloadReference]kueue.ClusterQueueReference{"workload_namespace/workload_name": "test", "test2": "test2"},
 			workload: workload.Info{
 				ClusterQueue: "ClusterQueue1",
 				Obj: &kueue.Workload{
@@ -3227,7 +3227,7 @@ func TestIsAssumedOrAdmittedCheckWorkload(t *testing.T) {
 			clusterQueues: map[string]*clusterQueue{
 				"ClusterQueue1": {
 					Name: "ClusterQueue1",
-					Workloads: map[string]*workload.Info{"workload_namespace/workload_name": {
+					Workloads: map[workload.WorkloadReference]*workload.Info{"workload_namespace/workload_name": {
 						Obj: &kueue.Workload{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "workload_name",
@@ -3253,7 +3253,7 @@ func TestIsAssumedOrAdmittedCheckWorkload(t *testing.T) {
 			clusterQueues: map[string]*clusterQueue{
 				"ClusterQueue1": {
 					Name: "ClusterQueue1",
-					Workloads: map[string]*workload.Info{"workload_namespace/workload_name": {
+					Workloads: map[workload.WorkloadReference]*workload.Info{"workload_namespace/workload_name": {
 						Obj: &kueue.Workload{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "workload_name",
@@ -3262,7 +3262,7 @@ func TestIsAssumedOrAdmittedCheckWorkload(t *testing.T) {
 						},
 					}},
 				}},
-			assumedWorkloads: map[string]kueue.ClusterQueueReference{"workload_namespace/workload_name": "test", "test2": "test2"},
+			assumedWorkloads: map[workload.WorkloadReference]kueue.ClusterQueueReference{"workload_namespace/workload_name": "test", "test2": "test2"},
 			workload: workload.Info{
 				ClusterQueue: "ClusterQueue1",
 				Obj: &kueue.Workload{
@@ -3279,7 +3279,7 @@ func TestIsAssumedOrAdmittedCheckWorkload(t *testing.T) {
 			clusterQueues: map[string]*clusterQueue{
 				"ClusterQueue1": {
 					Name: "ClusterQueue1",
-					Workloads: map[string]*workload.Info{"workload_namespace2/workload_name2": {
+					Workloads: map[workload.WorkloadReference]*workload.Info{"workload_namespace2/workload_name2": {
 						Obj: &kueue.Workload{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "workload_name2",

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -53,8 +53,8 @@ var (
 type clusterQueue struct {
 	Name              kueue.ClusterQueueReference
 	ResourceGroups    []ResourceGroup
-	Workloads         map[string]*workload.Info
-	WorkloadsNotReady sets.Set[string]
+	Workloads         map[workload.WorkloadReference]*workload.Info
+	WorkloadsNotReady sets.Set[workload.WorkloadReference]
 	NamespaceSelector labels.Selector
 	Preemption        kueue.ClusterQueuePreemption
 	FairWeight        resource.Quantity
@@ -88,7 +88,7 @@ type clusterQueue struct {
 
 	tasCache *tasCache
 
-	workloadsNotAccountedForTAS sets.Set[string]
+	workloadsNotAccountedForTAS sets.Set[workload.WorkloadReference]
 }
 
 func (c *clusterQueue) GetName() kueue.ClusterQueueReference {

--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -36,8 +36,8 @@ import (
 type ClusterQueueSnapshot struct {
 	Name              kueue.ClusterQueueReference
 	ResourceGroups    []ResourceGroup
-	Workloads         map[string]*workload.Info
-	WorkloadsNotReady sets.Set[string]
+	Workloads         map[workload.WorkloadReference]*workload.Info
+	WorkloadsNotReady sets.Set[workload.WorkloadReference]
 	NamespaceSelector labels.Selector
 	Preemption        kueue.ClusterQueuePreemption
 	FairWeight        resource.Quantity

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -76,7 +76,7 @@ func TestSnapshot(t *testing.T) {
 							Status:                        active,
 							FlavorFungibility:             defaultFlavorFungibility,
 							AllocatableResourceGeneration: 1,
-							Workloads: map[string]*workload.Info{
+							Workloads: map[workload.WorkloadReference]*workload.Info{
 								"/alpha": workload.NewInfo(
 									utiltesting.MakeWorkload("alpha", "").
 										ReserveQuota(&kueue.Admission{ClusterQueue: "a"}).Obj()),
@@ -90,7 +90,7 @@ func TestSnapshot(t *testing.T) {
 							Status:                        active,
 							FlavorFungibility:             defaultFlavorFungibility,
 							AllocatableResourceGeneration: 1,
-							Workloads: map[string]*workload.Info{
+							Workloads: map[workload.WorkloadReference]*workload.Info{
 								"/beta": workload.NewInfo(
 									utiltesting.MakeWorkload("beta", "").
 										ReserveQuota(&kueue.Admission{ClusterQueue: "b"}).Obj()),
@@ -255,7 +255,7 @@ func TestSnapshot(t *testing.T) {
 									},
 								},
 								FlavorFungibility: defaultFlavorFungibility,
-								Workloads: map[string]*workload.Info{
+								Workloads: map[workload.WorkloadReference]*workload.Info{
 									"/alpha": workload.NewInfo(utiltesting.MakeWorkload("alpha", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
@@ -299,7 +299,7 @@ func TestSnapshot(t *testing.T) {
 									},
 								},
 								FlavorFungibility: defaultFlavorFungibility,
-								Workloads: map[string]*workload.Info{
+								Workloads: map[workload.WorkloadReference]*workload.Info{
 									"/beta": workload.NewInfo(utiltesting.MakeWorkload("beta", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "1").
@@ -380,7 +380,7 @@ func TestSnapshot(t *testing.T) {
 							NamespaceSelector:             labels.Everything(),
 							AllocatableResourceGeneration: 1,
 							Status:                        active,
-							Workloads:                     map[string]*workload.Info{},
+							Workloads:                     map[workload.WorkloadReference]*workload.Info{},
 							FlavorFungibility:             defaultFlavorFungibility,
 							Preemption: kueue.ClusterQueuePreemption{
 								ReclaimWithinCohort: kueue.PreemptionPolicyAny,
@@ -405,7 +405,7 @@ func TestSnapshot(t *testing.T) {
 							NamespaceSelector:             labels.Everything(),
 							AllocatableResourceGeneration: 1,
 							Status:                        active,
-							Workloads:                     map[string]*workload.Info{},
+							Workloads:                     map[workload.WorkloadReference]*workload.Info{},
 							FlavorFungibility:             defaultFlavorFungibility,
 							Preemption:                    defaultPreemption,
 							FairWeight:                    resource.MustParse("3"),
@@ -504,7 +504,7 @@ func TestSnapshot(t *testing.T) {
 								},
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								Workloads: map[string]*workload.Info{
+								Workloads: map[workload.WorkloadReference]*workload.Info{
 									"/alpha": workload.NewInfo(utiltesting.MakeWorkload("alpha", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
@@ -659,7 +659,7 @@ func TestSnapshot(t *testing.T) {
 								},
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
-								Workloads: map[string]*workload.Info{
+								Workloads: map[workload.WorkloadReference]*workload.Info{
 									"/alpha": workload.NewInfo(utiltesting.MakeWorkload("alpha", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
@@ -999,7 +999,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 			t.Fatalf("Couldn't add ClusterQueue to cache: %v", err)
 		}
 	}
-	wlInfos := make(map[string]*workload.Info, len(workloads))
+	wlInfos := make(map[workload.WorkloadReference]*workload.Info, len(workloads))
 	for _, cq := range cqCache.hm.ClusterQueues() {
 		for _, wl := range cq.Workloads {
 			wlInfos[workload.Key(wl.Obj)] = wl
@@ -1011,17 +1011,17 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 	}
 	initialCohortResources := initialSnapshot.ClusterQueue("c1").Parent().ResourceNode.SubtreeQuota
 	cases := map[string]struct {
-		remove []string
-		add    []string
+		remove []workload.WorkloadReference
+		add    []workload.WorkloadReference
 		want   Snapshot
 	}{
 		"no-op remove add": {
-			remove: []string{"/c1-cpu", "/c2-cpu-1"},
-			add:    []string{"/c1-cpu", "/c2-cpu-1"},
+			remove: []workload.WorkloadReference{"/c1-cpu", "/c2-cpu-1"},
+			add:    []workload.WorkloadReference{"/c1-cpu", "/c2-cpu-1"},
 			want:   *initialSnapshot,
 		},
 		"remove all": {
-			remove: []string{"/c1-cpu", "/c1-memory-alpha", "/c1-memory-beta", "/c2-cpu-1", "/c2-cpu-2"},
+			remove: []workload.WorkloadReference{"/c1-cpu", "/c1-memory-alpha", "/c1-memory-beta", "/c2-cpu-1", "/c2-cpu-2"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "cohort",
@@ -1042,7 +1042,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"c1": {
 								Name:              "c1",
-								Workloads:         make(map[string]*workload.Info),
+								Workloads:         make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:    cqCache.hm.ClusterQueue("c1").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
@@ -1061,7 +1061,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							},
 							"c2": {
 								Name:                          "c2",
-								Workloads:                     make(map[string]*workload.Info),
+								Workloads:                     make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:                cqCache.hm.ClusterQueue("c2").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
@@ -1081,7 +1081,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 			}(),
 		},
 		"remove c1-cpu": {
-			remove: []string{"/c1-cpu"},
+			remove: []workload.WorkloadReference{"/c1-cpu"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "cohort",
@@ -1102,7 +1102,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"c1": {
 								Name: "c1",
-								Workloads: map[string]*workload.Info{
+								Workloads: map[workload.WorkloadReference]*workload.Info{
 									"/c1-memory-alpha": nil,
 									"/c1-memory-beta":  nil,
 								},
@@ -1124,7 +1124,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							},
 							"c2": {
 								Name: "c2",
-								Workloads: map[string]*workload.Info{
+								Workloads: map[workload.WorkloadReference]*workload.Info{
 									"/c2-cpu-1": nil,
 									"/c2-cpu-2": nil,
 								},
@@ -1147,7 +1147,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 			}(),
 		},
 		"remove c1-memory-alpha": {
-			remove: []string{"/c1-memory-alpha"},
+			remove: []workload.WorkloadReference{"/c1-memory-alpha"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "cohort",
@@ -1168,7 +1168,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"c1": {
 								Name: "c1",
-								Workloads: map[string]*workload.Info{
+								Workloads: map[workload.WorkloadReference]*workload.Info{
 									"/c1-memory-alpha": nil,
 									"/c1-memory-beta":  nil,
 								},
@@ -1190,7 +1190,7 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 							},
 							"c2": {
 								Name: "c2",
-								Workloads: map[string]*workload.Info{
+								Workloads: map[workload.WorkloadReference]*workload.Info{
 									"/c2-cpu-1": nil,
 									"/c2-cpu-2": nil,
 								},
@@ -1293,7 +1293,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			t.Fatalf("Couldn't add ClusterQueue to cache: %v", err)
 		}
 	}
-	wlInfos := make(map[string]*workload.Info, len(workloads))
+	wlInfos := make(map[workload.WorkloadReference]*workload.Info, len(workloads))
 	for _, cq := range cqCache.hm.ClusterQueues() {
 		for _, wl := range cq.Workloads {
 			wlInfos[workload.Key(wl.Obj)] = wl
@@ -1305,17 +1305,17 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 	}
 	initialCohortResources := initialSnapshot.ClusterQueue("lend-a").Parent().ResourceNode.SubtreeQuota
 	cases := map[string]struct {
-		remove []string
-		add    []string
+		remove []workload.WorkloadReference
+		add    []workload.WorkloadReference
 		want   Snapshot
 	}{
 		"remove all then add all": {
-			remove: []string{"/lend-a-1", "/lend-a-2", "/lend-a-3", "/lend-b-1"},
-			add:    []string{"/lend-a-1", "/lend-a-2", "/lend-a-3", "/lend-b-1"},
+			remove: []workload.WorkloadReference{"/lend-a-1", "/lend-a-2", "/lend-a-3", "/lend-b-1"},
+			add:    []workload.WorkloadReference{"/lend-a-1", "/lend-a-2", "/lend-a-3", "/lend-b-1"},
 			want:   *initialSnapshot,
 		},
 		"remove all": {
-			remove: []string{"/lend-a-1", "/lend-a-2", "/lend-a-3", "/lend-b-1"},
+			remove: []workload.WorkloadReference{"/lend-a-1", "/lend-a-2", "/lend-a-3", "/lend-b-1"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
@@ -1334,7 +1334,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
-								Workloads:         make(map[string]*workload.Info),
+								Workloads:         make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
@@ -1349,7 +1349,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							},
 							"lend-b": {
 								Name:              "lend-b",
-								Workloads:         make(map[string]*workload.Info),
+								Workloads:         make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
@@ -1368,7 +1368,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			}(),
 		},
 		"remove workload, but still using quota over GuaranteedQuota": {
-			remove: []string{"/lend-a-2"},
+			remove: []workload.WorkloadReference{"/lend-a-2"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
@@ -1387,7 +1387,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
-								Workloads:         make(map[string]*workload.Info),
+								Workloads:         make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
@@ -1402,7 +1402,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							},
 							"lend-b": {
 								Name:                          "lend-b",
-								Workloads:                     make(map[string]*workload.Info),
+								Workloads:                     make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:                cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
@@ -1422,7 +1422,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			}(),
 		},
 		"remove wokload, using same quota as GuaranteedQuota": {
-			remove: []string{"/lend-a-1", "/lend-a-2"},
+			remove: []workload.WorkloadReference{"/lend-a-1", "/lend-a-2"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
@@ -1441,7 +1441,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
-								Workloads:         make(map[string]*workload.Info),
+								Workloads:         make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
@@ -1456,7 +1456,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							},
 							"lend-b": {
 								Name:                          "lend-b",
-								Workloads:                     make(map[string]*workload.Info),
+								Workloads:                     make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:                cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
@@ -1476,7 +1476,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			}(),
 		},
 		"remove workload, using less quota than GuaranteedQuota": {
-			remove: []string{"/lend-a-2", "/lend-a-3"},
+			remove: []workload.WorkloadReference{"/lend-a-2", "/lend-a-3"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
@@ -1495,7 +1495,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
-								Workloads:         make(map[string]*workload.Info),
+								Workloads:         make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
@@ -1510,7 +1510,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							},
 							"lend-b": {
 								Name:                          "lend-b",
-								Workloads:                     make(map[string]*workload.Info),
+								Workloads:                     make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:                cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
@@ -1530,8 +1530,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			}(),
 		},
 		"remove all then add workload, using less quota than GuaranteedQuota": {
-			remove: []string{"/lend-a-1", "/lend-a-2", "/lend-a-3", "/lend-b-1"},
-			add:    []string{"/lend-a-1"},
+			remove: []workload.WorkloadReference{"/lend-a-1", "/lend-a-2", "/lend-a-3", "/lend-b-1"},
+			add:    []workload.WorkloadReference{"/lend-a-1"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
@@ -1550,7 +1550,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
-								Workloads:         make(map[string]*workload.Info),
+								Workloads:         make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
@@ -1565,7 +1565,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							},
 							"lend-b": {
 								Name:                          "lend-b",
-								Workloads:                     make(map[string]*workload.Info),
+								Workloads:                     make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:                cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,
@@ -1585,8 +1585,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			}(),
 		},
 		"remove all then add workload, using same quota as GuaranteedQuota": {
-			remove: []string{"/lend-a-1", "/lend-a-2", "/lend-a-3", "/lend-b-1"},
-			add:    []string{"/lend-a-3"},
+			remove: []workload.WorkloadReference{"/lend-a-1", "/lend-a-2", "/lend-a-3", "/lend-b-1"},
+			add:    []workload.WorkloadReference{"/lend-a-3"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
@@ -1605,7 +1605,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
-								Workloads:         make(map[string]*workload.Info),
+								Workloads:         make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
@@ -1620,7 +1620,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							},
 							"lend-b": {
 								Name:              "lend-b",
-								Workloads:         make(map[string]*workload.Info),
+								Workloads:         make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
@@ -1639,8 +1639,8 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 			}(),
 		},
 		"remove all then add workload, using quota over GuaranteedQuota": {
-			remove: []string{"/lend-a-1", "/lend-a-2", "/lend-a-3", "/lend-b-1"},
-			add:    []string{"/lend-a-2"},
+			remove: []workload.WorkloadReference{"/lend-a-1", "/lend-a-2", "/lend-a-3", "/lend-b-1"},
+			add:    []workload.WorkloadReference{"/lend-a-2"},
 			want: func() Snapshot {
 				cohort := &CohortSnapshot{
 					Name: "lend",
@@ -1659,7 +1659,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 						map[kueue.ClusterQueueReference]*ClusterQueueSnapshot{
 							"lend-a": {
 								Name:              "lend-a",
-								Workloads:         make(map[string]*workload.Info),
+								Workloads:         make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:    cqCache.hm.ClusterQueue("lend-a").ResourceGroups,
 								FlavorFungibility: defaultFlavorFungibility,
 								FairWeight:        oneQuantity,
@@ -1674,7 +1674,7 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 							},
 							"lend-b": {
 								Name:                          "lend-b",
-								Workloads:                     make(map[string]*workload.Info),
+								Workloads:                     make(map[workload.WorkloadReference]*workload.Info),
 								ResourceGroups:                cqCache.hm.ClusterQueue("lend-b").ResourceGroups,
 								FlavorFungibility:             defaultFlavorFungibility,
 								FairWeight:                    oneQuantity,

--- a/pkg/queue/cluster_queue.go
+++ b/pkg/queue/cluster_queue.go
@@ -56,12 +56,12 @@ var (
 type ClusterQueue struct {
 	hierarchy.ClusterQueue[*cohort]
 	name              kueue.ClusterQueueReference
-	heap              heap.Heap[workload.Info]
+	heap              heap.Heap[workload.Info, workload.WorkloadReference]
 	namespaceSelector labels.Selector
 	active            bool
 
 	// inadmissibleWorkloads are workloads that have been tried at least once and couldn't be admitted.
-	inadmissibleWorkloads map[string]*workload.Info
+	inadmissibleWorkloads map[workload.WorkloadReference]*workload.Info
 
 	// popCycle identifies the last call to Pop. It's incremented when calling Pop.
 	// popCycle and queueInadmissibleCycle are used to track when there is a requeuing
@@ -88,7 +88,7 @@ func (c *ClusterQueue) GetName() kueue.ClusterQueueReference {
 	return c.name
 }
 
-func workloadKey(i *workload.Info) string {
+func workloadKey(i *workload.Info) workload.WorkloadReference {
 	return workload.Key(i.Obj)
 }
 
@@ -115,7 +115,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 	lessFunc := queueOrderingFunc(ctx, client, wo, fsResWeights, enableAdmissionFs)
 	return &ClusterQueue{
 		heap:                   *heap.New(workloadKey, lessFunc),
-		inadmissibleWorkloads:  make(map[string]*workload.Info),
+		inadmissibleWorkloads:  make(map[workload.WorkloadReference]*workload.Info),
 		queueInadmissibleCycle: -1,
 		lessFunc:               lessFunc,
 		rwm:                    sync.RWMutex{},
@@ -274,7 +274,7 @@ func (c *ClusterQueue) requeueIfNotPresent(wInfo *workload.Info, immediate bool)
 	return true
 }
 
-func (c *ClusterQueue) forgetInflightByKey(key string) {
+func (c *ClusterQueue) forgetInflightByKey(key workload.WorkloadReference) {
 	if c.inflight != nil && workload.Key(c.inflight.Obj) == key {
 		c.inflight = nil
 	}
@@ -290,7 +290,7 @@ func (c *ClusterQueue) QueueInadmissibleWorkloads(ctx context.Context, client cl
 		return false
 	}
 
-	inadmissibleWorkloads := make(map[string]*workload.Info)
+	inadmissibleWorkloads := make(map[workload.WorkloadReference]*workload.Info)
 	moved := false
 	for key, wInfo := range c.inadmissibleWorkloads {
 		ns := corev1.Namespace{}
@@ -347,26 +347,26 @@ func (c *ClusterQueue) Pop() *workload.Info {
 // Dump produces a dump of the current workloads in the heap of
 // this ClusterQueue. It returns false if the queue is empty,
 // otherwise returns true.
-func (c *ClusterQueue) Dump() ([]string, bool) {
+func (c *ClusterQueue) Dump() ([]workload.WorkloadReference, bool) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
 	if c.heap.Len() == 0 {
 		return nil, false
 	}
-	elements := make([]string, c.heap.Len())
+	elements := make([]workload.WorkloadReference, c.heap.Len())
 	for i, info := range c.heap.List() {
 		elements[i] = workload.Key(info.Obj)
 	}
 	return elements, true
 }
 
-func (c *ClusterQueue) DumpInadmissible() ([]string, bool) {
+func (c *ClusterQueue) DumpInadmissible() ([]workload.WorkloadReference, bool) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
 	if len(c.inadmissibleWorkloads) == 0 {
 		return nil, false
 	}
-	elements := make([]string, 0, len(c.inadmissibleWorkloads))
+	elements := make([]workload.WorkloadReference, 0, len(c.inadmissibleWorkloads))
 	for _, info := range c.inadmissibleWorkloads {
 		elements = append(elements, workload.Key(info.Obj))
 	}
@@ -385,7 +385,7 @@ func (c *ClusterQueue) Snapshot() []*workload.Info {
 
 // Info returns workload.Info for the workload key.
 // Users of this method should not modify the returned object.
-func (c *ClusterQueue) Info(key string) *workload.Info {
+func (c *ClusterQueue) Info(key workload.WorkloadReference) *workload.Info {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
 	return c.heap.GetByKey(key)

--- a/pkg/queue/cluster_queue_test.go
+++ b/pkg/queue/cluster_queue_test.go
@@ -69,7 +69,7 @@ func Test_PushOrUpdate(t *testing.T) {
 	cases := map[string]struct {
 		workload                  *utiltesting.WorkloadWrapper
 		wantWorkload              *workload.Info
-		wantInAdmissibleWorkloads map[string]*workload.Info
+		wantInAdmissibleWorkloads map[workload.WorkloadReference]*workload.Info
 	}{
 		"workload doesn't have re-queue state": {
 			workload:     wlBase.Clone(),
@@ -87,7 +87,7 @@ func Test_PushOrUpdate(t *testing.T) {
 					Type:   kueue.WorkloadRequeued,
 					Status: metav1.ConditionFalse,
 				}),
-			wantInAdmissibleWorkloads: map[string]*workload.Info{
+			wantInAdmissibleWorkloads: map[workload.WorkloadReference]*workload.Info{
 				"default/workload-1": workload.NewInfo(wlBase.Clone().
 					ResourceVersion("1").
 					RequeueState(ptr.To[int32](10), ptr.To(metav1.NewTime(minuteLater))).
@@ -114,7 +114,7 @@ func Test_PushOrUpdate(t *testing.T) {
 					Type:   kueue.WorkloadRequeued,
 					Status: metav1.ConditionFalse,
 				}),
-			wantInAdmissibleWorkloads: map[string]*workload.Info{
+			wantInAdmissibleWorkloads: map[workload.WorkloadReference]*workload.Info{
 				"default/workload-1": workload.NewInfo(wlBase.Clone().
 					ResourceVersion("1").
 					Condition(metav1.Condition{
@@ -243,8 +243,8 @@ func Test_AddFromLocalQueue(t *testing.T) {
 	cq := newClusterQueueImpl(t.Context(), nil, defaultOrdering, testingclock.NewFakeClock(time.Now()), nil, false)
 	wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 	queue := &LocalQueue{
-		items: map[string]*workload.Info{
-			wl.Name: workload.NewInfo(wl),
+		items: map[workload.WorkloadReference]*workload.Info{
+			workload.WorkloadReference(wl.Name): workload.NewInfo(wl),
 		},
 	}
 	cq.PushOrUpdate(workload.NewInfo(wl))
@@ -333,7 +333,7 @@ func TestClusterQueueImpl(t *testing.T) {
 		workloadsToUpdate                 []*kueue.Workload
 		workloadsToDelete                 []*kueue.Workload
 		queueInadmissibleWorkloads        bool
-		wantActiveWorkloads               []string
+		wantActiveWorkloads               []workload.WorkloadReference
 		wantPending                       int
 		wantInadmissibleWorkloadsRequeued bool
 	}{
@@ -342,27 +342,27 @@ func TestClusterQueueImpl(t *testing.T) {
 			inadmissibleWorkloadsToRequeue: []*workload.Info{},
 			workloadsToUpdate:              []*kueue.Workload{updatedWorkloads[0]},
 			workloadsToDelete:              []*kueue.Workload{workloads[0]},
-			wantActiveWorkloads:            []string{workload.Key(workloads[1])},
+			wantActiveWorkloads:            []workload.WorkloadReference{workload.Key(workloads[1])},
 			wantPending:                    2,
 		},
 		"re-queue inadmissible workload; workloads with requeueState can't re-queue": {
 			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
 			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1]), workload.NewInfo(workloads[3])},
-			wantActiveWorkloads:            []string{workload.Key(workloads[0])},
+			wantActiveWorkloads:            []workload.WorkloadReference{workload.Key(workloads[0])},
 			wantPending:                    3,
 		},
 		"re-queue admissible workload that was inadmissible": {
 			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
 			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1]), workload.NewInfo(workloads[3])},
 			admissibleWorkloadsToRequeue:   []*workload.Info{workload.NewInfo(workloads[1]), workload.NewInfo(workloads[3])},
-			wantActiveWorkloads:            []string{workload.Key(workloads[0]), workload.Key(workloads[1])},
+			wantActiveWorkloads:            []workload.WorkloadReference{workload.Key(workloads[0]), workload.Key(workloads[1])},
 			wantPending:                    3,
 		},
 		"re-queue inadmissible workload and flush": {
 			workloadsToAdd:                    []*kueue.Workload{workloads[0]},
 			inadmissibleWorkloadsToRequeue:    []*workload.Info{workload.NewInfo(workloads[1]), workload.NewInfo(workloads[3])},
 			queueInadmissibleWorkloads:        true,
-			wantActiveWorkloads:               []string{workload.Key(workloads[0]), workload.Key(workloads[1])},
+			wantActiveWorkloads:               []workload.WorkloadReference{workload.Key(workloads[0]), workload.Key(workloads[1])},
 			wantPending:                       3,
 			wantInadmissibleWorkloadsRequeued: true,
 		},
@@ -370,14 +370,14 @@ func TestClusterQueueImpl(t *testing.T) {
 			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
 			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[2])},
 			queueInadmissibleWorkloads:     true,
-			wantActiveWorkloads:            []string{workload.Key(workloads[0])},
+			wantActiveWorkloads:            []workload.WorkloadReference{workload.Key(workloads[0])},
 			wantPending:                    2,
 		},
 		"update inadmissible workload": {
 			workloadsToAdd:                 []*kueue.Workload{workloads[0]},
 			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1])},
 			workloadsToUpdate:              []*kueue.Workload{updatedWorkloads[1]},
-			wantActiveWorkloads:            []string{workload.Key(workloads[0]), workload.Key(workloads[1])},
+			wantActiveWorkloads:            []workload.WorkloadReference{workload.Key(workloads[0]), workload.Key(workloads[1])},
 			wantPending:                    2,
 		},
 		"delete inadmissible workload": {
@@ -385,7 +385,7 @@ func TestClusterQueueImpl(t *testing.T) {
 			inadmissibleWorkloadsToRequeue: []*workload.Info{workload.NewInfo(workloads[1])},
 			workloadsToDelete:              []*kueue.Workload{workloads[1]},
 			queueInadmissibleWorkloads:     true,
-			wantActiveWorkloads:            []string{workload.Key(workloads[0])},
+			wantActiveWorkloads:            []workload.WorkloadReference{workload.Key(workloads[0])},
 			wantPending:                    1,
 		},
 		"update inadmissible workload without changes": {
@@ -406,7 +406,7 @@ func TestClusterQueueImpl(t *testing.T) {
 					ReclaimablePods(kueue.ReclaimablePod{Name: kueue.DefaultPodSetName, Count: 1}).
 					Obj(),
 			},
-			wantActiveWorkloads: []string{"/w"},
+			wantActiveWorkloads: []workload.WorkloadReference{"/w"},
 			wantPending:         1,
 		},
 	}
@@ -473,7 +473,7 @@ func TestQueueInadmissibleWorkloadsDuringScheduling(t *testing.T) {
 	ctx := t.Context()
 	cq.PushOrUpdate(workload.NewInfo(wl))
 
-	wantActiveWorkloads := []string{workload.Key(wl)}
+	wantActiveWorkloads := []workload.WorkloadReference{workload.Key(wl)}
 
 	activeWorkloads, _ := cq.Dump()
 	if diff := cmp.Diff(wantActiveWorkloads, activeWorkloads, cmpDump...); diff != "" {
@@ -486,7 +486,7 @@ func TestQueueInadmissibleWorkloadsDuringScheduling(t *testing.T) {
 	cq.requeueIfNotPresent(head, false)
 
 	activeWorkloads, _ = cq.Dump()
-	wantActiveWorkloads = []string{workload.Key(wl)}
+	wantActiveWorkloads = []workload.WorkloadReference{workload.Key(wl)}
 	if diff := cmp.Diff(wantActiveWorkloads, activeWorkloads, cmpDump...); diff != "" {
 		t.Errorf("Unexpected active workloads after scheduling with requeuing (-want,+got):\n%s", diff)
 	}

--- a/pkg/queue/dumper.go
+++ b/pkg/queue/dumper.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/klog/v2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 // LogDump dumps the pending and inadmissible workloads for each ClusterQueue into the log,
@@ -40,14 +41,14 @@ func (m *Manager) LogDump(log logr.Logger) {
 
 // Dump is a dump of the queues and it's elements (unordered).
 // Only use for testing purposes.
-func (m *Manager) Dump() map[kueue.ClusterQueueReference][]string {
+func (m *Manager) Dump() map[kueue.ClusterQueueReference][]workload.WorkloadReference {
 	m.Lock()
 	defer m.Unlock()
 	clusterQueues := m.hm.ClusterQueues()
 	if len(clusterQueues) == 0 {
 		return nil
 	}
-	dump := make(map[kueue.ClusterQueueReference][]string, len(clusterQueues))
+	dump := make(map[kueue.ClusterQueueReference][]workload.WorkloadReference, len(clusterQueues))
 	for key, cq := range clusterQueues {
 		if elements, ok := cq.Dump(); ok {
 			dump[key] = elements
@@ -61,14 +62,14 @@ func (m *Manager) Dump() map[kueue.ClusterQueueReference][]string {
 
 // DumpInadmissible is a dump of the inadmissible workloads list.
 // Only use for testing purposes.
-func (m *Manager) DumpInadmissible() map[kueue.ClusterQueueReference][]string {
+func (m *Manager) DumpInadmissible() map[kueue.ClusterQueueReference][]workload.WorkloadReference {
 	m.Lock()
 	defer m.Unlock()
 	clusterQueues := m.hm.ClusterQueues()
 	if len(clusterQueues) == 0 {
 		return nil
 	}
-	dump := make(map[kueue.ClusterQueueReference][]string, len(clusterQueues))
+	dump := make(map[kueue.ClusterQueueReference][]workload.WorkloadReference, len(clusterQueues))
 	for key, cq := range clusterQueues {
 		if elements, ok := cq.DumpInadmissible(); ok {
 			dump[key] = elements

--- a/pkg/queue/local_queue.go
+++ b/pkg/queue/local_queue.go
@@ -66,13 +66,13 @@ type LocalQueue struct {
 	Key          LocalQueueReference
 	ClusterQueue kueue.ClusterQueueReference
 
-	items map[string]*workload.Info
+	items map[workload.WorkloadReference]*workload.Info
 }
 
 func newLocalQueue(q *kueue.LocalQueue) *LocalQueue {
 	qImpl := &LocalQueue{
 		Key:   Key(q),
-		items: make(map[string]*workload.Info),
+		items: make(map[workload.WorkloadReference]*workload.Info),
 	}
 	qImpl.update(q)
 	return qImpl
@@ -99,7 +99,7 @@ func (m *Manager) PendingActiveInLocalQueue(lq *LocalQueue) int {
 			result++
 		}
 	}
-	if c.inflight != nil && workloadKey(c.inflight) == string(lq.Key) {
+	if c.inflight != nil && string(workloadKey(c.inflight)) == string(lq.Key) {
 		result++
 	}
 	return result

--- a/pkg/queue/second_pass_queue.go
+++ b/pkg/queue/second_pass_queue.go
@@ -25,12 +25,12 @@ import (
 type secondPassQueue struct {
 	sync.RWMutex
 
-	state map[string]*workload.Info
+	state map[workload.WorkloadReference]*workload.Info
 }
 
 func newSecondPassQueue() *secondPassQueue {
 	return &secondPassQueue{
-		state: make(map[string]*workload.Info),
+		state: make(map[workload.WorkloadReference]*workload.Info),
 	}
 }
 
@@ -42,7 +42,7 @@ func (q *secondPassQueue) takeAllReady() []workload.Info {
 	for _, v := range q.state {
 		result = append(result, *v)
 	}
-	q.state = make(map[string]*workload.Info)
+	q.state = make(map[workload.WorkloadReference]*workload.Info)
 	return result
 }
 
@@ -53,7 +53,7 @@ func (q *secondPassQueue) offer(w *workload.Info) {
 	q.state[workload.Key(w.Obj)] = w
 }
 
-func (q *secondPassQueue) deleteByKey(key string) {
+func (q *secondPassQueue) deleteByKey(key workload.WorkloadReference) {
 	q.Lock()
 	defer q.Unlock()
 

--- a/pkg/scheduler/fair_sharing_iterator.go
+++ b/pkg/scheduler/fair_sharing_iterator.go
@@ -156,7 +156,7 @@ func runTournament(cohort *cache.CohortSnapshot, ec entryComparer, cqToEntry map
 
 type drsKey struct {
 	parentCohort kueue.CohortReference
-	workloadKey  string
+	workloadKey  workload.WorkloadReference
 }
 
 type entryComparer struct {

--- a/pkg/scheduler/preemption/preempted_workloads.go
+++ b/pkg/scheduler/preemption/preempted_workloads.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
-type PreemptedWorkloads map[string]*workload.Info
+type PreemptedWorkloads map[workload.WorkloadReference]*workload.Info
 
 func (p PreemptedWorkloads) HasAny(newTargets []*Target) bool {
 	for _, target := range newTargets {

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -2787,7 +2787,7 @@ func TestFairPreemptions(t *testing.T) {
 	}
 }
 
-func targetKeyReason(key, reason string) string {
+func targetKeyReason(key workload.WorkloadReference, reason string) string {
 	return fmt.Sprintf("%s:%s", key, reason)
 }
 func TestCandidatesOrdering(t *testing.T) {
@@ -2825,11 +2825,11 @@ func TestCandidatesOrdering(t *testing.T) {
 			Obj()),
 	}
 	sort.Slice(candidates, CandidatesOrdering(candidates, "self", now))
-	gotNames := make([]string, len(candidates))
+	gotNames := make([]workload.WorkloadReference, len(candidates))
 	for i, c := range candidates {
 		gotNames[i] = workload.Key(c.Obj)
 	}
-	wantCandidates := []string{"/evicted", "/other", "/low", "/current", "/old-a", "/old-b", "/high"}
+	wantCandidates := []workload.WorkloadReference{"/evicted", "/other", "/low", "/current", "/old-a", "/old-b", "/high"}
 	if diff := cmp.Diff(wantCandidates, gotNames); diff != "" {
 		t.Errorf("Sorted with wrong order (-want,+got):\n%s", diff)
 	}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -69,6 +69,13 @@ var (
 	}
 )
 
+// WorkloadReference is the full reference to Workload formed as <namespace>/< kueue.WorkloadName >.
+type WorkloadReference string
+
+func NewWorkloadReference(namespace, name string) WorkloadReference {
+	return WorkloadReference(namespace + "/" + name)
+}
+
 func Status(w *kueue.Workload) string {
 	if apimeta.IsStatusConditionTrue(w.Status.Conditions, kueue.WorkloadFinished) {
 		return StatusFinished
@@ -386,8 +393,8 @@ func CanBePartiallyAdmitted(wl *kueue.Workload) bool {
 	return false
 }
 
-func Key(w *kueue.Workload) string {
-	return fmt.Sprintf("%s/%s", w.Namespace, w.Name)
+func Key(w *kueue.Workload) WorkloadReference {
+	return NewWorkloadReference(w.Namespace, w.Name)
 }
 
 func reclaimableCounts(wl *kueue.Workload) map[kueue.PodSetReference]int32 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Adds `WorkloadReference` to make it easier to reason about the code that uses strings to represent workload Keys.
- Cleans up `ClusterQueueReference` usage for improved code clarity and maintainability.
- Generalizes types in the `heap` package to improve code reuse and static analysis.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4975 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```