### PR TITLE
Fix the NeedsSecondPass check

### DIFF
--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -219,6 +219,18 @@ func (w *WorkloadWrapper) Finished() *WorkloadWrapper {
 	return w
 }
 
+func (w *WorkloadWrapper) Evicted() *WorkloadWrapper {
+	cond := metav1.Condition{
+		Type:               kueue.WorkloadEvicted,
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             "ByTest",
+		Message:            "Evicted by test",
+	}
+	apimeta.SetStatusCondition(&w.Status.Conditions, cond)
+	return w
+}
+
 func (w *WorkloadWrapper) Creation(t time.Time) *WorkloadWrapper {
 	w.CreationTimestamp = metav1.NewTime(t)
 	return w

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -651,21 +651,21 @@ func SetQuotaReservation(w *kueue.Workload, admission *kueue.Admission, clock cl
 // NeedsSecondPass checks if the second pass of scheduling is needed for the
 // workload.
 func NeedsSecondPass(w *kueue.Workload) bool {
+	if IsFinished(w) || IsEvicted(w) || !HasQuotaReservation(w) {
+		return false
+	}
 	return needsSecondPassForDelayedAssignment(w) || needsSecondPassAfterNodeFailure(w)
 }
 
 func needsSecondPassForDelayedAssignment(w *kueue.Workload) bool {
-	return HasQuotaReservation(w) &&
-		len(w.Status.AdmissionChecks) > 0 &&
+	return len(w.Status.AdmissionChecks) > 0 &&
 		HasAllChecksReady(w) &&
 		HasTopologyAssignmentsPending(w) &&
-		!IsAdmitted(w) &&
-		!IsFinished(w) &&
-		!IsEvicted(w)
+		!IsAdmitted(w)
 }
 
 func needsSecondPassAfterNodeFailure(w *kueue.Workload) bool {
-	return IsAdmitted(w) && HasNodeToReplace(w)
+	return HasTopologyAssignmentWithNodeToReplace(w)
 }
 
 // HasTopologyAssignmentsPending checks if the workload contains any


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

To avoid unnecessary second passes by scheduler. These were sometimes spot when running https://github.com/kubernetes-sigs/kueue/issues/5511. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: fix the bug which would trigger unnecessary second pass scheduling for nodeToReplace
in the following scenarios: 
1. Finished workload
2. Evicted workload
3. node to replace is not present in the workload's TopologyAssignment domains
```