### PR TITLE
Automated cherry pick of #5587: Fix second pass entries outliving the workload delete

### DIFF
--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -790,6 +790,9 @@ func (m *Manager) DeleteSecondPassWithoutLock(w *kueue.Workload) {
 // delay.
 func (m *Manager) QueueSecondPassIfNeeded(ctx context.Context, w *kueue.Workload) bool {
 	if workload.NeedsSecondPass(w) {
+		log := ctrl.LoggerFrom(ctx)
+		log.V(3).Info("Workload pre-queued for second pass", "workload", workload.Key(w))
+		m.secondPassQueue.prequeue(w)
 		m.clock.AfterFunc(time.Second, func() {
 			m.queueSecondPass(ctx, w)
 		})
@@ -801,14 +804,11 @@ func (m *Manager) QueueSecondPassIfNeeded(ctx context.Context, w *kueue.Workload
 func (m *Manager) queueSecondPass(ctx context.Context, w *kueue.Workload) {
 	m.Lock()
 	defer m.Unlock()
-	m.queueSecondPassWithoutLock(ctx, w)
-}
 
-func (m *Manager) queueSecondPassWithoutLock(ctx context.Context, w *kueue.Workload) {
 	log := ctrl.LoggerFrom(ctx)
-	log.V(3).Info("Workload queued for second pass of scheduling", "workload", workload.Key(w))
-
 	wInfo := workload.NewInfo(w, m.workloadInfoOptions...)
-	m.secondPassQueue.offer(wInfo)
-	m.Broadcast()
+	if m.secondPassQueue.queue(wInfo) {
+		log.V(3).Info("Workload queued for second pass of scheduling", "workload", workload.Key(w))
+		m.Broadcast()
+	}
 }

--- a/pkg/queue/second_pass_queue.go
+++ b/pkg/queue/second_pass_queue.go
@@ -19,18 +19,23 @@ package queue
 import (
 	"sync"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 type secondPassQueue struct {
 	sync.RWMutex
 
-	state map[string]*workload.Info
+	prequeued sets.Set[string]
+	queued    map[string]*workload.Info
 }
 
 func newSecondPassQueue() *secondPassQueue {
 	return &secondPassQueue{
-		state: make(map[string]*workload.Info),
+		prequeued: sets.New[string](),
+		queued:    make(map[string]*workload.Info),
 	}
 }
 
@@ -39,23 +44,37 @@ func (q *secondPassQueue) takeAllReady() []workload.Info {
 	defer q.Unlock()
 
 	var result []workload.Info
-	for _, v := range q.state {
+	for _, v := range q.queued {
 		result = append(result, *v)
 	}
-	q.state = make(map[string]*workload.Info)
+	q.queued = make(map[string]*workload.Info)
 	return result
 }
 
-func (q *secondPassQueue) offer(w *workload.Info) {
+func (q *secondPassQueue) prequeue(obj *kueue.Workload) {
 	q.Lock()
 	defer q.Unlock()
 
-	q.state[workload.Key(w.Obj)] = w
+	q.prequeued.Insert(workload.Key(obj))
+}
+
+func (q *secondPassQueue) queue(w *workload.Info) bool {
+	q.Lock()
+	defer q.Unlock()
+
+	key := workload.Key(w.Obj)
+	enqueued := q.prequeued.Has(key) && workload.NeedsSecondPass(w.Obj)
+	if enqueued {
+		q.queued[key] = w
+	}
+	q.prequeued.Delete(key)
+	return enqueued
 }
 
 func (q *secondPassQueue) deleteByKey(key string) {
 	q.Lock()
 	defer q.Unlock()
 
-	delete(q.state, key)
+	delete(q.queued, key)
+	q.prequeued.Delete(key)
 }

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -227,8 +227,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			util.MustCreate(ctx, k8sClient, admissionCheck)
 			util.SetAdmissionCheckActive(ctx, k8sClient, admissionCheck, metav1.ConditionTrue)
 
-			clusterQueue = testing.MakeClusterQueue("").
-				GeneratedName("cluster-queue-").
+			clusterQueue = testing.MakeClusterQueue("cq").
 				ResourceGroup(
 					*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj(),
 				).AdmissionChecks(kueue.AdmissionCheckReference(admissionCheck.Name)).Obj()
@@ -319,8 +318,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					TopologyName("default").Obj()
 				util.MustCreate(ctx, k8sClient, tasFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj()).
 					Obj()
 				util.MustCreate(ctx, k8sClient, clusterQueue)
@@ -798,8 +796,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					TopologyName("default").Obj()
 				util.MustCreate(ctx, k8sClient, tasFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj()).
 					Obj()
 				util.MustCreate(ctx, k8sClient, clusterQueue)
@@ -1264,8 +1261,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					TopologyName("default").Obj()
 				util.MustCreate(ctx, k8sClient, tasFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					Preemption(kueue.ClusterQueuePreemption{
 						WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
 					}).
@@ -1388,8 +1384,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					TopologyName("default").Obj()
 				util.MustCreate(ctx, k8sClient, tasFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					Cohort("cohort").
 					Preemption(kueue.ClusterQueuePreemption{
 						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
@@ -1405,8 +1400,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				localQueue = testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
 				util.MustCreate(ctx, k8sClient, localQueue)
 
-				clusterQueueB = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueueB = testing.MakeClusterQueue("cluster-queue-b").
 					Cohort("cohort").
 					Preemption(kueue.ClusterQueuePreemption{
 						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
@@ -1493,8 +1487,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					Obj()
 				util.MustCreate(ctx, k8sClient, tasFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj()).
 					Obj()
 				util.MustCreate(ctx, k8sClient, clusterQueue)
@@ -1573,8 +1566,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					Obj()
 				util.MustCreate(ctx, k8sClient, tasFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj()).
 					Obj()
 				util.MustCreate(ctx, k8sClient, clusterQueue)
@@ -1759,8 +1751,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				util.MustCreate(ctx, k8sClient, ac)
 				util.SetAdmissionCheckActive(ctx, k8sClient, ac, metav1.ConditionTrue)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cq").
 					ResourceGroup(
 						*testing.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "5").Obj(),
 					).AdmissionChecks(kueue.AdmissionCheckReference(ac.Name)).Obj()
@@ -2346,8 +2337,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					Obj()
 				util.MustCreate(ctx, k8sClient, tasCPUFlavor)
 
-				clusterQueue = testing.MakeClusterQueue("").
-					GeneratedName("cluster-queue-").
+				clusterQueue = testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(
 						*testing.MakeFlavorQuotas(tasGPUFlavor.Name).Resource(corev1.ResourceCPU, "1").Resource(gpuResName, "5").Obj(),
 						*testing.MakeFlavorQuotas(tasCPUFlavor.Name).Resource(corev1.ResourceCPU, "5").Resource(gpuResName, "0").Obj(),


### PR DESCRIPTION
Cherry pick of #5587 on release-0.12.

#5587: Fix second pass entries outliving the workload delete

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
TAS: fix the scenario when deleted workload still lives in the cache.
```