### PR TITLE
Automated cherry pick of #5760: Fix KueueViz frontend version.

### DIFF
--- a/cmd/kueueviz/frontend/package-lock.json
+++ b/cmd/kueueviz/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kueueviz-frontend",
-  "version": "1.0.0",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kueueviz-frontend",
-      "version": "1.0.0",
+      "version": "0.12.3",
       "license": "Apache 2.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/cmd/kueueviz/frontend/package.json
+++ b/cmd/kueueviz/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kueueviz-frontend",
-  "version": "1.0.0",
+  "version": "0.12.3",
   "private": true,
   "description": "Frontend dashboard for visualizing Kueue status",
   "main": "src/index.jsx",

--- a/test/e2e/kueueviz/package-lock.json
+++ b/test/e2e/kueueviz/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kueueviz-frontend-tests",
-  "version": "1.0.0",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kueueviz-frontend-tests",
-      "version": "1.0.0",
+      "version": "0.12.3",
       "devDependencies": {
         "cypress": "^14.3.3"
       }

--- a/test/e2e/kueueviz/package.json
+++ b/test/e2e/kueueviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kueueviz-frontend-tests",
-  "version": "1.0.0",
+  "version": "0.12.3",
   "scripts": {
     "cypress:run": "cypress run --headless"
   },


### PR DESCRIPTION
Cherry pick of #5760 on release-0.12.

#5760: Fix KueueViz frontend version.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```