### PR TITLE
Fix preemption in MultiKueue worker cluster

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -460,13 +460,6 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 			log.V(2).Error(err, "copying workload status", "remote", evictedRemote)
 			return reconcile.Result{}, err
 		}
-
-		for remote := range group.remotes {
-			if err := client.IgnoreNotFound(group.RemoveRemoteObjects(ctx, remote)); err != nil {
-				log.V(2).Error(err, "Deleting out of sync remote objects", "remote", remote)
-				return reconcile.Result{}, err
-			}
-		}
 	} else if acs.State == kueue.CheckStateReady {
 		// If there is no reserving and the AC is ready, the connection with the reserving remote might
 		// be lost, keep the workload admitted for keepReadyTimeout and put it back in the queue after that.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When using MultiKueue, it's possible for a workload to be preempted in the worker cluster but not the manager cluster. For example, this can happen if there is 5 CPU available in Cluster 1 and 5 in Cluster 2, and someone schedules a workload requesting 6 CPU. The manager cluster would see no issue with this, but one of the worker clusters would need to preempt to admit the new workload.

Currently in this case the manager cluster assumes it's lost connection to the workers. It waits for a timeout and then submits the workload to the worker clusters again.

This PR updates the behavior to instead sync the worker cluster's status back to the manager cluster, and then delete the workload in the worker cluster. This has the nice property that the preempted workload can be readmitted on any worker cluster (not just the one it was previously running on), potentially allowing it to restart sooner.

#### Special notes for your reviewer:
I didn't add unit tests yet because I'm not very confident in this approach. I just wanted to check if this is the right approach and then I'll add unit tests

#### Does this PR introduce a user-facing change?
```release-note
Reflect workload eviction statuses in the MultiKueue manager cluster.
```