### PR TITLE
FlavorFungibility: update documentation for FlavorFungibilityImplicitPreferenceDefault

### DIFF
--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -479,9 +479,10 @@ When there is not enough nominal quota of resources in a ResourceFlavor, the
 incoming Workload can borrow quota or preempt running Workloads in the
 ClusterQueue or Cohort. In the ClusterQueue there can be multiple Flavors
 for each resource, with potentially different amounts of quota available in each
-Kueue evaluates the flavors in a ClusterQueue in order and for each it
+Kueue evaluates the Flavors in a ClusterQueue in order and for each it
 checks if the required resource of the workload fits in this ResourceFlavor and
-if borrowing or preemption is required. You can influence the Flavor selection process by configuring the `flavorFungibility` field.
+if borrowing or preemption is required. You can influence the Flavor selection
+process by configuring the `flavorFungibility` field.
 
 A configuration for a ClusterQueue that configures this behavior looks like the following:
 
@@ -511,10 +512,11 @@ If during the search, the workload finds some ResourceFlavor in which it can fit
 without preemption or borrowing, such ResourceFlavor is immediately selected,
 regardless of the above configuration. Otherwise, out of the considered
 ResourceFlavors, Kueue selects a one that fits the workload using borrowing
-(without preemptions). If there is no such ResourceFlavor, Kueue selects a flavor
+(without preemptions). If there is no such ResourceFlavor, Kueue selects a Flavor
 that uses preemption and is preferably not borrowing.
 
-By default Kueue avoids preemptions and prefers borrowing when assigning flavors. Borrowing is not disruptive to other workloads but a
+By default Kueue avoids preemptions and prefers borrowing when assigning Flavors.
+Borrowing is not disruptive to other workloads but a
 workload that borrows risks being prempted (since it is using nominal quota
 from some other Cluster Queue). If you prefer to preempt rather than borrow when possible,
 you can enable the feature gate `FlavorFungibilityImplicitPreferenceDefault`, which

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -525,11 +525,11 @@ it assumes that preemption is preferred over borrowing and otherwise it assumes
 that borrowing is preferred over preemption.
 
 {{% alert title="Note" color="primary" %}}
-`FlavorFungibilityImplicitPreferenceDefault` is currently an alpha feature and is
-not enabled by default.
+`FlavorFungibilityImplicitPreferenceDefault` is currently an alpha feature,
+introduced to Kueue in version 0.13 and it is not enabled by default.
 
 To enable the feature, you have to set the `FlavorFungibilityImplicitPreferenceDefault`
-feature gate to `true`. This feature was introduced to Kueue in version 0.13. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration)
+feature gate to `true`. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration)
 guide for details on feature gate configuration.
 {{% /alert %}}
 

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -524,6 +524,16 @@ changes the default preference as follows: If `.spec.flavorFungibility.whenCanBo
 it assumes that preemption is preferred over borrowing and otherwise it assumes
 that borrowing is preferred over preemption.
 
+{{% alert title="Note" color="primary" %}}
+`FlavorFungibilityImplicitPreferenceDefault` is currently an alpha feature and is
+not enabled by default.
+
+To enable the feature, you have to set the `FlavorFungibilityImplicitPreferenceDefault`
+feature gate to `true`. This feature was introduced to Kueue in version 0.13. Check the [Installation](/docs/installation/#change-the-feature-gates-configuration)
+guide for details on feature gate configuration.
+{{% /alert %}}
+
+
 ## StopPolicy
 
 StopPolicy allows a cluster administrator to temporary stop the admission of workloads within a ClusterQueue by setting its value in the [spec](/docs/reference/kueue.v1beta1/#kueue-x-k8s-io-v1beta1-ClusterQueueSpec) like:

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -501,7 +501,7 @@ The fields above do the following:
 
 - `whenCanBorrow` defines what should happen if a workload can get enough resource by
 borrowing in current ResourceFlavor. The possible values are:
-  - `Borrow` (default): workload stops looking for a better assignment.
+  - `Borrow` (default): Kueue stops looking for a better assignment.
   - `TryNextFlavor`: workload tries the next ResourceFlavor.
 - `whenCanPreempt` defines what should happen if a workload can get enough resource by
 preempting in current ResourceFlavor. The possible values are:

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -505,8 +505,8 @@ borrowing in current ResourceFlavor. The possible values are:
   - `TryNextFlavor`: workload tries the next ResourceFlavor.
 - `whenCanPreempt` defines what should happen if a workload can get enough resource by
 preempting in current ResourceFlavor. The possible values are:
-  - `Preempt`: workload stops looking for a better assignment.
-  - `TryNextFlavor` (default): workload tries the next ResourceFlavor.
+  - `Preempt`: Kueue stops looking for a better assignment.
+  - `TryNextFlavor` (default): Kueue tries the next ResourceFlavor.
 
 If during the search, the workload finds some ResourceFlavor in which it can fit
 without preemption or borrowing, such ResourceFlavor is immediately selected,

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -520,7 +520,7 @@ Borrowing is not disruptive to other workloads but a
 workload that borrows risks being prempted (since it is using nominal quota
 from some other Cluster Queue). If you prefer to preempt rather than borrow when possible,
 you can enable the feature gate `FlavorFungibilityImplicitPreferenceDefault`, which
-changes the default preference as follows: If `whenCanBorrow = TryNextFlavor`
+changes the default preference as follows: If `.spec.flavorFungibility.whenCanBorrow` is `TryNextFlavor`,
 it assumes that preemption is preferred over borrowing and otherwise it assumes
 that borrowing is preferred over preemption.
 

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -477,12 +477,11 @@ the heuristics that Kueue implements to preempt as few Workloads as possible.
 
 When there is not enough nominal quota of resources in a ResourceFlavor, the
 incoming Workload can borrow quota or preempt running Workloads in the
-ClusterQueue or Cohort. In the ClusterQueue there can be multiple ResourceFlavors
-for each resource, and there might be different amounts of available quota in each
-of them. Kueue evaluates the flavors in a ClusterQueue in order and for each it
+ClusterQueue or Cohort. In the ClusterQueue there can be multiple Flavors
+for each resource, with potentially different amounts of quota available in each
+Kueue evaluates the flavors in a ClusterQueue in order and for each it
 checks if the required resource of the workload fits in this ResourceFlavor and
-if borrowing or preemption is required. You can influence how many flavors to
-consider by setting the `flavorFungibility` field.
+if borrowing or preemption is required. You can influence the Flavor selection process by configuring the `flavorFungibility` field.
 
 A configuration for a ClusterQueue that configures this behavior looks like the following:
 
@@ -499,28 +498,27 @@ spec:
 
 The fields above do the following:
 
-- `whenCanBorrow` what should happen if a workload can get enough resource by
+- `whenCanBorrow` defines what should happen if a workload can get enough resource by
 borrowing in current ResourceFlavor. The possible values are:
   - `Borrow` (default): workload stops looking for a better assignment.
   - `TryNextFlavor`: workload tries the next ResourceFlavor.
-- `whenCanPreempt` what should happen if a workload can get enough resource by
+- `whenCanPreempt` defines what should happen if a workload can get enough resource by
 preempting in current ResourceFlavor. The possible values are:
   - `Preempt`: workload stops looking for a better assignment.
   - `TryNextFlavor` (default): workload tries the next ResourceFlavor.
 
 If during the search, the workload finds some ResourceFlavor in which it can fit
-without preemption or borrowing, such ResourceFlavor is immediately selected
-(regardless of the above configuration). Otherwise, out of the considered
+without preemption or borrowing, such ResourceFlavor is immediately selected,
+regardless of the above configuration. Otherwise, out of the considered
 ResourceFlavors, Kueue selects a one that fits the workload using borrowing
 (without preemptions). If there is no such ResourceFlavor, Kueue selects a flavor
-that uses preemption and is preferably not using borrowing.
+that uses preemption and is preferably not borrowing.
 
-As explained above, when assigning flavors, by default Kueue avoids preemptions
-and prefers to borrow. Borrowing is not disruptive to other workloads but a
+By default Kueue avoids preemptions and prefers borrowing when assigning flavors. Borrowing is not disruptive to other workloads but a
 workload that borrows risks being prempted (since it is using nominal quota
-from some other Cluster Queue). If you prefer to sometimes preempt rather than borrow,
-you can enable feature gate `FlavorFungibilityImplicitPreferenceDefault`, which
-changes the default preference as follows. If `whenCanBorrow = TryNextFlavor`
+from some other Cluster Queue). If you prefer to preempt rather than borrow when possible,
+you can enable the feature gate `FlavorFungibilityImplicitPreferenceDefault`, which
+changes the default preference as follows: If `whenCanBorrow = TryNextFlavor`
 it assumes that preemption is preferred over borrowing and otherwise it assumes
 that borrowing is preferred over preemption.
 

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -477,8 +477,8 @@ the heuristics that Kueue implements to preempt as few Workloads as possible.
 
 When there is not enough nominal quota of resources in a ResourceFlavor, the
 incoming Workload can borrow quota or preempt running Workloads in the
-ClusterQueue or Cohort. In the ClusterQueue there can be multiple Flavors
-for each resource, with potentially different amounts of quota available in each
+ClusterQueue or Cohort. In the ClusterQueue, there can be multiple Flavors
+for each resource, with potentially different amounts of quota available in each.
 Kueue evaluates the Flavors in a ClusterQueue in order and for each it
 checks if the required resource of the workload fits in this ResourceFlavor and
 if borrowing or preemption is required. You can influence the Flavor selection
@@ -502,13 +502,13 @@ The fields above do the following:
 - `whenCanBorrow` defines what should happen if a workload can get enough resource by
 borrowing in current ResourceFlavor. The possible values are:
   - `Borrow` (default): Kueue stops looking for a better assignment.
-  - `TryNextFlavor`: workload tries the next ResourceFlavor.
+  - `TryNextFlavor`: Kueue tries the next ResourceFlavor.
 - `whenCanPreempt` defines what should happen if a workload can get enough resource by
 preempting in current ResourceFlavor. The possible values are:
   - `Preempt`: Kueue stops looking for a better assignment.
   - `TryNextFlavor` (default): Kueue tries the next ResourceFlavor.
 
-If during the search, the workload finds some ResourceFlavor in which it can fit
+If during the search, Kueue finds some ResourceFlavor in which it can fit
 without preemption or borrowing, such ResourceFlavor is immediately selected,
 regardless of the above configuration. Otherwise, out of the considered
 ResourceFlavors, Kueue selects a one that fits the workload using borrowing

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -477,10 +477,10 @@ the heuristics that Kueue implements to preempt as few Workloads as possible.
 
 When there is not enough nominal quota of resources in a ResourceFlavor, the
 incoming Workload can borrow quota or preempt running Workloads in the
-ClusterQueue or Cohort. In the cluster queue there can be multiple ResourceFlavors
+ClusterQueue or Cohort. In the ClusterQueue there can be multiple ResourceFlavors
 for each resource, and there might be different amounts of available quota in each
 of them. Kueue evaluates the flavors in a ClusterQueue in order and for each it
-checks if the required resource of the workload fit in this ResourceFlavor and
+checks if the required resource of the workload fits in this ResourceFlavor and
 if borrowing or preemption is required. You can influence how many flavors to
 consider by setting the `flavorFungibility` field.
 

--- a/site/content/en/docs/concepts/cluster_queue.md
+++ b/site/content/en/docs/concepts/cluster_queue.md
@@ -477,8 +477,8 @@ the heuristics that Kueue implements to preempt as few Workloads as possible.
 
 When there is not enough nominal quota of resources in a ResourceFlavor, the
 incoming Workload can borrow quota or preempt running Workloads in the
-ClusterQueue or Cohort. In the cluster queue there can be multiple ResourceFlavor
-for each resource, and there might be different amount of available quota in each
+ClusterQueue or Cohort. In the cluster queue there can be multiple ResourceFlavors
+for each resource, and there might be different amounts of available quota in each
 of them. Kueue evaluates the flavors in a ClusterQueue in order and for each it
 checks if the required resource of the workload fit in this ResourceFlavor and
 if borrowing or preemption is required. You can influence how many flavors to
@@ -512,15 +512,15 @@ If during the search, the workload finds some ResourceFlavor in which it can fit
 without preemption or borrowing, such ResourceFlavor is immediately selected
 (regardless of the above configuration). Otherwise, out of the considered
 ResourceFlavors, Kueue selects a one that fits the workload using borrowing
-(without preemptions). If there is no such ResourceFlavor, Kueue selects any
-flavor that fits the workload.
+(without preemptions). If there is no such ResourceFlavor, Kueue selects a flavor
+that uses preemption and is preferably not using borrowing.
 
 As explained above, when assigning flavors, by default Kueue avoids preemptions
 and prefers to borrow. Borrowing is not disruptive to other workloads but a
 workload that borrows risks being prempted (since it is using nominal quota
 from some other Cluster Queue). If you prefer to sometimes preempt rather than borrow,
-you can enable feature gate `FlavorFungibilityImplicitPreferenceDefault`.
-It changes the default preference as follows. If `whenCanBorrow = TryNextFlavor`
+you can enable feature gate `FlavorFungibilityImplicitPreferenceDefault`, which
+changes the default preference as follows. If `whenCanBorrow = TryNextFlavor`
 it assumes that preemption is preferred over borrowing and otherwise it assumes
 that borrowing is preferred over preemption.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6201

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```