### PR TITLE
Drop the QueueVisibility feature

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -305,7 +305,8 @@ type ClusterQueueStatus struct {
 
 	// PendingWorkloadsStatus contains the information exposed about the current
 	// status of the pending workloads in the cluster queue.
-	// Deprecated: This field will be removed on v1beta2, use VisibilityOnDemand
+	// Deprecated: This field is no longer effective since v0.14.0, which means Kueue no longer stores and updates information.
+	// You can migrate to VisibilityOnDemand
 	// (https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)
 	// instead.
 	// +optional

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -748,7 +748,8 @@ spec:
                   description: |-
                     PendingWorkloadsStatus contains the information exposed about the current
                     status of the pending workloads in the cluster queue.
-                    Deprecated: This field will be removed on v1beta2, use VisibilityOnDemand
+                    Deprecated: This field is no longer effective since v0.14.0, which means Kueue no longer stores and updates information.
+                    You can migrate to VisibilityOnDemand
                     (https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)
                     instead.
                   properties:

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -746,7 +746,8 @@ spec:
                 description: |-
                   PendingWorkloadsStatus contains the information exposed about the current
                   status of the pending workloads in the cluster queue.
-                  Deprecated: This field will be removed on v1beta2, use VisibilityOnDemand
+                  Deprecated: This field is no longer effective since v0.14.0, which means Kueue no longer stores and updates information.
+                  You can migrate to VisibilityOnDemand
                   (https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)
                   instead.
                 properties:

--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"iter"
 	"slices"
-	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
@@ -51,14 +49,11 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/constants"
-	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/resource"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
-
-const snapshotWorkers = 5
 
 type ClusterQueueUpdateWatcher interface {
 	NotifyClusterQueueUpdate(*kueue.ClusterQueue, *kueue.ClusterQueue)
@@ -66,31 +61,25 @@ type ClusterQueueUpdateWatcher interface {
 
 // ClusterQueueReconciler reconciles a ClusterQueue object
 type ClusterQueueReconciler struct {
-	client                               client.Client
-	log                                  logr.Logger
-	qManager                             *qcache.Manager
-	cache                                *schdcache.Cache
-	snapshotsQueue                       workqueue.TypedInterface[kueue.ClusterQueueReference]
-	snapUpdateCh                         chan event.GenericEvent
-	nonCQObjectUpdateCh                  chan event.TypedGenericEvent[iter.Seq[kueue.ClusterQueueReference]]
-	watchers                             []ClusterQueueUpdateWatcher
-	reportResourceMetrics                bool
-	fairSharingEnabled                   bool
-	queueVisibilityUpdateInterval        time.Duration
-	queueVisibilityClusterQueuesMaxCount int32
-	clock                                clock.Clock
+	client                client.Client
+	log                   logr.Logger
+	qManager              *qcache.Manager
+	cache                 *schdcache.Cache
+	nonCQObjectUpdateCh   chan event.TypedGenericEvent[iter.Seq[kueue.ClusterQueueReference]]
+	watchers              []ClusterQueueUpdateWatcher
+	reportResourceMetrics bool
+	fairSharingEnabled    bool
+	clock                 clock.Clock
 }
 
 var _ reconcile.Reconciler = (*ClusterQueueReconciler)(nil)
 var _ predicate.TypedPredicate[*kueue.ClusterQueue] = (*ClusterQueueReconciler)(nil)
 
 type ClusterQueueReconcilerOptions struct {
-	Watchers                             []ClusterQueueUpdateWatcher
-	ReportResourceMetrics                bool
-	FairSharingEnabled                   bool
-	QueueVisibilityUpdateInterval        time.Duration
-	QueueVisibilityClusterQueuesMaxCount int32
-	clock                                clock.Clock
+	Watchers              []ClusterQueueUpdateWatcher
+	ReportResourceMetrics bool
+	FairSharingEnabled    bool
+	clock                 clock.Clock
 }
 
 // ClusterQueueReconcilerOption configures the reconciler.
@@ -114,22 +103,6 @@ func WithFairSharing(enabled bool) ClusterQueueReconcilerOption {
 	}
 }
 
-// WithQueueVisibilityUpdateInterval specifies the time interval for updates to the structure
-// of the top pending workloads in the queues.
-func WithQueueVisibilityUpdateInterval(interval time.Duration) ClusterQueueReconcilerOption {
-	return func(o *ClusterQueueReconcilerOptions) {
-		o.QueueVisibilityUpdateInterval = interval
-	}
-}
-
-// WithQueueVisibilityClusterQueuesMaxCount indicates the maximal number of pending workloads exposed in the
-// cluster queue status
-func WithQueueVisibilityClusterQueuesMaxCount(value int32) ClusterQueueReconcilerOption {
-	return func(o *ClusterQueueReconcilerOptions) {
-		o.QueueVisibilityClusterQueuesMaxCount = value
-	}
-}
-
 var defaultCQOptions = ClusterQueueReconcilerOptions{
 	clock: realClock,
 }
@@ -145,19 +118,15 @@ func NewClusterQueueReconciler(
 		opt(&options)
 	}
 	return &ClusterQueueReconciler{
-		client:                               client,
-		log:                                  ctrl.Log.WithName("cluster-queue-reconciler"),
-		qManager:                             qMgr,
-		cache:                                cache,
-		snapshotsQueue:                       workqueue.NewTyped[kueue.ClusterQueueReference](),
-		snapUpdateCh:                         make(chan event.GenericEvent, updateChBuffer),
-		nonCQObjectUpdateCh:                  make(chan event.TypedGenericEvent[iter.Seq[kueue.ClusterQueueReference]], updateChBuffer),
-		watchers:                             options.Watchers,
-		reportResourceMetrics:                options.ReportResourceMetrics,
-		fairSharingEnabled:                   options.FairSharingEnabled,
-		queueVisibilityUpdateInterval:        options.QueueVisibilityUpdateInterval,
-		queueVisibilityClusterQueuesMaxCount: options.QueueVisibilityClusterQueuesMaxCount,
-		clock:                                options.clock,
+		client:                client,
+		log:                   ctrl.Log.WithName("cluster-queue-reconciler"),
+		qManager:              qMgr,
+		cache:                 cache,
+		nonCQObjectUpdateCh:   make(chan event.TypedGenericEvent[iter.Seq[kueue.ClusterQueueReference]], updateChBuffer),
+		watchers:              options.Watchers,
+		reportResourceMetrics: options.ReportResourceMetrics,
+		fairSharingEnabled:    options.FairSharingEnabled,
+		clock:                 options.clock,
 	}
 }
 
@@ -539,42 +508,11 @@ func (h *nonCQObjectHandler) Generic(_ context.Context, e event.TypedGenericEven
 	}
 }
 
-type cqSnapshotHandler struct {
-	queueVisibilityUpdateInterval time.Duration
-}
-
-func (h *cqSnapshotHandler) Create(context.Context, event.CreateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-}
-
-func (h *cqSnapshotHandler) Update(context.Context, event.UpdateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-}
-
-func (h *cqSnapshotHandler) Delete(context.Context, event.DeleteEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-}
-
-func (h *cqSnapshotHandler) Generic(_ context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	cq, isCq := e.Object.(*kueue.ClusterQueue)
-	if !isCq {
-		return
-	}
-	remainingTime := constants.UpdatesBatchPeriod
-	if cq.Status.PendingWorkloadsStatus != nil {
-		remainingTime = max(h.queueVisibilityUpdateInterval-time.Since(cq.Status.PendingWorkloadsStatus.LastChangeTime.Time), constants.UpdatesBatchPeriod)
-	}
-	q.AddAfter(reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name: cq.Name,
-		}}, remainingTime)
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterQueueReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Configuration) error {
 	nsHandler := cqNamespaceHandler{
 		qManager: r.qManager,
 		cache:    r.cache,
-	}
-	snapHandler := cqSnapshotHandler{
-		queueVisibilityUpdateInterval: r.queueVisibilityUpdateInterval,
 	}
 	return builder.TypedControllerManagedBy[reconcile.Request](mgr).
 		Named("clusterqueue_controller").
@@ -589,7 +527,6 @@ func (r *ClusterQueueReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.
 			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[kueue.GroupVersion.WithKind("ClusterQueue").GroupKind().String()],
 		}).
 		Watches(&corev1.Namespace{}, &nsHandler).
-		WatchesRawSource(source.Channel(r.snapUpdateCh, &snapHandler)).
 		WatchesRawSource(source.Channel(r.nonCQObjectUpdateCh, &nonCQObjectHandler{})).
 		Complete(WithLeadingManager(mgr, r, &kueue.ClusterQueue{}, cfg))
 }
@@ -618,7 +555,6 @@ func (r *ClusterQueueReconciler) updateCqStatusIfChanged(
 	cq.Status.ReservingWorkloads = int32(stats.ReservingWorkloads)
 	cq.Status.AdmittedWorkloads = int32(stats.AdmittedWorkloads)
 	cq.Status.PendingWorkloads = int32(pendingWorkloads)
-	cq.Status.PendingWorkloadsStatus = r.getWorkloadsStatus(cq)
 	meta.SetStatusCondition(&cq.Status.Conditions, metav1.Condition{
 		Type:               kueue.ClusterQueueActive,
 		Status:             conditionStatus,
@@ -641,80 +577,4 @@ func (r *ClusterQueueReconciler) updateCqStatusIfChanged(
 		return r.client.Status().Update(ctx, cq)
 	}
 	return nil
-}
-
-// Taking snapshot of cluster queue is enabled when maxcount non-zero
-func (r *ClusterQueueReconciler) isVisibilityEnabled() bool {
-	return features.Enabled(features.QueueVisibility) && r.queueVisibilityClusterQueuesMaxCount > 0
-}
-
-func (r *ClusterQueueReconciler) getWorkloadsStatus(cq *kueue.ClusterQueue) *kueue.ClusterQueuePendingWorkloadsStatus {
-	if !r.isVisibilityEnabled() {
-		return nil
-	}
-	pendingWorkloads := r.qManager.GetSnapshot(kueue.ClusterQueueReference(cq.Name))
-	if cq.Status.PendingWorkloadsStatus == nil ||
-		cq.Status.PendingWorkloadsStatus.Head == nil ||
-		!equality.Semantic.DeepEqual(cq.Status.PendingWorkloadsStatus.Head, pendingWorkloads) {
-		return &kueue.ClusterQueuePendingWorkloadsStatus{
-			Head:           pendingWorkloads,
-			LastChangeTime: metav1.Time{Time: r.clock.Now()},
-		}
-	}
-	return cq.Status.PendingWorkloadsStatus
-}
-
-func (r *ClusterQueueReconciler) Start(ctx context.Context) error {
-	if !r.isVisibilityEnabled() {
-		return nil
-	}
-
-	defer r.snapshotsQueue.ShutDown()
-
-	for range snapshotWorkers {
-		go wait.UntilWithContext(ctx, r.takeSnapshot, r.queueVisibilityUpdateInterval)
-	}
-
-	go wait.UntilWithContext(ctx, r.enqueueTakeSnapshot, r.queueVisibilityUpdateInterval)
-
-	<-ctx.Done()
-
-	return nil
-}
-
-func (r *ClusterQueueReconciler) enqueueTakeSnapshot(_ context.Context) {
-	for _, cq := range r.qManager.GetClusterQueueNames() {
-		r.snapshotsQueue.Add(cq)
-	}
-}
-
-func (r *ClusterQueueReconciler) takeSnapshot(ctx context.Context) {
-	for r.processNextSnapshot(ctx) {
-	}
-}
-
-func (r *ClusterQueueReconciler) processNextSnapshot(ctx context.Context) bool {
-	log := ctrl.LoggerFrom(ctx).WithName("processNextSnapshot")
-
-	cqName, quit := r.snapshotsQueue.Get()
-	if quit {
-		return false
-	}
-
-	startTime := r.clock.Now()
-	defer func() {
-		log.V(5).Info("Finished snapshot job", "clusterQueue", klog.KRef("", string(cqName)), "elapsed", time.Since(startTime))
-	}()
-
-	defer r.snapshotsQueue.Done(cqName)
-
-	if r.qManager.UpdateSnapshot(cqName, r.queueVisibilityClusterQueuesMaxCount) {
-		log.V(5).Info("Triggering CQ update due to snapshot change", "clusterQueue", klog.KRef("", string(cqName)))
-		r.snapUpdateCh <- event.GenericEvent{Object: &kueue.ClusterQueue{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: string(cqName),
-			},
-		}}
-	}
-	return true
 }

--- a/pkg/controller/core/clusterqueue_controller_test.go
+++ b/pkg/controller/core/clusterqueue_controller_test.go
@@ -17,22 +17,18 @@ limitations under the License.
 package core
 
 import (
-	"context"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
-	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingmetrics "sigs.k8s.io/kueue/pkg/util/testing/metrics"
@@ -514,93 +510,6 @@ func TestRecordResourceMetrics(t *testing.T) {
 			endMetrics := allMetricsForQueue(tc.queue.Name)
 			if len(endMetrics.NominalDPs) != 0 || len(endMetrics.BorrowingDPs) != 0 || len(endMetrics.UsageDPs) != 0 {
 				t.Errorf("Unexpected metrics after cleanup:\n%v", endMetrics)
-			}
-		})
-	}
-}
-
-func TestClusterQueuePendingWorkloadsStatus(t *testing.T) {
-	cqName := "test-cq"
-	lqName := "test-lq"
-	const lowPrio, highPrio = 0, 100
-	defaultWls := &kueue.WorkloadList{
-		Items: []kueue.Workload{
-			*utiltesting.MakeWorkload("one", "").Queue(kueue.LocalQueueName(lqName)).Priority(highPrio).Obj(),
-			*utiltesting.MakeWorkload("two", "").Queue(kueue.LocalQueueName(lqName)).Priority(lowPrio).Obj(),
-		},
-	}
-	testCases := map[string]struct {
-		queueVisibilityUpdateInterval        time.Duration
-		queueVisibilityClusterQueuesMaxCount int32
-		wantPendingWorkloadsStatus           *kueue.ClusterQueuePendingWorkloadsStatus
-		enableQueueVisibility                bool
-	}{
-		"queue visibility is disabled": {},
-		"queue visibility is disabled but maxcount is provided": {
-			queueVisibilityClusterQueuesMaxCount: 2,
-		},
-		"queue visibility is enabled": {
-			queueVisibilityClusterQueuesMaxCount: 2,
-			queueVisibilityUpdateInterval:        10 * time.Millisecond,
-			enableQueueVisibility:                true,
-			wantPendingWorkloadsStatus: &kueue.ClusterQueuePendingWorkloadsStatus{
-				Head: []kueue.ClusterQueuePendingWorkload{
-					{Name: "one"}, {Name: "two"},
-				},
-			},
-		},
-		"verify the head of pending workloads when the number of pending workloads exceeds MaxCount": {
-			queueVisibilityClusterQueuesMaxCount: 1,
-			queueVisibilityUpdateInterval:        10 * time.Millisecond,
-			enableQueueVisibility:                true,
-			wantPendingWorkloadsStatus: &kueue.ClusterQueuePendingWorkloadsStatus{
-				Head: []kueue.ClusterQueuePendingWorkload{
-					{Name: "one"},
-				},
-			},
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.QueueVisibility, tc.enableQueueVisibility)
-
-			cq := utiltesting.MakeClusterQueue(cqName).
-				QueueingStrategy(kueue.StrictFIFO).Obj()
-			lq := utiltesting.MakeLocalQueue(lqName, "").
-				ClusterQueue(cqName).Obj()
-
-			cl := utiltesting.NewClientBuilder().WithLists(defaultWls).WithObjects(lq, cq).WithStatusSubresource(lq, cq).
-				Build()
-			cCache := schdcache.New(cl)
-			qManager := qcache.NewManager(cl, cCache)
-			ctx, _ := utiltesting.ContextWithLog(t)
-			if err := qManager.AddClusterQueue(ctx, cq); err != nil {
-				t.Fatalf("Inserting clusterQueue in manager: %v", err)
-			}
-			if err := qManager.AddLocalQueue(ctx, lq); err != nil {
-				t.Fatalf("Inserting localQueue in manager: %v", err)
-			}
-
-			r := NewClusterQueueReconciler(
-				cl,
-				qManager,
-				cCache,
-				WithQueueVisibilityUpdateInterval(tc.queueVisibilityUpdateInterval),
-				WithQueueVisibilityClusterQueuesMaxCount(tc.queueVisibilityClusterQueuesMaxCount),
-			)
-
-			go func() {
-				if err := r.Start(ctx); err != nil {
-					t.Errorf("error starting the cluster queue reconciler: %v", err)
-				}
-			}()
-
-			diff := ""
-			if err := wait.PollUntilContextTimeout(ctx, time.Second, 10*time.Second, false, func(ctx context.Context) (done bool, err error) {
-				diff = cmp.Diff(tc.wantPendingWorkloadsStatus, r.getWorkloadsStatus(cq), cmpopts.IgnoreFields(kueue.ClusterQueuePendingWorkloadsStatus{}, "LastChangeTime"))
-				return diff == "", nil
-			}); err != nil {
-				t.Fatalf("Failed to get the expected pending workloads status, last diff=%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -67,15 +67,10 @@ func SetupControllers(mgr ctrl.Manager, qManager *qcache.Manager, cc *schdcache.
 		mgr.GetClient(),
 		qManager,
 		cc,
-		WithQueueVisibilityUpdateInterval(queueVisibilityUpdateInterval(cfg)),
 		WithReportResourceMetrics(cfg.Metrics.EnableClusterQueueResources),
-		WithQueueVisibilityClusterQueuesMaxCount(queueVisibilityClusterQueuesMaxCount(cfg)),
 		WithFairSharing(fairSharingEnabled),
 		WithWatchers(watchers...),
 	)
-	if err := mgr.Add(cqRec); err != nil {
-		return "Unable to add ClusterQueue to manager", err
-	}
 	rfRec.AddUpdateWatcher(cqRec)
 	acRec.AddUpdateWatchers(cqRec)
 	if err := cqRec.SetupWithManager(mgr, cfg); err != nil {
@@ -122,18 +117,4 @@ func workloadRetention(cfg *configapi.ObjectRetentionPolicies) *workloadRetentio
 	return &workloadRetentionConfig{
 		afterFinished: &cfg.Workloads.AfterFinished.Duration,
 	}
-}
-
-func queueVisibilityUpdateInterval(cfg *configapi.Configuration) time.Duration {
-	if cfg.QueueVisibility != nil {
-		return time.Duration(cfg.QueueVisibility.UpdateIntervalSeconds) * time.Second
-	}
-	return 0
-}
-
-func queueVisibilityClusterQueuesMaxCount(cfg *configapi.Configuration) int32 {
-	if cfg.QueueVisibility != nil && cfg.QueueVisibility.ClusterQueues != nil {
-		return cfg.QueueVisibility.ClusterQueues.MaxCount
-	}
-	return 0
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -35,12 +35,6 @@ const (
 	// Enables partial admission.
 	PartialAdmission featuregate.Feature = "PartialAdmission"
 
-	// owner: @stuton
-	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/168-pending-workloads-visibility
-	//
-	// Enables queue visibility.
-	QueueVisibility featuregate.Feature = "QueueVisibility"
-
 	// owner: @KunWuLuan
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/582-preempt-based-on-flavor-order
 	//
@@ -204,10 +198,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.4"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.5"), Default: true, PreRelease: featuregate.Beta},
 	},
-	QueueVisibility: {
-		{Version: version.MustParse("0.5"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("0.9"), Default: false, PreRelease: featuregate.Deprecated},
-	},
+
 	FlavorFungibility: {
 		{Version: version.MustParse("0.5"), Default: true, PreRelease: featuregate.Beta},
 	},

--- a/pkg/features/kube_features_test.go
+++ b/pkg/features/kube_features_test.go
@@ -24,9 +24,9 @@ import (
 )
 
 func TestFeatureGate(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, QueueVisibility, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, PartialAdmission, false)
 
-	if !utilfeature.DefaultFeatureGate.Enabled(PartialAdmission) {
-		t.Error("feature gate should be enabled")
+	if utilfeature.DefaultFeatureGate.Enabled(PartialAdmission) {
+		t.Error("feature gate should be disabled")
 	}
 }

--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -302,8 +302,6 @@ spec:
 | `ProvisioningACC`              | `false` | Alpha      | 0.5   | 0.6   |
 | `ProvisioningACC`              | `true`  | Beta       | 0.7   |       |
 | `ProvisioningACC`              | `true`  | GA         | 0.14  |       |
-| `QueueVisibility`              | `false` | Alpha      | 0.5   | 0.9   |
-| `QueueVisibility`              | `false` | Deprecated | 0.9   |       |
 | `TASProfileMostFreeCapacity`   | `false` | Deprecated | 0.11  | 0.13  |
 | `TASProfileLeastFreeCapacity`  | `false` | Deprecated | 0.11  |       |
 | `TASProfileMixed`              | `false` | Deprecated | 0.11  |       |

--- a/site/content/en/docs/reference/components-tools/feature-gate-removed.md
+++ b/site/content/en/docs/reference/components-tools/feature-gate-removed.md
@@ -23,7 +23,7 @@ In the following table:
   is removed.
 
 | Feature                           | Default | Stage      | From | To   |
-| --------------------------------- |---------|------------|------|------|
+|-----------------------------------|---------|------------|------|------|
 | `AdmissionCheckValidationRules`   | `false` | Deprecated | 0.9  | 0.12 |
 | `KeepQuotaForProvReqRetry`        | `false` | Deprecated | 0.9  | 0.12 |
 | `MultiplePreemptions`             | `false` | Alpha      | 0.8  | 0.8  |
@@ -32,3 +32,5 @@ In the following table:
 | `WorkloadResourceRequestsSummary` | `false` | Alpha      | 0.9  | 0.10 |
 | `WorkloadResourceRequestsSummary` | `true`  | Beta       | 0.10 | 0.11 |
 | `WorkloadResourceRequestsSummary` | `true`  | GA         | 0.11 | 0.13 |
+| `QueueVisibility`                 | `false` | Alpha      | 0.5  | 0.9  |
+| `QueueVisibility`                 | `false` | Deprecated | 0.9  | 0.14 |

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -1127,7 +1127,8 @@ current state.</p>
 <td>
    <p>PendingWorkloadsStatus contains the information exposed about the current
 status of the pending workloads in the cluster queue.
-Deprecated: This field will be removed on v1beta2, use VisibilityOnDemand
+Deprecated: This field is no longer effective since v0.14.0, which means Kueue no longer stores and updates information.
+You can migrate to VisibilityOnDemand
 (https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)
 instead.</p>
 </td>

--- a/site/content/zh-CN/docs/installation/_index.md
+++ b/site/content/zh-CN/docs/installation/_index.md
@@ -302,8 +302,6 @@ spec:
 | `ProvisioningACC`              | `false` | Alpha      | 0.5      | 0.6      |
 | `ProvisioningACC`              | `true`  | Beta       | 0.7      |          |
 | `ProvisioningACC`              | `true`  | GA         | 0.14     |          |
-| `QueueVisibility`              | `false` | Alpha      | 0.5      | 0.9      |
-| `QueueVisibility`              | `false` | Deprecated | 0.9      |          |
 | `TASProfileMostFreeCapacity`   | `false` | Deprecated | 0.11     | 0.13     |
 | `TASProfileLeastFreeCapacity`  | `false` | Deprecated | 0.11     |          |
 | `TASProfileMixed`              | `false` | Deprecated | 0.11     |          |


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind deprecation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Сleans up the code, and related testing of QueueVisibility feature

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4240

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Stop serving the QueueVisibility feature, but keep APIs (`.status.pendingWorkloadsStatus`) to avoid breaking changes.

ACTION REQUIRED:
If you rely on the QueueVisibility feature (`.status.pendingWorkloadsStatus` in the ClusterQueue), you must migrate to VisibilityOndDemand 
(https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand).
```