### PR TITLE
[Cleanup] Tests to use resource consts

### DIFF
--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -192,8 +192,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		ginkgo.It("Should create a pod on worker if admitted", func() {
 			pod := testingpod.MakePod("pod", managerNs.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
-				RequestAndLimit("cpu", "1").
-				RequestAndLimit("memory", "2G").
+				RequestAndLimit(corev1.ResourceCPU, "1").
+				RequestAndLimit(corev1.ResourceMemory, "2G").
 				Queue(managerLq.Name).
 				Obj()
 			// Since it requires 2G of memory, this pod can only be admitted in worker 2.
@@ -437,8 +437,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 			// Since it requires 2G of memory, this job can only be admitted in worker 2.
 			job := testingjob.MakeJob("job", managerNs.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
-				RequestAndLimit("cpu", "1").
-				RequestAndLimit("memory", "2G").
+				RequestAndLimit(corev1.ResourceCPU, "1").
+				RequestAndLimit(corev1.ResourceMemory, "2G").
 				TerminationGracePeriod(1).
 				// Give it the time to be observed Active in the live status update step.
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
@@ -531,8 +531,8 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 						Args: util.BehaviorWaitForDeletion,
 					},
 				).
-				RequestAndLimit("replicated-job-1", "cpu", "500m").
-				RequestAndLimit("replicated-job-1", "memory", "200M").
+				RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "500m").
+				RequestAndLimit("replicated-job-1", corev1.ResourceMemory, "200M").
 				Obj()
 
 			ginkgo.By("Creating the jobSet", func() {

--- a/test/e2e/singlecluster/fair_sharing_test.go
+++ b/test/e2e/singlecluster/fair_sharing_test.go
@@ -99,8 +99,8 @@ var _ = ginkgo.Describe("Fair Sharing", ginkgo.Ordered, ginkgo.ContinueOnFailure
 					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
 					Parallelism(3).
 					Completions(3).
-					RequestAndLimit("cpu", "1").
-					RequestAndLimit("memory", "200Mi").
+					RequestAndLimit(corev1.ResourceCPU, "1").
+					RequestAndLimit(corev1.ResourceMemory, "200Mi").
 					Obj()
 				util.MustCreate(ctx, k8sClient, job)
 			}

--- a/test/e2e/singlecluster/jobset_test.go
+++ b/test/e2e/singlecluster/jobset_test.go
@@ -82,8 +82,8 @@ var _ = ginkgo.Describe("JobSet", func() {
 						Completions: 2,
 					},
 				).
-				RequestAndLimit("replicated-job-1", "cpu", "500m").
-				RequestAndLimit("replicated-job-1", "memory", "200M").
+				RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "500m").
+				RequestAndLimit("replicated-job-1", corev1.ResourceMemory, "200M").
 				Obj()
 
 			ginkgo.By("Creating the jobSet", func() {
@@ -159,8 +159,8 @@ var _ = ginkgo.Describe("JobSet", func() {
 						Completions: 1,
 					},
 				).
-				RequestAndLimit("replicated-job-1", "cpu", "500m").
-				RequestAndLimit("replicated-job-1", "memory", "200M").
+				RequestAndLimit("replicated-job-1", corev1.ResourceCPU, "500m").
+				RequestAndLimit("replicated-job-1", corev1.ResourceMemory, "200M").
 				Obj()
 
 			ginkgo.By("Creating the jobSet", func() {

--- a/test/e2e/singlecluster/metrics_test.go
+++ b/test/e2e/singlecluster/metrics_test.go
@@ -260,7 +260,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 
 			createdJob = testingjob.MakeJob("admission-checked-job", ns.Name).
 				Queue(v1beta1.LocalQueueName(localQueue.Name)).
-				RequestAndLimit("cpu", "1").
+				RequestAndLimit(corev1.ResourceCPU, "1").
 				Obj()
 			util.MustCreate(ctx, k8sClient, createdJob)
 
@@ -403,7 +403,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 
 			lowerJob1 = testingjob.MakeJob("lower-job-1", ns.Name).
 				Queue(v1beta1.LocalQueueName(localQueue1.Name)).
-				RequestAndLimit("cpu", "1").
+				RequestAndLimit(corev1.ResourceCPU, "1").
 				Obj()
 			util.MustCreate(ctx, k8sClient, lowerJob1)
 
@@ -422,7 +422,7 @@ var _ = ginkgo.Describe("Metrics", func() {
 
 			lowerJob2 = testingjob.MakeJob("lower-job-2", ns.Name).
 				Queue(v1beta1.LocalQueueName(localQueue2.Name)).
-				RequestAndLimit("cpu", "1").
+				RequestAndLimit(corev1.ResourceCPU, "1").
 				Obj()
 			util.MustCreate(ctx, k8sClient, lowerJob2)
 

--- a/test/e2e/singlecluster/tas_test.go
+++ b/test/e2e/singlecluster/tas_test.go
@@ -92,8 +92,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 		ginkgo.It("should admit a Job via TAS", func() {
 			sampleJob := testingjob.MakeJob("test-job", ns.Name).
 				Queue(kueue.LocalQueueName(localQueue.Name)).
-				RequestAndLimit("cpu", "700m").
-				RequestAndLimit("memory", "20Mi").
+				RequestAndLimit(corev1.ResourceCPU, "700m").
+				RequestAndLimit(corev1.ResourceMemory, "20Mi").
 				Obj()
 			jobKey := client.ObjectKeyFromObject(sampleJob)
 			sampleJob = (&testingjob.JobWrapper{Job: *sampleJob}).
@@ -212,10 +212,10 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 						},
 					},
 				).
-				RequestAndLimit("rj1", "cpu", "200m").
-				RequestAndLimit("rj1", "memory", "20Mi").
-				RequestAndLimit("rj2", "cpu", "200m").
-				RequestAndLimit("rj2", "memory", "20Mi").
+				RequestAndLimit("rj1", corev1.ResourceCPU, "200m").
+				RequestAndLimit("rj1", corev1.ResourceMemory, "20Mi").
+				RequestAndLimit("rj2", corev1.ResourceCPU, "200m").
+				RequestAndLimit("rj2", corev1.ResourceMemory, "20Mi").
 				Obj()
 
 			ginkgo.By("Creating the JobSet", func() {
@@ -325,8 +325,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 				Queue(localQueue.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
 				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
-				RequestAndLimit("cpu", "200m").
-				RequestAndLimit("memory", "200Mi").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				RequestAndLimit(corev1.ResourceMemory, "200Mi").
 				Obj()
 
 			ginkgo.By("Creating the Pod", func() {
@@ -383,8 +383,8 @@ var _ = ginkgo.Describe("TopologyAwareScheduling", func() {
 				Queue(localQueue.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
 				Annotation(kueuealpha.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
-				RequestAndLimit("cpu", "200m").
-				RequestAndLimit("memory", "200Mi").
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				RequestAndLimit(corev1.ResourceMemory, "200Mi").
 				MakeGroup(2)
 
 			ginkgo.By("Creating the Pod group", func() {

--- a/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
@@ -1229,8 +1229,8 @@ var _ = ginkgo.Describe("JobSet controller when TopologyAwareScheduling enabled"
 					Args:  util.BehaviorExitFast,
 				},
 			).
-			Request("rj1", "cpu", "100m").
-			Request("rj2", "cpu", "100m").
+			Request("rj1", corev1.ResourceCPU, "100m").
+			Request("rj2", corev1.ResourceCPU, "100m").
 			Obj()
 		ginkgo.By("creating a JobSet", func() {
 			util.MustCreate(ctx, k8sClient, jobSet)

--- a/test/integration/singlecluster/kueuectl/create_test.go
+++ b/test/integration/singlecluster/kueuectl/create_test.go
@@ -212,11 +212,11 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 					g.Expect(createdQueue.Spec.Preemption.WithinClusterQueue).Should(gomega.Equal(v1beta1.PreemptionPolicyLowerPriority))
 					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]v1beta1.ResourceGroup{
 						{
-							CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+							CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
 							Flavors: []v1beta1.FlavorQuotas{
 								*testing.MakeFlavorQuotas("alpha").
-									Resource("cpu", "0").
-									Resource("memory", "0").
+									Resource(corev1.ResourceCPU, "0").
+									Resource(corev1.ResourceMemory, "0").
 									Obj(),
 							},
 						},
@@ -249,15 +249,15 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 					g.Expect(createdQueue.Name).Should(gomega.Equal(cqName))
 					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]v1beta1.ResourceGroup{
 						{
-							CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+							CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
 							Flavors: []v1beta1.FlavorQuotas{
 								*testing.MakeFlavorQuotas("alpha").
-									Resource("cpu", "0").
-									Resource("memory", "0").
+									Resource(corev1.ResourceCPU, "0").
+									Resource(corev1.ResourceMemory, "0").
 									Obj(),
 								*testing.MakeFlavorQuotas("beta").
-									Resource("cpu", "0").
-									Resource("memory", "0").
+									Resource(corev1.ResourceCPU, "0").
+									Resource(corev1.ResourceMemory, "0").
 									Obj(),
 							},
 						},
@@ -290,15 +290,15 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 					g.Expect(createdQueue.Name).Should(gomega.Equal(cqName))
 					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]v1beta1.ResourceGroup{
 						{
-							CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+							CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
 							Flavors: []v1beta1.FlavorQuotas{
 								*testing.MakeFlavorQuotas("alpha").
-									Resource("cpu", "0").
-									Resource("memory", "0").
+									Resource(corev1.ResourceCPU, "0").
+									Resource(corev1.ResourceMemory, "0").
 									Obj(),
 								*testing.MakeFlavorQuotas("gamma").
-									Resource("cpu", "0").
-									Resource("memory", "0").
+									Resource(corev1.ResourceCPU, "0").
+									Resource(corev1.ResourceMemory, "0").
 									Obj(),
 							},
 						},
@@ -346,11 +346,11 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 					g.Expect(createdQueue.Name).Should(gomega.Equal(cqName))
 					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]v1beta1.ResourceGroup{
 						{
-							CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+							CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
 							Flavors: []v1beta1.FlavorQuotas{
 								*testing.MakeFlavorQuotas("alpha").
-									Resource("cpu", "0", "0", "0").
-									Resource("memory", "0", "0", "0").
+									Resource(corev1.ResourceCPU, "0", "0", "0").
+									Resource(corev1.ResourceMemory, "0", "0", "0").
 									Obj(),
 							},
 						},
@@ -400,15 +400,15 @@ var _ = ginkgo.Describe("Kueuectl Create", ginkgo.Ordered, ginkgo.ContinueOnFail
 					g.Expect(createdQueue.Spec.Preemption.WithinClusterQueue).Should(gomega.Equal(v1beta1.PreemptionPolicyLowerPriority))
 					g.Expect(createdQueue.Spec.ResourceGroups).Should(gomega.Equal([]v1beta1.ResourceGroup{
 						{
-							CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+							CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
 							Flavors: []v1beta1.FlavorQuotas{
 								*testing.MakeFlavorQuotas("alpha").
-									Resource("cpu", "2", "1", "0").
-									Resource("memory", "2", "1", "0").
+									Resource(corev1.ResourceCPU, "2", "1", "0").
+									Resource(corev1.ResourceMemory, "2", "1", "0").
 									Obj(),
 								*testing.MakeFlavorQuotas("gamma").
-									Resource("cpu", "2", "1", "0").
-									Resource("memory", "2", "1", "0").
+									Resource(corev1.ResourceCPU, "2", "1", "0").
+									Resource(corev1.ResourceMemory, "2", "1", "0").
 									Obj(),
 							},
 						},

--- a/test/integration/singlecluster/webhook/core/clusterqueue_test.go
+++ b/test/integration/singlecluster/webhook/core/clusterqueue_test.go
@@ -304,7 +304,7 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", ginkgo.Ordered, func() {
 				testing.BeInvalidError()),
 			ginkgo.Entry("Should allow to create clusterQueue with built-in resources with qualified names",
 				testing.MakeClusterQueue("cluster-queue").
-					ResourceGroup(*testing.MakeFlavorQuotas("default").Resource("cpu").Obj()).
+					ResourceGroup(*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU).Obj()).
 					Obj(),
 				gomega.Succeed()),
 			ginkgo.Entry("Should forbid to create clusterQueue with invalid resource name",
@@ -325,7 +325,7 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", ginkgo.Ordered, func() {
 				gomega.Succeed()),
 			ginkgo.Entry("Should allow to create clusterQueue with flavor with qualified names",
 				testing.MakeClusterQueue("cluster-queue").
-					ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource("cpu").Obj()).
+					ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU).Obj()).
 					Obj(),
 				gomega.Succeed()),
 			ginkgo.Entry("Should forbid to create clusterQueue with flavor with unqualified names",
@@ -336,33 +336,33 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", ginkgo.Ordered, func() {
 			ginkgo.Entry("Should forbid to create clusterQueue with flavor quota with negative value",
 				testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(
-						*testing.MakeFlavorQuotas("x86").Resource("cpu", "-1").Obj()).
+						*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU, "-1").Obj()).
 					Obj(),
 				testing.BeForbiddenError()),
 			ginkgo.Entry("Should allow to create clusterQueue with flavor quota with zero values",
 				testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(
-						*testing.MakeFlavorQuotas("x86").Resource("cpu", "0").Obj()).
+						*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU, "0").Obj()).
 					Obj(),
 				gomega.Succeed()),
 			ginkgo.Entry("Should allow to create clusterQueue with flavor quota with borrowingLimit 0",
 				testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(
-						*testing.MakeFlavorQuotas("x86").Resource("cpu", "1", "0").Obj()).
+						*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU, "1", "0").Obj()).
 					Cohort("cohort").
 					Obj(),
 				gomega.Succeed()),
 			ginkgo.Entry("Should forbid to create clusterQueue with flavor quota with negative borrowingLimit",
 				testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(
-						*testing.MakeFlavorQuotas("x86").Resource("cpu", "1", "-1").Obj()).
+						*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU, "1", "-1").Obj()).
 					Cohort("cohort").
 					Obj(),
 				testing.BeForbiddenError()),
 			ginkgo.Entry("Should forbid to create clusterQueue with flavor quota with borrowingLimit and empty cohort",
 				testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(
-						*testing.MakeFlavorQuotas("x86").Resource("cpu", "1", "1").Obj()).
+						*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU, "1", "1").Obj()).
 					Obj(),
 				testing.BeInvalidError()),
 			ginkgo.Entry("Should allow to create clusterQueue with empty queueing strategy",
@@ -389,12 +389,12 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", ginkgo.Ordered, func() {
 				testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(
 						*testing.MakeFlavorQuotas("alpha").
-							Resource("cpu", "0").
-							Resource("memory", "0").
+							Resource(corev1.ResourceCPU, "0").
+							Resource(corev1.ResourceMemory, "0").
 							Obj(),
 						*testing.MakeFlavorQuotas("beta").
-							Resource("cpu", "0").
-							Resource("memory", "0").
+							Resource(corev1.ResourceCPU, "0").
+							Resource(corev1.ResourceMemory, "0").
 							Obj(),
 					).
 					ResourceGroup(
@@ -415,15 +415,15 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", ginkgo.Ordered, func() {
 					Spec: kueue.ClusterQueueSpec{
 						ResourceGroups: []kueue.ResourceGroup{
 							{
-								CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+								CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
 								Flavors: []kueue.FlavorQuotas{
 									*testing.MakeFlavorQuotas("alpha").
-										Resource("cpu", "0").
-										Resource("memory", "0").
+										Resource(corev1.ResourceCPU, "0").
+										Resource(corev1.ResourceMemory, "0").
 										Obj(),
 									*testing.MakeFlavorQuotas("beta").
-										Resource("memory", "0").
-										Resource("cpu", "0").
+										Resource(corev1.ResourceMemory, "0").
+										Resource(corev1.ResourceCPU, "0").
 										Obj(),
 								},
 							},
@@ -439,10 +439,10 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", ginkgo.Ordered, func() {
 					Spec: kueue.ClusterQueueSpec{
 						ResourceGroups: []kueue.ResourceGroup{
 							{
-								CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+								CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
 								Flavors: []kueue.FlavorQuotas{
 									*testing.MakeFlavorQuotas("alpha").
-										Resource("cpu", "0").
+										Resource(corev1.ResourceCPU, "0").
 										Obj(),
 								},
 							},
@@ -458,11 +458,11 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", ginkgo.Ordered, func() {
 					Spec: kueue.ClusterQueueSpec{
 						ResourceGroups: []kueue.ResourceGroup{
 							{
-								CoveredResources: []corev1.ResourceName{"cpu"},
+								CoveredResources: []corev1.ResourceName{corev1.ResourceCPU},
 								Flavors: []kueue.FlavorQuotas{
 									*testing.MakeFlavorQuotas("alpha").
-										Resource("cpu", "0").
-										Resource("memory", "0").
+										Resource(corev1.ResourceCPU, "0").
+										Resource(corev1.ResourceMemory, "0").
 										Obj(),
 								},
 							},
@@ -481,8 +481,8 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", ginkgo.Ordered, func() {
 								CoveredResources: []corev1.ResourceName{"blah"},
 								Flavors: []kueue.FlavorQuotas{
 									*testing.MakeFlavorQuotas("alpha").
-										Resource("cpu", "0").
-										Resource("memory", "0").
+										Resource(corev1.ResourceCPU, "0").
+										Resource(corev1.ResourceMemory, "0").
 										Obj(),
 								},
 							},
@@ -494,13 +494,13 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", ginkgo.Ordered, func() {
 				testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(
 						*testing.MakeFlavorQuotas("alpha").
-							Resource("cpu", "0").
-							Resource("memory", "0").
+							Resource(corev1.ResourceCPU, "0").
+							Resource(corev1.ResourceMemory, "0").
 							Obj(),
 					).
 					ResourceGroup(
 						*testing.MakeFlavorQuotas("beta").
-							Resource("memory", "0").
+							Resource(corev1.ResourceMemory, "0").
 							Obj(),
 					).
 					Obj(),
@@ -508,11 +508,11 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", ginkgo.Ordered, func() {
 			ginkgo.Entry("Should forbid to create clusterQueue with flavor in more than one resource group",
 				testing.MakeClusterQueue("cluster-queue").
 					ResourceGroup(
-						*testing.MakeFlavorQuotas("alpha").Resource("cpu").Obj(),
-						*testing.MakeFlavorQuotas("beta").Resource("cpu").Obj(),
+						*testing.MakeFlavorQuotas("alpha").Resource(corev1.ResourceCPU).Obj(),
+						*testing.MakeFlavorQuotas("beta").Resource(corev1.ResourceCPU).Obj(),
 					).
 					ResourceGroup(
-						*testing.MakeFlavorQuotas("beta").Resource("memory").Obj(),
+						*testing.MakeFlavorQuotas("beta").Resource(corev1.ResourceMemory).Obj(),
 					).
 					Obj(),
 				testing.BeForbiddenError()),

--- a/test/integration/singlecluster/webhook/core/cohort_test.go
+++ b/test/integration/singlecluster/webhook/core/cohort_test.go
@@ -75,7 +75,7 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 				testing.BeInvalidError()),
 			ginkgo.Entry("Should reject invalid flavor name",
 				testing.MakeCohort("cohort").
-					ResourceGroup(*testing.MakeFlavorQuotas("@x86").Resource("cpu", "5").Obj()).
+					ResourceGroup(*testing.MakeFlavorQuotas("@x86").Resource(corev1.ResourceCPU, "5").Obj()).
 					Obj(),
 				testing.BeInvalidError()),
 			ginkgo.Entry("Should allow valid resource name",
@@ -85,23 +85,23 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 				testing.BeForbiddenError()),
 			ginkgo.Entry("Should reject too many flavors in resource group",
 				testing.MakeCohort("cohort").ResourceGroup(
-					testing.MakeFlavorQuotas("f0").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f1").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f2").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f3").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f4").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f5").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f6").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f7").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f8").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f9").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f10").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f11").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f12").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f13").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f14").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f15").Resource("cpu").FlavorQuotas,
-					testing.MakeFlavorQuotas("f16").Resource("cpu").FlavorQuotas).Obj(),
+					testing.MakeFlavorQuotas("f0").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f2").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f3").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f4").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f5").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f6").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f7").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f8").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f9").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f10").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f11").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f12").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f13").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f14").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f15").Resource(corev1.ResourceCPU).FlavorQuotas,
+					testing.MakeFlavorQuotas("f16").Resource(corev1.ResourceCPU).FlavorQuotas).Obj(),
 				testing.BeInvalidError()),
 			ginkgo.Entry("Should reject too many resources in resource group",
 				testing.MakeCohort("cohort").ResourceGroup(
@@ -126,7 +126,7 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 				testing.BeInvalidError()),
 			ginkgo.Entry("Should allow resource with valid name",
 				testing.MakeCohort("cohort").
-					ResourceGroup(*testing.MakeFlavorQuotas("default").Resource("cpu").Obj()).
+					ResourceGroup(*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU).Obj()).
 					Obj(),
 				gomega.Succeed()),
 			ginkgo.Entry("Should reject resource with invalid name",
@@ -141,46 +141,46 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 				gomega.Succeed()),
 			ginkgo.Entry("Should allow flavor with valid name",
 				testing.MakeCohort("cohort").
-					ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource("cpu").Obj()).
+					ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU).Obj()).
 					Obj(),
 				gomega.Succeed()),
 			ginkgo.Entry("Should reject flavor with invalid name",
 				testing.MakeCohort("cohort").
-					ResourceGroup(*testing.MakeFlavorQuotas("x_86").Resource("cpu").Obj()).
+					ResourceGroup(*testing.MakeFlavorQuotas("x_86").Resource(corev1.ResourceCPU).Obj()).
 					Obj(),
 				testing.BeInvalidError()),
 			ginkgo.Entry("Should reject negative nominal quota",
 				testing.MakeCohort("cohort").
-					ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource("cpu", "-1").Obj()).
+					ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU, "-1").Obj()).
 					Obj(),
 				testing.BeForbiddenError()),
 			ginkgo.Entry("Should reject negative borrowing limit",
 				testing.MakeCohort("cohort").
-					ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource("cpu", "1", "-1").Obj()).
+					ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU, "1", "-1").Obj()).
 					Obj(),
 				testing.BeForbiddenError()),
 			ginkgo.Entry("Should reject negative lending limit",
 				testing.MakeCohort("cohort").
-					ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource("cpu", "1", "", "-1").Obj()).
+					ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU, "1", "", "-1").Obj()).
 					Obj(),
 				testing.BeForbiddenError()),
 			ginkgo.Entry("Should reject borrowingLimit when no parent",
 				testing.MakeCohort("cohort").
 					ResourceGroup(
-						*testing.MakeFlavorQuotas("x86").Resource("cpu", "1", "1").Obj()).
+						*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU, "1", "1").Obj()).
 					Obj(),
 				testing.BeForbiddenError()),
 			ginkgo.Entry("Should allow borrowingLimit 0 when parent exists",
 				testing.MakeCohort("cohort").
 					ResourceGroup(
-						*testing.MakeFlavorQuotas("x86").Resource("cpu", "1", "0").Obj()).
+						*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU, "1", "0").Obj()).
 					Parent("parent").
 					Obj(),
 				gomega.Succeed()),
 			ginkgo.Entry("Should allow borrowingLimit when parent exists",
 				testing.MakeCohort("cohort").
 					ResourceGroup(
-						*testing.MakeFlavorQuotas("x86").Resource("cpu", "1", "1").Obj()).
+						*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU, "1", "1").Obj()).
 					Parent("parent").
 					Obj(),
 				gomega.Succeed()),
@@ -188,7 +188,7 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 				testing.MakeCohort("cohort").
 					ResourceGroup(
 						testing.MakeFlavorQuotas("x86").
-							ResourceQuotaWrapper("cpu").NominalQuota("1").LendingLimit("1").Append().
+							ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("1").LendingLimit("1").Append().
 							FlavorQuotas,
 					).
 					Obj(),
@@ -197,7 +197,7 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 				testing.MakeCohort("cohort").
 					ResourceGroup(
 						testing.MakeFlavorQuotas("x86").
-							ResourceQuotaWrapper("cpu").NominalQuota("1").LendingLimit("1").Append().
+							ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("1").LendingLimit("1").Append().
 							FlavorQuotas,
 					).
 					Parent("parent").
@@ -207,7 +207,7 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 				testing.MakeCohort("cohort").
 					ResourceGroup(
 						testing.MakeFlavorQuotas("x86").
-							ResourceQuotaWrapper("cpu").NominalQuota("0").LendingLimit("0").Append().
+							ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("0").LendingLimit("0").Append().
 							FlavorQuotas,
 					).
 					Parent("parent").
@@ -217,7 +217,7 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 				testing.MakeCohort("cohort").
 					ResourceGroup(
 						testing.MakeFlavorQuotas("x86").
-							ResourceQuotaWrapper("cpu").NominalQuota("3").LendingLimit("5").Append().
+							ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("3").LendingLimit("5").Append().
 							FlavorQuotas,
 					).
 					Parent("parent").
@@ -227,12 +227,12 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 				testing.MakeCohort("cohort").
 					ResourceGroup(
 						*testing.MakeFlavorQuotas("alpha").
-							Resource("cpu", "0").
-							Resource("memory", "0").
+							Resource(corev1.ResourceCPU, "0").
+							Resource(corev1.ResourceMemory, "0").
 							Obj(),
 						*testing.MakeFlavorQuotas("beta").
-							Resource("cpu", "0").
-							Resource("memory", "0").
+							Resource(corev1.ResourceCPU, "0").
+							Resource(corev1.ResourceMemory, "0").
 							Obj(),
 					).
 					ResourceGroup(
@@ -253,15 +253,15 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 					Spec: kueue.CohortSpec{
 						ResourceGroups: []kueue.ResourceGroup{
 							{
-								CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+								CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
 								Flavors: []kueue.FlavorQuotas{
 									*testing.MakeFlavorQuotas("alpha").
-										Resource("cpu", "0").
-										Resource("memory", "0").
+										Resource(corev1.ResourceCPU, "0").
+										Resource(corev1.ResourceMemory, "0").
 										Obj(),
 									*testing.MakeFlavorQuotas("beta").
-										Resource("memory", "0").
-										Resource("cpu", "0").
+										Resource(corev1.ResourceMemory, "0").
+										Resource(corev1.ResourceCPU, "0").
 										Obj(),
 								},
 							},
@@ -277,10 +277,10 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 					Spec: kueue.CohortSpec{
 						ResourceGroups: []kueue.ResourceGroup{
 							{
-								CoveredResources: []corev1.ResourceName{"cpu", "memory"},
+								CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
 								Flavors: []kueue.FlavorQuotas{
 									*testing.MakeFlavorQuotas("alpha").
-										Resource("cpu", "0").
+										Resource(corev1.ResourceCPU, "0").
 										Obj(),
 								},
 							},
@@ -296,11 +296,11 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 					Spec: kueue.CohortSpec{
 						ResourceGroups: []kueue.ResourceGroup{
 							{
-								CoveredResources: []corev1.ResourceName{"cpu"},
+								CoveredResources: []corev1.ResourceName{corev1.ResourceCPU},
 								Flavors: []kueue.FlavorQuotas{
 									*testing.MakeFlavorQuotas("alpha").
-										Resource("cpu", "0").
-										Resource("memory", "0").
+										Resource(corev1.ResourceCPU, "0").
+										Resource(corev1.ResourceMemory, "0").
 										Obj(),
 								},
 							},
@@ -312,13 +312,13 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 				testing.MakeCohort("cohort").
 					ResourceGroup(
 						*testing.MakeFlavorQuotas("alpha").
-							Resource("cpu", "0").
-							Resource("memory", "0").
+							Resource(corev1.ResourceCPU, "0").
+							Resource(corev1.ResourceMemory, "0").
 							Obj(),
 					).
 					ResourceGroup(
 						*testing.MakeFlavorQuotas("beta").
-							Resource("memory", "0").
+							Resource(corev1.ResourceMemory, "0").
 							Obj(),
 					).
 					Obj(),
@@ -326,11 +326,11 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 			ginkgo.Entry("Should reject flavor in more than one resource group",
 				testing.MakeCohort("cohort").
 					ResourceGroup(
-						*testing.MakeFlavorQuotas("alpha").Resource("cpu").Obj(),
-						*testing.MakeFlavorQuotas("beta").Resource("cpu").Obj(),
+						*testing.MakeFlavorQuotas("alpha").Resource(corev1.ResourceCPU).Obj(),
+						*testing.MakeFlavorQuotas("beta").Resource(corev1.ResourceCPU).Obj(),
 					).
 					ResourceGroup(
-						*testing.MakeFlavorQuotas("beta").Resource("memory").Obj(),
+						*testing.MakeFlavorQuotas("beta").Resource(corev1.ResourceMemory).Obj(),
 					).
 					Obj(),
 				testing.BeForbiddenError()),
@@ -382,7 +382,7 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 		})
 		ginkgo.It("Should reject negative borrowing limit", func() {
 			cohort = testing.MakeCohort("cohort").
-				ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource("cpu", "-1").Obj()).
+				ResourceGroup(*testing.MakeFlavorQuotas("x86").Resource(corev1.ResourceCPU, "-1").Obj()).
 				Obj()
 			gomega.Expect(k8sClient.Create(ctx, cohort)).ShouldNot(gomega.Succeed())
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Cleanup of resources to use predefined consts.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```