### PR TITLE
Fix slice-only TAS

### DIFF
--- a/pkg/controller/jobframework/tas.go
+++ b/pkg/controller/jobframework/tas.go
@@ -71,7 +71,9 @@ func (p *podSetTopologyRequestBuilder) Build() (*kueue.PodSetTopologyRequest, er
 		}
 		psTopologyReq.Unconstrained = &unconstrained
 	default:
-		return nil, nil
+		if !sliceRequiredTopologyFound || !sliceSizeFound {
+			return nil, nil
+		}
 	}
 
 	if sliceRequiredTopologyFound && sliceSizeFound {

--- a/test/e2e/tas/jobset_test.go
+++ b/test/e2e/tas/jobset_test.go
@@ -146,7 +146,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", func() {
 			})
 		})
 
-		ginkgo.It("Should place pods in podset slices based on the ranks-ordering", func() {
+		ginkgo.It("Should place pods in podset slices with two-level scheduling based on the ranks-ordering", func() {
 			replicas := 2
 			parallelism := 3
 			numPods := replicas * parallelism
@@ -162,6 +162,70 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for JobSet", func() {
 						Completions: int32(parallelism),
 						PodAnnotations: map[string]string{
 							kueuealpha.PodSetPreferredTopologyAnnotation:     testing.DefaultBlockTopologyLevel,
+							kueuealpha.PodSetSliceRequiredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
+							kueuealpha.PodSetSliceSizeAnnotation:             "3",
+						},
+					},
+				).
+				RequestAndLimit("replicated-job-1", extraResource, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, sampleJob)
+
+			ginkgo.By("JobSet is unsuspended", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sampleJob), sampleJob)).To(gomega.Succeed())
+					g.Expect(sampleJob.Spec.Suspend).Should(gomega.Equal(ptr.To(false)))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			pods := &corev1.PodList{}
+			ginkgo.By("ensure all pods are created", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("ensure all pods are scheduled", func() {
+				listOpts := &client.ListOptions{
+					FieldSelector: fields.OneTermNotEqualSelector("spec.nodeName", ""),
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), listOpts)).To(gomega.Succeed())
+					g.Expect(pods.Items).Should(gomega.HaveLen(numPods))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verify the assignment of pods are as expected with rank-based ordering", func() {
+				gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+				gotAssignment := readRankAssignmentsFromJobSetPods(pods.Items)
+				wantAssignment := map[string]string{
+					"0/0": "kind-worker",
+					"0/1": "kind-worker2",
+					"0/2": "kind-worker3",
+					"1/0": "kind-worker5",
+					"1/1": "kind-worker6",
+					"1/2": "kind-worker7",
+				}
+				gomega.Expect(wantAssignment).Should(gomega.BeComparableTo(gotAssignment))
+			})
+		})
+
+		ginkgo.It("Should place pods in podset slices with slice-only scheduling based on the ranks-ordering", func() {
+			replicas := 2
+			parallelism := 3
+			numPods := replicas * parallelism
+			sampleJob := testingjobset.MakeJobSet("ranks-jobset", ns.Name).
+				Queue(localQueue.Name).
+				ReplicatedJobs(
+					testingjobset.ReplicatedJobRequirements{
+						Name:        "replicated-job-1",
+						Image:       util.GetAgnHostImage(),
+						Args:        util.BehaviorExitFast,
+						Replicas:    int32(replicas),
+						Parallelism: int32(parallelism),
+						Completions: int32(parallelism),
+						PodAnnotations: map[string]string{
 							kueuealpha.PodSetSliceRequiredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
 							kueuealpha.PodSetSliceSizeAnnotation:             "3",
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
To achieve slice-only TAS, user has to provide slice required topology, slice size and optionally unconstrained annotation. Due to a bug in validation, if user provides slice required topology without required, preferred or unconstrained annotations, Kueue will ignore slice topology and rank-ordering of the pods.

This PR fixes that issue and adds explicit end-to-end test for rank-ordering in slice-only TAS.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
I am leaving release notes as `NONE`, because this is a fix to TAS which is targeted at 0.13 anyway.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```