### PR TITLE
feat: add event when workload-priority or priority not found

### DIFF
--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -83,6 +83,7 @@ func (w *BaseWebhook) ValidateCreate(ctx context.Context, obj runtime.Object) (a
 	log := ctrl.LoggerFrom(ctx)
 	log.V(5).Info("Validating create")
 	allErrs := ValidateJobOnCreate(job)
+	allErrs = append(allErrs, ValidateWorkloadPriorityClass(ctx, w.Client, job)...)
 	if jobWithValidation, ok := job.(JobWithCustomValidation); ok {
 		validationErrs, err := jobWithValidation.ValidateOnCreate(ctx)
 		if err != nil {

--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -91,6 +91,7 @@ func (w *BaseWebhook[T]) ValidateCreate(ctx context.Context, obj T) (admission.W
 	log := ctrl.LoggerFrom(ctx)
 	log.V(5).Info("Validating create")
 	allErrs := ValidateJobOnCreate(job)
+	allErrs = append(allErrs, ValidateWorkloadPriorityClass(ctx, w.Client, job)...)
 	if jobWithValidation, ok := job.(JobWithCustomValidation); ok {
 		validationErrs, err := jobWithValidation.ValidateOnCreate(ctx)
 		if err != nil {

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -252,6 +252,7 @@ func TestValidateOnCreate(t *testing.T) {
 			job.MockJobWithCustomValidation.EXPECT().ValidateOnCreate(gomock.Any()).Return(tc.customValidationFailure, tc.customValidationError).AnyTimes()
 
 			w := &jobframework.BaseWebhook{
+				Client: utiltesting.NewClientBuilder().WithObjects(tc.objects...).Build(),
 				FromObject: func(object runtime.Object) jobframework.GenericJob {
 					return object.(*mockJob)
 				},

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -234,22 +234,6 @@ func TestValidateOnCreate(t *testing.T) {
 			wantError: field.InternalError(nil, errors.New("test-custom-validation-error")),
 		},
 		{
-			name: "valid workloadpriorityclass",
-			job: &batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "job",
-					Namespace: "default",
-					Labels: map[string]string{
-						constants.QueueLabel:                 "queue",
-						constants.WorkloadPriorityClassLabel: "test-wpc",
-					},
-				},
-			},
-			objects: []client.Object{
-				utiltestingapi.MakeWorkloadPriorityClass("test-wpc").Obj(),
-			},
-		},
-		{
 			name: "invalid workloadpriorityclass",
 			job: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
@@ -269,6 +253,15 @@ func TestValidateOnCreate(t *testing.T) {
 				),
 			}.ToAggregate(),
 		},
+		// {
+		// 	name: "valid workloadpriorityclass",
+		// 	job: utiljob.MakeJob("job", metav1.NamespaceDefault).
+		// 		Label(constants.QueueLabel, "queue").
+		// 		Label(constants.WorkloadPriorityClassLabel, "test-wpc").Obj(),
+		// 	objects: []client.Object{
+		// 		utiltestingapi.MakeWorkloadPriorityClass("test-wpc").PriorityValue(100).Obj(),
+		// 	},
+		// },
 	}
 
 	for _, tc := range testcases {

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -241,12 +241,12 @@ func TestValidateOnCreate(t *testing.T) {
 					Namespace: "default",
 					Labels: map[string]string{
 						constants.QueueLabel:                 "queue",
-						constants.WorkloadPriorityClassLabel: "priorityclass",
+						constants.WorkloadPriorityClassLabel: "test-wpc",
 					},
 				},
 			},
 			objects: []client.Object{
-				utiltesting.MakeWorkloadPriorityClass("priorityclass").Obj(),
+				utiltestingapi.MakeWorkloadPriorityClass("test-wpc").Obj(),
 			},
 		},
 		{

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -253,15 +253,15 @@ func TestValidateOnCreate(t *testing.T) {
 				),
 			}.ToAggregate(),
 		},
-		// {
-		// 	name: "valid workloadpriorityclass",
-		// 	job: utiljob.MakeJob("job", metav1.NamespaceDefault).
-		// 		Label(constants.QueueLabel, "queue").
-		// 		Label(constants.WorkloadPriorityClassLabel, "test-wpc").Obj(),
-		// 	objects: []client.Object{
-		// 		utiltestingapi.MakeWorkloadPriorityClass("test-wpc").PriorityValue(100).Obj(),
-		// 	},
-		// },
+		{
+			name: "valid workloadpriorityclass",
+			job: utiljob.MakeJob("job", metav1.NamespaceDefault).
+				Label(constants.QueueLabel, "queue").
+				Label(constants.WorkloadPriorityClassLabel, "test-wpc").Obj(),
+			objects: []client.Object{
+				utiltestingapi.MakeWorkloadPriorityClass("test-wpc").PriorityValue(100).Obj(),
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -291,6 +291,7 @@ func TestValidateOnCreate(t *testing.T) {
 			job.MockJobWithCustomValidation.EXPECT().ValidateOnCreate(gomock.Any()).Return(tc.customValidationFailure, tc.customValidationError).AnyTimes()
 
 			w := &jobframework.BaseWebhook[*mockJob]{
+				Client: utiltesting.NewClientBuilder().WithObjects(tc.objects...).Build(),
 				FromObject: func(object *mockJob) jobframework.GenericJob {
 					return object
 				},

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -291,15 +291,15 @@ func TestValidateOnCreate(t *testing.T) {
 				),
 			}.ToAggregate(),
 		},
-		// {
-		// 	name: "valid workloadpriorityclass",
-		// 	job: utiljob.MakeJob("job", metav1.NamespaceDefault).
-		// 		Label(constants.QueueLabel, "queue").
-		// 		Label(constants.WorkloadPriorityClassLabel, "test-wpc").Obj(),
-		// 	objects: []client.Object{
-		// 		utiltestingapi.MakeWorkloadPriorityClass("test-wpc").PriorityValue(100).Obj(),
-		// 	},
-		// },
+		{
+			name: "valid workloadpriorityclass",
+			job: utiljob.MakeJob("job", metav1.NamespaceDefault).
+				Label(constants.QueueLabel, "queue").
+				Label(constants.WorkloadPriorityClassLabel, "test-wpc").Obj(),
+			objects: []client.Object{
+				utiltestingapi.MakeWorkloadPriorityClass("test-wpc").PriorityValue(100).Obj(),
+			},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -279,12 +279,12 @@ func TestValidateOnCreate(t *testing.T) {
 					Namespace: "default",
 					Labels: map[string]string{
 						constants.QueueLabel:                 "queue",
-						constants.WorkloadPriorityClassLabel: "priorityclass",
+						constants.WorkloadPriorityClassLabel: "test-wpc",
 					},
 				},
 			},
 			objects: []client.Object{
-				utiltesting.MakeWorkloadPriorityClass("priorityclass").Obj(),
+				utiltestingapi.MakeWorkloadPriorityClass("test-wpc").Obj(),
 			},
 		},
 		{

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -239,6 +240,7 @@ func TestValidateOnCreate(t *testing.T) {
 		customValidationFailure field.ErrorList
 		customValidationError   error
 
+		objects     []client.Object
 		wantError   error
 		wantWarning admission.Warnings // Note: ValidateCreate always returns nil for admission.Warning.
 	}{
@@ -268,6 +270,42 @@ func TestValidateOnCreate(t *testing.T) {
 			// Note: In this test, we intentionally "piggyback" on the field.Error type to avoid mixing
 			// different error types. This simplifies the assertion logic.
 			wantError: field.InternalError(nil, errors.New("test-custom-validation-error")),
+		},
+		{
+			name: "valid workloadpriorityclass",
+			job: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job",
+					Namespace: "default",
+					Labels: map[string]string{
+						constants.QueueLabel:                 "queue",
+						constants.WorkloadPriorityClassLabel: "priorityclass",
+					},
+				},
+			},
+			objects: []client.Object{
+				utiltesting.MakeWorkloadPriorityClass("priorityclass").Obj(),
+			},
+		},
+		{
+			name: "invalid workloadpriorityclass",
+			job: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job",
+					Namespace: "default",
+					Labels: map[string]string{
+						constants.QueueLabel:                 "queue",
+						constants.WorkloadPriorityClassLabel: "nonexist",
+					},
+				},
+			},
+			wantError: field.ErrorList{
+				field.Invalid(
+					field.NewPath("metadata.labels[kueue.x-k8s.io/priority-class]"),
+					"nonexist",
+					`no WorkloadPriorityClass with name nonexist was found`,
+				),
+			}.ToAggregate(),
 		},
 	}
 

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -272,22 +272,6 @@ func TestValidateOnCreate(t *testing.T) {
 			wantError: field.InternalError(nil, errors.New("test-custom-validation-error")),
 		},
 		{
-			name: "valid workloadpriorityclass",
-			job: &batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "job",
-					Namespace: "default",
-					Labels: map[string]string{
-						constants.QueueLabel:                 "queue",
-						constants.WorkloadPriorityClassLabel: "test-wpc",
-					},
-				},
-			},
-			objects: []client.Object{
-				utiltestingapi.MakeWorkloadPriorityClass("test-wpc").Obj(),
-			},
-		},
-		{
 			name: "invalid workloadpriorityclass",
 			job: &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
@@ -307,6 +291,15 @@ func TestValidateOnCreate(t *testing.T) {
 				),
 			}.ToAggregate(),
 		},
+		// {
+		// 	name: "valid workloadpriorityclass",
+		// 	job: utiljob.MakeJob("job", metav1.NamespaceDefault).
+		// 		Label(constants.QueueLabel, "queue").
+		// 		Label(constants.WorkloadPriorityClassLabel, "test-wpc").Obj(),
+		// 	objects: []client.Object{
+		// 		utiltestingapi.MakeWorkloadPriorityClass("test-wpc").PriorityValue(100).Obj(),
+		// 	},
+		// },
 	}
 
 	for _, tc := range testcases {

--- a/pkg/controller/jobframework/events.go
+++ b/pkg/controller/jobframework/events.go
@@ -29,4 +29,5 @@ const (
 	ReasonErrWorkloadCompose    = "ErrWorkloadCompose"
 	ReasonUpdatedAdmissionCheck = "UpdatedAdmissionCheck"
 	ReasonJobNestingTooDeep     = "JobNestingTooDeep"
+	ReasonPriorityNotFound      = "PriorityNotFound"
 )

--- a/pkg/controller/jobframework/events.go
+++ b/pkg/controller/jobframework/events.go
@@ -29,5 +29,7 @@ const (
 	ReasonErrWorkloadCompose    = "ErrWorkloadCompose"
 	ReasonUpdatedAdmissionCheck = "UpdatedAdmissionCheck"
 	ReasonJobNestingTooDeep     = "JobNestingTooDeep"
-	ReasonPriorityNotFound      = "PriorityNotFound"
+
+	ReasonPriorityClassNotFound         = "PriorityClassNotFound"
+	ReasonWorkloadPriorityClassNotFound = "WorkloadPriorityClassNotFound"
 )

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -79,6 +79,7 @@ var (
 	ErrExtraWorkloads                 = errors.New("extra workloads")
 	ErrPrebuiltWorkloadNotFound       = errors.New("prebuilt workload not found")
 	ErrPriorityClassNotFound          = errors.New("priority class not found")
+	ErrWorkloadPriorityClassNotFound  = errors.New("workload priority class not found")
 )
 
 type WorkloadRetentionPolicy struct {
@@ -1364,6 +1365,7 @@ func ExtractPriority(ctx context.Context, c client.Client, r record.EventRecorde
 		priorityClassRef, priority, err := utilpriority.GetPriorityFromWorkloadPriorityClass(ctx, c, workloadPriorityClass)
 		if apierrors.IsNotFound(err) {
 			r.Eventf(obj, corev1.EventTypeWarning, ReasonWorkloadPriorityClassNotFound, "WorkloadPriorityClass %v not found", workloadPriorityClass)
+			return priorityClassRef, priority, fmt.Errorf("%w: workloadPriorityClass %v", ErrWorkloadPriorityClassNotFound, workloadPriorityClass)
 		}
 		return priorityClassRef, priority, err
 	}
@@ -1375,6 +1377,7 @@ func ExtractPriority(ctx context.Context, c client.Client, r record.EventRecorde
 	priorityClassRef, priority, err := utilpriority.GetPriorityFromPriorityClass(ctx, c, priorityClassName)
 	if apierrors.IsNotFound(err) {
 		r.Eventf(obj, corev1.EventTypeWarning, ReasonPriorityClassNotFound, "PriorityClass %v not found", priorityClassName)
+		return priorityClassRef, priority, fmt.Errorf("%w: priorityClass %v", ErrPriorityClassNotFound, priorityClassName)
 	}
 	return priorityClassRef, priority, err
 }

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -88,6 +88,7 @@ var (
 	ErrExtraWorkloads                 = errors.New("extra workloads")
 	ErrPrebuiltWorkloadNotFound       = errors.New("prebuilt workload not found")
 	ErrPriorityClassNotFound          = errors.New("priority class not found")
+	ErrWorkloadPriorityClassNotFound  = errors.New("workload priority class not found")
 )
 
 type WorkloadRetentionPolicy struct {
@@ -1686,6 +1687,7 @@ func ExtractPriority(ctx context.Context, c client.Client, r record.EventRecorde
 		priorityClassRef, priority, err := utilpriority.GetPriorityFromWorkloadPriorityClass(ctx, c, workloadPriorityClass)
 		if apierrors.IsNotFound(err) {
 			r.Eventf(obj, corev1.EventTypeWarning, ReasonWorkloadPriorityClassNotFound, "WorkloadPriorityClass %v not found", workloadPriorityClass)
+			return priorityClassRef, priority, fmt.Errorf("%w: workloadPriorityClass %v", ErrWorkloadPriorityClassNotFound, workloadPriorityClass)
 		}
 		return priorityClassRef, priority, err
 	}
@@ -1697,6 +1699,7 @@ func ExtractPriority(ctx context.Context, c client.Client, r record.EventRecorde
 	priorityClassRef, priority, err := utilpriority.GetPriorityFromPriorityClass(ctx, c, priorityClassName)
 	if apierrors.IsNotFound(err) {
 		r.Eventf(obj, corev1.EventTypeWarning, ReasonPriorityClassNotFound, "PriorityClass %v not found", priorityClassName)
+		return priorityClassRef, priority, fmt.Errorf("%w: priorityClass %v", ErrPriorityClassNotFound, priorityClassName)
 	}
 	return priorityClassRef, priority, err
 }

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1647,8 +1647,8 @@ func getCustomPriorityClassFuncFromJob(job GenericJob) func() string {
 	return nil
 }
 
-func PrepareWorkloadPriority(ctx context.Context, c client.Client, obj client.Object, wl *kueue.Workload, customPriorityClassFunc func() string) error {
-	priorityClassRef, priority, err := ExtractPriority(ctx, c, obj, wl.Spec.PodSets, customPriorityClassFunc)
+func PrepareWorkloadPriority(ctx context.Context, c client.Client, r record.EventRecorder, obj client.Object, wl *kueue.Workload, customPriorityClassFunc func() string) error {
+	priorityClassRef, priority, err := ExtractPriority(ctx, c, r, obj, wl.Spec.PodSets, customPriorityClassFunc)
 	if err != nil {
 		return err
 	}
@@ -1668,7 +1668,7 @@ func (r *JobReconciler) prepareWorkload(ctx context.Context, job GenericJob, wl 
 		PropagateAdmissionGatedByAnnotation(job.Object(), wl)
 	}
 
-	if err := PrepareWorkloadPriority(ctx, r.client, job.Object(), wl, getCustomPriorityClassFuncFromJob(job)); err != nil {
+	if err := PrepareWorkloadPriority(ctx, r.client, r.record, job.Object(), wl, getCustomPriorityClassFuncFromJob(job)); err != nil {
 		return err
 	}
 
@@ -1681,34 +1681,24 @@ func (r *JobReconciler) prepareWorkload(ctx context.Context, job GenericJob, wl 
 	return nil
 }
 
-func (r *JobReconciler) extractPriority(ctx context.Context, podSets []kueue.PodSet, job GenericJob) (string, string, int32, error) {
-	var customPriorityFunc func() string
-	if jobWithPriorityClass, isImplemented := job.(JobWithPriorityClass); isImplemented {
-		customPriorityFunc = jobWithPriorityClass.PriorityClass
-	}
-	priorityClassName, source, value, err := ExtractPriority(ctx, r.client, job.Object(), podSets, customPriorityFunc)
-	if apierrors.IsNotFound(err) {
-		reason := ReasonPriorityClassNotFound
-		message := fmt.Sprintf("PriorityClass %v not found", extractPriorityFromPodSets(podSets))
-		if workloadPriorityClass := WorkloadPriorityClassName(job.Object()); len(workloadPriorityClass) > 0 {
-			reason = ReasonWorkloadPriorityClassNotFound
-			message = fmt.Sprintf("WorkloadPriorityClass %v not found", WorkloadPriorityClassName(job.Object()))
-		}
-		r.record.Eventf(job.Object(), corev1.EventTypeWarning, reason, message)
-		return priorityClassName, source, value, ErrPriorityClassNotFound
-	}
-
-	return priorityClassName, source, value, err
-}
-
-func ExtractPriority(ctx context.Context, c client.Client, obj client.Object, podSets []kueue.PodSet, customPriorityClassFunc func() string) (*kueue.PriorityClassRef, int32, error) {
+func ExtractPriority(ctx context.Context, c client.Client, r record.EventRecorder, obj client.Object, podSets []kueue.PodSet, customPriorityClassFunc func() string) (*kueue.PriorityClassRef, int32, error) {
 	if workloadPriorityClass := WorkloadPriorityClassName(obj); len(workloadPriorityClass) > 0 {
-		return utilpriority.GetPriorityFromWorkloadPriorityClass(ctx, c, workloadPriorityClass)
+		priorityClassRef, priority, err := utilpriority.GetPriorityFromWorkloadPriorityClass(ctx, c, workloadPriorityClass)
+		if apierrors.IsNotFound(err) {
+			r.Eventf(obj, corev1.EventTypeWarning, ReasonWorkloadPriorityClassNotFound, "WorkloadPriorityClass %v not found", workloadPriorityClass)
+		}
+		return priorityClassRef, priority, err
 	}
+
+	priorityClassName := extractPriorityFromPodSets(podSets)
 	if customPriorityClassFunc != nil {
-		return utilpriority.GetPriorityFromPriorityClass(ctx, c, customPriorityClassFunc())
+		priorityClassName = customPriorityClassFunc()
 	}
-	return utilpriority.GetPriorityFromPriorityClass(ctx, c, extractPriorityFromPodSets(podSets))
+	priorityClassRef, priority, err := utilpriority.GetPriorityFromPriorityClass(ctx, c, priorityClassName)
+	if apierrors.IsNotFound(err) {
+		r.Eventf(obj, corev1.EventTypeWarning, ReasonPriorityClassNotFound, "PriorityClass %v not found", priorityClassName)
+	}
+	return priorityClassRef, priority, err
 }
 
 func extractPriorityFromPodSets(podSets []kueue.PodSet) string {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1688,7 +1688,13 @@ func (r *JobReconciler) extractPriority(ctx context.Context, podSets []kueue.Pod
 	}
 	priorityClassName, source, value, err := ExtractPriority(ctx, r.client, job.Object(), podSets, customPriorityFunc)
 	if apierrors.IsNotFound(err) {
-		r.record.Event(job.Object(), corev1.EventTypeWarning, ReasonPriorityNotFound, "PriorityClass not found")
+		reason := ReasonPriorityClassNotFound
+		message := fmt.Sprintf("PriorityClass %v not found", extractPriorityFromPodSets(podSets))
+		if workloadPriorityClass := WorkloadPriorityClassName(job.Object()); len(workloadPriorityClass) > 0 {
+			reason = ReasonWorkloadPriorityClassNotFound
+			message = fmt.Sprintf("WorkloadPriorityClass %v not found", WorkloadPriorityClassName(job.Object()))
+		}
+		r.record.Eventf(job.Object(), corev1.EventTypeWarning, reason, message)
 		return priorityClassName, source, value, ErrPriorityClassNotFound
 	}
 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1209,7 +1209,7 @@ func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.Event
 		return nil
 	}
 
-	priorityClassRef, priority, err := ExtractPriority(ctx, c, obj, needsClassChange[0].Spec.PodSets, customPriorityClassFunc)
+	priorityClassRef, priority, err := ExtractPriority(ctx, c, r, obj, needsClassChange[0].Spec.PodSets, customPriorityClassFunc)
 	if err != nil {
 		return fmt.Errorf("prepare workload priority: %w", err)
 	}
@@ -1648,7 +1648,7 @@ func getCustomPriorityClassFuncFromJob(job GenericJob) func() string {
 	return nil
 }
 
-func PrepareWorkloadPriority(ctx context.Context, c client.Client, r record.EventRecorder, obj client.Object, wl *kueue.Workload, customPriorityClassFunc func() string) error {
+func PrepareWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, wl *kueue.Workload, customPriorityClassFunc func() string) error {
 	priorityClassRef, priority, err := ExtractPriority(ctx, c, r, obj, wl.Spec.PodSets, customPriorityClassFunc)
 	if err != nil {
 		return err
@@ -1682,11 +1682,11 @@ func (r *JobReconciler) prepareWorkload(ctx context.Context, job GenericJob, wl 
 	return nil
 }
 
-func ExtractPriority(ctx context.Context, c client.Client, r record.EventRecorder, obj client.Object, podSets []kueue.PodSet, customPriorityClassFunc func() string) (*kueue.PriorityClassRef, int32, error) {
+func ExtractPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, podSets []kueue.PodSet, customPriorityClassFunc func() string) (*kueue.PriorityClassRef, int32, error) {
 	if workloadPriorityClass := WorkloadPriorityClassName(obj); len(workloadPriorityClass) > 0 {
 		priorityClassRef, priority, err := utilpriority.GetPriorityFromWorkloadPriorityClass(ctx, c, workloadPriorityClass)
 		if apierrors.IsNotFound(err) {
-			r.Eventf(obj, corev1.EventTypeWarning, ReasonWorkloadPriorityClassNotFound, "WorkloadPriorityClass %v not found", workloadPriorityClass)
+			r.Eventf(obj, nil, corev1.EventTypeWarning, ReasonWorkloadPriorityClassNotFound, ReasonWorkloadPriorityClassNotFound, "WorkloadPriorityClass %v not found", workloadPriorityClass)
 			return priorityClassRef, priority, fmt.Errorf("%w: workloadPriorityClass %v", ErrWorkloadPriorityClassNotFound, workloadPriorityClass)
 		}
 		return priorityClassRef, priority, err
@@ -1698,7 +1698,7 @@ func ExtractPriority(ctx context.Context, c client.Client, r record.EventRecorde
 	}
 	priorityClassRef, priority, err := utilpriority.GetPriorityFromPriorityClass(ctx, c, priorityClassName)
 	if apierrors.IsNotFound(err) {
-		r.Eventf(obj, corev1.EventTypeWarning, ReasonPriorityClassNotFound, "PriorityClass %v not found", priorityClassName)
+		r.Eventf(obj, nil, corev1.EventTypeWarning, ReasonPriorityClassNotFound, ReasonPriorityClassNotFound, "PriorityClass %v not found", priorityClassName)
 		return priorityClassRef, priority, fmt.Errorf("%w: priorityClass %v", ErrPriorityClassNotFound, priorityClassName)
 	}
 	return priorityClassRef, priority, err

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -87,6 +87,7 @@ var (
 	ErrNoMatchingWorkloads            = errors.New("no matching workloads")
 	ErrExtraWorkloads                 = errors.New("extra workloads")
 	ErrPrebuiltWorkloadNotFound       = errors.New("prebuilt workload not found")
+	ErrPriorityClassNotFound          = errors.New("priority class not found")
 )
 
 type WorkloadRetentionPolicy struct {
@@ -1678,6 +1679,20 @@ func (r *JobReconciler) prepareWorkload(ctx context.Context, job GenericJob, wl 
 	}
 	wl.Spec.Active = active
 	return nil
+}
+
+func (r *JobReconciler) extractPriority(ctx context.Context, podSets []kueue.PodSet, job GenericJob) (string, string, int32, error) {
+	var customPriorityFunc func() string
+	if jobWithPriorityClass, isImplemented := job.(JobWithPriorityClass); isImplemented {
+		customPriorityFunc = jobWithPriorityClass.PriorityClass
+	}
+	priorityClassName, source, value, err := ExtractPriority(ctx, r.client, job.Object(), podSets, customPriorityFunc)
+	if apierrors.IsNotFound(err) {
+		r.record.Event(job.Object(), corev1.EventTypeWarning, ReasonPriorityNotFound, "PriorityClass not found")
+		return priorityClassName, source, value, ErrPriorityClassNotFound
+	}
+
+	return priorityClassName, source, value, err
 }
 
 func ExtractPriority(ctx context.Context, c client.Client, obj client.Object, podSets []kueue.PodSet, customPriorityClassFunc func() string) (*kueue.PriorityClassRef, int32, error) {

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
+
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -40,7 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
-	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -17,6 +17,7 @@ limitations under the License.
 package jobframework
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"slices"
@@ -30,13 +31,15 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
-
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
@@ -225,6 +228,23 @@ func validateImmutablePodGroupPodSpecPath(newShape, oldShape map[string]any, fie
 	}
 
 	return allErrs
+}
+
+func ValidateWorkloadPriorityClass(ctx context.Context, client client.Client, job GenericJob) field.ErrorList {
+	workloadPriorityClass := WorkloadPriorityClassName(job.Object())
+	if len(workloadPriorityClass) == 0 {
+		return nil
+	}
+
+	wpc := &kueue.WorkloadPriorityClass{}
+	if err := client.Get(ctx, types.NamespacedName{Name: workloadPriorityClass}, wpc); err != nil {
+		if apierrors.IsNotFound(err) {
+			msg := fmt.Sprintf("no WorkloadPriorityClass with name %v was found", workloadPriorityClass)
+			return field.ErrorList{field.Invalid(workloadPriorityClassNamePath, workloadPriorityClass, msg)}
+		}
+		return field.ErrorList{(&field.Error{}).WithOrigin(err.Error())}
+	}
+	return nil
 }
 
 func IsWorkloadPriorityClassNameEmpty(obj client.Object) bool {

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -17,6 +17,7 @@ limitations under the License.
 package jobframework
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"slices"
@@ -30,14 +31,16 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
-
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
@@ -283,6 +286,23 @@ func validateImmutablePodGroupPodSpecPath(newShape, oldShape map[string]any, fie
 	}
 
 	return allErrs
+}
+
+func ValidateWorkloadPriorityClass(ctx context.Context, client client.Client, job GenericJob) field.ErrorList {
+	workloadPriorityClass := WorkloadPriorityClassName(job.Object())
+	if len(workloadPriorityClass) == 0 {
+		return nil
+	}
+
+	wpc := &kueue.WorkloadPriorityClass{}
+	if err := client.Get(ctx, types.NamespacedName{Name: workloadPriorityClass}, wpc); err != nil {
+		if apierrors.IsNotFound(err) {
+			msg := fmt.Sprintf("no WorkloadPriorityClass with name %v was found", workloadPriorityClass)
+			return field.ErrorList{field.Invalid(workloadPriorityClassNamePath, workloadPriorityClass, msg)}
+		}
+		return field.ErrorList{(&field.Error{}).WithOrigin(err.Error())}
+	}
+	return nil
 }
 
 func IsWorkloadPriorityClassNameEmpty(obj client.Object) bool {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4046,8 +4046,8 @@ func TestReconciler(t *testing.T) {
 				{
 					Key:       types.NamespacedName{Name: "job", Namespace: "labelled-ns"},
 					EventType: "Warning",
-					Reason:    "PriorityNotFound",
-					Message:   "PriorityClass not found",
+					Reason:    "WorkloadPriorityClassNotFound",
+					Message:   "WorkloadPriorityClass test-wpc-high not found",
 				},
 			},
 		},

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -3977,7 +3977,7 @@ func TestReconciler(t *testing.T) {
 				Parallelism(10).
 				Request(corev1.ResourceCPU, "1").
 				Image("", nil).
-				WorkloadPriorityClass("test-wpc-high").
+				WorkloadPriorityClass(highWPCWrapper.Name).
 				Obj(),
 			wantJob: *utiltestingjob.MakeJob("job", "labelled-ns").
 				Queue("test-queue").
@@ -3986,22 +3986,21 @@ func TestReconciler(t *testing.T) {
 				Parallelism(10).
 				Request(corev1.ResourceCPU, "1").
 				Image("", nil).
-				WorkloadPriorityClass("test-wpc-high").
+				WorkloadPriorityClass(highWPCWrapper.Name).
 				Obj(),
 			priorityClasses: []client.Object{
 				highWPCWrapper.Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("job", "labelled-ns").
+				*utiltestingapi.MakeWorkload("job", "labelled-ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					Queue("test-queue").
-					Priority(200).
-					PriorityClass("test-wpc-high").
-					PriorityClassSource(constants.WorkloadPriorityClassSource).
+					WorkloadPriorityClassRef(highWPCWrapper.Name).
+					Priority(highWPCWrapper.Value).
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
-					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Obj(),

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4029,7 +4029,7 @@ func TestReconciler(t *testing.T) {
 				Parallelism(10).
 				Request(corev1.ResourceCPU, "1").
 				Image("", nil).
-				WorkloadPriorityClass("test-wpc-high").
+				WorkloadPriorityClass("test-wpc-not-found").
 				Obj(),
 			wantJob: *utiltestingjob.MakeJob("job", "labelled-ns").
 				Queue("test-queue").
@@ -4038,15 +4038,15 @@ func TestReconciler(t *testing.T) {
 				Parallelism(10).
 				Request(corev1.ResourceCPU, "1").
 				Image("", nil).
-				WorkloadPriorityClass("test-wpc-high").
+				WorkloadPriorityClass("test-wpc-not-found").
 				Obj(),
-			wantErr: jobframework.ErrPriorityClassNotFound,
+			wantErr: jobframework.ErrWorkloadPriorityClassNotFound,
 			wantEvents: []utiltesting.EventRecord{
 				{
 					Key:       types.NamespacedName{Name: "job", Namespace: "labelled-ns"},
 					EventType: "Warning",
 					Reason:    "WorkloadPriorityClassNotFound",
-					Message:   "WorkloadPriorityClass test-wpc-high not found",
+					Message:   "WorkloadPriorityClass test-wpc-not-found not found",
 				},
 			},
 		},

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4897,7 +4897,7 @@ func TestReconciler(t *testing.T) {
 				Parallelism(10).
 				Request(corev1.ResourceCPU, "1").
 				Image("", nil).
-				WorkloadPriorityClass("test-wpc-high").
+				WorkloadPriorityClass("test-wpc-not-found").
 				Obj(),
 			wantJob: *utiltestingjob.MakeJob("job", "labelled-ns").
 				Queue("test-queue").
@@ -4906,15 +4906,15 @@ func TestReconciler(t *testing.T) {
 				Parallelism(10).
 				Request(corev1.ResourceCPU, "1").
 				Image("", nil).
-				WorkloadPriorityClass("test-wpc-high").
+				WorkloadPriorityClass("test-wpc-not-found").
 				Obj(),
-			wantErr: jobframework.ErrPriorityClassNotFound,
+			wantErr: jobframework.ErrWorkloadPriorityClassNotFound,
 			wantEvents: []utiltesting.EventRecord{
 				{
 					Key:       types.NamespacedName{Name: "job", Namespace: "labelled-ns"},
 					EventType: "Warning",
 					Reason:    "WorkloadPriorityClassNotFound",
-					Message:   "WorkloadPriorityClass test-wpc-high not found",
+					Message:   "WorkloadPriorityClass test-wpc-not-found not found",
 				},
 			},
 		},

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4830,6 +4830,95 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
+		"job with validate workload-priorityclass": {
+			enableManagedJobsNamespaceSelectorAlwaysRespected: true,
+			reconcilerOptions: []jobframework.Option{
+				jobframework.WithManagedJobsNamespaceSelector(labels.SelectorFromSet(map[string]string{
+					"managed-by-kueue": "true",
+				})),
+				jobframework.WithManageJobsWithoutQueueName(true),
+			},
+			job: *utiltestingjob.MakeJob("job", "labelled-ns").
+				Queue("test-queue").
+				Suspend(true).
+				UID("test-uid").
+				Parallelism(10).
+				Request(corev1.ResourceCPU, "1").
+				Image("", nil).
+				WorkloadPriorityClass("test-wpc-high").
+				Obj(),
+			wantJob: *utiltestingjob.MakeJob("job", "labelled-ns").
+				Queue("test-queue").
+				UID("test-uid").
+				Suspend(true).
+				Parallelism(10).
+				Request(corev1.ResourceCPU, "1").
+				Image("", nil).
+				WorkloadPriorityClass("test-wpc-high").
+				Obj(),
+			priorityClasses: []client.Object{
+				highWPCWrapper.Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("job", "labelled-ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Queue("test-queue").
+					Priority(200).
+					PriorityClass("test-wpc-high").
+					PriorityClassSource(constants.WorkloadPriorityClassSource).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "labelled-ns"},
+					EventType: "Normal",
+					Reason:    "CreatedWorkload",
+					Message:   "Created Workload: labelled-ns/" + GetWorkloadNameForJob("job", "test-uid"),
+				},
+			},
+		},
+		"job with invalid workload-priorityclass": {
+			enableManagedJobsNamespaceSelectorAlwaysRespected: true,
+			reconcilerOptions: []jobframework.Option{
+				jobframework.WithManagedJobsNamespaceSelector(labels.SelectorFromSet(map[string]string{
+					"managed-by-kueue": "true",
+				})),
+				jobframework.WithManageJobsWithoutQueueName(true),
+			},
+			job: *utiltestingjob.MakeJob("job", "labelled-ns").
+				Queue("test-queue").
+				Suspend(true).
+				UID("test-uid").
+				Parallelism(10).
+				Request(corev1.ResourceCPU, "1").
+				Image("", nil).
+				WorkloadPriorityClass("test-wpc-high").
+				Obj(),
+			wantJob: *utiltestingjob.MakeJob("job", "labelled-ns").
+				Queue("test-queue").
+				UID("test-uid").
+				Suspend(true).
+				Parallelism(10).
+				Request(corev1.ResourceCPU, "1").
+				Image("", nil).
+				WorkloadPriorityClass("test-wpc-high").
+				Obj(),
+			wantErr: jobframework.ErrPriorityClassNotFound,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "labelled-ns"},
+					EventType: "Warning",
+					Reason:    "PriorityNotFound",
+					Message:   "PriorityClass not found",
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		for _, enabled := range []bool{false, true} {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4845,7 +4845,7 @@ func TestReconciler(t *testing.T) {
 				Parallelism(10).
 				Request(corev1.ResourceCPU, "1").
 				Image("", nil).
-				WorkloadPriorityClass("test-wpc-high").
+				WorkloadPriorityClass(highWPCWrapper.Name).
 				Obj(),
 			wantJob: *utiltestingjob.MakeJob("job", "labelled-ns").
 				Queue("test-queue").
@@ -4854,22 +4854,21 @@ func TestReconciler(t *testing.T) {
 				Parallelism(10).
 				Request(corev1.ResourceCPU, "1").
 				Image("", nil).
-				WorkloadPriorityClass("test-wpc-high").
+				WorkloadPriorityClass(highWPCWrapper.Name).
 				Obj(),
 			priorityClasses: []client.Object{
 				highWPCWrapper.Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("job", "labelled-ns").
+				*utiltestingapi.MakeWorkload("job", "labelled-ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					Queue("test-queue").
-					Priority(200).
-					PriorityClass("test-wpc-high").
-					PriorityClassSource(constants.WorkloadPriorityClassSource).
+					WorkloadPriorityClassRef(highWPCWrapper.Name).
+					Priority(highWPCWrapper.Value).
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
-					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Obj(),

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4914,8 +4914,8 @@ func TestReconciler(t *testing.T) {
 				{
 					Key:       types.NamespacedName{Name: "job", Namespace: "labelled-ns"},
 					EventType: "Warning",
-					Reason:    "PriorityNotFound",
-					Message:   "PriorityClass not found",
+					Reason:    "WorkloadPriorityClassNotFound",
+					Message:   "WorkloadPriorityClass test-wpc-high not found",
 				},
 			},
 		},

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -3170,6 +3170,14 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 			},
 			wantErr: cmpopts.AnyError,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Warning",
+					Reason:    "WorkloadPriorityClassNotFound",
+					Message:   "WorkloadPriorityClass missing-wpc not found",
+				},
+			},
 		},
 		"the workload slice is updated when priority class has changed for suspended job": {
 			featureGates: map[featuregate.Feature]bool{
@@ -4831,14 +4839,16 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"job with validate workload-priorityclass": {
-			enableManagedJobsNamespaceSelectorAlwaysRespected: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManagedJobsNamespaceSelector(labels.SelectorFromSet(map[string]string{
 					"managed-by-kueue": "true",
 				})),
 				jobframework.WithManageJobsWithoutQueueName(true),
 			},
-			job: *utiltestingjob.MakeJob("job", "labelled-ns").
+			job: utiltestingjob.MakeJob("job", "labelled-ns").
 				Queue("test-queue").
 				Suspend(true).
 				UID("test-uid").
@@ -4883,14 +4893,16 @@ func TestReconciler(t *testing.T) {
 			},
 		},
 		"job with invalid workload-priorityclass": {
-			enableManagedJobsNamespaceSelectorAlwaysRespected: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: false,
+			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManagedJobsNamespaceSelector(labels.SelectorFromSet(map[string]string{
 					"managed-by-kueue": "true",
 				})),
 				jobframework.WithManageJobsWithoutQueueName(true),
 			},
-			job: *utiltestingjob.MakeJob("job", "labelled-ns").
+			job: utiltestingjob.MakeJob("job", "labelled-ns").
 				Queue("test-queue").
 				Suspend(true).
 				UID("test-uid").

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/go-logr/logr"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -182,11 +181,8 @@ func (r *Reconciler) createPrebuiltWorkload(ctx context.Context, lws *leaderwork
 		return err
 	}
 
-	err = jobframework.PrepareWorkloadPriority(ctx, r.client, lws, createdWorkload, nil)
+	err = jobframework.PrepareWorkloadPriority(ctx, r.client, r.record, lws, createdWorkload, nil)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			r.record.Event(lws, corev1.EventTypeWarning, jobframework.ReasonWorkloadPriorityClassNotFound, "PriorityClass not found")
-		}
 		return err
 	}
 

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -185,7 +185,7 @@ func (r *Reconciler) createPrebuiltWorkload(ctx context.Context, lws *leaderwork
 	err = jobframework.PrepareWorkloadPriority(ctx, r.client, lws, createdWorkload, nil)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			r.record.Event(lws, corev1.EventTypeWarning, jobframework.ReasonPriorityNotFound, "PriorityClass not found")
+			r.record.Event(lws, corev1.EventTypeWarning, jobframework.ReasonWorkloadPriorityClassNotFound, "PriorityClass not found")
 		}
 		return err
 	}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -183,6 +184,9 @@ func (r *Reconciler) createPrebuiltWorkload(ctx context.Context, lws *leaderwork
 
 	err = jobframework.PrepareWorkloadPriority(ctx, r.client, lws, createdWorkload, nil)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			r.record.Event(lws, corev1.EventTypeWarning, jobframework.ReasonPriorityNotFound, "PriorityClass not found")
+		}
 		return err
 	}
 

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -313,6 +314,9 @@ func (r *Reconciler) createWorkload(ctx context.Context, lws *leaderworkersetv1.
 	err = jobframework.PrepareWorkloadPriority(ctx, r.client, lws, createdWorkload, nil)
 	if err != nil {
 		log.Error(err, "Failed to prepare Workload priority")
+		if apierrors.IsNotFound(err) {
+			r.record.Event(lws, corev1.EventTypeWarning, jobframework.ReasonPriorityNotFound, "PriorityClass not found")
+		}
 		return err
 	}
 

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -315,7 +315,7 @@ func (r *Reconciler) createWorkload(ctx context.Context, lws *leaderworkersetv1.
 	if err != nil {
 		log.Error(err, "Failed to prepare Workload priority")
 		if apierrors.IsNotFound(err) {
-			r.record.Event(lws, corev1.EventTypeWarning, jobframework.ReasonPriorityNotFound, "PriorityClass not found")
+			r.record.Event(lws, corev1.EventTypeWarning, jobframework.ReasonWorkloadPriorityClassNotFound, "PriorityClass not found")
 		}
 		return err
 	}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -28,7 +28,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -311,12 +310,9 @@ func (r *Reconciler) createWorkload(ctx context.Context, lws *leaderworkersetv1.
 		return err
 	}
 
-	err = jobframework.PrepareWorkloadPriority(ctx, r.client, lws, createdWorkload, nil)
+	err = jobframework.PrepareWorkloadPriority(ctx, r.client, r.record, lws, createdWorkload, nil)
 	if err != nil {
 		log.Error(err, "Failed to prepare Workload priority")
-		if apierrors.IsNotFound(err) {
-			r.record.Event(lws, corev1.EventTypeWarning, jobframework.ReasonWorkloadPriorityClassNotFound, "PriorityClass not found")
-		}
 		return err
 	}
 

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -317,7 +317,7 @@ func (r *Reconciler) createPrebuiltWorkload(ctx context.Context, sts *appsv1.Sta
 		return err
 	}
 
-	if err := jobframework.PrepareWorkloadPriority(ctx, r.client, sts, createdWorkload, nil); err != nil {
+	if err := jobframework.PrepareWorkloadPriority(ctx, r.client, r.record, sts, createdWorkload, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

- [x] add event if workload-prorityclass not found
- [x] add validate for workload with non-exist workload-priorityclass
- [x] unit test and e2e test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
add event when workload-priority or priority not found
> When a job is created with a specified kueue.x-k8s.io/priority-class that does not exist ; then an event should be raised with a Warning level in the namespace of the job and with the job as the involvedObject.name

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3439

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- When a non-existent WorkloadPriorityClass or PriorityClass is specified for a job, the creation of the job will be denied
- The existing Job with non-existent WorkloadPriorityClass or PriorityClass, event with WorkloadPriorityClass/PriorityClass does not exist will be fire
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Jobs now validate referenced workload priority classes before creation.
  - Missing priority classes produce clear validation errors instead of allowing invalid workloads.
  - Reconciliation reports warning events when configured priority classes cannot be found.
  - Priority handling is now consistent across standard, elastic, leader-based, and stateful workloads.
- **Tests**
  - Added coverage for valid and missing workload priority class scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->