### PR TITLE
[website] Update Bootstrap utility classes following Bootstrap 5 breaking changes

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -6,11 +6,11 @@ description = "Kueue is a cloud-native job queueing system for batch, HPC, AI/ML
 
 {{< blocks/cover title="Welcome to Kueue" image_anchor="top" height="full" color="orange" >}}
 <div class="mx-auto">
-	<a class="btn btn-lg btn-primary mr-3 mb-4" href="/docs/">
-		Read the docs <i class="fas fa-arrow-alt-circle-right ml-2"></i>
+	<a class="btn btn-lg btn-primary me-3 mb-4" href="/docs/">
+		Read the docs <i class="fas fa-arrow-alt-circle-right ms-2"></i>
 	</a>
-	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/kubernetes-sigs/kueue">
-		GitHub <i class="fab fa-github ml-2 "></i>
+	<a class="btn btn-lg btn-secondary me-3 mb-4" href="https://github.com/kubernetes-sigs/kueue">
+		GitHub <i class="fab fa-github ms-2 "></i>
 	</a>
 	<p class="lead mt-5">Kubernetes-native Job Queueing</p>
 	{{< blocks/link-down color="info" id="description" >}}

--- a/site/content/zh-CN/_index.html
+++ b/site/content/zh-CN/_index.html
@@ -6,11 +6,11 @@ description = "Kueue 是一个云原生的作业队列系统，适用于 Kuberne
 
 {{< blocks/cover title="欢迎使用 Kueue" image_anchor="top" height="full" color="orange" >}}
 <div class="mx-auto">
-	<a class="btn btn-lg btn-primary mr-3 mb-4" href="/zh-cn/docs/">
-		阅读文档 <i class="fas fa-arrow-alt-circle-right ml-2"></i>
+	<a class="btn btn-lg btn-primary me-3 mb-4" href="/zh-cn/docs/">
+		阅读文档 <i class="fas fa-arrow-alt-circle-right ms-2"></i>
 	</a>
-	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/kubernetes-sigs/kueue">
-		GitHub <i class="fab fa-github ml-2 "></i>
+	<a class="btn btn-lg btn-secondary me-3 mb-4" href="https://github.com/kubernetes-sigs/kueue">
+		GitHub <i class="fab fa-github ms-2 "></i>
 	</a>
 	<p class="lead mt-5">Kubernetes 原生作业队列</p>
 	{{< blocks/link-down color="info" id="description" >}}

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -27,7 +27,7 @@ ignoreFiles = []
   [[menu.main]]
     name = "GitHub"
     weight = 99
-    pre = "<i class='fab fa-github pr-2'></i>"
+    pre = "<i class='fab fa-github pe-2'></i>"
     url = "https://github.com/kubernetes-sigs/kueue"
 
 ###############################################################################

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -18,7 +18,7 @@
       </div>
       <div class="col-12 col-sm-5 text-center py-2 order-sm-2">
         {{ with .Site.Params.copyright }}<small class="text-white">&copy; {{ now.Year}} {{ .}} {{ "| Documentation Distributed under CC BY 4.0" }}</small>{{ end }}
-        {{ with .Site.Params.privacy_policy }}<p><small class="ml-1"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></small></p>{{ end }}
+        {{ with .Site.Params.privacy_policy }}<p><small class="ms-1"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></small></p>{{ end }}
 	{{ if not .Site.Params.ui.footer_about_disable }}
 		{{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
 	{{ end }}

--- a/site/layouts/partials/navbar.html
+++ b/site/layouts/partials/navbar.html
@@ -6,11 +6,11 @@
 	<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_navbar" aria-controls="main_navbar" aria-expanded="false" aria-label="Toggle navigation">
 		<span class="navbar-toggler-icon"></span>
 	</button>
-	<div class="collapse navbar-collapse ml-md-auto" id="main_navbar">
-		<ul class="navbar-nav ml-auto pt-4 pt-md-0 my-2 my-md-1">
+	<div class="collapse navbar-collapse ms-md-auto" id="main_navbar">
+		<ul class="navbar-nav ms-auto pt-4 pt-md-0 my-2 my-md-1">
 			{{ $p := . }}
 			{{ range .Site.Menus.main }}
-			<li class="nav-item mr-2 mr-lg-4 mt-1 mt-lg-0">
+			<li class="nav-item me-2 mt-1 mt-lg-0">
 				{{ $active := or ($p.IsMenuCurrent "main" .) ($p.HasMenuCurrent "main" .) }}
 				{{ with .Page }}
 				{{ $active = or $active ( $.IsDescendant .)  }}
@@ -23,7 +23,7 @@
 			</li>
 			{{ end }}
 			{{ if  .Site.Params.versions }}
-			<li class="nav-item dropdown mt-1 mt-lg-0 mr-2">
+			<li class="nav-item dropdown mt-1 mt-lg-0 me-2">
 				{{ partial "navbar-version-selector.html" . }}
 			</li>
 			{{ end }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

I've always felt that the spacing between the two buttons on the official website is too narrow.

Kueue: https://kueue.sigs.k8s.io/
<img width="1672" height="474" alt="image" src="https://github.com/user-attachments/assets/598a36ed-6d35-48a7-b959-fa6716790d2c" />

docsy:  https://www.docsy.dev/
<img width="1566" height="716" alt="image" src="https://github.com/user-attachments/assets/566c04b1-6cdd-4cf3-bd30-6e49fefa9c97" />

After research, I found that this is due to some breaking changes in the Bootstrap 5 upgrade, where `.ml-*` and `.mr-*` were renamed to `.ms-*` and `.me-*`. Reference: https://getbootstrap.com/docs/5.1/migration/#utilities

So this PR updates Bootstrap utility classes in the site codebase to use logical property names, following Bootstrap 5 breaking changes for RTL support.

The modified version looks better.

<img width="1426" height="502" alt="image" src="https://github.com/user-attachments/assets/4b774d0d-078c-4623-a1aa-383f2a8e8d1f" />

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```