### PR TITLE
Documentation describing the TAS failed node replacement 

### DIFF
--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -132,7 +132,7 @@ assumed to have failed if its `conditions.Status.Ready` is not `True` for at lea
 seconds or if the node is missing (removed from the cluster). 
 
 Note that finding a replacement node within the old domain (like rack) may not always 
-be possible. Hence, we recommend configuring `waitForPodsReady.recoveryTimeout`, to prevent 
+be possible. Hence, we recommend using [WaitForPodsReady](link) and configuring `waitForPodsReady.recoveryTimeout`, to prevent 
 the workloads from waiting for the replacement indefinetly.
 
 

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -119,20 +119,23 @@ newly provisioned nodes (assuming the provisioning class supports it).
 
 ### Hot swap support
 TAS finds a fixed assignment of pods to nodes and injects a NodeSelector to make
-sure the pods get scheduled on the selected nodes. But this means that in case 
+sure the pods get scheduled on the selected nodes. But this means that in case
 of any node failures or deletions, which occur during the runtime of a workload,
-the workload cannot run on any other nodes. To mitigate this issue, a node hot swap was 
-introduced to Kueue (starting from version 0.12). To enable the feature, you have to 
-set the [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) 
-`TASFailedNodeReplacement` to `true` and the lowest topological label has to be
-`kubernetes.io/hostname`. With this feature, TAS tries to find a
-replacement upon node failure or deletion for all the affected workloads, without
-changing the rest of the topology assignment. Currently this works for only a single
-node failure and in case of multiple failures, the workload gets evicted. The node is 
-assumed to have failed if its `conditions.Status.Ready` is not `True` for at least 30 
-seconds or if the node is missing (removed from the cluster). 
+the workload cannot run on any other nodes. In order to avoid costly re-scheduling
+of the entire TAS workload we introduce the node hot swap feature to Kueue
+(starting from version 0.12).
 
-Note that finding a replacement node within the old domain (like rack) may not always 
+To enable the feature, you have to set the [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
+`TASFailedNodeReplacement` to `true` and the lowest topological label has to be
+`kubernetes.io/hostname`.
+
+With this feature, TAS tries to find a replacement upon node failure or deletion for
+all the affected workloads, without changing the rest of the topology assignment.
+Currently this works only for a single node failure and in case of multiple failures,
+the workload gets evicted. The node is assumed to have failed if its `conditions.Status.Ready`
+is not `True` for at least 30 seconds or if the node is missing (removed from the cluster).
+
+Note that finding a replacement node within the old domain (like rack) may not always
 be possible. Hence, we recommend using [WaitForPodsReady](/docs/tasks/manage/setup_wait_for_pods_ready/)
 and configuring `waitForPodsReady.recoveryTimeout`, to prevent the workloads from
 waiting for the replacement indefinetly.

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -117,6 +117,18 @@ Check also [PodSet updates in ProvisioningRequestConfig](site/content/en/docs/ad
 to see how you can configure Kueue if you want to restrict scheduling to the
 newly provisioned nodes (assuming the provisioning class supports it).
 
+### Hot swap support
+TAS finds a fixed assigmend of nodes to PodSets and in case of any node failures,
+during the runtime of a workload, the broken node cannot be automatically replaced
+by Kubernetes scheduler. To mitigate this issue, a node hot swap was introduced 
+to Kueue (starting from version 0.12). To enable the feature, you have to 
+set the feature gate `TASFailedNodeReplacement` to `true`. With this feature, 
+upon node failure, TAS tries to find a replacement of the broken node for all
+the affected workloads, without changing the rest of the topoogy assignment.
+Currently this works for only a single node failure and the node is assumed
+to have failed if its `conditions.Status.Ready` is not `True` or if the node
+is missing (removed from the cluster). 
+
 ### Limitations
 
 Currently, there are limitations for the compatibility of TAS with other

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -130,7 +130,7 @@ To enable the feature, you have to set the [feature gate](https://kubernetes.io/
 `TASFailedNodeReplacement` to `true` and the lowest topological label has to be
 `kubernetes.io/hostname`.
 
-With this feature, TAS tries to find a replacement upon node failure or deletion for
+With this feature, TAS tries to find a replacement of the failed or deleted node for
 all the affected workloads, without changing the rest of the topology assignment.
 Currently this works only for a single node failure and in case of multiple failures,
 the workload gets evicted. The node is assumed to have failed if its `conditions.Status.Ready`

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -124,7 +124,8 @@ of any node failures or deletions, which occur during the runtime of a workload,
 the workload cannot run on any other nodes. To mitigate this issue, a node hot swap was 
 introduced to Kueue (starting from version 0.12). To enable the feature, you have to 
 set the [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) 
-`TASFailedNodeReplacement` to `true`. With this feature, TAS tries to find a 
+`TASFailedNodeReplacement` to `true` and the lowest lowest topological label has to be
+`kubernetes.io/hostname`. With this feature, TAS tries to find a
 replacement upon node failure or deletion for all the affected workloads, without
 changing the rest of the topology assignment. Currently this works for only a single
 node failure and in case of multiple failures, the workload gets evicted. The node is 

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -118,19 +118,18 @@ to see how you can configure Kueue if you want to restrict scheduling to the
 newly provisioned nodes (assuming the provisioning class supports it).
 
 ### Hot swap support
+{{% alert title="Note" color="primary" %}}
+To enable the feature, you have to set the [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
+`TASFailedNodeReplacement` to `true` and the lowest topological label has to be
+`kubernetes.io/hostname`. This feature was introduced to Kueue in version 0.12.
+{{% /alert %}}
+
 When the lowest level of Topology is set to node, TAS finds a fixed assignment
 of pods to nodes and injects a NodeSelector to make sure the pods get scheduled
 on the selected nodes. But this means that in case
 of any node failures or deletions, which occur during the runtime of a workload,
 the workload cannot run on any other nodes. In order to avoid costly re-scheduling
-of the entire TAS workload we introduce the node hot swap feature to Kueue
-(starting from version 0.12).
-
-{{% alert title="Note" color="primary" %}}
-To enable the feature, you have to set the [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
-`TASFailedNodeReplacement` to `true` and the lowest topological label has to be
-`kubernetes.io/hostname`.
-{{% /alert %}}
+of the entire TAS workload we introduce the node hot swap feature.
 
 With this feature, TAS tries to find a replacement of the failed or deleted node for
 all the affected workloads, without changing the rest of the topology assignment.

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -118,16 +118,18 @@ to see how you can configure Kueue if you want to restrict scheduling to the
 newly provisioned nodes (assuming the provisioning class supports it).
 
 ### Hot swap support
-TAS finds a fixed assigmend of nodes to PodSets and in case of any node failures,
-during the runtime of a workload, the broken node cannot be automatically replaced
-by Kubernetes scheduler. To mitigate this issue, a node hot swap was introduced 
-to Kueue (starting from version 0.12). To enable the feature, you have to 
-set the feature gate `TASFailedNodeReplacement` to `true`. With this feature, 
-upon node failure, TAS tries to find a replacement of the broken node for all
-the affected workloads, without changing the rest of the topoogy assignment.
-Currently this works for only a single node failure and the node is assumed
-to have failed if its `conditions.Status.Ready` is not `True` or if the node
-is missing (removed from the cluster). 
+TAS finds a fixed assignment of pods to nodes and injects a NodeSelector to make
+sure the pods get scheduled on the selected nodes. But this means that in case 
+of any node failures or deletions, which occur during the runtime of a workload,
+the workload cannot run on any other nodes. To mitigate this issue, a node hot swap was 
+introduced to Kueue (starting from version 0.12). To enable the feature, you have to 
+set the [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)`TASFailedNodeReplacement` to `true`. With this feature, 
+TAS tries to find a replacement upon node failure or deletion for all
+the affected workloads, without changing the rest of the topology assignment.
+Currently this works for only a single node failure and in case of multiple
+failures, the workload gets evicted. The node is assumed to have failed if its 
+`conditions.Status.Ready` is not `True` or if the node is missing (removed from 
+the cluster). 
 
 ### Limitations
 

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -118,8 +118,9 @@ to see how you can configure Kueue if you want to restrict scheduling to the
 newly provisioned nodes (assuming the provisioning class supports it).
 
 ### Hot swap support
-TAS finds a fixed assignment of pods to nodes and injects a NodeSelector to make
-sure the pods get scheduled on the selected nodes. But this means that in case
+When the lowest level of Topology is set to node, TAS finds a fixed assignment
+of pods to nodes and injects a NodeSelector to make sure the pods get scheduled
+on the selected nodes. But this means that in case
 of any node failures or deletions, which occur during the runtime of a workload,
 the workload cannot run on any other nodes. In order to avoid costly re-scheduling
 of the entire TAS workload we introduce the node hot swap feature to Kueue

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -123,13 +123,13 @@ sure the pods get scheduled on the selected nodes. But this means that in case
 of any node failures or deletions, which occur during the runtime of a workload,
 the workload cannot run on any other nodes. To mitigate this issue, a node hot swap was 
 introduced to Kueue (starting from version 0.12). To enable the feature, you have to 
-set the [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)`TASFailedNodeReplacement` to `true`. With this feature, 
-TAS tries to find a replacement upon node failure or deletion for all
-the affected workloads, without changing the rest of the topology assignment.
-Currently this works for only a single node failure and in case of multiple
-failures, the workload gets evicted. The node is assumed to have failed if its 
-`conditions.Status.Ready` is not `True` or if the node is missing (removed from 
-the cluster). 
+set the [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) 
+`TASFailedNodeReplacement` to `true`. With this feature, TAS tries to find a 
+replacement upon node failure or deletion for all the affected workloads, without
+changing the rest of the topology assignment. Currently this works for only a single
+node failure and in case of multiple failures, the workload gets evicted. The node is 
+assumed to have failed if its  `conditions.Status.Ready` is not `True` or if the node 
+is missing (removed from the cluster). 
 
 ### Limitations
 

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -132,7 +132,7 @@ To enable the feature, you have to set the [feature gate](https://kubernetes.io/
 
 With this feature, TAS tries to find a replacement of the failed or deleted node for
 all the affected workloads, without changing the rest of the topology assignment.
-Currently this works only for a single node failure and in case of multiple failures,
+Currently this works only for a single node failure at the time and in case of multiple failures,
 the workload gets evicted. The node is assumed to have failed if its `conditions.Status.Ready`
 is not `True` for at least 30 seconds or if the node is missing (removed from the cluster).
 

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -126,9 +126,11 @@ the workload cannot run on any other nodes. In order to avoid costly re-scheduli
 of the entire TAS workload we introduce the node hot swap feature to Kueue
 (starting from version 0.12).
 
+{{% alert title="Note" color="primary" %}}
 To enable the feature, you have to set the [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)
 `TASFailedNodeReplacement` to `true` and the lowest topological label has to be
 `kubernetes.io/hostname`.
+{{% /alert %}}
 
 With this feature, TAS tries to find a replacement of the failed or deleted node for
 all the affected workloads, without changing the rest of the topology assignment.

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -128,8 +128,14 @@ set the [feature gate](https://kubernetes.io/docs/reference/command-line-tools-r
 replacement upon node failure or deletion for all the affected workloads, without
 changing the rest of the topology assignment. Currently this works for only a single
 node failure and in case of multiple failures, the workload gets evicted. The node is 
-assumed to have failed if its  `conditions.Status.Ready` is not `True` or if the node 
-is missing (removed from the cluster). 
+assumed to have failed if its `conditions.Status.Ready` is not `True` for at least 30 
+seconds or if the node is missing (removed from the cluster). 
+
+Note that finding a replacement node within the old domain (like rack) may not always 
+be possible. Hence, we recommend configuring `waitForPodsReady.recoveryTimeout`, to prevent 
+the workloads from waiting for the replacement indefinetly.
+
+
 
 ### Limitations
 

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -124,7 +124,7 @@ of any node failures or deletions, which occur during the runtime of a workload,
 the workload cannot run on any other nodes. To mitigate this issue, a node hot swap was 
 introduced to Kueue (starting from version 0.12). To enable the feature, you have to 
 set the [feature gate](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/) 
-`TASFailedNodeReplacement` to `true` and the lowest lowest topological label has to be
+`TASFailedNodeReplacement` to `true` and the lowest topological label has to be
 `kubernetes.io/hostname`. With this feature, TAS tries to find a
 replacement upon node failure or deletion for all the affected workloads, without
 changing the rest of the topology assignment. Currently this works for only a single

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -132,10 +132,9 @@ assumed to have failed if its `conditions.Status.Ready` is not `True` for at lea
 seconds or if the node is missing (removed from the cluster). 
 
 Note that finding a replacement node within the old domain (like rack) may not always 
-be possible. Hence, we recommend using [WaitForPodsReady](link) and configuring `waitForPodsReady.recoveryTimeout`, to prevent 
-the workloads from waiting for the replacement indefinetly.
-
-
+be possible. Hence, we recommend using [WaitForPodsReady](site/content/en/docs/tasks/manage/setup_wait_for_pods_ready.md)
+and configuring `waitForPodsReady.recoveryTimeout`, to prevent the workloads from
+waiting for the replacement indefinetly.
 
 ### Limitations
 

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -132,7 +132,7 @@ assumed to have failed if its `conditions.Status.Ready` is not `True` for at lea
 seconds or if the node is missing (removed from the cluster). 
 
 Note that finding a replacement node within the old domain (like rack) may not always 
-be possible. Hence, we recommend using [WaitForPodsReady](site/content/en/docs/tasks/manage/setup_wait_for_pods_ready.md)
+be possible. Hence, we recommend using [WaitForPodsReady](/docs/tasks/manage/setup_wait_for_pods_ready/)
 and configuring `waitForPodsReady.recoveryTimeout`, to prevent the workloads from
 waiting for the replacement indefinetly.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Documentation paragraph for TAS failed node replacement.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```