### PR TITLE
Automated cherry pick of #6300: Support disabling the client-side rate limiting

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -350,6 +350,8 @@ type InternalCertManagement struct {
 type ClientConnection struct {
 	// QPS controls the number of queries per second allowed for K8S api server
 	// connection.
+	//
+	// Setting this to a negative value will disable client-side ratelimiting.
 	QPS *float32 `json:"qps,omitempty"`
 
 	// Burst allows extra queries to accumulate when a client is exceeding its rate.

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -187,7 +187,11 @@ func main() {
 
 	// Set the RateLimiter here, otherwise the controller-runtime's typedClient will use a different RateLimiter
 	// for each API type.
-	kubeConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(*cfg.ClientConnection.QPS, int(*cfg.ClientConnection.Burst))
+	// When the controller-runtime > 0.21, the client-side ratelimiting will be disabled by default.
+	// The following QPS negative value chack allows us to disable the client-side ratelimiting.
+	if *cfg.ClientConnection.QPS >= 0.0 {
+		kubeConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(*cfg.ClientConnection.QPS, int(*cfg.ClientConnection.Burst))
+	}
 	setupLog.V(2).Info("K8S Client", "qps", *cfg.ClientConnection.QPS, "burst", *cfg.ClientConnection.Burst)
 	mgr, err := ctrl.NewManager(kubeConfig, options)
 	if err != nil {

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -187,10 +187,12 @@ func main() {
 
 	// Set the RateLimiter here, otherwise the controller-runtime's typedClient will use a different RateLimiter
 	// for each API type.
-	// When the controller-runtime > 0.21, the client-side ratelimiting will be disabled by default.
+	// When the controller-runtime <= 0.20, the client-side ratelimiting will be disabled only when a QPS has a negative value.
 	// The following QPS negative value chack allows us to disable the client-side ratelimiting.
 	if *cfg.ClientConnection.QPS >= 0.0 {
 		kubeConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(*cfg.ClientConnection.QPS, int(*cfg.ClientConnection.Burst))
+	} else {
+		kubeConfig.QPS = *cfg.ClientConnection.QPS
 	}
 	setupLog.V(2).Info("K8S Client", "qps", *cfg.ClientConnection.QPS, "burst", *cfg.ClientConnection.Burst)
 	mgr, err := ctrl.NewManager(kubeConfig, options)

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -75,6 +75,7 @@ Defaults to 1.</p>
 <td>
    <p>QPS controls the number of queries per second allowed for K8S api server
 connection.</p>
+<p>Setting this to a negative value will disable client-side ratelimiting.</p>
 </td>
 </tr>
 <tr><td><code>burst</code> <B>[Required]</B><br/>


### PR DESCRIPTION
Cherry pick of #6300 on release-0.12.

#6300: Support disabling the client-side rate limiting

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Support disabling client-side ratelimiting in Config API clientConnection.qps with a negative value (e.g., -1)
```