### PR TITLE
Cleanup and extend docs on podSetMergePolicy

### DIFF
--- a/site/content/en/docs/admission-check-controllers/provisioning.md
+++ b/site/content/en/docs/admission-check-controllers/provisioning.md
@@ -66,9 +66,14 @@ It offers two options:
 - `IdenticalWorkloadSchedulingRequirements` - merges PodTemplates which have
   identical fields which are considered for defining the workload scheduling
   requirements. The PodTemplate fields which are considered as workload
-  scheduling requirements: `spec.containers[*].resources.requests`,
-  `spec.initContainers[*].resources.requests`, `spec.resources`,
-  `spec.nodeSelector`, `spec.tolerations`, `spec.affinity`, `resourceClaims`.
+  scheduling requirements: 
+  - `spec.containers[*].resources.requests`
+  - `spec.initContainers[*].resources.requests`
+  - `spec.resources`
+  - `spec.nodeSelector`
+  - `spec.tolerations`
+  - `spec.affinity`
+  - `resourceClaims`
 
 When the field is not set, the PodTemplates are not merged when creating the ProvisioningRequest, even if identical.
 

--- a/site/content/en/docs/admission-check-controllers/provisioning.md
+++ b/site/content/en/docs/admission-check-controllers/provisioning.md
@@ -63,7 +63,7 @@ Where:
 
 It offers two options:
 - `IdenticalPodTemplates` - merges only identical PodTemplates
-- `IdenticalWorkloadSchedulingRequirements`  - merges PodTemplates which have
+- `IdenticalWorkloadSchedulingRequirements` - merges PodTemplates which have
   identical fields which are considered for defining the workload scheduling
   requirements. The PodTemplate fields which are considered as workload
   scheduling requirements: `spec.containers[*].resources.requests`,

--- a/site/content/en/docs/admission-check-controllers/provisioning.md
+++ b/site/content/en/docs/admission-check-controllers/provisioning.md
@@ -61,9 +61,14 @@ Where:
 {{% alert title="Note" color="primary" %}}
 `podSetMergePolicy` feature is available in Kueue v0.12.0 version or newer.
 
-It offers two options: 
-- `IdenticalPodTemplates` - merges only identical PodTemplates 
-- `IdenticalWorkloadSchedulingRequirements`  - merges PodTemplates which have identical fields which are considered for defining the workload scheduling requirements.
+It offers two options:
+- `IdenticalPodTemplates` - merges only identical PodTemplates
+- `IdenticalWorkloadSchedulingRequirements`  - merges PodTemplates which have
+  identical fields which are considered for defining the workload scheduling
+  requirements. The PodTemplate fields which are considered as workload
+  scheduling requirements: `spec.containers[*].resources.requests`,
+  `spec.initContainers[*].resources.requests`, `spec.resources`,
+  `spec.nodeSelector`, `spec.tolerations`, `spec.affinity`, `resourceClaims`.
 
 When the field is not set, the PodTemplates are not merged when creating the ProvisioningRequest, even if identical.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

To clarify the list of fields considering PodSets when podSetMergePolicy: IndenticalWorkloadSchedulingRequirements is used.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```