### PR TITLE
Automated cherry pick of #5378: Remove CronJob in AfterEach instead of DeferCleanup.

### DIFF
--- a/test/e2e/singlecluster/e2e_test.go
+++ b/test/e2e/singlecluster/e2e_test.go
@@ -112,6 +112,7 @@ var _ = ginkgo.Describe("Kueue", func() {
 			gomega.Expect(k8sClient.Create(ctx, localQueue)).Should(gomega.Succeed())
 		})
 		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteAllCronJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
 			gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
 			// Force remove workloads to be sure that cluster queue can be removed.
 			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
@@ -163,10 +164,6 @@ var _ = ginkgo.Describe("Kueue", func() {
 				},
 			}
 			gomega.Expect(k8sClient.Create(ctx, cronJob)).Should(gomega.Succeed())
-			ginkgo.DeferCleanup(func() {
-				gomega.Expect(util.DeleteAllCronJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
-			})
-
 			ginkgo.By("Patch the last start time to be in the past so that it starts immediately", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cronJob), cronJob)).To(gomega.Succeed())


### PR DESCRIPTION
Cherry pick of #5378 on release-0.11.

#5378: Remove CronJob in AfterEach instead of DeferCleanup.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

Fixes #5350

```release-note
NONE
```