### PR TITLE
Add GitVersion metric to report current controller version

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -26,6 +26,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/version"
 )
 
 type AdmissionResult string
@@ -96,6 +97,15 @@ The label 'result' can have the following values:
 	)
 
 	// Metrics tied to the queue system.
+
+	GitVersion = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: constants.KueueName,
+			Name:      "version",
+			Help:      "Which version is running. 1 for 'controller_version' label with current version.",
+		},
+		[]string{"controller_version"},
+	)
 
 	PendingWorkloads = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -687,7 +697,9 @@ func ClearClusterQueueResourceReservations(cqName, flavor, resource string) {
 }
 
 func Register() {
+	GitVersion.WithLabelValues(version.GitVersion).Set(1)
 	metrics.Registry.MustRegister(
+		GitVersion,
 		AdmissionAttemptsTotal,
 		admissionAttemptDuration,
 		AdmissionCyclePreemptionSkips,

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"sigs.k8s.io/kueue/pkg/util/testing/metrics"
+	"sigs.k8s.io/kueue/pkg/version"
 )
 
 func expectFilteredMetricsCount(t *testing.T, vec prometheus.Collector, count int, kvs ...string) {
@@ -172,4 +173,11 @@ func TestReportAndCleanupClusterQueuePreemptedNumber(t *testing.T) {
 	ClearClusterQueueMetrics("cluster_queue1")
 	expectFilteredMetricsCount(t, PreemptedWorkloadsTotal, 0, "preempting_cluster_queue", "cluster_queue1")
 	expectFilteredMetricsCount(t, EvictedWorkloadsTotal, 0, "cluster_queue", "cluster_queue1")
+}
+
+func TestGitVersionMetric(t *testing.T) {
+	// Set the GitVersion metric by calling Register()
+	Register()
+
+	expectFilteredMetricsCount(t, GitVersion, 1, "controller_version", version.GitVersion)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

It adds improves kueue's observability, version is always useful to be exported as a prometheus metric.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kueue_controller_version prometheus metric, that specifies the Git commit ID used to compile Kueue controller
```