### PR TITLE
Follow DAMP style in node_failure_controller_test

### DIFF
--- a/pkg/controller/tas/node_failure_controller_test.go
+++ b/pkg/controller/tas/node_failure_controller_test.go
@@ -99,6 +99,9 @@ func TestNodeFailureReconciler(t *testing.T) {
 		Admitted(true).
 		Obj()
 
+	now := metav1.NewTime(fakeClock.Now())
+	earlierTime := metav1.NewTime(now.Add(-NodeFailureDelay))
+
 	basePod := testingpod.MakePod("test-pod", nsName).
 		Annotation(kueuealpha.WorkloadAnnotation, wlName).
 		Label(kueuealpha.TASLabel, "true").
@@ -106,7 +109,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 		Obj()
 
 	terminatingPod := basePod.DeepCopy()
-	terminatingPod.DeletionTimestamp = &metav1.Time{Time: fakeClock.Now()}
+	terminatingPod.DeletionTimestamp = &now
 	terminatingPod.Finalizers = []string{podcontroller.PodFinalizer}
 
 	failedPod := basePod.DeepCopy()
@@ -114,14 +117,14 @@ func TestNodeFailureReconciler(t *testing.T) {
 	failedPod.Status.ContainerStatuses = []corev1.ContainerStatus{
 		{
 			State: corev1.ContainerState{
-				Terminated: &corev1.ContainerStateTerminated{FinishedAt: metav1.NewTime(fakeClock.Now())},
+				Terminated: &corev1.ContainerStateTerminated{FinishedAt: now},
 			},
 		},
 	}
 	failedPod.Status.ContainerStatuses = []corev1.ContainerStatus{
 		{
 			State: corev1.ContainerState{
-				Terminated: &corev1.ContainerStateTerminated{FinishedAt: metav1.NewTime(fakeClock.Now())},
+				Terminated: &corev1.ContainerStateTerminated{FinishedAt: now},
 			},
 		},
 	}
@@ -142,7 +145,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
 					Status:             corev1.ConditionTrue,
-					LastTransitionTime: metav1.NewTime(fakeClock.Now())}).Obj(),
+					LastTransitionTime: now}).Obj(),
 				baseWorkload.DeepCopy(),
 				basePod.DeepCopy(),
 			},
@@ -154,7 +157,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
 					Status:             corev1.ConditionTrue,
-					LastTransitionTime: metav1.NewTime(fakeClock.Now())}).Obj(),
+					LastTransitionTime: now}).Obj(),
 				workloadWithAnnotation.DeepCopy(),
 				basePod.DeepCopy(),
 			},
@@ -167,7 +170,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
 					Status:             corev1.ConditionFalse,
-					LastTransitionTime: metav1.NewTime(fakeClock.Now())}).Obj(),
+					LastTransitionTime: now}).Obj(),
 				baseWorkload.DeepCopy(),
 				basePod.DeepCopy(),
 			},
@@ -180,7 +183,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
 					Status:             corev1.ConditionFalse,
-					LastTransitionTime: metav1.NewTime(fakeClock.Now().Add(-NodeFailureDelay))}).Obj(),
+					LastTransitionTime: earlierTime}).Obj(),
 				baseWorkload.DeepCopy(),
 				basePod.DeepCopy(),
 			},
@@ -193,7 +196,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
 					Status:             corev1.ConditionFalse,
-					LastTransitionTime: metav1.NewTime(fakeClock.Now())}).Obj(),
+					LastTransitionTime: earlierTime}).Obj(),
 				baseWorkload.DeepCopy(),
 				terminatingPod,
 			},
@@ -206,7 +209,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
 					Status:             corev1.ConditionFalse,
-					LastTransitionTime: metav1.NewTime(fakeClock.Now())}).Obj(),
+					LastTransitionTime: now}).Obj(),
 				baseWorkload.DeepCopy(),
 				failedPod,
 			},
@@ -218,7 +221,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
 					Status:             corev1.ConditionFalse,
-					LastTransitionTime: metav1.NewTime(fakeClock.Now())}).Obj(),
+					LastTransitionTime: now}).Obj(),
 				baseWorkload.DeepCopy(),
 				failedPod,
 			},
@@ -232,7 +235,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
 					Status:             corev1.ConditionFalse,
-					LastTransitionTime: metav1.NewTime(fakeClock.Now())}).Obj(),
+					LastTransitionTime: now}).Obj(),
 				baseWorkload.DeepCopy(),
 				basePod.DeepCopy(),
 			},
@@ -254,11 +257,11 @@ func TestNodeFailureReconciler(t *testing.T) {
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
 					Status:             corev1.ConditionFalse,
-					LastTransitionTime: metav1.NewTime(fakeClock.Now().Add(-NodeFailureDelay))}).Obj(),
+					LastTransitionTime: earlierTime}).Obj(),
 				baseNode.Clone().Name(nodeName2).StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
 					Status:             corev1.ConditionFalse,
-					LastTransitionTime: metav1.NewTime(fakeClock.Now().Add(-NodeFailureDelay))}).Obj(),
+					LastTransitionTime: earlierTime}).Obj(),
 				workloadWithTwoNodes.DeepCopy(),
 				testingpod.MakePod("pod1", nsName).Annotation(kueuealpha.WorkloadAnnotation, wlName).Label(kueuealpha.TASLabel, "true").NodeName(nodeName).Obj(),
 				testingpod.MakePod("pod2", nsName).Annotation(kueuealpha.WorkloadAnnotation, wlName).Label(kueuealpha.TASLabel, "true").NodeName(nodeName2).Obj(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It's a refactor of pkg/controller/tas/node_failure_controller_test to use explicit clones of a `baseNode` instead of calling a helper function. This makes the test consistently follow the DAMP style (rather than DRY).

#### Which issue(s) this PR fixes:

Fixes #6333 

#### Special notes for your reviewer:

In #6333 , it was suggested to define `baseNode` with one `NodeCondition`, and then call `.StatusConditions` on the clones. \
I'm diverging from this by defining `baseNode` without any `NodeCondition`s. \
This seems necessary because `.StatusConditions` [appends](https://github.com/kubernetes-sigs/kueue/blob/04a669ea8b10f1805efad9579a2436675fe31159/pkg/util/testingjobs/node/wrappers.go#L77) a new condition - so if I used a "default" one, I'd need some other way of replacing it in the clone. \
(And even if there is such a way, I think the resulting test code would be a bit less clear).


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```