### PR TITLE
Bump testing-library/cypress.

### DIFF
--- a/test/e2e/kueueviz/package-lock.json
+++ b/test/e2e/kueueviz/package-lock.json
@@ -8,7 +8,7 @@
       "name": "kueueviz-frontend-tests",
       "version": "0.13.3",
       "devDependencies": {
-        "@testing-library/cypress": "^10.0.3",
+        "@testing-library/cypress": "^10.1.0",
         "cypress": "^14.5.4",
         "depcheck": "^1.4.7"
       }
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@testing-library/cypress": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-10.0.3.tgz",
-      "integrity": "sha512-TeZJMCNtiS59cPWalra7LgADuufO5FtbqQBYxuAgdX6ZFAR2D9CtQwAG8VbgvFcchW3K414va/+7P4OkQ80UVg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-10.1.0.tgz",
+      "integrity": "sha512-tNkNtYRqPQh71xXKuMizr146zlellawUfDth7A/urYU4J66g0VGZ063YsS0gqS79Z58u1G/uo9UxN05qvKXMag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -244,7 +244,7 @@
         "npm": ">=6"
       },
       "peerDependencies": {
-        "cypress": "^12.0.0 || ^13.0.0 || ^14.0.0"
+        "cypress": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/test/e2e/kueueviz/package.json
+++ b/test/e2e/kueueviz/package.json
@@ -6,7 +6,7 @@
     "check-unused": "depcheck"
   },
   "devDependencies": {
-    "@testing-library/cypress": "^10.0.3",
+    "@testing-library/cypress": "^10.1.0",
     "cypress": "^14.5.4",
     "depcheck": "^1.4.7"
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Bump testing-library/cypress.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Manual fix for https://github.com/kubernetes-sigs/kueue/pull/6752.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```