### PR TITLE
Automated cherry pick of #5625: Don’t add the Workload to the Queues Manager if it is deactivated.

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -608,7 +608,7 @@ func (r *WorkloadReconciler) Create(e event.TypedCreateEvent[*kueue.Workload]) b
 	wlCopy := e.Object.DeepCopy()
 	workload.AdjustResources(ctx, r.client, wlCopy)
 
-	if !workload.HasQuotaReservation(e.Object) {
+	if workload.IsActive(e.Object) && !workload.HasQuotaReservation(e.Object) {
 		if err := r.queues.AddOrUpdateWorkload(wlCopy); err != nil {
 			log.V(2).Info("ignored an error for now", "error", err)
 		}

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -272,7 +272,7 @@ func (m *Manager) AddLocalQueue(ctx context.Context, q *kueue.LocalQueue) error 
 		return fmt.Errorf("listing workloads that match the queue: %w", err)
 	}
 	for _, w := range workloads.Items {
-		if workload.HasQuotaReservation(&w) {
+		if !workload.IsActive(&w) || workload.HasQuotaReservation(&w) {
 			continue
 		}
 		workload.AdjustResources(ctx, m.client, &w)

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -42,6 +42,7 @@ const (
 	// a change in the deployment status.
 	StartUpTimeout     = 5 * time.Minute
 	ConsistentDuration = time.Second
+	ShortInterval      = 10 * time.Millisecond
 	Interval           = time.Millisecond * 250
 )
 


### PR DESCRIPTION
Cherry pick of #5625 on release-0.11.

#5625: Don’t add the Workload to the Queues Manager if it is deactivated.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix the bug that Kueue, upon startup, would incorrectly admit and then immediately deactivate
already deactivated Workloads.

This bug also prevented the ObjectRetentionPolicies feature from deleting Workloads
that were deactivated by Kueue before the feature was enabled.
```