### PR TITLE
Extract iteration over findFlavorForPodSetResource to a helper

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -541,7 +541,7 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 				// No need to compute again.
 				continue
 			}
-			flavors, status := a.findFlavorForPodSetResource(log, psIDs, requests, resName, assignment.Usage.Quota)
+			flavors, status := a.findFlavorForPodSets(log, psIDs, requests, resName, assignment.Usage.Quota)
 			if status.IsError() || len(flavors) == 0 {
 				groupFlavors = nil
 				groupStatus = *status
@@ -618,12 +618,12 @@ func (a *Assignment) append(requests resources.Requests, psAssignment *PodSetAss
 	a.LastState.LastTriedFlavorIdx = append(a.LastState.LastTriedFlavorIdx, flavorIdx)
 }
 
-// findFlavorForPodSetResource finds the flavor which can satisfy the podSet request
+// findFlavorForPodSets finds the flavor which can satisfy all the PodSet requests
 // for all resources in the same group as resName.
 // Returns the chosen flavor, along with the information about resources that need to be borrowed.
 // If the flavor cannot be immediately assigned, it returns a status with
 // reasons or failure.
-func (a *FlavorAssigner) findFlavorForPodSetResource(
+func (a *FlavorAssigner) findFlavorForPodSets(
 	log logr.Logger,
 	psIDs []int,
 	requests resources.Requests,
@@ -657,43 +657,12 @@ func (a *FlavorAssigner) findFlavorForPodSetResource(
 	for ; idx < len(resourceGroup.Flavors); idx++ {
 		attemptedFlavorIdx = idx
 		fName := resourceGroup.Flavors[idx]
-		flavor, exist := a.resourceFlavors[fName]
-		if !exist {
-			log.Error(nil, "Flavor not found", "Flavor", fName)
-			status.appendf("flavor %s not found", fName)
-			continue
-		}
 
-		var flavorUnmatchMessage *string
-		for psIdx, psID := range psIDs {
-			if features.Enabled(features.TopologyAwareScheduling) {
-				ps := &a.wl.Obj.Spec.PodSets[psID]
-				flavorUnmatchMessage = checkPodSetAndFlavorMatchForTAS(a.cq, ps, flavor)
-				if flavorUnmatchMessage != nil {
-					log.Error(nil, *flavorUnmatchMessage)
-					break
-				}
+		if fit, err := a.checkFlavorForPodSets(log, fName, psIDs, podSets, selectors, status); !fit {
+			if err != nil {
+				status.err = err
+				return nil, status
 			}
-			podSpec := podSets[psIdx].Template.Spec
-			taint, untolerated := corev1helpers.FindMatchingUntoleratedTaint(flavor.Spec.NodeTaints, append(podSpec.Tolerations, flavor.Spec.Tolerations...), func(t *corev1.Taint) bool {
-				return t.Effect == corev1.TaintEffectNoSchedule || t.Effect == corev1.TaintEffectNoExecute
-			})
-			if untolerated {
-				flavorUnmatchMessage = ptr.To(fmt.Sprintf("untolerated taint %s in flavor %s", taint, fName))
-				break
-			}
-			selector := selectors[psIdx]
-			if match, err := selector.Match(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: flavor.Spec.NodeLabels}}); !match || err != nil {
-				if err != nil {
-					status.err = err
-					return nil, status
-				}
-				flavorUnmatchMessage = ptr.To(fmt.Sprintf("flavor %s doesn't match node affinity", fName))
-				break
-			}
-		}
-		if flavorUnmatchMessage != nil {
-			status.reasons = append(status.reasons, *flavorUnmatchMessage)
 			continue
 		}
 		assignments := make(ResourceAssignment, len(requests))
@@ -774,6 +743,51 @@ func (a *FlavorAssigner) findFlavorForPodSetResource(
 		}
 	}
 	return bestAssignment, status
+}
+
+func (a *FlavorAssigner) checkFlavorForPodSets(
+	log logr.Logger,
+	flavorName kueue.ResourceFlavorReference,
+	psIDs []int,
+	podSets []*kueue.PodSet,
+	selectors []nodeaffinity.RequiredNodeAffinity,
+	status *Status,
+) (bool, error) {
+	flavor, exist := a.resourceFlavors[flavorName]
+	if !exist {
+		log.Error(nil, "Flavor not found", "Flavor", flavorName)
+		status.appendf("flavor %s not found", flavorName)
+		return false, nil
+	}
+
+	for psIdx, psID := range psIDs {
+		if features.Enabled(features.TopologyAwareScheduling) {
+			ps := &a.wl.Obj.Spec.PodSets[psID]
+			if message := checkPodSetAndFlavorMatchForTAS(a.cq, ps, flavor); message != nil {
+				log.Error(nil, *message)
+				status.appendf("%s", *message)
+				return false, nil
+			}
+		}
+		podSpec := podSets[psIdx].Template.Spec
+		taint, untolerated := corev1helpers.FindMatchingUntoleratedTaint(flavor.Spec.NodeTaints, append(podSpec.Tolerations, flavor.Spec.Tolerations...), func(t *corev1.Taint) bool {
+			return t.Effect == corev1.TaintEffectNoSchedule || t.Effect == corev1.TaintEffectNoExecute
+		})
+		if untolerated {
+			status.appendf("untolerated taint %s in flavor %s", taint, flavorName)
+			return false, nil
+		}
+		selector := selectors[psIdx]
+		if match, err := selector.Match(&corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: flavor.Spec.NodeLabels}}); !match || err != nil {
+			if err != nil {
+				status.err = err
+				return false, err
+			}
+			status.appendf("flavor %s doesn't match node affinity", flavorName)
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func shouldTryNextFlavor(representativeMode granularMode, flavorFungibility kueue.FlavorFungibility) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

It factors out an inner loop from a helper function which grew a bit complex.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6028 

#### Special notes for your reviewer:

1. I think the original function name (`findFlavorForPodSetResource`) was a bit out of date. \
    (Given that after #5878  it takes a slice of PodSets, not a single one). \
    I propose to rename it (to `findFlavorForPodSets`).

2. While the new helper should basically say "yes / no" (is the Flavor suitable for all PodSets?), there's one tricky case: \
   When matching the node selector returns _an error_ (not just "no match"), the original code breaks _all loops_ and returns.
   https://github.com/kubernetes-sigs/kueue/blob/21dbaa606e04d1a57c2fd17a703ff0e3ad48e5ed/pkg/scheduler/flavorassigner/flavorassigner.go#L686-L690
   (This seems legit; AFAICS an error is returned only in [one case](https://github.com/kubernetes/component-helpers/blob/c0d7e309359cffddadc08b8e1f0cbf8f4bef52a7/scheduling/corev1/nodeaffinity/nodeaffinity.go#L191-L192) - when the node selector contains parse errors - which is indeed independent from the flavor)

   This made me return `(bool, error)` from the new helper. \
   (So that `false, nil` leads to `continue`ing the outer loop; an error leads to `break`ing it).

3. The new helper takes some arguments (`podSets`, `selectors`) which it could easily compute based on the other info - just like in the original code:
   https://github.com/kubernetes-sigs/kueue/blob/21dbaa606e04d1a57c2fd17a703ff0e3ad48e5ed/pkg/scheduler/flavorassigner/flavorassigner.go#L641-L649
   But then this code would be run several times (once per flavor). \
   So it's a tradeoff between a more concise _internal_ interface and a _slightly_ faster implementation. \
   I was not sure how to weigh this. For now, I picked the latter because this is scheduler code.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```