### PR TITLE
Simplify Pod configuration options.

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -164,39 +164,37 @@ var (
 	_ jobframework.TopLevelJob                     = (*Pod)(nil)
 )
 
-type options struct {
-	excessPodExpectations *expectations.Store
-	clock                 clock.Clock
-}
+// PodOption is a function type that modifies a Pod. It allows customization of a Pod's
+// properties during its creation.
+type PodOption func(pod *Pod)
 
-type PodOption func(*options)
-
+// WithExcessPodExpectations sets the excessPodExpectations field of the Pod to the given expectations store.
+// This allows customizing the expectations for excess pods that are tracked by the Pod.
 func WithExcessPodExpectations(store *expectations.Store) PodOption {
-	return func(o *options) {
-		o.excessPodExpectations = store
+	return func(pod *Pod) {
+		pod.excessPodExpectations = store
 	}
 }
 
-func WithClock(c clock.Clock) PodOption {
-	return func(o *options) {
-		o.clock = c
+// WithClock sets the clock field of the Pod to the given clock. This allows the Pod to
+// use a custom clock instead of the default one.
+func WithClock(clock clock.Clock) PodOption {
+	return func(pod *Pod) {
+		pod.clock = clock
 	}
 }
 
-var defaultOptions = options{
-	clock: realClock,
-}
-
+// NewPod creates a new Pod with the provided options. It applies all the given PodOptions
+// to customize the Pod's fields. By default, the Pod is created with a real clock, unless
+// overridden by a WithClock option.
 func NewPod(opts ...PodOption) *Pod {
-	options := defaultOptions
+	pod := &Pod{
+		clock: realClock, // Default clock is set to realClock.
+	}
 	for _, opt := range opts {
-		opt(&options)
+		opt(pod) // Apply each option to the pod.
 	}
-
-	return &Pod{
-		excessPodExpectations: options.excessPodExpectations,
-		clock:                 options.clock,
-	}
+	return pod
 }
 
 func FromObject(o runtime.Object) *Pod {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR contains changes that simplifies `NewPod` instance creation options resulting in less confusing code.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```