### PR TITLE
TAS: Fix using reservation is the second flavor is Provisioning

### DIFF
--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -636,6 +636,20 @@ func (c *clusterQueue) isTASOnly() bool {
 	return true
 }
 
-func (c *clusterQueue) hasProvRequestAdmissionCheck() bool {
-	return len(c.provisioningAdmissionChecks) > 0
+func (c *clusterQueue) flavorsWithProvReqAdmissionCheck() sets.Set[kueue.ResourceFlavorReference] {
+	flvs := sets.New[kueue.ResourceFlavorReference]()
+	for _, ac := range c.provisioningAdmissionChecks {
+		flvs.Insert(c.flavorsForAdmissionCheck(ac).UnsortedList()...)
+	}
+	return flvs
+}
+
+func (c *clusterQueue) flavorsForAdmissionCheck(ac kueue.AdmissionCheckReference) sets.Set[kueue.ResourceFlavorReference] {
+	flvs := sets.New(c.AdmissionChecks[ac].UnsortedList()...)
+	if len(c.AdmissionChecks[ac]) == 0 {
+		for _, rg := range c.ResourceGroups {
+			flvs.Insert(rg.Flavors...)
+		}
+	}
+	return flvs
 }

--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -58,7 +58,7 @@ type ClusterQueueSnapshot struct {
 	TASFlavors map[kueue.ResourceFlavorReference]*TASFlavorSnapshot
 	tasOnly    bool
 
-	hasProvRequestAdmissionCheck bool
+	flavorsForProvReqACs sets.Set[kueue.ResourceFlavorReference]
 }
 
 // RGByResource returns the ResourceGroup which contains capacity
@@ -225,8 +225,8 @@ func (c *ClusterQueueSnapshot) IsTASOnly() bool {
 	return c.tasOnly
 }
 
-func (c *ClusterQueueSnapshot) HasProvRequestAdmissionCheck() bool {
-	return c.hasProvRequestAdmissionCheck
+func (c *ClusterQueueSnapshot) HasProvRequestAdmissionCheck(rf kueue.ResourceFlavorReference) bool {
+	return c.flavorsForProvReqACs.Has(rf)
 }
 
 // Returns all ancestors starting with parent and ending with root

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -172,7 +172,7 @@ func snapshotClusterQueue(c *clusterQueue) *ClusterQueueSnapshot {
 		ResourceNode:                  c.resourceNode.Clone(),
 		TASFlavors:                    make(map[kueue.ResourceFlavorReference]*TASFlavorSnapshot),
 		tasOnly:                       c.isTASOnly(),
-		hasProvRequestAdmissionCheck:  c.hasProvRequestAdmissionCheck(),
+		flavorsForProvReqACs:          c.flavorsWithProvReqAdmissionCheck(),
 	}
 	for i, rg := range c.ResourceGroups {
 		cc.ResourceGroups[i] = rg.Clone()

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -44,15 +44,11 @@ func (a *Assignment) WorkloadsTopologyRequests(wl *workload.Info, cq *cache.Clus
 				// we add it to the list of TASRequests
 				continue
 			}
-			if !workload.HasQuotaReservation(wl.Obj) && cq.HasProvRequestAdmissionCheck() {
-				psAssignment.DelayedTopologyRequest = ptr.To(kueue.DelayedTopologyRequestStatePending)
-				continue
-			}
 			isTASImplied := isTASImplied(&podSet, cq)
 			psTASRequest, err := podSetTopologyRequest(psAssignment, wl, cq, isTASImplied, i)
 			if err != nil {
 				psAssignment.error(err)
-			} else {
+			} else if psTASRequest != nil {
 				tasRequests[psTASRequest.Flavor] = append(tasRequests[psTASRequest.Flavor], *psTASRequest)
 			}
 		}
@@ -87,6 +83,12 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 	tasFlvr, err := onlyFlavor(psAssignment.Flavors)
 	if err != nil {
 		return nil, err
+	}
+	if !workload.HasQuotaReservation(wl.Obj) && cq.HasProvRequestAdmissionCheck(*tasFlvr) {
+		// We delay TAS as this is the first scheduling pass, and there is a
+		// ProvisioningRequest admission check used for the flavor.
+		psAssignment.DelayedTopologyRequest = ptr.To(kueue.DelayedTopologyRequestStatePending)
+		return nil, nil
 	}
 	if cq.TASFlavors[*tasFlvr] == nil {
 		return nil, errors.New("workload requires Topology, but there is no TAS cache information for the assigned flavor")

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4641,6 +4641,83 @@ func TestScheduleForTAS(t *testing.T) {
 				},
 			},
 		},
+		"workload in CQ with two TAS flavors, only the second is using Provisioning Admission Check": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("tas-group", "reservation").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			admissionChecks: []kueue.AdmissionCheck{defaultProvCheck},
+			topologies:      []kueuealpha.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltesting.MakeResourceFlavor("tas-reservation").
+					NodeLabel("tas-group", "reservation").
+					TopologyName("tas-single-level").
+					Obj(),
+				*utiltesting.MakeResourceFlavor("tas-provisioning").
+					NodeLabel("tas-group", "provisioning").
+					TopologyName("tas-single-level").
+					Obj()},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("tas-main").
+					ResourceGroup(
+						*utiltesting.MakeFlavorQuotas("tas-reservation").
+							Resource(corev1.ResourceCPU, "1").Obj(),
+						*utiltesting.MakeFlavorQuotas("tas-provisioning").
+							Resource(corev1.ResourceCPU, "1").Obj()).
+					AdmissionCheckStrategy(kueue.AdmissionCheckStrategyRule{
+						Name: "prov-check",
+						OnFlavors: []kueue.ResourceFlavorReference{
+							kueue.ResourceFlavorReference("tas-provisioning"),
+						},
+					}).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("foo", "default").
+					Queue("tas-main").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.WorkloadReference]kueue.Admission{
+				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
+					Assignment(corev1.ResourceCPU, "tas-reservation", "1000m").
+					AssignmentPodCount(1).
+					TopologyAssignment(&kueue.TopologyAssignment{
+						Levels: utiltas.Levels(&defaultSingleLevelTopology),
+						Domains: []kueue.TopologyDomainAssignment{
+							{
+								Count: 1,
+								Values: []string{
+									"x1",
+								},
+							},
+						},
+					}).Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Namespace: "default", Name: "foo"},
+					Reason:    "QuotaReserved",
+					EventType: corev1.EventTypeNormal,
+				},
+				{
+					Key:       types.NamespacedName{Namespace: "default", Name: "foo"},
+					Reason:    "Admitted",
+					EventType: corev1.EventTypeNormal,
+				},
+			},
+		},
 		"workload with nodeToReplace annotation; second pass; baseline scenario": {
 			nodes:           defaultNodes,
 			admissionChecks: []kueue.AdmissionCheck{defaultProvCheck},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

It fixes the scenario when the first resource flavor is using reservation, and the second is using provisioning. 

In that scenario, a workload assigned to the reservation flavor is pending indefinitely as they obtains `delayedTopologyRequest: Pending` which prevents admission. At the same time it will never be set to Ready, because this flavor is not handled by second pass scheduling.

#### Special notes for your reviewer:

I'm yet investigating if there is a downstream issue if we evict from Provisioning flavor, and attempt to re-admit into reservation. I suspect there is, but I believe it can be handled in a follow up when confirmed. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fix bug which prevented admitting any workloads if the first resource flavor is reservation, and the fallback is using ProvisioningRequest.
```