### PR TITLE
Add entrance penalty for admitted Workloads

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -414,6 +414,7 @@ func setupScheduler(mgr ctrl.Manager, cCache *cache.Cache, queues *queue.Manager
 		mgr.GetEventRecorderFor(constants.AdmissionName),
 		scheduler.WithPodsReadyRequeuingTimestamp(podsReadyRequeuingTimestamp(cfg)),
 		scheduler.WithFairSharing(cfg.FairSharing),
+		scheduler.WithAdmissionFairSharing(cfg.AdmissionFairSharing),
 	)
 	if err := mgr.Add(sched); err != nil {
 		setupLog.Error(err, "Unable to add scheduler to manager")

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -91,6 +91,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *queue.Manager, cc *cache.Cache
 		return "Workload", err
 	}
 	qManager.AddTopologyUpdateWatcher(cqRec)
+	qManager.AddWorkloadUpdateWatcher(qRec)
 	return "", nil
 }
 

--- a/pkg/queue/afs_entry_penalties.go
+++ b/pkg/queue/afs_entry_penalties.go
@@ -1,0 +1,94 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import (
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+
+	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+	"sigs.k8s.io/kueue/pkg/util/resource"
+)
+
+type AfsEntryPenalties struct {
+	sync.RWMutex
+	penalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]
+}
+
+func newPenaltyMap() *AfsEntryPenalties {
+	return &AfsEntryPenalties{
+		penalties: utilmaps.NewSyncMap[utilqueue.LocalQueueReference, corev1.ResourceList](0),
+	}
+}
+
+func (m *AfsEntryPenalties) Push(lqKey utilqueue.LocalQueueReference, penalty corev1.ResourceList) {
+	m.penalties.Add(lqKey, resource.MergeResourceListKeepSum(m.Peek(lqKey), penalty))
+}
+
+func (m *AfsEntryPenalties) Sub(lqKey utilqueue.LocalQueueReference, penalty corev1.ResourceList) {
+	for k, v := range penalty {
+		v.Neg()
+		penalty[k] = v
+	}
+	m.penalties.Add(lqKey, resource.MergeResourceListKeepSum(m.Peek(lqKey), penalty))
+}
+
+func (m *AfsEntryPenalties) Peek(lqKey utilqueue.LocalQueueReference) corev1.ResourceList {
+	penalty, found := m.penalties.Get(lqKey)
+	if !found {
+		return corev1.ResourceList{}
+	}
+
+	return penalty
+}
+
+func (m *AfsEntryPenalties) WithPenaltyLocked(lqKey utilqueue.LocalQueueReference, fn func(penalty corev1.ResourceList) error) error {
+	m.Lock()
+	defer m.Unlock()
+
+	penalty, found := m.penalties.Get(lqKey)
+	if !found {
+		penalty = corev1.ResourceList{}
+	}
+
+	err := fn(penalty)
+	if err == nil && found {
+		m.penalties.Delete(lqKey)
+	}
+
+	return err
+}
+
+func (m *AfsEntryPenalties) HasPendingFor(lqKey utilqueue.LocalQueueReference) bool {
+	m.Lock()
+	defer m.Unlock()
+
+	_, found := m.penalties.Get(lqKey)
+
+	return found
+}
+
+func (m *AfsEntryPenalties) HasAny() bool {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.penalties.Len() > 0
+}
+
+func (m *AfsEntryPenalties) GetPenalties() *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList] {
+	return m.penalties
+}

--- a/pkg/queue/cluster_queue.go
+++ b/pkg/queue/cluster_queue.go
@@ -36,7 +36,9 @@ import (
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 	afs "sigs.k8s.io/kueue/pkg/util/admissionfairsharing"
 	"sigs.k8s.io/kueue/pkg/util/heap"
+	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 	utilpriority "sigs.k8s.io/kueue/pkg/util/priority"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -94,9 +96,9 @@ func workloadKey(i *workload.Info) workload.Reference {
 	return workload.Key(i.Obj)
 }
 
-func newClusterQueue(ctx context.Context, client client.Client, cq *kueue.ClusterQueue, wo workload.Ordering, afsConfig *config.AdmissionFairSharing) (*ClusterQueue, error) {
+func newClusterQueue(ctx context.Context, client client.Client, cq *kueue.ClusterQueue, wo workload.Ordering, afsConfig *config.AdmissionFairSharing, penalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]) (*ClusterQueue, error) {
 	enableAdmissionFs, fsResWeights := afs.ResourceWeights(cq.Spec.AdmissionScope, afsConfig)
-	cqImpl := newClusterQueueImpl(ctx, client, wo, realClock, fsResWeights, enableAdmissionFs)
+	cqImpl := newClusterQueueImpl(ctx, client, wo, realClock, fsResWeights, enableAdmissionFs, penalties)
 	err := cqImpl.Update(cq)
 	if err != nil {
 		return nil, err
@@ -104,8 +106,8 @@ func newClusterQueue(ctx context.Context, client client.Client, cq *kueue.Cluste
 	return cqImpl, nil
 }
 
-func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.Ordering, clock clock.Clock, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool) *ClusterQueue {
-	lessFunc := queueOrderingFunc(ctx, client, wo, fsResWeights, enableAdmissionFs)
+func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.Ordering, clock clock.Clock, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, penalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]) *ClusterQueue {
+	lessFunc := queueOrderingFunc(ctx, client, wo, fsResWeights, enableAdmissionFs, penalties)
 	return &ClusterQueue{
 		heap:                   *heap.New(workloadKey, lessFunc),
 		inadmissibleWorkloads:  make(map[workload.Reference]*workload.Info),
@@ -426,12 +428,12 @@ func (c *ClusterQueue) RequeueIfNotPresent(wInfo *workload.Info, reason RequeueR
 // to sort workloads. The function sorts workloads based on their priority.
 // When priorities are equal, it uses the workload's creation or eviction
 // time.
-func queueOrderingFunc(ctx context.Context, c client.Client, wo workload.Ordering, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool) func(a, b *workload.Info) bool {
+func queueOrderingFunc(ctx context.Context, c client.Client, wo workload.Ordering, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, penalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]) func(a, b *workload.Info) bool {
 	log := ctrl.LoggerFrom(ctx)
 	return func(a, b *workload.Info) bool {
 		if enableAdmissionFs {
-			lqAUsage, errA := a.CalcLocalQueueFSUsage(ctx, c, fsResWeights)
-			lqBUsage, errB := b.CalcLocalQueueFSUsage(ctx, c, fsResWeights)
+			lqAUsage, errA := a.CalcLocalQueueFSUsage(ctx, c, fsResWeights, penalties)
+			lqBUsage, errB := b.CalcLocalQueueFSUsage(ctx, c, fsResWeights, penalties)
 			switch {
 			case errA != nil:
 				log.V(2).Error(errA, "Error determining LocalQueue usage")
@@ -455,5 +457,13 @@ func queueOrderingFunc(ctx context.Context, c client.Client, wo workload.Orderin
 		tA := wo.GetQueueOrderTimestamp(a.Obj)
 		tB := wo.GetQueueOrderTimestamp(b.Obj)
 		return !tB.Before(tA)
+	}
+}
+
+func (c *ClusterQueue) HeapifyAll() {
+	c.rwm.Lock()
+	defer c.rwm.Unlock()
+	for _, wl := range c.heap.List() {
+		c.heap.PushOrUpdate(wl)
 	}
 }

--- a/pkg/util/admissionfairsharing/admission_fair_sharing.go
+++ b/pkg/util/admissionfairsharing/admission_fair_sharing.go
@@ -17,11 +17,14 @@ limitations under the License.
 package admissionfairsharing
 
 import (
+	"math"
+
 	corev1 "k8s.io/api/core/v1"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/util/resource"
 )
 
 func ResourceWeights(cqAdmissionScope *kueue.AdmissionScope, afsConfig *config.AdmissionFairSharing) (bool, map[corev1.ResourceName]float64) {
@@ -31,4 +34,21 @@ func ResourceWeights(cqAdmissionScope *kueue.AdmissionScope, afsConfig *config.A
 		fsResWeights = afsConfig.ResourceWeights
 	}
 	return enableAdmissionFs, fsResWeights
+}
+
+func CalculateAlphaRate(sampling, halfLifeTime float64) float64 {
+	if halfLifeTime == 0 {
+		return 0.0
+	}
+
+	return 1.0 - math.Pow(0.5, sampling/halfLifeTime)
+}
+
+func CalculateEntryPenalty(totalRequests corev1.ResourceList, afs *config.AdmissionFairSharing) corev1.ResourceList {
+	alpha := CalculateAlphaRate(
+		afs.UsageSamplingInterval.Seconds(),
+		afs.UsageHalfLifeTime.Seconds(),
+	)
+
+	return resource.MulByFloat(totalRequests, alpha)
 }

--- a/pkg/util/queue/local_queue.go
+++ b/pkg/util/queue/local_queue.go
@@ -1,0 +1,29 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import (
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+)
+
+type LocalQueueReference string
+
+func NewLocalQueueReference(namespace string, name kueue.LocalQueueName) LocalQueueReference {
+	return LocalQueueReference(namespace + "/" + string(name))
+}
+
+func Key(q *kueue.LocalQueue) LocalQueueReference {
+	return NewLocalQueueReference(q.Namespace, kueue.LocalQueueName(q.Name))
+}

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -394,7 +394,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 		})
 	})
 
-	ginkgo.When("Using AdmissionFairSharing", func() {
+	ginkgo.When("Using AdmissionFairSharing at Cohort level", func() {
 		var (
 			cq1 *kueue.ClusterQueue
 			cq2 *kueue.ClusterQueue
@@ -506,6 +506,172 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("Checking that the workload from lq-A is preempted despite having bigger priority")
 			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, wlHighA)
+		})
+	})
+
+	ginkgo.When("Using AdmissionFairSharing at ClusterQueue level", func() {
+		var (
+			cq1 *kueue.ClusterQueue
+			lqA *kueue.LocalQueue
+			lqB *kueue.LocalQueue
+			lqC *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			gomega.Expect(features.SetEnable(features.AdmissionFairSharing, true)).To(gomega.Succeed())
+
+			cq1 = createQueue(testing.MakeClusterQueue("cq1").
+				ResourceGroup(*testing.MakeFlavorQuotas(defaultFlavor.Name).Resource(corev1.ResourceCPU, "8").Obj()).
+				AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
+				Obj())
+
+			lqA = testing.MakeLocalQueue("lq-a", ns.Name).
+				FairSharing(&kueue.FairSharing{Weight: ptr.To(resource.MustParse("1"))}).
+				ClusterQueue(cq1.Name).Obj()
+			lqB = testing.MakeLocalQueue("lq-b", ns.Name).
+				FairSharing(&kueue.FairSharing{Weight: ptr.To(resource.MustParse("1"))}).
+				ClusterQueue(cq1.Name).Obj()
+			lqC = testing.MakeLocalQueue("lq-c", ns.Name).
+				FairSharing(&kueue.FairSharing{Weight: ptr.To(resource.MustParse("1"))}).
+				ClusterQueue(cq1.Name).Obj()
+			lqs = append(lqs, lqA)
+			lqs = append(lqs, lqB)
+			lqs = append(lqs, lqC)
+
+			util.MustCreate(ctx, k8sClient, lqA)
+			util.MustCreate(ctx, k8sClient, lqB)
+			util.MustCreate(ctx, k8sClient, lqC)
+		})
+
+		ginkgo.It("admits one workload from each LocalQueue when quota is limited", func() {
+			ginkgo.By("Saturating the cq with lq-a and lq-b")
+			initialWls := []*kueue.Workload{
+				createWorkload("lq-a", "4"),
+				createWorkload("lq-b", "4"),
+			}
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, initialWls...)
+
+			ginkgo.By("Creating two pending workloads for each lq")
+			lqAWls := []*kueue.Workload{
+				createWorkload("lq-a", "4"),
+				createWorkload("lq-a", "4"),
+			}
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, lqAWls...)
+			lqBWls := []*kueue.Workload{
+				createWorkload("lq-b", "4"),
+				createWorkload("lq-b", "4"),
+			}
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, lqBWls...)
+
+			ginkgo.By("Checking that LQ's resource usage is updated")
+			util.ExpectLocalQueueUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqA), ">", 0)
+			util.ExpectLocalQueueUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqB), ">", 0)
+
+			ginkgo.By("Releasing quota")
+			util.FinishWorkloads(ctx, k8sClient, initialWls...)
+
+			ginkgo.By("Verifying one workload from each lq is admitted")
+			util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, lqAWls...)
+			util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, lqBWls...)
+		})
+
+		ginkgo.It("prioritizes workloads from less active LocalQueues to maintain fairness", func() {
+			ginkgo.By("Saturating the cq with lq-a")
+			initialWls := []*kueue.Workload{
+				createWorkload("lq-a", "4"),
+				createWorkload("lq-a", "4"),
+			}
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, initialWls...)
+
+			ginkgo.By("Creating pending workloads for lq-a")
+			lqAWls := []*kueue.Workload{
+				createWorkload("lq-a", "4"),
+				createWorkload("lq-a", "4"),
+				createWorkload("lq-a", "4"),
+			}
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, lqAWls...)
+
+			ginkgo.By("Creating a pending workload for lq-b")
+			wlB := createWorkload("lq-b", "4")
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wlB)
+
+			ginkgo.By("Checking that LQ's resource usage is updated")
+			util.ExpectLocalQueueUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqA), ">", 0)
+			util.ExpectLocalQueueUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqB), "==", 0)
+
+			ginkgo.By("Releasing quota")
+			util.FinishWorkloads(ctx, k8sClient, initialWls...)
+
+			ginkgo.By("Verifying workload from lq-b is admitted")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlB)
+		})
+
+		ginkgo.It("admits workload from new LocalQueue when all others have high usage", func() {
+			ginkgo.By("Saturating the cq with lq-a and lq-b")
+			initialWls := []*kueue.Workload{
+				createWorkload("lq-a", "4"),
+				createWorkload("lq-b", "4"),
+			}
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, initialWls...)
+
+			ginkgo.By("Creating pending workloads for lq-a and lq-b")
+			lqAWls := []*kueue.Workload{
+				createWorkload("lq-a", "4"),
+				createWorkload("lq-a", "4"),
+			}
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, lqAWls...)
+			lqBWls := []*kueue.Workload{
+				createWorkload("lq-b", "4"),
+				createWorkload("lq-b", "4"),
+			}
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, lqBWls...)
+
+			ginkgo.By("Creating a pending workload for lq-c")
+			wlC := createWorkload("lq-c", "4")
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wlC)
+
+			ginkgo.By("Checking that LQ's resource usage is updated")
+			util.ExpectLocalQueueUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqA), ">", 0)
+			util.ExpectLocalQueueUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqB), ">", 0)
+			util.ExpectLocalQueueUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqC), "==", 0)
+
+			ginkgo.By("Releasing quota")
+			util.FinishWorkloads(ctx, k8sClient, initialWls...)
+
+			ginkgo.By("Verifying workload from lq-c is admitted")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlC)
+		})
+
+		ginkgo.It("admits workloads from less active LocalQueues after quota is released", func() {
+			ginkgo.By("Saturating the cq with lq-a")
+			initialWls := []*kueue.Workload{
+				createWorkload("lq-a", "4"),
+				createWorkload("lq-a", "4"),
+			}
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, initialWls...)
+
+			ginkgo.By("Creating pending workloads for lq-b")
+			lqBWls := []*kueue.Workload{
+				createWorkload("lq-b", "4"),
+				createWorkload("lq-b", "4"),
+			}
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, lqBWls...)
+
+			ginkgo.By("Creating a pending workload for lq-c")
+			wlC := createWorkload("lq-c", "4")
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wlC)
+
+			ginkgo.By("Checking that LQ's resource usage is updated")
+			util.ExpectLocalQueueUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqA), ">", 0)
+			util.ExpectLocalQueueUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqB), "==", 0)
+			util.ExpectLocalQueueUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqC), "==", 0)
+
+			ginkgo.By("Releasing quota")
+			util.FinishWorkloads(ctx, k8sClient, initialWls...)
+
+			ginkgo.By("Verifying one workload from lq-b and one from lq-c to be admitted")
+			util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, lqBWls...)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlC)
 		})
 	})
 })

--- a/test/integration/singlecluster/scheduler/fairsharing/suite_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/suite_test.go
@@ -76,10 +76,10 @@ func managerAndSchedulerSetup(ctx context.Context, mgr manager.Manager) {
 	}
 	admissionFairSharing := &config.AdmissionFairSharing{
 		UsageHalfLifeTime: metav1.Duration{
-			Duration: 250 * time.Microsecond,
+			Duration: 3 * time.Second,
 		},
 		UsageSamplingInterval: metav1.Duration{
-			Duration: 250 * time.Millisecond,
+			Duration: 3 * time.Second,
 		},
 	}
 

--- a/test/integration/singlecluster/scheduler/fairsharing/suite_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/suite_test.go
@@ -104,7 +104,7 @@ func managerAndSchedulerSetup(ctx context.Context, mgr manager.Manager) {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName),
-		scheduler.WithFairSharing(fairSharing))
+		scheduler.WithFairSharing(fairSharing), scheduler.WithAdmissionFairSharing(admissionFairSharing))
 	err = sched.Start(ctx)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1109,3 +1109,15 @@ func SetNodeCondition(ctx context.Context, k8sClient client.Client, node *corev1
 		}
 	}, Timeout, Interval).Should(gomega.Succeed(), "Failed to set node condition %s to %s for node %s", newCondition.Type, newCondition.Status, node.Name)
 }
+
+func ExpectLocalQueueUsageToBe(ctx context.Context, k8sClient client.Client, lqKey client.ObjectKey, comparator string, compareTo any) {
+	lq := &kueue.LocalQueue{}
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, lqKey, lq)).Should(gomega.Succeed())
+		g.Expect(lq.Status.FairSharing).ShouldNot(gomega.BeNil())
+		g.Expect(lq.Status.FairSharing.AdmissionFairSharingStatus).ShouldNot(gomega.BeNil())
+		g.Expect(lq.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources).Should(gomega.HaveLen(1))
+		usage := lq.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources[corev1.ResourceCPU]
+		g.Expect(usage.MilliValue()).To(gomega.BeNumerically(comparator, compareTo))
+	}, Timeout, Interval).Should(gomega.Succeed())
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
Add entrance penalty to local queue for admitted workloads.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5339 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
AdmissionFairSharing: Introduce the "entry penalty" for newly admitted workloads in a LQ. 
This mechanism is designed to prevent exploiting a flaw in the previous design which allowed
to submit and get admitted multiple workloads from a single LQ before their usage would be
accounted by the admission fair sharing mechanism.
```