### PR TITLE
Automated cherry pick of #6326: [Flaky] Eliminate test flakiness - MK Dispatcher Incremental mode

### DIFF
--- a/test/e2e/multikueue/e2e_test.go
+++ b/test/e2e/multikueue/e2e_test.go
@@ -176,12 +176,12 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 		util.ExpectObjectToBeDeleted(ctx, k8sWorker2Client, worker2Cq, true)
 		util.ExpectObjectToBeDeleted(ctx, k8sWorker2Client, worker2Flavor, true)
 
-		util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, managerCq, true)
-		util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, managerFlavor, true)
-		util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, multiKueueAc, true)
-		util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, multiKueueConfig, true)
-		util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, workerCluster1, true)
-		util.ExpectObjectToBeDeleted(ctx, k8sManagerClient, workerCluster2, true)
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sManagerClient, managerCq, true, util.LongTimeout)
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sManagerClient, managerFlavor, true, util.LongTimeout)
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sManagerClient, multiKueueAc, true, util.LongTimeout)
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sManagerClient, multiKueueConfig, true, util.LongTimeout)
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sManagerClient, workerCluster1, true, util.LongTimeout)
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sManagerClient, workerCluster2, true, util.LongTimeout)
 
 		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sManagerClient, managerNs)
 		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sWorker1Client, worker1Ns)


### PR DESCRIPTION
Cherry pick of #6326 on release-0.12.

#6326: [Flaky] Eliminate test flakiness - MK Dispatcher Incremental mode

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```