### PR TITLE
Automated cherry pick of #5949: Restore managers image after deploy Kueue.

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -216,8 +216,19 @@ function install_cert_manager {
 INITIAL_IMAGE=$($YQ '.images[] | select(.name == "controller") | [.newName, .newTag] | join(":")' config/components/manager/kustomization.yaml)
 export INITIAL_IMAGE
 
+function set_managers_image {
+    (cd config/components/manager && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
+}
+
 function restore_managers_image {
     (cd config/components/manager && $KUSTOMIZE edit set image controller="$INITIAL_IMAGE")
+}
+
+# $1 cluster
+function kueue_deploy {
+    set_managers_image
+    cluster_kueue_deploy "$1"
+    restore_managers_image
 }
 
 function determine_kuberay_ray_image {

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -32,8 +32,6 @@ function cleanup {
         fi
         cluster_cleanup "$KIND_CLUSTER_NAME"
     fi
-    #do the image restore here for the case when an error happened during deploy
-    restore_managers_image
 }
 
 function startup {
@@ -76,14 +74,9 @@ function kind_load {
     fi
 }
 
-function kueue_deploy {
-    (cd config/components/manager && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
-    cluster_kueue_deploy "$KIND_CLUSTER_NAME"
-}
-
 trap cleanup EXIT
 startup
 kind_load
-kueue_deploy
+kueue_deploy "$KIND_CLUSTER_NAME"
 # shellcheck disable=SC2086
 $GINKGO $GINKGO_ARGS --junit-report=junit.xml --json-report=e2e.json --output-dir="$ARTIFACTS" -v ./test/e2e/$E2E_TARGET_FOLDER/...

--- a/hack/multikueue-e2e-test.sh
+++ b/hack/multikueue-e2e-test.sh
@@ -38,8 +38,6 @@ function cleanup {
         cluster_cleanup "$WORKER1_KIND_CLUSTER_NAME"
         cluster_cleanup "$WORKER2_KIND_CLUSTER_NAME"
     fi
-    #do the image restore here for the case when an error happened during deploy
-    restore_managers_image
 }
 
 
@@ -105,18 +103,18 @@ function kind_load {
     install_kuberay "$WORKER2_KIND_CLUSTER_NAME"
 }
 
-function kueue_deploy {
-    (cd config/components/manager && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
-
+function multikueue_kueue_deploy {
+    set_managers_image
     cluster_kueue_deploy "$MANAGER_KIND_CLUSTER_NAME"
     cluster_kueue_deploy "$WORKER1_KIND_CLUSTER_NAME"
     cluster_kueue_deploy "$WORKER2_KIND_CLUSTER_NAME"
+    restore_managers_image
 }
 
 trap cleanup EXIT
 startup
 kind_load
-kueue_deploy
+multikueue_kueue_deploy
 
 # shellcheck disable=SC2086
 $GINKGO $GINKGO_ARGS --junit-report=junit.xml --json-report=e2e.json --output-dir="$ARTIFACTS" -v ./test/e2e/multikueue/...


### PR DESCRIPTION
Cherry pick of #5949 on release-0.11.

#5949: Restore managers image after deploy Kueue.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```