### PR TITLE
Automated cherry pick of #5949: Restore managers image after deploy Kueue.

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -240,8 +240,19 @@ function install_cert_manager {
 INITIAL_IMAGE=$($YQ '.images[] | select(.name == "controller") | [.newName, .newTag] | join(":")' config/components/manager/kustomization.yaml)
 export INITIAL_IMAGE
 
+function set_managers_image {
+    (cd "${ROOT_DIR}/config/components/manager" && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
+}
+
 function restore_managers_image {
     (cd "${ROOT_DIR}/config/components/manager" && $KUSTOMIZE edit set image controller="$INITIAL_IMAGE")
+}
+
+# $1 cluster
+function kueue_deploy {
+    set_managers_image
+    cluster_kueue_deploy "$1"
+    restore_managers_image
 }
 
 function determine_kuberay_ray_image {

--- a/hack/e2e-kueueviz-backend.sh
+++ b/hack/e2e-kueueviz-backend.sh
@@ -31,9 +31,8 @@ fi
 # Function to clean up background processes
 cleanup() {
   echo "Cleaning up kueueviz processes"
-  kill "${BACKEND_PID}" 
+  kill "${BACKEND_PID}"
   cluster_cleanup "${KIND_CLUSTER_NAME}"
-  restore_managers_image
 }
 
 # Set trap to clean up on exit
@@ -44,8 +43,7 @@ cluster_create "${KIND_CLUSTER_NAME}" "$SOURCE_DIR/$KIND_CLUSTER_FILE"
 echo Waiting for kind cluster "${KIND_CLUSTER_NAME}" to start...
 prepare_docker_images
 cluster_kind_load "${KIND_CLUSTER_NAME}"
-(cd config/components/manager && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
-cluster_kueue_deploy "${KIND_CLUSTER_NAME}"
+kueue_deploy "${KIND_CLUSTER_NAME}"
 kubectl wait deploy/kueue-controller-manager -nkueue-system --for=condition=available --timeout=5m
 
 # Deploy KueueViz resources

--- a/hack/e2e-kueueviz-local.sh
+++ b/hack/e2e-kueueviz-local.sh
@@ -26,7 +26,6 @@ cleanup() {
   echo "Cleaning up kueueviz processes"
   kill $BACKEND_PID $FRONTEND_PID
   cluster_cleanup "$KIND_CLUSTER_NAME"
-  restore_managers_image
 }
 
 # Set trap to clean up on exit
@@ -36,8 +35,7 @@ cluster_create "${KIND_CLUSTER_NAME}" "$SOURCE_DIR/$KIND_CLUSTER_FILE"
 echo Waiting for kind cluster "${KIND_CLUSTER_NAME}" to start...
 prepare_docker_images
 cluster_kind_load "${KIND_CLUSTER_NAME}"
-(cd config/components/manager && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
-cluster_kueue_deploy "${KIND_CLUSTER_NAME}"
+kueue_deploy "${KIND_CLUSTER_NAME}"
 kubectl wait deploy/kueue-controller-manager -nkueue-system --for=condition=available --timeout=5m
 
 # Deploy kueueviz resources

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -32,8 +32,6 @@ function cleanup {
         fi
         cluster_cleanup "$KIND_CLUSTER_NAME"
     fi
-    #do the image restore here for the case when an error happened during deploy
-    restore_managers_image
 }
 
 function startup {
@@ -76,15 +74,10 @@ function kind_load {
     fi
 }
 
-function kueue_deploy {
-    (cd config/components/manager && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
-    cluster_kueue_deploy "$KIND_CLUSTER_NAME"
-}
-
 trap cleanup EXIT
 startup
 kind_load
-kueue_deploy
+kueue_deploy "$KIND_CLUSTER_NAME"
 
 if [ "$E2E_RUN_ONLY_ENV" == 'true' ]; then
   read -rp "Press Enter to cleanup."

--- a/hack/multikueue-e2e-test.sh
+++ b/hack/multikueue-e2e-test.sh
@@ -38,8 +38,6 @@ function cleanup {
         cluster_cleanup "$WORKER1_KIND_CLUSTER_NAME"
         cluster_cleanup "$WORKER2_KIND_CLUSTER_NAME"
     fi
-    #do the image restore here for the case when an error happened during deploy
-    restore_managers_image
 }
 
 
@@ -105,18 +103,18 @@ function kind_load {
     install_kuberay "$WORKER2_KIND_CLUSTER_NAME"
 }
 
-function kueue_deploy {
-    (cd config/components/manager && $KUSTOMIZE edit set image controller="$IMAGE_TAG")
-
+function multikueue_kueue_deploy {
+    set_managers_image
     cluster_kueue_deploy "$MANAGER_KIND_CLUSTER_NAME"
     cluster_kueue_deploy "$WORKER1_KIND_CLUSTER_NAME"
     cluster_kueue_deploy "$WORKER2_KIND_CLUSTER_NAME"
+    restore_managers_image
 }
 
 trap cleanup EXIT
 startup
 kind_load
-kueue_deploy
+multikueue_kueue_deploy
 
 if [ "$E2E_RUN_ONLY_ENV" == 'true' ]; then
   read -rp "Press Enter to cleanup."


### PR DESCRIPTION
Cherry pick of #5949 on release-0.12.

#5949: Restore managers image after deploy Kueue.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```