### PR TITLE
Automated cherry pick of #5063: Mutating webhook with reinvocation policy

### DIFF
--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -97,5 +97,6 @@ The following table lists the configurable parameters of the kueue chart and the
 | `managerConfig.controllerManagerConfigYaml`            | controllerManagerConfigYaml                            | abbr.                                       |
 | `metricsService`                                       | metricsService's ports                                 | abbr.                                       |
 | `webhookService`                                       | webhookService's ports                                 | abbr.                                       |
+| `webhook.reinvocationPolicy`                           | Webhook's reinvocation policy                          | `Never`                                     |
 | `metrics.prometheusNamespace`                          | prometheus namespace                                   | `monitoring`                                |
 | `metrics.serviceMonitor.tlsConfig`                     | service monitor for prometheus                         | abbr.                                       |

--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -97,6 +97,6 @@ The following table lists the configurable parameters of the kueue chart and the
 | `managerConfig.controllerManagerConfigYaml`            | controllerManagerConfigYaml                            | abbr.                                       |
 | `metricsService`                                       | metricsService's ports                                 | abbr.                                       |
 | `webhookService`                                       | webhookService's ports                                 | abbr.                                       |
-| `webhook.reinvocationPolicy`                           | Webhook's reinvocation policy                          | `Never`                                     |
+| `mutatingWebhook.reinvocationPolicy`                   | Webhook's reinvocation policy                          | `Never`                                     |
 | `metrics.prometheusNamespace`                          | prometheus namespace                                   | `monitoring`                                |
 | `metrics.serviceMonitor.tlsConfig`                     | service monitor for prometheus                         | abbr.                                       |

--- a/charts/kueue/templates/webhook/webhook.yaml
+++ b/charts/kueue/templates/webhook/webhook.yaml
@@ -1,5 +1,6 @@
 {{- $integrationsConfig := (fromYaml .Values.managerConfig.controllerManagerConfigYaml).integrations }}
 {{- $managerConfig := (fromYaml .Values.managerConfig.controllerManagerConfigYaml) }}
+{{- $reinvocationPolicy := .Values.webhook.reinvocationPolicy }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -21,6 +22,7 @@ webhooks:
         path: /mutate-workload-codeflare-dev-v1beta2-appwrapper
     failurePolicy: Fail
     name: mappwrapper.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - workload.codeflare.dev
@@ -55,6 +57,7 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - apps
@@ -75,6 +78,7 @@ webhooks:
         path: /mutate-batch-v1-job
     failurePolicy: Fail
     name: mjob.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - batch
@@ -94,6 +98,7 @@ webhooks:
         path: /mutate-jobset-x-k8s-io-v1alpha2-jobset
     failurePolicy: Fail
     name: mjobset.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - jobset.x-k8s.io
@@ -113,6 +118,7 @@ webhooks:
         path: /mutate-kubeflow-org-v1-paddlejob
     failurePolicy: Fail
     name: mpaddlejob.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -132,6 +138,7 @@ webhooks:
         path: /mutate-kubeflow-org-v1-pytorchjob
     failurePolicy: Fail
     name: mpytorchjob.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -151,6 +158,7 @@ webhooks:
         path: /mutate-kubeflow-org-v1-tfjob
     failurePolicy: Fail
     name: mtfjob.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -170,6 +178,7 @@ webhooks:
         path: /mutate-kubeflow-org-v1-xgboostjob
     failurePolicy: Fail
     name: mxgboostjob.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -204,6 +213,7 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - ""
@@ -223,6 +233,7 @@ webhooks:
         path: /mutate-leaderworkerset-x-k8s-io-v1-leaderworkerset
     failurePolicy: Fail
     name: mleaderworkerset.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - leaderworkerset.x-k8s.io
@@ -243,6 +254,7 @@ webhooks:
         path: /mutate-kubeflow-org-v2beta1-mpijob
     failurePolicy: Fail
     name: mmpijob.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -262,6 +274,7 @@ webhooks:
         path: /mutate-ray-io-v1-raycluster
     failurePolicy: Fail
     name: mraycluster.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - ray.io
@@ -281,6 +294,7 @@ webhooks:
         path: /mutate-ray-io-v1-rayjob
     failurePolicy: Fail
     name: mrayjob.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - ray.io
@@ -315,6 +329,7 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - apps
@@ -335,6 +350,7 @@ webhooks:
         path: /mutate-kueue-x-k8s-io-v1beta1-clusterqueue
     failurePolicy: Fail
     name: mclusterqueue.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kueue.x-k8s.io
@@ -354,6 +370,7 @@ webhooks:
         path: /mutate-kueue-x-k8s-io-v1beta1-resourceflavor
     failurePolicy: Fail
     name: mresourceflavor.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kueue.x-k8s.io
@@ -373,6 +390,7 @@ webhooks:
         path: /mutate-kueue-x-k8s-io-v1beta1-workload
     failurePolicy: Fail
     name: mworkload.kb.io
+    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kueue.x-k8s.io

--- a/charts/kueue/templates/webhook/webhook.yaml
+++ b/charts/kueue/templates/webhook/webhook.yaml
@@ -22,7 +22,6 @@ webhooks:
         path: /mutate-workload-codeflare-dev-v1beta2-appwrapper
     failurePolicy: Fail
     name: mappwrapper.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - workload.codeflare.dev
@@ -33,6 +32,7 @@ webhooks:
         resources:
           - appwrappers
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -57,7 +57,6 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - apps
@@ -69,6 +68,7 @@ webhooks:
         resources:
           - deployments
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -78,7 +78,6 @@ webhooks:
         path: /mutate-batch-v1-job
     failurePolicy: Fail
     name: mjob.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - batch
@@ -89,6 +88,7 @@ webhooks:
         resources:
           - jobs
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -98,7 +98,6 @@ webhooks:
         path: /mutate-jobset-x-k8s-io-v1alpha2-jobset
     failurePolicy: Fail
     name: mjobset.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - jobset.x-k8s.io
@@ -109,6 +108,7 @@ webhooks:
         resources:
           - jobsets
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -118,7 +118,6 @@ webhooks:
         path: /mutate-kubeflow-org-v1-paddlejob
     failurePolicy: Fail
     name: mpaddlejob.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -129,6 +128,7 @@ webhooks:
         resources:
           - paddlejobs
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -138,7 +138,6 @@ webhooks:
         path: /mutate-kubeflow-org-v1-pytorchjob
     failurePolicy: Fail
     name: mpytorchjob.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -149,6 +148,7 @@ webhooks:
         resources:
           - pytorchjobs
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -158,7 +158,6 @@ webhooks:
         path: /mutate-kubeflow-org-v1-tfjob
     failurePolicy: Fail
     name: mtfjob.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -169,6 +168,7 @@ webhooks:
         resources:
           - tfjobs
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -178,7 +178,6 @@ webhooks:
         path: /mutate-kubeflow-org-v1-xgboostjob
     failurePolicy: Fail
     name: mxgboostjob.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -189,6 +188,7 @@ webhooks:
         resources:
           - xgboostjobs
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -213,7 +213,6 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - ""
@@ -224,6 +223,7 @@ webhooks:
         resources:
           - pods
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -233,7 +233,6 @@ webhooks:
         path: /mutate-leaderworkerset-x-k8s-io-v1-leaderworkerset
     failurePolicy: Fail
     name: mleaderworkerset.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - leaderworkerset.x-k8s.io
@@ -245,6 +244,7 @@ webhooks:
         resources:
           - leaderworkersets
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -254,7 +254,6 @@ webhooks:
         path: /mutate-kubeflow-org-v2beta1-mpijob
     failurePolicy: Fail
     name: mmpijob.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kubeflow.org
@@ -265,6 +264,7 @@ webhooks:
         resources:
           - mpijobs
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -274,7 +274,6 @@ webhooks:
         path: /mutate-ray-io-v1-raycluster
     failurePolicy: Fail
     name: mraycluster.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - ray.io
@@ -285,6 +284,7 @@ webhooks:
         resources:
           - rayclusters
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -294,7 +294,6 @@ webhooks:
         path: /mutate-ray-io-v1-rayjob
     failurePolicy: Fail
     name: mrayjob.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - ray.io
@@ -305,6 +304,7 @@ webhooks:
         resources:
           - rayjobs
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -329,7 +329,6 @@ webhooks:
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - apps
@@ -341,6 +340,7 @@ webhooks:
         resources:
           - statefulsets
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -350,7 +350,6 @@ webhooks:
         path: /mutate-kueue-x-k8s-io-v1beta1-clusterqueue
     failurePolicy: Fail
     name: mclusterqueue.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kueue.x-k8s.io
@@ -361,6 +360,7 @@ webhooks:
         resources:
           - clusterqueues
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -370,7 +370,6 @@ webhooks:
         path: /mutate-kueue-x-k8s-io-v1beta1-resourceflavor
     failurePolicy: Fail
     name: mresourceflavor.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kueue.x-k8s.io
@@ -381,6 +380,7 @@ webhooks:
         resources:
           - resourceflavors
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -390,7 +390,6 @@ webhooks:
         path: /mutate-kueue-x-k8s-io-v1beta1-workload
     failurePolicy: Fail
     name: mworkload.kb.io
-    reinvocationPolicy: {{ $reinvocationPolicy }}
     rules:
       - apiGroups:
           - kueue.x-k8s.io
@@ -401,6 +400,7 @@ webhooks:
         resources:
           - workloads
     sideEffects: None
+    reinvocationPolicy: '{{ $reinvocationPolicy }}'
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/charts/kueue/templates/webhook/webhook.yaml
+++ b/charts/kueue/templates/webhook/webhook.yaml
@@ -31,7 +31,7 @@ webhooks:
         resources:
           - appwrappers
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -67,7 +67,7 @@ webhooks:
         resources:
           - deployments
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -87,7 +87,7 @@ webhooks:
         resources:
           - jobs
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -107,7 +107,7 @@ webhooks:
         resources:
           - jobsets
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -127,7 +127,7 @@ webhooks:
         resources:
           - paddlejobs
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -147,7 +147,7 @@ webhooks:
         resources:
           - pytorchjobs
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -167,7 +167,7 @@ webhooks:
         resources:
           - tfjobs
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -187,7 +187,7 @@ webhooks:
         resources:
           - xgboostjobs
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -222,7 +222,7 @@ webhooks:
         resources:
           - pods
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -243,7 +243,7 @@ webhooks:
         resources:
           - leaderworkersets
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -263,7 +263,7 @@ webhooks:
         resources:
           - mpijobs
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -283,7 +283,7 @@ webhooks:
         resources:
           - rayclusters
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -303,7 +303,7 @@ webhooks:
         resources:
           - rayjobs
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -339,7 +339,7 @@ webhooks:
         resources:
           - statefulsets
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -359,7 +359,7 @@ webhooks:
         resources:
           - clusterqueues
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -379,7 +379,7 @@ webhooks:
         resources:
           - resourceflavors
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -399,7 +399,7 @@ webhooks:
         resources:
           - workloads
     sideEffects: None
-    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.mutatingWebhook.reinvocationPolicy }}'
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/charts/kueue/templates/webhook/webhook.yaml
+++ b/charts/kueue/templates/webhook/webhook.yaml
@@ -1,6 +1,5 @@
 {{- $integrationsConfig := (fromYaml .Values.managerConfig.controllerManagerConfigYaml).integrations }}
 {{- $managerConfig := (fromYaml .Values.managerConfig.controllerManagerConfigYaml) }}
-{{- $reinvocationPolicy := .Values.webhook.reinvocationPolicy }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -32,7 +31,7 @@ webhooks:
         resources:
           - appwrappers
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -68,7 +67,7 @@ webhooks:
         resources:
           - deployments
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -88,7 +87,7 @@ webhooks:
         resources:
           - jobs
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -108,7 +107,7 @@ webhooks:
         resources:
           - jobsets
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -128,7 +127,7 @@ webhooks:
         resources:
           - paddlejobs
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -148,7 +147,7 @@ webhooks:
         resources:
           - pytorchjobs
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -168,7 +167,7 @@ webhooks:
         resources:
           - tfjobs
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -188,7 +187,7 @@ webhooks:
         resources:
           - xgboostjobs
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -223,7 +222,7 @@ webhooks:
         resources:
           - pods
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -244,7 +243,7 @@ webhooks:
         resources:
           - leaderworkersets
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -264,7 +263,7 @@ webhooks:
         resources:
           - mpijobs
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -284,7 +283,7 @@ webhooks:
         resources:
           - rayclusters
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -304,7 +303,7 @@ webhooks:
         resources:
           - rayjobs
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -340,7 +339,7 @@ webhooks:
         resources:
           - statefulsets
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -360,7 +359,7 @@ webhooks:
         resources:
           - clusterqueues
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -380,7 +379,7 @@ webhooks:
         resources:
           - resourceflavors
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
   - admissionReviewVersions:
       - v1
     clientConfig:
@@ -400,7 +399,7 @@ webhooks:
         resources:
           - workloads
     sideEffects: None
-    reinvocationPolicy: '{{ $reinvocationPolicy }}'
+    reinvocationPolicy: '{{ .Values.webhook.reinvocationPolicy }}'
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -151,9 +151,9 @@ webhookService:
       protocol: TCP
       targetPort: 9443
   type: ClusterIP
-webhook:
+mutatingWebhook:
   reinvocationPolicy: Never
-# kueueviz dashboard
+# kueue-viz dashboard
 enableKueueViz: false
 metrics:
   prometheusNamespace: monitoring

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -18,7 +18,7 @@ controllerManager:
     # priorityClassName: "system-cluster-critical"
     image:
       repository: us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue
-      # This should be set to 'IfNotPresent' for released version      
+      # This should be set to 'IfNotPresent' for released version
       pullPolicy: Always
     podAnnotations: {}
     resources:
@@ -151,7 +151,9 @@ webhookService:
       protocol: TCP
       targetPort: 9443
   type: ClusterIP
-# kueue-viz dashboard
+webhook:
+  reinvocationPolicy: Never
+# kueueviz dashboard
 enableKueueViz: false
 metrics:
   prometheusNamespace: monitoring

--- a/hack/update-helm.sh
+++ b/hack/update-helm.sh
@@ -102,6 +102,7 @@ replace_service_line=$(
   {{- .Values.webhookService.ports | toYaml | nindent 2 -}}
 EOF
 )
+
 search_webhook_pod_mutate="        path: /mutate--v1-pod"
 search_webhook_pod_validate="        path: /validate--v1-pod"
 search_webhook_deployment_mutate="        path: /mutate-apps-v1-deployment"

--- a/hack/update-helm.sh
+++ b/hack/update-helm.sh
@@ -309,9 +309,7 @@ for output_file in "${webhook_files[@]}"; do
     $YQ -N -i '.metadata.namespace = "{{ .Release.Namespace }}"' "$output_file"
   fi
   if [[ "$output_file" == "${DEST_WEBHOOK_DIR}/MutatingWebhookConfiguration.yml" ]]; then
-    echo "bla"
     $YQ -N -i '.webhooks.[].reinvocationPolicy = "{{ $reinvocationPolicy }}"' "$output_file"
-    cat ${DEST_WEBHOOK_DIR}/MutatingWebhookConfiguration.yml
   fi
   $YQ -N -i '.webhooks.[].clientConfig.service.name |= "{{ include \"kueue.fullname\" . }}-" + .' "$output_file"
   $YQ -N -i '.webhooks.[].clientConfig.service.namespace = "{{ .Release.Namespace }}"' "$output_file"

--- a/hack/update-helm.sh
+++ b/hack/update-helm.sh
@@ -114,7 +114,6 @@ add_webhook_line=$(
   cat <<'EOF'
 {{- $integrationsConfig := (fromYaml .Values.managerConfig.controllerManagerConfigYaml).integrations }}
 {{- $managerConfig := (fromYaml .Values.managerConfig.controllerManagerConfigYaml) }}
-{{- $reinvocationPolicy := .Values.webhook.reinvocationPolicy }}
 EOF
 )
 add_annotations_line=$(
@@ -309,7 +308,7 @@ for output_file in "${webhook_files[@]}"; do
     $YQ -N -i '.metadata.namespace = "{{ .Release.Namespace }}"' "$output_file"
   fi
   if [[ "$output_file" == "${DEST_WEBHOOK_DIR}/MutatingWebhookConfiguration.yml" ]]; then
-    $YQ -N -i '.webhooks.[].reinvocationPolicy = "{{ $reinvocationPolicy }}"' "$output_file"
+    $YQ -N -i '.webhooks.[].reinvocationPolicy = "{{ .Values.webhook.reinvocationPolicy }}"' "$output_file"
   fi
   $YQ -N -i '.webhooks.[].clientConfig.service.name |= "{{ include \"kueue.fullname\" . }}-" + .' "$output_file"
   $YQ -N -i '.webhooks.[].clientConfig.service.namespace = "{{ .Release.Namespace }}"' "$output_file"

--- a/hack/update-helm.sh
+++ b/hack/update-helm.sh
@@ -301,7 +301,6 @@ webhook_files=(
 "${DEST_WEBHOOK_DIR}/ValidatingWebhookConfiguration.yml"
 "${DEST_WEBHOOK_DIR}/service.yaml"
 )
-
 for output_file in "${webhook_files[@]}"; do
   if [ "$(< "$output_file" $YQ '.metadata | has("name")')" = "true" ]; then
     $YQ -N -i '.metadata.name |= "{{ include \"kueue.fullname\" . }}-" + .' "$output_file"

--- a/hack/update-helm.sh
+++ b/hack/update-helm.sh
@@ -102,7 +102,6 @@ replace_service_line=$(
   {{- .Values.webhookService.ports | toYaml | nindent 2 -}}
 EOF
 )
-
 search_webhook_pod_mutate="        path: /mutate--v1-pod"
 search_webhook_pod_validate="        path: /validate--v1-pod"
 search_webhook_deployment_mutate="        path: /mutate-apps-v1-deployment"
@@ -146,7 +145,6 @@ add_webhook_pod_mutate=$(
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
-    reinvocationPolicy: {{ $reinvocationPolicy }}
 EOF
 )
 add_webhook_pod_validate=$(
@@ -190,7 +188,6 @@ add_webhook_deployment_mutate=$(
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
-    reinvocationPolicy: {{ $reinvocationPolicy }}
 EOF
 )
 add_webhook_deployment_validate=$(
@@ -233,7 +230,6 @@ add_webhook_statefulset_mutate=$(
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
-    reinvocationPolicy: {{ $reinvocationPolicy }}
 EOF
 )
 add_webhook_statefulset_validate=$(
@@ -305,12 +301,18 @@ webhook_files=(
 "${DEST_WEBHOOK_DIR}/ValidatingWebhookConfiguration.yml"
 "${DEST_WEBHOOK_DIR}/service.yaml"
 )
+
 for output_file in "${webhook_files[@]}"; do
   if [ "$(< "$output_file" $YQ '.metadata | has("name")')" = "true" ]; then
     $YQ -N -i '.metadata.name |= "{{ include \"kueue.fullname\" . }}-" + .' "$output_file"
   fi
   if [ "$(< "$output_file" $YQ '.metadata | has("namespace")')" = "true" ]; then
     $YQ -N -i '.metadata.namespace = "{{ .Release.Namespace }}"' "$output_file"
+  fi
+  if [[ "$output_file" == "${DEST_WEBHOOK_DIR}/MutatingWebhookConfiguration.yml" ]]; then
+    echo "bla"
+    $YQ -N -i '.webhooks.[].reinvocationPolicy = "{{ $reinvocationPolicy }}"' "$output_file"
+    cat ${DEST_WEBHOOK_DIR}/MutatingWebhookConfiguration.yml
   fi
   $YQ -N -i '.webhooks.[].clientConfig.service.name |= "{{ include \"kueue.fullname\" . }}-" + .' "$output_file"
   $YQ -N -i '.webhooks.[].clientConfig.service.namespace = "{{ .Release.Namespace }}"' "$output_file"

--- a/hack/update-helm.sh
+++ b/hack/update-helm.sh
@@ -115,6 +115,7 @@ add_webhook_line=$(
   cat <<'EOF'
 {{- $integrationsConfig := (fromYaml .Values.managerConfig.controllerManagerConfigYaml).integrations }}
 {{- $managerConfig := (fromYaml .Values.managerConfig.controllerManagerConfigYaml) }}
+{{- $reinvocationPolicy := .Values.webhook.reinvocationPolicy }}
 EOF
 )
 add_annotations_line=$(
@@ -145,6 +146,7 @@ add_webhook_pod_mutate=$(
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
+    reinvocationPolicy: {{ $reinvocationPolicy }}
 EOF
 )
 add_webhook_pod_validate=$(
@@ -188,6 +190,7 @@ add_webhook_deployment_mutate=$(
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
+    reinvocationPolicy: {{ $reinvocationPolicy }}
 EOF
 )
 add_webhook_deployment_validate=$(
@@ -230,6 +233,7 @@ add_webhook_statefulset_mutate=$(
             - kube-system
             - '{{ .Release.Namespace }}'
       {{- end }}
+    reinvocationPolicy: {{ $reinvocationPolicy }}
 EOF
 )
 add_webhook_statefulset_validate=$(

--- a/hack/update-helm.sh
+++ b/hack/update-helm.sh
@@ -309,7 +309,7 @@ for output_file in "${webhook_files[@]}"; do
     $YQ -N -i '.metadata.namespace = "{{ .Release.Namespace }}"' "$output_file"
   fi
   if [[ "$output_file" == "${DEST_WEBHOOK_DIR}/MutatingWebhookConfiguration.yml" ]]; then
-    $YQ -N -i '.webhooks.[].reinvocationPolicy = "{{ .Values.webhook.reinvocationPolicy }}"' "$output_file"
+    $YQ -N -i '.webhooks.[].reinvocationPolicy = "{{ .Values.mutatingWebhook.reinvocationPolicy }}"' "$output_file"
   fi
   $YQ -N -i '.webhooks.[].clientConfig.service.name |= "{{ include \"kueue.fullname\" . }}-" + .' "$output_file"
   $YQ -N -i '.webhooks.[].clientConfig.service.namespace = "{{ .Release.Namespace }}"' "$output_file"


### PR DESCRIPTION
Cherry pick of #5063 on release-0.11.

#5063: Mutating webhook with reinvocation policy

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Helm: Add an option to configure Kueue's mutation webhook with "reinvocationPolicy"
```