### PR TITLE
TAS: Filter out Node updates with LastHeartbeatTime changes

### DIFF
--- a/pkg/controller/tas/resource_flavor_test.go
+++ b/pkg/controller/tas/resource_flavor_test.go
@@ -1,0 +1,252 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tas
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+)
+
+func TestNodeHandler_Update(t *testing.T) {
+	now := metav1.Now()
+	later := metav1.NewTime(now.Add(10 * time.Second))
+
+	baseNode := testingnode.MakeNode("test-node").
+		Annotation("test-annotation", "value").
+		Label("topology.kubernetes.io/zone", "zone-a").
+		Label("node-role", "worker").
+		Taints(corev1.Taint{
+			Key:    "test-taint",
+			Value:  "value",
+			Effect: corev1.TaintEffectNoSchedule,
+		}).
+		StatusAllocatable(corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("8"),
+			corev1.ResourceMemory: resource.MustParse("32Gi"),
+		})
+
+	testCases := map[string]struct {
+		oldNode     *corev1.Node
+		newNode     *corev1.Node
+		wantChanged bool
+	}{
+		"LastHeartbeatTime changed": {
+			oldNode: baseNode.Clone().
+				StatusConditions(
+					corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionTrue,
+						LastHeartbeatTime:  now,
+						LastTransitionTime: now,
+					},
+					corev1.NodeCondition{
+						Type:               corev1.NodeMemoryPressure,
+						Status:             corev1.ConditionFalse,
+						LastHeartbeatTime:  now,
+						LastTransitionTime: now,
+					},
+				).Obj(),
+			newNode: baseNode.Clone().
+				StatusConditions(
+					corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionTrue,
+						LastHeartbeatTime:  later,
+						LastTransitionTime: now,
+					},
+					corev1.NodeCondition{
+						Type:               corev1.NodeMemoryPressure,
+						Status:             corev1.ConditionFalse,
+						LastHeartbeatTime:  later,
+						LastTransitionTime: now,
+					},
+				).Obj(),
+			wantChanged: false,
+		},
+		"Annotation changed": {
+			oldNode:     baseNode.Clone().Obj(),
+			newNode:     baseNode.Clone().Annotation("new-annotation", "new-value").Obj(),
+			wantChanged: true,
+		},
+		"Label changed": {
+			oldNode:     baseNode.Clone().Obj(),
+			newNode:     baseNode.Clone().Label("new-label", "new-value").Obj(),
+			wantChanged: true,
+		},
+		"Node Ready status changed": {
+			oldNode: baseNode.Clone().
+				StatusConditions(
+					corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionTrue,
+						LastHeartbeatTime:  now,
+						LastTransitionTime: now,
+					},
+				).Obj(),
+			newNode: baseNode.Clone().
+				StatusConditions(
+					corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionFalse,
+						LastHeartbeatTime:  later,
+						LastTransitionTime: later,
+					},
+				).Obj(),
+			wantChanged: true,
+		},
+		"Allocatable resources changed": {
+			oldNode: baseNode.Clone().Obj(),
+			newNode: baseNode.Clone().StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("16"),
+				corev1.ResourceMemory: resource.MustParse("32Gi"),
+			}).Obj(),
+			wantChanged: true,
+		},
+		"Taints changed": {
+			oldNode: baseNode.Clone().Obj(),
+			newNode: baseNode.Clone().Taints(corev1.Taint{
+				Key:    "new-taint",
+				Value:  "new-value",
+				Effect: corev1.TaintEffectNoExecute,
+			}).Obj(),
+			wantChanged: true,
+		},
+		"Taints with TimeAdded": {
+			oldNode: baseNode.Clone().Taints(corev1.Taint{
+				Key:       "test",
+				Value:     "value",
+				Effect:    corev1.TaintEffectNoExecute,
+				TimeAdded: &now,
+			}).Obj(),
+			newNode: baseNode.Clone().Taints(corev1.Taint{
+				Key:       "test",
+				Value:     "value",
+				Effect:    corev1.TaintEffectNoExecute,
+				TimeAdded: &later,
+			}).Obj(),
+			wantChanged: true,
+		},
+		"Taints TimeAdded from null to non-null": {
+			oldNode: baseNode.Clone().Taints(corev1.Taint{
+				Key:       "test",
+				Value:     "value",
+				Effect:    corev1.TaintEffectNoExecute,
+				TimeAdded: nil,
+			}).Obj(),
+			newNode: baseNode.Clone().Taints(corev1.Taint{
+				Key:       "test",
+				Value:     "value",
+				Effect:    corev1.TaintEffectNoExecute,
+				TimeAdded: &later,
+			}).Obj(),
+			wantChanged: true,
+		},
+		"Unschedulable changed": {
+			oldNode:     baseNode.Clone().Obj(),
+			newNode:     baseNode.Clone().Unschedulable().Obj(),
+			wantChanged: true,
+		},
+		"Update Multiple properties": {
+			oldNode: baseNode.Clone().
+				StatusConditions(
+					corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionTrue,
+						LastHeartbeatTime:  now,
+						LastTransitionTime: now,
+					},
+					corev1.NodeCondition{
+						Type:               corev1.NodeMemoryPressure,
+						Status:             corev1.ConditionFalse,
+						LastHeartbeatTime:  now,
+						LastTransitionTime: now,
+					},
+				).Obj(),
+			newNode: baseNode.Clone().
+				StatusConditions(
+					corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionTrue,
+						LastHeartbeatTime:  later,
+						LastTransitionTime: now,
+					},
+					corev1.NodeCondition{
+						Type:               corev1.NodeMemoryPressure,
+						Status:             corev1.ConditionFalse,
+						LastHeartbeatTime:  later,
+						LastTransitionTime: now,
+					},
+				).
+				Annotation("another-annotation", "another-value").
+				ResourceVersion("12345").
+				Obj(),
+			wantChanged: true,
+		},
+		"New condition type added": {
+			oldNode: baseNode.Clone().Obj(),
+			newNode: baseNode.Clone().StatusConditions(corev1.NodeCondition{
+				Type:               corev1.NodeDiskPressure,
+				Status:             corev1.ConditionTrue,
+				LastHeartbeatTime:  now,
+				LastTransitionTime: now,
+			}).Obj(),
+			wantChanged: true,
+		},
+		"Condition removed": {
+			oldNode: baseNode.Clone().
+				StatusConditions(
+					corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionTrue,
+						LastHeartbeatTime:  now,
+						LastTransitionTime: now,
+					},
+					corev1.NodeCondition{
+						Type:               corev1.NodeDiskPressure,
+						Status:             corev1.ConditionFalse,
+						LastHeartbeatTime:  now,
+						LastTransitionTime: now,
+					},
+				).Obj(),
+			newNode: baseNode.Clone().
+				StatusConditions(
+					corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionTrue,
+						LastHeartbeatTime:  now,
+						LastTransitionTime: now,
+					},
+				).Obj(),
+			wantChanged: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := checkNodeSchedulingPropertiesChanged(tc.oldNode, tc.newNode)
+			if got != tc.wantChanged {
+				t.Errorf("nodeSchedulingPropertiesChanged() = %v, want %v", got, tc.wantChanged)
+			}
+		})
+	}
+}

--- a/pkg/util/testingjobs/node/wrappers.go
+++ b/pkg/util/testingjobs/node/wrappers.go
@@ -63,6 +63,15 @@ func (n *NodeWrapper) Label(k, v string) *NodeWrapper {
 	return n
 }
 
+// Annotation adds an annotation to the Node
+func (n *NodeWrapper) Annotation(k, v string) *NodeWrapper {
+	if n.Annotations == nil {
+		n.Annotations = make(map[string]string)
+	}
+	n.Annotations[k] = v
+	return n
+}
+
 // StatusConditions appends the given status conditions to the Node.
 func (n *NodeWrapper) StatusConditions(conditions ...corev1.NodeCondition) *NodeWrapper {
 	n.Status.Conditions = append(n.Status.Conditions, conditions...)
@@ -105,5 +114,22 @@ func (n *NodeWrapper) NotReady() *NodeWrapper {
 // Unschedulable sets the Node to an unschedulable state.
 func (n *NodeWrapper) Unschedulable() *NodeWrapper {
 	n.Spec.Unschedulable = true
+	return n
+}
+
+// ConditionHeartbeat updates the LastHeartbeatTime of an existing condition.
+func (n *NodeWrapper) ConditionHeartbeat(conditionType corev1.NodeConditionType, heartbeat metav1.Time) *NodeWrapper {
+	for i := range n.Status.Conditions {
+		if n.Status.Conditions[i].Type == conditionType {
+			n.Status.Conditions[i].LastHeartbeatTime = heartbeat
+			break
+		}
+	}
+	return n
+}
+
+// ResourceVersion sets the ResourceVersion of the Node.
+func (n *NodeWrapper) ResourceVersion(version string) *NodeWrapper {
+	n.ObjectMeta.ResourceVersion = version
 	return n
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

This PR adds filtering for Node update events in the TAS (Topology-Aware Scheduling) controller to skip reconciliation when only `LastHeartbeatTime` is updated.

Previously, the TAS controller would trigger reconciliation for every Node update, including the periodic heartbeat updates.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref: #6551

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fix a bug where new Workloads starve, caused by inadmissible workloads frequently requeueing due to unrelated Node LastHeartbeatTime update events.
```