### PR TITLE
Fix TAS LeastFreeCapacityFit for fit where nodes that are not the smallest one can accommodate Workload

### DIFF
--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -552,15 +552,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 				Levels: defaultOneLevel,
 				Domains: []kueue.TopologyDomainAssignment{
 					{
-						Count: 1,
+						Count: 2,
 						Values: []string{
-							"x2",
-						},
-					},
-					{
-						Count: 1,
-						Values: []string{
-							"x3",
+							"x4",
 						},
 					},
 				},
@@ -796,6 +790,66 @@ func TestFindTopologyAssignment(t *testing.T) {
 			},
 			enableFeatureGates: []featuregate.Feature{features.TASProfileMixed},
 		},
+		"host required; single Pod fits in the largest host; LeastFreeCapacityFit": {
+			nodes: defaultNodes,
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Required: ptr.To(corev1.LabelHostname),
+			},
+			levels: defaultThreeLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 2,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultOneLevel,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 2,
+						Values: []string{
+							"x6",
+						},
+					},
+				},
+			},
+			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+		},
+		"host preferred; single Pod fits in the largest host; LeastFreeCapacityFit": {
+			nodes: defaultNodes,
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Preferred: ptr.To(corev1.LabelHostname),
+			},
+			levels: defaultThreeLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 2,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultOneLevel,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 2,
+						Values: []string{
+							"x6",
+						},
+					},
+				},
+			},
+			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+		},
+		"host required; no single host fits all pods, expect notFitMessage; LeastFreeCapacityFit": {
+			nodes: defaultNodes,
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Required: ptr.To(corev1.LabelHostname),
+			},
+			levels: defaultThreeLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count:              3,
+			wantAssignment:     nil,
+			wantReason:         `topology "default" allows to fit only 2 out of 3 pod(s)`,
+			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+		},
 		"host preferred; single Pod fits in the host; BestFit; TASProfileMixed": {
 			nodes: defaultNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
@@ -879,14 +933,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 				Levels: defaultTwoLevels,
 				Domains: []kueue.TopologyDomainAssignment{
 					{
-						Count: 1,
-						Values: []string{
-							"b2",
-							"r1",
-						},
-					},
-					{
-						Count: 1,
+						Count: 2,
 						Values: []string{
 							"b2",
 							"r2",
@@ -2459,15 +2506,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 						},
 					},
 					{
-						Count: 2,
+						Count: 4,
 						Values: []string{
 							"x1",
-						},
-					},
-					{
-						Count: 2,
-						Values: []string{
-							"x5",
 						},
 					},
 				},

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -826,6 +826,17 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(levelIdx int, required bool,
 		// optimize the potentially last domain
 		topDomain = findBestFitDomainForSlices(sortedDomain, sliceCount)
 	}
+	if useLeastFreeCapacityAlgorithm(unconstrained) {
+		for _, candidateDomain := range sortedDomain {
+			if candidateDomain.sliceState >= sliceCount {
+				return levelIdx, []*domain{candidateDomain}, ""
+			}
+		}
+		if required {
+			maxCapacityFound := sortedDomain[len(sortedDomain)-1].state
+			return 0, nil, s.notFitMessage(maxCapacityFound, sliceCount, sliceSize)
+		}
+	}
 	if topDomain.sliceState < sliceCount {
 		if required {
 			return 0, nil, s.notFitMessage(topDomain.sliceState, sliceCount, sliceSize)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5450 

#### Special notes for your reviewer:
Took the same logic as here: https://github.com/kubernetes-sigs/kueue/pull/5450 and rebased, added new UTs and adjusted old ones

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Bug fix for TAS LeastFreeCapacityFit
```