### PR TITLE
Add tests for HasLevel.

### DIFF
--- a/pkg/cache/tas_flavor_snapshot_test.go
+++ b/pkg/cache/tas_flavor_snapshot_test.go
@@ -421,8 +421,6 @@ func TestHasLevel(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			log, _ := logr.FromContext(t.Context())
 			s := newTASFlavorSnapshot(log, "dummy", levels, nil)
-			s.initialize()
-
 			got := s.HasLevel(tc.podSetTopologyRequest)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected HasLevel result (-want,+got): %s", diff)

--- a/pkg/cache/tas_flavor_snapshot_test.go
+++ b/pkg/cache/tas_flavor_snapshot_test.go
@@ -27,6 +27,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/resources"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 )
 
@@ -419,7 +420,7 @@ func TestHasLevel(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			log, _ := logr.FromContext(t.Context())
+			_, log := utiltesting.ContextWithLog(t)
 			s := newTASFlavorSnapshot(log, "dummy", levels, nil)
 			got := s.HasLevel(tc.podSetTopologyRequest)
 			if diff := cmp.Diff(tc.want, got); diff != "" {

--- a/pkg/cache/tas_flavor_snapshot_test.go
+++ b/pkg/cache/tas_flavor_snapshot_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/resources"
@@ -353,6 +354,78 @@ func TestMergeTopologyAssignments(t *testing.T) {
 			got := s.mergeTopologyAssignments(tc.a, tc.b)
 			if diff := cmp.Diff(tc.want, *got); diff != "" {
 				t.Errorf("unexpected topology assignment (-want,+got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestHasLevel(t *testing.T) {
+	levels := []string{"level-1", "level-2"}
+
+	testCases := map[string]struct {
+		podSetTopologyRequest *kueue.PodSetTopologyRequest
+		want                  bool
+	}{
+		"topology request nil": {
+			podSetTopologyRequest: nil,
+			want:                  false,
+		},
+		"topology request empty": {
+			podSetTopologyRequest: &kueue.PodSetTopologyRequest{},
+			want:                  false,
+		},
+		"required": {
+			podSetTopologyRequest: &kueue.PodSetTopologyRequest{
+				Required: ptr.To("level-1"),
+			},
+			want: true,
+		},
+		"required – invalid level": {
+			podSetTopologyRequest: &kueue.PodSetTopologyRequest{
+				Required: ptr.To("invalid-level"),
+			},
+			want: false,
+		},
+		"preferred": {
+			podSetTopologyRequest: &kueue.PodSetTopologyRequest{
+				Preferred: ptr.To("level-1"),
+			},
+			want: true,
+		},
+		"preferred – invalid level": {
+			podSetTopologyRequest: &kueue.PodSetTopologyRequest{
+				Preferred: ptr.To("invalid-level"),
+			},
+			want: false,
+		},
+		"unconstrained": {
+			podSetTopologyRequest: &kueue.PodSetTopologyRequest{
+				Unconstrained: ptr.To(true),
+			},
+			want: true,
+		},
+		"slice-only": {
+			podSetTopologyRequest: &kueue.PodSetTopologyRequest{
+				PodSetSliceRequiredTopology: ptr.To("level-1"),
+			},
+			want: true,
+		},
+		"slice-only – invalid level": {
+			podSetTopologyRequest: &kueue.PodSetTopologyRequest{
+				PodSetSliceRequiredTopology: ptr.To("invalid-level"),
+			},
+			want: false,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			log, _ := logr.FromContext(t.Context())
+			s := newTASFlavorSnapshot(log, "dummy", levels, nil)
+			s.initialize()
+
+			got := s.HasLevel(tc.podSetTopologyRequest)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected HasLevel result (-want,+got): %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Add tests for HasLevel.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5927

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```