### PR TITLE
Helm chart : fix unwanted space trim which lead to yaml error

### DIFF
--- a/charts/kueue/templates/webhook/manifests.yaml
+++ b/charts/kueue/templates/webhook/manifests.yaml
@@ -21,9 +21,9 @@ webhooks:
         path: /mutate-workload-codeflare-dev-v1beta2-appwrapper
     failurePolicy: Fail
     name: mappwrapper.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -81,9 +81,9 @@ webhooks:
         path: /mutate-batch-v1-job
     failurePolicy: Fail
     name: mjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -105,9 +105,9 @@ webhooks:
         path: /mutate-jobset-x-k8s-io-v1alpha2-jobset
     failurePolicy: Fail
     name: mjobset.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -129,9 +129,9 @@ webhooks:
         path: /mutate-kubeflow-org-v1-jaxjob
     failurePolicy: Fail
     name: mjaxjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -153,9 +153,9 @@ webhooks:
         path: /mutate-kubeflow-org-v1-paddlejob
     failurePolicy: Fail
     name: mpaddlejob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -177,9 +177,9 @@ webhooks:
         path: /mutate-kubeflow-org-v1-pytorchjob
     failurePolicy: Fail
     name: mpytorchjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -201,9 +201,9 @@ webhooks:
         path: /mutate-kubeflow-org-v1-tfjob
     failurePolicy: Fail
     name: mtfjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -225,9 +225,9 @@ webhooks:
         path: /mutate-kubeflow-org-v1-xgboostjob
     failurePolicy: Fail
     name: mxgboostjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -284,9 +284,9 @@ webhooks:
         path: /mutate-leaderworkerset-x-k8s-io-v1-leaderworkerset
     failurePolicy: Fail
     name: mleaderworkerset.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -309,9 +309,9 @@ webhooks:
         path: /mutate-kubeflow-org-v2beta1-mpijob
     failurePolicy: Fail
     name: mmpijob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -333,9 +333,9 @@ webhooks:
         path: /mutate-ray-io-v1-raycluster
     failurePolicy: Fail
     name: mraycluster.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -357,9 +357,9 @@ webhooks:
         path: /mutate-ray-io-v1-rayjob
     failurePolicy: Fail
     name: mrayjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -490,9 +490,9 @@ webhooks:
         path: /validate-workload-codeflare-dev-v1beta2-appwrapper
     failurePolicy: Fail
     name: vappwrapper.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -549,9 +549,9 @@ webhooks:
         path: /validate-batch-v1-job
     failurePolicy: Fail
     name: vjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -573,9 +573,9 @@ webhooks:
         path: /validate-jobset-x-k8s-io-v1alpha2-jobset
     failurePolicy: Fail
     name: vjobset.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -597,9 +597,9 @@ webhooks:
         path: /validate-kubeflow-org-v1-jaxjob
     failurePolicy: Fail
     name: vjaxjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -621,9 +621,9 @@ webhooks:
         path: /validate-kubeflow-org-v1-paddlejob
     failurePolicy: Fail
     name: vpaddlejob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -645,9 +645,9 @@ webhooks:
         path: /validate-kubeflow-org-v1-pytorchjob
     failurePolicy: Fail
     name: vpytorchjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -669,9 +669,9 @@ webhooks:
         path: /validate-kubeflow-org-v1-tfjob
     failurePolicy: Fail
     name: vtfjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -693,9 +693,9 @@ webhooks:
         path: /validate-kubeflow-org-v1-xgboostjob
     failurePolicy: Fail
     name: vxgboostjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -752,9 +752,9 @@ webhooks:
         path: /validate-leaderworkerset-x-k8s-io-v1-leaderworkerset
     failurePolicy: Fail
     name: vleaderworkerset.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -776,9 +776,9 @@ webhooks:
         path: /validate-kubeflow-org-v2beta1-mpijob
     failurePolicy: Fail
     name: vmpijob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -800,9 +800,9 @@ webhooks:
         path: /validate-ray-io-v1-raycluster
     failurePolicy: Fail
     name: vraycluster.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:
@@ -824,9 +824,9 @@ webhooks:
         path: /validate-ray-io-v1-rayjob
     failurePolicy: Fail
     name: vrayjob.kb.io
-    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+    {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
     namespaceSelector:
-      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+      {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
     {{- end }}
     rules:
       - apiGroups:

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -361,216 +361,216 @@ files:
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-batch-v1-job"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-jobset-x-k8s-io-v1alpha2-jobset"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-jaxjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-paddlejob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-pytorchjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-tfjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v1-xgboostjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-leaderworkerset-x-k8s-io-v1-leaderworkerset"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-kubeflow-org-v2beta1-mpijob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-ray-io-v1-raycluster"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-ray-io-v1-rayjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-workload-codeflare-dev-v1beta2-appwrapper"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-batch-v1-job"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-jobset-x-k8s-io-v1alpha2-jobset"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-jaxjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-paddlejob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-pytorchjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-tfjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v1-xgboostjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-leaderworkerset-x-k8s-io-v1-leaderworkerset"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-kubeflow-org-v2beta1-mpijob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-ray-io-v1-raycluster"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "MutatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/mutate-ray-io-v1-rayjob"'
       - type: INSERT_TEXT
         key: .webhooks.[].name
         value: |
-            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") -}}
+            {{- if (hasKey $managerConfig "managedJobsNamespaceSelector") }}
             namespaceSelector:
-              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 -}}
+              {{- toYaml $managerConfig.managedJobsNamespaceSelector | nindent 6 }}
             {{- end }}
         onFileCondition: '.kind == "ValidatingWebhookConfiguration"'
         onItemCondition: '.webhooks.[].clientConfig.service.path == "/validate-workload-codeflare-dev-v1beta2-appwrapper"'


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

0.12.0 chart fails because of error :
YAML parse error on kueue/templates/webhook/manifests.yaml: error converting YAML to JSON: yaml: line 22: mapping values are not allowed in this context

Regression introduced in #5323


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix bug introduced in 0.12.0 about helm templating when configuring managedJobsNamespaceSelector.
```