### PR TITLE
Automated cherry pick of #5426: TAS: Fix using reservation is the second flavor is Provisioning

### DIFF
--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -638,6 +638,20 @@ func (c *clusterQueue) isTASOnly() bool {
 	return true
 }
 
-func (c *clusterQueue) hasProvRequestAdmissionCheck() bool {
-	return len(c.provisioningAdmissionChecks) > 0
+func (c *clusterQueue) flavorsWithProvReqAdmissionCheck() sets.Set[kueue.ResourceFlavorReference] {
+	flvs := sets.New[kueue.ResourceFlavorReference]()
+	for _, ac := range c.provisioningAdmissionChecks {
+		flvs.Insert(c.flavorsForAdmissionCheck(ac).UnsortedList()...)
+	}
+	return flvs
+}
+
+func (c *clusterQueue) flavorsForAdmissionCheck(ac kueue.AdmissionCheckReference) sets.Set[kueue.ResourceFlavorReference] {
+	flvs := sets.New(c.AdmissionChecks[ac].UnsortedList()...)
+	if len(c.AdmissionChecks[ac]) == 0 {
+		for _, rg := range c.ResourceGroups {
+			flvs.Insert(rg.Flavors...)
+		}
+	}
+	return flvs
 }

--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -57,7 +57,7 @@ type ClusterQueueSnapshot struct {
 	TASFlavors map[kueue.ResourceFlavorReference]*TASFlavorSnapshot
 	tasOnly    bool
 
-	hasProvRequestAdmissionCheck bool
+	flavorsForProvReqACs sets.Set[kueue.ResourceFlavorReference]
 }
 
 // RGByResource returns the ResourceGroup which contains capacity
@@ -226,8 +226,8 @@ func (c *ClusterQueueSnapshot) IsTASOnly() bool {
 	return c.tasOnly
 }
 
-func (c *ClusterQueueSnapshot) HasProvRequestAdmissionCheck() bool {
-	return c.hasProvRequestAdmissionCheck
+func (c *ClusterQueueSnapshot) HasProvRequestAdmissionCheck(rf kueue.ResourceFlavorReference) bool {
+	return c.flavorsForProvReqACs.Has(rf)
 }
 
 // Returns all ancestors starting with parent and ending with root

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -172,7 +172,7 @@ func snapshotClusterQueue(c *clusterQueue) *ClusterQueueSnapshot {
 		ResourceNode:                  c.resourceNode.Clone(),
 		TASFlavors:                    make(map[kueue.ResourceFlavorReference]*TASFlavorSnapshot),
 		tasOnly:                       c.isTASOnly(),
-		hasProvRequestAdmissionCheck:  c.hasProvRequestAdmissionCheck(),
+		flavorsForProvReqACs:          c.flavorsWithProvReqAdmissionCheck(),
 	}
 	for i, rg := range c.ResourceGroups {
 		cc.ResourceGroups[i] = rg.Clone()

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -44,15 +44,11 @@ func (a *Assignment) WorkloadsTopologyRequests(wl *workload.Info, cq *cache.Clus
 				// we add it to the list of TASRequests
 				continue
 			}
-			if !workload.HasQuotaReservation(wl.Obj) && cq.HasProvRequestAdmissionCheck() {
-				psAssignment.DelayedTopologyRequest = ptr.To(kueue.DelayedTopologyRequestStatePending)
-				continue
-			}
 			isTASImplied := isTASImplied(&podSet, cq)
 			psTASRequest, err := podSetTopologyRequest(psAssignment, wl, cq, isTASImplied, i)
 			if err != nil {
 				psAssignment.error(err)
-			} else {
+			} else if psTASRequest != nil {
 				tasRequests[psTASRequest.Flavor] = append(tasRequests[psTASRequest.Flavor], *psTASRequest)
 			}
 		}
@@ -87,6 +83,12 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 	tasFlvr, err := onlyFlavor(psAssignment.Flavors)
 	if err != nil {
 		return nil, err
+	}
+	if !workload.HasQuotaReservation(wl.Obj) && cq.HasProvRequestAdmissionCheck(*tasFlvr) {
+		// We delay TAS as this is the first scheduling pass, and there is a
+		// ProvisioningRequest admission check used for the flavor.
+		psAssignment.DelayedTopologyRequest = ptr.To(kueue.DelayedTopologyRequestStatePending)
+		return nil, nil
 	}
 	if cq.TASFlavors[*tasFlvr] == nil {
 		return nil, errors.New("workload requires Topology, but there is no TAS cache information for the assigned flavor")


### PR DESCRIPTION
Cherry pick of #5426 on release-0.12.

#5426: TAS: Fix using reservation is the second flavor is Provisioning

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
TAS: Fix bug which prevented admitting any workloads if the first resource flavor is reservation, and the fallback is using ProvisioningRequest.
```