### PR TITLE
Fix the links for GoReport to point to the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![GoReport Widget]][GoReport Status]
 [![Latest Release](https://img.shields.io/github/v/release/kubernetes-sigs/kueue?include_prereleases)](https://github.com/kubernetes-sigs/kueue/releases/latest)
 
-[GoReport Widget]: https://goreportcard.com/badge/github.com/kubernetes-sigs/kueue
-[GoReport Status]: https://goreportcard.com/report/github.com/kubernetes-sigs/kueue
+[GoReport Widget]: https://goreportcard.com/badge/sigs.k8s.io/kueue
+[GoReport Status]: https://goreportcard.com/report/sigs.k8s.io/kueue
 
 <img src="https://github.com/kubernetes-sigs/kueue/blob/main/site/static/images/logo.svg" width="100" alt="kueue logo">
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
To make the links point to the report for the latest release.

Currently the links point to report for Kueue v0.3.1 from 2 years back: 

![image](https://github.com/user-attachments/assets/3b0da8a1-d262-4b0a-89a6-841a949e2b7e)

using the new links:

![image](https://github.com/user-attachments/assets/b9485b83-e1f4-44eb-a029-d7555ad2f7d4)



Surprisingly when using "refresh report" it automatically redirects to report for sigs.k8s.io/kueue.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```