### PR TITLE
Automated cherry pick of #5918: Update main after v0.12.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ LD_FLAGS += -X '$(version_pkg).GitCommit=$(GIT_COMMIT)'
 
 # Update these variables when preparing a new release or a release branch.
 # Then run `make prepare-release-branch`
-RELEASE_VERSION=v0.12.3
+RELEASE_VERSION=v0.12.4
 RELEASE_BRANCH=main
 # Version used form Helm which is not using the leading "v"
 CHART_VERSION := $(shell echo $(RELEASE_VERSION) | cut -c2-)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Read the [overview](https://kueue.sigs.k8s.io/docs/overview/) and watch the Kueu
 To install the latest release of Kueue in your cluster, run the following command:
 
 ```shell
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.3/manifests.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.4/manifests.yaml
 ```
 
 The controller runs in the `kueue-system` namespace.

--- a/SECURITY-INSIGHTS.yaml
+++ b/SECURITY-INSIGHTS.yaml
@@ -1,11 +1,11 @@
 header:
   schema-version: 1.0.0
   expiration-date: '2024-09-28T01:00:00.000Z'
-  last-updated: '2025-06-24'
-  last-reviewed: '2025-06-24'
-  commit-hash: 5e45476a20cec4eb74fe1e553a03c543bbeb8a89
+  last-updated: '2025-07-09'
+  last-reviewed: '2025-07-09'
+  commit-hash: "ab6a91294a318ed6bf6f7d33862320445e0424a0"
   project-url: 'https://github.com/kubernetes-sigs/kueue'
-  project-release: 0.12.3
+  project-release: "0.12.4"
   changelog: 'https://github.com/kubernetes-sigs/kueue/tree/main/CHANGELOG'
   license: 'https://github.com/kubernetes-sigs/kueue/blob/main/LICENSE'
 project-lifecycle:
@@ -28,7 +28,7 @@ documentation:
   - 'https://kueue.sigs.k8s.io/docs/'
 distribution-points:
   - >-
-    https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.3/manifests.yaml
+    https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.4/manifests.yaml
 security-artifacts:
   threat-model:
     threat-model-created: false
@@ -62,5 +62,5 @@ dependencies:
   dependencies-lists:
     - 'https://github.com/kubernetes-sigs/kueue/blob/main/go.mod'
   sbom:
-    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.3/kueue-v0.12.3.spdx.json
+    - sbom-file: https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.4/kueue-v0.12.4.spdx.json
       sbom-format: SPDX

--- a/charts/kueue/Chart.yaml
+++ b/charts/kueue/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # NOTE: Do not modify manually. In Kueue, the version and appVersion are
 # overridden to GIT_TAG when building the artifacts, including the helm charts,
 # via Makefile.
-version: 0.12.3
+version: 0.12.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.12.3"
+appVersion: "v0.12.4"

--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -37,7 +37,7 @@ $ helm install kueue kueue/ --create-namespace --namespace kueue-system
 Or use the charts pushed to `oci://registry.k8s.io/kueue/charts/kueue`:
 
 ```bash
-helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.12.3" --create-namespace --namespace=kueue-system
+helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.12.4" --create-namespace --namespace=kueue-system
 ```
 
 ##### Verify that controller pods are running properly.

--- a/cmd/kueueviz/INSTALL.md
+++ b/cmd/kueueviz/INSTALL.md
@@ -3,7 +3,7 @@
 KueueViz can be installed using `kubectl` with the following command:
 
 ```
-kubectl create -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.3/kueueviz.yaml
+kubectl create -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.12.4/kueueviz.yaml
 ```
 If you are using `kind` and that you don't have an `ingress` controller, you can use `port-forward` to 
 configure and run `KueueViz`:
@@ -23,7 +23,7 @@ by ensuring that `enableKueueViz` is set to `true`:
 
 ```
 helm upgrade --install kueue oci://registry.k8s.io/kueue/charts/kueue \
-  --version="0.12.3"
+  --version="0.12.4"
   --namespace kueue-system \
   --set enableKueueViz=true \
   --create-namespace
@@ -44,7 +44,7 @@ kind create cluster
 kind get kubeconfig > kubeconfig
 export KUBECONFIG=$PWD/kubeconfig
 helm install kueue oci://us-central1-docker.pkg.dev/k8s-staging-images/charts/kueue \
-            --version="0.12.3" --create-namespace --namespace=kueue-system
+            --version="0.12.4" --create-namespace --namespace=kueue-system
 ```
 
 ## Build

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -99,10 +99,10 @@ ignoreFiles = []
   # The major.minor version tag for the version of the docs represented in this
   # branch of the repository. Used in the "version-banner" partial to display a
   # version number for this doc set.
-  version = "v0.12.3"
+  version = "v0.12.4"
 
   # Version of Kueue without the leading "v", as used for Helm charts.
-  chart_version = "0.12.3"
+  chart_version = "0.12.4"
 
   # Flag used in the "version-banner" partial to decide whether to display a
   # banner on every page indicating that this is an archived version of the docs.


### PR DESCRIPTION
Cherry pick of #5918 on website.

#5918: Update main after v0.12.4

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```