### PR TITLE
[Feature] Introduce MultiKueue Dispatcher API

### DIFF
--- a/keps/693-multikueue/README.md
+++ b/keps/693-multikueue/README.md
@@ -84,8 +84,7 @@ For each workload coming to a ClusterQueue (with the MultiKueue AdmissionCheck e
 in the management cluster, and getting past the preadmission phase in the 
 two-phase admission process (meaning that the global quota - total amount resources
 that can be consumed across all clusters - is ok), 
-MultiKueue controller will clone it in the defined worker clusters and wait 
-until some Kueue running there admits the workload.
+the MultiKueue controller will attempt to dispatch the workload to worker clusters based on the configured dispatcher strategy.
 If a remote workload is admitted first, the job will be created 
 in the remote cluster with a `kueue.x-k8s.io/prebuilt-workload-name` label pointing to that clone.
 Then it will remove the workloads from the remaining worker clusters and allow the
@@ -304,6 +303,19 @@ type MultiKueue struct {
 	GCInterval *metav1.Duration `json:"gcInterval"`
 	Origin *string `json:"origin,omitempty"`
 	WorkerLostTimeout *metav1.Duration `json:"workerLostTimeout,omitempty"`
+  Dispatcher *MultiKueueWorkloadDispatcher `json:"multiKueueWorkloadDispatcher,omitempty"`
+}
+
+type MultiKueueWorkloadDispatcher struct {
+  // Strategy defines the strategy for selecting a worker cluster to handle the workload.
+  // - All: The initial MultiKueue behavior where the workload is distributed to all workers simultaneously,
+  //        and the first worker to successfully reserve the workload's required resources is selected.
+  // - RoundRobin: Distributes the workload to one worker at a time in a circular order.
+  Strategy MultiKueueWorkloadDispatcherStrategy `json:"strategy"`
+
+  // Timeout specifies the duration given to a selected worker to attempt to reserve the workload's required resources.
+  // This field is only applicable when the Strategy is set to RoundRobin.
+  Timeout *metav1.Duration `json:"timeout,omitempty"`
 }
 ```
 
@@ -315,6 +327,7 @@ This is used by multikueue in components like its [garbage collector](#garbage-c
 that ware created by this multikueue manager cluster and delete them if their local counterpart no longer exists.
 - `WorkerLostTimeout` - defines the time a local workload's multikueue admission check state is kept Ready
 if the connection with its reserving worker cluster is lost.
+- `Dispatcher` -  configures the mechanism that determines how worker clusters are selected and attempted for processing a workload.
 
 ### Follow ups ideas
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The feature aims to improve performance and practicality by reducing the overhead of distributing workloads to all clusters simultaneously, minimizing the risk of duplicate admissions and unnecessary preemptions. 
It should  prevent triggering autoscaling across multiple worker clusters at the same time.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5141

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduce MultiKueue Dispatcher API to control how workloads are distributed and admitted across worker clusters
```