### PR TITLE
Fix RayJob preemption and waitForPodsReady when using MultiKueue

### DIFF
--- a/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter.go
@@ -54,17 +54,17 @@ func (b *multiKueueAdapter) SyncJob(ctx context.Context, localClient client.Clie
 	// However, the KubeRay operator isn't in the loop on the manager cluster when using MultiKueue, so we need to do it ourselves.
 	// This is necessary because code elsewhere assumes that after calling Suspend(), IsActive() will become false.
 	if localJob.Spec.Suspend && localJob.Status.JobDeploymentStatus != rayv1.JobDeploymentStatusSuspended {
-		err = clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
+		err = clientutil.PatchStatus(ctx, localClient, &localJob, func() (client.Object, bool, error) {
 			localJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusSuspended
-			return true, nil
+			return &localJob, true, nil
 		})
 		if err != nil {
 			return err
 		}
 	} else if !localJob.Spec.Suspend && localJob.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusSuspended {
-		err = clientutil.PatchStatus(ctx, localClient, &localJob, func() (bool, error) {
+		err = clientutil.PatchStatus(ctx, localClient, &localJob, func() (client.Object, bool, error) {
 			localJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusInitializing
-			return true, nil
+			return &localJob, true, nil
 		})
 		if err != nil {
 			return err

--- a/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_multikueue_adapter_test.go
@@ -108,6 +108,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			managersRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
 					Suspend(true).
+					JobDeploymentStatus(rayv1.JobDeploymentStatusSuspended).
 					Obj(),
 			},
 			workerRayJobs: []rayv1.RayJob{
@@ -124,6 +125,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantManagersRayJobs: []rayv1.RayJob{
 				*rayJobBuilder.Clone().
 					Suspend(true).
+					JobDeploymentStatus(rayv1.JobDeploymentStatusSuspended).
 					Obj(),
 			},
 			wantWorkerRayJobs: []rayv1.RayJob{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
It seems like Kueue assumes that when a workload becomes suspended it will shut down and then become inactive. For RayJobs, this means `.spec.suspend` is set to `true`, the KubeRay operator deletes the cluster, sets `.status.jobDeploymentStatus` to `Suspended`, and then Kueue removes the reservation for the workload. However, when using MultiKueue, the KubeRay operator isn't in the loop in the manager cluster. This means the workload never becomes inactive after being preempted (given the definition of IsActive [here](https://github.com/kubernetes-sigs/kueue/blob/a3887653ef8e71ef892afd327e9c0b35fc2471f9/pkg/controller/jobs/rayjob/rayjob_controller.go#L96)) and so continues reserving quota in the cluster.

The same thing happens in any place where the workload is evicted in the manager cluster - the ones I'm aware of are preemption and waitForPodsReady, but there may be others.

#### Special notes for your reviewer:
I didn't add unit tests yet because I'm not very confident in this approach. I just wanted to check if this is the right approach and then I'll add unit tests

#### Does this PR introduce a user-facing change?
```release-note
Fixed preemption and waitForPodsReady for RayJobs when using MultiKueue.
```