### PR TITLE
Remove duplication of findBestFitDomain function

### DIFF
--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -793,20 +793,20 @@ func findBestFitDomainForSlices(domains []*domain, sliceCount int32) *domain {
 	})
 }
 
-type domainStateGetter func(d *domain) int32
+type domainState func(d *domain) int32
 
-func findBestFitDomainBy(domains []*domain, needed int32, getState domainStateGetter) *domain {
+func findBestFitDomainBy(domains []*domain, needed int32, state domainState) *domain {
 	bestDomain := domains[0]
-	bestDomainState := getState(bestDomain)
+	bestDomainState := state(bestDomain)
 
 	for _, domain := range domains {
-		domainState := getState(domain)
+		domainState := state(domain)
 
 		if domainState >= needed && domainState < bestDomainState {
 			// choose the first occurrence of fitting domains
 			// to make it consecutive with other podSet's
 			bestDomain = domain
-			bestDomainState = getState(bestDomain)
+			bestDomainState = state(bestDomain)
 		}
 	}
 	return bestDomain


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR removes a duplication between two functions: `findBestFitDomain` and `findBestFitDomainForSlices`. This improvement was suggested in a comment here: https://github.com/kubernetes-sigs/kueue/pull/5353/files/4bfd8844c197791804491904ff032376d2f83975#r2142313188

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to: https://github.com/kubernetes-sigs/kueue/issues/5439

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```