### PR TITLE
Move LocalQueueReference type to utils

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -40,8 +40,8 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 	"sigs.k8s.io/kueue/pkg/metrics"
-	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/resources"
+	"sigs.k8s.io/kueue/pkg/util/queue"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -41,8 +41,8 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
-	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/resources"
+	"sigs.k8s.io/kueue/pkg/util/queue"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/workload"
 )

--- a/pkg/cache/clusterqueue.go
+++ b/pkg/cache/clusterqueue.go
@@ -36,10 +36,10 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/hierarchy"
 	"sigs.k8s.io/kueue/pkg/metrics"
-	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	"sigs.k8s.io/kueue/pkg/util/api"
+	"sigs.k8s.io/kueue/pkg/util/queue"
 	stringsutils "sigs.k8s.io/kueue/pkg/util/strings"
 	"sigs.k8s.io/kueue/pkg/workload"
 )

--- a/pkg/cache/localqueue.go
+++ b/pkg/cache/localqueue.go
@@ -21,8 +21,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"sigs.k8s.io/kueue/pkg/queue"
 	"sigs.k8s.io/kueue/pkg/resources"
+	"sigs.k8s.io/kueue/pkg/util/queue"
 )
 
 type LocalQueue struct {

--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/queue"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 )
 
 func ApplyDefaultForSuspend(ctx context.Context, job GenericJob, k8sClient client.Client,
@@ -102,7 +103,7 @@ func ApplyDefaultForManagedBy(job GenericJob, queues *queue.Manager, cache *cach
 			if !found {
 				return
 			}
-			clusterQueueName, ok := queues.ClusterQueueFromLocalQueue(queue.NewLocalQueueReference(job.Object().GetNamespace(), kueue.LocalQueueName(localQueueName)))
+			clusterQueueName, ok := queues.ClusterQueueFromLocalQueue(utilqueue.NewLocalQueueReference(job.Object().GetNamespace(), kueue.LocalQueueName(localQueueName)))
 			if !ok {
 				log.V(5).Info("Cluster queue for local queue not found", "localQueueName", localQueueName)
 				return

--- a/pkg/queue/local_queue.go
+++ b/pkg/queue/local_queue.go
@@ -17,53 +17,14 @@ limitations under the License.
 package queue
 
 import (
-	"fmt"
-	"strings"
-
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/util/queue"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
-// LocalQueueReference is the full reference to LocalQueue formed as <namespace>/< kueue.LocalQueueName >.
-type LocalQueueReference string
-
-func NewLocalQueueReference(namespace string, name kueue.LocalQueueName) LocalQueueReference {
-	return LocalQueueReference(namespace + "/" + string(name))
-}
-
-func ParseLocalQueueReference(ref LocalQueueReference) (string, kueue.LocalQueueName, error) {
-	parts := strings.Split(string(ref), "/")
-	if len(parts) != 2 {
-		return "", "", fmt.Errorf("invalid LocalQueueReference %s", ref)
-	}
-	return parts[0], kueue.LocalQueueName(parts[1]), nil
-}
-
-func MustParseLocalQueueReference(ref LocalQueueReference) (string, kueue.LocalQueueName) {
-	namespace, name, err := ParseLocalQueueReference(ref)
-	if err != nil {
-		panic(err)
-	}
-	return namespace, name
-}
-
-// Key is the key used to index the queue.
-func Key(q *kueue.LocalQueue) LocalQueueReference {
-	return NewLocalQueueReference(q.Namespace, kueue.LocalQueueName(q.Name))
-}
-
-func KeyFromWorkload(w *kueue.Workload) LocalQueueReference {
-	return NewLocalQueueReference(w.Namespace, w.Spec.QueueName)
-}
-
-func DefaultQueueKey(namespace string) LocalQueueReference {
-	return NewLocalQueueReference(namespace, constants.DefaultLocalQueueName)
-}
-
 // LocalQueue is the internal implementation of kueue.LocalQueue.
 type LocalQueue struct {
-	Key          LocalQueueReference
+	Key          queue.LocalQueueReference
 	ClusterQueue kueue.ClusterQueueReference
 
 	items map[workload.Reference]*workload.Info
@@ -71,7 +32,7 @@ type LocalQueue struct {
 
 func newLocalQueue(q *kueue.LocalQueue) *LocalQueue {
 	qImpl := &LocalQueue{
-		Key:   Key(q),
+		Key:   queue.Key(q),
 		items: make(map[workload.Reference]*workload.Info),
 	}
 	qImpl.update(q)
@@ -94,7 +55,7 @@ func (m *Manager) PendingActiveInLocalQueue(lq *LocalQueue) int {
 		return 0
 	}
 	for _, wl := range c.heap.List() {
-		wlLqKey := KeyFromWorkload(wl.Obj)
+		wlLqKey := queue.KeyFromWorkload(wl.Obj)
 		if wlLqKey == lq.Key {
 			result++
 		}
@@ -112,7 +73,7 @@ func (m *Manager) PendingInadmissibleInLocalQueue(lq *LocalQueue) int {
 	}
 	result := 0
 	for _, wl := range c.inadmissibleWorkloads {
-		wlLqKey := KeyFromWorkload(wl.Obj)
+		wlLqKey := queue.KeyFromWorkload(wl.Obj)
 		if wlLqKey == lq.Key {
 			result++
 		}

--- a/pkg/visibility/api/v1beta1/pending_workloads_lq.go
+++ b/pkg/visibility/api/v1beta1/pending_workloads_lq.go
@@ -31,6 +31,7 @@ import (
 	visibility "sigs.k8s.io/kueue/apis/visibility/v1beta1"
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/queue"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 
 	_ "k8s.io/metrics/pkg/apis/metrics/install"
 )
@@ -71,7 +72,7 @@ func (m *pendingWorkloadsInLqREST) Get(ctx context.Context, name string, opts ru
 
 	namespace := genericapirequest.NamespaceValue(ctx)
 	lqName := kueue.LocalQueueName(name)
-	cqName, ok := m.queueMgr.ClusterQueueFromLocalQueue(queue.NewLocalQueueReference(namespace, lqName))
+	cqName, ok := m.queueMgr.ClusterQueueFromLocalQueue(utilqueue.NewLocalQueueReference(namespace, lqName))
 	if !ok {
 		return nil, errors.NewNotFound(visibility.Resource("localqueue"), name)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

This is a follow-up to #5933 to remove the duplicated type introduced in that PR.
See: https://github.com/kubernetes-sigs/kueue/pull/5933#discussion_r2228884061

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to  #5933

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```