### PR TITLE
graduate managedJobNamespaceSelector to GA

### DIFF
--- a/apis/config/v1beta1/defaults.go
+++ b/apis/config/v1beta1/defaults.go
@@ -27,8 +27,6 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	configv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/ptr"
-
-	"sigs.k8s.io/kueue/pkg/features"
 )
 
 const (
@@ -116,20 +114,6 @@ func SetDefaults_Configuration(cfg *Configuration) {
 	cfg.QueueVisibility.ClusterQueues = cmp.Or(cfg.QueueVisibility.ClusterQueues, &ClusterQueueVisibility{
 		MaxCount: DefaultClusterQueuesMaxCount,
 	})
-
-	if !features.Enabled(features.ManagedJobsNamespaceSelector) {
-		// Backwards compatibility: default podOptions.NamespaceSelector if ManagedJobsNamespaceSelector disabled
-		cfg.Integrations.PodOptions = cmp.Or(cfg.Integrations.PodOptions, &PodIntegrationOptions{})
-		cfg.Integrations.PodOptions.NamespaceSelector = cmp.Or(cfg.Integrations.PodOptions.NamespaceSelector, &metav1.LabelSelector{
-			MatchExpressions: []metav1.LabelSelectorRequirement{
-				{
-					Key:      corev1.LabelMetadataName,
-					Operator: metav1.LabelSelectorOpNotIn,
-					Values:   []string{"kube-system", *cfg.Namespace},
-				},
-			},
-		})
-	}
 
 	cfg.ManagedJobsNamespaceSelector = cmp.Or(cfg.ManagedJobsNamespaceSelector, &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -364,14 +364,12 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, cCache *cache.Cache
 	if cfg.Integrations.PodOptions != nil {
 		opts = append(opts, jobframework.WithIntegrationOptions(corev1.SchemeGroupVersion.WithKind("Pod").String(), cfg.Integrations.PodOptions))
 	}
-	if features.Enabled(features.ManagedJobsNamespaceSelector) {
-		nsSelector, err := metav1.LabelSelectorAsSelector(cfg.ManagedJobsNamespaceSelector)
-		if err != nil {
-			setupLog.Error(err, "Failed to parse managedJobsNamespaceSelector")
-			os.Exit(1)
-		}
-		opts = append(opts, jobframework.WithManagedJobsNamespaceSelector(nsSelector))
+	nsSelector, err := metav1.LabelSelectorAsSelector(cfg.ManagedJobsNamespaceSelector)
+	if err != nil {
+		setupLog.Error(err, "Failed to parse managedJobsNamespaceSelector")
+		os.Exit(1)
 	}
+	opts = append(opts, jobframework.WithManagedJobsNamespaceSelector(nsSelector))
 
 	if err := jobframework.SetupControllers(ctx, mgr, setupLog, opts...); err != nil {
 		setupLog.Error(err, "Unable to create controller or webhook", "kubernetesVersion", serverVersionFetcher.GetServerVersion())

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -241,7 +241,7 @@ func validatePodIntegrationOptions(c *configapi.Configuration) field.ErrorList {
 	// At least one namespace selector must be non-nil and enabled.
 	// It is ok for both to be non-nil; pods will only be managed if all non-nil selectors match
 	hasNamespaceSelector := false
-	if features.Enabled(features.ManagedJobsNamespaceSelector) && c.ManagedJobsNamespaceSelector != nil {
+	if c.ManagedJobsNamespaceSelector != nil {
 		allErrs = validateNamespaceSelectorForPodIntegration(c, c.ManagedJobsNamespaceSelector, managedJobsNamespaceSelectorPath, allErrs)
 		hasNamespaceSelector = true
 	}
@@ -251,11 +251,7 @@ func validatePodIntegrationOptions(c *configapi.Configuration) field.ErrorList {
 	}
 
 	if !hasNamespaceSelector {
-		if features.Enabled(features.ManagedJobsNamespaceSelector) {
-			allErrs = append(allErrs, field.Required(managedJobsNamespaceSelectorPath, "cannot be empty when pod integration is enabled"))
-		} else {
-			allErrs = append(allErrs, field.Required(podOptionsNamespaceSelectorPath, "cannot be empty when pod integration is enabled"))
-		}
+		allErrs = append(allErrs, field.Required(managedJobsNamespaceSelectorPath, "cannot be empty when pod integration is enabled"))
 	}
 
 	return allErrs
@@ -353,14 +349,6 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 
 func validateManagedJobsNamespaceSelector(c *configapi.Configuration) field.ErrorList {
 	var allErrs field.ErrorList
-
-	if !features.Enabled(features.ManagedJobsNamespaceSelector) {
-		return allErrs
-	}
-
-	if c.ManagedJobsNamespaceSelector == nil {
-		return field.ErrorList{field.Required(managedJobsNamespaceSelectorPath, "required when feature gate is enabled")}
-	}
 
 	// The namespace selector must exempt every prohibitedNamespace
 	prohibitedNamespaces := []labels.Set{{corev1.LabelMetadataName: metav1.NamespaceSystem}}

--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -61,7 +61,7 @@ func WorkloadShouldBeSuspended(ctx context.Context, jobObj client.Object, k8sCli
 
 	// Logic for managing jobs without queue names.
 	if manageJobsWithoutQueueName {
-		if features.Enabled(features.ManagedJobsNamespaceSelector) && managedJobsNamespaceSelector != nil {
+		if managedJobsNamespaceSelector != nil {
 			// Default suspend the job if the namespace selector matches
 			ns := corev1.Namespace{}
 			err := k8sClient.Get(ctx, client.ObjectKey{Name: jobObj.GetNamespace()}, &ns)

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -367,7 +367,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 
 	// when manageJobsWithoutQueueName is enabled, standalone jobs without queue names
 	// are still not managed if they don't match the namespace selector.
-	if features.Enabled(features.ManagedJobsNamespaceSelector) && r.manageJobsWithoutQueueName && QueueName(job) == "" {
+	if r.manageJobsWithoutQueueName && QueueName(job) == "" {
 		ns := corev1.Namespace{}
 		err := r.client.Get(ctx, client.ObjectKey{Name: job.Object().GetNamespace()}, &ns)
 		if err != nil {

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -136,7 +136,7 @@ func (w *PodWebhook) Default(ctx context.Context, obj runtime.Object) error {
 		if err != nil {
 			return fmt.Errorf("failed to get namespace: %w", err)
 		}
-		if features.Enabled(features.ManagedJobsNamespaceSelector) && !w.managedJobsNamespaceSelector.Matches(labels.Set(ns.GetLabels())) {
+		if w.managedJobsNamespaceSelector != nil && !w.managedJobsNamespaceSelector.Matches(labels.Set(ns.GetLabels())) {
 			return nil
 		}
 

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -83,8 +83,7 @@ func TestDefault(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		enableTopologyAwareScheduling      bool
-		enableManagedJobsNamespaceSelector bool
+		enableTopologyAwareScheduling bool
 
 		initObjects                  []client.Object
 		pod                          *corev1.Pod
@@ -432,9 +431,8 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"ManagedJobsNamespaceSelector is enabled and the namespace matches the selector": {
-			enableManagedJobsNamespaceSelector: true,
-			initObjects:                        []client.Object{defaultNamespace},
-			managedJobsNamespaceSelector:       defaultManagedJobsNamespaceSelector,
+			initObjects:                  []client.Object{defaultNamespace},
+			managedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
 				Queue("queue").
 				Obj(),
@@ -446,7 +444,6 @@ func TestDefault(t *testing.T) {
 				Obj(),
 		},
 		"ManagedJobsNamespaceSelector is enabled but doesn’t match the managedJobsNamespaceSelector": {
-			enableManagedJobsNamespaceSelector: true,
 			initObjects: []client.Object{
 				utiltesting.MakeNamespaceWrapper("kube-system").Label(corev1.LabelMetadataName, "kube-system").Obj(),
 			},
@@ -515,7 +512,6 @@ func TestDefault(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
-			features.SetFeatureGateDuringTest(t, features.ManagedJobsNamespaceSelector, tc.enableManagedJobsNamespaceSelector)
 			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.enableIntegrations...))
 			builder := utiltesting.NewClientBuilder(rayv1.AddToScheme, kfmpi.AddToScheme, kftraining.AddToScheme, appsv1.AddToScheme)

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -100,7 +100,6 @@ func TestValidateDefault(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.ManagedJobsNamespaceSelector, false)
 			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			builder := utiltesting.NewClientBuilder()

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -100,7 +100,6 @@ func TestDefault(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.ManagedJobsNamespaceSelector, false)
 			features.SetFeatureGateDuringTest(t, features.LocalQueueDefaulting, tc.localQueueDefaulting)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			builder := utiltesting.NewClientBuilder()

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -218,6 +218,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	ManagedJobsNamespaceSelector: {
 		{Version: version.MustParse("0.10"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.13"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 0.15
 	},
 	LocalQueueMetrics: {
 		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -284,7 +284,7 @@ spec:
 | `TopologyAwareScheduling`             | `false` | Alpha | 0.9   |       |
 | `ConfigurableResourceTransformations` | `false` | Alpha | 0.9   | 0.9   |
 | `ConfigurableResourceTransformations` | `true`  | Beta  | 0.10  |       |
-| `ManagedJobsNamespaceSelector`        | `true`  | Beta  | 0.10  |       |
+| `ManagedJobsNamespaceSelector`        | `true`  | Beta  | 0.10  | 0.13  |
 | `LocalQueueDefaulting`                | `false` | Alpha | 0.10  | 0.11  |
 | `LocalQueueDefaulting`                | `true`  | Beta  | 0.12  |       |
 | `LocalQueueMetrics`                   | `false` | Alpha | 0.10  |       |
@@ -298,6 +298,7 @@ spec:
 
 | Feature                           | Default | Stage      | Since | Until |
 | --------------------------------- | ------- | ---------- | ----- | ----- |
+| `ManagedJobsNamespaceSelector`    | `true`  | GA         | 0.13  |       |
 | `QueueVisibility`                 | `false` | Alpha      | 0.4   | 0.9   |
 | `QueueVisibility`                 | `false` | Deprecated | 0.9   |       |
 | `TASProfileMostFreeCapacity`      | `false` | Deprecated | 0.11  | 0.13  |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Graduate ManagedJobNamespaceSelector to GA
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5983 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Graduate ManagedJobNamespaceSelector to GA
```