### PR TITLE
AFS: Add unit tests for scheduling logic with AFS

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -9411,3 +9411,292 @@ func TestScheduleForTASCohorts(t *testing.T) {
 		})
 	}
 }
+
+func TestScheduleForAFS(t *testing.T) {
+	afsConfig := &config.AdmissionFairSharing{
+		UsageHalfLifeTime:     metav1.Duration{Duration: 10 * time.Second},
+		UsageSamplingInterval: metav1.Duration{Duration: 1 * time.Second},
+	}
+	now := time.Now()
+	fakeClock := testingclock.NewFakeClock(now)
+	resourceFlavors := []*kueue.ResourceFlavor{
+		utiltesting.MakeResourceFlavor("default").Obj(),
+	}
+	clusterQueues := []kueue.ClusterQueue{
+		*utiltesting.MakeClusterQueue("cq1").
+			ResourceGroup(*utiltesting.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "8").
+				Resource(corev1.ResourceMemory, "8Gi").Obj()).
+			AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
+			Obj(),
+	}
+	queues := []kueue.LocalQueue{
+		*utiltesting.MakeLocalQueue("lq-a", "default").
+			FairSharing(&kueue.FairSharing{Weight: ptr.To(resource.MustParse("1"))}).
+			ClusterQueue("cq1").
+			FairSharingStatus(&kueue.FairSharingStatus{
+				WeightedShare: 1,
+				AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
+					ConsumedResources: corev1.ResourceList{},
+				},
+			}).
+			Obj(),
+		*utiltesting.MakeLocalQueue("lq-b", "default").
+			FairSharing(&kueue.FairSharing{Weight: ptr.To(resource.MustParse("1"))}).
+			ClusterQueue("cq1").
+			FairSharingStatus(&kueue.FairSharingStatus{
+				WeightedShare: 1,
+				AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
+					ConsumedResources: corev1.ResourceList{},
+				},
+			}).
+			Obj(),
+		*utiltesting.MakeLocalQueue("lq-c", "default").
+			FairSharing(&kueue.FairSharing{Weight: ptr.To(resource.MustParse("1"))}).
+			ClusterQueue("cq1").
+			FairSharingStatus(&kueue.FairSharingStatus{
+				WeightedShare: 1,
+				AdmissionFairSharingStatus: &kueue.AdmissionFairSharingStatus{
+					ConsumedResources: corev1.ResourceList{},
+				},
+			}).
+			Obj(),
+	}
+
+	cases := map[string]struct {
+		enableFairSharing bool
+		initialUsage      map[string]corev1.ResourceList
+		workloads         []kueue.Workload
+		wantAdmissions    map[workload.Reference]kueue.Admission
+		wantPending       []workload.Reference
+	}{
+		"admits workload from less active localqueue": {
+			enableFairSharing: true,
+			initialUsage: map[string]corev1.ResourceList{
+				"lq-a": {corev1.ResourceCPU: resource.MustParse("8")},
+				"lq-b": {corev1.ResourceCPU: resource.MustParse("2")},
+			},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("wl-a1", "default").
+					Queue("lq-a").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now).
+					Obj(),
+				*utiltesting.MakeWorkload("wl-b1", "default").
+					Queue("lq-b").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now.Add(1 * time.Second)).
+					Obj(),
+			},
+			wantAdmissions: map[workload.Reference]kueue.Admission{
+				"default/wl-b1": *utiltesting.MakeAdmission("cq1", "one").Assignment(corev1.ResourceCPU, "default", "8").Obj(),
+			},
+			wantPending: []workload.Reference{
+				"default/wl-a1",
+			},
+		},
+		"without AFS: classic admission decision ignores queue usage": {
+			enableFairSharing: false,
+			initialUsage: map[string]corev1.ResourceList{
+				"lq-a": {corev1.ResourceCPU: resource.MustParse("8")},
+				"lq-b": {corev1.ResourceCPU: resource.MustParse("2")},
+			},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("wl-a1", "default").
+					Queue("lq-a").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now).
+					Obj(),
+				*utiltesting.MakeWorkload("wl-b1", "default").
+					Queue("lq-b").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now.Add(1 * time.Second)).
+					Obj(),
+			},
+			wantAdmissions: map[workload.Reference]kueue.Admission{
+				"default/wl-a1": *utiltesting.MakeAdmission("cq1", "one").Assignment(corev1.ResourceCPU, "default", "8").Obj(),
+			},
+			wantPending: []workload.Reference{
+				"default/wl-b1",
+			},
+		},
+		"admits one workload from each localqueue when quota is limited": {
+			enableFairSharing: true,
+			initialUsage: map[string]corev1.ResourceList{
+				"lq-a": {corev1.ResourceCPU: resource.MustParse("4")},
+				"lq-b": {corev1.ResourceCPU: resource.MustParse("4")},
+			},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("wl-a1", "default").
+					Queue("lq-a").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "4").
+						Obj()).
+					Creation(now).
+					Obj(),
+				*utiltesting.MakeWorkload("wl-a2", "default").
+					Queue("lq-a").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "4").
+						Obj()).
+					Creation(now.Add(1 * time.Second)).
+					Obj(),
+				*utiltesting.MakeWorkload("wl-b1", "default").
+					Queue("lq-b").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "4").
+						Obj()).
+					Creation(now.Add(2 * time.Second)).
+					Obj(),
+				*utiltesting.MakeWorkload("wl-b2", "default").
+					Queue("lq-b").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "4").
+						Obj()).
+					Creation(now.Add(3 * time.Second)).
+					Obj(),
+			},
+			wantAdmissions: map[workload.Reference]kueue.Admission{
+				"default/wl-a1": *utiltesting.MakeAdmission("cq1", "one").Assignment(corev1.ResourceCPU, "default", "4").Obj(),
+				"default/wl-b1": *utiltesting.MakeAdmission("cq1", "one").Assignment(corev1.ResourceCPU, "default", "4").Obj(),
+			},
+			wantPending: []workload.Reference{
+				"default/wl-a2",
+				"default/wl-b2",
+			},
+		},
+		"schedules normally when queues have equal usage": {
+			enableFairSharing: true,
+			initialUsage: map[string]corev1.ResourceList{
+				"lq-a": {corev1.ResourceCPU: resource.MustParse("2")},
+				"lq-b": {corev1.ResourceCPU: resource.MustParse("2")},
+				"lq-c": {corev1.ResourceCPU: resource.MustParse("2")},
+			},
+			workloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("wl-a1", "default").
+					Queue("lq-a").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "4").
+						Obj()).
+					Obj(),
+				*utiltesting.MakeWorkload("wl-b1", "default").
+					Queue("lq-b").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Obj(),
+				*utiltesting.MakeWorkload("wl-c1", "default").
+					Queue("lq-c").
+					PodSets(*utiltesting.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			wantAdmissions: map[workload.Reference]kueue.Admission{
+				"default/wl-a1": *utiltesting.MakeAdmission("cq1", "one").Assignment(corev1.ResourceCPU, "default", "4").Obj(),
+				"default/wl-b1": *utiltesting.MakeAdmission("cq1", "one").Assignment(corev1.ResourceCPU, "default", "3").Obj(),
+				"default/wl-c1": *utiltesting.MakeAdmission("cq1", "one").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+			},
+			wantPending: []workload.Reference{},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.enableFairSharing {
+				features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
+			}
+
+			for i, q := range queues {
+				if resList, found := tc.initialUsage[q.Name]; found {
+					queues[i].Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources = resList
+				}
+			}
+
+			clientBuilder := utiltesting.NewClientBuilder().
+				WithLists(
+					&kueue.WorkloadList{Items: tc.workloads},
+					&kueue.ClusterQueueList{Items: clusterQueues},
+					&kueue.LocalQueueList{Items: queues}).
+				WithObjects(
+					utiltesting.MakeNamespace("default"),
+				)
+			cl := clientBuilder.Build()
+
+			fairSharing := &config.FairSharing{
+				Enable: tc.enableFairSharing,
+			}
+			cqCache := cache.New(cl, cache.WithFairSharing(fairSharing.Enable), cache.WithAdmissionFairSharing(afsConfig))
+			qManager := queue.NewManager(cl, cqCache, queue.WithAdmissionFairSharing(afsConfig))
+
+			ctx, log := utiltesting.ContextWithLog(t)
+			for _, q := range queues {
+				if err := qManager.AddLocalQueue(ctx, &q); err != nil {
+					t.Fatalf("Inserting queue %s/%s in manager: %v", q.Namespace, q.Name, err)
+				}
+			}
+			for _, rf := range resourceFlavors {
+				cqCache.AddOrUpdateResourceFlavor(log, rf)
+			}
+			for _, cq := range clusterQueues {
+				if err := cqCache.AddClusterQueue(ctx, &cq); err != nil {
+					t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
+				}
+				if err := qManager.AddClusterQueue(ctx, &cq); err != nil {
+					t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
+				}
+			}
+			recorder := &utiltesting.EventRecorder{}
+			scheduler := New(qManager, cqCache, cl, recorder,
+				WithFairSharing(fairSharing),
+				WithAdmissionFairSharing(afsConfig),
+				WithClock(t, fakeClock))
+			wg := sync.WaitGroup{}
+			scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
+				func() { wg.Add(1) },
+				func() { wg.Done() },
+			))
+
+			gotScheduled := make(map[workload.Reference]kueue.Admission)
+			var mu sync.Mutex
+			scheduler.applyAdmission = func(ctx context.Context, w *kueue.Workload) error {
+				mu.Lock()
+				gotScheduled[workload.Key(w)] = *w.Status.Admission
+				mu.Unlock()
+				return nil
+			}
+
+			ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
+			go qManager.CleanUpOnContext(ctx)
+			defer cancel()
+
+			for range len(tc.workloads) {
+				scheduler.schedule(ctx)
+				wg.Wait()
+			}
+
+			if diff := cmp.Diff(tc.wantAdmissions, gotScheduled); diff != "" {
+				t.Errorf("Unexpected scheduled workloads (-want,+got):\n%s", diff)
+			}
+
+			gotPending := make([]workload.Reference, 0)
+			for _, wl := range tc.workloads {
+				wlKey := workload.Key(&wl)
+				if _, scheduled := gotScheduled[wlKey]; !scheduled {
+					gotPending = append(gotPending, wlKey)
+				}
+			}
+			if diff := cmp.Diff(tc.wantPending, gotPending); diff != "" {
+				t.Errorf("Unexpected pending workloads (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
Add unit tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6248 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```