### PR TITLE
Automated cherry pick of #5985: Incorrect admission due to wrong borrowable resource when a cluster queue in cohort is deleted

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -468,8 +468,16 @@ func (c *Cache) DeleteClusterQueue(cq *kueue.ClusterQueue) {
 			metrics.ClearLocalQueueCacheMetrics(metrics.LQRefFromLocalQueueKey(q.key))
 		}
 	}
+
+	parent := curCq.Parent()
+
 	c.hm.DeleteClusterQueue(cqName)
 	metrics.ClearCacheMetrics(cq.Name)
+
+	// Update cohort resources after deletion
+	if parent != nil {
+		updateCohortTreeResourcesIfNoCycle(parent)
+	}
 }
 
 func (c *Cache) AddOrUpdateCohort(apiCohort *kueuealpha.Cohort) error {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -560,8 +560,11 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 			},
 			wantClusterQueues: map[kueue.ClusterQueueReference]*clusterQueue{
 				"b": {
-					Name:                          "b",
-					AllocatableResourceGeneration: 1,
+					Name: "b",
+					// AllocatableResourceGeneration is 2 because it was incremented:
+					// 1. Once during initial setup when added to cohort "one"
+					// 2. Once during deletion when cohort tree resources were recalculated after "a" was deleted
+					AllocatableResourceGeneration: 2,
 					NamespaceSelector:             labels.Nothing(),
 					FlavorFungibility:             defaultFlavorFungibility,
 					Status:                        active,

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -2631,21 +2631,21 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				Cohort("bug-test").
 				ResourceGroup(*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "8").Obj()).
 				Obj()
-			gomega.ExpectWithOffset(1, k8sClient.Create(ctx, cq1)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, cq1)).Should(gomega.Succeed())
 
 			// ClusterQueue with 0 CPU nominal quota - this will need to borrow
 			cq2 = testing.MakeClusterQueue("cluster-queue-2").
 				Cohort("bug-test").
 				ResourceGroup(*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "0").Obj()).
 				Obj()
-			gomega.ExpectWithOffset(1, k8sClient.Create(ctx, cq2)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, cq2)).Should(gomega.Succeed())
 
 			ginkgo.By("Creating LocalQueues for the corresponding ClusterQueues")
 			lq1 = testing.MakeLocalQueue("local-queue-1", ns.Name).ClusterQueue(cq1.Name).Obj()
-			gomega.ExpectWithOffset(1, k8sClient.Create(ctx, lq1)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, lq1)).Should(gomega.Succeed())
 
 			lq2 = testing.MakeLocalQueue("local-queue-2", ns.Name).ClusterQueue(cq2.Name).Obj()
-			gomega.ExpectWithOffset(1, k8sClient.Create(ctx, lq2)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, lq2)).Should(gomega.Succeed())
 
 			ginkgo.By("Deleting cluster-queue-1 which has 8 CPU nominal quota")
 			gomega.Expect(util.DeleteObject(ctx, k8sClient, cq1)).To(gomega.Succeed())
@@ -2653,7 +2653,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("Creating a workload that requests 8 CPU - should not be admitted due to no borrowable resources")
 			wl := testing.MakeWorkload("should-be-pending-wl", ns.Name).
 				Queue(lq2.Name).Request(corev1.ResourceCPU, "8").Obj()
-			gomega.ExpectWithOffset(1, k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
 
 			ginkgo.By("Verifying metrics reflect the correct state")
 			util.ExpectPendingWorkloadsMetric(cq2, 0, 1)

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -2609,4 +2609,61 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectPendingWorkloadsMetric(cq1, 0, 0)
 		})
 	})
+	ginkgo.When("Deleting ClusterQueue should update cohort borrowable resources", func() {
+		var (
+			cq1 *kueue.ClusterQueue
+			cq2 *kueue.ClusterQueue
+			lq1 *kueue.LocalQueue
+			lq2 *kueue.LocalQueue
+		)
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, cq1)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, cq2)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, onDemandFlavor)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq1, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq2, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, lq1, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, lq2, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
+		})
+
+		ginkgo.It("Should prevent incorrect admission through borrowing after ClusterQueue deletion", func() {
+			ginkgo.By("Creating two ClusterQueues in the same cohort")
+			// ClusterQueue with 8 CPU nominal quota - this will be the lender
+			cq1 = testing.MakeClusterQueue("cluster-queue-1").
+				Cohort("bug-test").
+				ResourceGroup(*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "8").Obj()).
+				Obj()
+			gomega.ExpectWithOffset(1, k8sClient.Create(ctx, cq1)).Should(gomega.Succeed())
+
+			// ClusterQueue with 0 CPU nominal quota - this will need to borrow
+			cq2 = testing.MakeClusterQueue("cluster-queue-2").
+				Cohort("bug-test").
+				ResourceGroup(*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "0").Obj()).
+				Obj()
+			gomega.ExpectWithOffset(1, k8sClient.Create(ctx, cq2)).Should(gomega.Succeed())
+
+			ginkgo.By("Creating LocalQueues for the corresponding ClusterQueues")
+			lq1 = testing.MakeLocalQueue("local-queue-1", ns.Name).ClusterQueue(cq1.Name).Obj()
+			gomega.ExpectWithOffset(1, k8sClient.Create(ctx, lq1)).Should(gomega.Succeed())
+
+			lq2 = testing.MakeLocalQueue("local-queue-2", ns.Name).ClusterQueue(cq2.Name).Obj()
+			gomega.ExpectWithOffset(1, k8sClient.Create(ctx, lq2)).Should(gomega.Succeed())
+
+			ginkgo.By("Deleting cluster-queue-1 which has 8 CPU nominal quota")
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, cq1)).To(gomega.Succeed())
+
+			ginkgo.By("Creating a workload that requests 8 CPU - should not be admitted due to no borrowable resources")
+			wl := testing.MakeWorkload("should-be-pending-wl", ns.Name).
+				Queue(lq2.Name).Request(corev1.ResourceCPU, "8").Obj()
+			gomega.ExpectWithOffset(1, k8sClient.Create(ctx, wl)).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying metrics reflect the correct state")
+			util.ExpectPendingWorkloadsMetric(cq2, 0, 1)
+			util.ExpectReservingActiveWorkloadsMetric(cq2, 0)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq2, 0)
+		})
+	})
 })

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -2619,13 +2619,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-			gomega.Expect(util.DeleteObject(ctx, k8sClient, cq1)).To(gomega.Succeed())
-			gomega.Expect(util.DeleteObject(ctx, k8sClient, cq2)).To(gomega.Succeed())
-			gomega.Expect(util.DeleteObject(ctx, k8sClient, onDemandFlavor)).To(gomega.Succeed())
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq1, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq2, true)
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, lq1, true)
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, lq2, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
 		})
 


### PR DESCRIPTION
Cherry pick of #5985 on release-0.11.

#5985: Incorrect admission due to wrong borrowable resource when a cluster queue in cohort is deleted

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix incorrect workload admission after CQ is deleted in a cohort reducing the amount of available quota. The culprit of the issue was that the cached amount of quota was not updated on CQ deletion.
```