### PR TITLE
Clean up wrappers

### DIFF
--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -741,7 +741,7 @@ func (q *LocalQueueWrapper) Active(status metav1.ConditionStatus) *LocalQueueWra
 	return q
 }
 
-// AdmittedWorkloads updates the admittedWorkloads in status.
+// FairSharingStatus updates the fairSharing in status.
 func (q *LocalQueueWrapper) FairSharingStatus(status *kueue.FairSharingStatus) *LocalQueueWrapper {
 	q.Status.FairSharing = status
 	return q
@@ -1551,38 +1551,38 @@ func MakePodTemplate(name, namespace string) *PodTemplateWrapper {
 	}
 }
 
-func (w *PodTemplateWrapper) Obj() *corev1.PodTemplate {
-	return &w.PodTemplate
+func (p *PodTemplateWrapper) Obj() *corev1.PodTemplate {
+	return &p.PodTemplate
 }
 
-func (w *PodTemplateWrapper) Clone() *PodTemplateWrapper {
-	return &PodTemplateWrapper{PodTemplate: *w.DeepCopy()}
+func (p *PodTemplateWrapper) Clone() *PodTemplateWrapper {
+	return &PodTemplateWrapper{PodTemplate: *p.DeepCopy()}
 }
 
-func (w *PodTemplateWrapper) Label(k, v string) *PodTemplateWrapper {
-	if w.Labels == nil {
-		w.Labels = make(map[string]string)
+func (p *PodTemplateWrapper) Label(k, v string) *PodTemplateWrapper {
+	if p.Labels == nil {
+		p.Labels = make(map[string]string)
 	}
-	w.Labels[k] = v
-	return w
+	p.Labels[k] = v
+	return p
 }
 
-func (w *PodTemplateWrapper) Containers(containers ...corev1.Container) *PodTemplateWrapper {
-	w.Template.Spec.Containers = containers
-	return w
+func (p *PodTemplateWrapper) Containers(containers ...corev1.Container) *PodTemplateWrapper {
+	p.Template.Spec.Containers = containers
+	return p
 }
 
-func (w *PodTemplateWrapper) NodeSelector(k, v string) *PodTemplateWrapper {
-	if w.Template.Spec.NodeSelector == nil {
-		w.Template.Spec.NodeSelector = make(map[string]string)
+func (p *PodTemplateWrapper) NodeSelector(k, v string) *PodTemplateWrapper {
+	if p.Template.Spec.NodeSelector == nil {
+		p.Template.Spec.NodeSelector = make(map[string]string)
 	}
-	w.Template.Spec.NodeSelector[k] = v
-	return w
+	p.Template.Spec.NodeSelector[k] = v
+	return p
 }
 
-func (w *PodTemplateWrapper) Toleration(toleration corev1.Toleration) *PodTemplateWrapper {
-	w.Template.Spec.Tolerations = append(w.Template.Spec.Tolerations, toleration)
-	return w
+func (p *PodTemplateWrapper) Toleration(toleration corev1.Toleration) *PodTemplateWrapper {
+	p.Template.Spec.Tolerations = append(p.Template.Spec.Tolerations, toleration)
+	return p
 }
 
 func (p *PodTemplateWrapper) PriorityClass(pc string) *PodTemplateWrapper {
@@ -1607,9 +1607,9 @@ func (p *PodTemplateWrapper) RequiredDuringSchedulingIgnoredDuringExecution(node
 	return p
 }
 
-func (w *PodTemplateWrapper) ControllerReference(gvk schema.GroupVersionKind, name, uid string) *PodTemplateWrapper {
-	AppendOwnerReference(&w.PodTemplate, gvk, name, uid, ptr.To(true), ptr.To(true))
-	return w
+func (p *PodTemplateWrapper) ControllerReference(gvk schema.GroupVersionKind, name, uid string) *PodTemplateWrapper {
+	AppendOwnerReference(&p.PodTemplate, gvk, name, uid, ptr.To(true), ptr.To(true))
+	return p
 }
 
 type NamespaceWrapper struct {

--- a/pkg/util/testingjobs/jaxjob/wrappers.go
+++ b/pkg/util/testingjobs/jaxjob/wrappers.go
@@ -58,7 +58,7 @@ type JAXReplicaSpecRequirement struct {
 }
 
 func (j *JAXJobWrapper) JAXReplicaSpecs(replicaSpecs ...JAXReplicaSpecRequirement) *JAXJobWrapper {
-	j = j.JAXReplicaSpecsDefault()
+	j.JAXReplicaSpecsDefault()
 	for _, rs := range replicaSpecs {
 		j.Spec.JAXReplicaSpecs[rs.ReplicaType].Replicas = ptr.To[int32](rs.ReplicaCount)
 		j.Spec.JAXReplicaSpecs[rs.ReplicaType].Template.Name = rs.Name

--- a/pkg/util/testingjobs/leaderworkerset/wrappers.go
+++ b/pkg/util/testingjobs/leaderworkerset/wrappers.go
@@ -149,7 +149,7 @@ func (w *LeaderWorkerSetWrapper) Replicas(n int32) *LeaderWorkerSetWrapper {
 	return w
 }
 
-// Replicas sets the number of ready replicas of the LeaderWorkerSet.
+// ReadyReplicas sets the number of ready replicas of the LeaderWorkerSet.
 func (w *LeaderWorkerSetWrapper) ReadyReplicas(n int32) *LeaderWorkerSetWrapper {
 	w.Status.ReadyReplicas = n
 	return w

--- a/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
+++ b/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
@@ -60,7 +60,7 @@ type MPIJobReplicaSpecRequirement struct {
 }
 
 func (j *MPIJobWrapper) MPIJobReplicaSpecs(replicaSpecs ...MPIJobReplicaSpecRequirement) *MPIJobWrapper {
-	j = j.GenericLauncherAndWorker()
+	j.GenericLauncherAndWorker()
 	for _, rs := range replicaSpecs {
 		j.Spec.MPIReplicaSpecs[rs.ReplicaType].Template.Spec.Containers[0].Image = rs.Image
 		j.Spec.MPIReplicaSpecs[rs.ReplicaType].Template.Spec.Containers[0].Args = rs.Args

--- a/pkg/util/testingjobs/paddlejob/wrappers.go
+++ b/pkg/util/testingjobs/paddlejob/wrappers.go
@@ -56,7 +56,7 @@ type PaddleReplicaSpecRequirement struct {
 }
 
 func (j *PaddleJobWrapper) PaddleReplicaSpecs(replicaSpecs ...PaddleReplicaSpecRequirement) *PaddleJobWrapper {
-	j = j.PaddleReplicaSpecsDefault()
+	j.PaddleReplicaSpecsDefault()
 	for _, rs := range replicaSpecs {
 		j.Spec.PaddleReplicaSpecs[rs.ReplicaType].Replicas = ptr.To[int32](rs.ReplicaCount)
 		j.Spec.PaddleReplicaSpecs[rs.ReplicaType].Template.Name = rs.Name

--- a/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
+++ b/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
@@ -58,7 +58,7 @@ type PyTorchReplicaSpecRequirement struct {
 }
 
 func (j *PyTorchJobWrapper) PyTorchReplicaSpecs(replicaSpecs ...PyTorchReplicaSpecRequirement) *PyTorchJobWrapper {
-	j = j.PyTorchReplicaSpecsDefault()
+	j.PyTorchReplicaSpecsDefault()
 	for _, rs := range replicaSpecs {
 		j.Spec.PyTorchReplicaSpecs[rs.ReplicaType].Replicas = ptr.To[int32](rs.ReplicaCount)
 		j.Spec.PyTorchReplicaSpecs[rs.ReplicaType].Template.Name = rs.Name

--- a/pkg/util/testingjobs/tfjob/wrappers_tfjob.go
+++ b/pkg/util/testingjobs/tfjob/wrappers_tfjob.go
@@ -56,7 +56,7 @@ type TFReplicaSpecRequirement struct {
 }
 
 func (j *TFJobWrapper) TFReplicaSpecs(replicaSpecs ...TFReplicaSpecRequirement) *TFJobWrapper {
-	j = j.TFReplicaSpecsDefault()
+	j.TFReplicaSpecsDefault()
 	for _, rs := range replicaSpecs {
 		j.Spec.TFReplicaSpecs[rs.ReplicaType].Replicas = ptr.To[int32](rs.ReplicaCount)
 		j.Spec.TFReplicaSpecs[rs.ReplicaType].Template.Name = rs.Name

--- a/pkg/util/testingjobs/xgboostjob/wrappers.go
+++ b/pkg/util/testingjobs/xgboostjob/wrappers.go
@@ -56,7 +56,7 @@ type XGBReplicaSpecRequirement struct {
 }
 
 func (j *XGBoostJobWrapper) XGBReplicaSpecs(replicaSpecs ...XGBReplicaSpecRequirement) *XGBoostJobWrapper {
-	j = j.XGBReplicaSpecsDefault()
+	j.XGBReplicaSpecsDefault()
 	for _, rs := range replicaSpecs {
 		j.Spec.XGBReplicaSpecs[rs.ReplicaType].Replicas = ptr.To[int32](rs.ReplicaCount)
 		j.Spec.XGBReplicaSpecs[rs.ReplicaType].Template.Name = rs.Name


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
I cleaned up wrappers in the following:

- Fixed incorrect function names in comments
- Use the same receiver names for the same wrapper.
- Remove redundant receiver pointer copies.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```