### PR TITLE
Automated cherry pick of #5525: Change repo only for promoted images in helm chart package.

### DIFF
--- a/hack/helm-chart-package.sh
+++ b/hack/helm-chart-package.sh
@@ -30,9 +30,11 @@ HELM=${HELM:-./bin/helm}
 YQ=${YQ:-./bin/yq}
 
 readonly k8s_registry="registry.k8s.io/kueue"
-readonly semver_regex='^v([0-9]+)(\.[0-9]+){1,2}$'
+# This regex matches only Kueue versions for which the images are
+# going to be promoted to registry.k8s.io.
+readonly promoted_version_regex='^v([0-9]+)(\.[0-9]+){1,2}$'
 
-if [[ ${GIT_TAG} =~ ${semver_regex} ]]
+if [[ ${GIT_TAG} =~ ${promoted_version_regex} ]]
 then
 	IMAGE_REGISTRY=${k8s_registry}
 fi


### PR DESCRIPTION
Cherry pick of #5525 on release-0.11.

#5525: Change repo only for promoted images in helm chart package.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```