### PR TITLE
Automated cherry pick of #5540: Use clean-manifests to cleaning up kueueviz manifests.

### DIFF
--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -150,10 +150,8 @@ webhookService:
       protocol: TCP
       targetPort: 9443
   type: ClusterIP
-
 # kueue-viz dashboard
 enableKueueViz: false
-
 metrics:
   prometheusNamespace: monitoring
   serviceMonitor:


### PR DESCRIPTION
Cherry pick of #5540 on release-0.11.

#5540: Use clean-manifests to cleaning up kueueviz manifests.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```