### PR TITLE
Prepare ./hack/releasing/wait_for_images.sh.

### DIFF
--- a/hack/releasing/wait_for_images.sh
+++ b/hack/releasing/wait_for_images.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "${0} <version>"
+  echo
+  echo "  Wait for images"
+  echo
+  echo "  Example:"
+  echo "    $0 v0.13.2"
+  echo
+  exit 2
+fi
+
+declare -r RELEASE_VERSION="$1"
+
+if [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "!!! Invalid release version. It should be semantic version like v0.13.2"
+  exit 1
+fi
+
+declare -r STAGING_IMAGE_REGISTRY="us-central1-docker.pkg.dev/k8s-staging-images/kueue"
+
+# $1 - image name
+# $2 - version
+function check_image() {
+  local image_name="$1"
+  local version="$2"
+  local full_image_name="${STAGING_IMAGE_REGISTRY}/${image_name}:${version}"
+  echo "Checking if \"${full_image_name}\" is available."
+  local image_details
+  image_details=$(gcloud container images describe "${full_image_name}" --verbosity error --format json || true)
+  if [ -n "$image_details" ]; then
+    image_name_with_digest=$(echo "$image_details" | jq -r '.image_summary.fully_qualified_digest')
+    echo " ✅ Image \"${image_name_with_digest}\" is available."
+    return 0
+  else
+    echo " 🚫 Image \"${full_image_name}\" is not found."
+    return 1
+  fi
+}
+
+function check_images() {
+  local images=(
+      kueue
+      kueueviz-backend
+      kueueviz-frontend
+  )
+
+  for image in "${images[@]}"; do
+    if ! check_image "${image}" "${RELEASE_VERSION}"; then
+      return 1
+    fi
+  done
+
+  # The charts/kueue image is require tag without `v` prefix.
+  if ! check_image "charts/kueue" "${RELEASE_VERSION#v}"; then
+    return 1
+  fi
+}
+
+while true; do
+  if check_images; then
+    break
+  fi
+  echo "Try again in 5 seconds..."
+  sleep 5
+done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
Prepare ./hack/releasing/wait_for_images.sh.

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Prepare ./hack/releasing/wait_for_images.sh.

Usage: 

```
./hack/releasing/wait_for_images.sh <version>

  Wait for images

  Example:
    ./hack/releasing/wait_for_images.sh v0.13.2
```

Success logs:

```
./hack/releasing/wait_for_images.sh v0.13.1
Checking if "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:v0.13.1" is available.
 ✅ Image "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue@sha256:f77326c7250c01a5389aa857a89e5ad69fc5700b811cea1c108c3da66b516091" is available.
Checking if "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-backend:v0.13.1" is available.
 ✅ Image "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-backend@sha256:5b53f49eb3535d727dce53a1f519662f0541d6bb274e75800c710a6d162fc281" is available.
Checking if "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-frontend:v0.13.1" is available.
 ✅ Image "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-frontend@sha256:114509dbf11606de789fe9b86a1a31288baa4bcbd97d70342a74e9af490c2d03" is available.
Checking if "us-central1-docker.pkg.dev/k8s-staging-images/kueue/charts/kueue:0.13.1" is available.
 ✅ Image "us-central1-docker.pkg.dev/k8s-staging-images/kueue/charts/kueue@sha256:4da30458c39432acd8eb5e0a2013af518919f982c52512d12e177148596be7e0" is available.
```

Error logs:
```
./hack/releasing/wait_for_images.sh v0.13.2
Checking if "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:v0.13.2" is available.
ERROR: (gcloud.container.images.describe) [us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:v0.13.2] is not found or is not a valid name. Expected tag in the form "base:tag" or "tag" or digest in the form "sha256:<digest>"
 🚫 Image "us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueue:v0.13.2" is not found.
Try again in 5 seconds...
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #6288

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```