### PR TITLE
Fix broken link related to the cert-manager doc

### DIFF
--- a/site/content/en/docs/installation/_index.md
+++ b/site/content/en/docs/installation/_index.md
@@ -42,7 +42,7 @@ Use [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus)
 if you don't have your own monitoring system.
 
 The webhook server in kueue uses an internal cert management for provisioning certificates. If you want to use
-a third-party one, e.g. [cert-manager](https://github.com/cert-manager/cert-manager), follow the [cert manager guide](/docs/tasks/manage/installation).
+a third-party one, e.g. [cert-manager](https://github.com/cert-manager/cert-manager), follow the [cert manager guide](/docs/tasks/manage/productization/cert_manager).
 
 [feature_gate]: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 


### PR DESCRIPTION
The link is broken here https://kueue.sigs.k8s.io/docs/installation/#before-you-begin
And I assume we would like to have it pointing to https://kueue.sigs.k8s.io/docs/tasks/manage/productization/cert_manager/.

/kind cleanup

#### Does this PR introduce a user-facing change?

```release-note
NONE
```