### PR TITLE
Fix cohort link in docs

### DIFF
--- a/site/content/en/docs/concepts/cohort.md
+++ b/site/content/en/docs/concepts/cohort.md
@@ -29,7 +29,7 @@ spec:
 ## Configuring Quotas
 
 Resource quotas may be defined at the Cohort level (similarly to how they are
-defined for (ClusterQueues)[/docs/concepts/cluster_queue/#flavors-and-resources]),
+defined for [ClusterQueues](/docs/concepts/cluster_queue/#flavors-and-resources)),
 and consumed by ClusterQueues within the Cohort.  Please note that
 `nominalQuota` defined at the Cohort level represents **additional resources**
 on top of those defined by ClusterQueues within the Cohort. The Cohort's


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
Minor fix in link i came across while reading docs [here](https://kueue.sigs.k8s.io/docs/concepts/cohort/#configuring-quotas)

#### Does this PR introduce a user-facing change?
```release-note
NONE
```