### PR TITLE
Change package name from maps to ptr for consistency

### DIFF
--- a/pkg/util/ptr/ptrs.go
+++ b/pkg/util/ptr/ptrs.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package maps
+package ptr
 
 // ValEquals returns true when ptr is non‑nil and *ptr == want.
 func ValEquals[T comparable](ptr *T, want T) bool {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The PR renames the package `maps` to `ptr` for clarity and consistency. It's confusing that the package containing utility functions for pointers was named `maps`.

#### Special notes for your reviewer:

This package is imported once, via an alias `utilptr`: 

https://github.com/kubernetes-sigs/kueue/blob/faf1eb382032a19a69d6dbed3c9718b12a625a71/pkg/workload/workload.go#L52

#### Does this PR introduce a user-facing change?

```release-note
NONE
```