### PR TITLE
Fix race condition for KubeConfigFSWatcher unit tests.

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/fswatch_test.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"k8s.io/utils/set"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
@@ -145,8 +146,11 @@ func TestFSWatch(t *testing.T) {
 					t.Fatalf("unexpected prepare error: %s", err)
 				}
 			}
-			ctx, _ := utiltesting.ContextWithLog(t)
+			// Using an empty context here to avoid a race condition with the test context when setting the logger.
+			ctx := context.Background()
+			ctrl.LoggerInto(ctx, utiltesting.NewLogger(t))
 			ctx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
 			watcher := newKubeConfigFSWatcher()
 
 			// start the recorder
@@ -196,7 +200,9 @@ func TestFSWatch(t *testing.T) {
 }
 
 func TestFSWatchAddRm(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	// Using an empty context here to avoid a race condition with the test context when setting the logger.
+	ctx := context.Background()
+	ctrl.LoggerInto(ctx, utiltesting.NewLogger(t))
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	basePath := t.TempDir()

--- a/pkg/util/testing/context.go
+++ b/pkg/util/testing/context.go
@@ -35,9 +35,13 @@ func LogLevelWithDefault(defaultLogLevel int) int {
 	return level
 }
 
-func ContextWithLog(t *testing.T) (context.Context, logr.Logger) {
-	logger := testr.NewWithOptions(t, testr.Options{
+func NewLogger(t *testing.T) logr.Logger {
+	return testr.NewWithOptions(t, testr.Options{
 		Verbosity: LogLevelWithDefault(2),
 	})
+}
+
+func ContextWithLog(t *testing.T) (context.Context, logr.Logger) {
+	logger := NewLogger(t)
 	return ctrl.LoggerInto(t.Context(), logger), logger
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fix race condition for KubeConfigFSWatcher unit tests.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6674

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```