### PR TITLE
Documentation: Update Admission Section 

### DIFF
--- a/site/content/en/docs/concepts/_index.md
+++ b/site/content/en/docs/concepts/_index.md
@@ -56,16 +56,47 @@ network throughput between the Pods.
 ### Quota Reservation
 
 _Quota reservation_ is the process during through which the kueue scheduler locks the resources needed by a workload within the targeted
-[ClusterQueues ResourceGroups](/docs/concepts/cluster_queue/#resource-groups)
+[ClusterQueues ResourceGroups](/site/content/en/docs/concepts/cluster_queue.md#resource-groups)
 
 Quota reservation is sometimes referred to as _workload scheduling_ or _job scheduling_,
 but it should not to be confused with [pod scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
 
 ### Admission
 
-_Admission_ is the process of allowing a Workload to start (Pods to be created). A Workload
-is admitted when it has a Quota Reservation and all its [AdmissionCheckStates](/docs/concepts/admission_check)
-are `Ready`.
+_Admission_ is the process of allowing a Workload to start (Pods to be created). Kueue uses a two-step admission cycle for Workload scheduling: 
+
+- Quota Reservation : When a Workload is submitted, it enters a LocalQueue first. This LocalQueue points to a ClusterQueue which is responsible for managing the available resources. The Kueue scheduler checks if the resources (CPU, memory, GPUs, etc.) requested by the Workload can be satisfied using the targeted ClusterQueue's available quota and resource flavors. If the quota is available, the resources are reserved for this workload and other Workloads are prevented from using the same resources. 
+
+- Admission Checks: After the quota is reserved, Kueue executes all AdmissionChecks configured in the ClusterQueue concurrently. These are pluggable AdmissionChecks controllers that can perform certain validations such as policy checks, compliance, etc.
+These checks can be external or internal and determine if additional criteria are met before the Workload is admitted. The Workload is admitted once all its [AdmissionCheckStates](site/content/en/docs/concepts/admission_check.md) are mark `Ready`.
+
+<h4> Example: Provisioning AdmissionCheck </h4>
+
+Earlier, Kueue admissions were mainly based on quota checks- if sufficient quota existed, the workload is admitted. However, just because the quota (logical resource) is available, doesn't mean there are enough actual(physical) compute resources in the cluster to schedule all pods successfully. This is critical in cloud environments where autoscaling provides nodes on-demand. 
+
+[ProvisioningRequest AdmissionCheck](keps/1136-provisioning-request-support/README.md) handles this issue by ensuring that the physical resources can be provisioned before admitting Workloads.
+Kueue's enhanced admission process now consists of two sequential checks before admitting a workload:
+- Quota Validation: It uses Kueue's existing quota management system to check if the workload fits within available cluster quotas. It verifies "logical" resource availability. <br>
+- Capacity Guarantee: It uses Provisioning Request and [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) to ensure actual resources will exist. It verifies "physical" resource availability. <br> The Kueue controller creates a ProvisioningRequest object, attaches PodTemplates from the Workload, applies configuration from ProvisioningRequestConfig and sets owner reference to Workload. <br> Cluster Autoscaler receives ProvisioningRequest, checks actual cluster capacity, triggers scaling if needed and updates ProvisioningRequest status as `Provisioned=true` if capacity guaranteed, `Provisioned=false` if scaling is in progress, and `Failed=true` if cannot provision.
+
+Lets understand this with a real-world usage - GPU Workload:
+
+Scenario: *AI training job needing 16 GPUs*
+
+- Step 1 (Quota Check): ClusterQueue has 32 GPU quota available, since requested is quota available, 16 GPUs are reserved.
+
+- Step 2 (Capacity Check): A ProvisioningRequest is created for 16 GPUs. Cluster Autoscaler checks cloud provider GPU inventory and initiates scaling of 4x GPU nodes (4 GPUs each). It sets `Provisioned=true` when nodes ready.
+
+Kueue sees the `Provisioned=true` proceeds to mark the AdmissionCheck `Ready` and admits workload
+
+Outcome:
+*Job starts immediately with all 16 GPUs available.*
+
+<h4>Failure Handling: </h4>
+If the capacity check fails, incase of temporary issues like cloud capacity shortages, exponential backoff retries is triggered while maintaining the workload's queue position and reserved quota. For permanent failures, the AdmissionCheck is marked Rejected, quota is released, and the workload is evicted, requiring user resubmission.
+
+<!-- A Workload is admitted when it has a Quota Reservation and all its [AdmissionCheckStates](/docs/concepts/admission_check)
+are `Ready`. -->
 
 ### [Cohort](/docs/concepts/cluster_queue#cohort)
 


### PR DESCRIPTION
…rovisioningRequest

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:

This PR enhances the the [Admission Section](https://kueue.sigs.k8s.io/docs/concepts/#admission) in the Kueue official documentation by:
- Clarifying the two-step admission cycle,
- Adding detailed explanation of the ProvisioningRequest admission check
- Fixing a few broken or outdated links in the [here](site/content/en/docs/concepts/_index.md) for better navigation and reference.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5172 

#### Special notes for your reviewer:
As my first contribution to Kueue, I’ve focused on:  
- Improving documentation clarity for the admission workflow  
- Adding technical examples 
- Ensuring accuracy in describing ProvisioningRequest integration  

Please feel free to suggest improvements and corrections—I’m eager to learn and refine this further!  
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
```release-note

```