### PR TITLE
fix: correct typo in AccumulatedPastExecutionTimeSeconds field name

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -395,11 +395,11 @@ type WorkloadStatus struct {
 	// +kubebuilder:validation:MaxItems=8
 	ResourceRequests []PodSetRequest `json:"resourceRequests,omitempty"`
 
-	// accumulatedPastExexcutionTimeSeconds holds the total time, in seconds, the workload spent
+	// AccumulatedPastExecutionTimeSeconds holds the total time, in seconds, the workload spent
 	// in Admitted state, in the previous `Admit` - `Evict` cycles.
 	//
 	// +optional
-	AccumulatedPastExexcutionTimeSeconds *int32 `json:"accumulatedPastExexcutionTimeSeconds,omitempty"`
+	AccumulatedPastExecutionTimeSeconds *int32 `json:"AccumulatedPastExecutionTimeSeconds,omitempty"`
 
 	// schedulingStats tracks scheduling statistics
 	//

--- a/apis/kueue/v1beta1/zz_generated.deepcopy.go
+++ b/apis/kueue/v1beta1/zz_generated.deepcopy.go
@@ -1976,8 +1976,8 @@ func (in *WorkloadStatus) DeepCopyInto(out *WorkloadStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.AccumulatedPastExexcutionTimeSeconds != nil {
-		in, out := &in.AccumulatedPastExexcutionTimeSeconds, &out.AccumulatedPastExexcutionTimeSeconds
+	if in.AccumulatedPastExecutionTimeSeconds != nil {
+		in, out := &in.AccumulatedPastExecutionTimeSeconds, &out.AccumulatedPastExecutionTimeSeconds
 		*out = new(int32)
 		**out = **in
 	}

--- a/client-go/applyconfiguration/kueue/v1beta1/workloadstatus.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/workloadstatus.go
@@ -24,14 +24,14 @@ import (
 // WorkloadStatusApplyConfiguration represents a declarative configuration of the WorkloadStatus type for use
 // with apply.
 type WorkloadStatusApplyConfiguration struct {
-	Admission                            *AdmissionApplyConfiguration            `json:"admission,omitempty"`
-	RequeueState                         *RequeueStateApplyConfiguration         `json:"requeueState,omitempty"`
-	Conditions                           []v1.ConditionApplyConfiguration        `json:"conditions,omitempty"`
-	ReclaimablePods                      []ReclaimablePodApplyConfiguration      `json:"reclaimablePods,omitempty"`
-	AdmissionChecks                      []AdmissionCheckStateApplyConfiguration `json:"admissionChecks,omitempty"`
-	ResourceRequests                     []PodSetRequestApplyConfiguration       `json:"resourceRequests,omitempty"`
-	AccumulatedPastExexcutionTimeSeconds *int32                                  `json:"accumulatedPastExexcutionTimeSeconds,omitempty"`
-	SchedulingStats                      *SchedulingStatsApplyConfiguration      `json:"schedulingStats,omitempty"`
+	Admission                           *AdmissionApplyConfiguration            `json:"admission,omitempty"`
+	RequeueState                        *RequeueStateApplyConfiguration         `json:"requeueState,omitempty"`
+	Conditions                          []v1.ConditionApplyConfiguration        `json:"conditions,omitempty"`
+	ReclaimablePods                     []ReclaimablePodApplyConfiguration      `json:"reclaimablePods,omitempty"`
+	AdmissionChecks                     []AdmissionCheckStateApplyConfiguration `json:"admissionChecks,omitempty"`
+	ResourceRequests                    []PodSetRequestApplyConfiguration       `json:"resourceRequests,omitempty"`
+	AccumulatedPastExecutionTimeSeconds *int32                                  `json:"AccumulatedPastExecutionTimeSeconds,omitempty"`
+	SchedulingStats                     *SchedulingStatsApplyConfiguration      `json:"schedulingStats,omitempty"`
 }
 
 // WorkloadStatusApplyConfiguration constructs a declarative configuration of the WorkloadStatus type for use with
@@ -108,11 +108,11 @@ func (b *WorkloadStatusApplyConfiguration) WithResourceRequests(values ...*PodSe
 	return b
 }
 
-// WithAccumulatedPastExexcutionTimeSeconds sets the AccumulatedPastExexcutionTimeSeconds field in the declarative configuration to the given value
+// WithAccumulatedPastExecutionTimeSeconds sets the AccumulatedPastExecutionTimeSeconds field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the AccumulatedPastExexcutionTimeSeconds field is set to the value of the last call.
-func (b *WorkloadStatusApplyConfiguration) WithAccumulatedPastExexcutionTimeSeconds(value int32) *WorkloadStatusApplyConfiguration {
-	b.AccumulatedPastExexcutionTimeSeconds = &value
+// If called multiple times, the AccumulatedPastExecutionTimeSeconds field is set to the value of the last call.
+func (b *WorkloadStatusApplyConfiguration) WithAccumulatedPastExecutionTimeSeconds(value int32) *WorkloadStatusApplyConfiguration {
+	b.AccumulatedPastExecutionTimeSeconds = &value
 	return b
 }
 

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -411,14 +411,14 @@ func (r *WorkloadReconciler) reconcileMaxExecutionTime(ctx context.Context, wl *
 		return 0, nil
 	}
 
-	remainingTime := time.Duration(*wl.Spec.MaximumExecutionTimeSeconds-ptr.Deref(wl.Status.AccumulatedPastExexcutionTimeSeconds, 0))*time.Second - r.clock.Since(admittedCondition.LastTransitionTime.Time)
+	remainingTime := time.Duration(*wl.Spec.MaximumExecutionTimeSeconds-ptr.Deref(wl.Status.AccumulatedPastExecutionTimeSeconds, 0))*time.Second - r.clock.Since(admittedCondition.LastTransitionTime.Time)
 	if remainingTime > 0 {
 		return remainingTime, nil
 	}
 
 	if !apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadDeactivationTarget) {
 		workload.SetDeactivationTarget(wl, kueue.WorkloadMaximumExecutionTimeExceeded, "exceeding the maximum execution time")
-		wl.Status.AccumulatedPastExexcutionTimeSeconds = nil
+		wl.Status.AccumulatedPastExecutionTimeSeconds = nil
 		if err := workload.ApplyAdmissionStatus(ctx, r.client, wl, true, r.clock); err != nil {
 			return 0, err
 		}

--- a/pkg/workload/admissionchecks.go
+++ b/pkg/workload/admissionchecks.go
@@ -71,10 +71,10 @@ func SyncAdmittedCondition(w *kueue.Workload, now time.Time) bool {
 		// in practice the oldCondition cannot be nil, however we should try to avoid nil ptr deref.
 		if oldCondition != nil {
 			d := int32(now.Sub(oldCondition.LastTransitionTime.Time).Seconds())
-			if w.Status.AccumulatedPastExexcutionTimeSeconds != nil {
-				*w.Status.AccumulatedPastExexcutionTimeSeconds += d
+			if w.Status.AccumulatedPastExecutionTimeSeconds != nil {
+				*w.Status.AccumulatedPastExecutionTimeSeconds += d
 			} else {
-				w.Status.AccumulatedPastExexcutionTimeSeconds = &d
+				w.Status.AccumulatedPastExecutionTimeSeconds = &d
 			}
 		}
 	}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -763,7 +763,7 @@ func AdmissionStatusPatch(w *kueue.Workload, wlCopy *kueue.Workload, strict bool
 	if strict {
 		wlCopy.ResourceVersion = w.ResourceVersion
 	}
-	wlCopy.Status.AccumulatedPastExexcutionTimeSeconds = w.Status.AccumulatedPastExexcutionTimeSeconds
+	wlCopy.Status.AccumulatedPastExecutionTimeSeconds = w.Status.AccumulatedPastExecutionTimeSeconds
 	if w.Status.SchedulingStats != nil {
 		if wlCopy.Status.SchedulingStats == nil {
 			wlCopy.Status.SchedulingStats = &kueue.SchedulingStats{}

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -3144,11 +3144,11 @@ If admission is non-null, resourceRequests will be empty because
 admission.resourceUsage contains the detailed information.</p>
 </td>
 </tr>
-<tr><td><code>accumulatedPastExexcutionTimeSeconds</code><br/>
+<tr><td><code>AccumulatedPastExecutionTimeSeconds</code><br/>
 <code>int32</code>
 </td>
 <td>
-   <p>accumulatedPastExexcutionTimeSeconds holds the total time, in seconds, the workload spent
+   <p>AccumulatedPastExecutionTimeSeconds holds the total time, in seconds, the workload spent
 in Admitted state, in the previous <code>Admit</code> - <code>Evict</code> cycles.</p>
 </td>
 </tr>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR fixes a typo in the `AccumulatedPastExecutionTimeSeconds` field name across the Kueue codebase. The field was incorrectly named `AccumulatedPastExexcutionTimeSeconds` (with "Exexcution" instead of "Execution").


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```