### PR TITLE
chore: Use ClusterAutoscaler constants for ProvReqs

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/constants.go
+++ b/pkg/controller/admissionchecks/provisioning/constants.go
@@ -17,11 +17,7 @@ limitations under the License.
 package provisioning
 
 const (
-	ConfigKind             = "ProvisioningRequestConfig"
-	ControllerName         = "kueue.x-k8s.io/provisioning-request"
-	ConsumesAnnotationKey  = "autoscaling.x-k8s.io/consume-provisioning-request"
-	ClassNameAnnotationKey = "autoscaling.x-k8s.io/provisioning-class-name"
-
+	ConfigKind           = "ProvisioningRequestConfig"
 	CheckInactiveMessage = "the check is not active"
 	NoRequestNeeded      = "the provisioning request is not needed"
 )

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -624,8 +624,9 @@ func podSetUpdates(log logr.Logger, wl *kueue.Workload, pr *autoscaling.Provisio
 		podSetUpdate := kueue.PodSetUpdate{
 			Name: refMap[ps.PodTemplateRef.Name],
 			Annotations: map[string]string{
-				ConsumesAnnotationKey:  pr.Name,
-				ClassNameAnnotationKey: pr.Spec.ProvisioningClassName},
+				autoscaling.ProvisioningRequestPodAnnotationKey: pr.Name,
+				autoscaling.ProvisioningClassPodAnnotationKey:   pr.Spec.ProvisioningClassName,
+			},
 		}
 		if psUpdate := prc.Spec.PodSetUpdates; psUpdate != nil {
 			podSetUpdate.NodeSelector = make(map[string]string, len(psUpdate.NodeSelector))

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -616,15 +616,15 @@ func TestReconcile(t *testing.T) {
 							{
 								Name: "ps1",
 								Annotations: map[string]string{
-									ConsumesAnnotationKey:  "wl-check1-1",
-									ClassNameAnnotationKey: "class1",
+									autoscaling.ProvisioningRequestPodAnnotationKey: "wl-check1-1",
+									autoscaling.ProvisioningClassPodAnnotationKey:   "class1",
 								},
 							},
 							{
 								Name: "ps2",
 								Annotations: map[string]string{
-									ConsumesAnnotationKey:  "wl-check1-1",
-									ClassNameAnnotationKey: "class1",
+									autoscaling.ProvisioningRequestPodAnnotationKey: "wl-check1-1",
+									autoscaling.ProvisioningClassPodAnnotationKey:   "class1",
 								},
 							},
 						},
@@ -1177,8 +1177,8 @@ func TestReconcile(t *testing.T) {
 							{
 								Name: "ps1",
 								Annotations: map[string]string{
-									ConsumesAnnotationKey:  "wl-check1-1",
-									ClassNameAnnotationKey: "class1",
+									autoscaling.ProvisioningRequestPodAnnotationKey: "wl-check1-1",
+									autoscaling.ProvisioningClassPodAnnotationKey:   "class1",
 								},
 								NodeSelector: map[string]string{
 									"node-selector-key": "nodes-selector-xyz",
@@ -1187,8 +1187,8 @@ func TestReconcile(t *testing.T) {
 							{
 								Name: "ps2",
 								Annotations: map[string]string{
-									ConsumesAnnotationKey:  "wl-check1-1",
-									ClassNameAnnotationKey: "class1",
+									autoscaling.ProvisioningRequestPodAnnotationKey: "wl-check1-1",
+									autoscaling.ProvisioningClassPodAnnotationKey:   "class1",
 								},
 								NodeSelector: map[string]string{
 									"node-selector-key": "nodes-selector-xyz",
@@ -1226,15 +1226,15 @@ func TestReconcile(t *testing.T) {
 							{
 								Name: "ps1",
 								Annotations: map[string]string{
-									ConsumesAnnotationKey:  "wl-check1-1",
-									ClassNameAnnotationKey: "class1",
+									autoscaling.ProvisioningRequestPodAnnotationKey: "wl-check1-1",
+									autoscaling.ProvisioningClassPodAnnotationKey:   "class1",
 								},
 							},
 							{
 								Name: "ps2",
 								Annotations: map[string]string{
-									ConsumesAnnotationKey:  "wl-check1-1",
-									ClassNameAnnotationKey: "class1",
+									autoscaling.ProvisioningRequestPodAnnotationKey: "wl-check1-1",
+									autoscaling.ProvisioningClassPodAnnotationKey:   "class1",
 								},
 							},
 						},

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -299,15 +299,15 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 						{
 							Name: "ps1",
 							Annotations: map[string]string{
-								provisioning.ConsumesAnnotationKey:  provReqKey.Name,
-								provisioning.ClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
+								autoscaling.ProvisioningRequestPodAnnotationKey: provReqKey.Name,
+								autoscaling.ProvisioningClassPodAnnotationKey:   prc.Spec.ProvisioningClassName,
 							},
 						},
 						{
 							Name: "ps2",
 							Annotations: map[string]string{
-								provisioning.ConsumesAnnotationKey:  provReqKey.Name,
-								provisioning.ClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
+								autoscaling.ProvisioningRequestPodAnnotationKey: provReqKey.Name,
+								autoscaling.ProvisioningClassPodAnnotationKey:   prc.Spec.ProvisioningClassName,
 							},
 						},
 					}))
@@ -740,15 +740,15 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 						{
 							Name: "ps1",
 							Annotations: map[string]string{
-								provisioning.ConsumesAnnotationKey:  provReqKey.Name,
-								provisioning.ClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
+								autoscaling.ProvisioningRequestPodAnnotationKey: provReqKey.Name,
+								autoscaling.ProvisioningClassPodAnnotationKey:   prc.Spec.ProvisioningClassName,
 							},
 						},
 						{
 							Name: "ps2",
 							Annotations: map[string]string{
-								provisioning.ConsumesAnnotationKey:  provReqKey.Name,
-								provisioning.ClassNameAnnotationKey: prc.Spec.ProvisioningClassName,
+								autoscaling.ProvisioningRequestPodAnnotationKey: provReqKey.Name,
+								autoscaling.ProvisioningClassPodAnnotationKey:   prc.Spec.ProvisioningClassName,
 							},
 						},
 					}))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
I refined the following ProvisioningRequest controller constants:

1. Removed the unused [duplicated](https://github.com/kubernetes-sigs/kueue/blob/fc19353ce2b6beb6eaf3838839f4b6c84a69ce5b/apis/kueue/v1beta1/provisioningrequestconfig_types.go#L27-L29) `ControllerName`.
2. Replaced `ConsumesAnnotationKey` with https://github.com/kubernetes/autoscaler/blob/9b8558e24cf29fbe4806d24ea8308fb2d6a898aa/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1/types.go#L204-L205
3. Replaced `ClassNameAnnotationKey` with https://github.com/kubernetes/autoscaler/blob/9b8558e24cf29fbe4806d24ea8308fb2d6a898aa/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1/types.go#L206-L207

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```