### PR TITLE
Automated cherry pick of #5397: Fix prepare-release-branch goal to adjust KueueViz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,6 +341,7 @@ prepare-release-branch: yq kustomize ## Prepare the release branch with the rele
 	$(SED) -r 's/KUEUE_VERSION="[0-9]+\.[0-9]+\.[0-9]+/KUEUE_VERSION="$(CHART_VERSION)/g' -i cmd/kueueviz/INSTALL.md
 	$(YQ) e '.appVersion = "$(RELEASE_VERSION)"' -i charts/kueue/Chart.yaml
 	@$(call clean-manifests)
+	@$(call clean-kueueviz-manifests)
 
 .PHONY: update-security-insights
 update-security-insights: yq

--- a/config/components/kueueviz/kustomization.yaml
+++ b/config/components/kueueviz/kustomization.yaml
@@ -13,7 +13,7 @@ kind: Kustomization
 images:
 - name: backend
   newName: us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-backend
-  newTag: main
+  newTag: release-0.12
 - name: frontend
   newName: us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-frontend
-  newTag: main
+  newTag: release-0.12


### PR DESCRIPTION
Cherry pick of #5397 on release-0.12.

#5397: Fix prepare-release-branch goal to adjust KueueViz

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```