### PR TITLE
Job reconcile only for jobs in opt-in namespaces

### DIFF
--- a/config/components/manager/controller_manager_config.yaml
+++ b/config/components/manager/controller_manager_config.yaml
@@ -22,6 +22,11 @@ controller:
 clientConnection:
   qps: 50
   burst: 100
+managedJobsNamespaceSelector:
+  matchExpressions:
+    - key: managed-by-kueue
+      operator: In
+      values: ["true"]
 #pprofBindAddress: :8083
 #waitForPodsReady:
 #  enable: false

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -311,6 +311,18 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	if features.Enabled(features.ManagedJobsNamespaceSelector) {
+		ns := corev1.Namespace{}
+		if err := r.client.Get(ctx, client.ObjectKey{Name: req.Namespace}, &ns); err != nil {
+			log.Error(err, "failed to get namespace for selector check")
+			return ctrl.Result{}, err
+		}
+		if !r.managedJobsNamespaceSelector.Matches(labels.Set(ns.GetLabels())) {
+			log.V(2).Info("Namespace not opted in for Kueue management", "namespace", ns.Name)
+			return ctrl.Result{}, nil
+		}
+	}
+
 	var (
 		ancestorJob   client.Object
 		isTopLevelJob bool


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Following the discussion in https://github.com/kubernetes-sigs/kueue/issues/5260, this PR introduces a fix to prevent the Job reconciler from managing and unsuspending workloads solely based on the presence of the queue-name label, without considering the namespace.

This change ensures that a Job is only managed by Kueue if it resides in a namespace explicitly labeled with managed-by-kueue: true. As a result, Jobs in unmanaged namespaces will be ignored by the reconciler, even if they specify a queue-name.

Note that this logic is evaluated at creation time. If the namespace is labeled after the Job is created, the existing Job will remain unmanaged. However, new Jobs created after labeling the namespace will be properly managed by Kueue.