### PR TITLE
Add message about GKE users being discourage from using 0.12.0 release

### DIFF
--- a/CHANGELOG/CHANGELOG-0.12.md
+++ b/CHANGELOG/CHANGELOG-0.12.md
@@ -1,5 +1,8 @@
 ## v0.12.0
 
+> [!NOTE]
+> This release is not deployable on GKE. GKE users should use Kueue 0.11.4 until 0.12.1 comes out.
+
 Changes since `v0.11.0`:
 
 ## Urgent Upgrade Notes


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

After releasing Kueue 0.12.0 an [issue](https://github.com/kubernetes-sigs/kueue/issues/5374) was found which prevents GKE users from installing version 0.12. This message is our best effort to warn GKE users that they shouldn't use Kueue 0.12.0. Version 0.12.1 is going to be released soon which will include a fix to the problem.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```