### PR TITLE
Fix customconfigs WaitForPodsReady E2E Tests.

### DIFF
--- a/test/e2e/customconfigs/waitforpodsready_test.go
+++ b/test/e2e/customconfigs/waitforpodsready_test.go
@@ -41,7 +41,7 @@ const (
 	metricsReaderClusterRoleName = "kueue-metrics-reader"
 )
 
-var _ = ginkgo.Describe("WaitForPodsReady Job Controller E2E", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("WaitForPodsReady with tiny Timeout and no RecoveryTimeout", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	var (
 		ns    *corev1.Namespace
 		rf    *kueue.ResourceFlavor
@@ -74,6 +74,33 @@ var _ = ginkgo.Describe("WaitForPodsReady Job Controller E2E", ginkgo.Ordered, f
 			},
 		}
 		util.MustCreate(ctx, k8sClient, metricsReaderClusterRoleBinding)
+
+		updateKueueConfiguration(func(cfg *configapi.Configuration) {
+			cfg.WaitForPodsReady = &configapi.WaitForPodsReady{
+				Enable:          true,
+				BlockAdmission:  ptr.To(true),
+				Timeout:         &metav1.Duration{Duration: util.TinyTimeout},
+				RecoveryTimeout: nil,
+				RequeuingStrategy: &configapi.RequeuingStrategy{
+					Timestamp:          ptr.To(configapi.EvictionTimestamp),
+					BackoffBaseSeconds: ptr.To(int32(10)),
+					BackoffLimitCount:  ptr.To(int32(1)),
+				},
+			}
+		})
+
+		curlPod = testingjobspod.MakePod("curl-metrics", configapi.DefaultNamespace).
+			ServiceAccountName(serviceAccountName).
+			Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+			TerminationGracePeriod(1).
+			Obj()
+		util.MustCreate(ctx, k8sClient, curlPod)
+
+		ginkgo.By("Waiting for the curl-metrics pod to run.", func() {
+			util.WaitForPodRunning(ctx, k8sClient, curlPod)
+		})
+
+		curlContainerName = curlPod.Spec.Containers[0].Name
 	})
 
 	ginkgo.BeforeEach(func() {
@@ -99,284 +126,360 @@ var _ = ginkgo.Describe("WaitForPodsReady Job Controller E2E", ginkgo.Ordered, f
 	})
 
 	ginkgo.AfterAll(func() {
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, curlPod, true, util.LongTimeout)
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, metricsReaderClusterRoleBinding, true)
 	})
 
-	ginkgo.When("WaitForPodsReady has a tiny Timeout and no RecoveryTimeout", func() {
-		ginkgo.BeforeEach(func() {
-			updateKueueConfiguration(func(cfg *configapi.Configuration) {
-				cfg.WaitForPodsReady = &configapi.WaitForPodsReady{
-					Enable:          true,
-					BlockAdmission:  ptr.To(true),
-					Timeout:         &metav1.Duration{Duration: util.TinyTimeout},
-					RecoveryTimeout: nil,
-					RequeuingStrategy: &configapi.RequeuingStrategy{
-						Timestamp:          ptr.To(configapi.EvictionTimestamp),
-						BackoffBaseSeconds: ptr.To(int32(10)),
-						BackoffLimitCount:  ptr.To(int32(1)),
-					},
-				}
-			})
-
-			curlPod = testingjobspod.MakePod("curl-metrics", configapi.DefaultNamespace).
-				ServiceAccountName(serviceAccountName).
-				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-				TerminationGracePeriod(1).
+	ginkgo.It("should evict and requeue workload when pods readiness timeout is surpassed", func() {
+		ginkgo.By("creating a suspended job so its pods never report Ready", func() {
+			job = testingjob.MakeJob("job-timeout", ns.Name).
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "2").
+				Parallelism(1).
 				Obj()
-			util.MustCreate(ctx, k8sClient, curlPod)
-
-			ginkgo.By("Waiting for the curl-metrics pod to run.", func() {
-				util.WaitForPodRunning(ctx, k8sClient, curlPod)
-			})
-
-			curlContainerName = curlPod.Spec.Containers[0].Name
+			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
 		})
 
-		ginkgo.AfterEach(func() {
-			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, curlPod, true, util.LongTimeout)
+		wlKey = types.NamespacedName{
+			Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+			Namespace: ns.Name,
+		}
+
+		ginkgo.By("waiting for the workload to be created and verifying it is not admitted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+				g.Expect(wl.Status.Admission).To(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("should evict and requeue workload when pods readiness timeout is surpassed", func() {
-			ginkgo.By("creating a suspended job so its pods never report Ready", func() {
-				job = testingjob.MakeJob("job-timeout", ns.Name).
-					Queue(kueue.LocalQueueName(lq.Name)).
-					Request(corev1.ResourceCPU, "2").
-					Parallelism(1).
-					Obj()
-				gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
-			})
+		ginkgo.By("waiting for the workload to be evicted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+				g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusFalseAndReason(kueue.WorkloadPodsReady, kueue.WorkloadWaitForStart))
+				g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason(kueue.WorkloadEvicted, kueue.WorkloadEvictedByPodsReadyTimeout))
+				g.Expect(wl.Status.SchedulingStats.Evictions).To(
+					gomega.BeComparableTo([]kueue.WorkloadSchedulingStatsEviction{{
+						Reason:          kueue.WorkloadEvictedByPodsReadyTimeout,
+						UnderlyingCause: kueue.WorkloadWaitForStart,
+						Count:           1,
+					}}),
+				)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
 
-			wlKey = types.NamespacedName{
-				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
-				Namespace: ns.Name,
+		ginkgo.By("verifying that the metric is updated", func() {
+			util.ExpectMetricsToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, [][]string{
+				{"kueue_evicted_workloads_once_total", cq.Name, string(kueue.WorkloadEvictedByPodsReadyTimeout), kueue.WorkloadWaitForStart, "1"},
+			})
+		})
+
+		ginkgo.By("verifying that the job is suspended", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).Should(gomega.Succeed())
+				g.Expect(ptr.Deref(job.Spec.Suspend, false)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verifying that the workload is requeued", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+				g.Expect(wl.Status.RequeueState).ShouldNot(gomega.BeNil())
+				g.Expect(*wl.Status.RequeueState.Count).To(gomega.Equal(int32(1)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verifying that the workload is deactivated after the second eviction", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+				g.Expect(ptr.Deref(wl.Spec.Active, true)).Should(gomega.BeFalse())
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+})
+
+var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a tiny RecoveryTimeout", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	var (
+		ns    *corev1.Namespace
+		rf    *kueue.ResourceFlavor
+		cq    *kueue.ClusterQueue
+		lq    *kueue.LocalQueue
+		job   *batchv1.Job
+		wl    kueue.Workload
+		wlKey types.NamespacedName
+
+		metricsReaderClusterRoleBinding *rbacv1.ClusterRoleBinding
+
+		curlContainerName string
+		curlPod           *corev1.Pod
+	)
+
+	ginkgo.BeforeAll(func() {
+		metricsReaderClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "metrics-reader-rolebinding"},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccountName,
+					Namespace: configapi.DefaultNamespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     metricsReaderClusterRoleName,
+			},
+		}
+		util.MustCreate(ctx, k8sClient, metricsReaderClusterRoleBinding)
+
+		updateKueueConfiguration(func(cfg *configapi.Configuration) {
+			cfg.WaitForPodsReady = &configapi.WaitForPodsReady{
+				Enable:          true,
+				BlockAdmission:  ptr.To(true),
+				RecoveryTimeout: &metav1.Duration{Duration: util.TinyTimeout},
+				RequeuingStrategy: &configapi.RequeuingStrategy{
+					Timestamp:          ptr.To(configapi.EvictionTimestamp),
+					BackoffBaseSeconds: ptr.To(int32(1)),
+					BackoffLimitCount:  ptr.To(int32(1)),
+				},
 			}
+		})
 
-			ginkgo.By("waiting for the workload to be created and verifying it is not admitted", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
-					g.Expect(wl.Status.Admission).To(gomega.BeNil())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
+		curlPod = testingjobspod.MakePod("curl-metrics", configapi.DefaultNamespace).
+			ServiceAccountName(serviceAccountName).
+			Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+			TerminationGracePeriod(1).
+			Obj()
+		util.MustCreate(ctx, k8sClient, curlPod)
 
-			ginkgo.By("waiting for the workload to be evicted", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
-					g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusFalseAndReason(kueue.WorkloadPodsReady, kueue.WorkloadWaitForStart))
-					g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason(kueue.WorkloadEvicted, kueue.WorkloadEvictedByPodsReadyTimeout))
-					g.Expect(wl.Status.SchedulingStats.Evictions).To(
-						gomega.BeComparableTo([]kueue.WorkloadSchedulingStatsEviction{{
-							Reason:          kueue.WorkloadEvictedByPodsReadyTimeout,
-							UnderlyingCause: kueue.WorkloadWaitForStart,
-							Count:           1,
-						}}),
-					)
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
+		ginkgo.By("Waiting for the curl-metrics pod to run.", func() {
+			util.WaitForPodRunning(ctx, k8sClient, curlPod)
+		})
 
-			ginkgo.By("verifying that the metric is updated", func() {
-				util.ExpectMetricsToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, [][]string{
-					{"kueue_evicted_workloads_once_total", cq.Name, string(kueue.WorkloadEvictedByPodsReadyTimeout), kueue.WorkloadWaitForStart, "1"},
-				})
-			})
+		curlContainerName = curlPod.Spec.Containers[0].Name
+	})
 
-			ginkgo.By("verifying that the job is suspended", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).Should(gomega.Succeed())
-					g.Expect(ptr.Deref(job.Spec.Suspend, false)).To(gomega.BeTrue())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "wfpr-")
 
-			ginkgo.By("verifying that the workload is requeued", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
-					g.Expect(wl.Status.RequeueState).ShouldNot(gomega.BeNil())
-					g.Expect(*wl.Status.RequeueState.Count).To(gomega.Equal(int32(1)))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
+		rf = testing.MakeResourceFlavor("default").Obj()
+		gomega.Expect(k8sClient.Create(ctx, rf)).Should(gomega.Succeed())
 
-			ginkgo.By("verifying that the workload is deactivated after the second eviction", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
-					g.Expect(ptr.Deref(wl.Spec.Active, true)).Should(gomega.BeFalse())
-				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		cq = testing.MakeClusterQueue("cq").
+			ResourceGroup(*testing.MakeFlavorQuotas(rf.Name).Resource(corev1.ResourceCPU, "10").Obj()).
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, cq)).Should(gomega.Succeed())
+
+		lq = testing.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+		gomega.Expect(k8sClient.Create(ctx, lq)).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, rf, true)
+		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
+	})
+
+	ginkgo.AfterAll(func() {
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, curlPod, true, util.LongTimeout)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, metricsReaderClusterRoleBinding, true)
+	})
+
+	ginkgo.It("should evict and requeue workload when pod failure causes recovery timeout", func() {
+		ginkgo.By("creating a job", func() {
+			job = testingjob.MakeJob("job-recovery-timeout", ns.Name).
+				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "2").
+				Parallelism(1).
+				BackoffLimitPerIndex(2).
+				CompletionMode(batchv1.IndexedCompletion).
+				Completions(1).
+				Obj()
+
+			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+		})
+
+		wlKey = types.NamespacedName{
+			Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+			Namespace: ns.Name,
+		}
+
+		ginkgo.By("checking workload availability", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+				g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrue(kueue.WorkloadPodsReady))
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("simulating pod failure", func() {
+			util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 1, 1)
+		})
+
+		ginkgo.By("verifying that the workload is requeued", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+				g.Expect(wl.Status.RequeueState).ShouldNot(gomega.BeNil())
+				g.Expect(*wl.Status.RequeueState.Count).To(gomega.Equal(int32(1)))
+				g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason(kueue.WorkloadPodsReady, kueue.WorkloadStarted))
+				g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusFalse(kueue.WorkloadEvicted))
+				g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrue(kueue.WorkloadRequeued))
+
+				g.Expect(wl.Status.SchedulingStats.Evictions).To(
+					gomega.BeComparableTo([]kueue.WorkloadSchedulingStatsEviction{{
+						Reason:          kueue.WorkloadEvictedByPodsReadyTimeout,
+						UnderlyingCause: kueue.WorkloadWaitForRecovery,
+						Count:           1,
+					}}),
+				)
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verifying that the metric is updated", func() {
+			util.ExpectMetricsToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, [][]string{
+				{"kueue_evicted_workloads_once_total", cq.Name, string(kueue.WorkloadEvictedByPodsReadyTimeout), kueue.WorkloadWaitForRecovery, "1"},
 			})
 		})
 	})
+})
 
-	ginkgo.When("WaitForPodsReady has default Timeout and a tiny RecoveryTimeout", func() {
-		ginkgo.BeforeEach(func() {
-			updateKueueConfiguration(func(cfg *configapi.Configuration) {
-				cfg.WaitForPodsReady = &configapi.WaitForPodsReady{
-					Enable:          true,
-					BlockAdmission:  ptr.To(true),
-					RecoveryTimeout: &metav1.Duration{Duration: util.TinyTimeout},
-					RequeuingStrategy: &configapi.RequeuingStrategy{
-						Timestamp:          ptr.To(configapi.EvictionTimestamp),
-						BackoffBaseSeconds: ptr.To(int32(1)),
-						BackoffLimitCount:  ptr.To(int32(1)),
-					},
-				}
-			})
+var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a long RecoveryTimeout", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	var (
+		ns    *corev1.Namespace
+		rf    *kueue.ResourceFlavor
+		cq    *kueue.ClusterQueue
+		lq    *kueue.LocalQueue
+		job   *batchv1.Job
+		wl    kueue.Workload
+		wlKey types.NamespacedName
 
-			curlPod = testingjobspod.MakePod("curl-metrics", configapi.DefaultNamespace).
-				ServiceAccountName(serviceAccountName).
-				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-				TerminationGracePeriod(1).
-				Obj()
-			util.MustCreate(ctx, k8sClient, curlPod)
+		metricsReaderClusterRoleBinding *rbacv1.ClusterRoleBinding
 
-			ginkgo.By("Waiting for the curl-metrics pod to run.", func() {
-				util.WaitForPodRunning(ctx, k8sClient, curlPod)
-			})
+		curlContainerName string
+		curlPod           *corev1.Pod
+	)
 
-			curlContainerName = curlPod.Spec.Containers[0].Name
-		})
+	ginkgo.BeforeAll(func() {
+		metricsReaderClusterRoleBinding = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "metrics-reader-rolebinding"},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      serviceAccountName,
+					Namespace: configapi.DefaultNamespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     metricsReaderClusterRoleName,
+			},
+		}
+		util.MustCreate(ctx, k8sClient, metricsReaderClusterRoleBinding)
 
-		ginkgo.AfterEach(func() {
-			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, curlPod, true, util.LongTimeout)
-		})
-
-		ginkgo.It("should evict and requeue workload when pod failure causes recovery timeout", func() {
-			ginkgo.By("creating a job", func() {
-				job = testingjob.MakeJob("job-recovery-timeout", ns.Name).
-					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-					Queue(kueue.LocalQueueName(lq.Name)).
-					Request(corev1.ResourceCPU, "2").
-					Parallelism(1).
-					BackoffLimitPerIndex(2).
-					CompletionMode(batchv1.IndexedCompletion).
-					Completions(1).
-					Obj()
-
-				gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
-			})
-
-			wlKey = types.NamespacedName{
-				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
-				Namespace: ns.Name,
+		updateKueueConfiguration(func(cfg *configapi.Configuration) {
+			cfg.WaitForPodsReady = &configapi.WaitForPodsReady{
+				Enable:          true,
+				BlockAdmission:  ptr.To(true),
+				RecoveryTimeout: &metav1.Duration{Duration: util.LongTimeout},
+				RequeuingStrategy: &configapi.RequeuingStrategy{
+					Timestamp:          ptr.To(configapi.EvictionTimestamp),
+					BackoffBaseSeconds: ptr.To(int32(1)),
+					BackoffLimitCount:  ptr.To(int32(1)),
+				},
 			}
-
-			ginkgo.By("checking workload availability", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
-					g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrue(kueue.WorkloadPodsReady))
-				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("simulating pod failure", func() {
-				util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 1, 1)
-			})
-
-			ginkgo.By("verifying that the workload is requeued", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
-					g.Expect(wl.Status.RequeueState).ShouldNot(gomega.BeNil())
-					g.Expect(*wl.Status.RequeueState.Count).To(gomega.Equal(int32(1)))
-					g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason(kueue.WorkloadPodsReady, kueue.WorkloadStarted))
-					g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusFalse(kueue.WorkloadEvicted))
-					g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrue(kueue.WorkloadRequeued))
-
-					g.Expect(wl.Status.SchedulingStats.Evictions).To(
-						gomega.BeComparableTo([]kueue.WorkloadSchedulingStatsEviction{{
-							Reason:          kueue.WorkloadEvictedByPodsReadyTimeout,
-							UnderlyingCause: kueue.WorkloadWaitForRecovery,
-							Count:           1,
-						}}),
-					)
-				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("verifying that the metric is updated", func() {
-				util.ExpectMetricsToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, [][]string{
-					{"kueue_evicted_workloads_once_total", cq.Name, string(kueue.WorkloadEvictedByPodsReadyTimeout), kueue.WorkloadWaitForRecovery, "1"},
-				})
-			})
 		})
+
+		curlPod = testingjobspod.MakePod("curl-metrics", configapi.DefaultNamespace).
+			ServiceAccountName(serviceAccountName).
+			Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
+			TerminationGracePeriod(1).
+			Obj()
+		util.MustCreate(ctx, k8sClient, curlPod)
+
+		ginkgo.By("Waiting for the curl-metrics pod to run.", func() {
+			util.WaitForPodRunning(ctx, k8sClient, curlPod)
+		})
+
+		curlContainerName = curlPod.Spec.Containers[0].Name
 	})
 
-	ginkgo.When("WaitForPodsReady has default Timeout and a long RecoveryTimeout", func() {
-		ginkgo.BeforeEach(func() {
-			updateKueueConfiguration(func(cfg *configapi.Configuration) {
-				cfg.WaitForPodsReady = &configapi.WaitForPodsReady{
-					Enable:          true,
-					BlockAdmission:  ptr.To(true),
-					RecoveryTimeout: &metav1.Duration{Duration: util.LongTimeout},
-					RequeuingStrategy: &configapi.RequeuingStrategy{
-						Timestamp:          ptr.To(configapi.EvictionTimestamp),
-						BackoffBaseSeconds: ptr.To(int32(1)),
-						BackoffLimitCount:  ptr.To(int32(1)),
-					},
-				}
-			})
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "wfpr-")
 
-			curlPod = testingjobspod.MakePod("curl-metrics", configapi.DefaultNamespace).
-				ServiceAccountName(serviceAccountName).
+		rf = testing.MakeResourceFlavor("default").Obj()
+		gomega.Expect(k8sClient.Create(ctx, rf)).Should(gomega.Succeed())
+
+		cq = testing.MakeClusterQueue("cq").
+			ResourceGroup(*testing.MakeFlavorQuotas(rf.Name).Resource(corev1.ResourceCPU, "10").Obj()).
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, cq)).Should(gomega.Succeed())
+
+		lq = testing.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+		gomega.Expect(k8sClient.Create(ctx, lq)).Should(gomega.Succeed())
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, rf, true)
+		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
+	})
+
+	ginkgo.AfterAll(func() {
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, curlPod, true, util.LongTimeout)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, metricsReaderClusterRoleBinding, true)
+	})
+
+	ginkgo.It("should continue running workload if pod recovers before recoveryTimeout", func() {
+		ginkgo.By("creating a job", func() {
+			job = testingjob.MakeJob("job-recovery-timeout", ns.Name).
 				Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-				TerminationGracePeriod(1).
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "2").
+				Parallelism(1).
+				BackoffLimitPerIndex(2).
+				CompletionMode(batchv1.IndexedCompletion).
+				Completions(1).
 				Obj()
-			util.MustCreate(ctx, k8sClient, curlPod)
 
-			ginkgo.By("Waiting for the curl-metrics pod to run.", func() {
-				util.WaitForPodRunning(ctx, k8sClient, curlPod)
-			})
-
-			curlContainerName = curlPod.Spec.Containers[0].Name
+			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
 		})
 
-		ginkgo.AfterEach(func() {
-			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, curlPod, true, util.LongTimeout)
+		wlKey = types.NamespacedName{
+			Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+			Namespace: ns.Name,
+		}
+
+		ginkgo.By("checking workload availability", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+				g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrue(kueue.WorkloadPodsReady))
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("should continue running workload if pod recovers before recoveryTimeout", func() {
-			ginkgo.By("creating a job", func() {
-				job = testingjob.MakeJob("job-recovery-timeout", ns.Name).
-					Image(util.E2eTestAgnHostImage, util.BehaviorWaitForDeletion).
-					Queue(kueue.LocalQueueName(lq.Name)).
-					Request(corev1.ResourceCPU, "2").
-					Parallelism(1).
-					BackoffLimitPerIndex(2).
-					CompletionMode(batchv1.IndexedCompletion).
-					Completions(1).
-					Obj()
+		ginkgo.By("verifying that the metric is updated", func() {
+			util.ExpectMetricsToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, [][]string{
+				{"kueue_ready_wait_time_seconds_count", cq.Name},
+				{"kueue_admitted_until_ready_wait_time_seconds_count", cq.Name},
+				{"kueue_local_queue_ready_wait_time_seconds", ns.Name, lq.Name},
+				{"kueue_local_queue_admitted_until_ready_wait_time_seconds", ns.Name, lq.Name}})
+		})
 
-				gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
-			})
+		ginkgo.By("simulating pod failure", func() {
+			util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 1, 1)
+		})
 
-			wlKey = types.NamespacedName{
-				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
-				Namespace: ns.Name,
-			}
+		ginkgo.By("verifying the pod is recovered before recoveryTimeout", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
+				g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason(kueue.WorkloadPodsReady, kueue.WorkloadRecovered))
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		})
 
-			ginkgo.By("checking workload availability", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
-					g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrue(kueue.WorkloadPodsReady))
-				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("verifying that the metric is updated", func() {
-				util.ExpectMetricsToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, [][]string{
-					{"kueue_ready_wait_time_seconds_count", cq.Name},
-					{"kueue_admitted_until_ready_wait_time_seconds_count", cq.Name},
-					{"kueue_local_queue_ready_wait_time_seconds", ns.Name, lq.Name},
-					{"kueue_local_queue_admitted_until_ready_wait_time_seconds", ns.Name, lq.Name}})
-			})
-
-			ginkgo.By("simulating pod failure", func() {
-				util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 1, 1)
-			})
-
-			ginkgo.By("verifying the pod is recovered before recoveryTimeout", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
-					g.Expect(wl.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason(kueue.WorkloadPodsReady, kueue.WorkloadRecovered))
-				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("verifying that the metric is not updated", func() {
-				util.ExpectMetricsNotToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, [][]string{
-					{"kueue_evicted_workloads_once_total", ns.Name},
-				})
+		ginkgo.By("verifying that the metric is not updated", func() {
+			util.ExpectMetricsNotToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, [][]string{
+				{"kueue_evicted_workloads_once_total", ns.Name},
 			})
 		})
 	})

--- a/test/e2e/customconfigs/waitforpodsready_test.go
+++ b/test/e2e/customconfigs/waitforpodsready_test.go
@@ -107,15 +107,15 @@ var _ = ginkgo.Describe("WaitForPodsReady with tiny Timeout and no RecoveryTimeo
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "wfpr-")
 
 		rf = testing.MakeResourceFlavor("default").Obj()
-		gomega.Expect(k8sClient.Create(ctx, rf)).Should(gomega.Succeed())
+		util.MustCreate(ctx, k8sClient, rf)
 
 		cq = testing.MakeClusterQueue("cq").
 			ResourceGroup(*testing.MakeFlavorQuotas(rf.Name).Resource(corev1.ResourceCPU, "10").Obj()).
 			Obj()
-		gomega.Expect(k8sClient.Create(ctx, cq)).Should(gomega.Succeed())
+		util.MustCreate(ctx, k8sClient, cq)
 
 		lq = testing.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
-		gomega.Expect(k8sClient.Create(ctx, lq)).Should(gomega.Succeed())
+		util.MustCreate(ctx, k8sClient, lq)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -137,7 +137,7 @@ var _ = ginkgo.Describe("WaitForPodsReady with tiny Timeout and no RecoveryTimeo
 				Request(corev1.ResourceCPU, "2").
 				Parallelism(1).
 				Obj()
-			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+			util.MustCreate(ctx, k8sClient, job)
 		})
 
 		wlKey = types.NamespacedName{
@@ -262,15 +262,15 @@ var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a tiny Recove
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "wfpr-")
 
 		rf = testing.MakeResourceFlavor("default").Obj()
-		gomega.Expect(k8sClient.Create(ctx, rf)).Should(gomega.Succeed())
+		util.MustCreate(ctx, k8sClient, rf)
 
 		cq = testing.MakeClusterQueue("cq").
 			ResourceGroup(*testing.MakeFlavorQuotas(rf.Name).Resource(corev1.ResourceCPU, "10").Obj()).
 			Obj()
-		gomega.Expect(k8sClient.Create(ctx, cq)).Should(gomega.Succeed())
+		util.MustCreate(ctx, k8sClient, cq)
 
 		lq = testing.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
-		gomega.Expect(k8sClient.Create(ctx, lq)).Should(gomega.Succeed())
+		util.MustCreate(ctx, k8sClient, lq)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -296,8 +296,7 @@ var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a tiny Recove
 				CompletionMode(batchv1.IndexedCompletion).
 				Completions(1).
 				Obj()
-
-			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+			util.MustCreate(ctx, k8sClient, job)
 		})
 
 		wlKey = types.NamespacedName{
@@ -408,15 +407,15 @@ var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a long Recove
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "wfpr-")
 
 		rf = testing.MakeResourceFlavor("default").Obj()
-		gomega.Expect(k8sClient.Create(ctx, rf)).Should(gomega.Succeed())
+		util.MustCreate(ctx, k8sClient, rf)
 
 		cq = testing.MakeClusterQueue("cq").
 			ResourceGroup(*testing.MakeFlavorQuotas(rf.Name).Resource(corev1.ResourceCPU, "10").Obj()).
 			Obj()
-		gomega.Expect(k8sClient.Create(ctx, cq)).Should(gomega.Succeed())
+		util.MustCreate(ctx, k8sClient, cq)
 
 		lq = testing.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
-		gomega.Expect(k8sClient.Create(ctx, lq)).Should(gomega.Succeed())
+		util.MustCreate(ctx, k8sClient, lq)
 	})
 
 	ginkgo.AfterEach(func() {
@@ -442,8 +441,7 @@ var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a long Recove
 				CompletionMode(batchv1.IndexedCompletion).
 				Completions(1).
 				Obj()
-
-			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+			util.MustCreate(ctx, k8sClient, job)
 		})
 
 		wlKey = types.NamespacedName{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix customconfigs WaitForPodsReady E2E Tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5358

#### Special notes for your reviewer:
Originally, we updated the Kueue Configuration after creating the `ResourceFlavor`, `ClusterQueue`, and `LocalQueue` resources in `BeforeEach` block. However, this can lead to race conditions – especially when resources are being deleted and created, and the controller manager is restarted during that time. This may interrupt operations.

To avoid this, we should update the Kueue Configuration first, and only then create the resources.

Since `updateKueueConfiguration` is a slow operation, I’ve split each configuration update into a separate Describe block and moved the logic into the BeforeAll block. This approach will make it easier to extend and add new test cases in the future.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```