### PR TITLE
Remove unnecessary `corev1.ResourceName()` conversion.

### DIFF
--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -304,27 +304,27 @@ func TestNewInfo(t *testing.T) {
 				Obj(),
 			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
 				{
-					Input:    corev1.ResourceName("nvidia.com/mig-1g.5gb"),
+					Input:    "nvidia.com/mig-1g.5gb",
 					Strategy: ptr.To(config.Replace),
 					Outputs: corev1.ResourceList{
-						corev1.ResourceName("example.com/accelerator-memory"): resource.MustParse("5Ki"),
-						corev1.ResourceName("example.com/credits"):            resource.MustParse("10"),
+						"example.com/accelerator-memory": resource.MustParse("5Ki"),
+						"example.com/credits":            resource.MustParse("10"),
 					},
 				},
 				{
-					Input:    corev1.ResourceName("nvidia.com/mig-2g.10gb"),
+					Input:    "nvidia.com/mig-2g.10gb",
 					Strategy: ptr.To(config.Replace),
 					Outputs: corev1.ResourceList{
-						corev1.ResourceName("example.com/accelerator-memory"): resource.MustParse("10Ki"),
-						corev1.ResourceName("example.com/credits"):            resource.MustParse("15"),
+						"example.com/accelerator-memory": resource.MustParse("10Ki"),
+						"example.com/credits":            resource.MustParse("15"),
 					},
 				},
 				{
-					Input:    corev1.ResourceName("nvidia.com/gpu"),
+					Input:    "nvidia.com/gpu",
 					Strategy: ptr.To(config.Retain),
 					Outputs: corev1.ResourceList{
-						corev1.ResourceName("example.com/accelerator-memory"): resource.MustParse("40Ki"),
-						corev1.ResourceName("example.com/credits"):            resource.MustParse("100"),
+						"example.com/accelerator-memory": resource.MustParse("40Ki"),
+						"example.com/credits":            resource.MustParse("100"),
 					},
 				},
 			})},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Remove unnecessary `corev1.ResourceName()` conversion.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```