### PR TITLE
use group version kind instead of hard coded strings

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -358,18 +358,10 @@ func TestReconcile(t *testing.T) {
 			},
 			wantTemplates: map[string]*corev1.PodTemplate{
 				baseTemplate1.Name: baseTemplate1.Clone().
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Obj(),
 				baseTemplate2.Name: baseTemplate2.Clone().
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -477,18 +469,10 @@ func TestReconcile(t *testing.T) {
 			},
 			wantTemplates: map[string]*corev1.PodTemplate{
 				baseTemplate1.Name: baseTemplate1.Clone().
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Obj(),
 				baseTemplate2.Name: baseTemplate2.Clone().
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -540,18 +524,10 @@ func TestReconcile(t *testing.T) {
 			},
 			wantTemplates: map[string]*corev1.PodTemplate{
 				baseTemplate1.Name: baseTemplate1.Clone().
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Obj(),
 				baseTemplate2.Name: baseTemplate2.Clone().
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -714,11 +690,7 @@ func TestReconcile(t *testing.T) {
 			},
 			wantTemplates: map[string]*corev1.PodTemplate{
 				baseTemplate2.Name: baseTemplate2.Clone().
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -763,11 +735,7 @@ func TestReconcile(t *testing.T) {
 			},
 			wantTemplates: map[string]*corev1.PodTemplate{
 				baseTemplate1.Name: baseTemplate1.Clone().
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Containers(corev1.Container{
 						Name: "c",
 						Resources: corev1.ResourceRequirements{
@@ -1392,11 +1360,7 @@ func TestReconcile(t *testing.T) {
 						Operator: corev1.TolerationOpEqual,
 						Effect:   corev1.TaintEffectNoSchedule,
 					}).
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Obj(),
 				"ppt-wl-check1-1-ps3": utiltesting.MakePodTemplate("ppt-wl-check1-1-ps3", TestNamespace).
 					Label(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue).
@@ -1410,11 +1374,7 @@ func TestReconcile(t *testing.T) {
 					}).
 					NodeSelector("f2l1", "v1").
 					PriorityClass("pc-100").
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Obj(),
 				"ppt-wl-check1-1-ps5": utiltesting.MakePodTemplate("ppt-wl-check1-1-ps5", TestNamespace).
 					Label(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue).
@@ -1428,11 +1388,7 @@ func TestReconcile(t *testing.T) {
 					}).
 					NodeSelector("f2l1", "v1").
 					PriorityClass("pc-200").
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Obj(),
 			},
 		},
@@ -1554,11 +1510,7 @@ func TestReconcile(t *testing.T) {
 						Operator: corev1.TolerationOpEqual,
 						Effect:   corev1.TaintEffectNoSchedule,
 					}).
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Obj(),
 				"ppt-wl-check1-1-ps3": utiltesting.MakePodTemplate("ppt-wl-check1-1-ps3", TestNamespace).
 					Label(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue).
@@ -1572,11 +1524,7 @@ func TestReconcile(t *testing.T) {
 					}).
 					NodeSelector("f2l1", "v1").
 					PriorityClass("pc-100").
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Obj(),
 				"ppt-wl-check1-1-ps5": utiltesting.MakePodTemplate("ppt-wl-check1-1-ps5", TestNamespace).
 					Label(constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue).
@@ -1601,11 +1549,7 @@ func TestReconcile(t *testing.T) {
 							},
 						},
 					}).
-					ControllerReference(schema.GroupVersionKind{
-						Group:   "autoscaling.x-k8s.io",
-						Version: "v1",
-						Kind:    "ProvisioningRequest",
-					}, "wl-check1-1", "").
+					ControllerReference(autoscaling.SchemeGroupVersion.WithKind("ProvisioningRequest"), "wl-check1-1", "").
 					Obj(),
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Follow up. Use GVK rather than hard coded strings.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5971 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```