### PR TITLE
Automated cherry pick of #5521: Remove redundant EXTRA_TAG variable from helm-chart-package.sh.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,8 +227,7 @@ image-push: image-build
 .PHONY: helm-chart-package
 helm-chart-package: yq helm ## Package a chart into a versioned chart archive file.
 	DEST_CHART_DIR=$(DEST_CHART_DIR) \
-	HELM="$(HELM)" YQ="$(YQ)" EXTRA_TAG="$(EXTRA_TAG)" GIT_TAG="$(GIT_TAG)" \
-	IMAGE_REGISTRY="$(IMAGE_REGISTRY)" IMAGE_REPO="$(IMAGE_REPO)" \
+	HELM="$(HELM)" YQ="$(YQ)" GIT_TAG="$(GIT_TAG)" IMAGE_REGISTRY="$(IMAGE_REGISTRY)" \
 	HELM_CHART_PUSH=$(HELM_CHART_PUSH) HELM_CHART_REPO=$(HELM_CHART_REPO) \
 	./hack/helm-chart-package.sh
 

--- a/hack/helm-chart-package.sh
+++ b/hack/helm-chart-package.sh
@@ -20,13 +20,11 @@ set -o pipefail
 
 DEST_CHART_DIR=${DEST_CHART_DIR:-bin/}
 
-EXTRA_TAG=${EXTRA_TAG:-$(git branch --show-current)}
 GIT_TAG=${GIT_TAG:-$(git describe --tags --dirty --always)}
 
 STAGING_IMAGE_REGISTRY=${STAGING_IMAGE_REGISTRY:-us-central1-docker.pkg.dev/k8s-staging-images}
 IMAGE_REGISTRY=${IMAGE_REGISTRY:-${STAGING_IMAGE_REGISTRY}/kueue}
 HELM_CHART_REPO=${HELM_CHART_REPO:-${STAGING_IMAGE_REGISTRY}/kueue/charts}
-IMAGE_REPO=${IMAGE_REPO:-${IMAGE_REGISTRY}/kueue}
 
 HELM=${HELM:-./bin/helm}
 YQ=${YQ:-./bin/yq}
@@ -34,23 +32,20 @@ YQ=${YQ:-./bin/yq}
 readonly k8s_registry="registry.k8s.io/kueue"
 readonly semver_regex='^v([0-9]+)(\.[0-9]+){1,2}$'
 
-image_repository=${IMAGE_REPO}
-app_version=${GIT_TAG}
-if [[ ${EXTRA_TAG} =~ ${semver_regex} ]]
+if [[ ${GIT_TAG} =~ ${semver_regex} ]]
 then
-	image_repository=${k8s_registry}/kueue
-	app_version=${EXTRA_TAG}
+	IMAGE_REGISTRY=${k8s_registry}
 fi
 # Strip leading v from version
-chart_version="${app_version/#v/}"
+chart_version="${GIT_TAG/#v/}"
 
 default_image_repo=$(${YQ} ".controllerManager.manager.image.repository" charts/kueue/values.yaml)
 readonly default_image_repo
 
 # Update the image repo, tag and policy
-${YQ}  e  ".controllerManager.manager.image.repository = \"${image_repository}\" | .controllerManager.manager.image.tag = \"${app_version}\" | .controllerManager.manager.image.pullPolicy = \"IfNotPresent\"" -i charts/kueue/values.yaml
+${YQ}  e  ".controllerManager.manager.image.repository = \"${IMAGE_REGISTRY}/kueue\" | .controllerManager.manager.image.tag = \"${GIT_TAG}\" | .controllerManager.manager.image.pullPolicy = \"IfNotPresent\"" -i charts/kueue/values.yaml
 
-${HELM} package --version "${chart_version}" --app-version "${app_version}" charts/kueue -d "${DEST_CHART_DIR}"
+${HELM} package --version "${chart_version}" --app-version "${GIT_TAG}" charts/kueue -d "${DEST_CHART_DIR}"
 
 # Revert the image changes
 ${YQ}  e  ".controllerManager.manager.image.repository = \"${default_image_repo}\" | del(.controllerManager.manager.image.tag) | .controllerManager.manager.image.pullPolicy = \"Always\"" -i charts/kueue/values.yaml


### PR DESCRIPTION
Cherry pick of #5521 on release-0.11.

#5521: Remove redundant EXTRA_TAG variable from helm-chart-package.sh.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```