### PR TITLE
Validate `kueue.x-k8s.io/podset-group-name` annotation value

### DIFF
--- a/pkg/controller/jobframework/tas_validation.go
+++ b/pkg/controller/jobframework/tas_validation.go
@@ -64,6 +64,12 @@ func ValidateTASPodSetRequest(replicaPath *field.Path, replicaMetadata *metav1.O
 		allErrs = append(allErrs, metavalidation.ValidateLabelName(sliceRequiredValue, annotationsPath.Key(kueuebeta.PodSetSliceRequiredTopologyAnnotation))...)
 	}
 
+	// validate PodSetGroupName annotation
+	podSetGroupNameValue, podSetGroupNameFound := replicaMetadata.Annotations[kueuebeta.PodSetGroupName]
+	if podSetGroupNameFound {
+		allErrs = append(allErrs, validatePodSetGroupNameAnnotation(podSetGroupNameValue, annotationsPath.Key(kueuebeta.PodSetGroupName))...)
+	}
+
 	unconstrainedErrs := validateTASUnconstrained(annotationsPath, replicaMetadata)
 	allErrs = append(allErrs, unconstrainedErrs...)
 
@@ -117,6 +123,18 @@ func validateSliceSizeAnnotation(annotationsPath *field.Path, replicaMetadata *m
 			field.Invalid(
 				annotationsPath.Key(kueuebeta.PodSetSliceSizeAnnotation), sliceSizeValue,
 				"must be greater than or equal to 1",
+			),
+		}
+	}
+
+	return nil
+}
+
+func validatePodSetGroupNameAnnotation(groupName string, annotationPath *field.Path) field.ErrorList {
+	if _, err := strconv.ParseUint(groupName, 10, 64); err == nil {
+		return field.ErrorList{
+			field.Invalid(
+				annotationPath, groupName, "must not be a number",
 			),
 		}
 	}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -259,6 +259,53 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 			topologyAwareScheduling: true,
 		},
+		"valid PodSet group name request": {
+			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				Queue("test-queue").
+				LeaderTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							kueuealpha.PodSetGroupName: "leadername1",
+						},
+					},
+				}).
+				WorkerTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							kueuealpha.PodSetGroupName: "workername1",
+						},
+					},
+				}).
+				Obj(),
+			wantErr:                 nil,
+			topologyAwareScheduling: true,
+		},
+		"invalid PodSet group name request - value is a number": {
+			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				Queue("test-queue").
+				LeaderTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							kueuealpha.PodSetGroupName: "1234",
+						},
+					},
+				}).
+				WorkerTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							kueuealpha.PodSetGroupName: "4321",
+						},
+					},
+				}).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("spec.leaderWorkerTemplate.leaderTemplate.metadata.annotations").
+					Key("kueue.x-k8s.io/podset-group-name"), "1234", "must not be a number"),
+				field.Invalid(field.NewPath("spec.leaderWorkerTemplate.workerTemplate.metadata.annotations").
+					Key("kueue.x-k8s.io/podset-group-name"), "4321", "must not be a number"),
+			}.ToAggregate(),
+			topologyAwareScheduling: true,
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Currently, the value of the `podset-group-name` annotation can be set to a value (matching `[0-9]+`) which will conflict of group keys:
https://github.com/kubernetes-sigs/kueue/blob/c824ca907b83c1f92c7381de072ecad2330c2d94/pkg/scheduler/flavorassigner/flavorassigner.go#L514-L517

Enforcing a stricter pattern will eliminate this possibility.

Even though, as far as I can see, this annotation is currently mostly geared towards `LeaderWorkerSet`, I made the validation part of the general TAS validation since it's part of `PodSetTopologyRequest`.

#### Which issue(s) this PR fixes:
This is the first of a series of PRs related to #6242.

#### Special notes for your reviewer:
Even though technically this introduces a new user facing error, I wasn't sure whether a release note is warranted. _In theory_, someone could have used a value like "123" or even "someGroup", requiring an action on their part.

This is only my second contribution here, so I looked at other `kind/feature` PRs and saw that significantly bigger TAS features do not add a release note, but I added one here, just in case. I can remove it if it's unnecessary and will introduce noise into the release notes.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Enforce a stricter value of the `kueue.x-k8s.io/podset-group-name` annotation in the creation webhook.

ACTION REQUIRED: Make sure the values of the `kueue.x-k8s.io/podset-group-name` annotation are not numbers.`
```