### PR TITLE
Enhance preemption handling in scheduler and preemptor

### DIFF
--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -438,6 +438,10 @@ func (p *Preemptor) findCandidates(wl *kueue.Workload, cq *cache.ClusterQueueSna
 				continue
 			}
 
+			if meta.IsStatusConditionTrue(candidateWl.Obj.Status.Conditions, kueue.WorkloadEvicted) {
+				continue
+			}
+
 			if !classical.WorkloadUsesResources(candidateWl, frsNeedPreemption) {
 				continue
 			}
@@ -456,6 +460,11 @@ func (p *Preemptor) findCandidates(wl *kueue.Workload, cq *cache.ClusterQueueSna
 				if onlyLowerPriority && priority.Priority(candidateWl.Obj) >= priority.Priority(wl) {
 					continue
 				}
+
+				if meta.IsStatusConditionTrue(candidateWl.Obj.Status.Conditions, kueue.WorkloadEvicted) {
+					continue
+				}
+
 				if !classical.WorkloadUsesResources(candidateWl, frsNeedPreemption) {
 					continue
 				}


### PR DESCRIPTION
This PR is not meant to be merged, but as an example for a potential way to improve preemption performance as discussed in [this issue](https://github.com/kubernetes-sigs/kueue/issues/6143)

- Introduced a new entry status 'preempting' to indicate when a workload is in the process of preempting others.
- Updated the scheduler to skip workloads that are already in the 'preempting' state during scheduling.
- Added checks in the preemptor to ignore candidates that have been evicted, ensuring only valid workloads are considered for preemption.
