### PR TITLE
Automated cherry pick of #5952: Use trap to restore managers image in kueue_deploy.

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -226,9 +226,12 @@ function restore_managers_image {
 
 # $1 cluster
 function kueue_deploy {
-    set_managers_image
-    cluster_kueue_deploy "$1"
-    restore_managers_image
+    # We use a subshell to avoid overwriting the global cleanup trap, which also uses the EXIT signal.
+    (
+        set_managers_image
+        trap restore_managers_image EXIT
+        cluster_kueue_deploy "$1"
+    )
 }
 
 function determine_kuberay_ray_image {

--- a/hack/multikueue-e2e-test.sh
+++ b/hack/multikueue-e2e-test.sh
@@ -104,11 +104,14 @@ function kind_load {
 }
 
 function multikueue_kueue_deploy {
-    set_managers_image
-    cluster_kueue_deploy "$MANAGER_KIND_CLUSTER_NAME"
-    cluster_kueue_deploy "$WORKER1_KIND_CLUSTER_NAME"
-    cluster_kueue_deploy "$WORKER2_KIND_CLUSTER_NAME"
-    restore_managers_image
+    # We use a subshell to avoid overwriting the global cleanup trap, which also uses the EXIT signal.
+    (
+        set_managers_image
+        trap restore_managers_image EXIT
+        cluster_kueue_deploy "$MANAGER_KIND_CLUSTER_NAME"
+        cluster_kueue_deploy "$WORKER1_KIND_CLUSTER_NAME"
+        cluster_kueue_deploy "$WORKER2_KIND_CLUSTER_NAME"
+    )
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
Cherry pick of #5952 on release-0.11.

#5952: Use trap to restore managers image in kueue_deploy.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```