### PR TITLE
Fix Deployment/StatefulSet wrappers using shared map for selector and template

### DIFF
--- a/pkg/util/testingjobs/deployment/wrappers.go
+++ b/pkg/util/testingjobs/deployment/wrappers.go
@@ -36,9 +36,6 @@ type DeploymentWrapper struct {
 
 // MakeDeployment creates a wrapper for a Deployment with a single container.
 func MakeDeployment(name, ns string) *DeploymentWrapper {
-	podLabels := map[string]string{
-		"app": fmt.Sprintf("%s-pod", name),
-	}
 	return &DeploymentWrapper{appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -47,11 +44,15 @@ func MakeDeployment(name, ns string) *DeploymentWrapper {
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: podLabels,
+				MatchLabels: map[string]string{
+					"app": fmt.Sprintf("%s-pod", name),
+				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: podLabels,
+					Labels: map[string]string{
+						"app": fmt.Sprintf("%s-pod", name),
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{

--- a/pkg/util/testingjobs/statefulset/wrappers.go
+++ b/pkg/util/testingjobs/statefulset/wrappers.go
@@ -42,9 +42,6 @@ type StatefulSetWrapper struct {
 
 // MakeStatefulSet creates a wrapper for a StatefulSet with a single container.
 func MakeStatefulSet(name, ns string) *StatefulSetWrapper {
-	podLabels := map[string]string{
-		"app": fmt.Sprintf("%s-pod", name),
-	}
 	return &StatefulSetWrapper{appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
@@ -53,11 +50,15 @@ func MakeStatefulSet(name, ns string) *StatefulSetWrapper {
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: podLabels,
+				MatchLabels: map[string]string{
+					"app": fmt.Sprintf("%s-pod", name),
+				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: podLabels,
+					Labels: map[string]string{
+						"app": fmt.Sprintf("%s-pod", name),
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:
Previously, both `.spec.selector.matchLabels` and `.spec.template.metadata.labels` referenced the same map instance. Modifying labels on either field would unexpectedly affect the other, causing incorrect selector or template definitions. This change ensures each field uses its own map to prevent unintended coupling.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE - test utility fix
```