### PR TITLE
Fix ManageJobsWithoutQueueName API docs

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -40,7 +40,7 @@ type Configuration struct {
 	ControllerManager `json:",inline"`
 
 	// ManageJobsWithoutQueueName controls whether or not Kueue reconciles
-	// jobs that don't set the annotation kueue.x-k8s.io/queue-name.
+	// jobs that don't set the label kueue.x-k8s.io/queue-name.
 	// If set to true, then those jobs will be suspended and never started unless
 	// they are assigned a queue and eventually admitted. This also applies to
 	// jobs created before starting the kueue controller.

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -148,7 +148,7 @@ If the file doesn't exist, default value is kueue-system.</p>
 </td>
 <td>
    <p>ManageJobsWithoutQueueName controls whether or not Kueue reconciles
-jobs that don't set the annotation kueue.x-k8s.io/queue-name.
+jobs that don't set the label kueue.x-k8s.io/queue-name.
 If set to true, then those jobs will be suspended and never started unless
 they are assigned a queue and eventually admitted. This also applies to
 jobs created before starting the kueue controller.


### PR DESCRIPTION
This commit fixes the `ManageJobsWithoutQueueName` API to mention that this feature controls jobs without the kueue.x-k8s.io/queue-name label and not an annotation.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```