### PR TITLE
WIP Find topology domain for grouped pod sets

### DIFF
--- a/apis/kueue/v1alpha1/topology_types.go
+++ b/apis/kueue/v1alpha1/topology_types.go
@@ -88,6 +88,11 @@ const (
 	// NodeToReplaceAnnotation is an annotation on a Workload. It holds a
 	// name of a failed node running at least one pod of this workload.
 	NodeToReplaceAnnotation = "alpha.kueue.x-k8s.io/node-to-replace"
+
+	// LeaderWorkerSetGroupRequiredTopologyAnnotation is an annotation set on LeaderWorkerSet
+	// to indicate that leader should be co-located with its workers within a single
+	// replica.
+	LeaderWorkerSetGroupRequiredTopologyAnnotation = "kueue.x-k8s.io/leaderworkerset-group-required-topology"
 )
 
 // TopologySpec defines the desired state of Topology

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -125,6 +125,8 @@ type PodSetTopologyRequest struct {
 	// For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.
 	SubGroupCount *int32 `json:"subGroupCount,omitempty"`
 
+	PodSetGroup *string `json:"podSetGroup,omitempty"`
+
 	// PodSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as
 	// indicated by the `kueue.x-k8s.io/podset-slice-required-topology` annotation.
 	//

--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -125,6 +125,10 @@ type PodSetTopologyRequest struct {
 	// For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.
 	SubGroupCount *int32 `json:"subGroupCount,omitempty"`
 
+	// PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
+	// PodSets with the same `PodSetGroup` should be assigned the same ResourceFlavor
+	//
+	// +optional
 	PodSetGroup *string `json:"podSetGroup,omitempty"`
 
 	// PodSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as

--- a/apis/kueue/v1beta1/zz_generated.deepcopy.go
+++ b/apis/kueue/v1beta1/zz_generated.deepcopy.go
@@ -1244,6 +1244,11 @@ func (in *PodSetTopologyRequest) DeepCopyInto(out *PodSetTopologyRequest) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.PodSetGroup != nil {
+		in, out := &in.PodSetGroup, &out.PodSetGroup
+		*out = new(string)
+		**out = **in
+	}
 	if in.PodSetSliceRequiredTopology != nil {
 		in, out := &in.PodSetSliceRequiredTopology, &out.PodSetSliceRequiredTopology
 		*out = new(string)

--- a/client-go/applyconfiguration/kueue/v1beta1/podsettopologyrequest.go
+++ b/client-go/applyconfiguration/kueue/v1beta1/podsettopologyrequest.go
@@ -26,6 +26,7 @@ type PodSetTopologyRequestApplyConfiguration struct {
 	PodIndexLabel               *string `json:"podIndexLabel,omitempty"`
 	SubGroupIndexLabel          *string `json:"subGroupIndexLabel,omitempty"`
 	SubGroupCount               *int32  `json:"subGroupCount,omitempty"`
+	PodSetGroup                 *string `json:"podSetGroup,omitempty"`
 	PodSetSliceRequiredTopology *string `json:"podSetSliceRequiredTopology,omitempty"`
 	PodSetSliceSize             *int32  `json:"podSetSliceSize,omitempty"`
 }
@@ -81,6 +82,14 @@ func (b *PodSetTopologyRequestApplyConfiguration) WithSubGroupIndexLabel(value s
 // If called multiple times, the SubGroupCount field is set to the value of the last call.
 func (b *PodSetTopologyRequestApplyConfiguration) WithSubGroupCount(value int32) *PodSetTopologyRequestApplyConfiguration {
 	b.SubGroupCount = &value
+	return b
+}
+
+// WithPodSetGroup sets the PodSetGroup field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the PodSetGroup field is set to the value of the last call.
+func (b *PodSetTopologyRequestApplyConfiguration) WithPodSetGroup(value string) *PodSetTopologyRequestApplyConfiguration {
+	b.PodSetGroup = &value
 	return b
 }
 

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -8299,6 +8299,11 @@ spec:
                             - JobSet: kubernetes.io/job-completion-index (inherited from Job)
                             - Kubeflow: training.kubeflow.org/replica-index
                           type: string
+                        podSetGroup:
+                          description: |-
+                            PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
+                            PodSets with the same `PodSetGroup` should be assigned the same ResourceFlavor
+                          type: string
                         podSetSliceRequiredTopology:
                           description: |-
                             PodSetSliceRequiredTopology indicates the topology level required by the PodSet slice, as

--- a/pkg/controller/jobframework/tas.go
+++ b/pkg/controller/jobframework/tas.go
@@ -30,6 +30,7 @@ type podSetTopologyRequestBuilder struct {
 	podIndexLabel      *string
 	subGroupIndexLabel *string
 	subGroupCount      *int32
+	podSetGroup        *string
 	meta               *metav1.ObjectMeta
 }
 
@@ -44,6 +45,10 @@ func (p *podSetTopologyRequestBuilder) SubGroup(subGroupIndexLabel *string, subG
 	return p
 }
 
+func (p *podSetTopologyRequestBuilder) PodSetGroup(podSetGroup *string) *podSetTopologyRequestBuilder {
+	p.podSetGroup = podSetGroup
+	return p
+}
 func NewPodSetTopologyRequest(meta *metav1.ObjectMeta) *podSetTopologyRequestBuilder {
 	return &podSetTopologyRequestBuilder{
 		meta: meta,
@@ -87,6 +92,7 @@ func (p *podSetTopologyRequestBuilder) Build() (*kueue.PodSetTopologyRequest, er
 	psTopologyReq.PodIndexLabel = p.podIndexLabel
 	psTopologyReq.SubGroupCount = p.subGroupCount
 	psTopologyReq.SubGroupIndexLabel = p.subGroupIndexLabel
+	psTopologyReq.PodSetGroup = p.podSetGroup
 
 	return &psTopologyReq, nil
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -216,7 +216,10 @@ func (r *Reconciler) podSets(lws *leaderworkersetv1.LeaderWorkerSet) ([]kueue.Po
 		}
 		if features.Enabled(features.TopologyAwareScheduling) {
 			topologyRequest, err := jobframework.NewPodSetTopologyRequest(
-				&lws.Spec.LeaderWorkerTemplate.LeaderTemplate.ObjectMeta).PodSetGroup(lwsGroupName).Build()
+				&lws.Spec.LeaderWorkerTemplate.LeaderTemplate.ObjectMeta).
+				PodIndexLabel(ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).
+				PodSetGroup(lwsGroupName).
+				Build()
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -208,7 +208,7 @@ func (r *Reconciler) podSets(lws *leaderworkersetv1.LeaderWorkerSet) ([]kueue.Po
 		}
 		if features.Enabled(features.TopologyAwareScheduling) {
 			topologyRequest, err := jobframework.NewPodSetTopologyRequest(
-				&lws.Spec.LeaderWorkerTemplate.LeaderTemplate.ObjectMeta).Build()
+				&lws.Spec.LeaderWorkerTemplate.LeaderTemplate.ObjectMeta).PodSetGroup(ptr.To("lws-group")).Build()
 			if err != nil {
 				return nil, err
 			}
@@ -238,7 +238,7 @@ func (r *Reconciler) podSets(lws *leaderworkersetv1.LeaderWorkerSet) ([]kueue.Po
 	if features.Enabled(features.TopologyAwareScheduling) {
 		topologyRequest, err := jobframework.NewPodSetTopologyRequest(
 			&lws.Spec.LeaderWorkerTemplate.WorkerTemplate.ObjectMeta).PodIndexLabel(
-			ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).Build()
+			ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).PodSetGroup(ptr.To("lws-group")).Build()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -179,6 +180,37 @@ func (r *topologyUngater) Reconcile(ctx context.Context, req reconcile.Request) 
 
 	psNameToTopologyRequest := workload.PodSetNameToTopologyRequest(wl)
 	allToUngate := make([]podWithUngateInfo, 0)
+	groupedPodSetAssignments := make(map[string][]*kueue.PodSetAssignment)
+
+	for i, psa := range wl.Status.Admission.PodSetAssignments {
+		groupName := strconv.Itoa(i)
+		if psNameToTopologyRequest[psa.Name] != nil && psNameToTopologyRequest[psa.Name].PodSetGroup != nil {
+			groupName = *psNameToTopologyRequest[psa.Name].PodSetGroup
+		}
+		groupedPodSetAssignments[groupName] = append(groupedPodSetAssignments[groupName], &psa)
+	}
+
+	psaOffsets := make(map[kueue.PodSetReference]int32)
+	maxRank := make(map[kueue.PodSetReference]int32)
+
+	for _, psas := range groupedPodSetAssignments {
+		if len(psas) > 1 {
+
+			leader := psas[0]
+			workers := psas[1]
+			if *leader.Count > *workers.Count {
+				leader = psas[1]
+				workers = psas[0]
+			}
+			psaOffsets[leader.Name] = 0
+			psaOffsets[workers.Name] = *leader.Count
+			maxRank[leader.Name] = 1
+			maxRank[workers.Name] = *workers.Count + 1
+		} else {
+			psaOffsets[psas[0].Name] = 0
+			maxRank[psas[0].Name] = *psas[0].Count
+		}
+	}
 	for _, psa := range wl.Status.Admission.PodSetAssignments {
 		if psa.TopologyAssignment != nil {
 			pods, err := r.podsForPodSet(ctx, wl.Namespace, wl.Name, psa.Name)
@@ -186,7 +218,7 @@ func (r *topologyUngater) Reconcile(ctx context.Context, req reconcile.Request) 
 				log.Error(err, "failed to list Pods for PodSet", "podset", psa.Name, "count", psa.Count)
 				return reconcile.Result{}, err
 			}
-			gatedPodsToDomains := assignGatedPodsToDomains(log, &psa, pods, psNameToTopologyRequest[psa.Name])
+			gatedPodsToDomains := assignGatedPodsToDomains(log, &psa, pods, psNameToTopologyRequest[psa.Name], psaOffsets[psa.Name], maxRank[psa.Name])
 			if len(gatedPodsToDomains) > 0 {
 				toUngate := podsToUngateInfo(&psa, gatedPodsToDomains)
 				log.V(2).Info("identified pods to ungate for podset", "podset", psa.Name, "count", len(toUngate))
@@ -289,8 +321,10 @@ func assignGatedPodsToDomains(
 	log logr.Logger,
 	psa *kueue.PodSetAssignment,
 	pods []*corev1.Pod,
-	psReq *kueue.PodSetTopologyRequest) []podWithDomain {
-	if rankToGatedPod, ok := readRanksIfAvailable(log, psa, pods, psReq); ok {
+	psReq *kueue.PodSetTopologyRequest,
+	offset int32,
+	maxRank int32) []podWithDomain {
+	if rankToGatedPod, ok := readRanksIfAvailable(log, psa, pods, psReq, offset, maxRank); ok {
 		return assignGatedPodsToDomainsByRanks(psa, rankToGatedPod)
 	}
 	return assignGatedPodsToDomainsGreedy(log, psa, pods)
@@ -315,7 +349,7 @@ func assignGatedPodsToDomainsByRanks(
 	for rank, pod := range rankToGatedPod {
 		toUngate = append(toUngate, podWithDomain{
 			pod:      pod,
-			domainID: rankToDomainID[rank],
+			domainID: rankToDomainID[int32(rank)],
 		})
 	}
 	return toUngate
@@ -367,11 +401,13 @@ func assignGatedPodsToDomainsGreedy(
 func readRanksIfAvailable(log logr.Logger,
 	psa *kueue.PodSetAssignment,
 	pods []*corev1.Pod,
-	psReq *kueue.PodSetTopologyRequest) (map[int]*corev1.Pod, bool) {
+	psReq *kueue.PodSetTopologyRequest,
+	offset int32,
+	maxRank int32) (map[int]*corev1.Pod, bool) {
 	if psReq == nil || psReq.PodIndexLabel == nil {
 		return nil, false
 	}
-	result, err := readRanksForLabels(psa, pods, psReq)
+	result, err := readRanksForLabels(psa, pods, psReq, offset, maxRank)
 	if err != nil {
 		log.Error(err, "failed to read rank information from Pods")
 		return nil, false
@@ -382,7 +418,9 @@ func readRanksIfAvailable(log logr.Logger,
 func readRanksForLabels(
 	psa *kueue.PodSetAssignment,
 	pods []*corev1.Pod,
-	psReq *kueue.PodSetTopologyRequest) (map[int]*corev1.Pod, error) {
+	psReq *kueue.PodSetTopologyRequest,
+	offset int32,
+	maxRank int32) (map[int]*corev1.Pod, error) {
 	result := make(map[int]*corev1.Pod)
 	podSetSize := int(*psa.Count)
 	singleJobSize := podSetSize
@@ -391,12 +429,12 @@ func readRanksForLabels(
 	}
 
 	for _, pod := range pods {
-		podIndex, err := utilpod.ReadUIntFromLabelBelowBound(pod, *psReq.PodIndexLabel, singleJobSize)
+		podIndex, err := utilpod.ReadUIntFromLabelBelowBound(pod, *psReq.PodIndexLabel, int(maxRank))
 		if err != nil {
 			// the Pod has no rank information - ranks cannot be used
 			return nil, err
 		}
-		rank := *podIndex
+		rank := *podIndex - int(offset)
 		if psReq.SubGroupIndexLabel != nil {
 			jobIndex, err := utilpod.ReadUIntFromLabelBelowBound(pod, *psReq.SubGroupIndexLabel, int(*psReq.SubGroupCount))
 			if err != nil {
@@ -408,12 +446,7 @@ func readRanksForLabels(
 				// supported by the rank-based ordering of pods.
 				return nil, fmt.Errorf("pod index %v of Pod %q exceeds the single Job size: %v", *podIndex, klog.KObj(pod), singleJobSize)
 			}
-			rank = *podIndex + *jobIndex*singleJobSize
-		}
-		if rank >= podSetSize {
-			// the rank exceeds the PodSet size, this scenario is not supported
-			// by the rank-based ordering of pods.
-			return nil, fmt.Errorf("rank %v of Pod %q exceeds PodSet size %v", rank, klog.KObj(pod), podSetSize)
+			rank = *podIndex + *jobIndex*singleJobSize - int(offset)
 		}
 		if _, found := result[rank]; found {
 			// there is a conflict in ranks, they cannot be used

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -42,6 +42,7 @@ import (
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
@@ -986,6 +987,164 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
 					Label(batchv1.JobCompletionIndexAnnotation, "4").
 					Label(controllerconsts.PodSetLabel, string(kueue.DefaultPodSetName)).
+					NodeSelector(tasBlockLabel, "b2").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+			},
+			wantCounts: []counts{
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b1",
+						tasRackLabel:  "r1",
+					},
+					Count: 2,
+				},
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b1",
+						tasRackLabel:  "r2",
+					},
+					Count: 1,
+				},
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b2",
+						tasRackLabel:  "r1",
+					},
+					Count: 2,
+				},
+			},
+		},
+		"ranks: ungate pods according to their ranks for LeaderWorkerSet - for all Pods": {
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltesting.MakePodSet("workers", 4).
+							Request(corev1.ResourceCPU, "1").
+							PodIndexLabel(ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).
+							PodSetGroup("lws-group").
+							Obj(),
+						*utiltesting.MakePodSet("leader", 1).
+							Request(corev1.ResourceCPU, "1").
+							PodIndexLabel(ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).
+							PodSetGroup("lws-group").
+							Obj(),
+					).
+					ReserveQuota(
+						utiltesting.MakeAdmission("cq", "workers", "leader").
+							AssignmentWithIndex(0, corev1.ResourceCPU, "unit-test-flavor", "4").
+							AssignmentPodCountWithIndex(0, 4).
+							TopologyAssignmentWithIndex(0, &kueue.TopologyAssignment{
+								Levels: defaultTestLevels,
+								Domains: []kueue.TopologyDomainAssignment{
+									{
+										Count: 1,
+										Values: []string{
+											"b1",
+											"r1",
+										},
+									},
+									{
+										Count: 1,
+										Values: []string{
+											"b1",
+											"r2",
+										},
+									},
+									{
+										Count: 2,
+										Values: []string{
+											"b2",
+											"r1",
+										},
+									},
+								},
+							}).
+							AssignmentWithIndex(1, corev1.ResourceCPU, "unit-test-flavor", "1").
+							AssignmentPodCountWithIndex(1, 1).
+							TopologyAssignmentWithIndex(1, &kueue.TopologyAssignment{
+								Levels: defaultTestLevels,
+								Domains: []kueue.TopologyDomainAssignment{
+									{
+										Count: 1,
+										Values: []string{
+											"b1",
+											"r1",
+										},
+									},
+								},
+							}).
+							Obj(),
+					).
+					Admitted(true).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("p0", "ns").
+					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
+					Label(leaderworkersetv1.WorkerIndexLabelKey, "0").
+					Label(controllerconsts.PodSetLabel, "leader").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("p1", "ns").
+					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
+					Label(leaderworkersetv1.WorkerIndexLabelKey, "1").
+					Label(controllerconsts.PodSetLabel, "workers").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("p2", "ns").
+					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
+					Label(leaderworkersetv1.WorkerIndexLabelKey, "2").
+					Label(controllerconsts.PodSetLabel, "workers").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("p3", "ns").
+					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
+					Label(leaderworkersetv1.WorkerIndexLabelKey, "3").
+					Label(controllerconsts.PodSetLabel, "workers").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("p4", "ns").
+					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
+					Label(leaderworkersetv1.WorkerIndexLabelKey, "4").
+					Label(controllerconsts.PodSetLabel, "workers").
+					TopologySchedulingGate().
+					Obj(),
+			},
+			cmpNS: true,
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("p0", "ns").
+					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
+					Label(leaderworkersetv1.WorkerIndexLabelKey, "0").
+					Label(controllerconsts.PodSetLabel, "leader").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+				*testingpod.MakePod("p1", "ns").
+					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
+					Label(leaderworkersetv1.WorkerIndexLabelKey, "1").
+					Label(controllerconsts.PodSetLabel, "workers").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+				*testingpod.MakePod("p2", "ns").
+					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
+					Label(leaderworkersetv1.WorkerIndexLabelKey, "2").
+					Label(controllerconsts.PodSetLabel, "workers").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r2").
+					Obj(),
+				*testingpod.MakePod("p3", "ns").
+					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
+					Label(leaderworkersetv1.WorkerIndexLabelKey, "3").
+					Label(controllerconsts.PodSetLabel, "workers").
+					NodeSelector(tasBlockLabel, "b2").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+				*testingpod.MakePod("p4", "ns").
+					Annotation(kueuealpha.WorkloadAnnotation, "unit-test").
+					Label(leaderworkersetv1.WorkerIndexLabelKey, "4").
+					Label(controllerconsts.PodSetLabel, "workers").
 					NodeSelector(tasBlockLabel, "b2").
 					NodeSelector(tasRackLabel, "r1").
 					Obj(),

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -446,6 +446,14 @@ func (p *PodSetWrapper) RequiredTopologyRequest(level string) *PodSetWrapper {
 	return p
 }
 
+func (p *PodSetWrapper) PodSetGroup(podSetGroup string) *PodSetWrapper {
+	if p.TopologyRequest == nil {
+		p.TopologyRequest = &kueue.PodSetTopologyRequest{}
+	}
+	p.TopologyRequest.PodSetGroup = &podSetGroup
+	return p
+}
+
 func (p *PodSetWrapper) PreferredTopologyRequest(level string) *PodSetWrapper {
 	if p.TopologyRequest == nil {
 		p.TopologyRequest = &kueue.PodSetTopologyRequest{}

--- a/pkg/util/testingjobs/leaderworkerset/wrappers.go
+++ b/pkg/util/testingjobs/leaderworkerset/wrappers.go
@@ -80,6 +80,15 @@ func (w *LeaderWorkerSetWrapper) Label(k, v string) *LeaderWorkerSetWrapper {
 	return w
 }
 
+// Label sets the label of the LeaderWorkerSet
+func (w *LeaderWorkerSetWrapper) Annotation(k, v string) *LeaderWorkerSetWrapper {
+	if w.Annotations == nil {
+		w.Annotations = make(map[string]string)
+	}
+	w.Annotations[k] = v
+	return w
+}
+
 // Queue updates the queue name of the LeaderWorkerSet
 func (w *LeaderWorkerSetWrapper) Queue(q string) *LeaderWorkerSetWrapper {
 	return w.Label(constants.QueueLabel, q)

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -2180,6 +2180,14 @@ within a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.i
 For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.</p>
 </td>
 </tr>
+<tr><td><code>podSetGroup</code><br/>
+<code>string</code>
+</td>
+<td>
+   <p>PodSetGroup indicates the name of the group of PodSets to which this PodSet belongs to.
+PodSets with the same <code>PodSetGroup</code> should be assigned the same ResourceFlavor</p>
+</td>
+</tr>
 <tr><td><code>podSetSliceRequiredTopology</code><br/>
 <code>string</code>
 </td>

--- a/test/e2e/tas/leaderworkerset_test.go
+++ b/test/e2e/tas/leaderworkerset_test.go
@@ -57,7 +57,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for LeaderWorkerSet", func() {
 		util.MustCreate(ctx, k8sClient, tasFlavor)
 
 		clusterQueue = testing.MakeClusterQueue("cluster-queue").
-			ResourceGroup(*testing.MakeFlavorQuotas("tas-flavor").Resource(extraResource, "8").Obj()).
+			ResourceGroup(*testing.MakeFlavorQuotas("tas-flavor").Resource(extraResource, "8").Resource(corev1.ResourceCPU, "8").Obj()).
 			Obj()
 		util.MustCreate(ctx, k8sClient, clusterQueue)
 		util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
@@ -162,6 +162,130 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for LeaderWorkerSet", func() {
 						"0/0": "kind-worker5",
 						"0/1": "kind-worker6",
 						"0/2": "kind-worker7",
+					}),
+				))
+			})
+		},
+		)
+	})
+
+	ginkgo.When("creating a LeaderWorkerSet co-locating leader and workers in a single topology domain", func() {
+		ginkgo.It("should place pods based on the ranks-ordering", func() {
+			const (
+				replicas = int32(2)
+				size     = int32(4)
+			)
+
+			podsTotalCount := replicas * size
+
+			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
+				Annotation(kueuealpha.LeaderWorkerSetGroupRequiredTopologyAnnotation, testing.DefaultBlockTopologyLevel).
+				Replicas(replicas).
+				Size(size).
+				Queue(localQueue.Name).
+				LeaderTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							kueuealpha.PodSetRequiredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "c",
+								Image: util.GetAgnHostImage(),
+								Args:  util.BehaviorWaitForDeletion,
+								Resources: corev1.ResourceRequirements{
+									Limits: map[corev1.ResourceName]resource.Quantity{
+										corev1.ResourceCPU: resource.MustParse("1"),
+									},
+									Requests: map[corev1.ResourceName]resource.Quantity{
+										corev1.ResourceCPU: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				}).
+				WorkerTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							kueuealpha.PodSetRequiredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "c",
+								Image: util.GetAgnHostImage(),
+								Args:  util.BehaviorWaitForDeletion,
+								Resources: corev1.ResourceRequirements{
+									Limits: map[corev1.ResourceName]resource.Quantity{
+										corev1.ResourceCPU: resource.MustParse("1"),
+										extraResource:      resource.MustParse("1"),
+									},
+									Requests: map[corev1.ResourceName]resource.Quantity{
+										corev1.ResourceCPU: resource.MustParse("1"),
+										extraResource:      resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				}).
+				TerminationGracePeriod(1).
+				Obj()
+			ginkgo.By("Creating a LeaderWorkerSet", func() {
+				util.MustCreate(ctx, k8sClient, lws)
+			})
+
+			ginkgo.By("Waiting for replicas to be ready", func() {
+				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(replicas))
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			pods := &corev1.PodList{}
+			ginkgo.By("ensure all pods are scheduled", func() {
+				listOpts := &client.ListOptions{
+					FieldSelector: fields.OneTermNotEqualSelector("spec.nodeName", ""),
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), listOpts)).To(gomega.Succeed())
+					g.Expect(pods.Items).Should(gomega.HaveLen(int(podsTotalCount)))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verify the assignment of pods are as expected with rank-based ordering", func() {
+				gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+				gotAssignment := make(map[string]string, podsTotalCount)
+				for _, pod := range pods.Items {
+					index := fmt.Sprintf("%s/%s", pod.Labels[leaderworkersetv1.GroupIndexLabelKey], pod.Labels[leaderworkersetv1.WorkerIndexLabelKey])
+					gotAssignment[index] = pod.Spec.NodeName
+				}
+				gomega.Expect(gotAssignment).Should(gomega.Or(
+					gomega.BeComparableTo(map[string]string{
+						"0/0": "kind-worker",
+						"0/1": "kind-worker",
+						"0/2": "kind-worker2",
+						"0/3": "kind-worker3",
+						"1/0": "kind-worker5",
+						"1/1": "kind-worker5",
+						"1/2": "kind-worker6",
+						"1/3": "kind-worker7",
+					}),
+					gomega.BeComparableTo(map[string]string{
+						"1/0": "kind-worker",
+						"1/1": "kind-worker",
+						"1/2": "kind-worker2",
+						"1/3": "kind-worker3",
+						"0/0": "kind-worker5",
+						"0/1": "kind-worker5",
+						"0/2": "kind-worker6",
+						"0/3": "kind-worker7",
 					}),
 				))
 			})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR is a next step after this PR: https://github.com/kubernetes-sigs/kueue/pull/5878. The goal is to allow for TAS to co-schedule leader and workers together in a single LWS group. To achieve that, we need to make sure both leader and workers are assigned to a single flavor (this is a goal of the aforementioned PR) and then place both PodSets in the same topology domain.

This PR does not solve the whole problem and is really limited. The goal is to get something done for 0.13 and improve it after the release.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to: https://github.com/kubernetes-sigs/kueue/issues/4531

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```