### PR TITLE
[Docs][zh] Locallize resource_flavor/admission_check

### DIFF
--- a/site/content/zh-CN/docs/concepts/admission_check.md
+++ b/site/content/zh-CN/docs/concepts/admission_check.md
@@ -6,7 +6,7 @@ description: >
   允许内部或外部组件影响工作负载准入的机制。
 ---
 
-AdmissionChecks（准入检查）是一种机制，允许 Kueue 在准入 Workload（工作负载）之前考虑额外的标准。
+AdmissionCheck（准入检查）是一种机制，允许 Kueue 在准入 Workload（工作负载）之前考虑额外的标准。
 在 Kueue 为 Workload 预留配额后，会并发运行在 ClusterQueue 中配置的所有准入检查。
 只有当所有 AdmissionChecks 都为 Workload 提供了正面信号时，Kueue 才能准入该 Workload。
 

--- a/site/content/zh-CN/docs/concepts/resource_flavor.md
+++ b/site/content/zh-CN/docs/concepts/resource_flavor.md
@@ -67,7 +67,8 @@ ResourceFlavor 上的污点与 [节点污点](https://kubernetes.io/zh-cn/docs/c
 Kueue 要[接纳](/docs/concepts#admission) Workload 使用 ResourceFlavor，Workload 的 PodSpec 必须包含相应的容忍度。
 另一方面，如果 ResourceFlavor 的 `.spec.tolerations` 字段也设置了匹配的容忍度，
 则在[接纳](/docs/concepts#admission)期间不会考虑污点。
-与[ResourceFlavor 容忍度实现自动调度](#ResourceFlavor-容忍度实现自动调度)不同，Kueue 不会为 flavor 污点自动添加容忍度。
+与 [ResourceFlavor 容忍度实现自动调度](#ResourceFlavor-容忍度实现自动调度)不同，
+Kueue 不会为 flavor 污点自动添加容忍度。
 
 此类型的 ResourceFlavor 示例如下：
 
@@ -88,5 +89,5 @@ Kueue 要[接纳](/docs/concepts#admission) Workload 使用 ResourceFlavor，Wor
 
 ## 下一步？
 
-- 了解 [集群队列（cluster queues）](/docs/concepts/cluster_queue)。
+- 了解[集群队列（cluster queues）](/docs/concepts/cluster_queue)。
 - 阅读 `ResourceFlavor` 的 [API 参考](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ResourceFlavor)。


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
/area localization
/language zh
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```