### PR TITLE
[#5743] Cleanup deleteWorkloads from the TestLastSchedulingContext unit test.

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -3958,7 +3958,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Obj(),
 			},
 			deleteWorkloads: []client.ObjectKey{{
-				Namespace: "default",
+				Namespace: metav1.NamespaceDefault,
 				Name:      "placeholder-alpha",
 			}},
 			wantPreempted:                 sets.New[workload.Reference]("default/placeholder-alpha"),
@@ -4044,7 +4044,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Obj(),
 			},
 			deleteWorkloads: []client.ObjectKey{{
-				Namespace: "default",
+				Namespace: metav1.NamespaceDefault,
 				Name:      "alpha2",
 			}},
 			wantPreempted: sets.New[workload.Reference]("default/alpha2"),


### PR DESCRIPTION
Refactors the deleteWorkloads test parameter in TestLastSchedulingContext to denote just the workload reference (ObjectKey{Namespace, Name}).
The test then uses the Get method to fetch the workload for deletion.

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Removes the need to specify an entire workload in the test, as opposed to just name and namespace.

#### Which issue(s) this PR fixes:
Fixes #5743

#### Special notes for your reviewer: -

#### Does this PR introduce a user-facing change?
```release-note
NONE
```