### PR TITLE
Automated cherry pick of #5698: Improve accuracy of flavor assignment using preemption simulation in more cases

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -1944,7 +1944,7 @@ func TestAssignFlavors(t *testing.T) {
 				}},
 			},
 		},
-		"when borrowing while preemption is needed for flavor one, fair sharing enabled, reclaimWithinCohor=Never": {
+		"when borrowing while preemption is needed for flavor one, fair sharing enabled, reclaimWithinCohort=Never": {
 			enableFairSharing: true,
 			wlPods: []kueue.PodSet{
 				*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -1972,6 +1972,9 @@ func TestAssignFlavors(t *testing.T) {
 				Obj(),
 			secondaryClusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: 10_000,
+			},
+			simulationResult: map[resources.FlavorResource]preemptioncommon.PreemptionPossibility{
+				{Flavor: "one", Resource: corev1.ResourceCPU}: preemptioncommon.NoCandidates,
 			},
 			wantRepMode: Fit,
 			wantAssignment: Assignment{


### PR DESCRIPTION
Cherry pick of #5698 on release-0.12.

#5698: Improve accuracy of flavor assignment using preemption simulation in more cases

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Use simulation of preemption for more accurate flavor assignment. 
In particular, the previous heuristic would wrongly state that preemption
in a flavor was possible even if no preemption candidates could be found. 

Additionally, in scenarios when preemption while borrowing is enabled,
the flavor in which reclaim is possible is preferred over flavor where 
priority-based preemption is required. This is consistent with prioritizing 
flavors when preemption without borrowing is used.
```