### PR TITLE
Configure Dependabot to automatically bump the Cypress image tag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,15 @@ updates:
       - "ok-to-test"
       - "release-note-none"
 
+  # Maintain kueue cypress dependency
+  - package-ecosystem: "docker"
+    directory: "/hack/cypress"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ok-to-test"
+      - "release-note-none"
+
   # Maintain go dependencies for KueueViz backend
   - package-ecosystem: "gomod"
     directories:

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -55,7 +55,6 @@ IMAGE_REGISTRY ?= $(STAGING_IMAGE_REGISTRY)/kueue
 IMAGE_NAME := kueue
 IMAGE_REPO ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME)
 IMAGE_TAG ?= $(IMAGE_REPO):$(GIT_TAG)
-CYPRESS_IMAGE_NAME ?= cypress/base:22.14.0
 
 # Versions for external controllers
 APPWRAPPER_VERSION = $(shell $(GO_CMD) list -m -f "{{.Version}}" github.com/project-codeflare/appwrapper)
@@ -271,4 +270,4 @@ test-e2e-kueueviz: setup-e2e-env ## Run end-to-end tests for kueueviz without ru
 	@echo Starting kueueviz end to end test in containers
 	ARTIFACTS=$(ARTIFACTS) KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) PROJECT_DIR=$(PROJECT_DIR)/ \
 	KIND_CLUSTER_FILE="kind-cluster.yaml" IMAGE_TAG=$(IMAGE_TAG) \
-	CYPRESS_IMAGE_NAME=$(CYPRESS_IMAGE_NAME) ${PROJECT_DIR}/hack/e2e-kueueviz-backend.sh
+	${PROJECT_DIR}/hack/e2e-kueueviz-backend.sh

--- a/hack/cypress/Dockerfile
+++ b/hack/cypress/Dockerfile
@@ -1,0 +1,1 @@
+FROM cypress/base:22.14.0

--- a/hack/e2e-kueueviz-backend.sh
+++ b/hack/e2e-kueueviz-backend.sh
@@ -76,9 +76,9 @@ if [ -z "$WORKSPACE_VOLUME" ]; then
 fi
 echo "Workspace Volume: $WORKSPACE_VOLUME"
 
-# if CYPRESS_IMAGE_NAME is not set, set it to cypress/base:22.14.0
+# if CYPRESS_IMAGE_NAME is not set, extract it from ./hack/cypress/Dockerfile
 if [ -z "$CYPRESS_IMAGE_NAME" ]; then
-  CYPRESS_IMAGE_NAME="cypress/base:22.14.0"
+  CYPRESS_IMAGE_NAME=$(grep '^FROM' "${ROOT_DIR}/hack/cypress/Dockerfile" | awk '{print $2}')
 fi
 
 # Start KueueViz frontend and cypress in a container


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Configure Dependabot to automatically bump the Cypress image tag

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```