### PR TITLE
setup for multikueue local development

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -244,6 +244,19 @@ ginkgo-top:
 setup-e2e-env: kustomize yq gomod-download dep-crds kind ginkgo ginkgo-top ## Setup environment for e2e tests without running tests.
 	@echo "Setting up environment for e2e tests"
 
+.PHONY: setup-multikueue-env
+setup-multikueue-env: setup-e2e-env kind-ray-project-mini-image-build ## Setup MultiKueue environment with manager and worker clusters.
+	@echo "Setting up MultiKueue environment..."
+	KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) CREATE_KIND_CLUSTER=$(CREATE_KIND_CLUSTER) \
+		ARTIFACTS="$(ARTIFACTS)" IMAGE_TAG=$(IMAGE_TAG) \
+		JOBSET_VERSION=$(JOBSET_VERSION) \
+		APPWRAPPER_VERSION=$(APPWRAPPER_VERSION) \
+		KUBEFLOW_VERSION=$(KUBEFLOW_VERSION) \
+		KUBEFLOW_MPI_VERSION=$(KUBEFLOW_MPI_VERSION) \
+		KUBERAY_VERSION=$(KUBERAY_VERSION) RAY_VERSION=$(RAY_VERSION) RAYMINI_VERSION=$(RAYMINI_VERSION) USE_RAY_FOR_TESTS=$(USE_RAY_FOR_TESTS) \
+		E2E_KIND_VERSION=$(E2E_KIND_VERSION) \
+		./hack/multikueue/setup-multikueue.sh
+
 .PHONY: test-e2e-kueueviz-local
 test-e2e-kueueviz-local: setup-e2e-env ## Run end-to-end tests for kueueviz without running kueue tests.
 	CYPRESS_SCREENSHOTS_FOLDER=$(ARTIFACTS)/cypress/screenshots CYPRESS_VIDEOS_FOLDER=$(ARTIFACTS)/cypress/videos \

--- a/hack/multikueue/create-multikueue-kubeconfig.sh
+++ b/hack/multikueue/create-multikueue-kubeconfig.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+
+# Copyright 2025 The Kubernetes Authors.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBECONFIG_OUT=${1:-kubeconfig}
+MULTIKUEUE_SA=multikueue-sa
+NAMESPACE=kueue-system
+
+# Creating a restricted MultiKueue role, service account and role binding"
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${MULTIKUEUE_SA}
+  namespace: ${NAMESPACE}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ${MULTIKUEUE_SA}-role
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets/status
+  verbs:
+  - get
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - workloads
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - workloads/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs
+  - pytorchjobs
+  - mpijobs
+  - paddlejobs
+  - xgboostjobs
+  - jaxjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs/status
+  - pytorchjobs/status
+  - mpijobs/status
+  - paddlejobs/status
+  - xgboostjobs/status
+  - jaxjobs/status
+  verbs:
+  - get
+- apiGroups:
+  - workload.codeflare.dev
+  resources:
+  - appwrappers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - workload.codeflare.dev
+  resources:
+  - appwrappers/status
+  verbs:
+  - get
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  - rayclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/status
+  - rayclusters/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ${MULTIKUEUE_SA}-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ${MULTIKUEUE_SA}-role
+subjects:
+- kind: ServiceAccount
+  name: ${MULTIKUEUE_SA}
+  namespace: ${NAMESPACE}
+EOF
+
+# Get or create a secret bound to the new service account.
+SA_SECRET_NAME=$(kubectl get -n ${NAMESPACE} sa/${MULTIKUEUE_SA} -o "jsonpath={.secrets[0]..name}")
+if [ -z "$SA_SECRET_NAME" ]
+then
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: ${MULTIKUEUE_SA}
+  namespace: ${NAMESPACE}
+  annotations:
+    kubernetes.io/service-account.name: "${MULTIKUEUE_SA}"
+EOF
+
+SA_SECRET_NAME=${MULTIKUEUE_SA}
+fi
+
+# Note: service account token is stored base64-encoded in the secret but must
+# be plaintext in kubeconfig.
+SA_TOKEN=$(kubectl get -n ${NAMESPACE} "secrets/${SA_SECRET_NAME}" -o "jsonpath={.data['token']}" | base64 -d)
+CA_CERT=$(kubectl get -n ${NAMESPACE} "secrets/${SA_SECRET_NAME}" -o "jsonpath={.data['ca\.crt']}")
+
+# Extract cluster IP from the current context
+CURRENT_CONTEXT=$(kubectl config current-context)
+CURRENT_CLUSTER=$(kubectl config view -o jsonpath="{.contexts[?(@.name == \"${CURRENT_CONTEXT}\"})].context.cluster}")
+CURRENT_CLUSTER_ADDR=$(kubectl config view -o jsonpath="{.clusters[?(@.name == \"${CURRENT_CLUSTER}\"})].cluster.server}")
+
+# For KIND clusters, replace localhost addresses with internal Docker network addresses
+if [[ "$CURRENT_CLUSTER" == *"kind"* ]]; then
+    echo "Detected KIND cluster: $CURRENT_CLUSTER"
+    
+    # Get the container name for this cluster
+    if [[ "$CURRENT_CLUSTER" == *"worker1"* ]]; then
+        CONTAINER_NAME="kind-worker1-control-plane"
+    elif [[ "$CURRENT_CLUSTER" == *"worker2"* ]]; then
+        CONTAINER_NAME="kind-worker2-control-plane"
+    else
+        echo "Warning: Unknown KIND cluster pattern: $CURRENT_CLUSTER"
+        CONTAINER_NAME=""
+    fi
+    
+    if [[ -n "$CONTAINER_NAME" ]]; then
+        # Get the internal IP address of the container
+        INTERNAL_IP=$(docker inspect "$CONTAINER_NAME" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+        if [[ -n "$INTERNAL_IP" ]]; then
+            echo "Using internal Docker network address: https://$INTERNAL_IP:6443"
+            CURRENT_CLUSTER_ADDR="https://$INTERNAL_IP:6443"
+        else
+            echo "Warning: Could not determine internal IP for $CONTAINER_NAME, using original address"
+        fi
+    fi
+fi
+
+# Create the Kubeconfig file
+echo "Writing kubeconfig in ${KUBECONFIG_OUT}"
+cat > "${KUBECONFIG_OUT}" <<EOF
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ${CA_CERT}
+    server: ${CURRENT_CLUSTER_ADDR}
+  name: ${CURRENT_CLUSTER}
+contexts:
+- context:
+    cluster: ${CURRENT_CLUSTER}
+    user: ${CURRENT_CLUSTER}-${MULTIKUEUE_SA}
+  name: ${CURRENT_CONTEXT}
+current-context: ${CURRENT_CONTEXT}
+kind: Config
+preferences: {}
+users:
+- name: ${CURRENT_CLUSTER}-${MULTIKUEUE_SA}
+  user:
+    token: ${SA_TOKEN}
+EOF

--- a/hack/multikueue/multikueue-config.yaml
+++ b/hack/multikueue/multikueue-config.yaml
@@ -1,0 +1,43 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: AdmissionCheck
+metadata:
+  name: sample-multikueue
+spec:
+  controllerName: kueue.x-k8s.io/multikueue
+  parameters:
+    apiGroup: kueue.x-k8s.io
+    kind: MultiKueueConfig
+    name: multikueue-test
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: MultiKueueConfig
+metadata:
+  name: multikueue-test
+spec:
+  clusters:
+  - multikueue-test-worker1
+  - multikueue-test-worker2
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: MultiKueueCluster
+metadata:
+  name: multikueue-test-worker1
+spec:
+  kubeConfig:
+    locationType: Secret
+    location: worker1-secret
+    # a secret called "worker1-secret" should be created in the namespace the kueue
+    # controller manager runs into, holding the kubeConfig needed to connect to the
+    # worker cluster in the "kubeconfig" key;
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: MultiKueueCluster
+metadata:
+  name: multikueue-test-worker2
+spec:
+  kubeConfig:
+    locationType: Secret
+    location: worker2-secret
+    # a secret called "worker2-secret" should be created in the namespace the kueue
+    # controller manager runs into, holding the kubeConfig needed to connect to the
+    # worker cluster in the "kubeconfig" key;

--- a/hack/multikueue/setup-multikueue.sh
+++ b/hack/multikueue/setup-multikueue.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Kubernetes Authors.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# =============================================================================
+# CONFIGURATION AND SETUP
+# =============================================================================
+
+SOURCE_DIR="$(cd "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT_DIR="$(cd "$SOURCE_DIR/../.." && pwd -P)"
+
+# Enable CRDs MultiKueue
+export JOBSET_VERSION="${JOBSET_VERSION:-v0.8.0}"
+export APPWRAPPER_VERSION="${APPWRAPPER_VERSION:-v0.27.0}"
+export KUBEFLOW_VERSION="${KUBEFLOW_VERSION:-v1.8.1}"
+export KUBEFLOW_MPI_VERSION="${KUBEFLOW_MPI_VERSION:-v0.5.0}"
+export RAY_VERSION="${RAY_VERSION:-2.9.0}"
+export RAYMINI_VERSION="${RAYMINI_VERSION:-2.9.0}"
+
+# Cluster names and kubeconfig paths
+export MANAGER_KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME}-manager
+export WORKER1_KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME}-worker1
+export WORKER2_KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME}-worker2
+
+export MANAGER_KUBECONFIG="${ARTIFACTS}/kubeconfig-$MANAGER_KIND_CLUSTER_NAME"
+export WORKER1_KUBECONFIG="${ARTIFACTS}/kubeconfig-$WORKER1_KIND_CLUSTER_NAME"
+export WORKER2_KUBECONFIG="${ARTIFACTS}/kubeconfig-$WORKER2_KIND_CLUSTER_NAME"
+
+# shellcheck source=hack/e2e-common.sh
+source "${ROOT_DIR}/hack/e2e-common.sh"
+
+# =============================================================================
+# UTILITY FUNCTIONS
+# =============================================================================
+
+function ensure_artifacts_dir() {
+    if [ ! -d "$ARTIFACTS" ]; then
+        mkdir -p "$ARTIFACTS"
+    fi
+}
+
+function print_environment_info() {
+    echo "Using environment variables:"
+    echo "  KIND_CLUSTER_NAME=$KIND_CLUSTER_NAME"
+    echo "  ARTIFACTS=$ARTIFACTS"
+    echo "  CREATE_KIND_CLUSTER=$CREATE_KIND_CLUSTER"
+    echo "  E2E_KIND_VERSION=$E2E_KIND_VERSION"
+    echo "  IMAGE_TAG=$IMAGE_TAG"
+    echo "  JOBSET_VERSION=$JOBSET_VERSION"
+    echo "  APPWRAPPER_VERSION=$APPWRAPPER_VERSION"
+    echo "  KUBEFLOW_VERSION=$KUBEFLOW_VERSION"
+    echo "  KUBEFLOW_MPI_VERSION=$KUBEFLOW_MPI_VERSION"
+    echo "  Ray operator will be installed directly on worker clusters"
+}
+
+function cleanup_stale_files() {
+    echo "Cleaning up any stale files from previous runs..."
+    
+    # Remove stale kubeconfig files
+    rm -f "${ARTIFACTS}/kubeconfig-kind-"*
+    rm -f "${ARTIFACTS}/"*"-multikueue-kubeconfig"
+    
+    # Remove any lock files that might be left behind
+    find "${ARTIFACTS}" -name "*.lock" -delete 2>/dev/null || true
+    
+    echo "Stale file cleanup completed."
+}
+
+# =============================================================================
+# REUSE EXISTING E2E FUNCTIONS
+# =============================================================================
+
+function cleanup() {
+    if [ "$CREATE_KIND_CLUSTER" == 'true' ]; then
+        ensure_artifacts_dir
+        cluster_cleanup "$MANAGER_KIND_CLUSTER_NAME" "$MANAGER_KUBECONFIG" &
+        cluster_cleanup "$WORKER1_KIND_CLUSTER_NAME" "$WORKER1_KUBECONFIG" &
+        cluster_cleanup "$WORKER2_KIND_CLUSTER_NAME" "$WORKER2_KUBECONFIG" &
+    fi
+    wait
+}
+
+function startup() {
+    if [ "$CREATE_KIND_CLUSTER" != 'true' ]; then
+        return 0
+    fi
+    
+    ensure_artifacts_dir
+    cp "${SOURCE_DIR}/manager-cluster.kind.yaml" "$ARTIFACTS"
+
+    # Enable the JobManagedBy feature gate for Kubernetes 1.31.
+    # In newer versions, this feature is in Beta and enabled by default.
+    IFS=. read -r -a varr <<< "$KIND_VERSION"
+    minor=$(( varr[1] ))        
+    if [ "$minor" -eq 31 ]; then
+        echo "Enable JobManagedBy feature in manager's kind config"
+        $YQ e -i '.featureGates.JobManagedBy = true' "${ARTIFACTS}/manager-cluster.kind.yaml"
+    fi
+
+    echo "Creating KIND clusters..."
+    cluster_create "$MANAGER_KIND_CLUSTER_NAME" "${ARTIFACTS}/manager-cluster.kind.yaml" "$MANAGER_KUBECONFIG" &
+    cluster_create "$WORKER1_KIND_CLUSTER_NAME" "$SOURCE_DIR/worker-cluster.kind.yaml" "$WORKER1_KUBECONFIG" &
+    cluster_create "$WORKER2_KIND_CLUSTER_NAME" "$SOURCE_DIR/worker-cluster.kind.yaml" "$WORKER2_KUBECONFIG" &
+}
+
+function wait_for_kueue_ready() {
+    local kubeconfig=$1
+    local cluster_name=$2
+    
+    echo "Waiting for Kueue to be ready in $cluster_name cluster..."
+    
+    # Wait for Kueue controller pods to be ready
+    echo "  Waiting for Kueue controller pods in $cluster_name..."
+    kubectl --kubeconfig="$kubeconfig" wait --for=condition=ready pod \
+        -l control-plane=controller-manager \
+        -n kueue-system \
+        --timeout=300s || {
+        echo "  Warning: Kueue controller pods not ready in $cluster_name, checking status..."
+        kubectl --kubeconfig="$kubeconfig" get pods -n kueue-system || true
+    }
+    
+    # Check if webhook service exists
+    echo "  Checking webhook service availability..."
+    kubectl --kubeconfig="$kubeconfig" get service kueue-webhook-service -n kueue-system >/dev/null 2>&1 && {
+        echo "  ✓ Webhook service found in $cluster_name"
+    } || {
+        echo "  Warning: Webhook service not found in $cluster_name"
+        kubectl --kubeconfig="$kubeconfig" get services -n kueue-system || true
+    }
+    
+    # Check if Kueue CRDs are registered
+    echo "  Verifying Kueue CRDs are registered..."
+    kubectl --kubeconfig="$kubeconfig" get crd clusterqueues.kueue.x-k8s.io >/dev/null 2>&1 && {
+        echo "  ✓ Kueue CRDs are registered in $cluster_name"
+    } || {
+        echo "  Warning: Kueue CRDs not found in $cluster_name"
+        kubectl --kubeconfig="$kubeconfig" get crd | grep -i kueue || echo "  No Kueue CRDs found"
+    }
+    
+    echo "  Kueue readiness check completed for $cluster_name cluster."
+}
+
+function deploy_kueue_to_clusters() {
+    # We use a subshell to avoid overwriting the global cleanup trap, which also uses the EXIT signal.
+    (
+        set_managers_image
+        trap restore_managers_image EXIT
+        
+        # Deploy to all clusters in parallel first
+        echo "Deploying Kueue to all clusters in parallel..."
+        echo "  Starting deployment to manager cluster..."
+        cluster_kueue_deploy "$MANAGER_KUBECONFIG" &
+        echo "  Starting deployment to worker1 cluster..."
+        cluster_kueue_deploy "$WORKER1_KUBECONFIG" &
+        echo "  Starting deployment to worker2 cluster..."
+        cluster_kueue_deploy "$WORKER2_KUBECONFIG" &
+        
+        # Wait for all deployments to complete
+        echo "Waiting for all Kueue deployments to complete..."
+        wait
+        
+        # Now check readiness for all clusters
+        echo "Checking Kueue readiness on all clusters..."
+        wait_for_kueue_ready "$MANAGER_KUBECONFIG" "manager"
+        wait_for_kueue_ready "$WORKER1_KUBECONFIG" "worker1"
+        wait_for_kueue_ready "$WORKER2_KUBECONFIG" "worker2"
+        
+        echo "Kueue deployment completed on all clusters."
+    )
+}
+
+# =============================================================================
+# MULTIKUEUE SETUP FUNCTIONS
+# =============================================================================
+
+function validate_kubeconfig_script() {
+    local script_path="${SOURCE_DIR}/create-multikueue-kubeconfig.sh"
+    
+    if [ ! -f "$script_path" ]; then
+        echo "Error: create-multikueue-kubeconfig.sh not found at $script_path"
+        exit 1
+    fi
+    
+    if [ ! -x "$script_path" ]; then
+        echo "Making create-multikueue-kubeconfig.sh executable..."
+        chmod +x "$script_path"
+    fi
+}
+
+function generate_worker_kubeconfig() {
+    local cluster_name=$1
+    local kubeconfig_path=$2
+    local output_name=$3
+    
+    echo "Generating kubeconfig for cluster: $cluster_name"
+    
+    # Switch to the worker cluster context
+    export KUBECONFIG="$kubeconfig_path"
+    
+    # Check if kueue-system namespace exists
+    echo "Checking for kueue-system namespace in $cluster_name..."
+    kubectl get namespace kueue-system >/dev/null 2>&1 || {
+        echo "Warning: kueue-system namespace not found in $cluster_name, continuing anyway..."
+    }
+    
+    # Generate the kubeconfig using the create-multikueue-kubeconfig.sh script
+    "${SOURCE_DIR}/create-multikueue-kubeconfig.sh" "${ARTIFACTS}/${output_name}" || {
+        echo "Error: Failed to generate kubeconfig for $cluster_name"
+        return 1
+    }
+    
+    echo "Successfully generated kubeconfig: ${ARTIFACTS}/${output_name}"
+}
+
+function generate_all_worker_kubeconfigs() {
+    echo "Generating MultiKueue kubeconfigs for worker clusters..."
+    
+    validate_kubeconfig_script
+    
+    # Generate kubeconfigs for both worker clusters in parallel
+    generate_worker_kubeconfig "$WORKER1_KIND_CLUSTER_NAME" "$WORKER1_KUBECONFIG" "worker1-multikueue-kubeconfig" &
+    generate_worker_kubeconfig "$WORKER2_KIND_CLUSTER_NAME" "$WORKER2_KUBECONFIG" "worker2-multikueue-kubeconfig" &
+    
+    # Wait for both kubeconfig generations to complete
+    wait
+}
+
+function create_worker_secret() {
+    local worker_name=$1
+    local kubeconfig_file="${ARTIFACTS}/${worker_name}-multikueue-kubeconfig"
+    local secret_name="${worker_name}-secret"
+    
+    if [ ! -f "$kubeconfig_file" ]; then
+        echo "Error: $kubeconfig_file not found"
+        return 1
+    fi
+    
+    echo "Creating secret for ${worker_name} cluster..."
+    kubectl create secret generic "$secret_name" \
+        -n kueue-system \
+        --from-file=kubeconfig="$kubeconfig_file" \
+        --dry-run=client -o yaml | kubectl apply -f - || {
+        echo "Error: Failed to create $secret_name"
+        return 1
+    }
+    echo "Successfully created $secret_name in kueue-system namespace"
+}
+
+function create_all_worker_secrets() {
+    echo "Creating secrets in manager cluster for worker clusters..."
+    
+    # Switch to manager cluster context
+    export KUBECONFIG="$MANAGER_KUBECONFIG"
+    
+    # Ensure kueue-system namespace exists in manager cluster
+    kubectl create namespace kueue-system --dry-run=client -o yaml | kubectl apply -f - || {
+        echo "Warning: Could not create/verify kueue-system namespace in manager cluster"
+    }
+    
+    # Create secrets for each worker cluster
+    create_worker_secret "worker1" || return 1
+    create_worker_secret "worker2" || return 1
+    
+    echo "All worker secrets created successfully!"
+}
+
+function apply_multikueue_config() {
+    echo "Applying MultiKueue configuration to manager cluster..."
+    
+    # Switch to manager cluster context
+    export KUBECONFIG="$MANAGER_KUBECONFIG"
+    
+    # Apply the MultiKueue configuration
+    kubectl apply -f "${SOURCE_DIR}/multikueue-config.yaml" || {
+        echo "Error: Failed to apply MultiKueue configuration"
+        return 1
+    }
+    
+    echo "MultiKueue configuration applied successfully!"
+}
+
+function setup_multikueue() {
+    generate_all_worker_kubeconfigs
+    create_all_worker_secrets
+    apply_multikueue_config
+}
+
+function print_completion_summary() {
+    echo "MultiKueue setup complete!"
+    echo "Generated kubeconfigs:"
+    echo "  - Worker1: ${ARTIFACTS}/worker1-multikueue-kubeconfig"
+    echo "  - Worker2: ${ARTIFACTS}/worker2-multikueue-kubeconfig"
+    echo ""
+    echo "Created secrets in manager cluster (kueue-system namespace):"
+    echo "  - worker1-secret (contains worker1 kubeconfig)"
+    echo "  - worker2-secret (contains worker2 kubeconfig)"
+    echo ""
+    echo "Applied MultiKueue configuration to manager cluster:"
+    echo "  - AdmissionCheck: sample-multikueue"
+    echo "  - MultiKueueConfig: multikueue-test (with worker1 and worker2)"
+    echo "  - MultiKueueCluster: multikueue-test-worker1"
+    echo "  - MultiKueueCluster: multikueue-test-worker2"
+    echo ""
+    echo "The MultiKueue setup is now ready for testing workload delegation across clusters."
+    
+    read -rp "Press Enter to cleanup."
+}
+
+# =============================================================================
+# MAIN EXECUTION
+# =============================================================================
+
+print_environment_info
+
+# Set up cleanup trap
+trap cleanup EXIT
+cleanup_stale_files
+
+# Ensure external CRDs are available
+echo "Setting up external CRDs..."
+
+# Set up clusters and infrastructure
+startup
+prepare_docker_images
+wait # for clusters creation
+
+# Load images to clusters in parallel
+kind_load "$MANAGER_KIND_CLUSTER_NAME" "$MANAGER_KUBECONFIG" &
+kind_load "$WORKER1_KIND_CLUSTER_NAME" "$WORKER1_KUBECONFIG" &
+kind_load "$WORKER2_KIND_CLUSTER_NAME" "$WORKER2_KUBECONFIG" &
+wait # for libraries installation
+
+# Deploy Kueue to all clusters
+deploy_kueue_to_clusters
+
+# Set up MultiKueue configuration
+setup_multikueue
+
+# Restore the merged kubeconfig for tests
+export KUBECONFIG="$MANAGER_KUBECONFIG:$WORKER1_KUBECONFIG:$WORKER2_KUBECONFIG"
+
+print_completion_summary


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This sets up a MultiKueue configuration with 1 manager and 2 worker clusters. It also installs the relevant CRDs, secrets, and seeds the AdmissionCheck, MultiKueueConfig for me. To run this, I run `make kind-image-build setup-multikueue-env PLATFORMS=linux/arm64`

To confirm success of setup, I ran:
```
Amys-MacBook-Pro:kueue amychen$ kubectl describe multikueuecluster multikueue-test-worker1 --kubeconfig "/Users/amychen/Gopath/src/github.com/kubernetes-sigs/kueue/bin/kubeconfig-kind-manager"
Name:         multikueue-test-worker1
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  kueue.x-k8s.io/v1beta1
Kind:         MultiKueueCluster
Metadata:
  Creation Timestamp:  2025-07-22T03:56:07Z
  Generation:          1
  Resource Version:    1125
  UID:                 b7d799f0-480c-4358-bfd3-d4bd76b0eca9
Spec:
  Kube Config:
    Location:       worker1-secret
    Location Type:  Secret
Status:
  Conditions:
    Last Transition Time:  2025-07-22T03:56:07Z
    Message:               Connected
    Observed Generation:   1
    Reason:                Active
    Status:                True
    Type:                  Active
Events:                    <none>
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6036

#### Special notes for your reviewer:
I will make a followup issue that dedupes the common functions for `setup-multikueue.sh` and `multikueue-e2e-test.sh`. I didn't do it in this PR because the diff was already large, and I didn't want to also touch code that already exists. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```