### PR TITLE
Automated cherry pick of #5803: Fix TAS LeastFreeCapacityFit for fit where nodes that are not the smallest one can accommodate Workload

### DIFF
--- a/pkg/cache/tas_cache_test.go
+++ b/pkg/cache/tas_cache_test.go
@@ -554,15 +554,9 @@ func TestFindTopologyAssignment(t *testing.T) {
 				Levels: defaultOneLevel,
 				Domains: []kueue.TopologyDomainAssignment{
 					{
-						Count: 1,
+						Count: 2,
 						Values: []string{
-							"x2",
-						},
-					},
-					{
-						Count: 1,
-						Values: []string{
-							"x3",
+							"x4",
 						},
 					},
 				},
@@ -915,6 +909,66 @@ func TestFindTopologyAssignment(t *testing.T) {
 			},
 			enableFeatureGates: []featuregate.Feature{features.TASProfileMixed},
 		},
+		"host required; single Pod fits in the largest host; LeastFreeCapacityFit": {
+			nodes: defaultNodes,
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Required: ptr.To(corev1.LabelHostname),
+			},
+			levels: defaultThreeLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 2,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultOneLevel,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 2,
+						Values: []string{
+							"x6",
+						},
+					},
+				},
+			},
+			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+		},
+		"host preferred; single Pod fits in the largest host; LeastFreeCapacityFit": {
+			nodes: defaultNodes,
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Preferred: ptr.To(corev1.LabelHostname),
+			},
+			levels: defaultThreeLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 2,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultOneLevel,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 2,
+						Values: []string{
+							"x6",
+						},
+					},
+				},
+			},
+			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+		},
+		"host required; no single host fits all pods, expect notFitMessage; LeastFreeCapacityFit": {
+			nodes: defaultNodes,
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Required: ptr.To(corev1.LabelHostname),
+			},
+			levels: defaultThreeLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count:              3,
+			wantAssignment:     nil,
+			wantReason:         `topology "default" allows to fit only 2 out of 3 pod(s)`,
+			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+		},
 		"host preferred; single Pod fits in the host; BestFit; TASProfileMixed": {
 			nodes: defaultNodes,
 			topologyRequest: &kueue.PodSetTopologyRequest{
@@ -1000,14 +1054,7 @@ func TestFindTopologyAssignment(t *testing.T) {
 				Levels: defaultTwoLevels,
 				Domains: []kueue.TopologyDomainAssignment{
 					{
-						Count: 1,
-						Values: []string{
-							"b2",
-							"r1",
-						},
-					},
-					{
-						Count: 1,
+						Count: 2,
 						Values: []string{
 							"b2",
 							"r2",
@@ -1016,6 +1063,30 @@ func TestFindTopologyAssignment(t *testing.T) {
 				},
 			},
 			enableFeatureGates: []featuregate.Feature{features.TASProfileLeastFreeCapacity},
+		},
+		"rack required; multiple Pods fits in a rack; MostFreeCapacity": {
+			nodes: defaultNodes,
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Required: ptr.To(tasRackLabel),
+			},
+			levels: defaultTwoLevels,
+			requests: resources.Requests{
+				corev1.ResourceCPU: 1000,
+			},
+			count: 3,
+			wantAssignment: &kueue.TopologyAssignment{
+				Levels: defaultTwoLevels,
+				Domains: []kueue.TopologyDomainAssignment{
+					{
+						Count: 3,
+						Values: []string{
+							"b1",
+							"r2",
+						},
+					},
+				},
+			},
+			enableFeatureGates: []featuregate.Feature{features.TASProfileMostFreeCapacity},
 		},
 		"rack required; multiple Pods fits in a rack; MostFreeCapacity": {
 			nodes: defaultNodes,

--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -545,6 +545,17 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(levelIdx int, required bool,
 		// optimize the potentially last domain
 		topDomain = sortedDomain[findBestFitDomainIdx(sortedDomain, count)]
 	}
+	if useLeastFreeCapacityAlgorithm(unconstrained) {
+		for _, candidateDomain := range sortedDomain {
+			if candidateDomain.state >= count {
+				return levelIdx, []*domain{candidateDomain}, ""
+			}
+		}
+		if required {
+			maxCapacityFound := sortedDomain[len(sortedDomain)-1].state
+			return 0, nil, s.notFitMessage(maxCapacityFound, count)
+		}
+	}
 	if topDomain.state < count {
 		if required {
 			return 0, nil, s.notFitMessage(topDomain.state, count)


### PR DESCRIPTION
Cherry pick of #5803 on release-0.11.

#5803: Fix TAS LeastFreeCapacityFit for fit where nodes that are not the smallest one can accommodate Workload

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
TAS: Fix a bug that Kueue unintentionally gives up a workload scheduling in LeastFreeCapacity if there is at least one unmatched domain.
```