### PR TITLE
[#6136] Integraton tests for ManagedJobsNamespaceSelectorAlwaysRespected

### DIFF
--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -3384,7 +3384,6 @@ var _ = ginkgo.Describe("Job reconciliation with ManagedJobsNamespaceSelectorAlw
 				jobframework.WithManagedJobsNamespaceSelector(util.NewManagedNamespaceSelector()),
 			),
 		)
-		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ManagedJobsNamespaceSelectorAlwaysRespected, true)
 
 		managedNs = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -3418,12 +3417,16 @@ var _ = ginkgo.Describe("Job reconciliation with ManagedJobsNamespaceSelectorAlw
 		util.MustCreate(ctx, k8sClient, lq)
 	})
 
+	ginkgo.BeforeEach(func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ManagedJobsNamespaceSelectorAlwaysRespected, true)
+	})
+
 	ginkgo.AfterAll(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, managedNs)).To(gomega.Succeed())
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, unmanagedNs)).To(gomega.Succeed())
 		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, rf, true, util.LongTimeout)
-		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, cq, true, util.LongTimeout)
 		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, lq, true, util.LongTimeout)
+		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, cq, true, util.LongTimeout)
 		fwk.StopManager(ctx)
 	})
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1184,3 +1184,19 @@ func ExpectNewWorkloadSlice(ctx context.Context, k8sClient client.Client, oldWor
 	}, Timeout, Interval).Should(gomega.Succeed())
 	return newWorkload
 }
+
+func NewManagedNamespaceSelector() (newSelector labels.Selector) {
+	ls := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "managed-by-kueue",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"true"},
+			},
+		},
+	}
+	newSelector, err := metav1.LabelSelectorAsSelector(ls)
+	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+
+	return newSelector
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Adds an integration test case for ManagedJobsNamespaceSelectorAlwaysRespected in test/integration/singlecluster/jobs/job/job_controller_test.go. It is as discussed in in https://github.com/kubernetes-sigs/kueue/pull/5638#discussion_r2216302030 - such tests were not implemented there but instead were planned for implementation in [#6136].

#### Which issue(s) this PR fixes:
Fixes #6136

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
NONE