### PR TITLE
WIP: Permit scheduling preemptible and nonpreemptible jobs

### DIFF
--- a/pkg/cache/clusterqueue_snapshot.go
+++ b/pkg/cache/clusterqueue_snapshot.go
@@ -100,6 +100,18 @@ func (c *ClusterQueueSnapshot) SimulateUsageAddition(usage workload.Usage) func(
 	}
 }
 
+// NonPreemptibleUsage calculates the current usage by non-preemptible workloads
+// for the given FlavorResource.
+func (c *ClusterQueueSnapshot) NonPreemptibleUsage(fr resources.FlavorResource) int64 {
+	var usage int64
+	for _, wl := range c.Workloads {
+		if workload.IsNonPreemptible(wl.Obj) {
+			usage += wl.Usage().Quota[fr]
+		}
+	}
+	return usage
+}
+
 // SimulateUsageRemoval modifies the snapshot by removing usage, and
 // returns a function used to restore the usage.
 func (c *ClusterQueueSnapshot) SimulateUsageRemoval(usage workload.Usage) func() {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -44,4 +44,9 @@ const (
 	// ManagedByKueueLabelKey label that signalize that an object is managed by Kueue
 	ManagedByKueueLabelKey   = "kueue.x-k8s.io/managed"
 	ManagedByKueueLabelValue = "true"
+
+	// NonPreemptibleAnnotation is the annotation key that indicates whether a workload cannot be preempted.
+	// Value should be "true" for non-preemptible workloads.
+	// If the annotation is missing, the workload is considered preemptible (backward compatibility).
+	NonPreemptibleAnnotation = "kueue.x-k8s.io/non-preemptible"
 )

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	mainconstants "sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/podset"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
@@ -215,13 +216,23 @@ func PrebuiltWorkloadFor(job GenericJob) (string, bool) {
 }
 
 func NewWorkload(name string, obj client.Object, podSets []kueue.PodSet, labelKeysToCopy []string) *kueue.Workload {
+	annotations := admissioncheck.FilterProvReqAnnotations(obj.GetAnnotations())
+
+	// Propagate non-preemptible annotation
+	if nonPreemptible, exists := obj.GetAnnotations()[mainconstants.NonPreemptibleAnnotation]; exists {
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[mainconstants.NonPreemptibleAnnotation] = nonPreemptible
+	}
+
 	return &kueue.Workload{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   obj.GetNamespace(),
 			Labels:      maps.FilterKeys(obj.GetLabels(), labelKeysToCopy),
 			Finalizers:  []string{kueue.ResourceInUseFinalizerName},
-			Annotations: admissioncheck.FilterProvReqAnnotations(obj.GetAnnotations()),
+			Annotations: annotations,
 		},
 		Spec: kueue.WorkloadSpec{
 			QueueName:                   QueueNameForObject(obj),

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -429,6 +429,11 @@ func (p *Preemptor) findCandidates(wl *kueue.Workload, cq *cache.ClusterQueueSna
 		preemptorTS := p.workloadOrdering.GetQueueOrderTimestamp(wl)
 
 		for _, candidateWl := range cq.Workloads {
+			// Skip non-preemptible workloads
+			if workload.IsNonPreemptible(candidateWl.Obj) {
+				continue
+			}
+
 			candidatePriority := priority.Priority(candidateWl.Obj)
 			if candidatePriority > wlPriority {
 				continue
@@ -453,6 +458,11 @@ func (p *Preemptor) findCandidates(wl *kueue.Workload, cq *cache.ClusterQueueSna
 				continue
 			}
 			for _, candidateWl := range cohortCQ.Workloads {
+				// Skip non-preemptible workloads
+				if workload.IsNonPreemptible(candidateWl.Obj) {
+					continue
+				}
+
 				if onlyLowerPriority && priority.Priority(candidateWl.Obj) >= priority.Priority(wl) {
 					continue
 				}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -930,6 +930,20 @@ func IsEvicted(w *kueue.Workload) bool {
 	return apimeta.IsStatusConditionPresentAndEqual(w.Status.Conditions, kueue.WorkloadEvicted, metav1.ConditionTrue)
 }
 
+// IsNonPreemptible returns true if the workload is marked as non-preemptible.
+// If the annotation is missing, the workload is considered preemptible for backward compatibility.
+func IsNonPreemptible(w *kueue.Workload) bool {
+	if w.Annotations == nil {
+		return false
+	}
+	value, exists := w.Annotations[constants.NonPreemptibleAnnotation]
+	if !exists {
+		return false // Default: preemptible for backward compatibility
+	}
+	// Parse boolean value - "true" means non-preemptible
+	return value == "true"
+}
+
 // HasConditionWithTypeAndReason checks if there is a condition in Workload's status
 // with exactly the same Type, Status and Reason
 func HasConditionWithTypeAndReason(w *kueue.Workload, cond *metav1.Condition) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:
Kueue doesn't natively support non-preemptible workloads. This is a useful feature because sometimes specific workloads should never be preempted, even when preemption is generally permitted in the cohort or queue.

This PR allows users to annotate underlying objects with `kueue.x-k8s.io/non-preemptible` to indicate that it should not be preempted.

This change is backwards compatible because currently all workloads are tacitly preemptible.



#### How this was tested
I updated the unit tests. I also manually tested it since I'm using this fork in my service.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added annotation `kueue.x-k8s.io/non-preemptible` which is used to identify workloads that should never be preempted regardless of preemption policy.
```