### PR TITLE
Add strict ResourceFlavor label validation

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -187,6 +187,12 @@ const (
 	// In flavor fungibility, the preference whether to preempt or borrow is inferred from flavor fungibility policy
 	// This feature gate is going to be replaced by an API before graduation or deprecation.
 	FlavorFungibilityImplicitPreferenceDefault featuregate.Feature = "FlavorFungibilityImplicitPreferenceDefault"
+
+	// owner: @zhangzhifei16
+	//
+	// Enforces strict validation that all ResourceFlavor label keys must be constrained
+	// in Pod's nodeSelector or nodeAffinity specifications.
+	StrictResourceFlavorLabeling featuregate.Feature = "StrictResourceFlavorLabeling"
 )
 
 func init() {
@@ -289,6 +295,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	FlavorFungibilityImplicitPreferenceDefault: {
 		{Version: version.MustParse("0.13"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	StrictResourceFlavorLabeling: {
+		{Version: version.MustParse("0.14"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -645,7 +645,11 @@ func (a *FlavorAssigner) findFlavorForPodSetResource(
 		ps := &a.wl.Obj.Spec.PodSets[psID]
 		podSets[idx] = ps
 
-		selectors[idx] = flavorSelector(&ps.Template.Spec, resourceGroup.LabelKeys)
+		selector, err := flavorSelector(&ps.Template.Spec, resourceGroup.LabelKeys)
+		if err != nil {
+			return nil, NewStatus(err.Error())
+		}
+		selectors[idx] = selector
 	}
 
 	var bestAssignment ResourceAssignment
@@ -796,9 +800,53 @@ func shouldTryNextFlavor(representativeMode granularMode, flavorFungibility kueu
 	return true
 }
 
-func flavorSelector(spec *corev1.PodSpec, allowedKeys sets.Set[string]) nodeaffinity.RequiredNodeAffinity {
+// validateAllowedKeysUsage validates that all keys in allowedKeys are used in Pod's NodeSelector or NodeAffinity.
+// This ensures that ResourceFlavor labels are properly constrained by the workload.
+// This validation is enabled by the StrictResourceFlavorLabeling feature gate.
+func validateAllowedKeysUsage(spec *corev1.PodSpec, allowedKeys sets.Set[string]) error {
+	// Skip validation if feature is not enabled or no allowed keys
+	if !features.Enabled(features.StrictResourceFlavorLabeling) || allowedKeys.Len() == 0 {
+		return nil
+	}
+
+	// Check if all allowedKeys are constrained in NodeSelector
+	nodeSelectorKeys := sets.New[string]()
+	for k := range spec.NodeSelector {
+		nodeSelectorKeys.Insert(k)
+	}
+
+	if nodeSelectorKeys.IsSuperset(allowedKeys) {
+		return nil
+	}
+
+	// Check if all allowedKeys are constrained in any single NodeAffinity term
+	if affinity := spec.Affinity; affinity != nil && affinity.NodeAffinity != nil {
+		if required := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution; required != nil {
+			for _, term := range required.NodeSelectorTerms {
+				termKeys := sets.New[string]()
+				for _, expr := range term.MatchExpressions {
+					termKeys.Insert(expr.Key)
+				}
+				if termKeys.IsSuperset(allowedKeys) {
+					return nil
+				}
+			}
+		}
+	}
+
+	// If we reach here, allowedKeys are not fully constrained in any single scope
+	return fmt.Errorf("ResourceFlavor label keys %v must be fully constrained either in Pod's nodeSelector or within a single nodeAffinity term", allowedKeys.UnsortedList())
+}
+
+func flavorSelector(spec *corev1.PodSpec, allowedKeys sets.Set[string]) (nodeaffinity.RequiredNodeAffinity, error) {
 	// This function generally replicates the implementation of kube-scheduler's NodeAffinity
 	// Filter plugin as of v1.24.
+
+	// Validate that all allowedKeys are used in Pod's NodeSelector or NodeAffinity
+	if err := validateAllowedKeysUsage(spec, allowedKeys); err != nil {
+		return nodeaffinity.RequiredNodeAffinity{}, err
+	}
+
 	var specCopy corev1.PodSpec
 
 	// Remove affinity constraints with irrelevant keys.
@@ -839,7 +887,7 @@ func flavorSelector(spec *corev1.PodSpec, allowedKeys sets.Set[string]) nodeaffi
 			}
 		}
 	}
-	return nodeaffinity.GetRequiredNodeAffinity(&corev1.Pod{Spec: specCopy})
+	return nodeaffinity.GetRequiredNodeAffinity(&corev1.Pod{Spec: specCopy}), nil
 }
 
 // fitsResourceQuota returns how this flavor could be assigned to the resource,

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -3161,10 +3161,8 @@ func TestValidateAllowedKeysUsage(t *testing.T) {
 				if tc.errContains != "" && !containsString(err.Error(), tc.errContains) {
 					t.Errorf("expected error to contain %q, but got: %v", tc.errContains, err)
 				}
-			} else {
-				if err != nil {
-					t.Errorf("expected no error but got: %v", err)
-				}
+			} else if err != nil {
+				t.Errorf("expected no error but got: %v", err)
 			}
 		})
 	}
@@ -3234,10 +3232,8 @@ func TestFlavorSelector_ValidateAllowedKeysIntegration(t *testing.T) {
 				if tc.errContains != "" && !containsString(err.Error(), tc.errContains) {
 					t.Errorf("expected error to contain %q, but got: %v", tc.errContains, err)
 				}
-			} else {
-				if err != nil {
-					t.Errorf("expected no error but got: %v", err)
-				}
+			} else if err != nil {
+				t.Errorf("expected no error but got: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:


1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
##### What this PR does:
This PR introduces strict validation for ResourceFlavor label keys to ensure proper constraint enforcement in Pod specifications. 
###### Key changes:
- Adds StrictResourceFlavorLabeling feature gate (Alpha, default disabled)
- Implements validation logic in the flavorSelector function
##### Why we need it:
Problem: Currently, Kueue allows workloads to be admitted even when ResourceFlavor label keys are partially or incorrectly constrained in Pod specifications. This can lead to:
- Inconsistent scheduling behavior - Pods may be scheduled to nodes that don't satisfy all ResourceFlavor constraints
- Resource misallocation - Workloads might consume resources they weren't intended to use

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
**Added strict validation for ResourceFlavor label constraints**

Added a new feature gate `StrictResourceFlavorLabeling` that enforces proper constraint validation for ResourceFlavor node labels in Pod specifications. When enabled, the system now validates that all ResourceFlavor label keys are fully constrained within a single scope - either in the Pod's `nodeSelector` or within a single `nodeAffinity` term.

This enhancement prevents workloads that do not meet ResourceFlavor constraints from being matched, thereby avoiding potential inconsistencies in scheduling behavior and resource misallocation.

**Action Required:** This feature is disabled by default (Alpha stage). To enable strict validation, add `--feature-gates=StrictResourceFlavorLabeling=true` to your Kueue deployment configuration. Review your existing workload specifications to ensure ResourceFlavor constraints are properly scoped before enabling this feature in production environments.

**Note:** When this feature is enabled, workloads with improperly constrained ResourceFlavor labels will be rejected with a clear error message indicating which labels need to be properly scoped.
```