### PR TITLE
Automated cherry pick of #5942: Fix Topology Aware Scheduling when Delete Topology when ResourceFlavor exists should not allow to delete topology test.

### DIFF
--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -59,11 +59,13 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 	ginkgo.When("Delete Topology", func() {
 		var (
-			tasFlavor *kueue.ResourceFlavor
-			topology  *kueuealpha.Topology
+			tasFlavor    *kueue.ResourceFlavor
+			topology     *kueuealpha.Topology
+			clusterQueue *kueue.ClusterQueue
 		)
 
 		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
 		})
@@ -83,14 +85,28 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			ginkgo.BeforeEach(func() {
 				tasFlavor = testing.MakeResourceFlavor("tas-flavor").
 					NodeLabel("node-group", "tas").
-					TopologyName(topology.Name).Obj()
+					TopologyName("topology").Obj()
 				gomega.Expect(k8sClient.Create(ctx, tasFlavor)).Should(gomega.Succeed())
 
 				topology = testing.MakeDefaultOneLevelTopology("topology")
 				gomega.Expect(k8sClient.Create(ctx, topology)).Should(gomega.Succeed())
+
+				clusterQueue = testing.MakeClusterQueue("cq").
+					ResourceGroup(
+						*testing.MakeFlavorQuotas(tasFlavor.Name).
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).Obj()
+				gomega.Expect(k8sClient.Create(ctx, clusterQueue)).Should(gomega.Succeed())
 			})
 
 			ginkgo.It("should not allow to delete topology", func() {
+				// A ClusterQueue is considered active only if its ResourceFlavors are present in the cache.
+				// We need to wait for the ClusterQueue to ensure the ResourceFlavors are cached.
+				ginkgo.By("waiting for the ClusterQueue to become active", func() {
+					util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+				})
+
 				createdTopology := &kueuealpha.Topology{}
 
 				ginkgo.By("check topology has finalizer", func() {


### PR DESCRIPTION
Cherry pick of #5942 on release-0.11.

#5942: Fix Topology Aware Scheduling when Delete Topology when ResourceFlavor exists should not allow to delete topology test.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```