### PR TITLE
Fix workload slices when creation timestamps collide

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -311,7 +311,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 		// Evict old workload-slice if any. Note: that oldWorkloadSlice is not nil only if
 		// this is a workload-slice enabled workload and there is an old slice to evict.
 		if features.Enabled(features.ElasticJobsViaWorkloadSlices) && oldWorkloadSlice != nil {
-			if err := s.replaceWorkloadSlice(ctx, oldWorkloadSlice.WorkloadInfo.ClusterQueue, e.Obj, oldWorkloadSlice.WorkloadInfo.Obj); err != nil {
+			if err := s.replaceWorkloadSlice(ctx, oldWorkloadSlice.WorkloadInfo.ClusterQueue, e.Obj, oldWorkloadSlice.WorkloadInfo.Obj.DeepCopy()); err != nil {
 				log.Error(err, "Failed to aggregate workload slice")
 				continue
 			}

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -233,6 +233,23 @@ func TestFindNotFinishedWorkloads(t *testing.T) {
 				*testWorkload("test-2", testJobObject.Name, testJobObject.UID, now).Obj(),
 			},
 		},
+		"TwoActiveWorkloadsSelectNotReplaced": {
+			args: args{
+				ctx: t.Context(),
+				clnt: testWorkloadClientBuilder().WithLists(&kueue.WorkloadList{
+					Items: []kueue.Workload{
+						*testWorkload("test-2", testJobObject.Name, testJobObject.UID, now).
+							Annotation(WorkloadSliceReplacementFor, string(workload.NewReference("default", "test-2"))).Obj(),
+						*testWorkload("test-1", testJobObject.Name, testJobObject.UID, now).Obj(),
+					},
+				}).Build(),
+				jobObject:    testJobObject,
+				jobObjectGVK: testJobGVK,
+			},
+			want: []kueue.Workload{
+				*testWorkload("test-1", testJobObject.Name, testJobObject.UID, now).Obj(),
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6161

#### Special notes for your reviewer:

An alternative fix to https://github.com/kubernetes-sigs/kueue/pull/6194 proposed for #6161

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```