### PR TITLE
Automated cherry pick of #6400: [AFS] Clean-up AFS integration tests

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -769,16 +769,8 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
 			util.ExpectReservingActiveWorkloadsMetric(cq1, 1)
 
-			ginkgo.By("Checking that LQ's resource usage is updated", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lqA), lqA)).Should(gomega.Succeed())
-					g.Expect(lqA.Status.FairSharing).ShouldNot(gomega.BeNil())
-					g.Expect(lqA.Status.FairSharing.AdmissionFairSharingStatus).ShouldNot(gomega.BeNil())
-					g.Expect(lqA.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources).Should(gomega.HaveLen(1))
-					usage := lqA.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources[corev1.ResourceCPU]
-					g.Expect(usage.MilliValue()).To(gomega.BeNumerically(">=", 0))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
+			ginkgo.By("Checking that LQ's resource usage is updated")
+			util.ExpectLocalQueueUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqA), ">", 0)
 
 			ginkgo.By("Creating two pending workloads")
 			wlA := createWorkload("lq-a", "32")


### PR DESCRIPTION
Cherry pick of #6400 on release-0.13.

#6400: [AFS] Clean-up AFS integration tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```