### PR TITLE
Drop MostFreeCapacity mode

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -731,7 +731,6 @@ For a given PodSet Kueue:
   does not fit, then it tries higher levels in the hierarchy.
 
 Kueue places pods on domains with different algorithms, depending on the annotation and chosen profile:
-- `MostFreeCapacity` algorithm - Kueue selects as many domains as needed (if it meets user's requirement) starting from the one with the most free capacity;
 - `LeastFreeCapacity` algorithm - Kueue selects as many domains as needed (if it meets user's requirement) starting from the one with the least free capacity;
 - `BestFit` algorithm (default) - Kueue selects as many domains as needed (if it meets user's requirement) starting from the one with the most free capacity.
 However, it optimizes the selection of the last domain at each level to minimize the remaining free resources.
@@ -739,10 +738,9 @@ However, it optimizes the selection of the last domain at each level to minimize
 #### Example
 Consider a rack with four nodes that can accommodate 3, 3, 2, and 1 pod, respectively. A PodSet consists of 7 pods.
 
-Both the BestFit and MostFreeCapacity algorithms will initially iterate over the nodes and select the first two nodes,
-each with 3 available pods, as they possess the most free capacity. With 1 pod remaining to schedule, the difference between the algorithms becomes apparent:
-- The `BestFit` algorithm optimizes the choice of the last node (domain) and selects the node that can accommodate exactly 1 pod.
-- The `MostFreeCapacity` algorithm simply selects the node with the most remaining free capacity, which is 2 in this case.
+BestFit algorithm iterates over the nodes and select the first two nodes,
+each with 3 available pods, as they possess the most free capacity. With 1 pod remaining to schedule, 
+algorithm optimizes the choice of the last node (domain) and selects the node that can accommodate exactly 1 pod.
 
 The `LeastFreeCapacity` algorithm iterates over the nodes in reverse order.
 Consequently, it selects the nodes with 1, 2, 3, and 3 available pods, reserving capacity for only 1 pod on the last node.
@@ -752,7 +750,6 @@ Selection of the algorithm depends on TAS profiles expressed by feature gates, a
 | featuregate/annotation                   | preferred         | required          | unconstrained     |
 | ---------------------------------------- | ----------------- | ----------------- | ----------------- |
 | None                                     | BestFit           | BestFit           | BestFit           |
-| TASProfileMostFreeCapacity (deprecated)  | MostFreeCapacity  | MostFreeCapacity  | MostFreeCapacity  |
 | TASProfileMixed (deprecated)             | BestFit           | BestFit           | LeastFreeCapacity |
 | TASProfileLeastFreeCapacity (deprecated) | LeastFreeCapacity | LeastFreeCapacity | LeastFreeCapacity |
 

--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -290,7 +290,6 @@ func TestFindTopologyAssignment(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		// TODO: remove after dropping the TASMostFreeCapacity feature gate
 		enableFeatureGates []featuregate.Feature
 		wantReason         string
 		topologyRequest    *kueue.PodSetTopologyRequest
@@ -304,8 +303,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 		tolerations        []corev1.Toleration
 		wantAssignment     *kueue.TopologyAssignment
 	}{
-		// TODO: remove suffixes MostFreeCapacity/BestFit after dropping the TASMostFreeCapacity feature gate
-		"minimize the number of used racks before optimizing the number of nodes; MostFreeCapacity": {
+		"minimize the number of used racks before optimizing the number of nodes; BestFit": {
 			// Solution by optimizing the number of racks then nodes: [r3]: [x3,x4,x5,x6]
 			// Solution by optimizing the number of nodes: [r1,r2]: [x1,x2]
 			//
@@ -414,7 +412,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 					},
 				},
 			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			enableFeatureGates: []featuregate.Feature{},
 		},
 		"minimize resource fragmentation; LeastFreeCapacityFit": {
 			//        b1
@@ -622,35 +620,6 @@ func TestFindTopologyAssignment(t *testing.T) {
 				},
 			},
 		},
-		"unconstrained; 6 pods fit into hosts scattered across the whole datacenter even they could fit into single rack; MostFreeCapacityFit": {
-			nodes: scatteredNodes,
-			topologyRequest: &kueue.PodSetTopologyRequest{
-				Unconstrained: ptr.To(true),
-			},
-			levels: defaultThreeLevels,
-			requests: resources.Requests{
-				corev1.ResourceCPU: 1000,
-			},
-			count: 6,
-			wantAssignment: &kueue.TopologyAssignment{
-				Levels: defaultOneLevel,
-				Domains: []kueue.TopologyDomainAssignment{
-					{
-						Count: 4,
-						Values: []string{
-							"x1",
-						},
-					},
-					{
-						Count: 2,
-						Values: []string{
-							"x4",
-						},
-					},
-				},
-			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
-		},
 		"unconstrained; a single pod fits into each host; BestFit": {
 			nodes: defaultNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
@@ -672,29 +641,6 @@ func TestFindTopologyAssignment(t *testing.T) {
 					},
 				},
 			},
-		},
-		"unconstrained; a single pod fits into each host; MostFreeCapacity": {
-			nodes: defaultNodes,
-			topologyRequest: &kueue.PodSetTopologyRequest{
-				Unconstrained: ptr.To(true),
-			},
-			levels: defaultThreeLevels,
-			requests: resources.Requests{
-				corev1.ResourceCPU: 1000,
-			},
-			count: 1,
-			wantAssignment: &kueue.TopologyAssignment{
-				Levels: defaultOneLevel,
-				Domains: []kueue.TopologyDomainAssignment{
-					{
-						Count: 1,
-						Values: []string{
-							"x6",
-						},
-					},
-				},
-			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
 		"unconstrained; a single pod fits into each host; LeastFreeCapacity; TASProfileLeastFreeCapacity": {
 			nodes: defaultNodes,
@@ -742,47 +688,6 @@ func TestFindTopologyAssignment(t *testing.T) {
 			},
 			enableFeatureGates: []featuregate.Feature{features.TASProfileMixed},
 		},
-		"block required; 4 pods fit into one host each; MostFreeCapacity": {
-			nodes: binaryTreesNodes,
-			topologyRequest: &kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasBlockLabel),
-			},
-			levels: defaultThreeLevels,
-			requests: resources.Requests{
-				corev1.ResourceCPU: 1000,
-			},
-			count: 4,
-			wantAssignment: &kueue.TopologyAssignment{
-				Levels: defaultOneLevel,
-				Domains: []kueue.TopologyDomainAssignment{
-					{
-						Count: 1,
-						Values: []string{
-							"x1",
-						},
-					},
-					{
-						Count: 1,
-						Values: []string{
-							"x2",
-						},
-					},
-					{
-						Count: 1,
-						Values: []string{
-							"x3",
-						},
-					},
-					{
-						Count: 1,
-						Values: []string{
-							"x4",
-						},
-					},
-				},
-			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
-		},
 		"block required; 4 pods fit into one host each; BestFit": {
 			nodes: binaryTreesNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
@@ -822,30 +727,6 @@ func TestFindTopologyAssignment(t *testing.T) {
 					},
 				},
 			},
-		},
-		"host required; single Pod fits in the host; MostFreeCapacity": {
-			// TODO: remove after dropping the TASMostFreeCapacity feature gate
-			nodes: defaultNodes,
-			topologyRequest: &kueue.PodSetTopologyRequest{
-				Required: ptr.To(corev1.LabelHostname),
-			},
-			levels: defaultThreeLevels,
-			requests: resources.Requests{
-				corev1.ResourceCPU: 1000,
-			},
-			count: 1,
-			wantAssignment: &kueue.TopologyAssignment{
-				Levels: defaultOneLevel,
-				Domains: []kueue.TopologyDomainAssignment{
-					{
-						Count: 1,
-						Values: []string{
-							"x6",
-						},
-					},
-				},
-			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
 		"host required; single Pod fits in the host; LeastFreeCapacityFit": {
 			nodes: defaultNodes,
@@ -938,31 +819,6 @@ func TestFindTopologyAssignment(t *testing.T) {
 			},
 			enableFeatureGates: []featuregate.Feature{features.TASProfileMixed},
 		},
-		"rack required; single Pod fits in a rack; MostFreeCapacity": {
-			// TODO: remove after dropping the TASMostFreeCapacity feature gate
-			nodes: defaultNodes,
-			topologyRequest: &kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasRackLabel),
-			},
-			levels: defaultTwoLevels,
-			requests: resources.Requests{
-				corev1.ResourceCPU: 1000,
-			},
-			count: 1,
-			wantAssignment: &kueue.TopologyAssignment{
-				Levels: defaultTwoLevels,
-				Domains: []kueue.TopologyDomainAssignment{
-					{
-						Count: 1,
-						Values: []string{
-							"b1",
-							"r2",
-						},
-					},
-				},
-			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
-		},
 		"rack required; single Pod fits in a rack; LeastFreeCapacityFit": {
 			nodes: defaultNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
@@ -985,6 +841,29 @@ func TestFindTopologyAssignment(t *testing.T) {
 				},
 			},
 			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+		},
+		"rack required; single Pod fits in a rack; BestFit": {
+			nodes: defaultNodes,
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasRackLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 1,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultTwoLevels,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 1,
+						Values: []string{
+							"b1",
+							"r1",
+						},
+					},
+				},
+			},
 		},
 		"rack preferred; multiple Pods fits in multiple racks; LeastFreeCapacityFit": {
 			nodes: defaultNodes,
@@ -1016,30 +895,6 @@ func TestFindTopologyAssignment(t *testing.T) {
 				},
 			},
 			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
-		},
-		"rack required; multiple Pods fits in a rack; MostFreeCapacity": {
-			nodes: defaultNodes,
-			topologyRequest: &kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasRackLabel),
-			},
-			levels: defaultTwoLevels,
-			requests: resources.Requests{
-				corev1.ResourceCPU: 1000,
-			},
-			count: 3,
-			wantAssignment: &kueue.TopologyAssignment{
-				Levels: defaultTwoLevels,
-				Domains: []kueue.TopologyDomainAssignment{
-					{
-						Count: 3,
-						Values: []string{
-							"b1",
-							"r2",
-						},
-					},
-				},
-			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
 		"rack required; multiple Pods fit in a rack; BestFit": {
 			nodes: defaultNodes,
@@ -1140,7 +995,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 				},
 			},
 		},
-		"rack required; too many pods to fit in any rack; MostFreeCapacity": {
+		"rack required; too many pods to fit in any rack; BestFit": {
 			nodes: defaultNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
 				Required: ptr.To(tasRackLabel),
@@ -1151,36 +1006,6 @@ func TestFindTopologyAssignment(t *testing.T) {
 			},
 			count:      4,
 			wantReason: `topology "default" allows to fit only 3 out of 4 pod(s)`,
-
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
-		},
-		"block required; single Pod fits in a block; MostFreeCapacity": {
-			// TODO: remove after dropping the TASMostFreeCapacity feature gate
-			nodes: defaultNodes,
-			topologyRequest: &kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasBlockLabel),
-			},
-			levels: defaultTwoLevels,
-			requests: resources.Requests{
-				corev1.ResourceCPU: 1000,
-			},
-			count: 1,
-			wantAssignment: &kueue.TopologyAssignment{
-				Levels: []string{
-					tasBlockLabel,
-					tasRackLabel,
-				},
-				Domains: []kueue.TopologyDomainAssignment{
-					{
-						Count: 1,
-						Values: []string{
-							"b1",
-							"r2",
-						},
-					},
-				},
-			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
 		"block required; single Pod fits in a block; LeastFreeCapacityFit": {
 			nodes: defaultNodes,
@@ -1293,7 +1118,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 				},
 			},
 		},
-		"block required; Pods fit in a block spread across two racks; MostFreeCapacity": {
+		"block required; Pods fit in a block spread across two racks; BestFit": {
 			nodes: defaultNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
 				Required: ptr.To(tasBlockLabel),
@@ -1322,9 +1147,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 					},
 				},
 			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
-		"block required; single Pod which cannot be split; MostFreeCapacity": {
+		"block required; single Pod which cannot be split; BestFit": {
 			nodes: defaultNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
 				Required: ptr.To(tasBlockLabel),
@@ -1333,11 +1157,10 @@ func TestFindTopologyAssignment(t *testing.T) {
 			requests: resources.Requests{
 				corev1.ResourceCPU: 4000,
 			},
-			count:              1,
-			wantReason:         `topology "default" doesn't allow to fit any of 1 pod(s)`,
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			count:      1,
+			wantReason: `topology "default" doesn't allow to fit any of 1 pod(s)`,
 		},
-		"block required; too many Pods to fit requested; MostFreeCapacity": {
+		"block required; too many Pods to fit requested; BestFit": {
 			nodes: defaultNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
 				Required: ptr.To(tasBlockLabel),
@@ -1346,12 +1169,10 @@ func TestFindTopologyAssignment(t *testing.T) {
 			requests: resources.Requests{
 				corev1.ResourceCPU: 1000,
 			},
-			count:              5,
-			wantReason:         `topology "default" allows to fit only 4 out of 5 pod(s)`,
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			count:      5,
+			wantReason: `topology "default" allows to fit only 4 out of 5 pod(s)`,
 		},
-		"rack required; single Pod requiring memory; MostFreeCapacity": {
-			// TODO: remove after dropping the TASMostFreeCapacity feature gate
+		"rack required; single Pod requiring memory; BestFit": {
 			nodes: defaultNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
 				Required: ptr.To(tasRackLabel),
@@ -1367,15 +1188,14 @@ func TestFindTopologyAssignment(t *testing.T) {
 					{
 						Count: 4,
 						Values: []string{
-							"b2",
-							"r2",
+							"b1",
+							"r1",
 						},
 					},
 				},
 			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
-		"rack preferred; but only block can accommodate the workload; MostFreeCapacity": {
+		"rack preferred; but only block can accommodate the workload; BestFit": {
 			nodes: defaultNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
 				Preferred: ptr.To(tasRackLabel),
@@ -1404,9 +1224,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 					},
 				},
 			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
-		"rack preferred; but only multiple blocks can accommodate the workload; MostFreeCapacity": {
+		"rack preferred; but only multiple blocks can accommodate the workload; BestFit": {
 			nodes: defaultNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
 				Preferred: ptr.To(tasRackLabel),
@@ -1442,9 +1261,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 					},
 				},
 			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
-		"block preferred; but only multiple blocks can accommodate the workload; MostFreeCapacity": {
+		"block preferred; but only multiple blocks can accommodate the workload; BestFit": {
 			nodes: defaultNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
 				Preferred: ptr.To(tasBlockLabel),
@@ -1480,9 +1298,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 					},
 				},
 			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
-		"block preferred; but the workload cannot be accommodate in entire topology; MostFreeCapacity": {
+		"block preferred; but the workload cannot be accommodate in entire topology; BestFit": {
 			nodes: defaultNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
 				Preferred: ptr.To(tasBlockLabel),
@@ -1491,11 +1308,10 @@ func TestFindTopologyAssignment(t *testing.T) {
 			requests: resources.Requests{
 				corev1.ResourceCPU: 1000,
 			},
-			count:              10,
-			wantReason:         `topology "default" allows to fit only 7 out of 10 pod(s)`,
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			count:      10,
+			wantReason: `topology "default" allows to fit only 7 out of 10 pod(s)`,
 		},
-		"only nodes with matching labels are considered; no matching node; MostFreeCapacity": {
+		"only nodes with matching labels are considered; no matching node; BestFit": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label("zone", "zone-a").
@@ -1517,11 +1333,10 @@ func TestFindTopologyAssignment(t *testing.T) {
 			requests: resources.Requests{
 				corev1.ResourceCPU: 1000,
 			},
-			count:              1,
-			wantReason:         "no topology domains at level: kubernetes.io/hostname",
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			count:      1,
+			wantReason: "no topology domains at level: kubernetes.io/hostname",
 		},
-		"only nodes with matching labels are considered; matching node is found; MostFreeCapacity": {
+		"only nodes with matching labels are considered; matching node is found; BestFit": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label("zone", "zone-a").
@@ -1556,9 +1371,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 					},
 				},
 			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
-		"only nodes with matching levels are considered; no host label on node; MostFreeCapacity": {
+		"only nodes with matching levels are considered; no host label on node; BestFit": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label(tasBlockLabel, "b1").
@@ -1579,11 +1393,10 @@ func TestFindTopologyAssignment(t *testing.T) {
 			requests: resources.Requests{
 				corev1.ResourceCPU: 1000,
 			},
-			count:              1,
-			wantReason:         "no topology domains at level: cloud.com/topology-rack",
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			count:      1,
+			wantReason: "no topology domains at level: cloud.com/topology-rack",
 		},
-		"don't consider unscheduled Pods when computing capacity; MostFreeCapacity": {
+		"don't consider unscheduled Pods when computing capacity; BestFit": {
 			// the Pod is not scheduled (no NodeName set, so is not blocking capacity)
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("x1").
@@ -1620,9 +1433,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 					},
 				},
 			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
-		"don't consider terminal pods when computing the capacity; MostFreeCapacity": {
+		"don't consider terminal pods when computing the capacity; BestFit": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("x1").
 					Label(corev1.LabelHostname, "x1").
@@ -1663,9 +1475,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 					},
 				},
 			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
-		"include usage from pending scheduled non-TAS pods, blocked assignment; MostFreeCapacity": {
+		"include usage from pending scheduled non-TAS pods, blocked assignment; BestFit": {
 			// there is not enough free capacity on the only node x1
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("x1").
@@ -1694,7 +1505,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 			count:      1,
 			wantReason: `topology "default" doesn't allow to fit any of 1 pod(s)`,
 		},
-		"include usage from running non-TAS pods, blocked assignment; MostFreeCapacity": {
+		"include usage from running non-TAS pods, blocked assignment; BestFit": {
 			// there is not enough free capacity on the only node x1
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("x1").
@@ -1720,11 +1531,10 @@ func TestFindTopologyAssignment(t *testing.T) {
 			requests: resources.Requests{
 				corev1.ResourceCPU: 600,
 			},
-			count:              1,
-			wantReason:         `topology "default" doesn't allow to fit any of 1 pod(s)`,
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			count:      1,
+			wantReason: `topology "default" doesn't allow to fit any of 1 pod(s)`,
 		},
-		"include usage from running non-TAS pods, found free capacity on another node; MostFreeCapacity": {
+		"include usage from running non-TAS pods, found free capacity on another node; BestFit": {
 			// there is not enough free capacity on the node x1 as the
 			// assignments lends on the free x2
 			nodes: []corev1.Node{
@@ -1771,9 +1581,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 					},
 				},
 			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
-		"no assignment as node is not ready; MostFreeCapacity": {
+		"no assignment as node is not ready; BestFit": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label("zone", "zone-a").
@@ -1800,11 +1609,10 @@ func TestFindTopologyAssignment(t *testing.T) {
 			requests: resources.Requests{
 				corev1.ResourceCPU: 1000,
 			},
-			count:              1,
-			wantReason:         "no topology domains at level: kubernetes.io/hostname",
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			count:      1,
+			wantReason: "no topology domains at level: kubernetes.io/hostname",
 		},
-		"no assignment as node is unschedulable; MostFreeCapacity": {
+		"no assignment as node is unschedulable; BestFit": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label("zone", "zone-a").
@@ -1828,11 +1636,10 @@ func TestFindTopologyAssignment(t *testing.T) {
 			requests: resources.Requests{
 				corev1.ResourceCPU: 1000,
 			},
-			count:              1,
-			wantReason:         "no topology domains at level: kubernetes.io/hostname",
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			count:      1,
+			wantReason: "no topology domains at level: kubernetes.io/hostname",
 		},
-		"skip node which has untolerated taint; MostFreeCapacity": {
+		"skip node which has untolerated taint; BestFit": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("x1").
 					Label("zone", "zone-a").
@@ -1860,11 +1667,10 @@ func TestFindTopologyAssignment(t *testing.T) {
 			requests: resources.Requests{
 				corev1.ResourceCPU: 1000,
 			},
-			count:              1,
-			wantReason:         `topology "default" doesn't allow to fit any of 1 pod(s)`,
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			count:      1,
+			wantReason: `topology "default" doesn't allow to fit any of 1 pod(s)`,
 		},
-		"allow to schedule on node with tolerated taint; MostFreeCapacity": {
+		"allow to schedule on node with tolerated taint; BestFit": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label("zone", "zone-a").
@@ -1911,9 +1717,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 					},
 				},
 			},
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
-		"no assignment as node does not have enough allocatable pods (.status.allocatable['pods']); MostFreeCapacity": {
+		"no assignment as node does not have enough allocatable pods (.status.allocatable['pods']); BestFit": {
 			nodes: []corev1.Node{
 				*testingnode.MakeNode("b1-r1-x1").
 					Label("zone", "zone-a").
@@ -1942,9 +1747,8 @@ func TestFindTopologyAssignment(t *testing.T) {
 			requests: resources.Requests{
 				corev1.ResourceCPU: 300,
 			},
-			count:              1,
-			wantReason:         `topology "default" doesn't allow to fit any of 1 pod(s)`,
-			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
+			count:      1,
+			wantReason: `topology "default" doesn't allow to fit any of 1 pod(s)`,
 		},
 		"skip node which doesn't match node selector, missing label; BestFit": {
 			nodes: []corev1.Node{

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -729,7 +729,7 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(levelIdx int, required bool,
 
 func useBestFitAlgorithm(unconstrained bool) bool {
 	// following the matrix from KEP#2724
-	return !features.Enabled(features.TASProfileMostFreeCapacity) && !useLeastFreeCapacityAlgorithm(unconstrained)
+	return !useLeastFreeCapacityAlgorithm(unconstrained)
 }
 
 func useLeastFreeCapacityAlgorithm(unconstrained bool) bool {

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -390,7 +390,6 @@ func ValidateFeatureGates(featureGateCLI string, featureGateMap map[string]bool)
 	}
 	TASProfilesEnabled := []bool{features.Enabled(features.TASProfileMixed),
 		features.Enabled(features.TASProfileLeastFreeCapacity),
-		features.Enabled(features.TASProfileMostFreeCapacity),
 	}
 	enabledProfilesCount := 0
 	for _, enabled := range TASProfilesEnabled {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -904,16 +904,16 @@ func TestValidateFeatureGates(t *testing.T) {
 			errorStr: "feature gates for CLI and configuration cannot both specified",
 		},
 		"cannot specify more than one TAS profile using GateMap": {
-			featureGateMap: map[string]bool{"TASProfileMostFreeCapacity": true,
+			featureGateMap: map[string]bool{"TASProfileMixed": true,
 				"TASProfileLeastFreeCapacity": true},
 			errorStr: "Cannot use more than one TAS profiles",
 		},
 		"cannot specify more than one TAS profile using GatesCLI": {
-			featureGatesCLI: "TASProfileMostFreeCapacity:true,TASProfileMixed:true",
+			featureGatesCLI: "TASProfileLeastFreeCapacity:true,TASProfileMixed:true",
 			errorStr:        "Cannot use more than one TAS profiles",
 		},
 		"cannot set TAS profile with TAS disabled": {
-			featureGateMap: map[string]bool{"TASProfileMostFreeCapacity": true,
+			featureGateMap: map[string]bool{"TASProfileLeastFreeCapacity": true,
 				"TopologyAwareScheduling": true},
 			errorStr: "Cannot use a TAS profile with TAS disabled",
 		},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -137,12 +137,6 @@ const (
 	// owner: @pbundyra
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
 	//
-	// Enable to set use MostFreeCapacity algorithm for TAS
-	TASProfileMostFreeCapacity featuregate.Feature = "TASProfileMostFreeCapacity"
-
-	// owner: @pbundyra
-	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
-	//
 	// Enable to set use LeastFreeCapacity algorithm for TAS
 	TASProfileLeastFreeCapacity featuregate.Feature = "TASProfileLeastFreeCapacity"
 
@@ -249,10 +243,6 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	LocalQueueDefaulting: {
 		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.12"), Default: true, PreRelease: featuregate.Beta},
-	},
-	TASProfileMostFreeCapacity: {
-		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("0.11"), Default: false, PreRelease: featuregate.Deprecated},
 	},
 	TASProfileLeastFreeCapacity: {
 		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -309,7 +309,6 @@ spec:
 | `WorkloadResourceRequestsSummary` | `false` | Alpha      | 0.9   | 0.10  |
 | `WorkloadResourceRequestsSummary` | `true`  | Beta       | 0.10  | 0.11  |
 | `WorkloadResourceRequestsSummary` | `true`  | GA         | 0.11  |       |
-| `TASProfileMostFreeCapacity`      | `false` | Deprecated | 0.11  |       |
 | `TASProfileLeastFreeCapacity`     | `false` | Deprecated | 0.11  |       |
 | `TASProfileMixed`                 | `false` | Deprecated | 0.11  |       |
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

According to the discussion in this PR: https://github.com/kubernetes-sigs/kueue/pull/5449, we have decided to drop the support for `MostFreeCapacity` mode.

This PR removes the `MostFreeCapacity` mode from Kueue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Drop support for MostFreeCapacity mode
```