### PR TITLE
doc: Update supported FG names

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -265,36 +265,39 @@ spec:
 
 ### Feature gates for alpha and beta features
 
-| Feature                               | Default | Stage | Since | Until |
-| ------------------------------------- | ------- | ----- | ----- | ----- |
-| `FlavorFungibility`                   | `true`  | Beta  | 0.5   |       |
-| `MultiKueue`                          | `false` | Alpha | 0.6   | 0.8   |
-| `MultiKueue`                          | `true`  | Beta  | 0.9   |       |
-| `MultiKueueBatchJobWithManagedBy`     | `false` | Alpha | 0.8   |       |
-| `PartialAdmission`                    | `false` | Alpha | 0.4   | 0.4   |
-| `PartialAdmission`                    | `true`  | Beta  | 0.5   |       |
-| `ProvisioningACC`                     | `false` | Alpha | 0.5   | 0.6   |
-| `ProvisioningACC`                     | `true`  | Beta  | 0.7   |       |
-| `QueueVisibility`                     | `false` | Alpha | 0.5   | 0.9   |
-| `VisibilityOnDemand`                  | `false` | Alpha | 0.6   | 0.8   |
-| `VisibilityOnDemand`                  | `true`  | Beta  | 0.9   |       |
-| `PrioritySortingWithinCohort`         | `true`  | Beta  | 0.6   |       |
-| `LendingLimit`                        | `false` | Alpha | 0.6   | 0.8   |
-| `LendingLimit`                        | `true`  | Beta  | 0.9   |       |
-| `TopologyAwareScheduling`             | `false` | Alpha | 0.9   |       |
-| `ConfigurableResourceTransformations` | `false` | Alpha | 0.9   | 0.9   |
-| `ConfigurableResourceTransformations` | `true`  | Beta  | 0.10  |       |
-| `ManagedJobsNamespaceSelector`        | `true`  | Beta  | 0.10  | 0.13  |
-| `LocalQueueDefaulting`                | `false` | Alpha | 0.10  | 0.11  |
-| `LocalQueueDefaulting`                | `true`  | Beta  | 0.12  |       |
-| `LocalQueueMetrics`                   | `false` | Alpha | 0.10  |       |
-| `HierarchicalCohort`                  | `true`  | Beta  | 0.11  |       |
-| `ObjectRetentionPolicies`             | `false` | Alpha | 0.12  | 0.12  |
-| `ObjectRetentionPolicies`             | `true`  | Beta  | 0.13  |       |
-| `TASFailedNodeReplacement`            | `false` | Alpha | 0.12  |       |
-| `AdmissionFairSharing`                | `false` | Alpha | 0.12  |       |
-| `TASFailedNodeReplacementFailFast`    | `false` | Alpha | 0.12  |       |
-| `TASReplaceNodeOnPodTermination`      | `false` | Alpha | 0.13  |       |
+| Feature                                       | Default | Stage | Since | Until |
+|-----------------------------------------------|---------|-------|-------|-------|
+| `FlavorFungibility`                           | `true`  | Beta  | 0.5   |       |
+| `MultiKueue`                                  | `false` | Alpha | 0.6   | 0.8   |
+| `MultiKueue`                                  | `true`  | Beta  | 0.9   |       |
+| `MultiKueueBatchJobWithManagedBy`             | `false` | Alpha | 0.8   |       |
+| `PartialAdmission`                            | `false` | Alpha | 0.4   | 0.4   |
+| `PartialAdmission`                            | `true`  | Beta  | 0.5   |       |
+| `ProvisioningACC`                             | `false` | Alpha | 0.5   | 0.6   |
+| `ProvisioningACC`                             | `true`  | Beta  | 0.7   |       |
+| `QueueVisibility`                             | `false` | Alpha | 0.5   | 0.9   |
+| `VisibilityOnDemand`                          | `false` | Alpha | 0.6   | 0.8   |
+| `VisibilityOnDemand`                          | `true`  | Beta  | 0.9   |       |
+| `PrioritySortingWithinCohort`                 | `true`  | Beta  | 0.6   |       |
+| `LendingLimit`                                | `false` | Alpha | 0.6   | 0.8   |
+| `LendingLimit`                                | `true`  | Beta  | 0.9   |       |
+| `TopologyAwareScheduling`                     | `false` | Alpha | 0.9   |       |
+| `ConfigurableResourceTransformations`         | `false` | Alpha | 0.9   | 0.9   |
+| `ConfigurableResourceTransformations`         | `true`  | Beta  | 0.10  |       |
+| `ManagedJobsNamespaceSelector`                | `true`  | Beta  | 0.10  | 0.13  |
+| `LocalQueueDefaulting`                        | `false` | Alpha | 0.10  | 0.11  |
+| `LocalQueueDefaulting`                        | `true`  | Beta  | 0.12  |       |
+| `LocalQueueMetrics`                           | `false` | Alpha | 0.10  |       |
+| `HierarchicalCohort`                          | `true`  | Beta  | 0.11  |       |
+| `ObjectRetentionPolicies`                     | `false` | Alpha | 0.12  | 0.12  |
+| `ObjectRetentionPolicies`                     | `true`  | Beta  | 0.13  |       |
+| `TASFailedNodeReplacement`                    | `false` | Alpha | 0.12  |       |
+| `AdmissionFairSharing`                        | `false` | Alpha | 0.12  |       |
+| `TASFailedNodeReplacementFailFast`            | `false` | Alpha | 0.12  |       |
+| `TASReplaceNodeOnPodTermination`              | `false` | Alpha | 0.13  |       |
+| `ElasticJobsViaWorkloadSlices`                | `false` | Alpha | 0.13  |       |
+| `ManagedJobsNamespaceSelectorAlwaysRespected` | `false` | Alpha | 0.13  |       |
+| `FlavorFungibilityImplicitPreferenceDefault`  | `false` | Alpha | 0.13  |       |
 
 ### Feature gates for graduated or deprecated features
 

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -265,38 +265,39 @@ spec:
 
 ### Alpha 和 Beta 级别特性的特性门控 {#feature-gates-for-alpha-and-beta-features}
 
-| 功能                                  | 默认值   | 阶段  | 起始版本| 截止版本|
-| ------------------------------------- | ------- | ----- | ----- | ----- |
-| `FlavorFungibility`                   | `true`  | Beta  | 0.5   |       |
-| `MultiKueue`                          | `false` | Alpha | 0.6   | 0.8   |
-| `MultiKueue`                          | `true`  | Beta  | 0.9   |       |
-| `MultiKueueBatchJobWithManagedBy`     | `false` | Alpha | 0.8   |       |
-| `PartialAdmission`                    | `false` | Alpha | 0.4   | 0.4   |
-| `PartialAdmission`                    | `true`  | Beta  | 0.5   |       |
-| `ProvisioningACC`                     | `false` | Alpha | 0.5   | 0.6   |
-| `ProvisioningACC`                     | `true`  | Beta  | 0.7   |       |
-| `QueueVisibility`                     | `false` | Alpha | 0.5   | 0.9   |
-| `VisibilityOnDemand`                  | `false` | Alpha | 0.6   | 0.8   |
-| `VisibilityOnDemand`                  | `true`  | Beta  | 0.9   |       |
-| `PrioritySortingWithinCohort`         | `true`  | Beta  | 0.6   |       |
-| `LendingLimit`                        | `false` | Alpha | 0.6   | 0.8   |
-| `LendingLimit`                        | `true`  | Beta  | 0.9   |       |
-| `TopologyAwareScheduling`             | `false` | Alpha | 0.9   |       |
-| `ConfigurableResourceTransformations` | `false` | Alpha | 0.9   | 0.9   |
-| `ConfigurableResourceTransformations` | `true`  | Beta  | 0.10  |       |
-| `WorkloadResourceRequestsSummary`     | `false` | Alpha | 0.9   | 0.9   |
-| `WorkloadResourceRequestsSummary`     | `true`  | Beta  | 0.10  | 0.10  |
-| `ManagedJobsNamespaceSelector`        | `true`  | Beta  | 0.10  | 0.13  |
-| `LocalQueueDefaulting`                | `false` | Alpha | 0.10  | 0.11  |
-| `LocalQueueDefaulting`                | `true`  | Beta  | 0.12  |       |
-| `LocalQueueMetrics`                   | `false` | Alpha | 0.10  |       |
-| `HierarchicalCohort`                  | `true`  | Beta  | 0.11  |       |
-| `ObjectRetentionPolicies`             | `false` | Alpha | 0.12  | 0.12  |
-| `ObjectRetentionPolicies`             | `true`  | Beta  | 0.13  |       |
-| `TASFailedNodeReplacement`            | `false` | Alpha | 0.12  |       |
-| `AdmissionFairSharing`                | `false` | Alpha | 0.12  |       |
-| `TASFailedNodeReplacementFailFast`    | `false` | Alpha | 0.12  |       |
-| `TASReplaceNodeOnPodTermination`      | `false` | Alpha | 0.13  |       |
+| 功能                                            | 默认值     | 阶段    | 起始版本 | 截止版本 |
+|-----------------------------------------------|---------|-------|------|------|
+| `FlavorFungibility`                           | `true`  | Beta  | 0.5  |      |
+| `MultiKueue`                                  | `false` | Alpha | 0.6  | 0.8  |
+| `MultiKueue`                                  | `true`  | Beta  | 0.9  |      |
+| `MultiKueueBatchJobWithManagedBy`             | `false` | Alpha | 0.8  |      |
+| `PartialAdmission`                            | `false` | Alpha | 0.4  | 0.4  |
+| `PartialAdmission`                            | `true`  | Beta  | 0.5  |      |
+| `ProvisioningACC`                             | `false` | Alpha | 0.5  | 0.6  |
+| `ProvisioningACC`                             | `true`  | Beta  | 0.7  |      |
+| `QueueVisibility`                             | `false` | Alpha | 0.5  | 0.9  |
+| `VisibilityOnDemand`                          | `false` | Alpha | 0.6  | 0.8  |
+| `VisibilityOnDemand`                          | `true`  | Beta  | 0.9  |      |
+| `PrioritySortingWithinCohort`                 | `true`  | Beta  | 0.6  |      |
+| `LendingLimit`                                | `false` | Alpha | 0.6  | 0.8  |
+| `LendingLimit`                                | `true`  | Beta  | 0.9  |      |
+| `TopologyAwareScheduling`                     | `false` | Alpha | 0.9  |      |
+| `ConfigurableResourceTransformations`         | `false` | Alpha | 0.9  | 0.9  |
+| `ConfigurableResourceTransformations`         | `true`  | Beta  | 0.10 |      |
+| `ManagedJobsNamespaceSelector`                | `true`  | Beta  | 0.10 | 0.13 |
+| `LocalQueueDefaulting`                        | `false` | Alpha | 0.10 | 0.11 |
+| `LocalQueueDefaulting`                        | `true`  | Beta  | 0.12 |      |
+| `LocalQueueMetrics`                           | `false` | Alpha | 0.10 |      |
+| `HierarchicalCohort`                          | `true`  | Beta  | 0.11 |      |
+| `ObjectRetentionPolicies`                     | `false` | Alpha | 0.12 | 0.12 |
+| `ObjectRetentionPolicies`                     | `true`  | Beta  | 0.13 |      |
+| `TASFailedNodeReplacement`                    | `false` | Alpha | 0.12 |      |
+| `AdmissionFairSharing`                        | `false` | Alpha | 0.12 |      |
+| `TASFailedNodeReplacementFailFast`            | `false` | Alpha | 0.12 |      |
+| `TASReplaceNodeOnPodTermination`              | `false` | Alpha | 0.13 |      |
+| `ElasticJobsViaWorkloadSlices`                | `false` | Alpha | 0.13 |      |
+| `ManagedJobsNamespaceSelectorAlwaysRespected` | `false` | Alpha | 0.13 |      |
+| `FlavorFungibilityImplicitPreferenceDefault`  | `false` | Alpha | 0.13 |      |
 
 ### 已毕业或已弃用特性的特性门控 {#feature-gates-for-graduated-or-deprecated-features}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

I added the following missing FGs to installation docs:

- `ElasticJobsViaWorkloadSlices`
- `ManagedJobsNamespaceSelectorAlwaysRespected`
- `FlavorFungibilityImplicitPreferenceDefault`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```