### PR TITLE
Prevent removal of queue-name label in namespaces with default localqueue

### DIFF
--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -94,7 +94,7 @@ func (w *BaseWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime
 	newJob := w.FromObject(newObj)
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Validating update")
-	allErrs := ValidateJobOnUpdate(oldJob, newJob)
+	allErrs := ValidateJobOnUpdate(oldJob, newJob, w.Queues.DefaultLocalQueueExist)
 	if jobWithValidation, ok := newJob.(JobWithCustomValidation); ok {
 		allErrs = append(allErrs, jobWithValidation.ValidateOnUpdate(oldJob)...)
 	}

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -37,6 +37,7 @@ import (
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/features"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 )
 
@@ -70,8 +71,8 @@ func ValidateJobOnCreate(job GenericJob) field.ErrorList {
 }
 
 // ValidateJobOnUpdate encapsulates all GenericJob validations that must be performed on a Update operation
-func ValidateJobOnUpdate(oldJob, newJob GenericJob) field.ErrorList {
-	allErrs := validateUpdateForQueueName(oldJob, newJob)
+func ValidateJobOnUpdate(oldJob, newJob GenericJob, defaultQueueExist func(string) bool) field.ErrorList {
+	allErrs := validateUpdateForQueueName(oldJob, newJob, defaultQueueExist)
 	allErrs = append(allErrs, validateUpdateForPrebuiltWorkload(oldJob, newJob)...)
 	allErrs = append(allErrs, validateUpdateForMaxExecTime(oldJob, newJob)...)
 	allErrs = append(allErrs, validateJobUpdateForWorkloadPriorityClassName(oldJob, newJob)...)
@@ -119,11 +120,17 @@ func ValidateQueueName(obj client.Object) field.ErrorList {
 	return allErrs
 }
 
-func validateUpdateForQueueName(oldJob, newJob GenericJob) field.ErrorList {
+func validateUpdateForQueueName(oldJob, newJob GenericJob, defaultQueueExist func(string) bool) field.ErrorList {
 	var allErrs field.ErrorList
 	if !newJob.IsSuspended() {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(QueueName(newJob), QueueName(oldJob), queueNameLabelPath)...)
 	}
+	if features.Enabled(features.LocalQueueDefaulting) {
+		if QueueName(newJob) == "" && QueueName(oldJob) != "" && defaultQueueExist(oldJob.Object().GetNamespace()) {
+			allErrs = append(allErrs, field.Invalid(queueNameLabelPath, "", "queue-name must not be empty in namespace with default queue"))
+		}
+	}
+
 	return allErrs
 }
 

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -21,15 +21,69 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/podset"
+	utiltestingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 )
 
 var (
 	testPath = field.NewPath("spec")
 )
+
+type testGenericJob struct {
+	*batchv1.Job
+}
+
+var _ GenericJob = (*testGenericJob)(nil)
+
+func (j *testGenericJob) Object() client.Object {
+	return j.Job
+}
+
+func (j *testGenericJob) IsSuspended() bool {
+	return ptr.Deref(j.Spec.Suspend, false)
+}
+
+func (j *testGenericJob) Suspend() {
+	j.Spec.Suspend = ptr.To(true)
+}
+
+func (j *testGenericJob) RunWithPodSetsInfo([]podset.PodSetInfo) error {
+	panic("not implemented")
+}
+
+func (j *testGenericJob) RestorePodSetsInfo([]podset.PodSetInfo) bool {
+	panic("not implemented")
+}
+
+func (j *testGenericJob) Finished() (string, bool, bool) {
+	panic("not implemented")
+}
+
+func (j *testGenericJob) PodSets() ([]kueue.PodSet, error) {
+	panic("not implemented")
+}
+
+func (j *testGenericJob) IsActive() bool {
+	panic("not implemented")
+}
+
+func (j *testGenericJob) PodsReady() bool {
+	panic("not implemented")
+}
+
+func (j *testGenericJob) GVK() schema.GroupVersionKind {
+	panic("not implemented")
+}
 
 func TestValidateImmutablePodSpec(t *testing.T) {
 	testCases := map[string]struct {
@@ -234,6 +288,78 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			gotErr := ValidateImmutablePodGroupPodSpec(tc.newPodSpec, tc.oldPodSpec, testPath)
+			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
+				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateUpdateForQueueName(t *testing.T) {
+	t.Cleanup(EnableIntegrationsForTest(t, "batch/job"))
+	fieldString := field.NewPath("metadata").Child("labels").Key(constants.QueueLabel).String()
+	testCases := map[string]struct {
+		oldJob                   *batchv1.Job
+		newJob                   *batchv1.Job
+		defaultLocalQueueEnabled bool
+		nsHasDefaultQueue        bool
+		wantErr                  field.ErrorList
+	}{
+		"local queue cannot be changed if job is not suspended": {
+			oldJob:                   utiltestingjob.MakeJob("test-job", "ns1").Queue("lq1").Suspend(false).Obj(),
+			newJob:                   utiltestingjob.MakeJob("test-job", "ns1").Queue("lq2").Suspend(false).Obj(),
+			defaultLocalQueueEnabled: true,
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: fieldString,
+				},
+			},
+		},
+		"local queue can be changed": {
+			oldJob:                   utiltestingjob.MakeJob("test-job", "ns1").Queue("lq1").Suspend(true).Obj(),
+			newJob:                   utiltestingjob.MakeJob("test-job", "ns1").Queue("lq2").Suspend(true).Obj(),
+			nsHasDefaultQueue:        true,
+			defaultLocalQueueEnabled: true,
+		},
+		"local queue can be changed from default": {
+			oldJob:                   utiltestingjob.MakeJob("test-job", "ns1").Queue("default").Suspend(true).Obj(),
+			newJob:                   utiltestingjob.MakeJob("test-job", "ns1").Queue("lq2").Suspend(true).Obj(),
+			nsHasDefaultQueue:        true,
+			defaultLocalQueueEnabled: true,
+		},
+		"local queue cannot be removed if default queue exists and feature is enabled": {
+			oldJob:                   utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("lq1").Obj(),
+			newJob:                   utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("").Obj(),
+			nsHasDefaultQueue:        true,
+			defaultLocalQueueEnabled: true,
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: fieldString,
+				},
+			},
+		},
+		"local queue can be removed if default queue does not exists and feature is enabled": {
+			oldJob:                   utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("lq1").Obj(),
+			newJob:                   utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("").Obj(),
+			nsHasDefaultQueue:        false,
+			defaultLocalQueueEnabled: true,
+		},
+		"local queue can be removed if feature is not enabled": {
+			oldJob:                   utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("lq1").Obj(),
+			newJob:                   utiltestingjob.MakeJob("test-job", "ns1").Suspend(true).Queue("").Obj(),
+			nsHasDefaultQueue:        true,
+			defaultLocalQueueEnabled: false,
+		},
+	}
+
+	for tcName, tc := range testCases {
+		t.Run(tcName, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.defaultLocalQueueEnabled)
+			oldGJ := &testGenericJob{Job: tc.oldJob}
+			newGJ := &testGenericJob{Job: tc.newJob}
+			gotErr := validateUpdateForQueueName(oldGJ, newGJ, func(string) bool { return tc.nsHasDefaultQueue })
 			if diff := cmp.Diff(tc.wantErr, gotErr, cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
 			}

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -157,7 +157,7 @@ func (w *JobWebhook) validateUpdate(oldJob, newJob *Job) field.ErrorList {
 		allErrs = append(allErrs, w.validatePartialAdmissionCreate(newJob)...)
 	}
 	allErrs = append(allErrs, w.validateSyncCompletionCreate(newJob)...)
-	allErrs = append(allErrs, jobframework.ValidateJobOnUpdate(oldJob, newJob)...)
+	allErrs = append(allErrs, jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)...)
 	allErrs = append(allErrs, validatePartialAdmissionUpdate(oldJob, newJob)...)
 	allErrs = append(allErrs, w.validateTopologyRequest(newJob)...)
 	return allErrs

--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -106,7 +106,7 @@ func (w *JobSetWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runti
 
 func (w *JobSetWebhook) validateUpdate(oldJob, newJob *JobSet) field.ErrorList {
 	var allErrs field.ErrorList
-	allErrs = append(allErrs, jobframework.ValidateJobOnUpdate(oldJob, newJob)...)
+	allErrs = append(allErrs, jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)...)
 	allErrs = append(allErrs, w.validateCreate(newJob)...)
 	return allErrs
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -285,6 +285,21 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
+		"delete queue name": {
+			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Obj(),
+			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: queueNameLabelPath.String(),
+				},
+			}.ToAggregate(),
+		},
 		"change priority class when suspended": {
 			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				LeaderTemplate(corev1.PodTemplateSpec{}).

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -105,7 +105,7 @@ func (w *MpiJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runti
 	newMpiJob := fromObject(newObj)
 	log := ctrl.LoggerFrom(ctx).WithName("mpijob-webhook")
 	log.Info("Validating update")
-	allErrs := jobframework.ValidateJobOnUpdate(oldMpiJob, newMpiJob)
+	allErrs := jobframework.ValidateJobOnUpdate(oldMpiJob, newMpiJob, w.queues.DefaultLocalQueueExist)
 	allErrs = append(allErrs, w.validateCommon(newMpiJob)...)
 	return nil, allErrs.ToAggregate()
 }

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -242,7 +242,7 @@ func (w *PodWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.
 	log := ctrl.LoggerFrom(ctx).WithName("pod-webhook")
 	log.V(5).Info("Validating update")
 
-	allErrs := jobframework.ValidateJobOnUpdate(oldPod, newPod)
+	allErrs := jobframework.ValidateJobOnUpdate(oldPod, newPod, w.queues.DefaultLocalQueueExist)
 	allErrs = append(allErrs, validateCommon(newPod)...)
 	allErrs = append(allErrs, validateUpdateForRetriableInGroupAnnotation(oldPod, newPod)...)
 

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -149,7 +149,7 @@ func (w *RayClusterWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj r
 	log := ctrl.LoggerFrom(ctx).WithName("raycluster-webhook")
 	if w.manageJobsWithoutQueueName || jobframework.QueueName((*RayCluster)(newJob)) != "" {
 		log.Info("Validating update")
-		allErrors := jobframework.ValidateJobOnUpdate((*RayCluster)(oldJob), (*RayCluster)(newJob))
+		allErrors := jobframework.ValidateJobOnUpdate((*RayCluster)(oldJob), (*RayCluster)(newJob), w.queues.DefaultLocalQueueExist)
 		allErrors = append(allErrors, w.validateCreate(newJob)...)
 		return nil, allErrors.ToAggregate()
 	}

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -161,7 +161,7 @@ func (w *RayJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj runti
 	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
 	if w.manageJobsWithoutQueueName || jobframework.QueueName((*RayJob)(newJob)) != "" {
 		log.Info("Validating update")
-		allErrors := jobframework.ValidateJobOnUpdate((*RayJob)(oldJob), (*RayJob)(newJob))
+		allErrors := jobframework.ValidateJobOnUpdate((*RayJob)(oldJob), (*RayJob)(newJob), w.queues.DefaultLocalQueueExist)
 		allErrors = append(allErrors, w.validateCreate(newJob)...)
 		return nil, allErrors.ToAggregate()
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:

The localQueueDefaulting feature enables cluster admins to configure namespaces with default localQueues, thus ensuring that all instances of Kinds that are being managed by Kueue that are created in such a namespace will have
`kueue.x-k8s.io/queue-name` labels.  However, nothing prevented a user from editing a job after it was created
to remove the label.  Without such enforcement, a user can easily bypass the admin-created mechanism for quota enforcement by editing a job to remove its local queue label and setting suspend to false.

This PR extends the validation logic for queue name updates to prevent them from being removed in namespaces with default local queues when localQueueDefaulting is enabled. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug that would allow a user to bypass localQueueDefaulting.
```