### PR TITLE
Include quotes in GINKGO_ARGS.

### DIFF
--- a/site/content/en/docs/contribution_guidelines/testing.md
+++ b/site/content/en/docs/contribution_guidelines/testing.md
@@ -122,7 +122,7 @@ or from VSCode.
 ### Use Ginkgo --focus arg
 ```shell
 GINKGO_ARGS="--focus=Scheduler" make test-integration
-GINKGO_ARGS="--focus=Creating a Pod requesting TAS" make test-e2e
+GINKGO_ARGS="--focus='Creating a Pod requesting TAS'" make test-e2e
 ```
 ### Use ginkgo.FIt
 If you want to focus on specific tests, you can change

--- a/site/content/zh-CN/docs/contribution_guidelines/testing.md
+++ b/site/content/zh-CN/docs/contribution_guidelines/testing.md
@@ -122,7 +122,7 @@ func TestValidateClusterQueue(t *testing.T) {
 ### 使用 Ginkgo --focus 参数 {#use-ginkgo-focus-arg}
 ```shell
 GINKGO_ARGS="--focus=Scheduler" make test-integration
-GINKGO_ARGS="--focus=Creating a Pod requesting TAS" make test-e2e
+GINKGO_ARGS="--focus='Creating a Pod requesting TAS'" make test-e2e
 ```
 ### 使用 ginkgo.FIt {#use-ginkgo-fit}
 如果你想专注于特定测试，可以将这些测试的


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Part of https://github.com/kubernetes-sigs/kueue/issues/5465

#### Special notes for your reviewer:
Without the quotes, `make test-integration` fails with:
```
ginkgo run failed
  Malformed arguments - detected a flag after the package liste
    Make sure all flags appear after the Ginkgo subcommand and before your list of
    packages (or './...').
    e.g. 'ginkgo run -p my_package' is valid but `ginkgo -p run my_package` is
    not.
    e.g. 'ginkgo -p -vet="" ./...' is valid but 'ginkgo -p ./... -vet=""' is not
```

#### Does this PR introduce a user-facing change?
```release-note
NONE
```