### PR TITLE
FlavorAssigner - Use Preemption Simulation Results in More Cases

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -292,14 +292,15 @@ type FlavorAssignmentMode int
 // The flavor assignment modes below are ordered from lowest to highest
 // preference.
 const (
-	// NoFit means that there is not enough quota to assign this flavor.
+	// NoFit means that there is not enough quota to assign this flavor,
+	// or we require preemption but we are already borrowing, and policy
+	// does not allow this.
 	NoFit FlavorAssignmentMode = iota
-	// Preempt means that there is not enough unused nominal quota in the ClusterQueue
-	// or cohort. Preempting other workloads in the ClusterQueue or cohort, or
-	// waiting for them to finish might make it possible to assign this flavor.
+	// Preempt indicates that admission is possible given Quotas.
+	// Preemption may be impossible due to policy/limits/priorities.
 	Preempt
-	// Fit means that there is enough unused quota in the cohort to assign this
-	// flavor.
+	// Fit means that there is enough unused quota to assign to this Flavor
+	// without preeemption, potentially with borrowing.
 	Fit
 )
 
@@ -322,20 +323,44 @@ type granularMode int
 
 const (
 	noFit granularMode = iota
+	// noPreemptionCandidates indicates that admission is possible with
+	// preemption, but simulation found no preemption targets.
+	noPreemptionCandidates
 	preempt
 	reclaim
 	fit
 )
 
-func (mode granularMode) flavorAssignmentMode() FlavorAssignmentMode {
-	if mode == fit {
-		return Fit
-	} else if mode.isPreemptMode() {
-		return Preempt
+func fromPreemptionPosibility(preemptionPossibility preemptioncommon.PreemptionPossibility) granularMode {
+	switch preemptionPossibility {
+	case preemptioncommon.NoCandidates:
+		return noPreemptionCandidates
+	case preemptioncommon.Preempt:
+		return preempt
+	case preemptioncommon.Reclaim:
+		return reclaim
 	}
-	return NoFit
+	panic("illegal state")
 }
 
+func (mode granularMode) flavorAssignmentMode() FlavorAssignmentMode {
+	switch mode {
+	case noFit:
+		return NoFit
+	case noPreemptionCandidates:
+		return Preempt
+	case preempt:
+		return Preempt
+	case reclaim:
+		return Preempt
+	case fit:
+		return Fit
+	default:
+		panic("illegal state")
+	}
+}
+
+// isPreemptMode indicates a mode where preemption targets were found.
 func (mode granularMode) isPreemptMode() bool {
 	return mode == preempt || mode == reclaim
 }
@@ -737,23 +762,15 @@ func (a *FlavorAssigner) fitsResourceQuota(log logr.Logger, fr resources.FlavorR
 		return fit, borrow, nil
 	}
 
-	// Check if preemption is possible
-	mode := noFit
-	// For single-level hierarchies, mayReclaimInHierarchy = true iff val <= rQuota.Nominal
-	preemptionPossibility := a.oracle.SimulatePreemption(log, a.cq, *a.wl, fr, val)
-	if val <= rQuota.Nominal || mayReclaimInHierarchy {
-		mode = preempt
-		if preemptionPossibility == preemptioncommon.Reclaim {
-			mode = reclaim
-		}
-	} else if a.canPreemptWhileBorrowing() && (preemptionPossibility != preemptioncommon.NoCandidates) {
-		mode = preempt
-	}
-
+	// Preempt
 	status.appendf("insufficient unused quota for %s in flavor %s, %s more needed",
 		fr.Resource, fr.Flavor, resources.ResourceQuantityString(fr.Resource, val-available))
 
-	return mode, borrow, &status
+	if val <= rQuota.Nominal || mayReclaimInHierarchy || a.canPreemptWhileBorrowing() {
+		mode := fromPreemptionPosibility(a.oracle.SimulatePreemption(log, a.cq, *a.wl, fr, val))
+		return mode, borrow, &status
+	}
+	return noFit, borrow, &status
 }
 
 func (a *FlavorAssigner) canPreemptWhileBorrowing() bool {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -1944,7 +1944,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 			},
 		},
-		"when borrowing while preemption is needed for flavor one, fair sharing enabled, reclaimWithinCohor=Never": {
+		"when borrowing while preemption is needed for flavor one, fair sharing enabled, reclaimWithinCohort=Never": {
 			enableFairSharing: true,
 			wlPods: []kueue.PodSet{
 				*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -1972,6 +1972,9 @@ func TestAssignFlavors(t *testing.T) {
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: 10_000,
+			},
+			simulationResult: map[resources.FlavorResource]preemptioncommon.PreemptionPossibility{
+				{Flavor: "one", Resource: corev1.ResourceCPU}: preemptioncommon.NoCandidates,
 			},
 			wantRepMode: Fit,
 			wantAssignment: Assignment{

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2958,7 +2958,10 @@ func TestSchedule(t *testing.T) {
 				"eng-gamma/Admitted-Workload-3": *utiltesting.MakeAdmission("CQ3").Assignment("gpu", "on-demand", "5").Obj(),
 			},
 		},
-		"capacity not blocked when lending clusterqueue can reclaim": {
+		// ClusterQueueA has 2 capacity, 1 admitted workload (req=1), and 1 pending workload (req=2)
+		// ClusterQueueB has 0 capacity, and 1 pending workload (req=1)
+		// Since ClusterQueueA knows it can reclaim capacity, it lets ClusterQueueB borrow.
+		"capacity not blocked when lending clusterqueue can reclaim (ReclaimWithinCohort=Any)": {
 			additionalClusterQueues: []kueue.ClusterQueue{
 				*utiltesting.MakeClusterQueue("ClusterQueueA").
 					Cohort("root").
@@ -3008,7 +3011,10 @@ func TestSchedule(t *testing.T) {
 				"eng-beta/b1-pending":   *utiltesting.MakeAdmission("ClusterQueueB").Assignment("gpu", "on-demand", "1").Obj(),
 			},
 		},
-		"capacity blocked when lending clusterqueue not guaranteed to reclaim": {
+		// ClusterQueueA has 2 capacity, 1 admitted workload (req=1), and 1 pending workload (req=2)
+		// ClusterQueueB has 0 capacity, and 1 pending workload (req=1)
+		// Since ClusterQueueA is not sure that it can reclaim this capacity, it doesn't let ClusterQueueB borrow.
+		"capacity blocked when lending clusterqueue not guaranteed to reclaim (ReclaimWithinCohort=LowerPriority)": {
 			additionalClusterQueues: []kueue.ClusterQueue{
 				*utiltesting.MakeClusterQueue("ClusterQueueA").
 					Cohort("root").
@@ -3017,6 +3023,57 @@ func TestSchedule(t *testing.T) {
 					).
 					Preemption(kueue.ClusterQueuePreemption{
 						ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
+					}).
+					Obj(),
+				*utiltesting.MakeClusterQueue("ClusterQueueB").
+					Cohort("root").
+					ResourceGroup(
+						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").FlavorQuotas,
+					).
+					Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltesting.MakeLocalQueue("lq", "eng-alpha").ClusterQueue("ClusterQueueA").Obj(),
+				*utiltesting.MakeLocalQueue("lq", "eng-beta").ClusterQueue("ClusterQueueB").Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("a1-admitted", "eng-alpha").
+					Queue("lq").
+					Request("gpu", "1").
+					SimpleReserveQuota("ClusterQueueA", "on-demand", now).
+					Obj(),
+				*utiltesting.MakeWorkload("a2-pending", "eng-alpha").
+					Queue("lq").
+					Request("gpu", "2").
+					Obj(),
+				*utiltesting.MakeWorkload("b1-pending", "eng-beta").
+					Creation(now).
+					Queue("lq").
+					Request("gpu", "1").
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"ClusterQueueB": {"eng-beta/b1-pending"},
+			},
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"ClusterQueueA": {"eng-alpha/a2-pending"},
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"eng-alpha/a1-admitted": *utiltesting.MakeAdmission("ClusterQueueA").Assignment("gpu", "on-demand", "1").Obj(),
+			},
+		},
+		// ClusterQueueA has 2 capacity, 1 admitted workload (req=1), and 1 pending workload (req=2)
+		// ClusterQueueB has 0 capacity, and 1 pending workload (req=1)
+		// Since ClusterQueueA is not sure that it can reclaim this capacity, it doesn't let ClusterQueueB borrow.
+		"capacity blocked when lending clusterqueue not guaranteed to reclaim (ReclaimWithinCohort=Never)": {
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("ClusterQueueA").
+					Cohort("root").
+					ResourceGroup(
+						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "2").FlavorQuotas,
+					).
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyNever,
 					}).
 					Obj(),
 				*utiltesting.MakeClusterQueue("ClusterQueueB").
@@ -3733,46 +3790,6 @@ func TestLastSchedulingContext(t *testing.T) {
 		wantAdmissionsOnSecondSchedule map[workload.Reference]kueue.Admission
 	}{
 		{
-			name: "scheduling context not changed: use next flavor if can't preempt",
-			cqs: []kueue.ClusterQueue{
-				*utiltesting.MakeClusterQueue("eng-alpha").
-					QueueingStrategy(kueue.BestEffortFIFO).
-					Preemption(kueue.ClusterQueuePreemption{
-						WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
-					}).
-					FlavorFungibility(kueue.FlavorFungibility{
-						WhenCanPreempt: kueue.Preempt,
-					}).
-					ResourceGroup(
-						*utiltesting.MakeFlavorQuotas("on-demand").
-							Resource(corev1.ResourceCPU, "50", "50").Obj(),
-						*utiltesting.MakeFlavorQuotas("spot").
-							Resource(corev1.ResourceCPU, "100", "0").Obj(),
-					).Obj(),
-			},
-			admittedWorkloads: []kueue.Workload{
-				utiltesting.MakeWorkload("low-1", "default").
-					Queue("main").
-					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
-					Admitted(true).
-					Workload,
-			},
-			workloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("new", "default").
-					Queue("main").
-					Request(corev1.ResourceCPU, "20").
-					Obj(),
-			},
-			deleteWorkloads:               []kueue.Workload{},
-			wantPreempted:                 sets.Set[workload.Reference]{},
-			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{},
-			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
-				"default/new":   *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "spot", "20").Obj(),
-				"default/low-1": *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj(),
-			},
-		},
-		{
 			name: "some workloads were deleted",
 			cqs: []kueue.ClusterQueue{
 				*utiltesting.MakeClusterQueue("eng-alpha").
@@ -3787,7 +3804,7 @@ func TestLastSchedulingContext(t *testing.T) {
 						*utiltesting.MakeFlavorQuotas("on-demand").
 							Resource(corev1.ResourceCPU, "50", "50").Obj(),
 						*utiltesting.MakeFlavorQuotas("spot").
-							Resource(corev1.ResourceCPU, "100", "0").Obj(),
+							Resource(corev1.ResourceCPU, "0", "0").Obj(),
 					).Obj(),
 			},
 			admittedWorkloads: []kueue.Workload{


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
We use the simulation preemption results for more accurate flavor assignment in the case when `val <= rQuota.Nominal || mayReclaimInHierarchy`. This allows upgrading to a flavor where preemption is possible.

Contributes to #4135

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
More accurate flavor assignment by using the results of preemption simulation in more cases
```