### PR TITLE
refactor: remove unused 'wlKey' parameter

### DIFF
--- a/pkg/controller/tas/node_failure_controller.go
+++ b/pkg/controller/tas/node_failure_controller.go
@@ -220,7 +220,7 @@ func (r *nodeFailureReconciler) getWorkloadsForImmediateReplacement(ctx context.
 
 // evictWorkload idempotently evicts the workload when the node has failed.
 // It returns whether the node was evicted, and whether an error was encountered.
-func (r *nodeFailureReconciler) evictWorkload(ctx context.Context, log logr.Logger, wl *kueue.Workload, wlKey types.NamespacedName, nodeName string) (bool, error) {
+func (r *nodeFailureReconciler) evictWorkload(ctx context.Context, log logr.Logger, wl *kueue.Workload, nodeName string) (bool, error) {
 	if failedNode, ok := wl.Annotations[kueuealpha.NodeToReplaceAnnotation]; ok && failedNode != nodeName && !workload.IsEvicted(wl) {
 		log = log.WithValues("failedNode", failedNode)
 		log.V(3).Info("Evicting workload due to multiple node failures")
@@ -254,7 +254,7 @@ func (r *nodeFailureReconciler) patchWorkloadsForNodeToReplace(ctx context.Conte
 		}
 
 		// evict workload when annotation present.
-		evictedNow, err := r.evictWorkload(ctx, log, &wl, wlKey, nodeName)
+		evictedNow, err := r.evictWorkload(ctx, log, &wl, nodeName)
 		if err != nil {
 			workloadProcessingErrors = append(workloadProcessingErrors, err)
 			continue


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR removes the unused parameter `wlKey types.NamespacedName` from the `evictWorkload` function in `node_failure_controller.go`.  
The parameter was not referenced within the function body, and removing it improves code readability and eliminates a compiler warning regarding unused arguments.

#### Which issue(s) this PR fixes:

Fixes #6595

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
