### PR TITLE
Add metric that measures workload eviction duration

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -369,12 +369,14 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		if features.Enabled(features.WorkloadRequestUseMergePatch) {
 			return reconcile.Result{}, clientutil.PatchStatus(ctx, w.client, group.local, func() (client.Object, bool, error) {
 				apimeta.SetStatusCondition(&group.local.Status.Conditions, finishCond)
+				workload.ReportEvictionCompleted(group.local, kueue.WorkloadFinished, w.clock.Now())
 				return group.local, true, nil
 			})
 		}
 
 		wlPatch := workload.BaseSSAWorkload(group.local, false)
 		apimeta.SetStatusCondition(&wlPatch.Status.Conditions, finishCond)
+		workload.ReportEvictionCompleted(wlPatch, kueue.WorkloadFinished, w.clock.Now())
 		return reconcile.Result{}, w.client.Status().Patch(ctx, wlPatch, client.Apply, client.FieldOwner(kueue.MultiKueueControllerName+"-finish"), client.ForceOwnership)
 	}
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -583,6 +583,7 @@ func UpdateStatus(ctx context.Context,
 // UnsetQuotaReservationWithCondition sets the QuotaReserved condition to false, clears
 // the admission and set the WorkloadRequeued status.
 // Returns whether any change was done.
+
 func UnsetQuotaReservationWithCondition(wl *kueue.Workload, reason, message string, now time.Time) bool {
 	condition := metav1.Condition{
 		Type:               kueue.WorkloadQuotaReserved,
@@ -593,6 +594,8 @@ func UnsetQuotaReservationWithCondition(wl *kueue.Workload, reason, message stri
 		ObservedGeneration: wl.Generation,
 	}
 	changed := apimeta.SetStatusCondition(&wl.Status.Conditions, condition)
+
+	ReportEvictionCompleted(wl, "QuotaReservedFalse", now)
 	if wl.Status.Admission != nil {
 		wl.Status.Admission = nil
 		changed = true
@@ -602,6 +605,7 @@ func UnsetQuotaReservationWithCondition(wl *kueue.Workload, reason, message stri
 	if SyncAdmittedCondition(wl, now) {
 		changed = true
 	}
+
 	return changed
 }
 
@@ -1334,6 +1338,36 @@ func reportEvictedWorkload(recorder record.EventRecorder, wl *kueue.Workload, cq
 
 func ReportPreemption(preemptingCqName kueue.ClusterQueueReference, preemptingReason string, targetCqName kueue.ClusterQueueReference) {
 	metrics.ReportPreemption(preemptingCqName, preemptingReason, targetCqName)
+}
+
+// ReportEvictionCompleted reports the how much time eviction takes. This is the between when eviction started for running pods (Evicted=True & PodsReady=True)
+// and when it completed (Evicted=True & (QuotaReserved=False || Finished=True || Deactivated=True))
+func ReportEvictionCompleted(wl *kueue.Workload, reason string, now time.Time) {
+	if wl.Status.Admission == nil || wl.Status.Admission.ClusterQueue == "" {
+		return
+	}
+
+	// diff between eviction start and eviction completion
+	evictionDuration := WorkloadCompletedEviction(wl, now)
+	if evictionDuration != nil {
+		metrics.ReportEvictionCompleted(wl.Status.Admission.ClusterQueue, reason, *evictionDuration)
+	}
+}
+
+// WorkloadCompletedEviction calculates the time between Evicted=True (if PodsReady=True) and
+// the time provided
+func WorkloadCompletedEviction(wl *kueue.Workload, now time.Time) *time.Duration {
+	evictedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadEvicted)
+	podsReadyCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadPodsReady)
+
+	// Only measure duration if PodsReady=True AND Evicted=True
+	if podsReadyCond == nil || podsReadyCond.Status != metav1.ConditionTrue ||
+		evictedCond == nil || evictedCond.Status != metav1.ConditionTrue {
+		return nil
+	}
+
+	completed := now.Sub(evictedCond.LastTransitionTime.Time)
+	return &completed
 }
 
 func References(wls []*Info) []klog.ObjectRef {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
--> /kind feature

#### What this PR does / why we need it:
We need to be able to measure how long eviction of a running workload takes. There's various production issues that are the result of long evictions.

If `PodsReady=True`, this measure the time between `Evicted=True` and:
- `QuotaReserved=False` OR
- `Finished=True` OR
- Evicted reason `Deactivated`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6122

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
New metric eviction_duration_seconds that measures time between eviction start and end
```