### PR TITLE
KEP: Reconcile jobs only in opt-in namespaces

### DIFF
--- a/keps/3589-manage-jobs-selectively/kep.yaml
+++ b/keps/3589-manage-jobs-selectively/kep.yaml
@@ -9,6 +9,7 @@ reviewers:
   - "@tenzen-y"
 approvers:
   - "@mimowo"
+  - "@tenzen-y"
 
 # The target maturity stage in the current dev cycle for this KEP.
 stage: beta
@@ -24,4 +25,5 @@ milestone:
 
 feature-gates:
   - name: ManagedJobsNamespaceSelector
+  - name: ManagedJobsNamespaceSelectorAlwaysRespected
 disable-supported: true


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind documentation

#### What this PR does / why we need it:

This PR updates the KEP to reflect that Kueue will reconcile Jobs only in namespaces selected by managedJobsNamespaceSelector, ensuring consistent behavior across all supported integrations, including Pods, Deployments, and StatefulSets.

#### Which issue(s) this PR fixes:

Fixes # https://github.com/kubernetes-sigs/kueue/issues/5260

#### Special notes for your reviewer:

Once this change is implemented, namespaces will need to match managedJobsNamespaceSelector (e.g., carry the appropriate label) for their Jobs to be reconciled by Kueue—even if those Jobs specify a queue-name. This makes opting into Kueue management explicit for all integrations, including Jobs, and no longer optional by default.