### PR TITLE
Fix second pass entries outliving the workload delete

### DIFF
--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -790,6 +790,9 @@ func (m *Manager) DeleteSecondPassWithoutLock(w *kueue.Workload) {
 // delay.
 func (m *Manager) QueueSecondPassIfNeeded(ctx context.Context, w *kueue.Workload) bool {
 	if workload.NeedsSecondPass(w) {
+		log := ctrl.LoggerFrom(ctx)
+		log.V(3).Info("Workload pre-queued for second pass", "workload", workload.Key(w))
+		m.secondPassQueue.prequeue(w)
 		m.clock.AfterFunc(time.Second, func() {
 			m.queueSecondPass(ctx, w)
 		})
@@ -801,14 +804,11 @@ func (m *Manager) QueueSecondPassIfNeeded(ctx context.Context, w *kueue.Workload
 func (m *Manager) queueSecondPass(ctx context.Context, w *kueue.Workload) {
 	m.Lock()
 	defer m.Unlock()
-	m.queueSecondPassWithoutLock(ctx, w)
-}
 
-func (m *Manager) queueSecondPassWithoutLock(ctx context.Context, w *kueue.Workload) {
 	log := ctrl.LoggerFrom(ctx)
-	log.V(3).Info("Workload queued for second pass of scheduling", "workload", workload.Key(w))
-
 	wInfo := workload.NewInfo(w, m.workloadInfoOptions...)
-	m.secondPassQueue.offer(wInfo)
-	m.Broadcast()
+	if m.secondPassQueue.queue(wInfo) {
+		log.V(3).Info("Workload queued for second pass of scheduling", "workload", workload.Key(w))
+		m.Broadcast()
+	}
 }

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -26,9 +26,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	testingclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1alpha1"
@@ -1281,6 +1283,90 @@ func TestGetPendingWorkloadsInfo(t *testing.T) {
 				cmpopts.IgnoreFields(workload.Info{}, "TotalRequests"),
 			); diff != "" {
 				t.Errorf("GetPendingWorkloadsInfo returned wrong heads (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestQueueSecondPassIfNeeded(t *testing.T) {
+	now := time.Now()
+
+	baseWorkloadBuilder := utiltesting.MakeWorkload("foo", "default").
+		Queue("tas-main").
+		PodSets(*utiltesting.MakePodSet("one", 1).
+			RequiredTopologyRequest(corev1.LabelHostname).
+			Request(corev1.ResourceCPU, "1").
+			Obj())
+	baseWorkloadNeedingSecondPass := baseWorkloadBuilder.Clone().
+		ReserveQuota(
+			utiltesting.MakeAdmission("tas-main", "one").
+				Assignment(corev1.ResourceCPU, "tas-default", "1000m").
+				DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+				AssignmentPodCount(1).Obj(),
+		).
+		AdmissionCheck(kueue.AdmissionCheckState{
+			Name:  "prov-check",
+			State: kueue.CheckStateReady,
+		})
+	baseWorkloadNotNeedingSecondPass := baseWorkloadBuilder.Clone()
+
+	cases := map[string]struct {
+		workloads []*kueue.Workload
+		deleted   sets.Set[workload.WorkloadReference]
+		passTime  time.Duration
+		wantReady sets.Set[workload.WorkloadReference]
+	}{
+		"single queued workload checked immediately": {
+			workloads: []*kueue.Workload{baseWorkloadNeedingSecondPass.Obj()},
+		},
+		"single queued workload checked after 1s": {
+			workloads: []*kueue.Workload{
+				baseWorkloadNeedingSecondPass.DeepCopy(),
+				baseWorkloadNotNeedingSecondPass.DeepCopy(),
+			},
+			passTime:  time.Second,
+			wantReady: sets.New(workload.Key(baseWorkloadNeedingSecondPass.Obj())),
+		},
+		"single queued workload deleted in the meanwhile": {
+			workloads: []*kueue.Workload{
+				baseWorkloadNeedingSecondPass.DeepCopy(),
+				baseWorkloadNotNeedingSecondPass.DeepCopy(),
+			},
+			deleted:  sets.New(workload.Key(baseWorkloadNeedingSecondPass.Obj())),
+			passTime: time.Second,
+		},
+		"two queued workloads, one deleted in the meanwhile": {
+			workloads: []*kueue.Workload{
+				baseWorkloadNeedingSecondPass.Clone().Name("second").Obj(),
+			},
+			deleted:   sets.New(workload.Key(baseWorkloadNeedingSecondPass.Obj())),
+			passTime:  time.Second,
+			wantReady: sets.New(workload.NewWorkloadReference("default", "second")),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx := t.Context()
+
+			fakeClock := testingclock.NewFakeClock(now)
+			opts := []Option{
+				WithClock(fakeClock),
+			}
+			manager := NewManager(utiltesting.NewFakeClient(), nil, opts...)
+
+			for _, wl := range tc.workloads {
+				manager.QueueSecondPassIfNeeded(ctx, wl)
+			}
+			for _, wl := range tc.deleted.UnsortedList() {
+				manager.secondPassQueue.deleteByKey(wl)
+			}
+			fakeClock.Step(tc.passTime)
+			gotReady := sets.New[workload.WorkloadReference]()
+			for _, wlInfo := range manager.secondPassQueue.takeAllReady() {
+				gotReady.Insert(workload.Key(wlInfo.Obj))
+			}
+			if diff := cmp.Diff(tc.wantReady, gotReady); diff != "" {
+				t.Errorf("Unexpected ready workloads returned (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/queue/second_pass_queue.go
+++ b/pkg/queue/second_pass_queue.go
@@ -19,18 +19,23 @@ package queue
 import (
 	"sync"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 type secondPassQueue struct {
 	sync.RWMutex
 
-	state map[workload.WorkloadReference]*workload.Info
+	prequeued sets.Set[workload.WorkloadReference]
+	queued    map[workload.WorkloadReference]*workload.Info
 }
 
 func newSecondPassQueue() *secondPassQueue {
 	return &secondPassQueue{
-		state: make(map[workload.WorkloadReference]*workload.Info),
+		prequeued: sets.New[workload.WorkloadReference](),
+		queued:    make(map[workload.WorkloadReference]*workload.Info),
 	}
 }
 
@@ -39,23 +44,37 @@ func (q *secondPassQueue) takeAllReady() []workload.Info {
 	defer q.Unlock()
 
 	var result []workload.Info
-	for _, v := range q.state {
+	for _, v := range q.queued {
 		result = append(result, *v)
 	}
-	q.state = make(map[workload.WorkloadReference]*workload.Info)
+	q.queued = make(map[workload.WorkloadReference]*workload.Info)
 	return result
 }
 
-func (q *secondPassQueue) offer(w *workload.Info) {
+func (q *secondPassQueue) prequeue(obj *kueue.Workload) {
 	q.Lock()
 	defer q.Unlock()
 
-	q.state[workload.Key(w.Obj)] = w
+	q.prequeued.Insert(workload.Key(obj))
+}
+
+func (q *secondPassQueue) queue(w *workload.Info) bool {
+	q.Lock()
+	defer q.Unlock()
+
+	key := workload.Key(w.Obj)
+	enqueued := q.prequeued.Has(key) && workload.NeedsSecondPass(w.Obj)
+	if enqueued {
+		q.queued[key] = w
+	}
+	q.prequeued.Delete(key)
+	return enqueued
 }
 
 func (q *secondPassQueue) deleteByKey(key workload.WorkloadReference) {
 	q.Lock()
 	defer q.Unlock()
 
-	delete(q.state, key)
+	delete(q.queued, key)
+	q.prequeued.Delete(key)
 }

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -227,8 +227,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			util.MustCreate(ctx, k8sClient, admissionCheck)
 			util.SetAdmissionCheckActive(ctx, k8sClient, admissionCheck, metav1.ConditionTrue)
 
-			clusterQueue = testing.MakeClusterQueue("").
-				GeneratedName("cluster-queue-").
+			clusterQueue = testing.MakeClusterQueue("cq").
 				ResourceGroup(
 					*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj(),
 				).AdmissionChecks(kueue.AdmissionCheckReference(admissionCheck.Name)).Obj()
@@ -319,8 +318,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					TopologyName("default").Obj()
 				util.MustCreate(ctx, k8sClient, tasFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj()).
 					Obj()
 				util.MustCreate(ctx, k8sClient, clusterQueue)
@@ -798,8 +796,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					TopologyName("default").Obj()
 				util.MustCreate(ctx, k8sClient, tasFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj()).
 					Obj()
 				util.MustCreate(ctx, k8sClient, clusterQueue)
@@ -1264,8 +1261,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					TopologyName("default").Obj()
 				util.MustCreate(ctx, k8sClient, tasFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					Preemption(kueue.ClusterQueuePreemption{
 						WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
 					}).
@@ -1388,8 +1384,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					TopologyName("default").Obj()
 				util.MustCreate(ctx, k8sClient, tasFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					Cohort("cohort").
 					Preemption(kueue.ClusterQueuePreemption{
 						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
@@ -1405,8 +1400,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				localQueue = testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
 				util.MustCreate(ctx, k8sClient, localQueue)
 
-				clusterQueueB = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueueB = testing.MakeClusterQueue("cluster-queue-b").
 					Cohort("cohort").
 					Preemption(kueue.ClusterQueuePreemption{
 						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
@@ -1493,8 +1487,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					Obj()
 				util.MustCreate(ctx, k8sClient, tasFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj()).
 					Obj()
 				util.MustCreate(ctx, k8sClient, clusterQueue)
@@ -1573,8 +1566,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					Obj()
 				util.MustCreate(ctx, k8sClient, tasFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj()).
 					Obj()
 				util.MustCreate(ctx, k8sClient, clusterQueue)
@@ -1759,8 +1751,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				util.MustCreate(ctx, k8sClient, ac)
 				util.SetAdmissionCheckActive(ctx, k8sClient, ac, metav1.ConditionTrue)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cq").
 					ResourceGroup(
 						*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj(),
 					).AdmissionChecks(kueue.AdmissionCheckReference(ac.Name)).Obj()
@@ -2346,8 +2337,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					Obj()
 				util.MustCreate(ctx, k8sClient, tasCPUFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(
 						*testing.MakeFlavorQuotas(tasGPUFlavor.Name).Resource(corev1.ResourceCPU, "1").Resource(gpuResName, "5").Obj(),
 						*testing.MakeFlavorQuotas(tasCPUFlavor.Name).Resource(corev1.ResourceCPU, "5").Resource(gpuResName, "0").Obj(),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake 

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5511

#### Special notes for your reviewer:

The issue is that the forgetWorkload called on the secondPassQueue would hit the void while the workload awaits for 1s [here](https://github.com/kubernetes-sigs/kueue/blob/d2f9f2efcd066f007930e9f04fe7629ed8983a0a/pkg/queue/manager.go#L793). Now we prequeue such a workload, and if forgetWorkload is called in the meanwhile, then "enqueue" is forgotten either.

Adding a reliably reproducing integration test is tricky. Running the test https://github.com/kubernetes-sigs/kueue/pull/5513 in a loop reproduces in consistently, but requires multiple many repeats.

To prove the fix works:
- I ran the CI build, with commit https://github.com/kubernetes-sigs/kueue/pull/5587/commits/418b65e2b5fe12fed7c5125cccad3be629d9cb3a, and it passed [here]( https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/5587/pull-kueue-test-integration-baseline-main/1932086255051345920)
- I ran it locally looped >100 times and it passed consistently
- I revert the mitigation: https://github.com/kubernetes-sigs/kueue/pull/5461. Before the mitigation it was failing pretty often.
- I add unit tests

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: fix the scenario when deleted workload still lives in the cache.
```