### PR TITLE
Avoid explicit Pod integration enablement for pod-dependent frameworks

### DIFF
--- a/pkg/controller/jobframework/integrationmanager.go
+++ b/pkg/controller/jobframework/integrationmanager.go
@@ -81,7 +81,10 @@ type IntegrationCallbacks struct {
 	// The job's MultiKueue adapter (optional)
 	MultiKueueAdapter MultiKueueAdapter
 	// The list of integration that need to be enabled along with the current one.
+	// Deprecated: Use ImplicitlyEnabledFrameworkNames instead.
 	DependencyList []string
+	// The list of integrations implicitly enabled as dependencies of the integration.
+	ImplicitlyEnabledFrameworkNames []string
 }
 
 func (i *IntegrationCallbacks) getGVK() schema.GroupVersionKind {
@@ -100,11 +103,13 @@ func (i *IntegrationCallbacks) matchingOwnerReference(ownerRef *metav1.OwnerRefe
 }
 
 type integrationManager struct {
-	names                []string
-	integrations         map[string]IntegrationCallbacks
-	enabledIntegrations  set.Set[string]
-	externalIntegrations map[string]runtime.Object
-	mu                   sync.RWMutex
+	names                         []string
+	integrations                  map[string]IntegrationCallbacks
+	enabledIntegrations           set.Set[string]
+	externalIntegrations          map[string]runtime.Object
+	implicitlyEnabledIntegrations sets.Set[string]
+	gvkToName                     map[schema.GroupVersionKind]string
+	mu                            sync.RWMutex
 }
 
 var manager integrationManager
@@ -131,6 +136,11 @@ func (m *integrationManager) register(name string, cb IntegrationCallbacks) erro
 
 	m.integrations[name] = cb
 	m.names = append(m.names, name)
+
+	if m.gvkToName == nil {
+		m.gvkToName = make(map[schema.GroupVersionKind]string)
+	}
+	m.gvkToName[cb.getGVK()] = name
 
 	return nil
 }
@@ -323,6 +333,15 @@ func GetIntegrationByGVK(gvk schema.GroupVersionKind) (IntegrationCallbacks, boo
 	return IntegrationCallbacks{}, false
 }
 
+// HasImplicitlyEnabledFramework returns true if the given GVK maps to an implicitly enabled framework.
+func HasImplicitlyEnabledFramework(gvk schema.GroupVersionKind) bool {
+	name, found := manager.gvkToName[gvk]
+	if !found {
+		return false
+	}
+	return manager.implicitlyEnabledIntegrations.Has(name)
+}
+
 func ownerReferenceMatchingGVK(ownerRef *metav1.OwnerReference, gvk schema.GroupVersionKind) bool {
 	apiVersion, kind := gvk.ToAPIVersionAndKind()
 	return ownerRef.APIVersion == apiVersion && ownerRef.Kind == kind
@@ -369,4 +388,25 @@ func GetMultiKueueAdapters(enabledIntegrations sets.Set[string]) (map[string]Mul
 		return nil, err
 	}
 	return ret, nil
+}
+
+func (m *integrationManager) collectImplicitlyEnabledIntegrations(enabledFrameworks sets.Set[string]) sets.Set[string] {
+	result := sets.New[string]()
+	for frameworkName := range enabledFrameworks {
+		callbacks, found := m.get(frameworkName)
+		if !found {
+			continue
+		}
+
+		for _, implicitFramework := range callbacks.ImplicitlyEnabledFrameworkNames {
+			if !enabledFrameworks.Has(implicitFramework) {
+				result.Insert(implicitFramework)
+			}
+		}
+	}
+	return result
+}
+
+func (m *integrationManager) setImplicitlyEnabledIntegrations(implicitlyIntegrations sets.Set[string]) {
+	m.implicitlyEnabledIntegrations = implicitlyIntegrations
 }

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -56,7 +56,11 @@ func SetupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, op
 func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
 	options := ProcessOptions(opts...)
 
-	if err := m.checkEnabledListDependencies(options.EnabledFrameworks); err != nil {
+	implicitlyEnabledIntegrations := m.collectImplicitlyEnabledIntegrations(options.EnabledFrameworks)
+	m.setImplicitlyEnabledIntegrations(implicitlyEnabledIntegrations)
+	allEnabledIntegrations := options.EnabledFrameworks.Union(implicitlyEnabledIntegrations)
+
+	if err := m.checkEnabledListDependencies(allEnabledIntegrations); err != nil {
 		return fmt.Errorf("check enabled frameworks list: %w", err)
 	}
 
@@ -69,7 +73,7 @@ func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Mana
 		logger := log.WithValues("jobFrameworkName", name)
 		fwkNamePrefix := fmt.Sprintf("jobFrameworkName %q", name)
 
-		if options.EnabledFrameworks.Has(name) {
+		if allEnabledIntegrations.Has(name) {
 			if cb.CanSupportIntegration != nil {
 				if canSupport, err := cb.CanSupportIntegration(opts...); !canSupport || err != nil {
 					return fmt.Errorf("failed to configure reconcilers: %w", err)
@@ -178,8 +182,10 @@ func restMappingExists(mgr ctrl.Manager, gvk schema.GroupVersionKind) error {
 // Note that the second argument, "indexer" needs to be the fieldIndexer obtained from the Manager.
 func SetupIndexes(ctx context.Context, indexer client.FieldIndexer, opts ...Option) error {
 	options := ProcessOptions(opts...)
+
+	allEnabledIntegrations := options.EnabledFrameworks.Union(manager.collectImplicitlyEnabledIntegrations(options.EnabledFrameworks))
 	return ForEachIntegration(func(name string, cb IntegrationCallbacks) error {
-		if options.EnabledFrameworks.Has(name) {
+		if allEnabledIntegrations.Has(name) {
 			if err := cb.SetupIndexes(ctx, indexer); err != nil {
 				return fmt.Errorf("jobFrameworkName %q: %w", name, err)
 			}

--- a/pkg/controller/jobs/deployment/deployment_controller.go
+++ b/pkg/controller/jobs/deployment/deployment_controller.go
@@ -38,13 +38,13 @@ const (
 
 func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
-		SetupIndexes:   SetupIndexes,
-		NewReconciler:  jobframework.NewNoopReconcilerFactory(gvk),
-		GVK:            gvk,
-		SetupWebhook:   SetupWebhook,
-		JobType:        &appsv1.Deployment{},
-		AddToScheme:    appsv1.AddToScheme,
-		DependencyList: []string{"pod"},
+		SetupIndexes:                    SetupIndexes,
+		NewReconciler:                   jobframework.NewNoopReconcilerFactory(gvk),
+		GVK:                             gvk,
+		SetupWebhook:                    SetupWebhook,
+		JobType:                         &appsv1.Deployment{},
+		AddToScheme:                     appsv1.AddToScheme,
+		ImplicitlyEnabledFrameworkNames: []string{"pod"},
 	}))
 }
 

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_controller.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_controller.go
@@ -38,14 +38,14 @@ const (
 
 func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
-		SetupIndexes:             SetupIndexes,
-		NewReconciler:            NewReconciler,
-		NewAdditionalReconcilers: []jobframework.ReconcilerFactory{NewPodReconciler},
-		SetupWebhook:             SetupWebhook,
-		JobType:                  &leaderworkersetv1.LeaderWorkerSet{},
-		AddToScheme:              leaderworkersetv1.AddToScheme,
-		DependencyList:           []string{"pod"},
-		GVK:                      gvk,
+		SetupIndexes:                    SetupIndexes,
+		NewReconciler:                   NewReconciler,
+		NewAdditionalReconcilers:        []jobframework.ReconcilerFactory{NewPodReconciler},
+		SetupWebhook:                    SetupWebhook,
+		JobType:                         &leaderworkersetv1.LeaderWorkerSet{},
+		AddToScheme:                     leaderworkersetv1.AddToScheme,
+		ImplicitlyEnabledFrameworkNames: []string{"pod"},
+		GVK:                             gvk,
 	}))
 }
 

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -565,6 +565,11 @@ func (p *Pod) Skip() bool {
 	if v, ok := p.pod.GetLabels()[constants.ManagedByKueueLabelKey]; p.isFound && (!ok || v != constants.ManagedByKueueLabelValue) {
 		return true
 	}
+	if jobframework.HasImplicitlyEnabledFramework(p.pod.GroupVersionKind()) &&
+		p.pod.GetAnnotations()[podconstants.SuspendedByParentAnnotation] == "" {
+		ctrl.Log.V(3).Info("Pod Integration was implicitly enabled but object lacks parent annotation, skipping")
+		return true
+	}
 	return false
 }
 

--- a/pkg/controller/jobs/statefulset/statefulset_controller.go
+++ b/pkg/controller/jobs/statefulset/statefulset_controller.go
@@ -38,13 +38,13 @@ const (
 
 func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
-		SetupIndexes:   SetupIndexes,
-		NewReconciler:  NewReconciler,
-		SetupWebhook:   SetupWebhook,
-		JobType:        &appsv1.StatefulSet{},
-		AddToScheme:    appsv1.AddToScheme,
-		DependencyList: []string{"pod"},
-		GVK:            gvk,
+		SetupIndexes:                    SetupIndexes,
+		NewReconciler:                   NewReconciler,
+		SetupWebhook:                    SetupWebhook,
+		JobType:                         &appsv1.StatefulSet{},
+		AddToScheme:                     appsv1.AddToScheme,
+		ImplicitlyEnabledFrameworkNames: []string{"pod"},
+		GVK:                             gvk,
 	}))
 }
 

--- a/test/e2e/customconfigs/podintegrationautoenablement_test.go
+++ b/test/e2e/customconfigs/podintegrationautoenablement_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package customconfigse2e
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/statefulset"
+	"sigs.k8s.io/kueue/pkg/util/testing"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	testingsts "sigs.k8s.io/kueue/pkg/util/testingjobs/statefulset"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("Auto-Enablement of Pod Integration for Pod-Dependent Frameworks", ginkgo.Ordered, func() {
+	var (
+		ns           *corev1.Namespace
+		defaultRf    *kueue.ResourceFlavor
+		localQueue   *kueue.LocalQueue
+		clusterQueue *kueue.ClusterQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		util.UpdateKueueConfiguration(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+			cfg.Integrations.Frameworks = []string{"statefulset"}
+		})
+
+		currentCfg := util.GetKueueConfiguration(ctx, k8sClient)
+		frameworkSet := make(map[string]bool)
+		for _, framework := range currentCfg.Integrations.Frameworks {
+			frameworkSet[framework] = true
+		}
+		gomega.Expect(frameworkSet["statefulset"]).To(gomega.BeTrue())
+		gomega.Expect(frameworkSet["pod"]).To(gomega.BeFalse())
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-disabled-pod-")
+		defaultRf = testing.MakeResourceFlavor("default").Obj()
+		util.MustCreate(ctx, k8sClient, defaultRf)
+		clusterQueue = testing.MakeClusterQueue("cluster-queue").
+			ResourceGroup(
+				*testing.MakeFlavorQuotas(defaultRf.Name).
+					Resource(corev1.ResourceCPU, "2").
+					Resource(corev1.ResourceMemory, "2G").Obj()).Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+		localQueue = testing.MakeLocalQueue("main", ns.Name).ClusterQueue("cluster-queue").Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, clusterQueue, true, util.LongTimeout)
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, defaultRf, true, util.LongTimeout)
+		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
+	})
+
+	ginkgo.It("should successfully run StatefulSets when pod integration is auto-enabled", func() {
+		testSts := testingsts.MakeStatefulSet("test-sts", ns.Name).
+			Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+			Replicas(2).
+			RequestAndLimit(corev1.ResourceCPU, "200m").
+			TerminationGracePeriod(1).
+			Queue(localQueue.Name).
+			Obj()
+		util.MustCreate(ctx, k8sClient, testSts)
+
+		ginkgo.By("verifying StatefulSet workload is created and admitted", func() {
+			wlLookupKey := types.NamespacedName{Name: statefulset.GetWorkloadName(testSts.Name), Namespace: ns.Name}
+			createdWorkload := &kueue.Workload{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(createdWorkload.Status.Conditions).To(testing.HaveConditionStatusTrue(kueue.WorkloadAdmitted))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verifying StatefulSet pods are managed correctly", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				pods := &corev1.PodList{}
+				g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name),
+					client.MatchingLabels(testSts.Spec.Selector.MatchLabels))).To(gomega.Succeed())
+				g.Expect(pods.Items).To(gomega.HaveLen(2))
+				for _, pod := range pods.Items {
+					g.Expect(pod.Annotations).To(gomega.HaveKey(podconstants.SuspendedByParentAnnotation))
+				}
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verifying StatefulSet becomes ready", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdStatefulSet := &appsv1.StatefulSet{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testSts), createdStatefulSet)).To(gomega.Succeed())
+				g.Expect(createdStatefulSet.Status.ReadyReplicas).To(gomega.Equal(int32(2)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("should not manage pods without queue names regardless of auto-enablement", func() {
+		testPod := testingpod.MakePod("plain-pod", ns.Name).
+			Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+			RequestAndLimit(corev1.ResourceCPU, "200m").
+			Obj()
+		util.MustCreate(ctx, k8sClient, testPod)
+
+		ginkgo.By("verifying pod is not managed by Kueue", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				createdPod := &corev1.Pod{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testPod), createdPod)).To(gomega.Succeed())
+				g.Expect(createdPod.Spec.SchedulingGates).To(gomega.BeEmpty())
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verifying no workload is created for the pod", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				workloads := &kueue.WorkloadList{}
+				g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).To(gomega.Succeed())
+				for _, wl := range workloads.Items {
+					g.Expect(wl.Name).NotTo(gomega.ContainSubstring("plain-pod"))
+				}
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+	})
+})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Automatically enable pod integration when pod-dependent frameworks (LWS, StatefulSet,
Deployment) are enabled, avoiding the need for users to explicitly enable it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6516

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Pod integration is now auto-enabled when using LeaderWorkerSet, StatefulSet, or Deployment frameworks.
```