### PR TITLE
Rename ClusterQueue functions to hide heap implementation details

### DIFF
--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -182,7 +182,7 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err := r.reconcileConsumedUsage(ctx, &queueObj); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
-		if err := r.queues.HeapifyClusterQueue(&cq, queueObj.Name); err != nil {
+		if err := r.queues.RebuildClusterQueue(&cq, queueObj.Name); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: r.admissionFSConfig.UsageSamplingInterval.Duration}, nil

--- a/pkg/queue/cluster_queue.go
+++ b/pkg/queue/cluster_queue.go
@@ -179,7 +179,7 @@ func (c *ClusterQueue) PushOrUpdate(wInfo *workload.Info) {
 	c.heap.PushOrUpdate(wInfo)
 }
 
-func (c *ClusterQueue) Heapify(lqName string) {
+func (c *ClusterQueue) RebuildLocalQueue(lqName string) {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
 	for _, wl := range c.heap.List() {
@@ -460,7 +460,7 @@ func queueOrderingFunc(ctx context.Context, c client.Client, wo workload.Orderin
 	}
 }
 
-func (c *ClusterQueue) HeapifyAll() {
+func (c *ClusterQueue) RebuildAll() {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
 	for _, wl := range c.heap.List() {

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -259,14 +259,14 @@ func (m *Manager) UpdateClusterQueue(ctx context.Context, cq *kueue.ClusterQueue
 	return nil
 }
 
-func (m *Manager) HeapifyClusterQueue(cq *kueue.ClusterQueue, lqName string) error {
+func (m *Manager) RebuildClusterQueue(cq *kueue.ClusterQueue, lqName string) error {
 	m.Lock()
 	defer m.Unlock()
 	cqImpl := m.hm.ClusterQueue(kueue.ClusterQueueReference(cq.Name))
 	if cqImpl == nil {
 		return ErrClusterQueueDoesNotExist
 	}
-	cqImpl.Heapify(lqName)
+	cqImpl.RebuildLocalQueue(lqName)
 	return nil
 }
 
@@ -808,7 +808,7 @@ func (m *Manager) queueSecondPass(ctx context.Context, w *kueue.Workload) {
 	}
 }
 
-func (m *Manager) HeapifyClusterQueuesWithEntryPenalties() {
+func (m *Manager) RebuildClusterQueuesWithEntryPenalties() {
 	m.Lock()
 	defer m.Unlock()
 
@@ -821,7 +821,7 @@ func (m *Manager) HeapifyClusterQueuesWithEntryPenalties() {
 
 	for cqName := range clusterQueuesWithPenalties {
 		if cq := m.hm.ClusterQueue(cqName); cq != nil {
-			cq.HeapifyAll()
+			cq.RebuildAll()
 		}
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -196,7 +196,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 
 	var snapshotOpts []cache.SnapshotOption
 	if features.Enabled(features.AdmissionFairSharing) {
-		s.queues.HeapifyClusterQueuesWithEntryPenalties()
+		s.queues.RebuildClusterQueuesWithEntryPenalties()
 		snapshotOpts = append(snapshotOpts, cache.WithAfsEntryPenalties(s.queues.GetAfsEntryPenalties()))
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Avoid leaking implementation details about heaps in the public API of a struct.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6243 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```