### PR TITLE
Automated cherry pick of #6258: AFS: Heapify only ClusterQueues with pending penalties

### DIFF
--- a/pkg/queue/afs_entry_penalties.go
+++ b/pkg/queue/afs_entry_penalties.go
@@ -92,3 +92,10 @@ func (m *AfsEntryPenalties) HasAny() bool {
 func (m *AfsEntryPenalties) GetPenalties() *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList] {
 	return m.penalties
 }
+
+func (m *AfsEntryPenalties) GetLocalQueueKeysWithPenalties() []utilqueue.LocalQueueReference {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.penalties.Keys()
+}

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -807,11 +807,19 @@ func (m *Manager) queueSecondPass(ctx context.Context, w *kueue.Workload) {
 	}
 }
 
-func (m *Manager) HeapifyAllClusterQueues() {
+func (m *Manager) HeapifyClusterQueuesWithEntryPenalties() {
 	m.Lock()
 	defer m.Unlock()
-	for _, cq := range m.hm.ClusterQueues() {
-		if cq != nil {
+
+	clusterQueuesWithPenalties := sets.New[kueue.ClusterQueueReference]()
+	for _, lqKey := range m.afsEntryPenalties.GetLocalQueueKeysWithPenalties() {
+		if lq, exists := m.localQueues[lqKey]; exists {
+			clusterQueuesWithPenalties.Insert(lq.ClusterQueue)
+		}
+	}
+
+	for cqName := range clusterQueuesWithPenalties {
+		if cq := m.hm.ClusterQueue(cqName); cq != nil {
 			cq.HeapifyAll()
 		}
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -195,8 +195,8 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	ctx = ctrl.LoggerInto(ctx, log)
 
 	var snapshotOpts []cache.SnapshotOption
-	if afs.Enabled(s.admissionFairSharing) {
-		s.queues.HeapifyAllClusterQueues()
+	if features.Enabled(features.AdmissionFairSharing) {
+		s.queues.HeapifyClusterQueuesWithEntryPenalties()
 		snapshotOpts = append(snapshotOpts, cache.WithAfsEntryPenalties(s.queues.GetAfsEntryPenalties()))
 	}
 

--- a/pkg/util/maps/maps.go
+++ b/pkg/util/maps/maps.go
@@ -19,6 +19,7 @@ package maps
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -125,4 +126,10 @@ func (dwc *SyncMap[K, V]) Delete(k K) {
 	dwc.lock.Lock()
 	defer dwc.lock.Unlock()
 	delete(dwc.m, k)
+}
+
+func (dwc *SyncMap[K, V]) Keys() []K {
+	dwc.lock.RLock()
+	defer dwc.lock.RUnlock()
+	return slices.Collect(maps.Keys(dwc.m))
 }


### PR DESCRIPTION
Cherry pick of #6258 on release-0.13.

#6258: AFS: Heapify only ClusterQueues with pending penalties

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```