### PR TITLE
Automated cherry pick of #5750: Update main branch with the latest v0.12.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ LD_FLAGS += -X '$(version_pkg).GitCommit=$(GIT_COMMIT)'
 
 # Update these variables when preparing a new release or a release branch.
 # Then run `make prepare-release-branch`
-RELEASE_VERSION=v0.12.2
+RELEASE_VERSION=v0.12.3
 RELEASE_BRANCH=main
 # Version used form Helm which is not using the leading "v"
 CHART_VERSION := $(shell echo $(RELEASE_VERSION) | cut -c2-)
@@ -337,6 +337,7 @@ prepare-release-branch: yq kustomize ## Prepare the release branch with the rele
 	$(SED) -r 's/KUEUE_VERSION="[0-9]+\.[0-9]+\.[0-9]+/KUEUE_VERSION="$(CHART_VERSION)/g' -i cmd/kueueviz/INSTALL.md
 	$(YQ) e '.appVersion = "$(RELEASE_VERSION)" | .version = "$(CHART_VERSION)"' -i charts/kueue/Chart.yaml
 	$(YQ) e '.controllerManager.manager.image.tag = "$(RELEASE_BRANCH)" | .kueueViz.backend.image.tag = "$(RELEASE_BRANCH)" | .kueueViz.frontend.image.tag = "$(RELEASE_BRANCH)"' -i charts/kueue/values.yaml
+	$(MAKE) generate-helm-docs
 
 .PHONY: update-security-insights
 update-security-insights: yq

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) and watch the Kueu
 To install the latest release of Kueue in your cluster, run the following command:
 
 ```shell
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.2/manifests.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.3/manifests.yaml
 ```
 
 The controller runs in the `kueue-system` namespace.

--- a/SECURITY-INSIGHTS.yaml
+++ b/SECURITY-INSIGHTS.yaml
@@ -1,11 +1,11 @@
 header:
   schema-version: 1.0.0
   expiration-date: '2024-09-28T01:00:00.000Z'
-  last-updated: '2025-06-03'
-  last-reviewed: '2025-06-03'
-  commit-hash: b5234c619aa542cbaf48dc324a8b06a2856ec826
+  last-updated: '2025-06-24'
+  last-reviewed: '2025-06-24'
+  commit-hash: 5e45476a20cec4eb74fe1e553a03c543bbeb8a89
   project-url: 'https://github.com/kubernetes-sigs/kueue'
-  project-release: 0.12.2
+  project-release: 0.12.3
   changelog: 'https://github.com/kubernetes-sigs/kueue/tree/main/CHANGELOG'
   license: 'https://github.com/kubernetes-sigs/kueue/blob/main/LICENSE'
 project-lifecycle:
@@ -28,7 +28,7 @@ documentation:
   - 'https://kueue.sigs.k8s.io/docs/'
 distribution-points:
   - >-
-    https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.2/manifests.yaml
+    https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.3/manifests.yaml
 security-artifacts:
   threat-model:
     threat-model-created: false
@@ -62,5 +62,5 @@ dependencies:
   dependencies-lists:
     - 'https://github.com/kubernetes-sigs/kueue/blob/main/go.mod'
   sbom:
-    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.2/kueue-v0.12.2.spdx.json
+    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.3/kueue-v0.12.3.spdx.json
       sbom-format: SPDX

--- a/charts/kueue/Chart.yaml
+++ b/charts/kueue/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # NOTE: Do not modify manually. In Kueue, the version and appVersion are
 # overridden to GIT_TAG when building the artifacts, including the helm charts,
 # via Makefile.
-version: 0.1.0
+version: 0.12.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.12.2"
+appVersion: "v0.12.3"

--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -37,7 +37,7 @@ $ helm install kueue kueue/ --create-namespace --namespace kueue-system
 Or use the charts pushed to `oci://registry.k8s.io/kueue/charts/kueue`:
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.12.2" --create-namespace --namespace=kueue-system
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.12.3" --create-namespace --namespace=kueue-system
 ```
 
 ##### Verify that controller pods are running properly.

--- a/charts/kueue/README.md.gotmpl
+++ b/charts/kueue/README.md.gotmpl
@@ -1,0 +1,96 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepage" . }}
+
+### Installation
+
+Quick start instructions for the setup and configuration of kueue using Helm.
+
+#### Prerequisites
+
+- [Helm](https://helm.sh/docs/intro/quickstart/#install-helm)
+- (Optional) [Cert-manager](https://cert-manager.io/docs/installation/)
+
+#### Installing the chart
+
+##### Install chart using Helm v3.0+
+
+Either clone the kueue repository:
+
+```bash
+$ git clone git@github.com:kubernetes-sigs/kueue.git
+$ cd kueue/charts
+$ helm install kueue kueue/ --create-namespace --namespace kueue-system
+```
+
+Or use the charts pushed to `oci://registry.k8s.io/kueue/charts/kueue`:
+
+```bash
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.12.3" --create-namespace --namespace=kueue-system
+```
+
+For more advanced parametrization of Kueue, we recommend using a local overrides file, passed via the `--values` flag. For example:
+
+```yaml
+controllerManager:
+  featureGates:
+    - name: TopologyAwareScheduling
+      enabled: true
+  replicas: 2
+  manager:
+    resources:
+      limits:
+        cpu: "2"
+        memory: 2Gi
+      requests:
+        cpu: "2"
+        memory: 2Gi
+```
+
+```bash
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.12.3" \
+  --create-namespace --namespace=kueue-system \
+  --values overrides.yaml
+```
+
+You can also use the `--set` flag. For example, to enable a feature gate (e.g., `TopologyAwareScheduling`):
+
+```bash
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.12.3" \
+  --create-namespace --namespace=kueue-system \
+  --set "controllerManager.featureGates[0].name=TopologyAwareScheduling" \
+  --set "controllerManager.featureGates[0].enabled=true"
+```
+
+##### Verify that controller pods are running properly.
+
+```bash
+$ kubectl get deploy -n kueue-system
+NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
+kueue-controller-manager       1/1     1            1           7s
+```
+
+##### Cert Manager
+
+Kueue has support for third-party certificates.
+One can enable this by setting `enableCertManager` to true.
+This will use certManager to generate a secret, inject the CABundles and set up the tls.
+
+Check out the [site](https://kueue.sigs.k8s.io/docs/tasks/manage/productization/cert_manager/)
+for more information on installing cert manager with our Helm chart.
+
+##### Prometheus
+
+Kueue supports prometheus metrics.
+Check out the [site](https://kueue.sigs.k8s.io/docs/tasks/manage/productization/prometheus/)
+for more information on installing kueue with metrics using our Helm chart.
+
+### Configuration
+
+The following table lists the configurable parameters of the kueue chart and their default values.
+
+{{ template "chart.valuesTable" . }}

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -90,10 +90,10 @@ ignoreFiles = []
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
   # version number for this doc set.
-  version = "v0.12.2"
+  version = "v0.12.3"
 
   # Version of Kueue without the leading "v", as used for Helm charts.
-  chart_version = "0.12.2"
+  chart_version = "0.12.3"
 
   # Flag used in the "version-banner" partial to decide whether to display a
   # banner on every page indicating that this is an archived version of the docs.


### PR DESCRIPTION
Cherry pick of #5750 on website.

#5750: Update main branch with the latest v0.12.3

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```