### PR TITLE
Automated cherry pick of #6418: [AFS] Fix the integration flaky test by correcting an assert value

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -762,16 +762,10 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			_ = createWorkloadWithPriority("lq-b", "12", 1)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 2)
 
-			ginkgo.By("Checking that LQs' resource usage is updated", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lqA), lqA)).Should(gomega.Succeed())
-					g.Expect(lqA.Status.FairSharing).ShouldNot(gomega.BeNil())
-					g.Expect(lqA.Status.FairSharing.AdmissionFairSharingStatus).ShouldNot(gomega.BeNil())
-					g.Expect(lqA.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources).Should(gomega.HaveLen(1))
-					usage := lqA.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources[corev1.ResourceCPU]
-					g.Expect(usage.MilliValue()).To(gomega.BeNumerically(">", 12))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
+
+			ginkgo.By("Checking that LQs' resource usage is updated")
+			util.ExpectLocalQueueUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqA), ">", 12_000)
+
 
 			ginkgo.By("Creating a workload in CQ2 that reclaims the quota")
 			_ = createWorkload(kueue.LocalQueueName(cq2.Name), "10")


### PR DESCRIPTION
Cherry pick of #6418 on release-0.13.

#6418: [AFS] Fix the integration flaky test by correcting an assert value

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```