### PR TITLE
Remove skipOnDarwin for TestFSWatchAddRm.

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/fswatch_test.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch_test.go
@@ -206,7 +206,6 @@ func TestFSWatchAddRm(t *testing.T) {
 	f3Path := filepath.Join(f3Dir, "file.three")
 	steps := []struct {
 		name               string
-		skipOnDarwin       bool
 		opFnc              func(*KubeConfigFSWatcher) error
 		wantOpErr          error
 		wantClustersToFile map[string]string
@@ -310,12 +309,6 @@ func TestFSWatchAddRm(t *testing.T) {
 		},
 		{
 			name: "add fourth cluster, missing dir ",
-			// For some reason on the Darwin platform, when we try to add an invalid directory,
-			// an error is returned, but it is also added to the watchlist, so we don't have
-			// the same result as we expected.
-			// It's not critical to test it on MacOS, so we can skip it for now until it's
-			// fixed https://github.com/fsnotify/fsnotify/issues/637.
-			skipOnDarwin: true,
 			opFnc: func(kcf *KubeConfigFSWatcher) error {
 				return kcf.AddOrUpdate("c4", f3Path)
 			},
@@ -444,10 +437,6 @@ func TestFSWatchAddRm(t *testing.T) {
 	w := newKubeConfigFSWatcher()
 
 	for _, tc := range steps {
-		if tc.skipOnDarwin && runtime.GOOS == "darwin" {
-			continue
-		}
-
 		t.Run(tc.name, func(t *testing.T) {
 			gotErr := tc.opFnc(w)
 			if diff := cmp.Diff(tc.wantOpErr, gotErr, cmpopts.EquateErrors()); diff != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Remove skipOnDarwin for TestFSWatchAddRm.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Here's an optimized and polished version of your text:
The issue https://github.com/fsnotify/fsnotify/issues/637 has been fixed and released. These tests now work on Darwin.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```