### PR TITLE
Kueueviz: Helm values.yaml for ingress annotations, tls and environment variables

### DIFF
--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -125,20 +125,24 @@ The following table lists the configurable parameters of the kueue chart and the
 | enableVisibilityAPF | bool | `false` | Enable API Priority and Fairness configuration for the visibility API |
 | fullnameOverride | string | `""` | Override the resource name |
 | kubernetesClusterDomain | string | `"cluster.local"` | Kubernetes cluster's domain |
+| kueueViz.backend.env | list | `[{"name":"KUEUEVIZ_ALLOWED_ORIGINS","value":"frontend.kueueviz.local"}]` | Environment variables for KueueViz backend deployment |
 | kueueViz.backend.image.pullPolicy | string | `"Always"` | KueueViz dashboard backend image pullPolicy. This should be set to 'IfNotPresent' for released version |
 | kueueViz.backend.image.repository | string | `"us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-backend"` | KueueViz dashboard backend image repository |
 | kueueViz.backend.image.tag | string | `"main"` | KueueViz dashboard backend image tag |
 | kueueViz.backend.imagePullSecrets | list | `[]` | Sets ImagePullSecrets for KueueViz dashboard backend deployments. This is useful when the images are in a private registry. |
+| kueueViz.backend.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/rewrite-target":"/","nginx.ingress.kubernetes.io/ssl-redirect":"true"}` | KueueViz dashboard backend ingress annotations |
 | kueueViz.backend.ingress.host | string | `"backend.kueueviz.local"` | KueueViz dashboard backend ingress host |
 | kueueViz.backend.ingress.ingressClassName | string | `nil` | KueueViz dashboard backend ingress class name |
 | kueueViz.backend.ingress.tlsSecretName | string | `"kueueviz-backend-tls"` | KueueViz dashboard backend ingress tls secret name |
 | kueueViz.backend.nodeSelector | object | `{}` | KueueViz backend nodeSelector |
 | kueueViz.backend.priorityClassName | string | `nil` | Enable PriorityClass for KueueViz dashboard backend deployments |
 | kueueViz.backend.tolerations | list | `[]` | KueueViz backend tolerations |
+| kueueViz.frontend.env | list | `[{"name":"REACT_APP_WEBSOCKET_URL","value":"wss://backend.kueueviz.local"}]` | Environment variables for KueueViz frontend deployment |
 | kueueViz.frontend.image.pullPolicy | string | `"Always"` | KueueViz dashboard frontend image pullPolicy. This should be set to 'IfNotPresent' for released version |
 | kueueViz.frontend.image.repository | string | `"us-central1-docker.pkg.dev/k8s-staging-images/kueue/kueueviz-frontend"` | KueueViz dashboard frontend image repository |
 | kueueViz.frontend.image.tag | string | `"main"` | KueueViz dashboard frontend image tag |
 | kueueViz.frontend.imagePullSecrets | list | `[]` | Sets ImagePullSecrets for KueueViz dashboard frontend deployments. This is useful when the images are in a private registry. |
+| kueueViz.frontend.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/rewrite-target":"/","nginx.ingress.kubernetes.io/ssl-redirect":"true"}` | KueueViz dashboard frontend ingress annotations |
 | kueueViz.frontend.ingress.host | string | `"frontend.kueueviz.local"` | KueueViz dashboard frontend ingress host |
 | kueueViz.frontend.ingress.ingressClassName | string | `nil` | KueueViz dashboard frontend ingress class name |
 | kueueViz.frontend.ingress.tlsSecretName | string | `"kueueviz-frontend-tls"` | KueueViz dashboard frontend ingress tls secret name |

--- a/charts/kueue/templates/kueueviz/backend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/backend-deployment.yaml
@@ -33,6 +33,10 @@ spec:
       {{- end }}
       containers:
         - name: backend
+          {{- with .Values.kueueViz.backend.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: '{{ .Values.kueueViz.backend.image.repository }}:{{ .Values.kueueViz.backend.image.tag | default .Chart.AppVersion }}'
           imagePullPolicy: '{{ .Values.kueueViz.backend.image.pullPolicy }}'
           ports:

--- a/charts/kueue/templates/kueueviz/backend-ingress.yaml
+++ b/charts/kueue/templates/kueueviz/backend-ingress.yaml
@@ -4,19 +4,22 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  {{- with .Values.kueueViz.backend.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: '{{ include "kueue.fullname" . }}-kueueviz-backend-ingress'
   namespace: '{{ .Release.Namespace }}'
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
-  {{- if .Values.kueueViz.backend.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.kueueViz.backend.ingress.ingressClassName }}
-  {{- end }}
+  {{- if .Values.kueueViz.backend.ingress.tlsSecretName }}
   tls:
     - hosts:
         - '{{ .Values.kueueViz.backend.ingress.host | default "backend.kueueviz.local" }}'
-      secretName: '{{ .Values.kueueViz.backend.ingress.tlsSecretName | default "kueueviz-backend-tls" }}'
+      secretName: '{{ .Values.kueueViz.backend.ingress.tlsSecretName }}'
+  {{- end }}
+  {{- if .Values.kueueViz.backend.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.kueueViz.backend.ingress.ingressClassName }}
+  {{- end }}
   rules:
     - host: '{{ .Values.kueueViz.backend.ingress.host | default "backend.kueueviz.local" }}'
       http:

--- a/charts/kueue/templates/kueueviz/frontend-deployment.yaml
+++ b/charts/kueue/templates/kueueviz/frontend-deployment.yaml
@@ -33,13 +33,14 @@ spec:
       {{- end }}
       containers:
         - name: frontend
+          {{- with .Values.kueueViz.frontend.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: '{{ .Values.kueueViz.frontend.image.repository }}:{{ .Values.kueueViz.frontend.image.tag | default .Chart.AppVersion }}'
           imagePullPolicy: '{{ .Values.kueueViz.frontend.image.pullPolicy }}'
           ports:
             - containerPort: 8080
-          env:
-            - name: REACT_APP_WEBSOCKET_URL
-              value: 'wss://{{ .Values.kueueViz.backend.ingress.host | default "backend.kueueviz.local" }}'
           resources:
             limits:
               cpu: 500m

--- a/charts/kueue/templates/kueueviz/frontend-ingress.yaml
+++ b/charts/kueue/templates/kueueviz/frontend-ingress.yaml
@@ -4,19 +4,22 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  {{- with .Values.kueueViz.frontend.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: '{{ include "kueue.fullname" . }}-kueueviz-frontend-ingress'
   namespace: '{{ .Release.Namespace }}'
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
-  {{- if .Values.kueueViz.frontend.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.kueueViz.frontend.ingress.ingressClassName }}
-  {{- end }}
+  {{- if .Values.kueueViz.frontend.ingress.tlsSecretName }}
   tls:
     - hosts:
         - '{{ .Values.kueueViz.frontend.ingress.host | default "frontend.kueueviz.local" }}'
-      secretName: '{{ .Values.kueueViz.frontend.ingress.tlsSecretName | default "kueueviz-frontend-tls" }}'
+      secretName: '{{ .Values.kueueViz.frontend.ingress.tlsSecretName }}'
+  {{- end }}
+  {{- if .Values.kueueViz.frontend.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.kueueViz.frontend.ingress.ingressClassName }}
+  {{- end }}
   rules:
     - host: '{{ .Values.kueueViz.frontend.ingress.host | default "frontend.kueueviz.local" }}'
       http:

--- a/charts/kueue/tests/kueue_test.yaml
+++ b/charts/kueue/tests/kueue_test.yaml
@@ -57,10 +57,25 @@ tests:
             ingressClassName: "ingress-external"
             host: "backend.kueueviz.fr"
             tlsSecretName: "kueueviz-frontend-tls"
+        frontend:
+          env:
+            - name: REACT_APP_WEBSOCKET_URL
+              value: "wss://backend.kueueviz.fr"
     asserts:
       - equal:
           path: spec.template.spec.containers[0].env[0].value
           value: "wss://backend.kueueviz.fr"
+  - it: should not render the tls if not set for backend ingress
+    template: kueueviz/backend-ingress.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        backend:
+          ingress:
+            tlsSecretName: ""
+    asserts:
+      - notExists:
+          path: spec.tls[0]
   - it: Should Render Ingress for Backend Component
     template: kueueviz/backend-ingress.yaml
     set:
@@ -68,6 +83,9 @@ tests:
       kueueViz:  
         backend:
           ingress:
+            annotations: 
+              nginx.ingress.kubernetes.io/rewrite-target: "/"
+              nginx.ingress.kubernetes.io/ssl-redirect: "true"
             ingressClassName: "nginx-external-ingress"
             host: "backend.kueueviz.in"
             tlsSecretName: "kueueviz-backend-tls-secret"
@@ -81,7 +99,34 @@ tests:
       - equal:
           path: spec.tls[0].secretName
           value: "kueueviz-backend-tls-secret"
-
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
+          value: "/"
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/ssl-redirect"]
+          value: "true"
+  - it: should not render annotations if not set for backend ingress
+    template: kueueviz/backend-ingress.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        backend:
+          ingress:
+            annotations: ""
+    asserts:
+      - notExists:
+          path: metadata.annotations
+  - it: should not render the tls if not set for frontend ingress
+    template: kueueviz/frontend-ingress.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        frontend:
+          ingress:
+            tlsSecretName: ""
+    asserts:
+      - notExists:
+          path: spec.tls[0]
   - it: Should Render Ingress for Frontend Component
     template: kueueviz/frontend-ingress.yaml
     set:
@@ -90,6 +135,9 @@ tests:
         ingressClassName: "nginx-external"
         frontend:
           ingress:
+            annotations: 
+              nginx.ingress.kubernetes.io/rewrite-target: "/"
+              nginx.ingress.kubernetes.io/ssl-redirect: "true"
             ingressClassName: "nginx-external"
             host: "frontend.kueueviz.in"
             tlsSecretName: "frontend-tls"
@@ -103,6 +151,23 @@ tests:
       - equal:
           path: spec.tls[0].secretName
           value: "frontend-tls"
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
+          value: "/"
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/ssl-redirect"]
+          value: "true"
+  - it: should not render annotations if not set for frontend ingress
+    template: kueueviz/frontend-ingress.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        frontend:
+          ingress:
+            annotations: ""
+    asserts:
+      - notExists:
+          path: metadata.annotations
   - it: should set the imagePullSecrets for backend deployment
     template: kueueviz/backend-deployment.yaml
     set:
@@ -127,3 +192,63 @@ tests:
       - equal:
           path: spec.template.spec.imagePullSecrets[0].name
           value: "my-secret"
+  - it: should set the environment variables for backend deployment
+    template: kueueviz/backend-deployment.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        backend:
+          env:
+            - name: KUEUEVIZ_ALLOWED_ORIGINS
+              value: "frontend.kueueviz.local"
+            - name: KUEUEVIZ_PORT
+              value: "8080"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: KUEUEVIZ_ALLOWED_ORIGINS
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "frontend.kueueviz.local"
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: KUEUEVIZ_PORT
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "8080"
+  - it: should not set the environment variables if not set for backend deployment
+    template: kueueviz/backend-deployment.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        backend:
+          env: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].env[0]
+  - it: should set the environment variables for frontend deployment
+    template: kueueviz/frontend-deployment.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        frontend:
+          env:
+            - name: REACT_APP_WEBSOCKET_URL
+              value: "wss://backend.kueueviz.local"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: REACT_APP_WEBSOCKET_URL
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "wss://backend.kueueviz.local"
+  - it: should not set the environment variables if not set for frontend deployment
+    template: kueueviz/frontend-deployment.yaml
+    set:
+      enableKueueViz: true
+      kueueViz:
+        frontend:
+          env: []
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].env[0]

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -222,7 +222,15 @@ kueueViz:
     imagePullSecrets: []
     # -- Enable PriorityClass for KueueViz dashboard backend deployments
     priorityClassName:
+    # -- Environment variables for KueueViz backend deployment
+    env:
+      - name: KUEUEVIZ_ALLOWED_ORIGINS
+        value: "frontend.kueueviz.local"
     ingress:
+      # -- KueueViz dashboard backend ingress annotations
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: "/"
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
       # -- KueueViz dashboard backend ingress class name
       ingressClassName:
       # -- KueueViz dashboard backend ingress host
@@ -247,7 +255,15 @@ kueueViz:
     imagePullSecrets: []
     # -- Enable PriorityClass for KueueViz dashboard frontend deployments
     priorityClassName:
+    # -- Environment variables for KueueViz frontend deployment
+    env:
+      - name: REACT_APP_WEBSOCKET_URL
+        value: "wss://backend.kueueviz.local"
     ingress:
+      # -- KueueViz dashboard frontend ingress annotations
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: "/"
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
       # -- KueueViz dashboard frontend ingress class name
       ingressClassName:
       # -- KueueViz dashboard frontend ingress host

--- a/config/components/kueueviz/backend-ingress.yaml
+++ b/config/components/kueueviz/backend-ingress.yaml
@@ -4,14 +4,7 @@ kind: Ingress
 metadata:
   name: kueueviz-backend-ingress
   namespace: system
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
-  tls:
-    - hosts:
-        - backend.kueueviz.local
-      secretName: kueueviz-tls-secret
   rules:
     - host: backend.kueueviz.local
       http:

--- a/config/components/kueueviz/frontend-deployment.yaml
+++ b/config/components/kueueviz/frontend-deployment.yaml
@@ -20,9 +20,6 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          env:
-            - name: REACT_APP_WEBSOCKET_URL
-              value: 'wss://backend.kueueviz.local'
           resources:
             limits:
               cpu: 500m

--- a/config/components/kueueviz/frontend-ingress.yaml
+++ b/config/components/kueueviz/frontend-ingress.yaml
@@ -4,14 +4,7 @@ kind: Ingress
 metadata:
   name: kueueviz-frontend-ingress
   namespace: system
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
-  tls:
-    - hosts:
-        - frontend.kueueviz.local
-      secretName: kueueviz-tls-secret
   rules:
     - host: frontend.kueueviz.local
       http:

--- a/config/kueueviz/backend_ingress_patch.yaml
+++ b/config/kueueviz/backend_ingress_patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kueueviz-backend-ingress
+  namespace: system
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  tls:
+    - hosts:
+        - backend.kueueviz.local
+      secretName: kueueviz-tls-secret

--- a/config/kueueviz/frontend_deployment_patch.yaml
+++ b/config/kueueviz/frontend_deployment_patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kueueviz-frontend
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - name: frontend
+          env:
+            - name: REACT_APP_WEBSOCKET_URL
+              value: 'wss://backend.kueueviz.local'

--- a/config/kueueviz/frontend_ingress_patch.yaml
+++ b/config/kueueviz/frontend_ingress_patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kueueviz-frontend-ingress
+  namespace: system
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  tls:
+    - hosts:
+        - frontend.kueueviz.local
+      secretName: kueueviz-tls-secret

--- a/config/kueueviz/kustomization.yaml
+++ b/config/kueueviz/kustomization.yaml
@@ -11,3 +11,11 @@ labels:
 
 resources:
   - ../components/kueueviz/
+
+patches:
+# Add ingress annotations and tls config for nginx backend ingress controller
+- path: backend_ingress_patch.yaml
+# Add ingress annotations and tls config for nginx frontend ingress controller
+- path: frontend_ingress_patch.yaml
+# Add environment variables for frontend deployment
+- path: frontend_deployment_patch.yaml

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -588,26 +588,6 @@ files:
     continueOnError: true
     operations:
       - type: UPDATE
-        key: .spec.tls.[].secretName
-        value: '"{{ .Values.kueueViz.backend.ingress.tlsSecretName | default \"kueueviz-backend-tls\" }}"'
-        onFileCondition: '.kind == "Ingress" and .metadata.name | contains("kueueviz-backend-ingress")'
-        onItemCondition: '.spec.tls.[].secretName == "kueueviz-tls-secret"'
-      - type: UPDATE
-        key: .spec.tls.[].secretName
-        value: '"{{ .Values.kueueViz.frontend.ingress.tlsSecretName | default \"kueueviz-frontend-tls\" }}"'
-        onFileCondition: '.kind == "Ingress" and .metadata.name | contains("kueueviz-frontend-ingress")'
-        onItemCondition: '.spec.tls.[].secretName == "kueueviz-tls-secret"'
-      - type: UPDATE
-        key: .spec.tls.[].hosts
-        value: '["{{ .Values.kueueViz.backend.ingress.host | default \"backend.kueueviz.local\" }}"]'
-        onFileCondition: '.kind == "Ingress" and .metadata.name | contains("kueueviz-backend-ingress")'
-        onItemCondition: '.spec.tls.[].hosts.[] == "backend.kueueviz.local"'
-      - type: UPDATE
-        key: .spec.tls.[].hosts
-        value: '["{{ .Values.kueueViz.frontend.ingress.host | default \"frontend.kueueviz.local\" }}"]'
-        onFileCondition: '.kind == "Ingress" and .metadata.name | contains("kueueviz-frontend-ingress")'
-        onItemCondition: '.spec.tls.[].hosts.[] == "frontend.kueueviz.local"'
-      - type: UPDATE
         key: .spec.rules[0].host
         value: '"{{ .Values.kueueViz.backend.ingress.host | default \"backend.kueueviz.local\" }}"'
         onFileCondition: '.kind == "Ingress" and .metadata.name | contains("kueueviz-backend-ingress")'
@@ -690,6 +670,64 @@ files:
           {{- end }}
         indentation: 2
         onFileCondition: '.kind == "Deployment" and  .metadata.name | contains("frontend")'
+      - type: INSERT_TEXT
+        key: .spec
+        value: |
+          {{- if .Values.kueueViz.backend.ingress.tlsSecretName }}
+          tls:
+            - hosts:
+                - '{{ .Values.kueueViz.backend.ingress.host | default "backend.kueueviz.local" }}'
+              secretName: '{{ .Values.kueueViz.backend.ingress.tlsSecretName }}'
+          {{- end }}
+        indentation: 2
+        onFileCondition: '.kind == "Ingress" and  .metadata.name | contains("backend")'
+      - type: INSERT_TEXT
+        key: .spec
+        value: |
+          {{- if .Values.kueueViz.frontend.ingress.tlsSecretName }}
+          tls:
+            - hosts:
+                - '{{ .Values.kueueViz.frontend.ingress.host | default "frontend.kueueviz.local" }}'
+              secretName: '{{ .Values.kueueViz.frontend.ingress.tlsSecretName }}'
+          {{- end }}
+        indentation: 2
+        onFileCondition: '.kind == "Ingress" and  .metadata.name | contains("frontend")'
+      - type: INSERT_TEXT
+        key: .metadata
+        value: |
+          {{- with .Values.kueueViz.backend.ingress.annotations }}
+          annotations:
+            {{- toYaml . | nindent 4 }}
+          {{- end }}
+        indentation: 2
+        onFileCondition: '.kind == "Ingress" and  .metadata.name | contains("backend")'
+      - type: INSERT_TEXT
+        key: .metadata
+        value: |
+          {{- with .Values.kueueViz.frontend.ingress.annotations }}
+          annotations:
+            {{- toYaml . | nindent 4 }}
+          {{- end }}
+        indentation: 2
+        onFileCondition: '.kind == "Ingress" and  .metadata.name | contains("frontend")'
+      - type: INSERT_TEXT
+        key: .spec.template.spec.containers.[].name
+        value: |
+          {{- with .Values.kueueViz.frontend.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        indentation: 2
+        onFileCondition: '.kind == "Deployment" and  .metadata.name | contains("frontend")'
+      - type: INSERT_TEXT
+        key: .spec.template.spec.containers.[].name
+        value: |
+          {{- with .Values.kueueViz.backend.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        indentation: 2
+        onFileCondition: '.kind == "Deployment" and  .metadata.name | contains("backend")'
       - type: INSERT_TEXT
         key: .spec.template.spec
         value: |


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
- KueueViz frontend and backend Ingresses previously had **hardcoded NGINX annotations**.
  - This PR allows you to set your own annotations in Helm's values.yaml, with NGINX as the default. You can for example disable `nginx.ingress.kubernetes.io/ssl-redirect: "true"`
- KueueViz frontend and backend Ingresses also previously had **hardcoded TLS**.
  - This PR allows you to use HTTP, which can be important for users who terminate TLS on AWS ALB.
- The KueueViz backend **deployment** didn't expose **environment** **variables**.
  - This PR allows you to set, for example, **KUEUEVIZ_ALLOWED_ORIGINS** from values.yaml.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
I'm setting KUEUEVIZ_ALLOWED_ORIGINS to "frontend.kueueviz.local" by default. Let me know if there is a better option.
<img width="1231" height="649" alt="image" src="https://github.com/user-attachments/assets/98391ee6-2e0a-4ba3-b0af-d8476951014d" />


#### Does this PR introduce a user-facing change?
```release-note
KueueViz: Enhancing the following endpoint customizations and optimizations:
- The frontend and backend ingress no longer have hardcoded NGINX annotations. You can now set your own annotations in Helm’s values.yaml using kueueViz.backend.ingress.annotations and kueueViz.frontend.ingress.annotations
- The Ingress resources for KueueViz frontend and backend no longer require hardcoded TLS. You can now choose to use HTTP only by not providing kueueViz.backend.ingress.tlsSecretName and kueueViz.frontend.ingress.tlsSecretName
- You can set environment variables like KUEUEVIZ_ALLOWED_ORIGINS directly from values.yaml using kueueViz.backend.env
```