### PR TITLE
Fix sync-notes.sh.

### DIFF
--- a/hack/releasing/sync-notes.sh
+++ b/hack/releasing/sync-notes.sh
@@ -51,6 +51,8 @@ if [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 
+git fetch "${UPSTREAM_REMOTE}" --tags
+
 # $1 - release version
 find_previous_version() {
   local release_version="$1"
@@ -73,14 +75,8 @@ function find_head_branch() {
 
   IFS='.' read -r major minor patch <<< "${release_version#v}"
 
-  # Get the latest release version tag (sorted semver)
-  latest_release_version=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
-  IFS='.' read -r latest_major latest_minor _ <<< "${latest_release_version#v}"
-
-  # Check if current major.minor is less than latest
-  if [[ "$major" -lt "$latest_major" ]] || { [[ "$major" -eq "$latest_major" ]] && [[ "$minor" -lt "$latest_minor" ]]; }; then
+  if [[ "${patch}" -ne "0" ]]; then
     candidate_branch="release-${major}.${minor}"
-
     # Use release branch if it exists
     if git ls-remote --heads "$UPSTREAM_REMOTE" "$candidate_branch" | grep -q "$candidate_branch"; then
       head_branch="$candidate_branch"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix sync-notes.sh.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #6288

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```