### PR TITLE
[AFS] Support preemption based on historical LQ's usage

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -220,6 +220,7 @@ func main() {
 	}
 	if cfg.AdmissionFairSharing != nil {
 		queueOptions = append(queueOptions, queue.WithAdmissionFairSharing(cfg.AdmissionFairSharing))
+		cacheOptions = append(cacheOptions, cache.WithAdmissionFairSharing(cfg.AdmissionFairSharing))
 	}
 	cCache := cache.New(mgr.GetClient(), cacheOptions...)
 	queues := queue.NewManager(mgr.GetClient(), cCache, queueOptions...)

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -89,6 +89,7 @@ type clusterQueue struct {
 	tasCache *tasCache
 
 	workloadsNotAccountedForTAS sets.Set[workload.Reference]
+	AdmissionScope              *kueue.AdmissionScope
 }
 
 func (c *clusterQueue) GetName() kueue.ClusterQueueReference {
@@ -166,7 +167,7 @@ func (c *clusterQueue) updateClusterQueue(log logr.Logger, in *kueue.ClusterQueu
 	}
 
 	c.FairWeight = parseFairWeight(in.Spec.FairSharing)
-
+	c.AdmissionScope = in.Spec.AdmissionScope
 	return nil
 }
 

--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -43,6 +43,7 @@ type ClusterQueueSnapshot struct {
 	Preemption        kueue.ClusterQueuePreemption
 	FairWeight        resource.Quantity
 	FlavorFungibility kueue.FlavorFungibility
+	AdmissionScope    kueue.AdmissionScope
 	// Aggregates AdmissionChecks from both .spec.AdmissionChecks and .spec.AdmissionCheckStrategy
 	// Sets hold ResourceFlavors to which an AdmissionCheck should apply.
 	// In case its empty, it means an AdmissionCheck should apply to all ResourceFlavor

--- a/pkg/cache/snapshot.go
+++ b/pkg/cache/snapshot.go
@@ -25,10 +25,12 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
+	afs "sigs.k8s.io/kueue/pkg/util/admissionfairsharing"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -137,7 +139,10 @@ func (c *Cache) Snapshot(ctx context.Context) (*Snapshot, error) {
 			snap.InactiveClusterQueueSets.Insert(cq.Name)
 			continue
 		}
-		cqSnapshot := snapshotClusterQueue(cq)
+		cqSnapshot, err := c.snapshotClusterQueue(ctx, cq)
+		if err != nil {
+			return nil, err
+		}
 		snap.AddClusterQueue(cqSnapshot)
 		if cq.HasParent() {
 			snap.UpdateClusterQueueEdge(cq.Name, cq.Parent().Name)
@@ -157,7 +162,7 @@ func (c *Cache) Snapshot(ctx context.Context) (*Snapshot, error) {
 
 // snapshotClusterQueue creates a copy of ClusterQueue that includes
 // references to immutable objects and deep copies of changing ones.
-func snapshotClusterQueue(cq *clusterQueue) *ClusterQueueSnapshot {
+func (c *Cache) snapshotClusterQueue(ctx context.Context, cq *clusterQueue) (*ClusterQueueSnapshot, error) {
 	cc := &ClusterQueueSnapshot{
 		Name:                          cq.Name,
 		ResourceGroups:                make([]ResourceGroup, len(cq.ResourceGroups)),
@@ -177,7 +182,21 @@ func snapshotClusterQueue(cq *clusterQueue) *ClusterQueueSnapshot {
 	for i, rg := range cq.ResourceGroups {
 		cc.ResourceGroups[i] = rg.Clone()
 	}
-	return cc
+	if cq.AdmissionScope != nil {
+		cc.AdmissionScope = *cq.AdmissionScope.DeepCopy()
+	}
+	afsEnabled, resourceWeights := afs.ResourceWeights(&cc.AdmissionScope, c.admissionFairSharing)
+	if !afsEnabled {
+		return cc, nil
+	}
+	for _, wl := range cc.Workloads {
+		usage, err := wl.CalcLocalQueueFSUsage(ctx, c.client, resourceWeights)
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate LocalQueue FS usage for LocalQueue %v", client.ObjectKey{Namespace: wl.Obj.Namespace, Name: string(wl.Obj.Spec.QueueName)})
+		}
+		wl.LocalQueueFSUsage = &usage
+	}
+	return cc, nil
 }
 
 func newCohortSnapshot(name kueue.CohortReference) *CohortSnapshot {

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -513,12 +513,21 @@ func queueUnderNominalInResourcesNeedingPreemption(preemptionCtx *preemptionCtx)
 	return true
 }
 
+func resourceUsagePreemptionEnabled(a, b *workload.Info) bool {
+	// If both workloads are in the same ClusterQueue, but different LocalQueues,
+	// we can compare their LocalQueue usage.
+	// If the LocalQueueUsage is not nil for both Workloads, it means the feature gate has been enabled, and the
+	// AdmissionScope of the ClusterQueue is set to UsageBasedFairSharing. We inherit this information from the snapshot initialization.
+	return a.ClusterQueue == b.ClusterQueue && a.Obj.Spec.QueueName != b.Obj.Spec.QueueName && a.LocalQueueFSUsage != nil && b.LocalQueueFSUsage != nil
+}
+
 // candidatesOrdering criteria:
 // 0. Workloads already marked for preemption first.
 // 1. Workloads from other ClusterQueues in the cohort before the ones in the
 // same ClusterQueue as the preemptor.
-// 2. Workloads with lower priority first.
-// 3. Workloads admitted more recently first.
+// 2. (AdmissionFairSharing only) Workloads with lower LocalQueue's usage first
+// 3. Workloads with lower priority first.
+// 4. Workloads admitted more recently first.
 func CandidatesOrdering(a, b *workload.Info, cq kueue.ClusterQueueReference, now time.Time) bool {
 	aEvicted := meta.IsStatusConditionTrue(a.Obj.Status.Conditions, kueue.WorkloadEvicted)
 	bEvicted := meta.IsStatusConditionTrue(b.Obj.Status.Conditions, kueue.WorkloadEvicted)
@@ -531,6 +540,11 @@ func CandidatesOrdering(a, b *workload.Info, cq kueue.ClusterQueueReference, now
 		return !aInCQ
 	}
 
+	if resourceUsagePreemptionEnabled(a, b) {
+		if a.LocalQueueFSUsage != b.LocalQueueFSUsage {
+			return *a.LocalQueueFSUsage > *b.LocalQueueFSUsage
+		}
+	}
 	pa := priority.Priority(a.Obj)
 	pb := priority.Priority(b.Obj)
 	if pa != pb {

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -39,6 +39,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/cache"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
@@ -540,7 +541,7 @@ func CandidatesOrdering(a, b *workload.Info, cq kueue.ClusterQueueReference, now
 		return !aInCQ
 	}
 
-	if resourceUsagePreemptionEnabled(a, b) {
+	if features.Enabled(features.AdmissionFairSharing) && resourceUsagePreemptionEnabled(a, b) {
 		if a.LocalQueueFSUsage != b.LocalQueueFSUsage {
 			return *a.LocalQueueFSUsage > *b.LocalQueueFSUsage
 		}

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -2791,48 +2791,115 @@ func targetKeyReason(key workload.Reference, reason string) string {
 }
 func TestCandidatesOrdering(t *testing.T) {
 	now := time.Now()
-	candidates := []*workload.Info{
-		workload.NewInfo(utiltesting.MakeWorkload("high", "").
-			ReserveQuotaAt(utiltesting.MakeAdmission("self").Obj(), now).
-			Priority(10).
-			Obj()),
-		workload.NewInfo(utiltesting.MakeWorkload("low", "").
-			ReserveQuotaAt(utiltesting.MakeAdmission("self").Obj(), now).
-			Priority(-10).
-			Obj()),
-		workload.NewInfo(utiltesting.MakeWorkload("other", "").
-			ReserveQuotaAt(utiltesting.MakeAdmission("other").Obj(), now).
-			Priority(10).
-			Obj()),
-		workload.NewInfo(utiltesting.MakeWorkload("evicted", "").
-			SetOrReplaceCondition(metav1.Condition{
-				Type:               kueue.WorkloadEvicted,
-				Status:             metav1.ConditionTrue,
-				LastTransitionTime: metav1.NewTime(now),
-			}).
-			Obj()),
-		workload.NewInfo(utiltesting.MakeWorkload("old-a", "").
-			UID("old-a").
-			ReserveQuotaAt(utiltesting.MakeAdmission("self").Obj(), now).
-			Obj()),
-		workload.NewInfo(utiltesting.MakeWorkload("old-b", "").
-			UID("old-b").
-			ReserveQuotaAt(utiltesting.MakeAdmission("self").Obj(), now).
-			Obj()),
-		workload.NewInfo(utiltesting.MakeWorkload("current", "").
-			ReserveQuotaAt(utiltesting.MakeAdmission("self").Obj(), now.Add(time.Second)).
-			Obj()),
-	}
-	sort.Slice(candidates, func(i int, j int) bool {
-		return CandidatesOrdering(candidates[i], candidates[j], "self", now)
-	})
-	gotNames := make([]workload.Reference, len(candidates))
-	for i, c := range candidates {
-		gotNames[i] = workload.Key(c.Obj)
-	}
-	wantCandidates := []workload.Reference{"/evicted", "/other", "/low", "/current", "/old-a", "/old-b", "/high"}
-	if diff := cmp.Diff(wantCandidates, gotNames); diff != "" {
-		t.Errorf("Sorted with wrong order (-want,+got):\n%s", diff)
+
+	preemptorCq := "preemptor"
+
+	wlLowUsageLq := workload.NewInfo(utiltesting.MakeWorkload("low_lq_usage", "").
+		Queue("low_usage_lq").
+		ReserveQuotaAt(utiltesting.MakeAdmission(preemptorCq).Obj(), now).
+		Priority(1).
+		Obj())
+	wlLowUsageLq.LocalQueueFSUsage = ptr.To(0.1)
+
+	wlMidUsageLq := workload.NewInfo(utiltesting.MakeWorkload("mid_lq_usage", "").
+		Queue("mid_usage_lq").
+		ReserveQuotaAt(utiltesting.MakeAdmission(preemptorCq).Obj(), now).
+		Priority(10).
+		Obj())
+	wlMidUsageLq.LocalQueueFSUsage = ptr.To(0.5)
+
+	wlHighUsageLqDifCQ := workload.NewInfo(utiltesting.MakeWorkload("high_lq_usage_different_cq", "").
+		Queue("high_usage_lq_different_cq").
+		ReserveQuotaAt(utiltesting.MakeAdmission("different_cq").Obj(), now).
+		Priority(1).
+		Obj())
+	wlHighUsageLqDifCQ.LocalQueueFSUsage = ptr.To(1.0)
+
+	cases := map[string]struct {
+		candidates     []workload.Info
+		wantCandidates []workload.Reference
+	}{
+		"workloads sorted by priority": {
+			candidates: []workload.Info{
+				*workload.NewInfo(utiltesting.MakeWorkload("high", "").
+					ReserveQuotaAt(utiltesting.MakeAdmission(preemptorCq).Obj(), now).
+					Priority(10).
+					Obj()),
+				*workload.NewInfo(utiltesting.MakeWorkload("low", "").
+					ReserveQuotaAt(utiltesting.MakeAdmission(preemptorCq).Obj(), now).
+					Priority(-10).
+					Obj()),
+			},
+			wantCandidates: []workload.Reference{"low", "high"},
+		},
+		"evicted workload first": {
+			candidates: []workload.Info{
+				*workload.NewInfo(utiltesting.MakeWorkload("other", "").
+					ReserveQuotaAt(utiltesting.MakeAdmission(preemptorCq).Obj(), now).
+					Priority(10).
+					Obj()),
+				*workload.NewInfo(utiltesting.MakeWorkload("evicted", "").
+					SetOrReplaceCondition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Obj()),
+			},
+			wantCandidates: []workload.Reference{"evicted", "other"},
+		},
+		"workload from different CQ first": {
+			candidates: []workload.Info{
+				*workload.NewInfo(utiltesting.MakeWorkload("preemptorCq", "").
+					ReserveQuotaAt(utiltesting.MakeAdmission(preemptorCq).Obj(), now).
+					Priority(10).
+					Obj()),
+				*workload.NewInfo(utiltesting.MakeWorkload("other", "").
+					ReserveQuotaAt(utiltesting.MakeAdmission("other").Obj(), now).
+					Priority(10).
+					Obj()),
+			},
+			wantCandidates: []workload.Reference{"other", "preemptorCq"},
+		},
+		"old workloads last": {
+			candidates: []workload.Info{
+				*workload.NewInfo(utiltesting.MakeWorkload("older", "").
+					ReserveQuotaAt(utiltesting.MakeAdmission(preemptorCq).Obj(), now.Add(-time.Second)).
+					Obj()),
+				*workload.NewInfo(utiltesting.MakeWorkload("younger", "").
+					ReserveQuotaAt(utiltesting.MakeAdmission(preemptorCq).Obj(), now.Add(time.Second)).
+					Obj()),
+				*workload.NewInfo(utiltesting.MakeWorkload("current", "").
+					ReserveQuotaAt(utiltesting.MakeAdmission(preemptorCq).Obj(), now).
+					Obj()),
+			},
+			wantCandidates: []workload.Reference{"younger", "current", "older"},
+		},
+		"workloads with higher LQ usage first": {
+			candidates: []workload.Info{
+				*wlLowUsageLq,
+				*wlMidUsageLq,
+			},
+			wantCandidates: []workload.Reference{"mid_lq_usage", "low_lq_usage"},
+		},
+		"workloads from different CQ are sorted based on priority and timestamp": {
+			candidates: []workload.Info{
+				*wlMidUsageLq,
+				*wlHighUsageLqDifCQ,
+			},
+			wantCandidates: []workload.Reference{"high_lq_usage_different_cq", "mid_lq_usage"},
+		}}
+
+	for _, tc := range cases {
+		sort.Slice(tc.candidates, func(i int, j int) bool {
+			return CandidatesOrdering(&tc.candidates[i], &tc.candidates[j], kueue.ClusterQueueReference(preemptorCq), now)
+		})
+		got := slices.Map(tc.candidates, func(c *workload.Info) workload.Reference {
+			return workload.Reference(c.Obj.Name)
+		})
+		if diff := cmp.Diff(tc.wantCandidates, got); diff != "" {
+			t.Errorf("Sorted with wrong order (-want,+got):\n%s", diff)
+		}
 	}
 }
 

--- a/pkg/util/admissionfairsharing/admission_fair_sharing.go
+++ b/pkg/util/admissionfairsharing/admission_fair_sharing.go
@@ -1,0 +1,34 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admissionfairsharing
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/features"
+)
+
+func ResourceWeights(cqAdmissionScope *kueue.AdmissionScope, afsConfig *config.AdmissionFairSharing) (bool, map[corev1.ResourceName]float64) {
+	enableAdmissionFs, fsResWeights := false, make(map[corev1.ResourceName]float64)
+	if afsConfig != nil && cqAdmissionScope != nil && cqAdmissionScope.AdmissionMode == kueue.UsageBasedAdmissionFairSharing && features.Enabled(features.AdmissionFairSharing) {
+		enableAdmissionFs = true
+		fsResWeights = afsConfig.ResourceWeights
+	}
+	return enableAdmissionFs, fsResWeights
+}

--- a/pkg/util/admissionfairsharing/admission_fair_sharing.go
+++ b/pkg/util/admissionfairsharing/admission_fair_sharing.go
@@ -26,7 +26,7 @@ import (
 
 func ResourceWeights(cqAdmissionScope *kueue.AdmissionScope, afsConfig *config.AdmissionFairSharing) (bool, map[corev1.ResourceName]float64) {
 	enableAdmissionFs, fsResWeights := false, make(map[corev1.ResourceName]float64)
-	if afsConfig != nil && cqAdmissionScope != nil && cqAdmissionScope.AdmissionMode == kueue.UsageBasedAdmissionFairSharing && features.Enabled(features.AdmissionFairSharing) {
+	if features.Enabled(features.AdmissionFairSharing) && afsConfig != nil && cqAdmissionScope != nil && cqAdmissionScope.AdmissionMode == kueue.UsageBasedAdmissionFairSharing {
 		enableAdmissionFs = true
 		fsResWeights = afsConfig.ResourceWeights
 	}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -168,6 +168,10 @@ type Info struct {
 	// already admitted.
 	ClusterQueue   kueue.ClusterQueueReference
 	LastAssignment *AssignmentClusterQueueState
+
+	// LocalQueueFSUsage indicates the historical usage of resource in the LocalQueue, needed for the
+	// AdmissionFairSharing feature, it is only populated for Infos in cache.Snapshot (not in queue manager).
+	LocalQueueFSUsage *float64
 }
 
 type PodSetResources struct {
@@ -294,7 +298,7 @@ func dropExcludedResources(input corev1.ResourceList, excludedPrefixes []string)
 	return res
 }
 
-func (i *Info) LocalQueueUsage(ctx context.Context, c client.Client, resWeights map[corev1.ResourceName]float64) (float64, error) {
+func (i *Info) CalcLocalQueueFSUsage(ctx context.Context, c client.Client, resWeights map[corev1.ResourceName]float64) (float64, error) {
 	var lq kueue.LocalQueue
 	lqKey := client.ObjectKey{Namespace: i.Obj.Namespace, Name: string(i.Obj.Spec.QueueName)}
 	if err := c.Get(ctx, lqKey, &lq); err != nil {

--- a/test/integration/singlecluster/scheduler/fairsharing/suite_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/suite_test.go
@@ -87,7 +87,7 @@ func managerAndSchedulerSetup(ctx context.Context, mgr manager.Manager) {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	_ = features.SetEnable(features.AdmissionFairSharing, true)
-	cCache := cache.New(mgr.GetClient(), cache.WithFairSharing(fairSharing.Enable))
+	cCache := cache.New(mgr.GetClient(), cache.WithFairSharing(fairSharing.Enable), cache.WithAdmissionFairSharing(admissionFairSharing))
 	queues := queue.NewManager(mgr.GetClient(), cCache, queue.WithAdmissionFairSharing(admissionFairSharing))
 
 	configuration := &config.Configuration{FairSharing: fairSharing, AdmissionFairSharing: admissionFairSharing}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Adds `AdmissionScope` field to the interal ClusterQueue representation and CQ Snapshot
- Adds `LocalQueueUsage` field to Workload info to represent the historical LQ's usage in Snapshot
- Populates the `LocalQueueUsage` field if the AFS feature gate is enabled, and the CQ AdmissionMode is set to `UsageBasedAdmissionFairSharing`
- Order candidates for preemption based on the LQ's historical usage

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5827 

#### Special notes for your reviewer:
KEP update: https://github.com/kubernetes-sigs/kueue/pull/5817

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
AdmissionFairSharing: preemption candidates are now ordered within ClusterQueue with respect to LQ's usage. 
The ordering of candidates coming from other ClusterQueues is unchanged.
```