### PR TITLE
fix(kueueviz): use wildcard for CORS allowed origins in development mode

### DIFF
--- a/cmd/kueueviz/backend/README.md
+++ b/cmd/kueueviz/backend/README.md
@@ -41,10 +41,11 @@ KUEUE_VIZ_PORT=8181 ./kueue_ws_app
 
 ## Variables
 
-| Environment variables | Description              | Default value |
-| --------------------- | ------------------------ | ------------- |
-| `KUEUE_VIZ_PORT`      | Default application port | 8080          |
-| `GIN_MODE`            | Gin mode                 | debug         |
+| Environment variables      | Description                          | Default value |
+| -------------------------- | ------------------------------------ | ------------- |
+| `KUEUE_VIZ_PORT`           | Default application port             | 8080          |
+| `GIN_MODE`                 | Gin mode                             | debug         |
+| `KUEUEVIZ_ALLOWED_ORIGINS` | Comma-separated list of CORS origins | `*` (dev only)|
 
 ## Endpoints
 

--- a/cmd/kueueviz/backend/middleware/cors.go
+++ b/cmd/kueueviz/backend/middleware/cors.go
@@ -31,6 +31,12 @@ import (
 
 // validateOrigin validates and sanitizes a CORS origin URL
 func validateOrigin(origin string) (string, bool) {
+	// Special case for wildcard origin
+	if origin == "*" {
+		// Only allow wildcard origin in development mode
+		return origin, gin.Mode() != gin.ReleaseMode
+	}
+
 	u, err := url.Parse(origin)
 	if err != nil {
 		return "", false
@@ -44,6 +50,7 @@ func validateOrigin(origin string) (string, bool) {
 		return "", false
 	}
 
+	// Only include scheme and host (which includes port if specified)
 	cleanOrigin := fmt.Sprintf("%s://%s", u.Scheme, u.Host)
 	return cleanOrigin, true
 }
@@ -70,10 +77,7 @@ func ConfigureCORS() (cors.Config, error) {
 	} else {
 		// Default development origins (only in development mode)
 		if gin.Mode() != gin.ReleaseMode {
-			allowedOrigins = []string{
-				"http://localhost:3000",
-				"http://127.0.0.1:3000",
-			}
+			allowedOrigins = append(allowedOrigins, "*")
 			log.Println("KUEUEVIZ_ALLOWED_ORIGINS not set, using default development origins")
 		} else {
 			log.Println("Production mode: KUEUEVIZ_ALLOWED_ORIGINS must be explicitly set")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

- Changed the default CORS setting in development mode from hardcoded localhost URLs to wildcard (`*`)
- Updated documentation in the backend README.md with current environment variables

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6584

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
KueueViz: Fix KueueViz CORS configuration for development environments
```