### PR TITLE
Allow setting the controller-manager PriorityClassName in helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,8 @@ helm-verify: helm helm-lint ## run helm template and detect any rendering failur
 	$(HELM) template charts/kueue --set enableKueueViz=true --set enableCertManager=true --set enablePrometheus=true > /dev/null
 # test added managedJobsNamespaceSelector option
 	$(HELM) template charts/kueue --set managerConfig.controllerManagerConfigYaml="managedJobsNamespaceSelector:\n  matchExpressions:\n    - key: kubernetes.io/metadata.name\n      operator: In\n      values: [ kube-system ]" > /dev/null
+# test priorityClassName option
+	$(HELM) template charts/kueue --set controllerManager.manager.priorityClassName="system-cluster-critical" > /dev/null
 
 # test
 .PHONY: helm-unit-test

--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -108,6 +108,7 @@ The following table lists the configurable parameters of the kueue chart and the
 | `kueueViz.backend.image`                               | KueueViz dashboard backend image                       | `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-backend:main`  |
 | `kueueViz.frontend.image`                              | KueueViz dashboard frontend image                      | `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-frontend:main` |
 | `controllerManager.manager.featureGates`               | controllerManager.manager's feature gates              | `[]`                                                                         |
+| `controllerManager.manager.priorityClassName`          | controllerManager.manager's Pod priorityClassName      | ``                                          |
 | `controllerManager.manager.image.repository`           | controllerManager.manager's repository and image       | `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue` |
 | `controllerManager.manager.image.tag`                  | controllerManager.manager's tag                        | `main`                                      |
 | `controllerManager.manager.resources`                  | controllerManager.manager's resources                  | abbr.                                       |

--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -21,6 +21,9 @@ spec:
         {{- toYaml .Values.controllerManager.manager.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- with  .Values.controllerManager.manager.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
       - args:
         - --config=/controller_manager_config.yaml

--- a/charts/kueue/tests/manager_test.yaml
+++ b/charts/kueue/tests/manager_test.yaml
@@ -13,3 +13,22 @@ tests:
       - equal:
           path: spec.replicas
           value: 2
+  - it: should set the pod priorityClassName when provided
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        manager:
+          priorityClassName: "foo"
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: foo
+  - it: should not render the pod priorityClassName if not set
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        manager:
+          priorityClassName: ""
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -15,6 +15,7 @@ controllerManager:
   #  - name: PartialAdmission
   #    enabled: true
   manager:
+    # priorityClassName: "system-cluster-critical"
     image:
       repository: us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue
       # This should be set to 'IfNotPresent' for released version


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
On some deployments Kueue is a critical Pod, and to reflect that users would like to set the priority as `system-cluster-critical`. This PR allows setting the Pod priority from the Helm chart by exposing the `priorityClassName` property

#### Which issue(s) this PR fixes:

Fixes #5614

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Allow setting the controller-manager's Pod `PriorityClassName` from the Helm chart
```