### PR TITLE
Add logging to verify target selection for fairsharing

### DIFF
--- a/pkg/scheduler/logging.go
+++ b/pkg/scheduler/logging.go
@@ -21,8 +21,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/kueue/pkg/cache"
-	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
-	"sigs.k8s.io/kueue/pkg/util/slices"
+	"sigs.k8s.io/kueue/pkg/util/logging"
 )
 
 func logAdmissionAttemptIfVerbose(log logr.Logger, e *entry) {
@@ -38,7 +37,7 @@ func logAdmissionAttemptIfVerbose(log logr.Logger, e *entry) {
 	}
 	if log.V(4).Enabled() {
 		args = append(args, "nominatedAssignment", e.assignment)
-		args = append(args, "preempted", getWorkloadReferences(e.preemptionTargets))
+		args = append(args, "preempted", logging.GetObjectReferences(e.preemptionTargets))
 	}
 	logV.Info("Workload evaluated for admission", args...)
 }
@@ -47,8 +46,4 @@ func logSnapshotIfVerbose(log logr.Logger, s *cache.Snapshot) {
 	if logV := log.V(6); logV.Enabled() {
 		s.Log(logV)
 	}
-}
-
-func getWorkloadReferences(targets []*preemption.Target) []klog.ObjectRef {
-	return slices.Map(targets, func(t **preemption.Target) klog.ObjectRef { return klog.KObj((*t).WorkloadInfo.Obj) })
 }

--- a/pkg/util/logging/logging.go
+++ b/pkg/util/logging/logging.go
@@ -1,0 +1,37 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logging
+
+import (
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kueue/pkg/util/slices"
+)
+
+// ObjectRefProvider is an interface for types that can provide a Kubernetes object reference.
+type ObjectRefProvider interface {
+	GetObject() client.Object
+}
+
+// GetObjectReferences converts a slice of ObjectRefProvider items to klog.ObjectRef slice.
+// This is a generic utility that can work with any type that provides a Kubernetes object.
+func GetObjectReferences[T ObjectRefProvider](items []T) []klog.ObjectRef {
+	return slices.Map(items, func(item *T) klog.ObjectRef {
+		return klog.KObj((*item).GetObject())
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
--> /kind cleanup

#### What this PR does / why we need it:
Adds logging to verify target selection for fairsharing.
Related to: https://github.com/kubernetes-sigs/kueue/issues/6577

We had no insight into why we were left with no preemption targets and what preemption targets were being considered after filtering during scheduling cycle for fairsharing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```