### PR TITLE
bug fix: ServiceMonitor tlsConfig field

### DIFF
--- a/charts/kueue/templates/prometheus/monitor.yaml
+++ b/charts/kueue/templates/prometheus/monitor.yaml
@@ -17,5 +17,6 @@ spec:
       port: https
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig: '{{- toYaml .Values.metrics.serviceMonitor.tlsConfig | nindent 6 }}'
+      tlsConfig:
+      {{- toYaml .Values.metrics.serviceMonitor.tlsConfig | nindent 8 }}
 {{- end }}

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -764,9 +764,8 @@ files:
       - type: UPDATE
         key: .metadata.namespace
         value: '"{{ .Release.Namespace }}"'
-      - type: UPDATE
+      - type: DELETE
         key: .spec.endpoints.[].tlsConfig
-        value: '"{{- toYaml .Values.metrics.serviceMonitor.tlsConfig | nindent 6 }}"'
         onFileCondition: '.kind == "ServiceMonitor"'
         onItemCondition: '.spec.endpoints.[].path == "/metrics"'
       - type: UPDATE
@@ -791,6 +790,13 @@ files:
             {{- include "kueue.metricsService.labels" . | nindent 6 }}
         indentation: 2
         onFileCondition: '.kind == "ServiceMonitor"'
+      - type: INSERT_TEXT
+        key: .spec.endpoints.[].bearerTokenFile
+        value: |
+          tlsConfig:
+          {{- toYaml .Values.metrics.serviceMonitor.tlsConfig | nindent 8 }}
+        onFileCondition: '.kind == "ServiceMonitor"'
+        onItemCondition: '.spec.endpoints.[].path == "/metrics"'
       - type: INSERT_TEXT
         position: START
         value: |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
The Helm chart's ServiceMonitor template incorrectly renders the tlsConfig field as a string instead of a YAML object, causing schema validation failures when deploying with tools that validate against the ServiceMonitor CRD schema.

`ServiceMonitor kueue-controller-manager-metrics-monitor is invalid: problem validating schema. Check JSON formatting: jsonschema: '/spec/endpoints/0/tlsConfig' does not validate with https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/monitoring.coreos.com/servicemonitor_v1.json#/properties/spec/properties/endpoints/items/properties/tlsConfig/type: expected object, but got string`

Instead of using `UPDATE`, I replaced it with `DELETE` and `INSERT_TEXT` following other examples in the file. I then regenerated monitor.yaml with `make update-helm`.

#### How this was tested
```
helm template test charts/kueue \
  --set enablePrometheus=true \
  --show-only templates/prometheus/monitor.yaml
```
This renders the tlsConfig correctly now.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```