### PR TITLE
Make RayJob a TopLevelJob

### DIFF
--- a/test/integration/singlecluster/controller/jobs/rayjobAndRaycluster/rayjob_and_raycluster_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjobAndRaycluster/rayjob_and_raycluster_controller_test.go
@@ -1,0 +1,355 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rayjobandraycluster
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/util/testing"
+	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
+	testingrayjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+const (
+	instanceKey = "cloud.provider.com/instance"
+)
+
+var _ = ginkgo.Describe("RayJob and RayCluster Ancestor Workload Handling", ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	// These tests verify that Kueue's FindAncestorJobManagedByKueue function correctly
+	// handles the parent-child relationship between RayJob and RayCluster.
+	//
+	// The expected behavior is:
+	// - If a RayCluster is owned by a RayJob that has a queue-name label, the RayCluster
+	//   should NOT create its own workload (even if it has a queue-name label).
+	// - Only the top-level job in the ownership chain should create a workload.
+	// - This prevents duplicate workloads and resource double-counting when KubeRay
+	//   propagates labels from RayJob to RayCluster.
+
+	ginkgo.BeforeAll(func() {
+		// Start both RayJob and RayCluster controllers
+		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup(
+			jobframework.WithManageJobsWithoutQueueName(false)))
+	})
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	var (
+		ns           *corev1.Namespace
+		flavor       *kueue.ResourceFlavor
+		clusterQueue *kueue.ClusterQueue
+		localQueue   *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "ray-toplevel-")
+
+		// Create test infrastructure
+		flavor = testing.MakeResourceFlavor("default").NodeLabel(instanceKey, "default").Obj()
+		util.MustCreate(ctx, k8sClient, flavor)
+
+		clusterQueue = testing.MakeClusterQueue("cluster-queue").
+			ResourceGroup(
+				*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+
+		localQueue = testing.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, localQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
+	})
+
+	ginkgo.It("Should NOT create a workload for RayCluster when owned by RayJob (both have queue-name labels)", func() {
+		ginkgo.By("1. Create a RayJob with queue label")
+		rayJob := testingrayjob.MakeJob("test-rayjob", ns.Name).
+			Queue(localQueue.Name).
+			RequestHead(corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			Obj()
+		util.MustCreate(ctx, k8sClient, rayJob)
+
+		ginkgo.By("2. Wait for RayJob to have a workload created")
+		var rayJobWorkload *kueue.Workload
+		gomega.Eventually(func() bool {
+			var workloads kueue.WorkloadList
+			err := k8sClient.List(ctx, &workloads, client.InNamespace(ns.Name))
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			for i := range workloads.Items {
+				wl := &workloads.Items[i]
+				for _, owner := range wl.OwnerReferences {
+					if owner.Kind == "RayJob" && owner.Name == rayJob.Name {
+						rayJobWorkload = wl
+						return true
+					}
+				}
+			}
+			return false
+		}, util.Timeout, util.Interval).Should(gomega.BeTrue(),
+			"Expected a workload to be created for the RayJob")
+		gomega.Expect(rayJobWorkload).ToNot(gomega.BeNil())
+
+		ginkgo.By("3. Create a RayCluster owned by the RayJob (with queue-name label to simulate KubeRay label propagation)")
+		rayCluster := testingraycluster.MakeCluster("test-raycluster", ns.Name).
+			Label("kueue.x-k8s.io/queue-name", localQueue.Name). // This simulates KubeRay propagating the label
+			RequestHead(corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			Obj()
+
+		// Set the RayJob as owner of the RayCluster
+		rayCluster.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion:         "ray.io/v1",
+				Kind:               "RayJob",
+				Name:               rayJob.Name,
+				UID:                rayJob.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			},
+		}
+
+		util.MustCreate(ctx, k8sClient, rayCluster)
+
+		ginkgo.By("4. Verify that NO workload is created for the RayCluster (FindAncestorJobManagedByKueue should prevent it)")
+		// Count total workloads - should remain 1 (just the RayJob workload)
+		gomega.Consistently(func() int {
+			var workloads kueue.WorkloadList
+			err := k8sClient.List(ctx, &workloads, client.InNamespace(ns.Name))
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			return len(workloads.Items)
+		}, util.ConsistentDuration, util.Interval).Should(gomega.Equal(1),
+			"Expected only 1 workload (for RayJob), but RayCluster created a duplicate")
+
+		// Also verify specifically no RayCluster workload exists
+		gomega.Consistently(func() int {
+			var workloads kueue.WorkloadList
+			err := k8sClient.List(ctx, &workloads, client.InNamespace(ns.Name))
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			rayClusterWorkloads := 0
+			for _, wl := range workloads.Items {
+				for _, owner := range wl.OwnerReferences {
+					if owner.Kind == "RayCluster" && owner.Name == rayCluster.Name {
+						rayClusterWorkloads++
+					}
+				}
+			}
+			return rayClusterWorkloads
+		}, util.ConsistentDuration, util.Interval).Should(gomega.Equal(0),
+			"Expected no workload to be created for RayCluster owned by RayJob")
+	})
+
+	ginkgo.It("Should create a workload for standalone RayCluster (not owned by RayJob)", func() {
+		ginkgo.By("1. Create a standalone RayCluster")
+		rayCluster := testingraycluster.MakeCluster("standalone-raycluster", ns.Name).
+			Label("kueue.x-k8s.io/queue-name", localQueue.Name).
+			RequestHead(corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			Obj()
+
+		// Ensure no owner references
+		rayCluster.OwnerReferences = nil
+
+		util.MustCreate(ctx, k8sClient, rayCluster)
+
+		ginkgo.By("2. Verify that a workload IS created for the standalone RayCluster")
+		var rayClusterWorkload *kueue.Workload
+		gomega.Eventually(func() bool {
+			var workloads kueue.WorkloadList
+			err := k8sClient.List(ctx, &workloads, client.InNamespace(ns.Name))
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			for i := range workloads.Items {
+				wl := &workloads.Items[i]
+				for _, owner := range wl.OwnerReferences {
+					if owner.Kind == "RayCluster" && owner.Name == rayCluster.Name {
+						rayClusterWorkload = wl
+						return true
+					}
+				}
+			}
+			return false
+		}, util.Timeout, util.Interval).Should(gomega.BeTrue(),
+			"Expected a workload to be created for standalone RayCluster")
+
+		gomega.Expect(rayClusterWorkload).ToNot(gomega.BeNil())
+	})
+
+	ginkgo.It("Should handle RayCluster created before RayJob (edge case)", func() {
+		ginkgo.By("1. Create a RayCluster with queue-name label first")
+		rayCluster := testingraycluster.MakeCluster("orphan-raycluster", ns.Name).
+			Label("kueue.x-k8s.io/queue-name", localQueue.Name).
+			RequestHead(corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			Obj()
+
+		util.MustCreate(ctx, k8sClient, rayCluster)
+
+		ginkgo.By("2. Verify workload is created for the RayCluster initially")
+		gomega.Eventually(func() bool {
+			var workloads kueue.WorkloadList
+			err := k8sClient.List(ctx, &workloads, client.InNamespace(ns.Name))
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+
+			for i := range workloads.Items {
+				wl := &workloads.Items[i]
+				for _, owner := range wl.OwnerReferences {
+					if owner.Kind == "RayCluster" && owner.Name == rayCluster.Name {
+						return true
+					}
+				}
+			}
+			return false
+		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+
+		ginkgo.By("3. Create RayJob with queue-name and update RayCluster to be owned by it")
+		rayJob := testingrayjob.MakeJob("late-rayjob", ns.Name).
+			Queue(localQueue.Name).
+			RequestHead(corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			Obj()
+		util.MustCreate(ctx, k8sClient, rayJob)
+
+		// Update RayCluster to be owned by RayJob
+		gomega.Eventually(func() error {
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: rayCluster.Name, Namespace: ns.Name}, rayCluster)
+			if err != nil {
+				return err
+			}
+
+			rayCluster.OwnerReferences = []metav1.OwnerReference{
+				{
+					APIVersion:         "ray.io/v1",
+					Kind:               "RayJob",
+					Name:               rayJob.Name,
+					UID:                rayJob.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			}
+			return k8sClient.Update(ctx, rayCluster)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		// Note: In this case, the existing RayCluster workload would remain because workloads
+		// are not retroactively deleted when ownership changes. However, if the RayCluster
+		// was recreated, FindAncestorJobManagedByKueue would prevent a new workload creation.
+	})
+
+	ginkgo.It("Should NOT create workload for RayCluster without queue-name when owned by RayJob with queue-name", func() {
+		ginkgo.By("1. Create a RayJob with queue label")
+		rayJob := testingrayjob.MakeJob("parent-rayjob", ns.Name).
+			Queue(localQueue.Name).
+			RequestHead(corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			Obj()
+		util.MustCreate(ctx, k8sClient, rayJob)
+
+		ginkgo.By("2. Wait for RayJob to have a workload created")
+		gomega.Eventually(func() bool {
+			var workloads kueue.WorkloadList
+			err := k8sClient.List(ctx, &workloads, client.InNamespace(ns.Name))
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			return len(workloads.Items) == 1
+		}, util.Timeout, util.Interval).Should(gomega.BeTrue())
+
+		ginkgo.By("3. Create a RayCluster owned by the RayJob WITHOUT queue-name label")
+		rayCluster := testingraycluster.MakeCluster("child-raycluster", ns.Name).
+			// Intentionally NOT setting queue-name label
+			RequestHead(corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			Obj()
+
+		// Set the RayJob as owner of the RayCluster
+		rayCluster.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion:         "ray.io/v1",
+				Kind:               "RayJob",
+				Name:               rayJob.Name,
+				UID:                rayJob.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			},
+		}
+
+		util.MustCreate(ctx, k8sClient, rayCluster)
+
+		ginkgo.By("4. Verify that NO workload is created for the RayCluster")
+		gomega.Consistently(func() int {
+			var workloads kueue.WorkloadList
+			err := k8sClient.List(ctx, &workloads, client.InNamespace(ns.Name))
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			return len(workloads.Items)
+		}, util.ConsistentDuration, util.Interval).Should(gomega.Equal(1),
+			"Expected only 1 workload (for RayJob)")
+	})
+
+	ginkgo.It("Should NOT create any workloads when neither RayJob nor RayCluster have queue-name", func() {
+		ginkgo.By("1. Create a RayJob WITHOUT queue label")
+		rayJob := testingrayjob.MakeJob("no-queue-rayjob", ns.Name).
+			// Intentionally NOT setting queue
+			RequestHead(corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			Obj()
+		util.MustCreate(ctx, k8sClient, rayJob)
+
+		ginkgo.By("2. Create a RayCluster owned by the RayJob also WITHOUT queue-name label")
+		rayCluster := testingraycluster.MakeCluster("no-queue-raycluster", ns.Name).
+			// Intentionally NOT setting queue-name label
+			RequestHead(corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			Obj()
+
+		// Set the RayJob as owner of the RayCluster
+		rayCluster.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion:         "ray.io/v1",
+				Kind:               "RayJob",
+				Name:               rayJob.Name,
+				UID:                rayJob.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			},
+		}
+
+		util.MustCreate(ctx, k8sClient, rayCluster)
+
+		ginkgo.By("3. Verify that NO workloads are created")
+		gomega.Consistently(func() int {
+			var workloads kueue.WorkloadList
+			err := k8sClient.List(ctx, &workloads, client.InNamespace(ns.Name))
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			return len(workloads.Items)
+		}, util.ConsistentDuration, util.Interval).Should(gomega.Equal(0),
+			"Expected no workloads when neither job has queue-name")
+	})
+})

--- a/test/integration/singlecluster/controller/jobs/rayjobAndRaycluster/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjobAndRaycluster/suite_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rayjobandraycluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta1"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
+	"sigs.k8s.io/kueue/pkg/scheduler"
+	"sigs.k8s.io/kueue/test/integration/framework"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	ctx       context.Context
+	fwk       *framework.Framework
+)
+
+func TestAPIs(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	ginkgo.RunSpecs(t,
+		"RayJob and RayCluster Controllers Suite",
+	)
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	fwk = &framework.Framework{
+		DepCRDPaths: []string{util.RayOperatorCrds},
+	}
+
+	cfg = fwk.Init()
+	ctx, k8sClient = fwk.SetupClient(cfg)
+})
+
+var _ = ginkgo.AfterSuite(func() {
+	fwk.Teardown()
+})
+
+func managerAndSchedulerSetup(opts ...jobframework.Option) framework.ManagerSetup {
+	return func(ctx context.Context, mgr manager.Manager) {
+		// Setup common indexes
+		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Setup core controllers and scheduler
+		cCache := schdcache.New(mgr.GetClient())
+		queues := qcache.NewManager(mgr.GetClient(), cCache)
+		opts = append(opts, jobframework.WithQueues(queues))
+
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, &config.Configuration{})
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+
+		// Setup RayCluster controller
+		err = raycluster.SetupIndexes(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		rayClusterReconciler := raycluster.NewReconciler(mgr.GetClient(),
+			mgr.GetEventRecorderFor(constants.JobControllerName), opts...)
+		err = rayClusterReconciler.SetupWithManager(mgr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = raycluster.SetupRayClusterWebhook(mgr, opts...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Setup RayJob controller
+		err = rayjob.SetupIndexes(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		rayJobReconciler := rayjob.NewReconciler(mgr.GetClient(),
+			mgr.GetEventRecorderFor(constants.JobControllerName), opts...)
+		err = rayJobReconciler.SetupWithManager(mgr)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		err = rayjob.SetupRayJobWebhook(mgr, opts...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Enable both integrations
+		jobframework.EnableIntegration(raycluster.FrameworkName)
+		jobframework.EnableIntegration(rayjob.FrameworkName)
+
+		// Start scheduler
+		sched := scheduler.New(queues, cCache, mgr.GetClient(), mgr.GetEventRecorderFor(constants.AdmissionName))
+		err = sched.Start(ctx)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This PR introduces a key distinction for Kueue to correctly handle two separate use cases: jobs submitted via RayJob CRs and jobs submitted to an existing standalone RayCluster.

* **The Problem:** When a user submits a RayJob CR, Kuberay lifecycles a RayCluster to run the Job. Without this change, Kueue would see two separate objects (RayJob and RayCluster) that both appear to need scheduling, resulting in a duplicate workload, essentially halving the kueue resource constraints.

* **The Solution**: This PR makes RayJob a TopLevelJob. Now, when Kueue processes a RayCluster, it checks its owner reference. If the owner is a RayJob that Kueue is already managing, Kueue understands that the cluster is just a component of that job and does not create a new, redundant workload for it. This correctly associates the cluster's resources with the parent RayJob's workload. If a standalone RayCluster is created and labelled for Kueue processing, it won't have an owner reference and so Kueue will handle it as such.


**Please let me know if / where I should add a test for this. Thank you!**