### PR TITLE
Automated cherry pick of #5543: Remove IMAGE_EXTRA_TAG and use branch name instead.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,7 +14,6 @@ steps:
       - kueue-viz-image-push
     env:
       - IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/kueue
-      - IMAGE_EXTRA_TAG=$_PULL_BASE_REF
       - DOCKER_BUILDX_CMD=/buildx-entrypoint
       - GOTOOLCHAIN=auto
 substitutions:


### PR DESCRIPTION
Cherry pick of #5543 on release-0.11.

#5543: Remove IMAGE_EXTRA_TAG and use branch name instead.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```