### PR TITLE
Add tests for validation that Kueue takes into consideration slice-only topology.

### DIFF
--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -393,6 +393,81 @@ func TestPodSets(t *testing.T) {
 			},
 			enableTopologyAwareScheduling: true,
 		},
+		"with slice-only topology": {
+			job: (*Job)(
+				jobTemplate.Clone().
+					Parallelism(3).
+					PodAnnotation(kueuealpha.PodSetSliceRequiredTopologyAnnotation, "cloud.com/block").
+					PodAnnotation(kueuealpha.PodSetSliceSizeAnnotation, "1").
+					Obj(),
+			),
+			wantPodSets: []kueue.PodSet{
+				*utiltesting.MakePodSet(kueue.DefaultPodSetName, 3).
+					PodSpec(jobTemplate.Clone().Spec.Template.Spec).
+					Annotations(map[string]string{
+						kueuealpha.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
+						kueuealpha.PodSetSliceSizeAnnotation:             "1",
+					}).
+					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+					PodSetSliceRequiredTopology("cloud.com/block").
+					PodSetSliceSize(1).
+					Obj(),
+			},
+			enableTopologyAwareScheduling: true,
+		},
+		"with slice-only topology if TAS is disabled": {
+			job: (*Job)(
+				jobTemplate.Clone().
+					Parallelism(3).
+					PodAnnotation(kueuealpha.PodSetSliceRequiredTopologyAnnotation, "cloud.com/block").
+					PodAnnotation(kueuealpha.PodSetSliceSizeAnnotation, "1").
+					Obj(),
+			),
+			wantPodSets: []kueue.PodSet{
+				*utiltesting.MakePodSet(kueue.DefaultPodSetName, 3).
+					PodSpec(jobTemplate.Clone().Spec.Template.Spec).
+					Annotations(map[string]string{
+						kueuealpha.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
+						kueuealpha.PodSetSliceSizeAnnotation:             "1",
+					}).
+					Obj(),
+			},
+			enableTopologyAwareScheduling: false,
+		},
+		"with slice-only topology – only podset slice required topology annotation": {
+			job: (*Job)(
+				jobTemplate.Clone().
+					Parallelism(3).
+					PodAnnotation(kueuealpha.PodSetSliceRequiredTopologyAnnotation, "cloud.com/block").
+					Obj(),
+			),
+			wantPodSets: []kueue.PodSet{
+				*utiltesting.MakePodSet(kueue.DefaultPodSetName, 3).
+					PodSpec(jobTemplate.Clone().Spec.Template.Spec).
+					Annotations(map[string]string{
+						kueuealpha.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
+					}).
+					Obj(),
+			},
+			enableTopologyAwareScheduling: true,
+		},
+		"with slice-only topology – only podset slice size annotation": {
+			job: (*Job)(
+				jobTemplate.Clone().
+					Parallelism(3).
+					PodAnnotation(kueuealpha.PodSetSliceSizeAnnotation, "1").
+					Obj(),
+			),
+			wantPodSets: []kueue.PodSet{
+				*utiltesting.MakePodSet(kueue.DefaultPodSetName, 3).
+					PodSpec(jobTemplate.Clone().Spec.Template.Spec).
+					Annotations(map[string]string{
+						kueuealpha.PodSetSliceSizeAnnotation: "1",
+					}).
+					Obj(),
+			},
+			enableTopologyAwareScheduling: true,
+		},
 		"without preferred topology annotation if TAS is disabled": {
 			job: (*Job)(
 				jobTemplate.Clone().

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -464,6 +464,22 @@ func (p *PodSetWrapper) PodSetGroup(name string) *PodSetWrapper {
 	return p
 }
 
+func (p *PodSetWrapper) PodSetSliceRequiredTopology(level string) *PodSetWrapper {
+	if p.TopologyRequest == nil {
+		p.TopologyRequest = &kueue.PodSetTopologyRequest{}
+	}
+	p.TopologyRequest.PodSetSliceRequiredTopology = &level
+	return p
+}
+
+func (p *PodSetWrapper) PodSetSliceSize(size int32) *PodSetWrapper {
+	if p.TopologyRequest == nil {
+		p.TopologyRequest = &kueue.PodSetTopologyRequest{}
+	}
+	p.TopologyRequest.PodSetSliceSize = &size
+	return p
+}
+
 func (p *PodSetWrapper) PreferredTopologyRequest(level string) *PodSetWrapper {
 	if p.TopologyRequest == nil {
 		p.TopologyRequest = &kueue.PodSetTopologyRequest{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add tests for validation that Kueue takes into consideration slice-only topology.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #5927

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```