### PR TITLE
Automated cherry pick of #6468: chore: FlavorQuotas testing wrapper should be built by Obj()

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3606,15 +3606,18 @@ func TestCohortCycles(t *testing.T) {
 		}
 
 		cohort := utiltesting.MakeCohort("cohort").
-			ResourceGroup(utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").FlavorQuotas).Obj()
+			ResourceGroup(
+				*utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
+			).Obj()
 		if err := cache.AddOrUpdateCohort(cohort); err != nil {
 			t.Fatal("Expected success")
 		}
 
 		// Error when creating cq with parent that has cycle
 		cq := utiltesting.MakeClusterQueue("cq").
-			ResourceGroup(utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").FlavorQuotas).
-			Cohort("cycle").Obj()
+			ResourceGroup(
+				*utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj(),
+			).Cohort("cycle").Obj()
 		if err := cache.AddClusterQueue(ctx, cq); err == nil {
 			t.Fatal("Expected failure")
 		}
@@ -3649,15 +3652,14 @@ func TestCohortCycles(t *testing.T) {
 			t.Fatal("Expected failure")
 		}
 		cohort := utiltesting.MakeCohort("cohort").
-			ResourceGroup(utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").FlavorQuotas).Obj()
+			ResourceGroup(*utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
 		if err := cache.AddOrUpdateCohort(cohort); err != nil {
 			t.Fatal("Expected success")
 		}
 
 		// Add CQ to cohort
 		cq := utiltesting.MakeClusterQueue("cq").
-			ResourceGroup(utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").FlavorQuotas).
-			Cohort("cohort").Obj()
+			ResourceGroup(*utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj()).Cohort("cohort").Obj()
 		if err := cache.AddClusterQueue(ctx, cq); err != nil {
 			t.Fatal("Expected success")
 		}
@@ -3711,7 +3713,7 @@ func TestCohortCycles(t *testing.T) {
 		}
 
 		cohort := utiltesting.MakeCohort("cohort").Parent("root1").
-			ResourceGroup(utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").FlavorQuotas).Obj()
+			ResourceGroup(*utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
 		if err := cache.AddOrUpdateCohort(cohort); err != nil {
 			t.Fatal("Expected success")
 		}
@@ -3776,7 +3778,9 @@ func TestCohortCycles(t *testing.T) {
 		}
 
 		cohort := utiltesting.MakeCohort("cohort").Parent("cycle-root").
-			ResourceGroup(utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").FlavorQuotas).Obj()
+			ResourceGroup(
+				*utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
+			).Obj()
 		if err := cache.AddOrUpdateCohort(cohort); err == nil {
 			t.Fatal("Expected failure")
 		}
@@ -3809,7 +3813,9 @@ func TestCohortCycles(t *testing.T) {
 		}
 
 		cohort := utiltesting.MakeCohort("cohort").Parent("root").
-			ResourceGroup(utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").FlavorQuotas).Obj()
+			ResourceGroup(
+				*utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
+			).Obj()
 		if err := cache.AddOrUpdateCohort(cohort); err != nil {
 			t.Fatal("Expected success")
 		}
@@ -3863,9 +3869,9 @@ func TestSnapshotError(t *testing.T) {
 	localQueue := *utiltesting.MakeLocalQueue("lq", "default").ClusterQueue("cq").Obj()
 	clusterQueue := utiltesting.MakeClusterQueue("cq").
 		ResourceGroup(
-			utiltesting.MakeFlavorQuotas("tas-default").
+			*utiltesting.MakeFlavorQuotas("tas-default").
 				ResourceQuotaWrapper("cpu").NominalQuota("8").Append().
-				FlavorQuotas,
+				Obj(),
 		).ClusterQueue
 
 	clientBuilder := utiltesting.NewClientBuilder()

--- a/pkg/cache/clusterqueue_test.go
+++ b/pkg/cache/clusterqueue_test.go
@@ -498,9 +498,9 @@ func TestClusterQueueReadinessWithTAS(t *testing.T) {
 			name: "TAS CQ goes active state",
 			cq: utiltesting.MakeClusterQueue("cq").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("tas-flavor").
+					*utiltesting.MakeFlavorQuotas("tas-flavor").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			wantReason:  "Ready",
 			wantMessage: "Can admit new workloads",
@@ -509,15 +509,15 @@ func TestClusterQueueReadinessWithTAS(t *testing.T) {
 			name: "TAS do not support Cohorts",
 			cq: utiltesting.MakeClusterQueue("cq").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("tas-flavor").
+					*utiltesting.MakeFlavorQuotas("tas-flavor").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			updatedCq: utiltesting.MakeClusterQueue("cq").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("tas-flavor").
+					*utiltesting.MakeFlavorQuotas("tas-flavor").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Cohort("some-cohort").Obj(),
 			wantReason:  kueue.ClusterQueueActiveReasonReady,
 			wantMessage: "Can admit new workloads",
@@ -526,15 +526,15 @@ func TestClusterQueueReadinessWithTAS(t *testing.T) {
 			name: "TAS do not support Preemption",
 			cq: utiltesting.MakeClusterQueue("cq").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("tas-flavor").
+					*utiltesting.MakeFlavorQuotas("tas-flavor").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			updatedCq: utiltesting.MakeClusterQueue("cq").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("tas-flavor").
+					*utiltesting.MakeFlavorQuotas("tas-flavor").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).
 				Preemption(kueue.ClusterQueuePreemption{
 					WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
@@ -550,15 +550,15 @@ func TestClusterQueueReadinessWithTAS(t *testing.T) {
 			name: "TAS do not support MultiKueue AdmissionCheck",
 			cq: utiltesting.MakeClusterQueue("cq").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("tas-flavor").
+					*utiltesting.MakeFlavorQuotas("tas-flavor").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			updatedCq: utiltesting.MakeClusterQueue("cq").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("tas-flavor").
+					*utiltesting.MakeFlavorQuotas("tas-flavor").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).AdmissionChecks("mk-check").Obj(),
 			wantReason:  kueue.ClusterQueueActiveReasonNotSupportedWithTopologyAwareScheduling,
 			wantMessage: "Can't admit new workloads: TAS is not supported with MultiKueue admission check.",
@@ -568,9 +568,9 @@ func TestClusterQueueReadinessWithTAS(t *testing.T) {
 			skipTopology: true,
 			cq: utiltesting.MakeClusterQueue("cq").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("tas-flavor").
+					*utiltesting.MakeFlavorQuotas("tas-flavor").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			wantReason:  kueue.ClusterQueueActiveReasonTopologyNotFound,
 			wantMessage: `Can't admit new workloads: there is no Topology "example-topology" for TAS flavor "tas-flavor".`,

--- a/pkg/cache/fair_sharing_test.go
+++ b/pkg/cache/fair_sharing_test.go
@@ -62,10 +62,10 @@ func TestDominantResourceShare(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("cq").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("cpu").NominalQuota("2000").Append().
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			want: []fairSharingResult{
 				{
@@ -85,19 +85,19 @@ func TestDominantResourceShare(t *testing.T) {
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("cpu").NominalQuota("2").Append().
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			lendingClusterQueue: utiltesting.MakeClusterQueue("lending-cq").
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("cpu").NominalQuota("8").Append().
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			want: []fairSharingResult{
 				{
@@ -129,19 +129,19 @@ func TestDominantResourceShare(t *testing.T) {
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("cpu").NominalQuota("2").Append().
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			lendingClusterQueue: utiltesting.MakeClusterQueue("lending-cq").
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("cpu").NominalQuota("8").Append().
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			want: []fairSharingResult{
 				{
@@ -173,19 +173,19 @@ func TestDominantResourceShare(t *testing.T) {
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("cpu").NominalQuota("2").Append().
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			lendingClusterQueue: utiltesting.MakeClusterQueue("lending-cq").
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("cpu").NominalQuota("8").Append().
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			want: []fairSharingResult{
 				{
@@ -217,19 +217,19 @@ func TestDominantResourceShare(t *testing.T) {
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("cpu").NominalQuota("2").Append().
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			lendingClusterQueue: utiltesting.MakeClusterQueue("lending-cq").
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("cpu").NominalQuota("8").Append().
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			flvResQ: resources.FlavorResourceQuantities{
 				{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
@@ -265,19 +265,19 @@ func TestDominantResourceShare(t *testing.T) {
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("cpu").NominalQuota("2").Append().
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("2").LendingLimit("0").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			lendingClusterQueue: utiltesting.MakeClusterQueue("lending-cq").
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("cpu").NominalQuota("8").Append().
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("64").LendingLimit("0").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			flvResQ: resources.FlavorResourceQuantities{
 				{Flavor: "default", Resource: corev1.ResourceCPU}: 4_000,
@@ -313,20 +313,20 @@ func TestDominantResourceShare(t *testing.T) {
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("on-demand").
+					*utiltesting.MakeFlavorQuotas("on-demand").
 						ResourceQuotaWrapper("cpu").NominalQuota("20").Append().
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("spot").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("spot").
 						ResourceQuotaWrapper("cpu").NominalQuota("80").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			lendingClusterQueue: utiltesting.MakeClusterQueue("lending-cq").
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("cpu").NominalQuota("100").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			flvResQ: resources.FlavorResourceQuantities{
 				{Flavor: "on-demand", Resource: corev1.ResourceCPU}: 10_000,
@@ -360,17 +360,17 @@ func TestDominantResourceShare(t *testing.T) {
 				Cohort("test-cohort").
 				FairWeight(resource.MustParse("2")).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			lendingClusterQueue: utiltesting.MakeClusterQueue("lending-cq").
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			want: []fairSharingResult{
 				{
@@ -401,17 +401,17 @@ func TestDominantResourceShare(t *testing.T) {
 				Cohort("test-cohort").
 				FairWeight(resource.MustParse("0.5")).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			lendingClusterQueue: utiltesting.MakeClusterQueue("lending-cq").
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			want: []fairSharingResult{
 				{
@@ -442,17 +442,17 @@ func TestDominantResourceShare(t *testing.T) {
 				Cohort("test-cohort").
 				FairWeight(resource.MustParse("0")).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			lendingClusterQueue: utiltesting.MakeClusterQueue("lending-cq").
 				Cohort("test-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("10").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			want: []fairSharingResult{
 				{
@@ -483,16 +483,16 @@ func TestDominantResourceShare(t *testing.T) {
 				Cohort("child-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("5").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			cohorts: []*kueuealpha.Cohort{
 				utiltesting.MakeCohort("child-cohort").FairWeight(resource.MustParse("2")).Parent("root").Obj(),
 				utiltesting.MakeCohort("root").ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("45").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			},
 			want: []fairSharingResult{
@@ -524,16 +524,16 @@ func TestDominantResourceShare(t *testing.T) {
 				Cohort("child-cohort").
 				FairWeight(oneQuantity).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("0").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			cohorts: []*kueuealpha.Cohort{
 				utiltesting.MakeCohort("child-cohort").FairWeight(resource.MustParse("2")).Parent("root").Obj(),
 				utiltesting.MakeCohort("root").ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("50").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			},
 			want: []fairSharingResult{
@@ -567,20 +567,20 @@ func TestDominantResourceShare(t *testing.T) {
 			clusterQueue: utiltesting.MakeClusterQueue("cq").
 				Cohort("child-cohort").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("0").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			cohorts: []*kueuealpha.Cohort{
 				utiltesting.MakeCohort("child-cohort").ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("0").BorrowingLimit("10").Append().
-						FlavorQuotas,
+						Obj(),
 				).Parent("root").Obj(),
 				utiltesting.MakeCohort("root").ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper("example.com/gpu").NominalQuota("50").Append().
-						FlavorQuotas,
+						Obj(),
 				).Obj(),
 			},
 			want: []fairSharingResult{

--- a/pkg/cache/resource_node_test.go
+++ b/pkg/cache/resource_node_test.go
@@ -30,18 +30,18 @@ func TestCohortLendable(t *testing.T) {
 
 	cq1 := utiltesting.MakeClusterQueue("cq1").
 		ResourceGroup(
-			utiltesting.MakeFlavorQuotas("default").
+			*utiltesting.MakeFlavorQuotas("default").
 				ResourceQuotaWrapper("cpu").NominalQuota("8").LendingLimit("8").Append().
 				ResourceQuotaWrapper("example.com/gpu").NominalQuota("3").LendingLimit("3").Append().
-				FlavorQuotas,
+				Obj(),
 		).Cohort("test-cohort").
 		ClusterQueue
 
 	cq2 := utiltesting.MakeClusterQueue("cq2").
 		ResourceGroup(
-			utiltesting.MakeFlavorQuotas("default").
+			*utiltesting.MakeFlavorQuotas("default").
 				ResourceQuotaWrapper("cpu").NominalQuota("2").LendingLimit("2").Append().
-				FlavorQuotas,
+				Obj(),
 		).Cohort("test-cohort").
 		ClusterQueue
 

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -815,22 +815,22 @@ func TestSnapshot(t *testing.T) {
 				utiltesting.MakeClusterQueue("cq-autocycle").
 					Cohort("autocycle").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "0").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "0").Obj(),
 					).Obj(),
 				utiltesting.MakeClusterQueue("cq-a").
 					Cohort("cycle-a").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "0").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "0").Obj(),
 					).Obj(),
 				utiltesting.MakeClusterQueue("cq-b").
 					Cohort("cycle-b").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "0").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "0").Obj(),
 					).Obj(),
 				utiltesting.MakeClusterQueue("cq-nocycle").
 					Cohort("nocycle").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "0").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "0").Obj(),
 					).Obj(),
 			},
 			wantSnapshot: Snapshot{

--- a/pkg/controller/core/cohort_controller_test.go
+++ b/pkg/controller/core/cohort_controller_test.go
@@ -188,7 +188,7 @@ func TestCohortReconcileErrorOtherThanNotFoundNotDeleted(t *testing.T) {
 func TestCohortReconcileLifecycle(t *testing.T) {
 	ctx := t.Context()
 	cohort := utiltesting.MakeCohort("cohort").ResourceGroup(
-		utiltesting.MakeFlavorQuotas("red").Resource("cpu", "10").FlavorQuotas,
+		*utiltesting.MakeFlavorQuotas("red").Resource("cpu", "10").Obj(),
 	).Obj()
 	cl := utiltesting.NewClientBuilder().WithObjects(cohort).WithStatusSubresource(&kueue.Cohort{}).Build()
 	cache := cache.New(cl)
@@ -227,7 +227,7 @@ func TestCohortReconcileLifecycle(t *testing.T) {
 			t.Fatal("unexpected error")
 		}
 		cohort.Spec.ResourceGroups[0] = utiltesting.ResourceGroup(
-			utiltesting.MakeFlavorQuotas("red").Resource("cpu", "5").FlavorQuotas,
+			*utiltesting.MakeFlavorQuotas("red").Resource("cpu", "5").Obj(),
 		)
 		if err := cl.Update(ctx, cohort); err != nil {
 			t.Fatal("unexpected error updating cohort", err)
@@ -310,19 +310,19 @@ func TestCohortReconcilerFilters(t *testing.T) {
 	}{
 		"unchanged returns false": {
 			old: utiltesting.MakeCohort("cohort").ResourceGroup(
-				utiltesting.MakeFlavorQuotas("red").Resource("cpu", "5").FlavorQuotas,
+				*utiltesting.MakeFlavorQuotas("red").Resource("cpu", "5").Obj(),
 			).Obj(),
 			new: utiltesting.MakeCohort("cohort").ResourceGroup(
-				utiltesting.MakeFlavorQuotas("red").Resource("cpu", "5").FlavorQuotas,
+				*utiltesting.MakeFlavorQuotas("red").Resource("cpu", "5").Obj(),
 			).Obj(),
 			want: false,
 		},
 		"changed resource returns true": {
 			old: utiltesting.MakeCohort("cohort").ResourceGroup(
-				utiltesting.MakeFlavorQuotas("red").Resource("cpu", "5").FlavorQuotas,
+				*utiltesting.MakeFlavorQuotas("red").Resource("cpu", "5").Obj(),
 			).Obj(),
 			new: utiltesting.MakeCohort("cohort").ResourceGroup(
-				utiltesting.MakeFlavorQuotas("red").Resource("cpu", "10").FlavorQuotas,
+				*utiltesting.MakeFlavorQuotas("red").Resource("cpu", "10").Obj(),
 			).Obj(),
 			want: true,
 		},

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -99,10 +99,10 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						Resource(corev1.ResourceCPU, "1").
 						Resource(corev1.ResourceMemory, "2Mi").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			wantRepMode: Fit,
 			wantAssignment: Assignment{
@@ -140,9 +140,9 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("tainted").
+					*utiltesting.MakeFlavorQuotas("tainted").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 
 			wantRepMode: Fit,
@@ -168,9 +168,9 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("taint_and_toleration").
+					*utiltesting.MakeFlavorQuotas("taint_and_toleration").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 
 			wantRepMode: Fit,
@@ -198,9 +198,9 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "default", Resource: corev1.ResourceCPU}: 3_000,
@@ -234,20 +234,20 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "2").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
+						Obj(),
 				).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("b_one").
+					*utiltesting.MakeFlavorQuotas("b_one").
 						Resource(corev1.ResourceMemory, "1Gi").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("b_two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("b_two").
 						Resource(corev1.ResourceMemory, "5Gi").
-						FlavorQuotas,
+						Obj(),
 				).
 				ClusterQueue,
 			wantRepMode: Fit,
@@ -279,13 +279,13 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "3").
-						FlavorQuotas,
+						Obj(),
 				).ResourceGroup(
-				utiltesting.MakeFlavorQuotas("b_one").
+				*utiltesting.MakeFlavorQuotas("b_one").
 					Resource(corev1.ResourceMemory, "1Mi").
-					FlavorQuotas,
+					Obj(),
 			).ClusterQueue,
 
 			clusterQueueUsage: resources.FlavorResourceQuantities{
@@ -319,21 +319,21 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "2").
 						Resource(corev1.ResourceMemory, "1Gi").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "4").
 						Resource(corev1.ResourceMemory, "15Mi").
-						FlavorQuotas,
+						Obj(),
 				).ResourceGroup(
-				utiltesting.MakeFlavorQuotas("b_one").
+				*utiltesting.MakeFlavorQuotas("b_one").
 					Resource("example.com/gpu", "4").
-					FlavorQuotas,
-				utiltesting.MakeFlavorQuotas("b_two").
+					Obj(),
+				*utiltesting.MakeFlavorQuotas("b_two").
 					Resource("example.com/gpu", "2").
-					FlavorQuotas,
+					Obj(),
 			).ClusterQueue,
 
 			wantRepMode: Fit,
@@ -369,18 +369,18 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "2").
 						Resource(corev1.ResourceMemory, "1Gi").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "4").
 						Resource(corev1.ResourceMemory, "15Mi").
-						FlavorQuotas,
+						Obj(),
 				).ResourceGroup(
-				utiltesting.MakeFlavorQuotas("b_one").
+				*utiltesting.MakeFlavorQuotas("b_one").
 					Resource("example.com/gpu", "4").
-					FlavorQuotas,
+					Obj(),
 			).Cohort("test-cohort").
 				ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
@@ -388,9 +388,9 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("b_one").
+					*utiltesting.MakeFlavorQuotas("b_one").
 						Resource("example.com/gpu", "0").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -437,14 +437,14 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "2").
 						Resource(corev1.ResourceMemory, "1Gi").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "4").
 						Resource(corev1.ResourceMemory, "5Mi").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			wantAssignment: Assignment{
 				PodSets: []PodSetAssignment{{
@@ -472,12 +472,12 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("tainted").
+					*utiltesting.MakeFlavorQuotas("tainted").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			wantRepMode: Fit,
 			wantAssignment: Assignment{
@@ -522,12 +522,12 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			wantRepMode: Fit,
 			wantAssignment: Assignment{
@@ -571,14 +571,14 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "4").
 						Resource(corev1.ResourceMemory, "1Gi").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "4").
 						Resource(corev1.ResourceMemory, "1Gi").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 
 			wantRepMode: Fit,
@@ -637,12 +637,12 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 
 			wantRepMode: Fit,
@@ -685,12 +685,12 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 
 			wantAssignment: Assignment{
@@ -721,12 +721,12 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "10").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 
 			wantRepMode: Fit,
@@ -772,10 +772,10 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("2").BorrowingLimit("98").Append().
 						Resource(corev1.ResourceMemory, "2Gi").
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").
 				ClusterQueue,
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
@@ -830,15 +830,15 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "1").
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").ClusterQueue,
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("10").LendingLimit("0").Append().
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -867,9 +867,9 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("2").BorrowingLimit("8").Append().
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").
 				ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
@@ -877,9 +877,9 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "98").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -916,9 +916,9 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "2").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: 1_000,
@@ -951,18 +951,18 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "3").
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
 			},
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "7").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -1000,12 +1000,12 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: 3_000,
@@ -1051,12 +1051,12 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("tainted").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("tainted").
 						Resource(corev1.ResourceCPU, "10").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "one", Resource: corev1.ResourceCPU}:     3_000,
@@ -1112,9 +1112,9 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "4").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			wantAssignment: Assignment{
 				PodSets: []PodSetAssignment{{
@@ -1138,10 +1138,10 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						Resource(corev1.ResourcePods, "3").
 						Resource(corev1.ResourceCPU, "10").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 
 			wantAssignment: Assignment{
@@ -1173,10 +1173,10 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						Resource(corev1.ResourcePods, "2").
 						Resource(corev1.ResourceCPU, "10").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 
 			wantAssignment: Assignment{
@@ -1208,10 +1208,10 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("default").
+					*utiltesting.MakeFlavorQuotas("default").
 						Resource(corev1.ResourcePods, "3").
 						Resource(corev1.ResourceCPU, "10").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			wantAssignment: Assignment{
 				PodSets: []PodSetAssignment{{
@@ -1243,14 +1243,14 @@ func TestAssignFlavors(t *testing.T) {
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				FlavorFungibility(kueue.FlavorFungibility{WhenCanBorrow: kueue.Borrow, WhenCanPreempt: kueue.Preempt}).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourcePods, "10").
 						Resource(corev1.ResourceCPU, "10").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourcePods, "10").
 						Resource(corev1.ResourceCPU, "10").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
@@ -1286,14 +1286,14 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourcePods, "10").
 						Resource(corev1.ResourceCPU, "10").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourcePods, "10").
 						Resource(corev1.ResourceCPU, "10").
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
@@ -1327,14 +1327,14 @@ func TestAssignFlavors(t *testing.T) {
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				FlavorFungibility(kueue.FlavorFungibility{WhenCanBorrow: kueue.TryNextFlavor, WhenCanPreempt: kueue.TryNextFlavor}).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourcePods, "10").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("10").BorrowingLimit("1").Append().
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourcePods, "10").
 						Resource(corev1.ResourceCPU, "1").
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").
 				ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
@@ -1342,9 +1342,9 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "1").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -1378,14 +1378,14 @@ func TestAssignFlavors(t *testing.T) {
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				FlavorFungibility(kueue.FlavorFungibility{WhenCanBorrow: kueue.TryNextFlavor, WhenCanPreempt: kueue.TryNextFlavor}).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourcePods, "10").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("10").BorrowingLimit("1").Append().
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourcePods, "10").
 						Resource(corev1.ResourceCPU, "10").
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").
 				ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
@@ -1394,9 +1394,9 @@ func TestAssignFlavors(t *testing.T) {
 
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "1").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -1428,14 +1428,14 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourcePods, "10").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("10").BorrowingLimit("1").Append().
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourcePods, "10").
 						Resource(corev1.ResourceCPU, "10").
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").
 				ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
@@ -1443,9 +1443,9 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "1").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -1488,18 +1488,18 @@ func TestAssignFlavors(t *testing.T) {
 					WhenCanPreempt: kueue.Preempt,
 				}).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("0").BorrowingLimit("12").Append().
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "12").
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").ClusterQueue,
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "12").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -1545,18 +1545,18 @@ func TestAssignFlavors(t *testing.T) {
 					WhenCanPreempt: kueue.Preempt,
 				}).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "0").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "12").
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").ClusterQueue,
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "12").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -1602,19 +1602,19 @@ func TestAssignFlavors(t *testing.T) {
 					WhenCanPreempt: kueue.Preempt,
 				}).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("0").BorrowingLimit("12").Append().
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "12").
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").
 				ClusterQueue,
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "12").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -1649,15 +1649,15 @@ func TestAssignFlavors(t *testing.T) {
 					},
 				}).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("0").BorrowingLimit("12").Append().
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").ClusterQueue,
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "11").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -1693,14 +1693,14 @@ func TestAssignFlavors(t *testing.T) {
 					WhenCanPreempt: kueue.TryNextFlavor},
 				).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourcePods, "10").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("10").LendingLimit("1").Append().
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourcePods, "10").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("10").LendingLimit("0").Append().
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").
 				ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
@@ -1708,9 +1708,9 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "1").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -1743,14 +1743,14 @@ func TestAssignFlavors(t *testing.T) {
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				FlavorFungibility(kueue.FlavorFungibility{WhenCanBorrow: kueue.TryNextFlavor, WhenCanPreempt: kueue.TryNextFlavor}).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourcePods, "10").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("10").LendingLimit("1").Append().
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourcePods, "10").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("1").LendingLimit("0").Append().
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").
 				ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
@@ -1758,9 +1758,9 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "1").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -1800,22 +1800,22 @@ func TestAssignFlavors(t *testing.T) {
 					},
 				}).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("0").BorrowingLimit("2").Append().
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("0").BorrowingLimit("2").Append().
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").
 				ClusterQueue,
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("2").Append().
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("2").Append().
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -1852,20 +1852,20 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourcePods, "10").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("10").LendingLimit("0").Append().
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").ClusterQueue,
 			clusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: 2_000,
 			},
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourcePods, "0").
 						Resource(corev1.ResourceCPU, "0").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -1905,18 +1905,18 @@ func TestAssignFlavors(t *testing.T) {
 				Preemption(kueue.ClusterQueuePreemption{ReclaimWithinCohort: kueue.PreemptionPolicyAny}).
 				FlavorFungibility(kueue.FlavorFungibility{WhenCanBorrow: kueue.Borrow, WhenCanPreempt: kueue.Preempt}).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "0").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "12").
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").ClusterQueue,
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "12").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -1955,18 +1955,18 @@ func TestAssignFlavors(t *testing.T) {
 				Preemption(kueue.ClusterQueuePreemption{ReclaimWithinCohort: kueue.PreemptionPolicyNever}).
 				FlavorFungibility(kueue.FlavorFungibility{WhenCanBorrow: kueue.Borrow, WhenCanPreempt: kueue.Preempt}).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "0").
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("two").
 						Resource(corev1.ResourceCPU, "12").
-						FlavorQuotas,
+						Obj(),
 				).Cohort("test-cohort").ClusterQueue,
 			secondaryClusterQueue: utiltesting.MakeClusterQueue("test-secondary-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").
+					*utiltesting.MakeFlavorQuotas("one").
 						Resource(corev1.ResourceCPU, "12").
-						FlavorQuotas,
+						Obj(),
 				).
 				Cohort("test-cohort").
 				Obj(),
@@ -2167,16 +2167,16 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 					WhenCanPreempt: kueue.TryNextFlavor,
 				}).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("uno").Resource("compute", "10").Resource("gpu", "10").FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("due").Resource("compute", "10").Resource("gpu", "10").FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("tre").Resource("compute", "10").Resource("gpu", "10").FlavorQuotas,
+					*utiltesting.MakeFlavorQuotas("uno").Resource("compute", "10").Resource("gpu", "10").Obj(),
+					*utiltesting.MakeFlavorQuotas("due").Resource("compute", "10").Resource("gpu", "10").Obj(),
+					*utiltesting.MakeFlavorQuotas("tre").Resource("compute", "10").Resource("gpu", "10").Obj(),
 				).ClusterQueue
 			otherCq := utiltesting.MakeClusterQueue("other-clusterqueue").
 				Cohort("cohort").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("uno").Resource("compute", "0").Resource("gpu", "0").FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("due").Resource("compute", "0").Resource("gpu", "0").FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("tre").Resource("compute", "0").Resource("gpu", "0").FlavorQuotas,
+					*utiltesting.MakeFlavorQuotas("uno").Resource("compute", "0").Resource("gpu", "0").Obj(),
+					*utiltesting.MakeFlavorQuotas("due").Resource("compute", "0").Resource("gpu", "0").Obj(),
+					*utiltesting.MakeFlavorQuotas("tre").Resource("compute", "0").Resource("gpu", "0").Obj(),
 				).ClusterQueue
 
 			wlInfo := workload.NewInfo(&kueue.Workload{
@@ -2248,12 +2248,12 @@ func TestDeletedFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("deleted-flavor").
+					*utiltesting.MakeFlavorQuotas("deleted-flavor").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("4").Append().
-						FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("flavor").
+						Obj(),
+					*utiltesting.MakeFlavorQuotas("flavor").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("4").Append().
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			wantRepMode: Fit,
 			wantAssignment: Assignment{
@@ -2280,9 +2280,9 @@ func TestDeletedFlavors(t *testing.T) {
 			},
 			clusterQueue: utiltesting.MakeClusterQueue("test-clusterqueue").
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("deleted-flavor").
+					*utiltesting.MakeFlavorQuotas("deleted-flavor").
 						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("4").Append().
-						FlavorQuotas,
+						Obj(),
 				).ClusterQueue,
 			wantAssignment: Assignment{
 				PodSets: []PodSetAssignment{{
@@ -2468,18 +2468,18 @@ func TestHierarchical(t *testing.T) {
 					ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 				}).
 				ResourceGroup(
-					utiltesting.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "0").FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").FlavorQuotas,
-					utiltesting.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").FlavorQuotas,
+					*utiltesting.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "0").Obj(),
+					*utiltesting.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").Obj(),
+					*utiltesting.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").Obj(),
 				).
 				FlavorFungibility(kueue.FlavorFungibility{
 					WhenCanPreempt: kueue.TryNextFlavor,
 				}).ClusterQueue
 			otherCq := utiltesting.MakeClusterQueue("other-clusterqueue").
 				Cohort("two").ResourceGroup(
-				utiltesting.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "0").FlavorQuotas,
-				utiltesting.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").FlavorQuotas,
-				utiltesting.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").FlavorQuotas,
+				*utiltesting.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "0").Obj(),
+				*utiltesting.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").Obj(),
+				*utiltesting.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").Obj(),
 			).ClusterQueue
 
 			wlInfo := workload.NewInfo(&kueue.Workload{

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -2736,8 +2736,8 @@ func TestSchedule(t *testing.T) {
 						ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 					}).
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "10").FlavorQuotas,
-						utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "10").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "10").Obj(),
+						*utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "10").Obj(),
 					).
 					Obj(),
 				*utiltesting.MakeClusterQueue("other-beta").
@@ -2747,8 +2747,8 @@ func TestSchedule(t *testing.T) {
 						ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 					}).
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").FlavorQuotas,
-						utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "0").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").Obj(),
+						*utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "0").Obj(),
 					).
 					Obj(),
 			},
@@ -2799,15 +2799,15 @@ func TestSchedule(t *testing.T) {
 						ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 					}).
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "7").FlavorQuotas,
-						utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "7").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "7").Obj(),
+						*utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "7").Obj(),
 					).
 					Obj(),
 				*utiltesting.MakeClusterQueue("other-beta").
 					Cohort("other").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "3").FlavorQuotas,
-						utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "3").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "3").Obj(),
+						*utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "3").Obj(),
 					).
 					Obj(),
 			},
@@ -2855,15 +2855,15 @@ func TestSchedule(t *testing.T) {
 						ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 					}).
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "10").FlavorQuotas,
-						utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "10").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "10").Obj(),
+						*utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "10").Obj(),
 					).
 					Obj(),
 				*utiltesting.MakeClusterQueue("other-beta").
 					Cohort("other").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").FlavorQuotas,
-						utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "0").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").Obj(),
+						*utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "0").Obj(),
 					).
 					Obj(),
 			},
@@ -2919,15 +2919,15 @@ func TestSchedule(t *testing.T) {
 						ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 					}).
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "10").FlavorQuotas,
-						utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "10").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "10").Obj(),
+						*utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "10").Obj(),
 					).
 					Obj(),
 				*utiltesting.MakeClusterQueue("other-beta").
 					Cohort("other").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").FlavorQuotas,
-						utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "0").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").Obj(),
+						*utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "0").Obj(),
 					).
 					Obj(),
 			},
@@ -3007,7 +3007,7 @@ func TestSchedule(t *testing.T) {
 				*utiltesting.MakeClusterQueue("CQ1").
 					Cohort("other").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "10").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "10").Obj(),
 					).
 					Obj(),
 				*utiltesting.MakeClusterQueue("CQ2").
@@ -3016,13 +3016,13 @@ func TestSchedule(t *testing.T) {
 						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
 					}).
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "10").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "10").Obj(),
 					).
 					Obj(),
 				*utiltesting.MakeClusterQueue("CQ3").
 					Cohort("other").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").Obj(),
 					).
 					Obj(),
 			},
@@ -3083,7 +3083,7 @@ func TestSchedule(t *testing.T) {
 				*utiltesting.MakeClusterQueue("ClusterQueueA").
 					Cohort("root").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "2").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "2").Obj(),
 					).
 					Preemption(kueue.ClusterQueuePreemption{
 						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
@@ -3092,7 +3092,7 @@ func TestSchedule(t *testing.T) {
 				*utiltesting.MakeClusterQueue("ClusterQueueB").
 					Cohort("root").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").Obj(),
 					).
 					Obj(),
 			},
@@ -3136,7 +3136,7 @@ func TestSchedule(t *testing.T) {
 				*utiltesting.MakeClusterQueue("ClusterQueueA").
 					Cohort("root").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "2").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "2").Obj(),
 					).
 					Preemption(kueue.ClusterQueuePreemption{
 						ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
@@ -3145,7 +3145,7 @@ func TestSchedule(t *testing.T) {
 				*utiltesting.MakeClusterQueue("ClusterQueueB").
 					Cohort("root").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").Obj(),
 					).
 					Obj(),
 			},
@@ -3187,7 +3187,7 @@ func TestSchedule(t *testing.T) {
 				*utiltesting.MakeClusterQueue("ClusterQueueA").
 					Cohort("root").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "2").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "2").Obj(),
 					).
 					Preemption(kueue.ClusterQueuePreemption{
 						ReclaimWithinCohort: kueue.PreemptionPolicyNever,
@@ -3196,7 +3196,7 @@ func TestSchedule(t *testing.T) {
 				*utiltesting.MakeClusterQueue("ClusterQueueB").
 					Cohort("root").
 					ResourceGroup(
-						utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").FlavorQuotas,
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "0").Obj(),
 					).
 					Obj(),
 			},

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -296,7 +296,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			cohortSecondRight := createCohort(testing.MakeCohort("second-right").Parent("first-left").Obj())
 			cohortBank := createCohort(testing.MakeCohort("bank").Parent("first-right").
 				ResourceGroup(
-					testing.MakeFlavorQuotas(defaultFlavor.Name).Resource(corev1.ResourceCPU, "10").FlavorQuotas,
+					*testing.MakeFlavorQuotas(defaultFlavor.Name).Resource(corev1.ResourceCPU, "10").Obj(),
 				).Obj())
 
 			cqSecondLeft := createQueue(testing.MakeClusterQueue("second-left").

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -1515,7 +1515,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("cohort with resources created and workload admitted")
 			cohortBank := testing.MakeCohort("bank").Parent("right").
 				ResourceGroup(
-					testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "10").FlavorQuotas,
+					*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "10").Obj(),
 				).Obj()
 			util.MustCreate(ctx, k8sClient, cohortBank)
 			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()
@@ -2545,12 +2545,18 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			createQueue(testing.MakeClusterQueue("cq1").
 				FlavorFungibility(fungibility).Cohort("cohort").
 				Preemption(preemption).
-				ResourceGroup(testing.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "0").FlavorQuotas, testing.MakeFlavorQuotas("f2").Resource(corev1.ResourceCPU, "1").FlavorQuotas).Obj())
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "0").Obj(),
+					*testing.MakeFlavorQuotas("f2").Resource(corev1.ResourceCPU, "1").Obj(),
+				).Obj())
 
 			createQueue(testing.MakeClusterQueue("cq2").Cohort("cohort").
 				FlavorFungibility(fungibility).
 				Preemption(preemption).
-				ResourceGroup(testing.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "1").FlavorQuotas, testing.MakeFlavorQuotas("f2").Resource(corev1.ResourceCPU, "0").FlavorQuotas).Obj())
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "1").Obj(),
+					*testing.MakeFlavorQuotas("f2").Resource(corev1.ResourceCPU, "0").Obj(),
+				).Obj())
 
 			cq1LowPriority := createWorkloadWithPriority("cq1", "1", 0)
 			{

--- a/test/integration/singlecluster/webhook/core/cohort_test.go
+++ b/test/integration/singlecluster/webhook/core/cohort_test.go
@@ -74,27 +74,27 @@ var _ = ginkgo.Describe("Cohort Webhook", func() {
 				testing.BeForbiddenError()),
 			ginkgo.Entry("Should reject too many flavors in resource group",
 				testing.MakeCohort("cohort").ResourceGroup(
-					testing.MakeFlavorQuotas("f0").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f2").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f3").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f4").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f5").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f6").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f7").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f8").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f9").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f10").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f11").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f12").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f13").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f14").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f15").Resource(corev1.ResourceCPU).FlavorQuotas,
-					testing.MakeFlavorQuotas("f16").Resource(corev1.ResourceCPU).FlavorQuotas).Obj(),
+					*testing.MakeFlavorQuotas("f0").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f2").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f3").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f4").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f5").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f6").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f7").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f8").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f9").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f10").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f11").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f12").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f13").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f14").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f15").Resource(corev1.ResourceCPU).Obj(),
+					*testing.MakeFlavorQuotas("f16").Resource(corev1.ResourceCPU).Obj()).Obj(),
 				testing.BeInvalidError()),
 			ginkgo.Entry("Should reject too many resources in resource group",
 				testing.MakeCohort("cohort").ResourceGroup(
-					testing.MakeFlavorQuotas("flavor").
+					*testing.MakeFlavorQuotas("flavor").
 						Resource("cpu0").
 						Resource("cpu1").
 						Resource("cpu2").
@@ -111,7 +111,7 @@ var _ = ginkgo.Describe("Cohort Webhook", func() {
 						Resource("cpu13").
 						Resource("cpu14").
 						Resource("cpu15").
-						Resource("cpu16").FlavorQuotas).Obj(),
+						Resource("cpu16").Obj()).Obj(),
 				testing.BeInvalidError()),
 			ginkgo.Entry("Should allow resource with valid name",
 				testing.MakeCohort("cohort").
@@ -176,18 +176,18 @@ var _ = ginkgo.Describe("Cohort Webhook", func() {
 			ginkgo.Entry("Should reject lendingLimit when no parent",
 				testing.MakeCohort("cohort").
 					ResourceGroup(
-						testing.MakeFlavorQuotas("x86").
+						*testing.MakeFlavorQuotas("x86").
 							ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("1").LendingLimit("1").Append().
-							FlavorQuotas,
+							Obj(),
 					).
 					Obj(),
 				testing.BeForbiddenError()),
 			ginkgo.Entry("Should allow lendingLimit when parent exists",
 				testing.MakeCohort("cohort").
 					ResourceGroup(
-						testing.MakeFlavorQuotas("x86").
+						*testing.MakeFlavorQuotas("x86").
 							ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("1").LendingLimit("1").Append().
-							FlavorQuotas,
+							Obj(),
 					).
 					Parent("parent").
 					Obj(),
@@ -195,9 +195,9 @@ var _ = ginkgo.Describe("Cohort Webhook", func() {
 			ginkgo.Entry("Should allow lendingLimit 0 when parent exists",
 				testing.MakeCohort("cohort").
 					ResourceGroup(
-						testing.MakeFlavorQuotas("x86").
+						*testing.MakeFlavorQuotas("x86").
 							ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("0").LendingLimit("0").Append().
-							FlavorQuotas,
+							Obj(),
 					).
 					Parent("parent").
 					Obj(),
@@ -205,9 +205,9 @@ var _ = ginkgo.Describe("Cohort Webhook", func() {
 			ginkgo.Entry("Should allow lending limit to exceed nominal quota",
 				testing.MakeCohort("cohort").
 					ResourceGroup(
-						testing.MakeFlavorQuotas("x86").
+						*testing.MakeFlavorQuotas("x86").
 							ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("3").LendingLimit("5").Append().
-							FlavorQuotas,
+							Obj(),
 					).
 					Parent("parent").
 					Obj(),


### PR DESCRIPTION
Cherry pick of #6468 on release-0.12.

#6468: chore: FlavorQuotas testing wrapper should be built by Obj()

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```