### PR TITLE
Restore managers image after deploy Kueue.

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -290,8 +290,18 @@ function install_cert_manager {
 INITIAL_IMAGE=$($YQ '.images[] | select(.name == "controller") | [.newName, .newTag] | join(":")' config/components/manager/kustomization.yaml)
 export INITIAL_IMAGE
 
+function set_managers_image {
+    (cd "${ROOT_DIR}/config/components/manager" && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
+}
+
 function restore_managers_image {
     (cd "${ROOT_DIR}/config/components/manager" && $KUSTOMIZE edit set image controller="$INITIAL_IMAGE")
+}
+
+function kueue_deploy {
+    set_managers_image
+    cluster_kueue_deploy ""
+    restore_managers_image
 }
 
 function determine_kuberay_ray_image {

--- a/hack/e2e-kueueviz-backend.sh
+++ b/hack/e2e-kueueviz-backend.sh
@@ -33,7 +33,6 @@ cleanup() {
   echo "Cleaning up kueueviz processes"
   kill "${BACKEND_PID}" 
   cluster_cleanup "${KIND_CLUSTER_NAME}" ""
-  restore_managers_image
 }
 
 # Set trap to clean up on exit
@@ -44,8 +43,7 @@ cluster_create "${KIND_CLUSTER_NAME}" "$SOURCE_DIR/$KIND_CLUSTER_FILE" ""
 echo Waiting for kind cluster "${KIND_CLUSTER_NAME}" to start...
 prepare_docker_images
 cluster_kind_load "${KIND_CLUSTER_NAME}"
-(cd config/components/manager && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
-cluster_kueue_deploy ""
+kueue_deploy
 kubectl wait deploy/kueue-controller-manager -n"$KUEUE_NAMESPACE" --for=condition=available --timeout=5m
 
 # Deploy KueueViz resources

--- a/hack/e2e-kueueviz-local.sh
+++ b/hack/e2e-kueueviz-local.sh
@@ -26,7 +26,6 @@ cleanup() {
   echo "Cleaning up kueueviz processes"
   kill $BACKEND_PID $FRONTEND_PID
   cluster_cleanup "$KIND_CLUSTER_NAME" ""
-  restore_managers_image
 }
 
 # Set trap to clean up on exit
@@ -36,8 +35,7 @@ cluster_create "${KIND_CLUSTER_NAME}" "$SOURCE_DIR/$KIND_CLUSTER_FILE" ""
 echo Waiting for kind cluster "${KIND_CLUSTER_NAME}" to start...
 prepare_docker_images
 cluster_kind_load "${KIND_CLUSTER_NAME}"
-(cd config/components/manager && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
-cluster_kueue_deploy ""
+kueue_deploy
 kubectl wait deploy/kueue-controller-manager -n"$KUEUE_NAMESPACE" --for=condition=available --timeout=5m
 
 # Deploy kueueviz resources

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -32,8 +32,6 @@ function cleanup {
         fi
         cluster_cleanup "$KIND_CLUSTER_NAME" ""
     fi
-    #do the image restore here for the case when an error happened during deploy
-    restore_managers_image
 }
 
 function startup {
@@ -44,11 +42,6 @@ function startup {
         fi
         cluster_create "$KIND_CLUSTER_NAME"  "$SOURCE_DIR/$KIND_CLUSTER_FILE" ""
     fi
-}
-
-function kueue_deploy {
-    (cd config/components/manager && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
-    cluster_kueue_deploy ""
 }
 
 trap cleanup EXIT

--- a/hack/multikueue-e2e-test.sh
+++ b/hack/multikueue-e2e-test.sh
@@ -42,8 +42,6 @@ function cleanup {
         cluster_cleanup "$WORKER1_KIND_CLUSTER_NAME" "$WORKER1_KUBECONFIG" &
         cluster_cleanup "$WORKER2_KIND_CLUSTER_NAME" "$WORKER2_KUBECONFIG" &
     fi
-    #do the image restore here for the case when an error happened during deploy
-    restore_managers_image
     wait
 }
 
@@ -72,11 +70,11 @@ function startup {
 }
 
 function kueue_deploy {
-    (cd "${ROOT_DIR}/config/components/manager" && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
-
+    set_managers_image
     cluster_kueue_deploy "$MANAGER_KUBECONFIG"
     cluster_kueue_deploy "$WORKER1_KUBECONFIG"
     cluster_kueue_deploy "$WORKER2_KUBECONFIG"
+    restore_managers_image
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Running `make kind-image-build test-e2e E2E_RUN_ONLY_ENV=true` leaves changes in the Kustomize file, which can sometimes be accidentally committed. Since we no longer use these changes, we should revert them after deploying Kueue to prevent this.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```