### PR TITLE
Don’t add the Workload to the Queues Manager if it is deactivated.

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -676,7 +676,7 @@ func (r *WorkloadReconciler) Create(e event.TypedCreateEvent[*kueue.Workload]) b
 	wlCopy := e.Object.DeepCopy()
 	workload.AdjustResources(ctx, r.client, wlCopy)
 
-	if !workload.HasQuotaReservation(e.Object) {
+	if workload.IsActive(e.Object) && !workload.HasQuotaReservation(e.Object) {
 		if err := r.queues.AddOrUpdateWorkload(wlCopy); err != nil {
 			log.V(2).Info("ignored an error for now", "error", err)
 		}

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -310,7 +310,7 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 		return fmt.Errorf("listing workloads that match the queue: %w", err)
 	}
 	for _, w := range workloads.Items {
-		if workload.HasQuotaReservation(&w) {
+		if !workload.IsActive(&w) || workload.HasQuotaReservation(&w) {
 			continue
 		}
 		workload.AdjustResources(ctx, m.client, &w)

--- a/test/e2e/customconfigs/objectretentionpolicies_test.go
+++ b/test/e2e/customconfigs/objectretentionpolicies_test.go
@@ -35,6 +35,102 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
+var _ = ginkgo.Describe("ObjectRetentionPolicies", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	var (
+		ns *corev1.Namespace
+		rf *kueue.ResourceFlavor
+		cq *kueue.ClusterQueue
+		lq *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "orp-")
+
+		rf = testing.MakeResourceFlavor("default").Obj()
+		gomega.Expect(k8sClient.Create(ctx, rf)).Should(gomega.Succeed())
+
+		cq = testing.MakeClusterQueue("cq").
+			ResourceGroup(*testing.MakeFlavorQuotas(rf.Name).Resource(corev1.ResourceCPU, "10").Obj()).
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, cq)).Should(gomega.Succeed())
+
+		lq = testing.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+		gomega.Expect(k8sClient.Create(ctx, lq)).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, rf, true)
+	})
+
+	ginkgo.It("should delete the Workload after enabling the ObjectRetentionPolicies feature gate", func() {
+		waitForPodsReady := &configapi.WaitForPodsReady{
+			Enable:          true,
+			BlockAdmission:  ptr.To(true),
+			Timeout:         &metav1.Duration{Duration: util.TinyTimeout},
+			RecoveryTimeout: nil,
+			RequeuingStrategy: &configapi.RequeuingStrategy{
+				Timestamp:          ptr.To(configapi.EvictionTimestamp),
+				BackoffBaseSeconds: ptr.To(int32(1)),
+				BackoffLimitCount:  ptr.To(int32(1)),
+			},
+		}
+
+		updateKueueConfiguration(func(cfg *configapi.Configuration) {
+			cfg.FeatureGates = nil
+			cfg.ObjectRetentionPolicies = nil
+			cfg.WaitForPodsReady = waitForPodsReady.DeepCopy()
+		})
+
+		job := testingjob.MakeJob("job", ns.Name).
+			Queue(kueue.LocalQueueName(lq.Name)).
+			RequestAndLimit(corev1.ResourceCPU, "1").
+			Obj()
+		ginkgo.By("Creating a Job", func() {
+			util.MustCreate(ctx, k8sClient, job)
+		})
+
+		wlKey := types.NamespacedName{
+			Namespace: job.Namespace,
+			Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+		}
+		wl := &kueue.Workload{}
+
+		ginkgo.By("Waiting for the Workload to be deactivated", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+				g.Expect(wl.Spec.Active).To(gomega.Equal(ptr.To(false)))
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Enable ObjectRetentionPolicies feature gate", func() {
+			updateKueueConfiguration(func(cfg *configapi.Configuration) {
+				cfg.FeatureGates = map[string]bool{string(features.ObjectRetentionPolicies): true}
+				cfg.ObjectRetentionPolicies = &configapi.ObjectRetentionPolicies{
+					Workloads: &configapi.WorkloadRetentionPolicy{
+						AfterDeactivatedByKueue: &metav1.Duration{Duration: util.TinyTimeout},
+					},
+				}
+				cfg.WaitForPodsReady = waitForPodsReady.DeepCopy()
+			})
+		})
+
+		ginkgo.By("Checking that the Job is deleted", func() {
+			createdJob := &batchv1.Job{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), createdJob)).To(testing.BeNotFoundError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Checking that the Workload is deleted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(testing.BeNotFoundError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+})
+
 var _ = ginkgo.Describe("ObjectRetentionPolicies with TinyTimeout", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns *corev1.Namespace

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -1285,11 +1285,24 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 		devLocalQ           *kueue.LocalQueue
 	)
 
-	ginkgo.BeforeAll(func() {
+	startManager := func() {
 		fwk.StartManager(ctx, cfg, managerAndControllersSetup(false, true, nil))
+	}
+
+	stopManager := func() {
+		fwk.StopManager(ctx)
+	}
+
+	restartManager := func() {
+		stopManager()
+		startManager()
+	}
+
+	ginkgo.BeforeAll(func() {
+		startManager()
 	})
 	ginkgo.AfterAll(func() {
-		fwk.StopManager(ctx)
+		stopManager()
 	})
 
 	ginkgo.BeforeEach(func() {
@@ -1896,6 +1909,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 			})
 		})
 	})
+
 	ginkgo.It("Should schedule updated job and update the workload", func() {
 		localQueue := testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(prodClusterQ.Name).Obj()
 		ginkgo.By("create a localQueue", func() {
@@ -2086,6 +2100,67 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 					Should(gomega.Succeed())
 				g.Expect(sampleJob.Spec.Suspend).To(gomega.Equal(ptr.To(false)))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("Shouldn't admit deactivated Workload after manager restart", func() {
+		localQueue := testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(prodClusterQ.Name).Obj()
+		ginkgo.By("Create a LocalQueue", func() {
+			util.MustCreate(ctx, k8sClient, localQueue)
+		})
+
+		job := testingjob.MakeJob("job", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "2").
+			Obj()
+
+		ginkgo.By("Creating a Job", func() {
+			util.MustCreate(ctx, k8sClient, job)
+		})
+
+		wl := &kueue.Workload{}
+		wlKey := types.NamespacedName{
+			Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+			Namespace: job.Namespace,
+		}
+
+		ginkgo.By("Checking that the Workload is admitted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+				g.Expect(workload.IsAdmitted(wl)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 1)
+		})
+
+		ginkgo.By("Deactivate the Workload", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+				wl.Spec.Active = ptr.To(false)
+				g.Expect(k8sClient.Update(ctx, wl)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Checking that the Workload is deactivated and evicted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+				g.Expect(workload.IsActive(wl)).To(gomega.BeFalse())
+				g.Expect(workload.IsEvicted(wl)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Restarting the manager", func() {
+			restartManager()
+		})
+
+		ginkgo.By("Checking that the Workload is not admitted after restart the manager", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+				g.Expect(workload.IsAdmitted(wl)).To(gomega.BeFalse())
+				g.Expect(workload.IsEvicted(wl)).To(gomega.BeTrue())
+				// Using short intervals to make it likely to fail if the conditions flip
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			// NOTE: controller restart in integration tests does not reset the metrics
+			util.ExpectAdmittedWorkloadsTotalMetric(prodClusterQ, 1)
 		})
 	})
 })

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -42,6 +42,7 @@ const (
 	// a change in the deployment status.
 	StartUpTimeout     = 5 * time.Minute
 	ConsistentDuration = time.Second
+	ShortInterval      = 10 * time.Millisecond
 	Interval           = time.Millisecond * 250
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Don’t add the Workload to the Queues Manager if it is deactivated.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5623

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix the bug that Kueue, upon startup, would incorrectly admit and then immediately deactivate
already deactivated Workloads.

This bug also prevented the ObjectRetentionPolicies feature from deleting Workloads
that were deactivated by Kueue before the feature was enabled.
```