### PR TITLE
Cleanup comments no longer relevant today

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -33,9 +33,6 @@ description: >
 Make sure the following conditions are met:
 
 - A Kubernetes cluster with version 1.29 or newer is running. Learn how to [install the Kubernetes tools](https://kubernetes.io/docs/tasks/tools/).
-- The `SuspendJob` [feature gate][feature_gate] is enabled. In Kubernetes 1.22 or newer, the feature gate is enabled by default.
-- (Optional) The `JobMutableNodeSchedulingDirectives` [feature gate][feature_gate] (available in Kubernetes 1.22 or newer) is enabled.
-  In Kubernetes 1.23 or newer, the feature gate is enabled by default.
 - The kubectl command-line tool has communication with your cluster.
 
 Kueue publishes [metrics](/docs/reference/metrics) to monitor its operators.

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -33,9 +33,6 @@ description: >
 确保满足以下条件：
 
 - 运行版本为 1.29 或更新的 Kubernetes 集群。了解如何[安装 Kubernetes 工具](https://kubernetes.io/docs/tasks/tools/)。
-- 启用了 `SuspendJob` [特性][feature_gate]。在 Kubernetes 1.22 或更新版本中，该特性默认启用。
-- （可选）启用了 `JobMutableNodeSchedulingDirectives` [特性][feature_gate]（在 Kubernetes 1.22 或更新版本中可用）。
-  在 Kubernetes 1.23 或更新版本中，该特性默认启用。
 - kubectl 命令行工具已与你的集群通信。
 
 Kueue 发布[指标](/docs/reference/metrics)以监控其控制器组件。


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation

#### What this PR does / why we need it:

drop comments which are no longer relevant 2.5 years since Kubernetes 1.22. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Note that 1.31 is currently the last supported version of K8s: https://endoflife.date/kubernetes

 I'm ok to keep 1.29 for while in the first point as some Cloud Providers may still be supporting older clusters.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```