### PR TITLE
Automated cherry pick of #5631: Allow setting the controller-manager PriorityClassName in helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,8 @@ helm-verify: helm helm-lint ## run helm template and detect any rendering failur
 	$(HELM) template charts/kueue --set enableKueueViz=true --set enableCertManager=true --set enablePrometheus=true > /dev/null
 # test added managedJobsNamespaceSelector option
 	$(HELM) template charts/kueue --set managerConfig.controllerManagerConfigYaml="managedJobsNamespaceSelector:\n  matchExpressions:\n    - key: kubernetes.io/metadata.name\n      operator: In\n      values: [ kube-system ]" > /dev/null
+# test priorityClassName option
+	$(HELM) template charts/kueue --set controllerManager.manager.priorityClassName="system-cluster-critical" > /dev/null
 
 # test
 .PHONY: helm-unit-test

--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -77,6 +77,7 @@ The following table lists the configurable parameters of the kueue chart and the
 | `enableKueueViz`                                       | enable KueueViz dashboard                              | `false`                                     |
 | `KueueViz.backend.image`                               | KueueViz dashboard backend image                       | `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-backend:main` |
 | `KueueViz.frontend.image`                              | KueueViz dashboard frontend image                      | `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-frontend:main` |
+| `controllerManager.manager.priorityClassName`          | controllerManager.manager's Pod priorityClassName      | ``                                          |
 | `controllerManager.manager.image.repository`           | controllerManager.manager's repository and image       | `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue` |
 | `controllerManager.manager.image.tag`                  | controllerManager.manager's tag                        | `main`                                      |
 | `controllerManager.manager.resources`                  | controllerManager.manager's resources                  | abbr.                                       |

--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -21,6 +21,9 @@ spec:
         {{- toYaml .Values.controllerManager.manager.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- with  .Values.controllerManager.manager.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
       - args:
         - --config=/controller_manager_config.yaml

--- a/charts/kueue/tests/manager_test.yaml
+++ b/charts/kueue/tests/manager_test.yaml
@@ -13,3 +13,22 @@ tests:
       - equal:
           path: spec.replicas
           value: 2
+  - it: should set the pod priorityClassName when provided
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        manager:
+          priorityClassName: "foo"
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: foo
+  - it: should not render the pod priorityClassName if not set
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        manager:
+          priorityClassName: ""
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -15,6 +15,7 @@ controllerManager:
   #  - name: PartialAdmission
   #    enabled: true
   manager:
+    # priorityClassName: "system-cluster-critical"
     image:
       repository: us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue
       # This should be set to 'IfNotPresent' for released version


### PR DESCRIPTION
Cherry pick of #5631 on release-0.12.

#5631: Allow setting the controller-manager PriorityClassName in helm

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Allow setting the controller-manager's Pod `PriorityClassName` from the Helm chart
```