### PR TITLE
Automated cherry pick of #5537: Cleanup Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,13 @@ CLI_PLATFORMS ?= linux/amd64,linux/arm64,darwin/amd64,darwin/arm64
 VIZ_PLATFORMS ?= linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
 DOCKER_BUILDX_CMD ?= docker buildx
 IMAGE_BUILD_CMD ?= $(DOCKER_BUILDX_CMD) build
-STAGING_IMAGE_REGISTRY := us-central1-docker.pkg.dev/k8s-staging-images
-IMAGE_REGISTRY ?= $(STAGING_IMAGE_REGISTRY)/kueue
+
+STAGING_IMAGE_REGISTRY := us-central1-docker.pkg.dev/k8s-staging-images/kueue
+IMAGE_REGISTRY ?= $(STAGING_IMAGE_REGISTRY)
+
 IMAGE_REPO := $(IMAGE_REGISTRY)/kueue
 IMAGE_TAG ?= $(IMAGE_REPO):$(GIT_TAG)
-HELM_CHART_REPO := $(STAGING_IMAGE_REGISTRY)/kueue/charts
+
 RAY_VERSION := 2.41.0
 RAYMINI_VERSION ?= 0.0.1
 
@@ -221,7 +223,7 @@ image-push: image-build
 helm-chart-package: yq helm ## Package a chart into a versioned chart archive file.
 	DEST_CHART_DIR=$(DEST_CHART_DIR) \
 	HELM="$(HELM)" YQ="$(YQ)" GIT_TAG="$(GIT_TAG)" IMAGE_REGISTRY="$(IMAGE_REGISTRY)" \
-	HELM_CHART_PUSH=$(HELM_CHART_PUSH) HELM_CHART_REPO=$(HELM_CHART_REPO) \
+	HELM_CHART_PUSH=$(HELM_CHART_PUSH) \
 	./hack/helm-chart-package.sh
 
 .PHONY: helm-chart-push
@@ -240,7 +242,7 @@ ifndef ignore-not-found
   ignore-not-found = false
 endif
 
-clean-manifests = (cd config/components/manager && $(KUSTOMIZE) edit set image controller=$(STAGING_IMAGE_REGISTRY)/kueue/kueue:$(RELEASE_BRANCH))
+clean-manifests = (cd config/components/manager && $(KUSTOMIZE) edit set image controller=$(STAGING_IMAGE_REGISTRY)/kueue:$(RELEASE_BRANCH))
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,7 +13,6 @@ steps:
       - helm-chart-push
       - kueue-viz-image-push
     env:
-      - IMAGE_REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/kueue
       - DOCKER_BUILDX_CMD=/buildx-entrypoint
       - GOTOOLCHAIN=auto
 substitutions:

--- a/hack/helm-chart-package.sh
+++ b/hack/helm-chart-package.sh
@@ -22,9 +22,9 @@ DEST_CHART_DIR=${DEST_CHART_DIR:-bin/}
 
 GIT_TAG=${GIT_TAG:-$(git describe --tags --dirty --always)}
 
-STAGING_IMAGE_REGISTRY=${STAGING_IMAGE_REGISTRY:-us-central1-docker.pkg.dev/k8s-staging-images}
-IMAGE_REGISTRY=${IMAGE_REGISTRY:-${STAGING_IMAGE_REGISTRY}/kueue}
-HELM_CHART_REPO=${HELM_CHART_REPO:-${STAGING_IMAGE_REGISTRY}/kueue/charts}
+STAGING_IMAGE_REGISTRY=${STAGING_IMAGE_REGISTRY:-us-central1-docker.pkg.dev/k8s-staging-images/kueue}
+IMAGE_REGISTRY=${IMAGE_REGISTRY:-${STAGING_IMAGE_REGISTRY}}
+HELM_CHART_REPO=${HELM_CHART_REPO:-${STAGING_IMAGE_REGISTRY}/charts}
 
 HELM=${HELM:-./bin/helm}
 YQ=${YQ:-./bin/yq}


### PR DESCRIPTION
Cherry pick of #5537 on release-0.11.

#5537: Cleanup Makefile.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```