### PR TITLE
Align the Workload webhook tests with TAS

### DIFF
--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -301,10 +301,8 @@ func validateAdmissionUpdate(new, old *kueue.Admission, path *field.Path) field.
 		if len(new.PodSetAssignments) != len(old.PodSetAssignments) {
 			return apivalidation.ValidateImmutableField(new, old, path)
 		}
-		// Allow to update (set) TopologyAssignment when DelayedTopologyRequest
-		// transitions from Pending to Ready.
+		// Allow to update (set) TopologyAssignments
 		for i := range new.PodSetAssignments {
-			// allow to update TopologyAssignments
 			old.PodSetAssignments[i].TopologyAssignment = new.PodSetAssignments[i].TopologyAssignment
 			old.PodSetAssignments[i].DelayedTopologyRequest = new.PodSetAssignments[i].DelayedTopologyRequest
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

**_TL;DR_** - This aligns the unit test with the business logic. The deleted cases might have been there to test some real-life scenarios (i.e. `Admission` structures that actually can be encountered by the webhook in practice), but it begs the question whether it's suitable for a **unit** test.

Currently, the TAS-specific `Admission` validation logic inside the `Workload` webhook is not tested due to the flag never being enabled in the test.
https://github.com/kubernetes-sigs/kueue/blob/04a669ea8b10f1805efad9579a2436675fe31159/pkg/webhooks/workload_webhook.go#L300-L311

It was first added in https://github.com/kubernetes-sigs/kueue/commit/3117559223d7d9760bf4f96fb892489c437ddc39 and was later changed in https://github.com/kubernetes-sigs/kueue/commit/27fb9e340536b8b942bbdae384ca25a0b5fbaf60 which removed the `DelayedTopologyRequest` state transition check, resulting in all changes to `DelayedTopologyRequest` and `TopologyAssignment` to be permitted.

I'll go through the affected cases one by one:
1. `TopologyAssignment cannot be mutated` - the current logic allows for arbitrary changes if TAS is enabled.
2. `TopologyAssignment cannot be set without delayedTopologyRequest` - originally in https://github.com/kubernetes-sigs/kueue/commit/3117559223d7d9760bf4f96fb892489c437ddc39, it seems to be designed to test this check: https://github.com/kubernetes-sigs/kueue/blob/3117559223d7d9760bf4f96fb892489c437ddc39/pkg/webhooks/workload_webhook.go#L304 It was removed in https://github.com/kubernetes-sigs/kueue/commit/27fb9e340536b8b942bbdae384ca25a0b5fbaf60 hence the test case is irrelevant.
3. `TopologyAssignment can be set if delayedTopologyRequest is Pending` - this case was improperly constructed because it expects an error while stating that it "can" be set. Even when checking out the original commit and enabling the feature, the test still passes because of this check:
https://github.com/kubernetes-sigs/kueue/blob/3117559223d7d9760bf4f96fb892489c437ddc39/pkg/webhooks/workload_webhook.go#L305
4. `TopologyAssignment cannot be set if delayedTopologyRequest is Ready` - again, this was testing this check which is not gone:
https://github.com/kubernetes-sigs/kueue/blob/3117559223d7d9760bf4f96fb892489c437ddc39/pkg/webhooks/workload_webhook.go#L304
5. `PodSets cannot be removed from admission` - still relevant. **Added a complementary "cannot be added" test**.

**Unfortunately I cannot judge whether the current logic is correct** - I simply made it so the current branch of code is tested. I presume making the validator more strict would be part of another issue.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5926

#### Special notes for your reviewer:
This is my first PR taken as part of the onboarding process. It was supposed to be as simple as adding the flag-enabling line, but turned out to be a little more complex, as mentioned earlier.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```