### PR TITLE
Introduce multi-Kueue support for ElasticJobs, with specific support for `batch/v1.Job` workloads when ElasticJob functionality is enabled.

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -424,7 +424,12 @@ type WorkloadStatus struct {
 	// +optional
 	NominatedClusterNames []string `json:"nominatedClusterNames,omitempty"`
 
-	// clusterName is the name of the cluster where the workload is actually assigned.
+	// clusterName is the name of the cluster where the workload is currently assigned.
+	//
+	// With ElasticJobs, this field may also indicate the cluster where the original (old) workload
+	// was assigned, providing placement context for new scaled-up workloads. This supports
+	// affinity or propagation policies across workload slices.
+	//
 	// This field is reset after the Workload is evicted.
 	// +optional
 	ClusterName *string `json:"clusterName,omitempty"`

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -8612,7 +8612,12 @@ spec:
                   x-kubernetes-list-type: map
                 clusterName:
                   description: |-
-                    clusterName is the name of the cluster where the workload is actually assigned.
+                    clusterName is the name of the cluster where the workload is currently assigned.
+
+                    With ElasticJobs, this field may also indicate the cluster where the original (old) workload
+                    was assigned, providing placement context for new scaled-up workloads. This supports
+                    affinity or propagation policies across workload slices.
+
                     This field is reset after the Workload is evicted.
                   type: string
                 conditions:

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -9096,7 +9096,12 @@ spec:
                 x-kubernetes-list-type: map
               clusterName:
                 description: |-
-                  clusterName is the name of the cluster where the workload is actually assigned.
+                  clusterName is the name of the cluster where the workload is currently assigned.
+
+                  With ElasticJobs, this field may also indicate the cluster where the original (old) workload
+                  was assigned, providing placement context for new scaled-up workloads. This supports
+                  affinity or propagation policies across workload slices.
+
                   This field is reset after the Workload is evicted.
                 type: string
               conditions:

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -123,7 +123,9 @@ func TestReconcileGenericJob(t *testing.T) {
 				Obj(),
 			podSets: basePodSets,
 			wantWorkloads: []kueue.Workload{
-				*baseWl.Clone().Name("job-test-job-3991b").Obj(),
+				*baseWl.Clone().Name("job-test-job-3991b").
+					Annotations(map[string]string{workloadslicing.EnabledAnnotationKey: workloadslicing.EnabledAnnotationValue}).
+					Obj(),
 			},
 		},
 		"update workload to match job (one existing workload)": {

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
 var (
@@ -78,6 +79,7 @@ func ValidateJobOnUpdate(oldJob, newJob GenericJob, defaultQueueExist func(strin
 	allErrs = append(allErrs, validateUpdateForPrebuiltWorkload(oldJob, newJob)...)
 	allErrs = append(allErrs, validateUpdateForMaxExecTime(oldJob, newJob)...)
 	allErrs = append(allErrs, validateJobUpdateForWorkloadPriorityClassName(oldJob, newJob)...)
+	allErrs = append(allErrs, validatedUpdateForEnabledWorkloadSlice(oldJob, newJob)...)
 	return allErrs
 }
 
@@ -137,16 +139,13 @@ func validateUpdateForQueueName(oldJob, newJob GenericJob, defaultQueueExist fun
 }
 
 func validateUpdateForPrebuiltWorkload(oldJob, newJob GenericJob) field.ErrorList {
-	var allErrs field.ErrorList
-	if !newJob.IsSuspended() {
-		oldWlName, _ := PrebuiltWorkloadFor(oldJob)
-		newWlName, _ := PrebuiltWorkloadFor(newJob)
-
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newWlName, oldWlName, labelsPath.Key(constants.PrebuiltWorkloadLabel))...)
-	} else {
-		allErrs = append(allErrs, validateCreateForPrebuiltWorkload(newJob)...)
+	if newJob.IsSuspended() || workloadslicing.Enabled(oldJob.Object()) {
+		return validateCreateForPrebuiltWorkload(newJob)
 	}
-	return allErrs
+
+	oldWlName, _ := PrebuiltWorkloadFor(oldJob)
+	newWlName, _ := PrebuiltWorkloadFor(newJob)
+	return apivalidation.ValidateImmutableField(newWlName, oldWlName, labelsPath.Key(constants.PrebuiltWorkloadLabel))
 }
 
 func validateJobUpdateForWorkloadPriorityClassName(oldJob, newJob GenericJob) field.ErrorList {
@@ -155,6 +154,19 @@ func validateJobUpdateForWorkloadPriorityClassName(oldJob, newJob GenericJob) fi
 		allErrs = append(allErrs, ValidateUpdateForWorkloadPriorityClassName(oldJob.Object(), newJob.Object())...)
 	}
 	return allErrs
+}
+
+// validatedUpdateForEnabledWorkloadSlice validates that the workload-slicing toggle remains immutable on update.
+//
+// It compares the boolean returned by workloadslicing.Enabled for the old and new Job objects.
+// If the value changed, it returns a field.ErrorList with a single field.Invalid pointing at
+// labels[workloadslicing.EnabledAnnotationKey] and using apivalidation.FieldImmutableErrorMsg.
+// If the value did not change, // it returns nil.
+func validatedUpdateForEnabledWorkloadSlice(oldJob, newJob GenericJob) field.ErrorList {
+	if oldEnabled, newEnabled := workloadslicing.Enabled(oldJob.Object()), workloadslicing.Enabled(newJob.Object()); oldEnabled != newEnabled {
+		return field.ErrorList{field.Invalid(labelsPath.Key(workloadslicing.EnabledAnnotationKey), newEnabled, apivalidation.FieldImmutableErrorMsg)}
+	}
+	return nil
 }
 
 func ValidateUpdateForWorkloadPriorityClassName(oldObj, newObj client.Object) field.ErrorList {

--- a/pkg/controller/jobs/job/job_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter_test.go
@@ -26,8 +26,12 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -36,6 +40,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
 const (
@@ -288,6 +293,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.MultiKueueBatchJobWithManagedBy, !tc.withoutJobManagedBy)
+
 			managerBuilder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
 			managerBuilder = managerBuilder.WithLists(&batchv1.JobList{Items: tc.managersJobs})
 			managerBuilder = managerBuilder.WithStatusSubresource(slices.Map(tc.managersJobs, func(w *batchv1.Job) client.Object { return w })...)
@@ -322,6 +328,409 @@ func TestMultiKueueAdapter(t *testing.T) {
 			} else {
 				if diff := cmp.Diff(tc.wantWorkerJobs, gotWorkerJobs.Items, objCheckOpts...); diff != "" {
 					t.Errorf("unexpected worker's jobs (-want/+got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func Test_multiKueueAdapter_SyncJob(t *testing.T) {
+	type fields struct {
+		features map[featuregate.Feature]bool
+	}
+	type args struct {
+		ctx          context.Context
+		localClient  client.Client
+		remoteClient client.Client
+		key          types.NamespacedName
+		workloadName string
+		origin       string
+	}
+	type want struct {
+		err       bool
+		localJob  *batchv1.Job
+		remoteJob *batchv1.Job
+	}
+
+	schema := runtime.NewScheme()
+	_ = scheme.AddToScheme(schema)
+	_ = kueue.AddToScheme(schema)
+
+	newJob := func() *utiltestingjob.JobWrapper {
+		return utiltestingjob.MakeJob("test", TestNamespace).ResourceVersion("1")
+	}
+	runningJobCondition := batchv1.JobCondition{
+		Type:   batchv1.JobSuccessCriteriaMet,
+		Status: corev1.ConditionFalse,
+	}
+
+	tests := map[string]struct {
+		fields fields
+		args   args
+		want   want
+	}{
+		"FailureToRetrieveLocalJob": {
+			args: args{
+				ctx:         t.Context(),
+				localClient: fake.NewClientBuilder().Build(),
+			},
+			want: want{
+				err: true,
+			},
+		},
+		"FailureToRetrieveRemoteJob": {
+			args: args{
+				ctx: t.Context(),
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					ManagedBy("parent").Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return errors.New("test-error")
+					},
+				}).Build(),
+				key: client.ObjectKeyFromObject(newJob().Obj()),
+			},
+			want: want{
+				err:      true,
+				localJob: newJob().ManagedBy("parent").Obj(),
+			},
+		},
+		"RemoteJobNotFound": {
+			args: args{
+				ctx: t.Context(),
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					ManagedBy("parent").Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).Build(),
+				key:          client.ObjectKeyFromObject(newJob().Obj()),
+			},
+			want: want{
+				localJob: newJob().ManagedBy("parent").Obj(),
+				remoteJob: newJob().Label(kueue.MultiKueueOriginLabel, "").
+					Label(constants.PrebuiltWorkloadLabel, "").
+					ManagedBy("parent").
+					Obj(),
+			},
+		},
+		"RemoteJobNotFound_ResetManagedBy": {
+			fields: fields{
+				features: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
+			},
+			args: args{
+				ctx: t.Context(),
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					ManagedBy("parent").Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).Build(),
+				key:          client.ObjectKeyFromObject(newJob().Obj()),
+			},
+			want: want{
+				localJob: newJob().ManagedBy("parent").Obj(),
+				remoteJob: newJob().Label(kueue.MultiKueueOriginLabel, "").
+					Label(constants.PrebuiltWorkloadLabel, "").
+					Obj(),
+			},
+		},
+		"RemoteJobInProgress_LocalIsManagedButStillSuspended": {
+			fields: fields{
+				features: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
+			},
+			args: args{
+				ctx:         t.Context(),
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				key: client.ObjectKeyFromObject(newJob().Obj()),
+			},
+			want: want{
+				localJob: newJob().Obj(),
+				remoteJob: newJob().
+					Condition(runningJobCondition).
+					Obj(),
+			},
+		},
+		"RemoteJobInProgress_LocalIsManagedAndUnsuspended": {
+			fields: fields{
+				features: map[featuregate.Feature]bool{features.MultiKueueBatchJobWithManagedBy: true},
+			},
+			args: args{
+				ctx:         t.Context(),
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Suspend(false).Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				key: client.ObjectKeyFromObject(newJob().Obj()),
+			},
+			want: want{
+				localJob: newJob().
+					ResourceVersion("2").
+					Suspend(false).
+					Condition(runningJobCondition).
+					Obj(),
+				remoteJob: newJob().
+					Condition(runningJobCondition).
+					Obj(),
+			},
+		},
+		"RemoteJobInProgress_LocalIsNotManaged": {
+			args: args{
+				ctx:         t.Context(),
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				key: client.ObjectKeyFromObject(newJob().Obj()),
+			},
+			want: want{
+				localJob: newJob().Obj(),
+				remoteJob: newJob().
+					Condition(runningJobCondition).
+					Obj(),
+			},
+		},
+		"RemoteJobFinished_Completed": {
+			args: args{
+				ctx:         t.Context(),
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					Condition(batchv1.JobCondition{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionTrue,
+					}).
+					Obj()).Build(),
+				key: client.ObjectKeyFromObject(newJob().Obj()),
+			},
+			want: want{
+				localJob: newJob().
+					ResourceVersion("2").
+					Condition(
+						batchv1.JobCondition{
+							Type:   batchv1.JobComplete,
+							Status: corev1.ConditionTrue,
+						}).
+					Obj(),
+			},
+		},
+		"RemoteJobFinished_Failed": {
+			args: args{
+				ctx:         t.Context(),
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					Condition(batchv1.JobCondition{
+						Type:   batchv1.JobFailed,
+						Status: corev1.ConditionTrue,
+					}).
+					Obj()).Build(),
+				key: client.ObjectKeyFromObject(newJob().Obj()),
+			},
+			want: want{
+				localJob: newJob().
+					ResourceVersion("2").
+					Condition(
+						batchv1.JobCondition{
+							Type:   batchv1.JobFailed,
+							Status: corev1.ConditionTrue,
+						}).
+					Obj(),
+			},
+		},
+		"ElasticJob_RemoteInSync": {
+			fields: fields{
+				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			},
+			args: args{
+				ctx: t.Context(),
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				key:          client.ObjectKeyFromObject(newJob().Obj()),
+				workloadName: "test-workload",
+			},
+			want: want{
+				localJob: newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Condition(runningJobCondition).
+					Obj(),
+				remoteJob: newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					Condition(runningJobCondition).
+					Obj(),
+			},
+		},
+		"ElasticJob_WorkloadNameOnlyChange_EdgeCase": {
+			fields: fields{
+				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			},
+			args: args{
+				ctx: t.Context(),
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				key:          client.ObjectKeyFromObject(newJob().Obj()),
+				workloadName: "test-workload-new",
+			},
+			want: want{
+				localJob: newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Condition(runningJobCondition).
+					Obj(),
+				remoteJob: newJob().
+					ResourceVersion("2").
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Label(constants.PrebuiltWorkloadLabel, "test-workload-new").
+					Condition(runningJobCondition).
+					Obj(),
+			},
+		},
+		"ElasticJob_ParallelismOnlyChange_EdgeCase": {
+			fields: fields{
+				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			},
+			args: args{
+				ctx: t.Context(),
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Parallelism(22).
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				key:          client.ObjectKeyFromObject(newJob().Obj()),
+				workloadName: "test-workload",
+			},
+			want: want{
+				localJob: newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Parallelism(22).
+					Condition(runningJobCondition).
+					Obj(),
+				remoteJob: newJob().
+					ResourceVersion("2").
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					Parallelism(22).
+					Condition(runningJobCondition).
+					Obj(),
+			},
+		},
+		"ElasticJob_RemoteOutOfSync": {
+			fields: fields{
+				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			},
+			args: args{
+				ctx: t.Context(),
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Parallelism(22).
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				key:          client.ObjectKeyFromObject(newJob().Obj()),
+				workloadName: "test-workload-new",
+			},
+			want: want{
+				localJob: newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Parallelism(22).
+					Condition(runningJobCondition).
+					Obj(),
+				remoteJob: newJob().
+					ResourceVersion("2").
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Label(constants.PrebuiltWorkloadLabel, "test-workload-new").
+					Parallelism(22).
+					Condition(runningJobCondition).
+					Obj(),
+			},
+		},
+		"ElasticJob_RemoteOutOfSync_PatchFailure": {
+			fields: fields{
+				features: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			},
+			args: args{
+				ctx: t.Context(),
+				localClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Parallelism(22).
+					Condition(runningJobCondition).
+					Obj()).Build(),
+				remoteClient: fake.NewClientBuilder().WithScheme(schema).WithObjects(newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					Condition(runningJobCondition).
+					Obj()).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+							return errors.New("test-patch-error")
+						},
+					}).Build(),
+				key:          client.ObjectKeyFromObject(newJob().Obj()),
+				workloadName: "test-workload-new",
+			},
+			want: want{
+				err: true,
+				localJob: newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Parallelism(22).
+					Condition(runningJobCondition).
+					Obj(),
+				remoteJob: newJob().
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Label(constants.PrebuiltWorkloadLabel, "test-workload").
+					Condition(runningJobCondition).
+					Obj(),
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Setup feature gates if any provided.
+			for featureName, enabled := range tt.fields.features {
+				features.SetFeatureGateDuringTest(t, featureName, enabled)
+			}
+
+			adapter := &multiKueueAdapter{}
+			// Function call under test with result (error) assertion.
+			if err := adapter.SyncJob(tt.args.ctx, tt.args.localClient, tt.args.remoteClient, tt.args.key, tt.args.workloadName, tt.args.origin); (err != nil) != tt.want.err {
+				t.Errorf("SyncJob() error = %v, wantErr %v", err, tt.want.err)
+			}
+
+			// Side effect assertion: changes to the local job. Must have (not nil) both the client and the job.
+			if tt.args.localClient != nil && tt.want.localJob != nil {
+				got := &batchv1.Job{}
+				if err := tt.args.localClient.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.want.localJob), got); err != nil {
+					t.Errorf("SyncJob() unexpected assertion error retrieving local job: %v", err)
+				}
+				if diff := cmp.Diff(tt.want.localJob, got, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("SyncJob() localJob (-want,+got):\n%s", diff)
+				}
+			}
+			// Side effect assertion: changes on the remote job. Must have (not nil) both the client and the job.
+			if tt.args.remoteClient != nil && tt.want.remoteJob != nil {
+				got := &batchv1.Job{}
+				if err := tt.args.remoteClient.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.want.remoteJob), got); err != nil {
+					t.Errorf("SyncJob() unexpected assertion error retrieving remote job: %v", err)
+				}
+				if diff := cmp.Diff(tt.want.remoteJob, got, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("SyncJob() remoteJob (-want,+got):\n%s", diff)
 				}
 			}
 		})

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -156,6 +156,12 @@ func (j *JobWrapper) SetAnnotation(key, content string) *JobWrapper {
 	return j
 }
 
+// ResourceVersion sets resource version on job object - helpful when using controller-runtime fake client.
+func (j *JobWrapper) ResourceVersion(resourceVersion string) *JobWrapper {
+	j.ObjectMeta.ResourceVersion = resourceVersion
+	return j
+}
+
 // Toleration adds a toleration to the job.
 func (j *JobWrapper) Toleration(t corev1.Toleration) *JobWrapper {
 	j.Spec.Template.Spec.Tolerations = append(j.Spec.Template.Spec.Tolerations, t)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1371,3 +1371,10 @@ func setSchedulingStatsEviction(wl *kueue.Workload, newEvictionState kueue.Workl
 func ReasonWithCause(reason, underlyingCause string) string {
 	return fmt.Sprintf("%sDueTo%s", reason, underlyingCause)
 }
+
+// ClusterName returns the name of the remote cluster where the original workload
+// was scheduled in a multikueue context. If the corresponding annotation is not set,
+// it returns an empty string.
+func ClusterName(wl *kueue.Workload) string {
+	return ptr.Deref(wl.Status.ClusterName, "")
+}

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -91,6 +91,11 @@ func TestEnabled(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			// Always false when feature is disabled (not enabled).
+			if got := Enabled(tt.args.object); got {
+				t.Error("Enabled() = true, want false when feature is not enabled")
+			}
+			features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
 			if got := Enabled(tt.args.object); got != tt.want {
 				t.Errorf("Enabled() = %v, want %v", got, tt.want)
 			}

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -3315,8 +3315,11 @@ This field is optional.</p>
 <code>string</code>
 </td>
 <td>
-   <p>clusterName is the name of the cluster where the workload is actually assigned.
-This field is reset after the Workload is evicted.</p>
+   <p>clusterName is the name of the cluster where the workload is currently assigned.</p>
+<p>With ElasticJobs, this field may also indicate the cluster where the original (old) workload
+was assigned, providing placement context for new scaled-up workloads. This supports
+affinity or propagation policies across workload slices.</p>
+<p>This field is reset after the Workload is evicted.</p>
 </td>
 </tr>
 <tr><td><code>unhealthyNodes</code><br/>

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -42,6 +42,7 @@ import (
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadappwrapper "sigs.k8s.io/kueue/pkg/controller/jobs/appwrapper"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	workloadjobset "sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
@@ -69,6 +70,7 @@ import (
 	testingtfjob "sigs.k8s.io/kueue/pkg/util/testingjobs/tfjob"
 	testingtrainjob "sigs.k8s.io/kueue/pkg/util/testingjobs/trainjob"
 	testingxgboostjob "sigs.k8s.io/kueue/pkg/util/testingjobs/xgboostjob"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -1624,6 +1626,292 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			waitForWorkloadToFinishAndRemoteWorkloadToBeDeleted(wlLookupKey, finishJobReason)
+		})
+	})
+
+	ginkgo.It("Should run an ElasticJob on worker if admitted", func() {
+		manager := managerTestCluster
+		worker1 := worker1TestCluster
+		worker2 := worker2TestCluster
+
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+
+		jobGVK := batchv1.SchemeGroupVersion.WithKind("Job")
+
+		getJob := func(ctx context.Context, clnt client.Client, job *batchv1.Job) {
+			ginkgo.GinkgoHelper()
+			gomega.Expect(clnt.Get(ctx, client.ObjectKeyFromObject(job), job)).To(gomega.Succeed())
+		}
+		getWorkloadKey := func(job *batchv1.Job) types.NamespacedName {
+			ginkgo.GinkgoHelper()
+			getJob(manager.ctx, manager.client, job)
+			return types.NamespacedName{Name: jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.Name, job.UID, jobGVK, job.GetGeneration()), Namespace: job.Namespace}
+		}
+		getWorkload := func(g gomega.Gomega, ctx context.Context, clnt client.Client, key types.NamespacedName) *kueue.Workload {
+			ginkgo.GinkgoHelper()
+			workload := &kueue.Workload{}
+			g.Expect(clnt.Get(ctx, key, workload)).To(gomega.Succeed())
+			return workload
+		}
+
+		job := testingjob.MakeJob("job", managerNs.Name).
+			Parallelism(1).
+			Completions(2).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Obj()
+		util.MustCreate(manager.ctx, manager.client, job)
+
+		ginkgo.By("observe: the job is created in the manager cluster", func() {
+			getJob(manager.ctx, manager.client, job)
+			gomega.Expect(job.Spec.Suspend).To(gomega.BeEquivalentTo(ptr.To(true)))
+		})
+
+		ginkgo.By("observe: a new workload is created in the manager cluster")
+		workloadKey := getWorkloadKey(job)
+		gomega.Eventually(func(g gomega.Gomega) {
+			getWorkload(g, manager.ctx, manager.client, workloadKey)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("admit workload on the manager cluster")
+		util.SetQuotaReservation(manager.ctx, manager.client, workloadKey, utiltesting.MakeAdmission(managerCq.Name).Obj())
+
+		ginkgo.By("observe: workload is created on all worker clusters", func() {
+			localWorkload := getWorkload(gomega.Default, manager.ctx, manager.client, workloadKey)
+			gomega.Eventually(func(g gomega.Gomega) {
+				workload := getWorkload(g, worker1.ctx, worker1.client, workloadKey)
+				g.Expect(workload.Spec).To(gomega.BeComparableTo(localWorkload.Spec))
+				workload = getWorkload(g, worker2.ctx, worker2.client, workloadKey)
+				g.Expect(workload.Spec).To(gomega.BeComparableTo(localWorkload.Spec))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("admit the workload on the worker1 cluster")
+		util.SetQuotaReservation(worker1.ctx, worker1.client, workloadKey, utiltesting.MakeAdmission(managerCq.Name).Obj())
+
+		ginkgo.By("observe: the local workload admission check and local events reflect reservation on the worker1 cluster")
+		gomega.Eventually(func(g gomega.Gomega) {
+			localWorkload := getWorkload(g, manager.ctx, manager.client, workloadKey)
+			acs := admissioncheck.FindAdmissionCheck(localWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
+			g.Expect(acs).NotTo(gomega.BeNil())
+			g.Expect(acs.State).To(gomega.Equal(kueue.CheckStatePending))
+			g.Expect(acs.Message).To(gomega.Equal(`The workload got reservation on "worker1"`))
+			ok, err := utiltesting.HasEventAppeared(manager.ctx, manager.client, corev1.Event{
+				Reason:  "MultiKueue",
+				Type:    corev1.EventTypeNormal,
+				Message: `The workload got reservation on "worker1"`,
+			})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(ok).To(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("observe: job is synced to the worker1 cluster and is active", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteJob := job.DeepCopy()
+				getJob(worker1.ctx, worker1.client, remoteJob)
+				g.Expect(remoteJob.Spec.Suspend).To(gomega.BeEquivalentTo(ptr.To(false)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: the workload is removed from the worker2 cluster")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(worker2.client.Get(worker2.ctx, workloadKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("observe: there are no jobs in the worker2 cluster", func() {
+			list := &batchv1.JobList{}
+			gomega.Expect(worker2.client.List(worker2.ctx, list, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(list.Items).To(gomega.BeEmpty())
+		})
+
+		ginkgo.By("observe: job is still suspended in the manager cluster", func() {
+			getJob(manager.ctx, manager.client, job)
+			gomega.Expect(job.Spec.Suspend).To(gomega.BeEquivalentTo(ptr.To(true)))
+		})
+
+		/*
+			Scale-up Section
+		*/
+
+		ginkgo.By("scale-up the job", func() {
+			getJob(manager.ctx, manager.client, job)
+			job.Spec.Parallelism = ptr.To(int32(2))
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(manager.client.Update(manager.ctx, job)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: a new workload slice is created")
+		newWorkloadKey := getWorkloadKey(job)
+		gomega.Eventually(func(g gomega.Gomega) {
+			getWorkload(g, manager.ctx, manager.client, newWorkloadKey)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("copy clusterName from the old workload to the new workload", func() {
+			oldWorkload := getWorkload(gomega.Default, manager.ctx, manager.client, workloadKey)
+			newWorkload := getWorkload(gomega.Default, manager.ctx, manager.client, newWorkloadKey)
+			// This step is done by the scheduler during the new slice admission and the old slice replacement.
+			// Since we are not "running" scheduler for this test suit, we need to "emulate" this step.
+			newWorkload.Status.ClusterName = oldWorkload.Status.ClusterName
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(manager.client.Status().Update(manager.ctx, newWorkload)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			newWorkload = getWorkload(gomega.Default, manager.ctx, manager.client, newWorkloadKey)
+			gomega.Expect(newWorkload.Status.ClusterName).Should(gomega.BeEquivalentTo(oldWorkload.Status.ClusterName))
+		})
+
+		ginkgo.By("admit the new workload and finish the old workload in the manager cluster", func() {
+			util.SetQuotaReservation(manager.ctx, manager.client, newWorkloadKey, utiltesting.MakeAdmission(managerCq.Name).Obj())
+			gomega.Eventually(func(g gomega.Gomega) {
+				oldWorkload := getWorkload(g, manager.ctx, manager.client, workloadKey)
+				g.Expect(workloadslicing.Finish(manager.ctx, manager.client, oldWorkload, kueue.WorkloadSliceReplaced, "Replaced to accommodate a new slice")).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: the new workload is crated in the worker1 cluster")
+		gomega.Eventually(func(g gomega.Gomega) {
+			local := getWorkload(g, manager.ctx, manager.client, newWorkloadKey)
+			remote := getWorkload(g, worker1.ctx, worker1.client, newWorkloadKey)
+			g.Expect(remote.Spec).To(gomega.BeComparableTo(local.Spec))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("observe: there are no workloads or jobs in the worker2 cluster", func() {
+			workloads := &kueue.WorkloadList{}
+			gomega.Expect(worker2.client.List(worker2.ctx, workloads, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(workloads.Items).To(gomega.BeEmpty())
+			jobs := &batchv1.JobList{}
+			gomega.Expect(worker2.client.List(worker2.ctx, jobs, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(jobs.Items).To(gomega.BeEmpty())
+		})
+
+		ginkgo.By("observe: the old workload is still admitted in the worker1 cluster", func() {
+			workload := getWorkload(gomega.Default, worker1.ctx, worker1.client, workloadKey)
+			util.ExpectWorkloadsToBeAdmitted(worker1.ctx, worker1.client, workload)
+		})
+
+		ginkgo.By("observe: the remote job is still active and has old parallelism count", func() {
+			remoteJob := job.DeepCopy()
+			getJob(worker1.ctx, worker1.client, remoteJob)
+			gomega.Expect(remoteJob.Spec.Suspend).To(gomega.BeEquivalentTo(ptr.To(false)))
+			gomega.Expect(remoteJob.Spec.Parallelism).To(gomega.BeEquivalentTo(ptr.To(int32(1))))
+		})
+
+		ginkgo.By("admit the new workload replacing the old workload in the worker1 cluster", func() {
+			util.SetQuotaReservation(worker1.ctx, worker1.client, newWorkloadKey, utiltesting.MakeAdmission(managerCq.Name).Obj())
+			gomega.Eventually(func(g gomega.Gomega) {
+				workload := getWorkload(g, worker1.ctx, worker1.client, workloadKey)
+				g.Expect(workloadslicing.Finish(worker1.ctx, worker1.client, workload, kueue.WorkloadSliceReplaced, "Replaced to accommodate a new slice")).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: the new local workload admission check and local events reflect reservation in the worker1 cluster")
+		gomega.Eventually(func(g gomega.Gomega) {
+			workload := getWorkload(g, manager.ctx, manager.client, newWorkloadKey)
+			acs := admissioncheck.FindAdmissionCheck(workload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
+			g.Expect(acs).NotTo(gomega.BeNil())
+			g.Expect(acs.State).To(gomega.Equal(kueue.CheckStatePending))
+			g.Expect(acs.Message).To(gomega.Equal(`The workload got reservation on "worker1"`))
+			ok, err := utiltesting.HasEventAppeared(manager.ctx, manager.client, corev1.Event{
+				Reason:  "MultiKueue",
+				Type:    corev1.EventTypeNormal,
+				Message: `The workload got reservation on "worker1"`,
+			})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			g.Expect(ok).To(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("observe: job changes are synced to the worker1 cluster", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteJob := job.DeepCopy()
+				getJob(worker1.ctx, worker1.client, remoteJob)
+				g.Expect(remoteJob.Spec.Suspend).To(gomega.BeEquivalentTo(ptr.To(false)))
+				g.Expect(remoteJob.Spec.Parallelism).To(gomega.BeEquivalentTo(ptr.To(int32(2))))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		/*
+			Scale-down Section.
+			Note: Scaling down does not create a new workload slice, so we continue using the previously generated `newWorkloadKey`.
+		*/
+		ginkgo.By("scale-down the job", func() {
+			getJob(manager.ctx, manager.client, job)
+			job.Spec.Parallelism = ptr.To(int32(1))
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(manager.client.Update(manager.ctx, job)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+		ginkgo.By("observe: workload changed in the manager cluster", func() {
+			getJob(manager.ctx, manager.client, job)
+			gomega.Eventually(func(g gomega.Gomega) {
+				workload := getWorkload(g, manager.ctx, manager.client, newWorkloadKey)
+				g.Expect(workload.Spec.PodSets[0].Count).To(gomega.BeEquivalentTo(int32(1)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+		ginkgo.By("observe: there are no new workloads created in response to scale-down even in the manager cluster", func() {
+			list := &kueue.WorkloadList{}
+			gomega.Expect(manager.client.List(manager.ctx, list, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(list.Items).To(gomega.HaveLen(2))
+		})
+		ginkgo.By("observe: job changed in the worker1 cluster", func() {
+			remoteJob := job.DeepCopy()
+			gomega.Eventually(func(g gomega.Gomega) {
+				getJob(worker1.ctx, worker1.client, remoteJob)
+				g.Expect(remoteJob.Spec.Parallelism).To(gomega.BeEquivalentTo(ptr.To(int32(1))))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+		ginkgo.By("observe: there are no new workloads created in response to scale-down even in the worker1 cluster", func() {
+			list := &kueue.WorkloadList{}
+			gomega.Expect(worker1.client.List(worker1.ctx, list, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(list.Items).To(gomega.HaveLen(2))
+		})
+		ginkgo.By("observe: there are still no workloads or jobs in the worker2 cluster", func() {
+			workloads := &kueue.WorkloadList{}
+			gomega.Expect(worker2.client.List(worker2.ctx, workloads, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(workloads.Items).To(gomega.BeEmpty())
+			jobs := &batchv1.JobList{}
+			gomega.Expect(worker2.client.List(worker2.ctx, jobs, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(jobs.Items).To(gomega.BeEmpty())
+		})
+
+		/*
+			Finish Job Section.
+		*/
+		ginkgo.By("finishing the job in the worker1 cluster", func() {
+			now := metav1.Now()
+			completedJobCondition := batchv1.JobCondition{
+				Type:               batchv1.JobComplete,
+				Status:             corev1.ConditionTrue,
+				LastProbeTime:      now,
+				LastTransitionTime: now,
+				Message:            "Job finished successfully",
+			}
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteJob := job.DeepCopy()
+				getJob(worker1.ctx, worker1.client, remoteJob)
+				remoteJob.Status.Conditions = append(remoteJob.Status.Conditions,
+					completedJobCondition,
+					batchv1.JobCondition{
+						Type:               batchv1.JobSuccessCriteriaMet,
+						Status:             corev1.ConditionTrue,
+						LastProbeTime:      now,
+						LastTransitionTime: now,
+						Message:            "Reached expected number of succeeded pods",
+					})
+				remoteJob.Status.Succeeded = 1
+				remoteJob.Status.StartTime = ptr.To(now)
+				remoteJob.Status.CompletionTime = ptr.To(now)
+				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, remoteJob)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			waitForWorkloadToFinishAndRemoteWorkloadToBeDeleted(newWorkloadKey, completedJobCondition.Message)
+
+			getJob(manager.ctx, manager.client, job)
+			gomega.Expect(job.Status.Conditions).Should(gomega.ContainElement(gomega.WithTransform(func(condition batchv1.JobCondition) batchv1.JobCondition {
+				condition.LastProbeTime = now
+				condition.LastTransitionTime = now
+				return condition
+			}, gomega.Equal(completedJobCondition))))
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Now that the core ElasticJobsViaWorkloadSlices functionality has been introduced in Kueue as part of [KEP-77](https://github.com/kubernetes-sigs/kueue/tree/main/keps/77-dynamically-sized-jobs), this PR introduces MultiKueue support for ElasticJobsViaWorkloadSlices.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6335 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add: Multikueue support for ElasticJobsViaWorklaodSlices with `batchv1/Job` support.
```