### PR TITLE
Fix "should update workload TopologyAssignment when node fails" test time

### DIFF
--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -991,11 +991,14 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				ginkgo.By("making the node NotReady", func() {
 					nodeToUpdate := &corev1.Node{}
 					gomega.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: nodeName}, nodeToUpdate)).Should(gomega.Succeed())
-					util.SetNodeCondition(ctx, k8sClient, nodeToUpdate, &corev1.NodeCondition{
-						Type:               corev1.NodeReady,
-						Status:             corev1.ConditionFalse,
-						LastTransitionTime: metav1.NewTime(time.Now()),
-					})
+					for i, cond := range nodeToUpdate.Status.Conditions {
+						if cond.Type == corev1.NodeReady {
+							nodeToUpdate.Status.Conditions[i].Status = corev1.ConditionFalse
+							nodeToUpdate.Status.Conditions[i].LastTransitionTime = metav1.NewTime(time.Now())
+							break
+						}
+					}
+					gomega.Expect(k8sClient.Status().Update(ctx, nodeToUpdate)).Should(gomega.Succeed())
 				})
 
 				ginkgo.By("verify the workload does not have the NodeToReplaceAnnotation", func() {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1086,7 +1086,7 @@ func SetNodeCondition(ctx context.Context, k8sClient client.Client, node *corev1
 			condition.Status = newCondition.Status
 			condition.LastTransitionTime = newCondition.LastTransitionTime
 			changed = true
-		case condition.LastTransitionTime != newCondition.LastTransitionTime:
+		case (condition.LastTransitionTime != newCondition.LastTransitionTime) && !newCondition.LastTransitionTime.IsZero():
 			condition.LastTransitionTime = newCondition.LastTransitionTime
 			changed = true
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5435

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```