### PR TITLE
refactor: improve error handling with client.IgnoreNotFound in controllers

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/admissioncheck.go
+++ b/pkg/controller/admissionchecks/multikueue/admissioncheck.go
@@ -122,10 +122,10 @@ func (a *ACReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 
 	if needsUpdate {
 		err := a.client.Status().Update(ctx, ac)
-		if err != nil {
+		if client.IgnoreNotFound(err) != nil {
 			log.V(2).Error(err, "Updating check condition", "newCondition", newCondition)
+			return reconcile.Result{}, err
 		}
-		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -422,7 +422,9 @@ func (c *clustersReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 			return reconcile.Result{RequeueAfter: ptr.Deref(retryAfter, 0)}, nil
 		}
 	}
-	return reconcile.Result{}, c.updateStatus(ctx, cluster, true, "Active", "Connected")
+
+	err = c.updateStatus(ctx, cluster, true, "Active", "Connected")
+	return reconcile.Result{}, client.IgnoreNotFound(err)
 }
 
 func (c *clustersReconciler) getKubeConfig(ctx context.Context, ref *kueue.KubeConfig) ([]byte, bool, error) {

--- a/pkg/controller/admissionchecks/provisioning/admissioncheck_reconciler.go
+++ b/pkg/controller/admissionchecks/provisioning/admissioncheck_reconciler.go
@@ -58,7 +58,9 @@ func (a *acReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 
 	if currentCondition.Status != newCondition.Status {
 		apimeta.SetStatusCondition(&ac.Status.Conditions, newCondition)
-		return reconcile.Result{}, a.client.Status().Update(ctx, ac)
+		if err := a.client.Status().Update(ctx, ac); err != nil {
+			return reconcile.Result{}, client.IgnoreNotFound(err)
+		}
 	}
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/core/admissioncheck_controller.go
+++ b/pkg/controller/core/admissioncheck_controller.go
@@ -93,7 +93,7 @@ func (r *AdmissionCheckReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if ac.DeletionTimestamp.IsZero() {
 		if controllerutil.AddFinalizer(ac, kueue.ResourceInUseFinalizerName) {
 			if err := r.client.Update(ctx, ac); err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, client.IgnoreNotFound(err)
 			}
 			log.V(5).Info("Added finalizer")
 		}
@@ -108,7 +108,7 @@ func (r *AdmissionCheckReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			}
 			controllerutil.RemoveFinalizer(ac, kueue.ResourceInUseFinalizerName)
 			if err := r.client.Update(ctx, ac); err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, client.IgnoreNotFound(err)
 			}
 			log.V(5).Info("Removed finalizer")
 		}

--- a/pkg/controller/core/cohort_controller.go
+++ b/pkg/controller/core/cohort_controller.go
@@ -149,7 +149,7 @@ func (r *CohortReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	r.qManager.AddOrUpdateCohort(ctx, &cohort)
 
 	err := r.updateCohortStatusIfChanged(ctx, &cohort)
-	return ctrl.Result{}, err
+	return ctrl.Result{}, client.IgnoreNotFound(err)
 }
 
 func (r *CohortReconciler) updateCohortStatusIfChanged(ctx context.Context, cohort *kueue.Cohort) error {

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -169,7 +169,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	if len(wl.OwnerReferences) == 0 && !wl.DeletionTimestamp.IsZero() {
 		// manual deletion triggered by the user
-		return ctrl.Result{}, workload.RemoveFinalizer(ctx, r.client, &wl)
+		err := workload.RemoveFinalizer(ctx, r.client, &wl)
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	finishedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadFinished)
@@ -200,7 +201,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				annotations := wl.GetAnnotations()
 				delete(annotations, kueuealpha.NodeToReplaceAnnotation)
 				wl.SetAnnotations(annotations)
-				r.log.V(3).Info("Deleting %v annotation from Workload", "annotation", kueuealpha.NodeToReplaceAnnotation)
+				r.log.V(3).Info("Deleting annotation from Workload", "annotation", kueuealpha.NodeToReplaceAnnotation)
 				return true, nil
 			}); err != nil {
 				return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -238,7 +239,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 
 		if updated {
-			return ctrl.Result{}, workload.ApplyAdmissionStatus(ctx, r.client, &wl, true, r.clock)
+			err := workload.ApplyAdmissionStatus(ctx, r.client, &wl, true, r.clock)
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 	} else {
 		var updated, evicted bool
@@ -264,7 +266,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		reportWorkloadEvictedOnce := workload.WorkloadEvictionStateInc(&wl, kueue.WorkloadDeactivated, "")
 		updated = workload.ResetChecksOnEviction(&wl, r.clock.Now()) || updated
 		if updated {
-			if err := workload.ApplyAdmissionStatus(ctx, r.client, &wl, true, r.clock); err != nil {
+			err := workload.ApplyAdmissionStatus(ctx, r.client, &wl, true, r.clock)
+			if client.IgnoreNotFound(err) != nil {
 				return ctrl.Result{}, fmt.Errorf("setting eviction: %w", err)
 			}
 			if evicted && wl.Status.Admission != nil {
@@ -287,20 +290,23 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	lqActive := ptr.Deref(lq.Spec.StopPolicy, kueue.None) == kueue.None
 	if lqExists && lqActive && isDisabledRequeuedByLocalQueueStopped(&wl) {
 		workload.SetRequeuedCondition(&wl, kueue.WorkloadLocalQueueRestarted, "The LocalQueue was restarted after being stopped", true)
-		return ctrl.Result{}, workload.ApplyAdmissionStatus(ctx, r.client, &wl, true, r.clock)
+		err := workload.ApplyAdmissionStatus(ctx, r.client, &wl, true, r.clock)
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	cqName, cqOk := r.queues.ClusterQueueForWorkload(&wl)
 	if cqOk {
 		// because we need to react to API cluster cq events, the list of checks from a cache can lead to race conditions
 		cq := kueue.ClusterQueue{}
-		if err := r.client.Get(ctx, types.NamespacedName{Name: string(cqName)}, &cq); err != nil {
+		err := r.client.Get(ctx, types.NamespacedName{Name: string(cqName)}, &cq)
+		if client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
 		}
 		// If stopped cluster queue is started we need to set the WorkloadRequeued condition to true.
 		if isDisabledRequeuedByClusterQueueStopped(&wl) && ptr.Deref(cq.Spec.StopPolicy, kueue.None) == kueue.None {
 			workload.SetRequeuedCondition(&wl, kueue.WorkloadClusterQueueRestarted, "The ClusterQueue was restarted after being stopped", true)
-			return ctrl.Result{}, workload.ApplyAdmissionStatus(ctx, r.client, &wl, true, r.clock)
+			err := workload.ApplyAdmissionStatus(ctx, r.client, &wl, true, r.clock)
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 		if updated, err := r.reconcileSyncAdmissionChecks(ctx, &wl, &cq); updated || err != nil {
 			return ctrl.Result{}, err
@@ -310,7 +316,8 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// If the workload is admitted, updating the status here would set the Admitted condition to
 	// false before the workloads eviction.
 	if !workload.IsAdmitted(&wl) && workload.SyncAdmittedCondition(&wl, r.clock.Now()) {
-		if err := workload.ApplyAdmissionStatus(ctx, r.client, &wl, true, r.clock); err != nil {
+		err := workload.ApplyAdmissionStatus(ctx, r.client, &wl, true, r.clock)
+		if client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
 		}
 		if workload.IsAdmitted(&wl) {
@@ -330,24 +337,24 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	if workload.HasQuotaReservation(&wl) {
 		if evictionTriggered, err := r.reconcileCheckBasedEviction(ctx, &wl); evictionTriggered || err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 
 		if updated, err := r.reconcileOnLocalQueueActiveState(ctx, &wl, lqExists, &lq); updated || err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 
 		if updated, err := r.reconcileOnClusterQueueActiveState(ctx, &wl, cqName); updated || err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 
 		podsReadyRecheckAfter, err := r.reconcileNotReadyTimeout(ctx, req, &wl)
 		if err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 		maxExecRecheckAfter, err := r.reconcileMaxExecutionTime(ctx, &wl)
 		if err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 
 		// get the minimun non-zero value
@@ -442,7 +449,7 @@ func (r *WorkloadReconciler) reconcileCheckBasedEviction(ctx context.Context, wl
 		}
 		workload.SetDeactivationTarget(wl, kueue.WorkloadEvictedByAdmissionCheck, fmt.Sprintf("Admission check(s): %v, were rejected", stringsutils.Join(rejectedCheckNames, ",")))
 		if err := workload.ApplyAdmissionStatus(ctx, r.client, wl, true, r.clock); err != nil {
-			return false, client.IgnoreNotFound(err)
+			return false, err
 		}
 		log.V(3).Info("Workload is evicted due to rejected admission checks", "workload", klog.KObj(wl), "rejectedChecks", rejectedCheckNames)
 		rejectedCheck := workload.RejectedChecks(wl)[0]
@@ -455,7 +462,7 @@ func (r *WorkloadReconciler) reconcileCheckBasedEviction(ctx context.Context, wl
 	workload.ResetChecksOnEviction(wl, r.clock.Now())
 	reportWorkloadEvictedOnce := workload.WorkloadEvictionStateInc(wl, kueue.WorkloadEvictedByAdmissionCheck, "")
 	if err := workload.ApplyAdmissionStatus(ctx, r.client, wl, true, r.clock); err != nil {
-		return false, client.IgnoreNotFound(err)
+		return false, err
 	}
 	cqName, _ := r.queues.ClusterQueueForWorkload(wl)
 	workload.ReportEvictedWorkload(r.recorder, wl, cqName, kueue.WorkloadEvictedByAdmissionCheck, message)
@@ -504,7 +511,7 @@ func (r *WorkloadReconciler) reconcileOnLocalQueueActiveState(ctx context.Contex
 				}
 			}
 		}
-		return true, client.IgnoreNotFound(err)
+		return true, err
 	}
 
 	if !lqExists || !lq.DeletionTimestamp.IsZero() {
@@ -553,7 +560,7 @@ func (r *WorkloadReconciler) reconcileOnClusterQueueActiveState(ctx context.Cont
 				metrics.ReportEvictedWorkloadsOnce(wl.Status.Admission.ClusterQueue, kueue.WorkloadEvictedByClusterQueueStopped, "")
 			}
 		}
-		return true, client.IgnoreNotFound(err)
+		return true, err
 	}
 
 	if !cqExists || !cq.DeletionTimestamp.IsZero() {
@@ -624,7 +631,7 @@ func (r *WorkloadReconciler) reconcileNotReadyTimeout(ctx context.Context, req c
 	}
 	log.V(2).Info("Start the eviction of the workload due to exceeding the PodsReady timeout")
 	if deactivated, err := r.triggerDeactivationOrBackoffRequeue(ctx, wl); deactivated || err != nil {
-		return 0, client.IgnoreNotFound(err)
+		return 0, err
 	}
 	message := fmt.Sprintf("Exceeded the PodsReady timeout %s", req.String())
 	workload.SetEvictedCondition(wl, kueue.WorkloadEvictedByPodsReadyTimeout, message)
@@ -638,7 +645,7 @@ func (r *WorkloadReconciler) reconcileNotReadyTimeout(ctx context.Context, req c
 			metrics.ReportEvictedWorkloadsOnce(cqName, kueue.WorkloadEvictedByPodsReadyTimeout, underlyingCause)
 		}
 	}
-	return 0, client.IgnoreNotFound(err)
+	return 0, err
 }
 
 // triggerDeactivationOrBackoffRequeue trigger deactivation of workload


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

follow-up: https://github.com/kubernetes-sigs/kueue/pull/5786#issuecomment-3012681011


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```