### PR TITLE
Automated cherry pick of #5581: [release-0.12] Remove redundant CYPRESS_IMAGE_NAME variable.

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -50,8 +50,6 @@ E2E_RUN_ONLY_ENV ?= false
 # Default will delete default kind cluster
 KIND_CLUSTER_NAME ?= kind
 
-CYPRESS_IMAGE_NAME ?= cypress/base:22.14.0
-
 ##@ Tests
 
 # Periodic builds are tested with full ray image

--- a/hack/e2e-kueueviz-local.sh
+++ b/hack/e2e-kueueviz-local.sh
@@ -21,9 +21,6 @@ ROOT_DIR="$SOURCE_DIR/.."
 # shellcheck source=hack/e2e-common.sh
 source "${SOURCE_DIR}/e2e-common.sh"
 
-# Set CYPRESS_IMAGE_NAME to the value of the env var or default to cypress/base
-CYPRESS_IMAGE_NAME="${CYPRESS_IMAGE_NAME:-cypress/base}"
-
 # Function to clean up background processes
 cleanup() {
   echo "Cleaning up kueueviz processes"


### PR DESCRIPTION
Cherry pick of #5581 on release-0.12.

#5581: [release-0.12] Remove redundant CYPRESS_IMAGE_NAME variable.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```