### PR TITLE
Doc: Add missing FGs to installation guide

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -261,47 +261,52 @@ spec:
 
 ### Feature gates for alpha and beta features
 
-| Feature                               | Default | Stage      | Since | Until |
-|---------------------------------------|---------|------------|-------|-------|
-| `FlavorFungibility`                   | `true`  | Beta       | 0.5   |       |
-| `MultiKueue`                          | `false` | Alpha      | 0.6   | 0.8   |
-| `MultiKueue`                          | `true`  | Beta       | 0.9   |       |
-| `MultiKueueBatchJobWithManagedBy`     | `false` | Alpha      | 0.8   |       |
-| `PartialAdmission`                    | `false` | Alpha      | 0.4   | 0.4   |
-| `PartialAdmission`                    | `true`  | Beta       | 0.5   |       |
-| `ProvisioningACC`                     | `false` | Alpha      | 0.5   | 0.6   |
-| `ProvisioningACC`                     | `true`  | Beta       | 0.7   |       |
-| `QueueVisibility`                     | `false` | Alpha      | 0.5   | 0.9   |
-| `VisibilityOnDemand`                  | `false` | Alpha      | 0.6   |  0.8  |
-| `VisibilityOnDemand`                  | `true`  | Beta       | 0.9   |       |
-| `PrioritySortingWithinCohort`         | `true`  | Beta       | 0.6   |       |
-| `LendingLimit`                        | `false` | Alpha      | 0.6   | 0.8   |
-| `LendingLimit`                        | `true`  | Beta       | 0.9   |       |
-| `MultiplePreemptions`                 | `false` | Alpha      | 0.8   | 0.8   |
-| `MultiplePreemptions`                 | `true`  | Beta       | 0.9   | 0.9   |
-| `TopologyAwareScheduling`             | `false` | Alpha      | 0.9   |       |
-| `ConfigurableResourceTransformations` | `false` | Alpha      | 0.9   | 0.9   |
-| `ConfigurableResourceTransformations` | `true`  | Beta       | 0.10  |       |
-| `WorkloadResourceRequestsSummary`     | `false` | Alpha      | 0.9   | 0.9   |
-| `WorkloadResourceRequestsSummary`     | `true`  | Beta       | 0.10  | 0.10  |
-| `ManagedJobsNamespaceSelector`        | `true`  | Beta       | 0.10  |       |
-| `LocalQueueDefaulting`                | `false` | Alpha      | 0.10  | 0.11  |
-| `LocalQueueDefaulting`                | `true`  | Beta       | 0.12  |       |
-| `LocalQueueMetrics`                   | `false` | Alpha      | 0.10  |       |
-| `ObjectRetentionPolicies`             | `false` | Alpha      | 0.12  |       |
+| Feature                               | Default | Stage | Since | Until |
+|---------------------------------------|---------|-------|-------|-------|
+| `FlavorFungibility`                   | `true`  | Beta  | 0.5   |       |
+| `MultiKueue`                          | `false` | Alpha | 0.6   | 0.8   |
+| `MultiKueue`                          | `true`  | Beta  | 0.9   |       |
+| `MultiKueueBatchJobWithManagedBy`     | `false` | Alpha | 0.8   |       |
+| `PartialAdmission`                    | `false` | Alpha | 0.4   | 0.4   |
+| `PartialAdmission`                    | `true`  | Beta  | 0.5   |       |
+| `ProvisioningACC`                     | `false` | Alpha | 0.5   | 0.6   |
+| `ProvisioningACC`                     | `true`  | Beta  | 0.7   |       |
+| `QueueVisibility`                     | `false` | Alpha | 0.5   | 0.9   |
+| `VisibilityOnDemand`                  | `false` | Alpha | 0.6   | 0.8   |
+| `VisibilityOnDemand`                  | `true`  | Beta  | 0.9   |       |
+| `PrioritySortingWithinCohort`         | `true`  | Beta  | 0.6   |       |
+| `LendingLimit`                        | `false` | Alpha | 0.6   | 0.8   |
+| `LendingLimit`                        | `true`  | Beta  | 0.9   |       |
+| `MultiplePreemptions`                 | `false` | Alpha | 0.8   | 0.8   |
+| `MultiplePreemptions`                 | `true`  | Beta  | 0.9   | 0.9   |
+| `TopologyAwareScheduling`             | `false` | Alpha | 0.9   |       |
+| `ConfigurableResourceTransformations` | `false` | Alpha | 0.9   | 0.9   |
+| `ConfigurableResourceTransformations` | `true`  | Beta  | 0.10  |       |
+| `WorkloadResourceRequestsSummary`     | `false` | Alpha | 0.9   | 0.9   |
+| `WorkloadResourceRequestsSummary`     | `true`  | Beta  | 0.10  | 0.10  |
+| `ManagedJobsNamespaceSelector`        | `true`  | Beta  | 0.10  |       |
+| `LocalQueueDefaulting`                | `false` | Alpha | 0.10  | 0.11  |
+| `LocalQueueDefaulting`                | `true`  | Beta  | 0.12  |       |
+| `LocalQueueMetrics`                   | `false` | Alpha | 0.10  |       |
+| `HierarchicalCohort`                  | `true`  | Beta  | 0.11  |       |
+| `ObjectRetentionPolicies`             | `false` | Alpha | 0.12  |       |
+| `TASFailedNodeReplacement`            | `false` | Alpha | 0.12  |       |
 
 ### Feature gates for graduated or deprecated features
 
-| Feature                               | Default | Stage      | Since | Until |
-|---------------------------------------|---------|------------|-------|-------|
-| `QueueVisibility`                     | `false` | Alpha      | 0.4   | 0.9   |
-| `QueueVisibility`                     | `false` | Deprecated | 0.9   |       |
-| `MultiplePreemptions`                 | `false` | Alpha      | 0.8   | 0.8   |
-| `MultiplePreemptions`                 | `true`  | Beta       | 0.9   | 0.9   |
-| `MultiplePreemptions`                 | `true`  | GA         | 0.10  |       |
-| `WorkloadResourceRequestsSummary`     | `false` | Alpha      | 0.9   | 0.10  |
-| `WorkloadResourceRequestsSummary`     | `true`  | Beta       | 0.10  | 0.11  |
-| `WorkloadResourceRequestsSummary`     | `true`  | GA         | 0.11  |       |
+| Feature                           | Default | Stage      | Since | Until |
+|-----------------------------------|---------|------------|-------|-------|
+| `QueueVisibility`                 | `false` | Alpha      | 0.4   | 0.9   |
+| `QueueVisibility`                 | `false` | Deprecated | 0.9   |       |
+| `MultiplePreemptions`             | `false` | Alpha      | 0.8   | 0.8   |
+| `MultiplePreemptions`             | `true`  | Beta       | 0.9   | 0.9   |
+| `MultiplePreemptions`             | `true`  | GA         | 0.10  |       |
+| `WorkloadResourceRequestsSummary` | `false` | Alpha      | 0.9   | 0.10  |
+| `WorkloadResourceRequestsSummary` | `true`  | Beta       | 0.10  | 0.11  |
+| `WorkloadResourceRequestsSummary` | `true`  | GA         | 0.11  |       |
+| `TASProfileMostFreeCapacity`      | `false` | Deprecated | 0.11  |       |
+| `TASProfileLeastFreeCapacity`     | `false` | Deprecated | 0.11  |       |
+| `TASProfileMixed`                 | `false` | Deprecated | 0.11  |       |
 
 ## What's next
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
There are no below FGs in the installation guides.

- HierarchicalCohort
- TASFailedNodeReplacement
- TASProfileMostFreeCapacity
- TASProfileLeastFreeCapacity
- TASProfileMixed
- AdmissionFairSharing

However, I did not add AdmissionFairSharing in this PR since https://github.com/kubernetes-sigs/kueue/pull/5476 tries to introduce it to the list.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```