### PR TITLE
Automated cherry pick of #5631: Allow setting the controller-manager PriorityClassName in helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,8 @@ helm-lint: helm ## Run Helm chart lint test.
 helm-verify: helm helm-lint ## run helm template and detect any rendering failures
 # test default values
 	$(HELM) template charts/kueue > /dev/null
+# test priorityClassName option
+	$(HELM) template charts/kueue --set controllerManager.manager.priorityClassName="system-cluster-critical" > /dev/null
 .PHONY: vet
 vet: ## Run go vet against code.
 	$(GO_CMD) vet ./...

--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -77,6 +77,7 @@ The following table lists the configurable parameters of the kueue chart and the
 | `enableKueueViz`                                       | enable KueueViz dashboard                              | `false`                                     |
 | `kueueViz.backend.image`                               | KueueViz dashboard backend image                       | `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue-viz-backend:main-latest` |
 | `kueueViz.frontend.image`                              | KueueViz dashboard frontend image                      | `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue-viz-frontend:main-latest` |
+| `controllerManager.manager.priorityClassName`          | controllerManager.manager's Pod priorityClassName      | ``                                          |
 | `controllerManager.manager.image.repository`           | controllerManager.manager's repository and image       | `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue` |
 | `controllerManager.manager.image.tag`                  | controllerManager.manager's tag                        | `main`                                      |
 | `controllerManager.manager.resources`                  | controllerManager.manager's resources                  | abbr.                                       |

--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -21,6 +21,9 @@ spec:
         {{- toYaml .Values.controllerManager.manager.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
+      {{- with  .Values.controllerManager.manager.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
       - args:
         - --config=/controller_manager_config.yaml

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -15,6 +15,7 @@ controllerManager:
   #  - name: PartialAdmission
   #    enabled: true
   manager:
+    # priorityClassName: "system-cluster-critical"
     image:
       repository: us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue
       # This should be set to 'IfNotPresent' for released version      


### PR DESCRIPTION
Cherry pick of #5631 on release-0.11.

#5631: Allow setting the controller-manager PriorityClassName in helm

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Allow setting the controller-manager's Pod `PriorityClassName` from the Helm chart
```