### PR TITLE
Group PodSets together for finding common flavor

### DIFF
--- a/apis/kueue/v1alpha1/topology_types.go
+++ b/apis/kueue/v1alpha1/topology_types.go
@@ -89,7 +89,7 @@ const (
 	// name of a failed node running at least one pod of this workload.
 	NodeToReplaceAnnotation = "alpha.kueue.x-k8s.io/node-to-replace"
 
-	// PodSetGroupName describes a name of the group of PodSets. PodSet Group
+	// PodSetGroupName is an annotation indicating the name of the group of PodSets. PodSet Group
 	// is a unit flavor assignment and topology domain fitting.
 	PodSetGroupName = "kueue.x-k8s.io/podset-group-name"
 )

--- a/apis/kueue/v1alpha1/topology_types.go
+++ b/apis/kueue/v1alpha1/topology_types.go
@@ -88,6 +88,10 @@ const (
 	// NodeToReplaceAnnotation is an annotation on a Workload. It holds a
 	// name of a failed node running at least one pod of this workload.
 	NodeToReplaceAnnotation = "alpha.kueue.x-k8s.io/node-to-replace"
+
+	// PodSetGroupName describes a name of the group of PodSets. PodSet Group
+	// is a unit flavor assignment and topology domain fitting.
+	PodSetGroupName = "kueue.x-k8s.io/podset-group-name"
 )
 
 // TopologySpec defines the desired state of Topology

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -125,11 +125,11 @@ type PodSetTopologyRequest struct {
 	// For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.
 	SubGroupCount *int32 `json:"subGroupCount,omitempty"`
 
-	// PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
-	// PodSets with the same `PodSetGroup` should be assigned the same ResourceFlavor
+	// PodSetGroupName indicates the name of the group of PodSets to which this PodSet belongs to.
+	// PodSets with the same `PodSetGroupName` should be assigned the same ResourceFlavor
 	//
 	// +optional
-	PodSetGroup *string `json:"podSetGroup,omitempty"`
+	PodSetGroupName *string `json:"podSetGroupName,omitempty"`
 
 	// PodSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as
 	// indicated by the `kueue.x-k8s.io/podset-slice-required-topology` annotation.

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -125,6 +125,12 @@ type PodSetTopologyRequest struct {
 	// For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.
 	SubGroupCount *int32 `json:"subGroupCount,omitempty"`
 
+	// PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
+	// PodSets with the same `PodSetGroup` should be assigned the same ResourceFlavor
+	//
+	// +optional
+	PodSetGroup *string `json:"podSetGroup,omitempty"`
+
 	// PodSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as
 	// indicated by the `kueue.x-k8s.io/podset-slice-required-topology` annotation.
 	//

--- a/apis/kueue/v1beta1/zz_generated.deepcopy.go
+++ b/apis/kueue/v1beta1/zz_generated.deepcopy.go
@@ -1244,6 +1244,11 @@ func (in *PodSetTopologyRequest) DeepCopyInto(out *PodSetTopologyRequest) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.PodSetGroup != nil {
+		in, out := &in.PodSetGroup, &out.PodSetGroup
+		*out = new(string)
+		**out = **in
+	}
 	if in.PodSetSliceRequiredTopology != nil {
 		in, out := &in.PodSetSliceRequiredTopology, &out.PodSetSliceRequiredTopology
 		*out = new(string)

--- a/apis/kueue/v1beta1/zz_generated.deepcopy.go
+++ b/apis/kueue/v1beta1/zz_generated.deepcopy.go
@@ -1244,8 +1244,8 @@ func (in *PodSetTopologyRequest) DeepCopyInto(out *PodSetTopologyRequest) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.PodSetGroup != nil {
-		in, out := &in.PodSetGroup, &out.PodSetGroup
+	if in.PodSetGroupName != nil {
+		in, out := &in.PodSetGroupName, &out.PodSetGroupName
 		*out = new(string)
 		**out = **in
 	}

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -7835,6 +7835,11 @@ spec:
                               - JobSet: kubernetes.io/job-completion-index (inherited from Job)
                               - Kubeflow: training.kubeflow.org/replica-index
                             type: string
+                          podSetGroup:
+                            description: |-
+                              PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
+                              PodSets with the same `PodSetGroup` should be assigned the same ResourceFlavor
+                            type: string
                           podSetSliceRequiredTopology:
                             description: |-
                               PodSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -7835,10 +7835,10 @@ spec:
                               - JobSet: kubernetes.io/job-completion-index (inherited from Job)
                               - Kubeflow: training.kubeflow.org/replica-index
                             type: string
-                          podSetGroup:
+                          podSetGroupName:
                             description: |-
-                              PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
-                              PodSets with the same `PodSetGroup` should be assigned the same ResourceFlavor
+                              PodSetGroupName indicates the name of the group of PodSets to which this PodSet belongs to.
+                              PodSets with the same `PodSetGroupName` should be assigned the same ResourceFlavor
                             type: string
                           podSetSliceRequiredTopology:
                             description: |-

--- a/client-go/applyconfiguration/kueue/v1beta1/podsettopologyrequest.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/podsettopologyrequest.go
@@ -26,6 +26,7 @@ type PodSetTopologyRequestApplyConfiguration struct {
 	PodIndexLabel               *string `json:"podIndexLabel,omitempty"`
 	SubGroupIndexLabel          *string `json:"subGroupIndexLabel,omitempty"`
 	SubGroupCount               *int32  `json:"subGroupCount,omitempty"`
+	PodSetGroup                 *string `json:"podSetGroup,omitempty"`
 	PodSetSliceRequiredTopology *string `json:"podSetSliceRequiredTopology,omitempty"`
 	PodSetSliceSize             *int32  `json:"podSetSliceSize,omitempty"`
 }
@@ -81,6 +82,14 @@ func (b *PodSetTopologyRequestApplyConfiguration) WithSubGroupIndexLabel(value s
 // If called multiple times, the SubGroupCount field is set to the value of the last call.
 func (b *PodSetTopologyRequestApplyConfiguration) WithSubGroupCount(value int32) *PodSetTopologyRequestApplyConfiguration {
 	b.SubGroupCount = &value
+	return b
+}
+
+// WithPodSetGroup sets the PodSetGroup field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PodSetGroup field is set to the value of the last call.
+func (b *PodSetTopologyRequestApplyConfiguration) WithPodSetGroup(value string) *PodSetTopologyRequestApplyConfiguration {
+	b.PodSetGroup = &value
 	return b
 }
 

--- a/client-go/applyconfiguration/kueue/v1beta1/podsettopologyrequest.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/podsettopologyrequest.go
@@ -26,7 +26,7 @@ type PodSetTopologyRequestApplyConfiguration struct {
 	PodIndexLabel               *string `json:"podIndexLabel,omitempty"`
 	SubGroupIndexLabel          *string `json:"subGroupIndexLabel,omitempty"`
 	SubGroupCount               *int32  `json:"subGroupCount,omitempty"`
-	PodSetGroup                 *string `json:"podSetGroup,omitempty"`
+	PodSetGroupName             *string `json:"podSetGroupName,omitempty"`
 	PodSetSliceRequiredTopology *string `json:"podSetSliceRequiredTopology,omitempty"`
 	PodSetSliceSize             *int32  `json:"podSetSliceSize,omitempty"`
 }
@@ -85,11 +85,11 @@ func (b *PodSetTopologyRequestApplyConfiguration) WithSubGroupCount(value int32)
 	return b
 }
 
-// WithPodSetGroup sets the PodSetGroup field in the declarative configuration to the given value
+// WithPodSetGroupName sets the PodSetGroupName field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the PodSetGroup field is set to the value of the last call.
-func (b *PodSetTopologyRequestApplyConfiguration) WithPodSetGroup(value string) *PodSetTopologyRequestApplyConfiguration {
-	b.PodSetGroup = &value
+// If called multiple times, the PodSetGroupName field is set to the value of the last call.
+func (b *PodSetTopologyRequestApplyConfiguration) WithPodSetGroupName(value string) *PodSetTopologyRequestApplyConfiguration {
+	b.PodSetGroupName = &value
 	return b
 }
 

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -8299,10 +8299,10 @@ spec:
                             - JobSet: kubernetes.io/job-completion-index (inherited from Job)
                             - Kubeflow: training.kubeflow.org/replica-index
                           type: string
-                        podSetGroup:
+                        podSetGroupName:
                           description: |-
-                            PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
-                            PodSets with the same `PodSetGroup` should be assigned the same ResourceFlavor
+                            PodSetGroupName indicates the name of the group of PodSets to which this PodSet belongs to.
+                            PodSets with the same `PodSetGroupName` should be assigned the same ResourceFlavor
                           type: string
                         podSetSliceRequiredTopology:
                           description: |-

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -8299,6 +8299,11 @@ spec:
                             - JobSet: kubernetes.io/job-completion-index (inherited from Job)
                             - Kubeflow: training.kubeflow.org/replica-index
                           type: string
+                        podSetGroup:
+                          description: |-
+                            PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
+                            PodSets with the same `PodSetGroup` should be assigned the same ResourceFlavor
+                          type: string
                         podSetSliceRequiredTopology:
                           description: |-
                             PodSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as

--- a/pkg/controller/jobframework/tas.go
+++ b/pkg/controller/jobframework/tas.go
@@ -92,7 +92,7 @@ func (p *podSetTopologyRequestBuilder) Build() (*kueue.PodSetTopologyRequest, er
 	psTopologyReq.PodIndexLabel = p.podIndexLabel
 	psTopologyReq.SubGroupCount = p.subGroupCount
 	psTopologyReq.SubGroupIndexLabel = p.subGroupIndexLabel
-	if podSetGroupNameFound {
+	if podSetGroupNameFound && (requiredFound || preferredFound) {
 		psTopologyReq.PodSetGroup = &podSetGroupName
 	}
 

--- a/pkg/controller/jobframework/tas.go
+++ b/pkg/controller/jobframework/tas.go
@@ -92,7 +92,7 @@ func (p *podSetTopologyRequestBuilder) Build() (*kueue.PodSetTopologyRequest, er
 	psTopologyReq.SubGroupCount = p.subGroupCount
 	psTopologyReq.SubGroupIndexLabel = p.subGroupIndexLabel
 	if podSetGroupNameFound && (requiredFound || preferredFound) {
-		psTopologyReq.PodSetGroup = &podSetGroupName
+		psTopologyReq.PodSetGroupName = &podSetGroupName
 	}
 
 	return &psTopologyReq, nil

--- a/pkg/controller/jobframework/tas.go
+++ b/pkg/controller/jobframework/tas.go
@@ -30,7 +30,6 @@ type podSetTopologyRequestBuilder struct {
 	podIndexLabel      *string
 	subGroupIndexLabel *string
 	subGroupCount      *int32
-	podSetGroup        *string
 	meta               *metav1.ObjectMeta
 }
 

--- a/pkg/controller/jobframework/tas.go
+++ b/pkg/controller/jobframework/tas.go
@@ -30,6 +30,7 @@ type podSetTopologyRequestBuilder struct {
 	podIndexLabel      *string
 	subGroupIndexLabel *string
 	subGroupCount      *int32
+	podSetGroup        *string
 	meta               *metav1.ObjectMeta
 }
 
@@ -58,6 +59,8 @@ func (p *podSetTopologyRequestBuilder) Build() (*kueue.PodSetTopologyRequest, er
 
 	sliceRequiredTopologyValue, sliceRequiredTopologyFound := p.meta.Annotations[kueuealpha.PodSetSliceRequiredTopologyAnnotation]
 	sliceSizeValue, sliceSizeFound := p.meta.Annotations[kueuealpha.PodSetSliceSizeAnnotation]
+
+	podSetGroupName, podSetGroupNameFound := p.meta.Annotations[kueuealpha.PodSetGroupName]
 
 	switch {
 	case requiredFound:
@@ -89,6 +92,9 @@ func (p *podSetTopologyRequestBuilder) Build() (*kueue.PodSetTopologyRequest, er
 	psTopologyReq.PodIndexLabel = p.podIndexLabel
 	psTopologyReq.SubGroupCount = p.subGroupCount
 	psTopologyReq.SubGroupIndexLabel = p.subGroupIndexLabel
+	if podSetGroupNameFound {
+		psTopologyReq.PodSetGroup = &podSetGroupName
+	}
 
 	return &psTopologyReq, nil
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -48,9 +48,8 @@ import (
 )
 
 const (
-	leaderPodSetName         = "leader"
-	workerPodSetName         = "worker"
-	leaderWorkerSetGroupName = "leader-worker-set-group"
+	leaderPodSetName = "leader"
+	workerPodSetName = "worker"
 )
 
 type Reconciler struct {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -48,8 +48,9 @@ import (
 )
 
 const (
-	leaderPodSetName = "leader"
-	workerPodSetName = "worker"
+	leaderPodSetName         = "leader"
+	workerPodSetName         = "worker"
+	leaderWorkerSetGroupName = "leader-worker-set-group"
 )
 
 type Reconciler struct {

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -494,9 +494,9 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 
 		podSets := groupedRequests[groupKey]
 		requests := make(resources.Requests)
-		psIDs := make([]int, len(requests))
-		for _, podset := range podSets {
-			psIDs = append(psIDs, podset.OriginalIndex)
+		psIDs := make([]int, len(podSets))
+		for idx, podset := range podSets {
+			psIDs[idx] = podset.OriginalIndex
 			requests.Add(podset.PodSet.Requests)
 		}
 
@@ -569,15 +569,6 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 		}
 	}
 	return assignment
-}
-
-func (psa *PodSetAssignment) append(flavors ResourceAssignment, status *Status) {
-	maps.Copy(psa.Flavors, flavors)
-	if psa.Status == nil {
-		psa.Status = status
-	} else if status != nil {
-		psa.Status.reasons = append(psa.Status.reasons, status.reasons...)
-	}
 }
 
 func (a *Assignment) append(requests resources.Requests, psAssignment *PodSetAssignment) {

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -500,6 +500,12 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 		}
 
 		groupFlavors := make(ResourceAssignment)
+		for _, ips := range podSets {
+			for resName := range ips.PodSetAssignment.Flavors {
+				groupFlavors[resName] = ips.PodSetAssignment.Flavors[resName]
+				break
+			}
+		}
 		var groupStatus *Status
 
 		for resName := range requests {
@@ -509,7 +515,6 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 				continue
 			}
 			flavors, status := a.findFlavorForPodSetResource(log, psIDs, requests, resName, assignment.Usage.Quota)
-
 			if status.IsError() || len(flavors) == 0 {
 				groupFlavors = nil
 				groupStatus = status

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -445,9 +445,6 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 		},
 	}
 
-	// groupedRequests := make(map[string][]indexedPodSet)
-	// var groupsOrder []string
-
 	groupedRequests := newPodSetGroups()
 
 	for i, podSet := range requests {

--- a/pkg/scheduler/flavorassigner/podset_groups.go
+++ b/pkg/scheduler/flavorassigner/podset_groups.go
@@ -1,0 +1,44 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flavorassigner
+
+type podSetGroups struct {
+	psGroups       map[string][]indexedPodSet
+	insertionOrder []string
+}
+
+func newPodSetGroups() *podSetGroups {
+	return &podSetGroups{
+		psGroups:       make(map[string][]indexedPodSet),
+		insertionOrder: make([]string, 0),
+	}
+}
+
+func (om *podSetGroups) insert(groupName string, value indexedPodSet) {
+	if _, present := om.psGroups[groupName]; !present {
+		om.insertionOrder = append(om.insertionOrder, groupName)
+	}
+	om.psGroups[groupName] = append(om.psGroups[groupName], value)
+}
+
+func (om *podSetGroups) orderedPodSetGroups() [][]indexedPodSet {
+	orderedPodSetGroups := make([][]indexedPodSet, len(om.insertionOrder))
+	for i, key := range om.insertionOrder {
+		orderedPodSetGroups[i] = om.psGroups[key]
+	}
+	return orderedPodSetGroups
+}

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -446,6 +446,14 @@ func (p *PodSetWrapper) RequiredTopologyRequest(level string) *PodSetWrapper {
 	return p
 }
 
+func (p *PodSetWrapper) PodSetGroup(podSetGroup string) *PodSetWrapper {
+	if p.TopologyRequest == nil {
+		p.TopologyRequest = &kueue.PodSetTopologyRequest{}
+	}
+	p.TopologyRequest.PodSetGroup = &podSetGroup
+	return p
+}
+
 func (p *PodSetWrapper) PreferredTopologyRequest(level string) *PodSetWrapper {
 	if p.TopologyRequest == nil {
 		p.TopologyRequest = &kueue.PodSetTopologyRequest{}

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -446,11 +446,11 @@ func (p *PodSetWrapper) RequiredTopologyRequest(level string) *PodSetWrapper {
 	return p
 }
 
-func (p *PodSetWrapper) PodSetGroup(podSetGroup string) *PodSetWrapper {
+func (p *PodSetWrapper) PodSetGroup(name string) *PodSetWrapper {
 	if p.TopologyRequest == nil {
 		p.TopologyRequest = &kueue.PodSetTopologyRequest{}
 	}
-	p.TopologyRequest.PodSetGroup = &podSetGroup
+	p.TopologyRequest.PodSetGroupName = &name
 	return p
 }
 

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -2184,8 +2184,8 @@ For example, in the context of JobSet this value is read from jobset.sigs.k8s.io
 <code>string</code>
 </td>
 <td>
-   <p>PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
-PodSets with the same <code>PodSetGroup</code> should be assigned the same ResourceFlavor</p>
+   <p>PodSetGroupName indicates the name of the group of PodSets to which this PodSet belongs to.
+PodSets with the same <code>PodSetGroupName</code> should be assigned the same ResourceFlavor</p>
 </td>
 </tr>
 <tr><td><code>podSetSliceRequiredTopology</code><br/>

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -2180,6 +2180,14 @@ within a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.i
 For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.</p>
 </td>
 </tr>
+<tr><td><code>podSetGroup</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
+PodSets with the same <code>PodSetGroup</code> should be assigned the same ResourceFlavor</p>
+</td>
+</tr>
 <tr><td><code>podSetSliceRequiredTopology</code><br/>
 <code>string</code>
 </td>

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -2180,7 +2180,7 @@ within a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.i
 For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.</p>
 </td>
 </tr>
-<tr><td><code>podSetGroup</code><br/>
+<tr><td><code>podSetGroupName</code><br/>
 <code>string</code>
 </td>
 <td>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

To be able to co-locate leaders and workers in LeaderWorkerSet we need to ensure it is possible to find the same flavor for two (or more) PodSets.

This PR introduces `PodSetGroup` as a way to request flavor finding for a group of PodSets.

Details are described in KEP update here: https://github.com/kubernetes-sigs/kueue/pull/5895

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes-sigs/kueue/issues/4531

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```