### PR TITLE
Cleanup after graduation ManagedJobsNamespaceSelector feature.

### DIFF
--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -430,7 +430,7 @@ func TestDefault(t *testing.T) {
 				KueueFinalizer().
 				Obj(),
 		},
-		"ManagedJobsNamespaceSelector is enabled and the namespace matches the selector": {
+		"the namespace matches the selector": {
 			initObjects:                  []client.Object{defaultNamespace},
 			managedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
@@ -443,7 +443,7 @@ func TestDefault(t *testing.T) {
 				KueueFinalizer().
 				Obj(),
 		},
-		"ManagedJobsNamespaceSelector is enabled but doesn’t match the managedJobsNamespaceSelector": {
+		"doesn’t match the managedJobsNamespaceSelector": {
 			initObjects: []client.Object{
 				utiltesting.MakeNamespaceWrapper("kube-system").Label(corev1.LabelMetadataName, "kube-system").Obj(),
 			},

--- a/site/content/en/docs/tasks/manage/enforce_job_management/manage_jobs_without_queue_name.md
+++ b/site/content/en/docs/tasks/manage/enforce_job_management/manage_jobs_without_queue_name.md
@@ -39,14 +39,6 @@ managedJobsNamespaceSelector:
     kueue.x-k8s.io/managed-namespace: true
 ```
 
-{{< feature-state state="beta" for_version="v0.10" >}}
-{{% alert title="Note" color="primary" %}}
-
-`managedJobsNamespaceSelector` is a Beta feature that is enabled by default.
-
-You can disable it by setting the `ManagedJobsNamespaceSelector` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
-{{% /alert %}}
-
 ## Expected Behavior
 
 In all namespaces that match the namespace selector, any Workloads submitted without a `kueue.x-k8s.io/queue-name`

--- a/site/content/en/docs/tasks/run/plain_pods.md
+++ b/site/content/en/docs/tasks/run/plain_pods.md
@@ -48,12 +48,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
       - "pod"
    ```
 
-{{< feature-state state="beta" for_version="v0.10" >}}
 {{% alert title="Note" color="primary" %}}
-
-`managedJobsNamespaceSelector` is a Beta feature that is enabled by default.
-You can disable it by setting the `ManagedJobsNamespaceSelector` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
-
   Prior to Kueue v0.10, the Configuration fields `integrations.podOptions.namespaceSelector`
   and `integrations.podOptions.podSelector` were used instead. The use of `podOptions` was
   deprecated in Kueue v0.11. Users should migrate to using `managedJobsNamespaceSelector`.

--- a/site/content/en/docs/tasks/troubleshooting/troubleshooting_pods.md
+++ b/site/content/en/docs/tasks/troubleshooting/troubleshooting_pods.md
@@ -29,12 +29,7 @@ A Pod might not have the `kueue.x-k8s.io/managed` due to one of the following re
 4. The Pod doesn't have a `kueue.x-k8s.io/queue-name` label and [`manageJobsWithoutQueueName`](/docs/reference/kueue-config.v1beta1/#Configuration)
    is set to `false`.
 
-{{< feature-state state="beta" for_version="v0.10" >}}
 {{% alert title="Note" color="primary" %}}
-
-`managedJobsNamespaceSelector` is a Beta feature that is enabled by default.
-You can disable it by setting the `ManagedJobsNamespaceSelector` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
-
 Prior to Kueue v0.10, the Configuration field `integrations.podOptions.namespaceSelector`
 was used instead. The use of `podOptions` was
 deprecated in Kueue v0.11. Users should migrate to using `managedJobsNamespaceSelector`.

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -288,7 +288,7 @@ spec:
 | `ConfigurableResourceTransformations` | `true`  | Beta  | 0.10  |       |
 | `WorkloadResourceRequestsSummary`     | `false` | Alpha | 0.9   | 0.9   |
 | `WorkloadResourceRequestsSummary`     | `true`  | Beta  | 0.10  | 0.10  |
-| `ManagedJobsNamespaceSelector`        | `true`  | Beta  | 0.10  |       |
+| `ManagedJobsNamespaceSelector`        | `true`  | Beta  | 0.10  | 0.13  |
 | `LocalQueueDefaulting`                | `false` | Alpha | 0.10  | 0.11  |
 | `LocalQueueDefaulting`                | `true`  | Beta  | 0.12  |       |
 | `LocalQueueMetrics`                   | `false` | Alpha | 0.10  |       |
@@ -302,6 +302,7 @@ spec:
 
 | 功能 | 默认值 | 阶段 | 起始版本 | 截止版本 |
 | --------------------------------- | ------- | ---------- | ----- | ----- |
+| `ManagedJobsNamespaceSelector`    | `true`  | GA          | 0.13 |       |
 | `QueueVisibility`                 | `false` | Alpha      | 0.4   | 0.9   |
 | `QueueVisibility`                 | `false` | Deprecated | 0.9   |       |
 | `MultiplePreemptions`             | `false` | Alpha      | 0.8   | 0.8   |

--- a/site/content/zh-CN/docs/tasks/manage/enforce_job_management/manage_jobs_without_queue_name.md
+++ b/site/content/zh-CN/docs/tasks/manage/enforce_job_management/manage_jobs_without_queue_name.md
@@ -42,15 +42,6 @@ managedJobsNamespaceSelector:
     kueue.x-k8s.io/managed-namespace: true
 ```
 
-{{< feature-state state="beta" for_version="v0.10" >}}
-{{% alert title="Note" color="primary" %}}
-
-`managedJobsNamespaceSelector` 是一个默认启用的 Beta 特性。
-
-你可以通过设置 `ManagedJobsNamespaceSelector` 特性门控来禁用它。
-查看[安装](/zh-CN/docs/installation/#change-the-feature-gates-configuration)指南以获取关于特性门控配置的详细信息。
-{{% /alert %}}
-
 ## 预期行为
 
 在所有匹配命名空间选择器的命名空间中，任何未带有 `kueue.x-k8s.io/queue-name`

--- a/site/content/zh-CN/docs/tasks/run/plain_pods.md
+++ b/site/content/zh-CN/docs/tasks/run/plain_pods.md
@@ -48,12 +48,7 @@ This guide is for [batch users](/docs/tasks#batch-user) that have a basic unders
       - "pod"
    ```
 
-{{< feature-state state="beta" for_version="v0.10" >}}
 {{% alert title="Note" color="primary" %}}
-
-`managedJobsNamespaceSelector` is a Beta feature that is enabled by default.
-You can disable it by setting the `ManagedJobsNamespaceSelector` feature gate. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
-
   Prior to Kueue v0.10, the Configuration fields `integrations.podOptions.namespaceSelector`
   and `integrations.podOptions.podSelector` were used instead. The use of `podOptions` was
   deprecated in Kueue v0.11. Users should migrate to using `managedJobsNamespaceSelector`.

--- a/site/content/zh-CN/docs/tasks/troubleshooting/troubleshooting_pods.md
+++ b/site/content/zh-CN/docs/tasks/troubleshooting/troubleshooting_pods.md
@@ -30,13 +30,7 @@ Pod 可能没有 `kueue.x-k8s.io/managed` 标签的原因如下：
    [`manageJobsWithoutQueueName`](/docs/reference/kueue-config.v1beta1/#Configuration)
    设置为 `false`。
 
-{{< feature-state state="beta" for_version="v0.10" >}}
 {{% alert title="注意" color="primary" %}}
-
-`managedJobsNamespaceSelector` 是一个默认启用的 Beta 特性。
-你可以通过设置 `ManagedJobsNamespaceSelector` 特性门控来禁用它。
-查看[安装](/docs/installation/#change-the-feature-gates-configuration)指南了解特性门控配置的详细信息。
-
 在 Kueue v0.10 之前，使用配置字段 `integrations.podOptions.namespaceSelector`。
 在 Kueue v0.11 中，`podOptions` 的使用被弃用。
 用户应该迁移到使用 `managedJobsNamespaceSelector`。


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Cleanup after graduation `ManagedJobsNamespaceSelector` feature.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #5983

#### Special notes for your reviewer:
Follow-up for https://github.com/kubernetes-sigs/kueue/pull/5987.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```