### PR TITLE
Automated cherry pick of #5820: helm: support for specifying nodeSelector and tolerations for all Kueue components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,12 @@ helm-verify: helm helm-lint ## run helm template and detect any rendering failur
 	$(HELM) template charts/kueue --set managerConfig.controllerManagerConfigYaml="managedJobsNamespaceSelector:\n  matchExpressions:\n    - key: kubernetes.io/metadata.name\n      operator: In\n      values: [ kube-system ]" > /dev/null
 # test priorityClassName option
 	$(HELM) template charts/kueue --set controllerManager.manager.priorityClassName="system-cluster-critical" > /dev/null
+# test controllerManager nodeSelector and tolerations
+	$(HELM) template charts/kueue --set controllerManager.nodeSelector.nodetype=infra --set 'controllerManager.tolerations[0].key=node-role.kubernetes.io/master' --set 'controllerManager.tolerations[0].operator=Exists' --set 'controllerManager.tolerations[0].effect=NoSchedule' > /dev/null
+# test kueueViz backend nodeSelector and tolerations
+	$(HELM) template charts/kueue --set enableKueueViz=true --set kueueViz.backend.nodeSelector.nodetype=infra --set 'kueueViz.backend.tolerations[0].key=node-role.kubernetes.io/master' --set 'kueueViz.backend.tolerations[0].operator=Exists' --set 'kueueViz.backend.tolerations[0].effect=NoSchedule' > /dev/null
+# test kueueViz frontend nodeSelector and tolerations
+	$(HELM) template charts/kueue --set enableKueueViz=true --set kueueViz.frontend.nodeSelector.nodetype=infra --set 'kueueViz.frontend.tolerations[0].key=node-role.kubernetes.io/master' --set 'kueueViz.frontend.tolerations[0].operator=Exists' --set 'kueueViz.frontend.tolerations[0].effect=NoSchedule' > /dev/null
 
 # test
 .PHONY: helm-unit-test

--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -76,13 +76,19 @@ The following table lists the configurable parameters of the kueue chart and the
 | `enableVisibilityAPF`                                  | enable APF for the visibility API                      | `false`                                     |
 | `enableKueueViz`                                       | enable KueueViz dashboard                              | `false`                                     |
 | `KueueViz.backend.image`                               | KueueViz dashboard backend image                       | `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-backend:main` |
+| `kueueViz.backend.nodeSelector`                        | KueueViz backend nodeSelector                          | `{}`                                        |
+| `kueueViz.backend.tolerations`                         | KueueViz backend tolerations                           | `[]`                                        |
 | `KueueViz.frontend.image`                              | KueueViz dashboard frontend image                      | `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-frontend:main` |
+| `kueueViz.frontend.nodeSelector`                       | KueueViz frontend nodeSelector                         | `{}`                                        |
+| `kueueViz.frontend.tolerations`                        | KueueViz frontend tolerations                          | `[]`                                        |
 | `controllerManager.manager.priorityClassName`          | controllerManager.manager's Pod priorityClassName      | ``                                          |
 | `controllerManager.manager.image.repository`           | controllerManager.manager's repository and image       | `us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue` |
 | `controllerManager.manager.image.tag`                  | controllerManager.manager's tag                        | `main`                                      |
 | `controllerManager.manager.resources`                  | controllerManager.manager's resources                  | abbr.                                       |
 | `controllerManager.replicas`                           | ControllerManager's replicaCount                       | `1`                                         |
 | `controllerManager.imagePullSecrets`                   | ControllerManager's imagePullSecrets                   | `[]`                                        |
+| `controllerManager.nodeSelector`                       | ControllerManager's nodeSelector                       | `{}`                                        |
+| `controllerManager.tolerations`                        | ControllerManager's tolerations                        | `[]`                                        |
 | `controllerManager.readinessProbe.initialDelaySeconds` | ControllerManager's readinessProbe initialDelaySeconds | `5`                                         |
 | `controllerManager.readinessProbe.periodSeconds`       | ControllerManager's readinessProbe periodSeconds       | `10`                                        |
 | `controllerManager.readinessProbe.timeoutSeconds`      | ControllerManager's readinessProbe timeoutSeconds      | `1`                                         |

--- a/charts/kueue/templates/kueueviz/backend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/backend-deployment.yaml
@@ -14,6 +14,14 @@ spec:
       labels:
         app: kueueviz-backend
     spec:
+      {{- with .Values.kueueViz.backend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kueueViz.backend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: backend
           image: '{{ .Values.kueueViz.backend.image.repository }}:{{ .Values.kueueViz.backend.image.tag | default .Chart.AppVersion }}'

--- a/charts/kueue/templates/kueueviz/backend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/backend-deployment.yaml
@@ -16,11 +16,11 @@ spec:
     spec:
       {{- with .Values.kueueViz.backend.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.kueueViz.backend.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: backend

--- a/charts/kueue/templates/kueueviz/frontend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/frontend-deployment.yaml
@@ -16,11 +16,11 @@ spec:
     spec:
       {{- with .Values.kueueViz.frontend.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.kueueViz.frontend.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: frontend

--- a/charts/kueue/templates/kueueviz/frontend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/frontend-deployment.yaml
@@ -14,6 +14,14 @@ spec:
       labels:
         app: kueueviz-frontend
     spec:
+      {{- with .Values.kueueViz.frontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kueueViz.frontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: frontend
           image: '{{ .Values.kueueViz.frontend.image.repository }}:{{ .Values.kueueViz.frontend.image.tag | default .Chart.AppVersion }}'

--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -88,6 +88,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 10
+      {{- with .Values.controllerManager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.controllerManager.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}

--- a/charts/kueue/tests/manager_test.yaml
+++ b/charts/kueue/tests/manager_test.yaml
@@ -32,3 +32,55 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.priorityClassName
+  - it: should set nodeSelector when provided
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        nodeSelector:
+          disktype: ssd
+          environment: production
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            disktype: ssd
+            environment: production
+  - it: should not render nodeSelector if not set
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        nodeSelector: {}
+    asserts:
+      - notExists:
+          path: spec.template.spec.nodeSelector
+  - it: should set tolerations when provided
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        tolerations:
+          - key: "key1"
+            operator: "Equal"
+            value: "value1"
+            effect: "NoSchedule"
+          - key: "key2"
+            operator: "Exists"
+            effect: "NoExecute"
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations
+          value:
+            - key: "key1"
+              operator: "Equal"
+              value: "value1"
+              effect: "NoSchedule"
+            - key: "key2"
+              operator: "Exists"
+              effect: "NoExecute"
+  - it: should not render tolerations if not set
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        tolerations: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.tolerations

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -52,6 +52,11 @@ controllerManager:
     timeoutSeconds: 1
     failureThreshold: 3
     successThreshold: 1
+  # -- ControllerManager's nodeSelector
+  nodeSelector: {}
+  # -- ControllerManager's tolerations
+  tolerations: []
+  # -- ControllerManager's topologySpreadConstraints
   topologySpreadConstraints: []
   podDisruptionBudget:
     enabled: false
@@ -174,11 +179,19 @@ kueueViz:
       repository: "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-backend"
       # This should be set to 'IfNotPresent' for released version
       pullPolicy: Always
+    # -- KueueViz backend nodeSelector
+    nodeSelector: {}
+    # -- KueueViz backend tolerations
+    tolerations: []
   frontend:
     image:
       repository: "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-frontend"
       # This should be set to 'IfNotPresent' for released version
       pullPolicy: Always
+    # -- KueueViz frontend nodeSelector
+    nodeSelector: {}
+    # -- KueueViz frontend tolerations
+    tolerations: []
 metrics:
   prometheusNamespace: monitoring
   serviceMonitor:

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -175,23 +175,23 @@ mutatingWebhook:
 enableKueueViz: false
 kueueViz:
   backend:
-    image:
-      repository: "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-backend"
-      # This should be set to 'IfNotPresent' for released version
-      pullPolicy: Always
     # -- KueueViz backend nodeSelector
     nodeSelector: {}
     # -- KueueViz backend tolerations
     tolerations: []
-  frontend:
     image:
-      repository: "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-frontend"
+      repository: "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-backend"
       # This should be set to 'IfNotPresent' for released version
       pullPolicy: Always
+  frontend:
     # -- KueueViz frontend nodeSelector
     nodeSelector: {}
     # -- KueueViz frontend tolerations
     tolerations: []
+    image:
+      repository: "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-frontend"
+      # This should be set to 'IfNotPresent' for released version
+      pullPolicy: Always
 metrics:
   prometheusNamespace: monitoring
   serviceMonitor:

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -626,3 +626,29 @@ files:
         position: END
         value: |
           {{- end }}
+      - type: INSERT_TEXT
+        key: .spec.template.spec
+        value: |
+          {{- with .Values.kueueViz.backend.nodeSelector }}
+          nodeSelector:
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- with .Values.kueueViz.backend.tolerations }}
+          tolerations:
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+        onFileCondition: '.kind == "Deployment" and (.metadata.name | contains("kueueviz-backend"))'
+        indentation: 2
+      - type: INSERT_TEXT
+        key: .spec.template.spec
+        value: |
+          {{- with .Values.kueueViz.frontend.nodeSelector }}
+          nodeSelector:
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+          {{- with .Values.kueueViz.frontend.tolerations }}
+          tolerations:
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+        onFileCondition: '.kind == "Deployment" and (.metadata.name | contains("kueueviz-frontend"))'
+        indentation: 2


### PR DESCRIPTION
Cherry pick of #5820 on release-0.12.

#5820: helm: support for specifying nodeSelector and tolerations for all Kueue components

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Helm: support for specifying nodeSelector and tolerations for all Kueue components
```