### PR TITLE
Fix MultiKueue workload re-evaluation bug

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/indexer.go
+++ b/pkg/controller/admissionchecks/multikueue/indexer.go
@@ -35,7 +35,9 @@ const (
 	WorkloadsWithAdmissionCheckKey = "status.admissionChecks"
 )
 
-var configGVK = kueue.GroupVersion.WithKind("MultiKueueConfig")
+var (
+	configGVK = kueue.GroupVersion.WithKind("MultiKueueConfig")
+)
 
 func getIndexUsingKubeConfigs(configNamespace string) func(obj client.Object) []string {
 	return func(obj client.Object) []string {

--- a/pkg/controller/admissionchecks/multikueue/indexer_test.go
+++ b/pkg/controller/admissionchecks/multikueue/indexer_test.go
@@ -185,7 +185,7 @@ func TestListWorkloadsWithAdmissionCheck(t *testing.T) {
 		},
 		"single workload, single match": {
 			workloads: []*kueue.Workload{
-				utiltesting.MakeWorkload("wl1", TestNamespace).
+				utiltestingapi.MakeWorkload("wl1", TestNamespace).
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:  "ac1",
 						State: kueue.CheckStatePending,
@@ -196,7 +196,7 @@ func TestListWorkloadsWithAdmissionCheck(t *testing.T) {
 		},
 		"single workload, no match": {
 			workloads: []*kueue.Workload{
-				utiltesting.MakeWorkload("wl2", TestNamespace).
+				utiltestingapi.MakeWorkload("wl2", TestNamespace).
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:  "ac2",
 						State: kueue.CheckStatePending,
@@ -206,12 +206,12 @@ func TestListWorkloadsWithAdmissionCheck(t *testing.T) {
 		},
 		"multiple workloads, single match": {
 			workloads: []*kueue.Workload{
-				utiltesting.MakeWorkload("wl1", TestNamespace).
+				utiltestingapi.MakeWorkload("wl1", TestNamespace).
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:  "ac1",
 						State: kueue.CheckStatePending,
 					}).Obj(),
-				utiltesting.MakeWorkload("wl2", TestNamespace).
+				utiltestingapi.MakeWorkload("wl2", TestNamespace).
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:  "ac2",
 						State: kueue.CheckStatePending,

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -54,7 +54,9 @@ import (
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
-var realClock = clock.RealClock{}
+var (
+	realClock = clock.RealClock{}
+)
 
 type wlReconciler struct {
 	client            client.Client
@@ -558,7 +560,8 @@ func newWlReconciler(c client.Client, helper *admissioncheck.MultiKueueStoreHelp
 }
 
 type configHandler struct {
-	client client.Client
+	client            client.Client
+	eventsBatchPeriod time.Duration
 }
 
 func (c *configHandler) Create(context.Context, event.CreateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -595,11 +598,13 @@ func (c *configHandler) Generic(context.Context, event.GenericEvent, workqueue.T
 
 func (c *configHandler) queueWorkloadsForConfig(ctx context.Context, configName string, q workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
 	admissionChecks := &kueue.AdmissionCheckList{}
+	var errs []error
+
 	if err := c.client.List(ctx, admissionChecks, client.MatchingFields{AdmissionCheckUsingConfigKey: configName}); err != nil {
-		return err
+		errs = append(errs, err)
+		return errors.Join(errs...)
 	}
 
-	var errs []error
 	for _, admissionCheck := range admissionChecks.Items {
 		workloads := &kueue.WorkloadList{}
 		if err := c.client.List(ctx, workloads, client.MatchingFields{WorkloadsWithAdmissionCheckKey: admissionCheck.Name}); err != nil {
@@ -607,7 +612,7 @@ func (c *configHandler) queueWorkloadsForConfig(ctx context.Context, configName 
 			continue
 		}
 		for _, workload := range workloads.Items {
-			q.Add(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&workload)})
+			q.AddAfter(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&workload)}, c.eventsBatchPeriod)
 		}
 	}
 	return errors.Join(errs...)
@@ -627,7 +632,7 @@ func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 		Named("multikueue_workload").
 		For(&kueue.Workload{}).
 		WatchesRawSource(source.Channel(w.clusters.wlUpdateCh, syncHndl)).
-		Watches(&kueue.MultiKueueConfig{}, &configHandler{client: w.client}).
+		Watches(&kueue.MultiKueueConfig{}, &configHandler{client: w.client, eventsBatchPeriod: w.eventsBatchPeriod}).
 		WithEventFilter(w).
 		Complete(w)
 }

--- a/test/integration/multikueue/dispatcher_test.go
+++ b/test/integration/multikueue/dispatcher_test.go
@@ -124,14 +124,7 @@ var _ = ginkgo.Describe("MultiKueueDispatcherIncremental", ginkgo.Ordered, ginkg
 			Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, multiKueueAC)).Should(gomega.Succeed())
 
-		ginkgo.By("wait for check active", func() {
-			updatedAc := kueue.AdmissionCheck{}
-			acKey := client.ObjectKeyFromObject(multiKueueAC)
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatedAc)).To(gomega.Succeed())
-				g.Expect(updatedAc.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.AdmissionCheckActive))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		})
+		util.ExpectAdmissionChecksToBeActive(managerTestCluster.ctx, managerTestCluster.client, multiKueueAC)
 
 		managerCq = utiltestingapi.MakeClusterQueue("q1").
 			AdmissionChecks(kueue.AdmissionCheckReference(multiKueueAC.Name)).
@@ -320,14 +313,7 @@ var _ = ginkgo.Describe("MultiKueueDispatcherExternal", ginkgo.Ordered, ginkgo.C
 			Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, multiKueueAC)).Should(gomega.Succeed())
 
-		ginkgo.By("wait for check active", func() {
-			updatedAc := kueue.AdmissionCheck{}
-			acKey := client.ObjectKeyFromObject(multiKueueAC)
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatedAc)).To(gomega.Succeed())
-				g.Expect(updatedAc.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.AdmissionCheckActive))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		})
+		util.ExpectAdmissionChecksToBeActive(managerTestCluster.ctx, managerTestCluster.client, multiKueueAC)
 
 		managerCq = utiltestingapi.MakeClusterQueue("q1").
 			AdmissionChecks(kueue.AdmissionCheckReference(multiKueueAC.Name)).
@@ -567,14 +553,7 @@ var _ = ginkgo.Describe("MultiKueueDispatcherAllAtOnce", ginkgo.Ordered, ginkgo.
 			Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, multiKueueAC)).Should(gomega.Succeed())
 
-		ginkgo.By("wait for check active", func() {
-			updatedAc := kueue.AdmissionCheck{}
-			acKey := client.ObjectKeyFromObject(multiKueueAC)
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatedAc)).To(gomega.Succeed())
-				g.Expect(updatedAc.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.AdmissionCheckActive))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		})
+		util.ExpectAdmissionChecksToBeActive(managerTestCluster.ctx, managerTestCluster.client, multiKueueAC)
 
 		managerCq = utiltestingapi.MakeClusterQueue("q1").
 			AdmissionChecks(kueue.AdmissionCheckReference(multiKueueAC.Name)).
@@ -723,6 +702,7 @@ var _ = ginkgo.Describe("MultiKueueDispatcherAllAtOnce", ginkgo.Ordered, ginkgo.
 		})
 	})
 })
+
 var _ = ginkgo.Describe("MultiKueueConfig Re-evaluation", ginkgo.Ordered, func() {
 	var (
 		managerNs *corev1.Namespace
@@ -753,6 +733,8 @@ var _ = ginkgo.Describe("MultiKueueConfig Re-evaluation", ginkgo.Ordered, func()
 	})
 
 	ginkgo.BeforeEach(func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueBatchJobWithManagedBy, true)
+
 		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-re-eval-")
 		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
 		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
@@ -785,44 +767,37 @@ var _ = ginkgo.Describe("MultiKueueConfig Re-evaluation", ginkgo.Ordered, func()
 		}
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerMultiKueueSecret2)).To(gomega.Succeed())
 
-		workerCluster1 = utiltesting.MakeMultiKueueCluster("worker1-re-eval").KubeConfig(kueue.SecretLocationType, managerMultiKueueSecret1.Name).Obj()
+		workerCluster1 = utiltestingapi.MakeMultiKueueCluster("worker1-re-eval").KubeConfig(kueue.SecretLocationType, managerMultiKueueSecret1.Name).Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, workerCluster1)).To(gomega.Succeed())
 
-		workerCluster2 = utiltesting.MakeMultiKueueCluster("worker2-re-eval").KubeConfig(kueue.SecretLocationType, managerMultiKueueSecret2.Name).Obj()
+		workerCluster2 = utiltestingapi.MakeMultiKueueCluster("worker2-re-eval").KubeConfig(kueue.SecretLocationType, managerMultiKueueSecret2.Name).Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, workerCluster2)).To(gomega.Succeed())
 
-		managerMultiKueueConfig = utiltesting.MakeMultiKueueConfig("isolated-config").Clusters(workerCluster1.Name).Obj()
+		managerMultiKueueConfig = utiltestingapi.MakeMultiKueueConfig("isolated-config").Clusters(workerCluster1.Name).Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerMultiKueueConfig)).To(gomega.Succeed())
 
-		multiKueueAC = utiltesting.MakeAdmissionCheck("isolated-ac").
+		multiKueueAC = utiltestingapi.MakeAdmissionCheck("isolated-ac").
 			ControllerName(kueue.MultiKueueControllerName).
 			Parameters(kueue.GroupVersion.Group, "MultiKueueConfig", managerMultiKueueConfig.Name).
 			Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, multiKueueAC)).To(gomega.Succeed())
 
-		ginkgo.By("wait for check active", func() {
-			updatedAc := kueue.AdmissionCheck{}
-			acKey := client.ObjectKeyFromObject(multiKueueAC)
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, acKey, &updatedAc)).To(gomega.Succeed())
-				g.Expect(updatedAc.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.AdmissionCheckActive))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		})
+		util.ExpectAdmissionChecksToBeActive(managerTestCluster.ctx, managerTestCluster.client, multiKueueAC)
 
-		managerCq = utiltesting.MakeClusterQueue("isolated-cq").
+		managerCq = utiltestingapi.MakeClusterQueue("isolated-cq").
 			AdmissionChecks(kueue.AdmissionCheckReference(multiKueueAC.Name)).
 			Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerCq)).To(gomega.Succeed())
 		util.ExpectClusterQueuesToBeActive(managerTestCluster.ctx, managerTestCluster.client, managerCq)
 
-		managerLq = utiltesting.MakeLocalQueue("isolated-lq", managerNs.Name).ClusterQueue(managerCq.Name).Obj()
+		managerLq = utiltestingapi.MakeLocalQueue("isolated-lq", managerNs.Name).ClusterQueue(managerCq.Name).Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, managerLq)).To(gomega.Succeed())
 		util.ExpectLocalQueuesToBeActive(managerTestCluster.ctx, managerTestCluster.client, managerLq)
 
-		worker1Cq = utiltesting.MakeClusterQueue("q1-re-eval").Obj()
+		worker1Cq = utiltestingapi.MakeClusterQueue("q1-re-eval").Obj()
 		gomega.Expect(worker1TestCluster.client.Create(worker1TestCluster.ctx, worker1Cq)).Should(gomega.Succeed())
 
-		worker2Cq = utiltesting.MakeClusterQueue("q1-re-eval").Obj()
+		worker2Cq = utiltestingapi.MakeClusterQueue("q1-re-eval").Obj()
 		gomega.Expect(worker2TestCluster.client.Create(worker2TestCluster.ctx, worker2Cq)).Should(gomega.Succeed())
 	})
 
@@ -841,226 +816,82 @@ var _ = ginkgo.Describe("MultiKueueConfig Re-evaluation", ginkgo.Ordered, func()
 		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerMultiKueueSecret2, true)
 	})
 
-	ginkgo.It("should create workload that requires more CPU than worker1 can provide", func() {
-		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueBatchJobWithManagedBy, true)
-		job := testingjob.MakeJob("cpu-job", managerNs.Name).
-			ManagedBy(kueue.MultiKueueControllerName).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
-			Request(corev1.ResourceCPU, "100m").
-			Obj()
-		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).To(gomega.Succeed())
-	})
+	ginkgo.Context("when MultiKueueConfig changes", func() {
+		var (
+			workloadLookupKey types.NamespacedName
+			admission         *kueue.Admission
+		)
 
-	ginkgo.It("should initially nominate only worker1 and set reservation", func() {
-		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueBatchJobWithManagedBy, true)
-		createdWorkload := &kueue.Workload{}
-		admission := utiltesting.MakeAdmission(managerCq.Name).Obj()
-
-		job := testingjob.MakeJob("cpu-job", managerNs.Name).
-			ManagedBy(kueue.MultiKueueControllerName).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
-			Request(corev1.ResourceCPU, "100m").
-			Obj()
-		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).To(gomega.Succeed())
-		workloadLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
-
-		gomega.Eventually(func() error {
-			if err := managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, createdWorkload); err != nil {
-				return err
+		ginkgo.BeforeEach(func() {
+			ginkgo.By("Create job and workload")
+			job := testingjob.MakeJob("cpu-job-reeval", managerNs.Name).
+				ManagedBy(kueue.MultiKueueControllerName).
+				Queue(kueue.LocalQueueName(managerLq.Name)).
+				Request(corev1.ResourceCPU, "100m").
+				Obj()
+			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).To(gomega.Succeed())
+			workloadLookupKey = types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+				Namespace: managerNs.Name,
 			}
+
+			// Set quota reservation to trigger MultiKueue processing
+			admission = utiltestingapi.MakeAdmission(managerCq.Name).Obj()
 			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, workloadLookupKey, admission)
-			return nil
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
 
-		gomega.Eventually(func(g gomega.Gomega) {
-			managerWorkload := &kueue.Workload{}
-			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, managerWorkload)).To(gomega.Succeed())
-			g.Expect(managerWorkload.Status.NominatedClusterNames).To(gomega.ConsistOf(workerCluster1.Name))
-			g.Expect(managerWorkload.Status.ClusterName).To(gomega.BeNil())
+		ginkgo.It("should re-evaluate existing workload when worker2 is added to config", func() {
+			ginkgo.By("Verify workload initially only sees worker1")
+			gomega.Eventually(func(g gomega.Gomega) {
+				managerWorkload := &kueue.Workload{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, managerWorkload)).To(gomega.Succeed())
+				g.Expect(managerWorkload.Status.NominatedClusterNames).To(gomega.ConsistOf(workerCluster1.Name))
 
-			remoteWorkload := &kueue.Workload{}
-			g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(gomega.Succeed())
+				// Workload should be created on worker1
+				remoteWorkload := &kueue.Workload{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(gomega.Succeed())
 
-			g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(utiltesting.BeNotFoundError())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-	})
+				// But not on worker2 (not in config yet)
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(utiltesting.BeNotFoundError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-	ginkgo.It("should re-evaluate existing workload when worker2 is added to config", func() {
-		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueBatchJobWithManagedBy, true)
+			// Now add worker2 to the MultiKueueConfig
+			gomega.Eventually(func() error {
+				if err := managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(managerMultiKueueConfig), managerMultiKueueConfig); err != nil {
+					return err
+				}
+				managerMultiKueueConfig.Spec.Clusters = []string{workerCluster1.Name, workerCluster2.Name}
+				return managerTestCluster.client.Update(managerTestCluster.ctx, managerMultiKueueConfig)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-		// First, create a workload when only worker1 is in the config
-		job := testingjob.MakeJob("cpu-job", managerNs.Name).
-			ManagedBy(kueue.MultiKueueControllerName).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
-			Request(corev1.ResourceCPU, "100m").
-			Obj()
-		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).To(gomega.Succeed())
-		workloadLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+			ginkgo.By("Wait for admission check to remain active with both clusters")
+			util.ExpectAdmissionChecksToBeActive(managerTestCluster.ctx, managerTestCluster.client, multiKueueAC)
 
-		// Set quota reservation to trigger MultiKueue processing
-		createdWorkload := &kueue.Workload{}
-		admission := utiltesting.MakeAdmission(managerCq.Name).Obj()
-		gomega.Eventually(func() error {
-			if err := managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, createdWorkload); err != nil {
-				return err
-			}
-			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, workloadLookupKey, admission)
-			return nil
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			ginkgo.By("Wait for worker2 cluster to become active")
+			gomega.Eventually(func(g gomega.Gomega) {
+				cluster2 := &kueue.MultiKueueCluster{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(workerCluster2), cluster2)).To(gomega.Succeed())
+				g.Expect(cluster2.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.MultiKueueClusterActive))
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 
-		// Verify workload initially only sees worker1
-		gomega.Eventually(func(g gomega.Gomega) {
-			managerWorkload := &kueue.Workload{}
-			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, managerWorkload)).To(gomega.Succeed())
-			g.Expect(managerWorkload.Status.NominatedClusterNames).To(gomega.ConsistOf(workerCluster1.Name))
+			ginkgo.By("Verify existing workload gets re-evaluated and sees both workers")
+			gomega.Eventually(func(g gomega.Gomega) {
+				managerWorkload := &kueue.Workload{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, managerWorkload)).To(gomega.Succeed())
+				actualClusters := sets.New(managerWorkload.Status.NominatedClusterNames...)
+				g.Expect(actualClusters.Has(workerCluster2.Name)).To(gomega.BeTrue(),
+					"workload should see worker2 after it's added to MultiKueueConfig")
+				g.Expect(actualClusters.Has(workerCluster1.Name)).To(gomega.BeTrue(),
+					"workload should still see worker1")
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 
-			// Workload should be created on worker1
-			remoteWorkload := &kueue.Workload{}
-			g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(gomega.Succeed())
-
-			// But not on worker2 (not in config yet)
-			g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(utiltesting.BeNotFoundError())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		// Now add worker2 to the MultiKueueConfig
-		gomega.Eventually(func() error {
-			if err := managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(managerMultiKueueConfig), managerMultiKueueConfig); err != nil {
-				return err
-			}
-			managerMultiKueueConfig.Spec.Clusters = []string{workerCluster1.Name, workerCluster2.Name}
-			return managerTestCluster.client.Update(managerTestCluster.ctx, managerMultiKueueConfig)
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		// Wait for admission check to remain active with both clusters
-		gomega.Eventually(func(g gomega.Gomega) {
-			updatedAdmissionCheck := kueue.AdmissionCheck{}
-			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(multiKueueAC), &updatedAdmissionCheck)).To(gomega.Succeed())
-			g.Expect(updatedAdmissionCheck.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.AdmissionCheckActive))
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		// Wait for worker2 cluster to become active
-		gomega.Eventually(func(g gomega.Gomega) {
-			cluster2 := &kueue.MultiKueueCluster{}
-			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(workerCluster2), cluster2)).To(gomega.Succeed())
-			g.Expect(cluster2.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.MultiKueueClusterActive))
-		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-
-		// Verify existing workload gets re-evaluated and sees both workers
-		gomega.Eventually(func(g gomega.Gomega) {
-			managerWorkload := &kueue.Workload{}
-			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, managerWorkload)).To(gomega.Succeed())
-			actualClusters := sets.New(managerWorkload.Status.NominatedClusterNames...)
-			g.Expect(actualClusters.Has(workerCluster2.Name)).To(gomega.BeTrue(),
-				"workload should see worker2 after it's added to MultiKueueConfig")
-			g.Expect(actualClusters.Has(workerCluster1.Name)).To(gomega.BeTrue(),
-				"workload should still see worker1")
-		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-
-		// Verify workloads get created on both worker clusters
-		gomega.Eventually(func(g gomega.Gomega) {
-			remoteWorkload1 := &kueue.Workload{}
-			g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, workloadLookupKey, remoteWorkload1)).To(gomega.Succeed())
-			remoteWorkload2 := &kueue.Workload{}
-			g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, workloadLookupKey, remoteWorkload2)).To(gomega.Succeed())
-		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-	})
-
-	ginkgo.It("should assign workload to worker2 after reservation", func() {
-		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueBatchJobWithManagedBy, true)
-
-		// Configure worker1 with 50m CPU (insufficient)
-		worker1ResourceFlavor := utiltesting.MakeResourceFlavor("w1-re-eval-flavor").Obj()
-		gomega.Expect(worker1TestCluster.client.Create(worker1TestCluster.ctx, worker1ResourceFlavor)).To(gomega.Succeed())
-		gomega.Eventually(func() error {
-			if err := worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(worker1Cq), worker1Cq); err != nil {
-				return err
-			}
-			worker1Cq.Spec.ResourceGroups = []kueue.ResourceGroup{
-				{
-					CoveredResources: []corev1.ResourceName{corev1.ResourceCPU},
-					Flavors: []kueue.FlavorQuotas{
-						*utiltesting.MakeFlavorQuotas("w1-re-eval-flavor").Resource(corev1.ResourceCPU, "50m").Obj(),
-					},
-				},
-			}
-			return worker1TestCluster.client.Update(worker1TestCluster.ctx, worker1Cq)
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		// Configure worker2 with 200m CPU (sufficient)
-		worker2ResourceFlavor := utiltesting.MakeResourceFlavor("w2-re-eval-flavor").Obj()
-		gomega.Expect(worker2TestCluster.client.Create(worker2TestCluster.ctx, worker2ResourceFlavor)).To(gomega.Succeed())
-		gomega.Eventually(func() error {
-			if err := worker2TestCluster.client.Get(worker2TestCluster.ctx, client.ObjectKeyFromObject(worker2Cq), worker2Cq); err != nil {
-				return err
-			}
-			worker2Cq.Spec.ResourceGroups = []kueue.ResourceGroup{
-				{
-					CoveredResources: []corev1.ResourceName{corev1.ResourceCPU},
-					Flavors: []kueue.FlavorQuotas{
-						*utiltesting.MakeFlavorQuotas("w2-re-eval-flavor").Resource(corev1.ResourceCPU, "200m").Obj(),
-					},
-				},
-			}
-			return worker2TestCluster.client.Update(worker2TestCluster.ctx, worker2Cq)
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		util.ExpectClusterQueuesToBeActive(worker1TestCluster.ctx, worker1TestCluster.client, worker1Cq)
-		util.ExpectClusterQueuesToBeActive(worker2TestCluster.ctx, worker2TestCluster.client, worker2Cq)
-
-		// Update the config to include both clusters
-		gomega.Eventually(func() error {
-			if err := managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(managerMultiKueueConfig), managerMultiKueueConfig); err != nil {
-				return err
-			}
-			managerMultiKueueConfig.Spec.Clusters = []string{workerCluster1.Name, workerCluster2.Name}
-			return managerTestCluster.client.Update(managerTestCluster.ctx, managerMultiKueueConfig)
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		admission := utiltesting.MakeAdmission(managerCq.Name).Obj()
-
-		job := testingjob.MakeJob("cpu-job", managerNs.Name).
-			ManagedBy(kueue.MultiKueueControllerName).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
-			Request(corev1.ResourceCPU, "100m").
-			Obj()
-		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).To(gomega.Succeed())
-		workloadLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
-
-		// First, wait for workload to be created on manager cluster and set reservation
-		createdWorkload := &kueue.Workload{}
-		gomega.Eventually(func() error {
-			if err := managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, createdWorkload); err != nil {
-				return err
-			}
-			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, workloadLookupKey, admission)
-			return nil
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		// Wait for workload to be propagated to worker2 and set reservation there
-		gomega.Eventually(func(g gomega.Gomega) {
-			remoteWorkload := &kueue.Workload{}
-			g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(gomega.Succeed())
-			util.SetQuotaReservation(worker2TestCluster.ctx, worker2TestCluster.client, workloadLookupKey, admission)
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		gomega.Eventually(func(g gomega.Gomega) {
-			remoteWorkload := &kueue.Workload{}
-			g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, workloadLookupKey, remoteWorkload)).To(utiltesting.BeNotFoundError())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		gomega.Eventually(func(g gomega.Gomega) {
-			managerWorkload := &kueue.Workload{}
-			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, workloadLookupKey, managerWorkload)).To(gomega.Succeed())
-			g.Expect(managerWorkload.Status.ClusterName).ToNot(gomega.BeNil(),
-				"workload should be assigned to a worker cluster")
-			assignedCluster := *managerWorkload.Status.ClusterName
-			g.Expect(assignedCluster).To(gomega.Equal(workerCluster2.Name),
-				"workload should be assigned to worker2 (200m CPU) not worker1 (50m CPU)")
-			g.Expect(managerWorkload.Status.NominatedClusterNames).To(gomega.BeEmpty(),
-				"nominated clusters should be cleared when workload is assigned")
-			admissionCheckState := admissioncheck.FindAdmissionCheck(managerWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
-			g.Expect(admissionCheckState).ToNot(gomega.BeNil())
-			g.Expect(admissionCheckState.State).To(gomega.Equal(kueue.CheckStateReady))
-		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			ginkgo.By("Verify workloads get created on both worker clusters")
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteWorkload1 := &kueue.Workload{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, workloadLookupKey, remoteWorkload1)).To(gomega.Succeed())
+				remoteWorkload2 := &kueue.Workload{}
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, workloadLookupKey, remoteWorkload2)).To(gomega.Succeed())
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		})
 	})
 })

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1042,6 +1042,16 @@ func ExpectLocalQueuesToBeActive(ctx context.Context, c client.Client, lqs ...*k
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
+func ExpectAdmissionChecksToBeActive(ctx context.Context, c client.Client, acs ...*kueue.AdmissionCheck) {
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+		readAc := &kueue.AdmissionCheck{}
+		for _, ac := range acs {
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(ac), readAc)).To(gomega.Succeed())
+			g.Expect(readAc.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.AdmissionCheckActive))
+		}
+	}, Timeout, Interval).Should(gomega.Succeed())
+}
+
 func ExpectJobUnsuspendedWithNodeSelectors(ctx context.Context, c client.Client, key types.NamespacedName, nodeSelector map[string]string) {
 	job := &batchv1.Job{}
 	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
 /kind bug

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
 This PR fixes a bug where existing workloads were not re-evaluated when new clusters were added to a MultiKueueConfig. Previously, only newly created workloads would see the updated cluster list, causing existing workloads to miss opportunities to be scheduled on newly available clusters.
  **Root Cause**: The workload controller was not watching MultiKueueConfig changes, so existing workloads remained stuck with their original cluster nominations.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6738 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix existing workloads not being re-evaluated when new clusters are added to MultiKueueConfig. Previously, only newly created workloads would see updated cluster lists.
```