### PR TITLE
Automated cherry pick of #5666: Fix prepare-release-branch target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,9 +333,9 @@ artifacts: clean-artifacts kustomize helm-chart-package prepare-manifests ## Gen
 
 .PHONY: prepare-release-branch
 prepare-release-branch: yq kustomize ## Prepare the release branch with the release version.
-	$(SED) -r 's/v[0-9]+\.[0-9]+\.[0-9]+/$(RELEASE_VERSION)/g' -i README.md -i site/hugo.toml
+	$(SED) -r 's/v[0-9]+\.[0-9]+\.[0-9]+/$(RELEASE_VERSION)/g' -i README.md -i site/hugo.toml -i cmd/kueueviz/INSTALL.md
 	$(SED) -r 's/chart_version = "[0-9]+\.[0-9]+\.[0-9]+/chart_version = "$(CHART_VERSION)/g' -i README.md -i site/hugo.toml
-	$(SED) -r 's/--version="v?[0-9]+\.[0-9]+\.[0-9]+/--version="$(CHART_VERSION)/g' -i charts/kueue/README.md
+	$(SED) -r 's/--version="v?[0-9]+\.[0-9]+\.[0-9]+/--version="$(CHART_VERSION)/g' -i charts/kueue/README.md -i cmd/kueueviz/INSTALL.md
 	$(SED) -r 's/KUEUE_VERSION="[0-9]+\.[0-9]+\.[0-9]+/KUEUE_VERSION="$(CHART_VERSION)/g' -i cmd/kueueviz/INSTALL.md
 	$(YQ) e '.appVersion = "$(RELEASE_VERSION)"' -i charts/kueue/Chart.yaml
 

--- a/cmd/kueueviz/INSTALL.md
+++ b/cmd/kueueviz/INSTALL.md
@@ -3,8 +3,7 @@
 KueueViz can be installed using `kubectl` with the following command:
 
 ```
-KUEUE_VERSION=0.11.1
-kubectl create -f https://github.com/kubernetes-sigs/kueue/releases/download/v$KUEUE_VERSION/kueueviz.yaml
+kubectl create -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.3/kueueviz.yaml
 ```
 If you are using `kind` and that you don't have an `ingress` controller, you can use `port-forward` to 
 configure and run `KueueViz`:
@@ -23,9 +22,8 @@ KueueViz can be installed using helm using the following command and
 by ensuring that `enableKueueViz` is set to `true`:
 
 ```
-KUEUE_VERSION=0.11.1
 helm upgrade --install kueue oci://registry.k8s.io/kueue/charts/kueue \
-  --version=$KUEUE_VERSION
+  --version="0.12.3"
   --namespace kueue-system \
   --set enableKueueViz=true \
   --create-namespace
@@ -42,12 +40,11 @@ You need a kubernetes cluster running kueue.
 If you don't have a running cluster, you can create one using kind and install kueue using helm.
 
 ```
-KUEUE_VERSION=0.11.1
 kind create cluster
 kind get kubeconfig > kubeconfig
 export KUBECONFIG=$PWD/kubeconfig
 helm install kueue oci://us-central1-docker.pkg.dev/k8s-staging-images/charts/kueue \
-            --version="$KUEUE_VERSION" --create-namespace --namespace=kueue-system
+            --version="0.12.3" --create-namespace --namespace=kueue-system
 ```
 
 ## Build


### PR DESCRIPTION
Cherry pick of #5666 on release-0.12.

#5666: Fix prepare-release-branch target.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```