### PR TITLE
Allow to rank-order pods in grouped podsets

### DIFF
--- a/pkg/cache/tas_flavor_snapshot.go
+++ b/pkg/cache/tas_flavor_snapshot.go
@@ -348,6 +348,7 @@ type TASPodSetRequests struct {
 	Count             int32
 	Flavor            kueue.ResourceFlavorReference
 	Implied           bool
+	PodSetGroupName   *string
 }
 
 func (t *TASPodSetRequests) TotalRequests() resources.Requests {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -208,7 +208,8 @@ func (r *Reconciler) podSets(lws *leaderworkersetv1.LeaderWorkerSet) ([]kueue.Po
 		}
 		if features.Enabled(features.TopologyAwareScheduling) {
 			topologyRequest, err := jobframework.NewPodSetTopologyRequest(
-				&lws.Spec.LeaderWorkerTemplate.LeaderTemplate.ObjectMeta).Build()
+				&lws.Spec.LeaderWorkerTemplate.LeaderTemplate.ObjectMeta).PodIndexLabel(
+				ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).Build()
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -179,6 +180,37 @@ func (r *topologyUngater) Reconcile(ctx context.Context, req reconcile.Request) 
 
 	psNameToTopologyRequest := workload.PodSetNameToTopologyRequest(wl)
 	allToUngate := make([]podWithUngateInfo, 0)
+	groupedPodSetAssignments := make(map[string][]*kueue.PodSetAssignment)
+
+	for i, psa := range wl.Status.Admission.PodSetAssignments {
+		groupName := strconv.Itoa(i)
+		if psNameToTopologyRequest[psa.Name] != nil && psNameToTopologyRequest[psa.Name].PodSetGroupName != nil {
+			groupName = *psNameToTopologyRequest[psa.Name].PodSetGroupName
+		}
+		groupedPodSetAssignments[groupName] = append(groupedPodSetAssignments[groupName], &psa)
+	}
+
+	rankOffsets := make(map[kueue.PodSetReference]int32)
+	maxRank := make(map[kueue.PodSetReference]int32)
+
+	for _, psas := range groupedPodSetAssignments {
+		if len(psas) > 1 {
+
+			leader := psas[0]
+			workers := psas[1]
+			if *leader.Count > *workers.Count {
+				leader = psas[1]
+				workers = psas[0]
+			}
+			rankOffsets[leader.Name] = 0
+			rankOffsets[workers.Name] = *leader.Count
+			maxRank[leader.Name] = *leader.Count
+			maxRank[workers.Name] = *workers.Count + *leader.Count
+		} else {
+			rankOffsets[psas[0].Name] = 0
+			maxRank[psas[0].Name] = *psas[0].Count
+		}
+	}
 	for _, psa := range wl.Status.Admission.PodSetAssignments {
 		if psa.TopologyAssignment != nil {
 			pods, err := r.podsForPodSet(ctx, wl.Namespace, wl.Name, psa.Name)
@@ -186,7 +218,7 @@ func (r *topologyUngater) Reconcile(ctx context.Context, req reconcile.Request) 
 				log.Error(err, "failed to list Pods for PodSet", "podset", psa.Name, "count", psa.Count)
 				return reconcile.Result{}, err
 			}
-			gatedPodsToDomains := assignGatedPodsToDomains(log, &psa, pods, psNameToTopologyRequest[psa.Name])
+			gatedPodsToDomains := assignGatedPodsToDomains(log, &psa, pods, psNameToTopologyRequest[psa.Name], rankOffsets[psa.Name], maxRank[psa.Name])
 			if len(gatedPodsToDomains) > 0 {
 				toUngate := podsToUngateInfo(&psa, gatedPodsToDomains)
 				log.V(2).Info("identified pods to ungate for podset", "podset", psa.Name, "count", len(toUngate))
@@ -289,8 +321,10 @@ func assignGatedPodsToDomains(
 	log logr.Logger,
 	psa *kueue.PodSetAssignment,
 	pods []*corev1.Pod,
-	psReq *kueue.PodSetTopologyRequest) []podWithDomain {
-	if rankToGatedPod, ok := readRanksIfAvailable(log, psa, pods, psReq); ok {
+	psReq *kueue.PodSetTopologyRequest,
+	offset int32,
+	maxRank int32) []podWithDomain {
+	if rankToGatedPod, ok := readRanksIfAvailable(log, psa, pods, psReq, offset, maxRank); ok {
 		return assignGatedPodsToDomainsByRanks(psa, rankToGatedPod)
 	}
 	return assignGatedPodsToDomainsGreedy(log, psa, pods)
@@ -367,11 +401,13 @@ func assignGatedPodsToDomainsGreedy(
 func readRanksIfAvailable(log logr.Logger,
 	psa *kueue.PodSetAssignment,
 	pods []*corev1.Pod,
-	psReq *kueue.PodSetTopologyRequest) (map[int]*corev1.Pod, bool) {
+	psReq *kueue.PodSetTopologyRequest,
+	offset int32,
+	maxRank int32) (map[int]*corev1.Pod, bool) {
 	if psReq == nil || psReq.PodIndexLabel == nil {
 		return nil, false
 	}
-	result, err := readRanksForLabels(psa, pods, psReq)
+	result, err := readRanksForLabels(psa, pods, psReq, offset, maxRank)
 	if err != nil {
 		log.Error(err, "failed to read rank information from Pods")
 		return nil, false
@@ -382,7 +418,9 @@ func readRanksIfAvailable(log logr.Logger,
 func readRanksForLabels(
 	psa *kueue.PodSetAssignment,
 	pods []*corev1.Pod,
-	psReq *kueue.PodSetTopologyRequest) (map[int]*corev1.Pod, error) {
+	psReq *kueue.PodSetTopologyRequest,
+	offset int32,
+	maxRank int32) (map[int]*corev1.Pod, error) {
 	result := make(map[int]*corev1.Pod)
 	podSetSize := int(*psa.Count)
 	singleJobSize := podSetSize
@@ -391,12 +429,12 @@ func readRanksForLabels(
 	}
 
 	for _, pod := range pods {
-		podIndex, err := utilpod.ReadUIntFromLabelBelowBound(pod, *psReq.PodIndexLabel, singleJobSize)
+		podIndex, err := utilpod.ReadUIntFromLabelBelowBound(pod, *psReq.PodIndexLabel, int(maxRank))
 		if err != nil {
 			// the Pod has no rank information - ranks cannot be used
 			return nil, err
 		}
-		rank := *podIndex
+		rank := *podIndex - int(offset)
 		if psReq.SubGroupIndexLabel != nil {
 			jobIndex, err := utilpod.ReadUIntFromLabelBelowBound(pod, *psReq.SubGroupIndexLabel, int(*psReq.SubGroupCount))
 			if err != nil {
@@ -408,12 +446,15 @@ func readRanksForLabels(
 				// supported by the rank-based ordering of pods.
 				return nil, fmt.Errorf("pod index %v of Pod %q exceeds the single Job size: %v", *podIndex, klog.KObj(pod), singleJobSize)
 			}
-			rank = *podIndex + *jobIndex*singleJobSize
+			rank = *podIndex + *jobIndex*singleJobSize - int(offset)
 		}
 		if rank >= podSetSize {
 			// the rank exceeds the PodSet size, this scenario is not supported
 			// by the rank-based ordering of pods.
 			return nil, fmt.Errorf("rank %v of Pod %q exceeds PodSet size %v", rank, klog.KObj(pod), podSetSize)
+		}
+		if rank < 0 {
+			return nil, fmt.Errorf("rank %v of Pod %q is below 0", rank, klog.KObj(pod))
 		}
 		if _, found := result[rank]; found {
 			// there is a conflict in ranks, they cannot be used

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -104,6 +104,11 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 			}
 		}
 	}
+	var podSetGroupName *string
+	if podSet.TopologyRequest != nil {
+		podSetGroupName = podSet.TopologyRequest.PodSetGroupName
+	}
+
 	return &cache.TASPodSetRequests{
 		Count:             podCount,
 		SinglePodRequests: singlePodRequests,
@@ -111,6 +116,7 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 		PodSetUpdates:     podSetUpdates,
 		Flavor:            *tasFlvr,
 		Implied:           isTASImplied,
+		PodSetGroupName:   podSetGroupName,
 	}, nil
 }
 

--- a/test/e2e/tas/leaderworkerset_test.go
+++ b/test/e2e/tas/leaderworkerset_test.go
@@ -168,4 +168,122 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for LeaderWorkerSet", func() {
 		},
 		)
 	})
+
+	ginkgo.When("creating a LeaderWorkerSet with leader", func() {
+		ginkgo.It("should place pods based on the ranks-ordering", func() {
+			const (
+				replicas = int32(2)
+				size     = int32(3)
+			)
+
+			podsTotalCount := replicas * size
+
+			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
+				Replicas(replicas).
+				Size(size).
+				Queue(localQueue.Name).
+				WorkerTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							kueuealpha.PodSetRequiredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "c",
+								Image: util.GetAgnHostImage(),
+								Args:  util.BehaviorWaitForDeletion,
+								Resources: corev1.ResourceRequirements{
+									Limits: map[corev1.ResourceName]resource.Quantity{
+										extraResource: resource.MustParse("1"),
+									},
+									Requests: map[corev1.ResourceName]resource.Quantity{
+										extraResource: resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				}).
+				LeaderTemplate(
+					corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								kueuealpha.PodSetRequiredTopologyAnnotation: testing.DefaultBlockTopologyLevel,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "c",
+									Image: util.GetAgnHostImage(),
+									Args:  util.BehaviorWaitForDeletion,
+									Resources: corev1.ResourceRequirements{
+										Limits: map[corev1.ResourceName]resource.Quantity{
+											extraResource: resource.MustParse("1"),
+										},
+										Requests: map[corev1.ResourceName]resource.Quantity{
+											extraResource: resource.MustParse("1"),
+										},
+									},
+								},
+							},
+						},
+					}).
+				TerminationGracePeriod(1).
+				Obj()
+			ginkgo.By("Creating a LeaderWorkerSet", func() {
+				util.MustCreate(ctx, k8sClient, lws)
+			})
+
+			ginkgo.By("Waiting for replicas to be ready", func() {
+				createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+					g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(replicas))
+					g.Expect(createdLeaderWorkerSet.Status.Conditions).To(testing.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			pods := &corev1.PodList{}
+			ginkgo.By("ensure all pods are scheduled", func() {
+				listOpts := &client.ListOptions{
+					FieldSelector: fields.OneTermNotEqualSelector("spec.nodeName", ""),
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), listOpts)).To(gomega.Succeed())
+					g.Expect(pods.Items).Should(gomega.HaveLen(int(podsTotalCount)))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verify the assignment of pods are as expected with rank-based ordering", func() {
+				gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+				gotAssignment := make(map[string]string, podsTotalCount)
+				for _, pod := range pods.Items {
+					index := fmt.Sprintf("%s/%s", pod.Labels[leaderworkersetv1.GroupIndexLabelKey], pod.Labels[leaderworkersetv1.WorkerIndexLabelKey])
+					gotAssignment[index] = pod.Spec.NodeName
+				}
+				gomega.Expect(gotAssignment).Should(gomega.Or(
+					gomega.BeComparableTo(map[string]string{
+						"0/0": "kind-worker",
+						"0/1": "kind-worker2",
+						"0/2": "kind-worker3",
+						"1/0": "kind-worker5",
+						"1/1": "kind-worker6",
+						"1/2": "kind-worker7",
+					}),
+					gomega.BeComparableTo(map[string]string{
+						"1/0": "kind-worker",
+						"1/1": "kind-worker2",
+						"1/2": "kind-worker3",
+						"0/0": "kind-worker5",
+						"0/1": "kind-worker6",
+						"0/2": "kind-worker7",
+					}),
+				))
+			})
+		},
+		)
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

As part of the broader task to allow co-location of leader with workers in LeaderWorkerSet (and similar workload types), Kueue has to be able to rank-order pods whose indexes do not start from 0.

LeaderWorkerSet is one of such example, where all pods (both leader and workers) in a single replica are counted consecutively which now result in Kueue falling back to greedy rank assignment.

This PR allows topology ungater to interpret 2 grouped PodSets and order their pods based on their ranks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```