### PR TITLE
[KEP-2724] Add cross-podset TAS scheduling documentation

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -39,7 +39,7 @@
     - [Example](#example)
   - [Two-level Topology Aware scheduling](#two-level-topology-aware-scheduling)
     - [Example](#example-1)
-  - [Cross-PodSet scheduling](#cross-podset-scheduling)
+  - [Cross-PodSet Topology Aware scheduling](#cross-podset-topology-aware-scheduling)
     - [Ensure leader and workers end up on the same flavor](#ensure-leader-and-workers-end-up-on-the-same-flavor)
   - [Enforcing the assignment](#enforcing-the-assignment)
   - [Support for ProvisioningRequests](#support-for-provisioningrequests)
@@ -1040,11 +1040,12 @@ Explanation:
 
 It is worth noting that the tight fit mentioned above does not guarantee that no free capacity will be left within the assigned domains.
 
-### Cross-PodSet scheduling
+### Cross-PodSet Topology Aware scheduling
 
-In consideration of a [Story 6](#story-6) a cross-podset scheduling is required,
-due to the fact that leader and workers are separate PodSets. To be able to co-locate
-leaders with its workers, we divide the problem into subproblems:
+In consideration of a [Story 6](#story-6) a cross-podset topology aware scheduling
+is required, due to the fact that leader and workers are separate PodSets. To be able 
+to co-locate leaders with its workers in the same topology domain, we divide the
+problem into subproblems:
 
 - Ensure leader and workers end up on the same flavor
 - Find topology domain to co-locate leader and workers

--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -31,7 +31,6 @@
   - [User-facing API](#user-facing-api)
   - [Validation](#validation)
     - [PodSet Slice size validation](#podset-slice-size-validation)
-    - [LeaderWorkerSet validation](#leaderworkerset-validation)
   - [Internal APIs](#internal-apis)
     - [Node failures](#node-failures)
   - [Implicit defaulting of TAS annotations](#implicit-defaulting-of-tas-annotations)

--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -1044,7 +1044,7 @@ It is worth noting that the tight fit mentioned above does not guarantee that no
 
 In consideration of a [Story 6](#story-6) a cross-podset scheduling is required,
 due to the fact that leader and workers are separate PodSets. To be able to co-locate
-leaders with its workers, two mechanisms have to be introduced:
+leaders with its workers, we divide the problem into subproblems:
 
 - Ensure leader and workers end up on the same flavor
 - Find topology domain to co-locate leader and workers
@@ -1068,7 +1068,7 @@ type PodSetTopologyRequest struct {
 ```
 
 This field specifies the name of a group of PodSets that should be placed on the same flavor.
-This field is optionl and if a PodSet does not define it, it will be placed on a flavor 
+This field is optional and if a PodSet does not define it, it will be placed on a flavor 
 independently of any other PodSets.
 
 If two or more PodSets use the same value in `PodSetGroup`, they will be grouped together.

--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -1066,7 +1066,7 @@ problem into subproblems:
 #### Ensure leader and workers end up on the same flavor
 
 To ensure leader and workers are assigned the same flavor a notion of `PodSet Group` is 
-introduced, indicated by the PodSetTopologyRequest's PodSetGroupName field (see [Internal APIs](Internal APIs)):
+introduced, indicated by the PodSetTopologyRequest's PodSetGroupName field (see [Internal APIs](#internal-apis)):
 
 This field specifies the name of a group of PodSets that should be placed on the same flavor.
 This field is optional and if a PodSet does not define it, it will be placed on a flavor 

--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -772,11 +772,11 @@ type PodSetTopologyRequest struct {
   // For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.
   SubGroupCount *int32
 
-	// PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
-	// PodSets with the same `PodSetGroup` should be assigned the same ResourceFlavor
-	//
-	// +optional
-	PodSetGroup *string `json:"podSetGroup,omitempty"`
+  // PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
+  // PodSets with the same `PodSetGroup` should be assigned the same ResourceFlavor
+  //
+  // +optional
+  PodSetGroup *string `json:"podSetGroup,omitempty"`
   
   // PodSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as
   // indicated by the `kueue.x-k8s.io/podset-slice-required-topology` annotation.

--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -1065,21 +1065,8 @@ problem into subproblems:
 
 #### Ensure leader and workers end up on the same flavor
 
-To ensure leader and workers are assigned the same flavor a notion of PodSetGroup is introduced:
-
-```golang
-type PodSetTopologyRequest struct {
-  // ...
-
-	// PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
-	// PodSets with the same `PodSetGroup` should be assigned the same ResourceFlavor
-	//
-	// +optional
-	PodSetGroup *string `json:"podSetGroup,omitempty"`
-  
-  // ...
-}
-```
+To ensure leader and workers are assigned the same flavor a notion of `PodSet Group` is 
+introduced, indicated by the PodSetTopologyRequest's PodSetGroupName field (see [Internal APIs](Internal APIs)):
 
 This field specifies the name of a group of PodSets that should be placed on the same flavor.
 This field is optional and if a PodSet does not define it, it will be placed on a flavor 

--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -772,11 +772,11 @@ type PodSetTopologyRequest struct {
   // For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.
   SubGroupCount *int32
 
-  // PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
-  // PodSets with the same `PodSetGroup` should be assigned the same ResourceFlavor
+  // PodSetGroupName indicates the name of the group of PodSets to which this PodSet belongs to.
+  // PodSets with the same `PodSetGroupName` should be assigned the same ResourceFlavor
   //
   // +optional
-  PodSetGroup *string `json:"podSetGroup,omitempty"`
+  PodSetGroupName *string `json:"podSetGroupName,omitempty"`
   
   // PodSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as
   // indicated by the `kueue.x-k8s.io/podset-slice-required-topology` annotation.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR updates Topology-Aware Scheduling KEP introducing LeaderWorkerSet improvements to co-locate leader and workers within a single replica.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes-sigs/kueue/issues/4531

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```