### PR TITLE
Fix template geenration to details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,10 @@ helm-verify: helm helm-lint ## run helm template and detect any rendering failur
 	$(HELM) template charts/kueue --set managerConfig.controllerManagerConfigYaml="managedJobsNamespaceSelector:\n  matchExpressions:\n    - key: kubernetes.io/metadata.name\n      operator: In\n      values: [ kube-system ]" > /dev/null
 # test priorityClassName option
 	$(HELM) template charts/kueue --set controllerManager.manager.priorityClassName="system-cluster-critical" > /dev/null
+# test priorityClassName option
+	$(HELM) template charts/kueue --set controllerManager.manager.priorityClassName="system-cluster-critical" > /dev/null
+# test kueueViz priorityClassName options
+	$(HELM) template charts/kueue --set enableKueueViz=true --set kueueViz.priorityClassName="system-cluster-critical" > /dev/null
 
 # test
 .PHONY: helm-unit-test

--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -126,9 +126,17 @@ The following table lists the configurable parameters of the kueue chart and the
 | kueueViz.backend.image.pullPolicy | string | `"Always"` | KueueViz dashboard backend image pullPolicy. This should be set to 'IfNotPresent' for released version |
 | kueueViz.backend.image.repository | string | `"us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-backend"` | KueueViz dashboard backend image repository |
 | kueueViz.backend.image.tag | string | `"main"` | KueueViz dashboard backend image tag |
+| kueueViz.backend.ingress.host | string | `"backend.kueueviz.local"` | KueueViz dashboard backend ingress host |
+| kueueViz.backend.ingress.ingressClassName | string | `nil` | KueueViz dashboard backend ingress class name |
+| kueueViz.backend.ingress.tlsSecretName | string | `"kueueviz-backend-tls"` | KueueViz dashboard backend ingress tls secret name |
 | kueueViz.frontend.image.pullPolicy | string | `"Always"` | KueueViz dashboard frontend image pullPolicy. This should be set to 'IfNotPresent' for released version |
 | kueueViz.frontend.image.repository | string | `"us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-frontend"` | KueueViz dashboard frontend image repository |
 | kueueViz.frontend.image.tag | string | `"main"` | KueueViz dashboard frontend image tag |
+| kueueViz.frontend.ingress.host | string | `"frontend.kueueviz.local"` | KueueViz dashboard frontend ingress host |
+| kueueViz.frontend.ingress.ingressClassName | string | `nil` | KueueViz dashboard frontend ingress class name |
+| kueueViz.frontend.ingress.tlsSecretName | string | `"kueueviz-frontend-tls"` | KueueViz dashboard frontend ingress tls secret name |
+| kueueViz.imagePullSecrets | list | `[]` |  |
+| kueueViz.priorityClassName | string | `nil` |  |
 | managerConfig.controllerManagerConfigYaml | string | controllerManagerConfigYaml | controller_manager_config.yaml. ControllerManager utilizes this yaml via manager-config Configmap. |
 | metrics.prometheusNamespace | string | `"monitoring"` | Prometheus namespace |
 | metrics.serviceMonitor.tlsConfig | object | `{"insecureSkipVerify":true}` | ServiceMonitor's tlsConfig |

--- a/charts/kueue/templates/kueueviz/backend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/backend-deployment.yaml
@@ -14,6 +14,13 @@ spec:
       labels:
         app: kueueviz-backend
     spec:
+    {{- with .Values.kueueViz.imagePullSecrets  }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with  .Values.kueueViz.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
       containers:
         - name: backend
           image: '{{ .Values.kueueViz.backend.image.repository }}:{{ .Values.kueueViz.backend.image.tag | default .Chart.AppVersion }}'

--- a/charts/kueue/templates/kueueviz/backend-ingress.yaml
+++ b/charts/kueue/templates/kueueviz/backend-ingress.yaml
@@ -8,12 +8,15 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
+  {{- if .Values.kueueViz.backend.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.kueueViz.backend.ingress.ingressClassName }}
+  {{- end }}
   tls:
     - hosts:
-        - backend.kueueviz.local
-      secretName: '{{ include "kueue.fullname" . }}-kueueviz-tls-secret'
+      - {{ .Values.kueueViz.backend.ingress.host | default "backend.kueueviz.local" }}
+      secretName: '{{ .Values.kueueViz.backend.ingress.tlsSecretName | default "kueueviz-backend-tls" }}'
   rules:
-    - host: backend.kueueviz.local
+    - host: '{{ .Values.kueueViz.backend.ingress.host | default "backend.kueueviz.local" }}'
       http:
         paths:
           - path: /

--- a/charts/kueue/templates/kueueviz/frontend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/frontend-deployment.yaml
@@ -14,15 +14,19 @@ spec:
       labels:
         app: kueueviz-frontend
     spec:
+    {{- with .Values.kueueViz.imagePullSecrets  }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with  .Values.kueueViz.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
       containers:
         - name: frontend
           image: '{{ .Values.kueueViz.frontend.image.repository }}:{{ .Values.kueueViz.frontend.image.tag | default .Chart.AppVersion }}'
           imagePullPolicy: '{{ .Values.kueueViz.frontend.image.pullPolicy }}'
           ports:
             - containerPort: 8080
-          env:
-            - name: REACT_APP_WEBSOCKET_URL
-              value: "wss://backend.kueueviz.local"
           resources:
             limits:
               cpu: 500m
@@ -30,4 +34,7 @@ spec:
             requests:
               cpu: 500m
               memory: 512Mi
+          env:
+            - name: REACT_APP_WEBSOCKET_URL
+              value: wss://{{ .Values.kueueViz.backend.ingress.host | default "backend.kueueviz.local" }}
 {{- end }}

--- a/charts/kueue/templates/kueueviz/frontend-ingress.yaml
+++ b/charts/kueue/templates/kueueviz/frontend-ingress.yaml
@@ -8,12 +8,15 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
+  {{- if .Values.kueueViz.frontend.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.kueueViz.frontend.ingress.ingressClassName }}
+  {{- end }}
   tls:
     - hosts:
-        - frontend.kueueviz.local
-      secretName: '{{ include "kueue.fullname" . }}-kueueviz-tls-secret'
+      - {{ .Values.kueueViz.frontend.ingress.host | default "frontend.kueueviz.local" }}
+      secretName: '{{ .Values.kueueViz.frontend.ingress.tlsSecretName | default "kueueviz-frontend-tls" }}'
   rules:
-    - host: frontend.kueueviz.local
+    - host: '{{ .Values.kueueViz.frontend.ingress.host | default "frontend.kueueviz.local" }}'
       http:
         paths:
           - path: /

--- a/charts/kueue/tests/kueue_test.yaml
+++ b/charts/kueue/tests/kueue_test.yaml
@@ -1,0 +1,123 @@
+suite: test kueueviz deployment
+templates:
+  - kueueviz/backend-deployment.yaml
+  - kueueviz/frontend-deployment.yaml
+  - kueueviz/backend-ingress.yaml
+  - kueueviz/frontend-ingress.yaml
+tests:
+  - it: should set the pod priorityClassName when provided for backend deployment
+    template: kueueviz/backend-deployment.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        priorityClassName: "foo"
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: foo
+  - it: should not render the pod priorityClassName if not set for backend deployment
+    template: kueueviz/backend-deployment.yaml
+    set:
+      enableKueueViz: true
+      priorityClassName:
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+  - it: should set the pod priorityClassName when provided for frontend deployment 
+    template: kueueviz/frontend-deployment.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        priorityClassName: "foo"
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: foo
+  - it: should not render the pod priorityClassName if not set for frontend deployment
+    template: kueueviz/frontend-deployment.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        priorityClassName:       
+    asserts:
+      - notExists:
+          path: spec.template.spec.priorityClassName
+  - it: should  render the ingress value of backend ingress in frontend deployment as ENV variables
+    template: kueueviz/frontend-deployment.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        backend:
+          ingress:
+            ingressClassName: "ingress-external"
+            host: "backend.kueueviz.local"
+            tlsSecretName: "kueueviz-frontend-tls"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "wss://backend.kueueviz.local"
+  - it: Render  Ingress for Backend Component
+    template: kueueviz/backend-ingress.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        
+        backend:
+          ingress:
+            ingressClassName: "ingress-internal"
+            host: "backend.kueueviz.in"
+            tlsSecretName: "kueueviz-backend-tls"
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: "ingress-internal"
+      - equal:
+          path: spec.rules[0].host
+          value: "backend.kueueviz.in"
+      - equal:
+          path: spec.tls[0].secretName
+          value: "kueueviz-backend-tls"
+
+  - it: Render  Ingress for Frontend Component
+    template: kueueviz/frontend-ingress.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        ingressClassName: "ingress-external"
+        frontend:
+          ingress:
+            ingressClassName: "ingress-external"
+            host: "frontend.kueueviz.in"
+            tlsSecretName: "kueueviz-frontend-tls"
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: "ingress-external"
+      - equal:
+          path: spec.rules[0].host
+          value: "frontend.kueueviz.in"
+      - equal:
+          path: spec.tls[0].secretName
+          value: "kueueviz-frontend-tls"
+  - it: should set the imagePullSecrets for backend deployment
+    template: kueueviz/backend-deployment.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        imagePullSecrets:
+          - name: "my-secret"
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: "my-secret"
+  - it: should set the imagePullSecrets for frontend deployment
+    template: kueueviz/frontend-deployment.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        imagePullSecrets:
+          - name: "my-secret"
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: "my-secret"

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -208,7 +208,16 @@ mutatingWebhook:
   # -- MutatingWebhookConfiguration's reinvocationPolicy
   reinvocationPolicy: Never
 kueueViz:
+  imagePullSecrets: []
+  priorityClassName:
   backend:
+    ingress:
+      # -- KueueViz dashboard backend ingress class name
+      ingressClassName:
+      # -- KueueViz dashboard backend ingress host
+      host: "backend.kueueviz.local"
+      # -- KueueViz dashboard backend ingress tls secret name
+      tlsSecretName: "kueueviz-backend-tls"
     image:
       # -- KueueViz dashboard backend image repository
       repository: "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-backend"
@@ -218,6 +227,13 @@ kueueViz:
       # This should be set to 'IfNotPresent' for released version
       pullPolicy: Always
   frontend:
+    ingress:
+      # -- KueueViz dashboard frontend ingress class name
+      ingressClassName:
+      # -- KueueViz dashboard frontend ingress host
+      host: "frontend.kueueviz.local"
+      # -- KueueViz dashboard frontend ingress tls secret name
+      tlsSecretName: "kueueviz-frontend-tls"
     image:
       # -- KueueViz dashboard frontend image repository
       repository: "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-frontend"

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -580,6 +580,19 @@ files:
       - kustomization.yaml
     continueOnError: true
     operations:
+      - type: DELETE
+        key: .spec.template.spec.containers[0].env
+      - type: DELETE
+        key: .spec.tls
+        onFileCondition: '.kind == "Ingress"'
+      - type: UPDATE
+        key: .spec.rules[0].host
+        value: '"{{ .Values.kueueViz.backend.ingress.host | default \"backend.kueueviz.local\" }}"'
+        onFileCondition: '.kind == "Ingress" and .metadata.name | contains("kueueviz-backend-ingress")'
+      - type: UPDATE
+        key: .spec.rules[0].host
+        value: '"{{ .Values.kueueViz.frontend.ingress.host | default \"frontend.kueueviz.local\" }}"'
+        onFileCondition: '.kind == "Ingress" and .metadata.name | contains("kueueviz-frontend-ingress")'
       - type: UPDATE
         key: .spec.template.spec.containers[0].image
         value: '"{{ .Values.kueueViz.backend.image.repository }}:{{ .Values.kueueViz.backend.image.tag | default .Chart.AppVersion }}"'
@@ -617,7 +630,59 @@ files:
       - type: UPDATE
         key: .metadata.namespace
         value: '"{{ .Release.Namespace }}"'
+      - type: INSERT_OBJECT
+        addKeyIfMissing: true
+        key: .spec.template.spec.containers[0].env
+        onFileCondition: '.kind == "Deployment" and .metadata.name | contains("kueueviz-frontend")'
+        value: |
+          - name: REACT_APP_WEBSOCKET_URL
+            value: wss://{{ .Values.kueueViz.backend.ingress.host | default "backend.kueueviz.local" }}
     postOperations:
+      - type: INSERT_TEXT
+        key: .spec
+        indentation: 2
+        value: |
+          tls:
+            - hosts:
+              - {{ .Values.kueueViz.backend.ingress.host | default "backend.kueueviz.local" }}
+              secretName: '{{ .Values.kueueViz.backend.ingress.tlsSecretName | default "kueueviz-backend-tls" }}'
+        onFileCondition: '.kind == "Ingress" and .metadata.name | contains("kueueviz-backend-ingress")'
+      - type: INSERT_TEXT
+        key: .spec
+        indentation: 2
+        value: |
+          tls:
+            - hosts:
+              - {{ .Values.kueueViz.frontend.ingress.host | default "frontend.kueueviz.local" }}
+              secretName: '{{ .Values.kueueViz.frontend.ingress.tlsSecretName | default "kueueviz-frontend-tls" }}'
+        onFileCondition: '.kind == "Ingress" and .metadata.name | contains("kueueviz-frontend-ingress")'
+      - type: INSERT_TEXT
+        key: .spec
+        value: |
+          {{- if .Values.kueueViz.backend.ingress.ingressClassName }}
+          ingressClassName: {{ .Values.kueueViz.backend.ingress.ingressClassName }}
+          {{- end }}
+        indentation: 2
+        onFileCondition: '.kind == "Ingress" and .metadata.name | contains("kueueviz-backend-ingress")'
+      - type: INSERT_TEXT
+        key: .spec
+        value: |
+          {{- if .Values.kueueViz.frontend.ingress.ingressClassName }}
+          ingressClassName: {{ .Values.kueueViz.frontend.ingress.ingressClassName }}
+          {{- end }}
+        indentation: 2
+        onFileCondition: '.kind == "Ingress" and .metadata.name | contains("kueueviz-frontend-ingress")'
+      - type: INSERT_TEXT
+        key: .spec.template.spec
+        value: |
+          {{- with .Values.kueueViz.imagePullSecrets  }}
+            imagePullSecrets:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- with  .Values.kueueViz.priorityClassName }}
+            priorityClassName: {{ . }}
+          {{- end }}
+        onFileCondition: '.kind == "Deployment"'
       - type: INSERT_TEXT
         position: START
         value: |


### PR DESCRIPTION
/kind bug
/kind cleanup
/kind feature

#### What this PR does / why we need it:
1. Current helm chart has no way to configure host for ingress in kueueviz it ends up referring  a random TLS-Secret(bug)
2. PriorityClass only added to manager not extended to kueueviz ,  frontend or backend deployments

Fixes #
-  https://github.com/kubernetes-sigs/kueue/issues/5437

## Previously Closed MR(for info):
https://github.com/kubernetes-sigs/kueue/pull/5754

#### Does this PR introduce a user-facing change?
```release-note
1. Add Support for configuring host for ingress in kueueviz.
2. changing PriorityClassName support extended to kueueviz  frontend or backend deployments.
3. Add imagePullSecrets for kueueViz frontend and backend deployments
4. Added test cases for kueueviz components in helm unit-test 
```