### PR TITLE
TAS: Keep level ordering even when algorithm is LeastFreeCapacityAlgorithm

### DIFF
--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -556,13 +556,13 @@ func TestFindTopologyAssignment(t *testing.T) {
 					{
 						Count: 1,
 						Values: []string{
-							"x3",
+							"x2",
 						},
 					},
 					{
 						Count: 1,
 						Values: []string{
-							"x5",
+							"x3",
 						},
 					},
 				},
@@ -712,7 +712,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					{
 						Count: 1,
 						Values: []string{
-							"x5",
+							"x1",
 						},
 					},
 				},
@@ -735,7 +735,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					{
 						Count: 1,
 						Values: []string{
-							"x5",
+							"x1",
 						},
 					},
 				},
@@ -863,7 +863,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					{
 						Count: 1,
 						Values: []string{
-							"x5",
+							"x1",
 						},
 					},
 				},
@@ -979,7 +979,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					{
 						Count: 1,
 						Values: []string{
-							"x5",
+							"x1",
 						},
 					},
 				},

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -808,18 +808,20 @@ func (s *TASFlavorSnapshot) lowerLevelDomains(domains []*domain) []*domain {
 }
 
 func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool) []*domain {
+	isLeastFreeCapacity := useLeastFreeCapacityAlgorithm(unconstrained)
 	result := slices.Clone(domains)
 	slices.SortFunc(result, func(a, b *domain) int {
 		if a.state == b.state {
 			return slices.Compare(a.levelValues, b.levelValues)
 		}
-		// descending order.
+		if isLeastFreeCapacity {
+			// Start from the domain with the least amount of free resources.
+			// Ascending order.
+			return cmp.Compare(a.state, b.state)
+		}
+		// Descending order.
 		return cmp.Compare(b.state, a.state)
 	})
-	if useLeastFreeCapacityAlgorithm(unconstrained) {
-		// start from the domain with the least amount of free resources
-		slices.Reverse(result)
-	}
 	return result
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In the current TAS domain sorting algorithm with LeastFreeCapacityAlgorihtm, it violates the domain level ordering.
However, we should keep the level ordering even when the algorithm is LeastFreeCapacityAlgorithm.

For example, if the cluster has a flat host domain in the following, the LeastFreeCapacityAlgorihtm selects `x3`.
However, the expectation is `x1`.

```
x1 (free cpu=1) x2 (free cpu=2) x3 (free cpu=1)
```


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Before this PR, `sortedDomains()` sorts in the following steps:

1. The sort func (`slices.SortFunc`) sorts in descending order

```
x2 (free cpu=2) x1 (free cpu=1) x3 (free cpu=1)
```

2. The reverse func (`slices.Reverse`) just reverses those, ignoring level ordering:

```
x3 (free cpu=1) x1 (free cpu=1) x2 (free cpu=2)
```

Since this PR, `sortedDomains()` sorts in the following:

```
x1 (free cpu=1) x3 (free cpu=1) x2 (free cpu=2)
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fix a bug that LeastFreeCapacityAlgorithm does not respect level ordering
```