### PR TITLE
Respect configured webhook.certDir in cert-manager rotator

### DIFF
--- a/apis/config/v1beta1/defaults.go
+++ b/apis/config/v1beta1/defaults.go
@@ -35,6 +35,7 @@ const (
 	DefaultWebhookServiceName                           = "kueue-webhook-service"
 	DefaultWebhookSecretName                            = "kueue-webhook-server-cert"
 	DefaultWebhookPort                                  = 9443
+	DefaultWebhookCertDir                               = "/tmp/k8s-webhook-server/serving-certs"
 	DefaultHealthProbeBindAddress                       = ":8081"
 	DefaultMetricsBindAddress                           = ":8443"
 	DefaultLeaderElectionID                             = "c1f6bfd2.kueue.x-k8s.io"
@@ -73,6 +74,9 @@ func SetDefaults_Configuration(cfg *Configuration) {
 	}
 	if cfg.Webhook.Port == nil {
 		cfg.Webhook.Port = ptr.To(DefaultWebhookPort)
+	}
+	if cfg.Webhook.CertDir == "" {
+		cfg.Webhook.CertDir = DefaultWebhookCertDir
 	}
 	if len(cfg.Metrics.BindAddress) == 0 {
 		cfg.Metrics.BindAddress = DefaultMetricsBindAddress

--- a/apis/config/v1beta1/defaults_test.go
+++ b/apis/config/v1beta1/defaults_test.go
@@ -30,6 +30,7 @@ import (
 const (
 	overwriteNamespace              = "kueue-tenant-a"
 	overwriteWebhookPort            = 9444
+	overwriteWebhookCertDir         = "/tmp/test"
 	overwriteMetricBindAddress      = ":38081"
 	overwriteHealthProbeBindAddress = ":38080"
 	overwriteLeaderElectionID       = "foo.kueue.x-k8s.io"
@@ -46,7 +47,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 			ResourceName:  "c1f6bfd2.kueue.x-k8s.io",
 		},
 		Webhook: ControllerWebhook{
-			Port: ptr.To(DefaultWebhookPort),
+			Port:    ptr.To(DefaultWebhookPort),
+			CertDir: DefaultWebhookCertDir,
 		},
 		Metrics: ControllerMetrics{
 			BindAddress: DefaultMetricsBindAddress,
@@ -139,7 +141,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				Namespace: ptr.To(DefaultNamespace),
 				ControllerManager: ControllerManager{
 					Webhook: ControllerWebhook{
-						Port: ptr.To(DefaultWebhookPort),
+						Port:    ptr.To(DefaultWebhookPort),
+						CertDir: DefaultWebhookCertDir,
 					},
 					Metrics: ControllerMetrics{
 						BindAddress: DefaultMetricsBindAddress,
@@ -170,7 +173,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 			original: &Configuration{
 				ControllerManager: ControllerManager{
 					Webhook: ControllerWebhook{
-						Port: ptr.To(overwriteWebhookPort),
+						Port:    ptr.To(overwriteWebhookPort),
+						CertDir: overwriteWebhookCertDir,
 					},
 					Metrics: ControllerMetrics{
 						BindAddress: overwriteMetricBindAddress,
@@ -197,7 +201,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				Namespace: ptr.To(DefaultNamespace),
 				ControllerManager: ControllerManager{
 					Webhook: ControllerWebhook{
-						Port: ptr.To(overwriteWebhookPort),
+						Port:    ptr.To(overwriteWebhookPort),
+						CertDir: overwriteWebhookCertDir,
 					},
 					Metrics: ControllerMetrics{
 						BindAddress: overwriteMetricBindAddress,
@@ -239,7 +244,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				Namespace: ptr.To(DefaultNamespace),
 				ControllerManager: ControllerManager{
 					Webhook: ControllerWebhook{
-						Port: ptr.To(DefaultWebhookPort),
+						Port:    ptr.To(DefaultWebhookPort),
+						CertDir: DefaultWebhookCertDir,
 					},
 					Metrics: ControllerMetrics{
 						BindAddress: DefaultMetricsBindAddress,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -354,7 +354,8 @@ objectRetentionPolicies:
 		RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 		WebhookServer: &webhook.DefaultServer{
 			Options: webhook.Options{
-				Port: configapi.DefaultWebhookPort,
+				Port:    configapi.DefaultWebhookPort,
+				CertDir: configapi.DefaultWebhookCertDir,
 			},
 		},
 	}
@@ -444,7 +445,8 @@ objectRetentionPolicies:
 				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
-						Port: configapi.DefaultWebhookPort,
+						Port:    configapi.DefaultWebhookPort,
+						CertDir: configapi.DefaultWebhookCertDir,
 					},
 				},
 			},
@@ -518,7 +520,8 @@ objectRetentionPolicies:
 				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
-						Port: 9444,
+						Port:    9444,
+						CertDir: configapi.DefaultWebhookCertDir,
 					},
 				},
 			},
@@ -598,7 +601,8 @@ objectRetentionPolicies:
 				LeaderElection:                false,
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
-						Port: configapi.DefaultWebhookPort,
+						Port:    configapi.DefaultWebhookPort,
+						CertDir: configapi.DefaultWebhookCertDir,
 					},
 				},
 			},
@@ -646,7 +650,8 @@ objectRetentionPolicies:
 				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
-						Port: configapi.DefaultWebhookPort,
+						Port:    configapi.DefaultWebhookPort,
+						CertDir: configapi.DefaultWebhookCertDir,
 					},
 				},
 			},
@@ -760,7 +765,8 @@ objectRetentionPolicies:
 				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
-						Port: configapi.DefaultWebhookPort,
+						Port:    configapi.DefaultWebhookPort,
+						CertDir: configapi.DefaultWebhookCertDir,
 					},
 				},
 			},
@@ -801,7 +807,8 @@ objectRetentionPolicies:
 				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
-						Port: configapi.DefaultWebhookPort,
+						Port:    configapi.DefaultWebhookPort,
+						CertDir: configapi.DefaultWebhookCertDir,
 					},
 				},
 			},
@@ -861,7 +868,8 @@ objectRetentionPolicies:
 				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
 				WebhookServer: &webhook.DefaultServer{
 					Options: webhook.Options{
-						Port: configapi.DefaultWebhookPort,
+						Port:    configapi.DefaultWebhookPort,
+						CertDir: configapi.DefaultWebhookCertDir,
 					},
 				},
 			},
@@ -1031,7 +1039,8 @@ func TestEncode(t *testing.T) {
 				"kind":       "Configuration",
 				"namespace":  configapi.DefaultNamespace,
 				"webhook": map[string]any{
-					"port": int64(configapi.DefaultWebhookPort),
+					"port":    int64(configapi.DefaultWebhookPort),
+					"certDir": configapi.DefaultWebhookCertDir,
 				},
 				"metrics": map[string]any{
 					"bindAddress": configapi.DefaultMetricsBindAddress,

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -28,7 +28,6 @@ import (
 )
 
 const (
-	certDir        = "/tmp/k8s-webhook-server/serving-certs"
 	vwcName        = "kueue-validating-webhook-configuration"
 	mwcName        = "kueue-mutating-webhook-configuration"
 	caName         = "kueue-ca"
@@ -49,7 +48,7 @@ func ManageCerts(mgr ctrl.Manager, cfg config.Configuration, setupFinished chan 
 			Namespace: *cfg.Namespace,
 			Name:      *cfg.InternalCertManagement.WebhookSecretName,
 		},
-		CertDir:        certDir,
+		CertDir:        cfg.Webhook.CertDir,
 		CAName:         caName,
 		CAOrganization: caOrganization,
 		DNSName:        dnsName,


### PR DESCRIPTION
The cert-manager rotator previously used a hardcoded default certificate directory (/tmp/k8s-webhook-server/serving-certs), ignoring the configured webhook.certDir value. This commit updates the logic to use the configured value if provided, falling back to the default only when necessary.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5430

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix the bug that the webhook certificate setting under `controllerManager.webhook.certDir` was ignored by the internal cert manager, effectively always defaulting to /tmp/k8s-webhook-server/serving-certs.
```