### PR TITLE
Automated cherry pick of #6544: Reduce verbosity scheduler unit tests
#6815: Follow-up: Refactor assignment-related wrappers

### DIFF
--- a/cmd/importer/pod/import_test.go
+++ b/cmd/importer/pod/import_test.go
@@ -49,7 +49,9 @@ func TestImportNamespace(t *testing.T) {
 			Request(corev1.ResourceCPU, "1").
 			Obj()).
 		ReserveQuota(utiltesting.MakeAdmission("cq1").
-			Assignment(corev1.ResourceCPU, "f1", "1").
+			PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+				Assignment(corev1.ResourceCPU, "f1", "1").
+				Obj()).
 			Obj()).
 		Condition(metav1.Condition{
 			Type:    kueue.WorkloadQuotaReserved,

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1990,12 +1990,12 @@ func TestClusterQueueUsage(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("partial-one", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("foo").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "4000m").Count(2).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("foo").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "4000m").Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("partial-two", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("foo").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "4000m").Count(2).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("foo").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "4000m").Count(2).Obj()).Obj()).
 					Obj(),
 			},
 			wantReservedResources: []kueue.FlavorUsage{

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -424,8 +424,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				wl := utiltesting.MakeWorkload("one", "").
 					Request(corev1.ResourceCPU, "5").
 					ReserveQuota(utiltesting.MakeAdmission("a").
-						Assignment(corev1.ResourceCPU, "default", "5000m").
-						Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "5000m").
+							Obj()).Obj()).
 					Condition(metav1.Condition{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue}).
 					Obj()
 
@@ -465,8 +466,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							Obj: utiltesting.MakeWorkload("one", "").
 								Request(corev1.ResourceCPU, "5").
 								ReserveQuota(utiltesting.MakeAdmission("a").
-									Assignment(corev1.ResourceCPU, "default", "5000m").
-									Obj()).
+									PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+										Assignment(corev1.ResourceCPU, "default", "5000m").
+										Obj()).Obj()).
 								Condition(metav1.Condition{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue}).
 								Obj(),
 							TotalRequests: []workload.PodSetResources{
@@ -853,13 +855,25 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				utiltesting.MakeLocalQueue("lq1", "ns").ClusterQueue("cq1").Obj(),
 				utiltesting.MakeWorkload("pending", "ns").Obj(),
 				utiltesting.MakeWorkload("reserving", "ns").ReserveQuota(
-					utiltesting.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj(),
+					utiltesting.MakeAdmission("cq1").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "f1", "1").
+							Obj()).
+						Obj(),
 				).Obj(),
 				utiltesting.MakeWorkload("admitted", "ns").ReserveQuota(
-					utiltesting.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj(),
+					utiltesting.MakeAdmission("cq1").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "f1", "1").
+							Obj()).
+						Obj(),
 				).Admitted(true).Obj(),
 				utiltesting.MakeWorkload("finished", "ns").ReserveQuota(
-					utiltesting.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj(),
+					utiltesting.MakeAdmission("cq1").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "f1", "1").
+							Obj()).
+						Obj(),
 				).Admitted(true).Finished().Obj(),
 			},
 			operation: func(log logr.Logger, cache *Cache) error {
@@ -1740,13 +1754,23 @@ func TestClusterQueueUsage(t *testing.T) {
 		*utiltesting.MakeWorkload("one", "").
 			Request(corev1.ResourceCPU, "8").
 			Request("example.com/gpu", "5").
-			ReserveQuota(utiltesting.MakeAdmission("foo").Assignment(corev1.ResourceCPU, "default", "8000m").Assignment("example.com/gpu", "model_a", "5").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("foo").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "8000m").
+					Assignment("example.com/gpu", "model_a", "5").
+					Obj()).
+				Obj()).
 			Condition(metav1.Condition{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue}).
 			Obj(),
 		*utiltesting.MakeWorkload("two", "").
 			Request(corev1.ResourceCPU, "5").
 			Request("example.com/gpu", "6").
-			ReserveQuota(utiltesting.MakeAdmission("foo").Assignment(corev1.ResourceCPU, "default", "5000m").Assignment("example.com/gpu", "model_b", "6").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("foo").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "5000m").
+					Assignment("example.com/gpu", "model_b", "6").
+					Obj()).
+				Obj()).
 			Obj(),
 	}
 	cases := map[string]struct {
@@ -2157,8 +2181,9 @@ func TestLocalQueueUsage(t *testing.T) {
 					Request("example.com/gpu", "5").
 					ReserveQuota(
 						utiltesting.MakeAdmission("foo").
-							Assignment(corev1.ResourceCPU, "default", "5000m").
-							Assignment("example.com/gpu", "model-a", "5").Obj(),
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "5000m").
+								Assignment("example.com/gpu", "model-a", "5").Obj()).Obj(),
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("two", "ns1").
@@ -2167,8 +2192,9 @@ func TestLocalQueueUsage(t *testing.T) {
 					Request("example.com/gpu", "3").
 					ReserveQuota(
 						utiltesting.MakeAdmission("foo").
-							Assignment(corev1.ResourceCPU, "default", "3000m").
-							Assignment("example.com/gpu", "model-b", "3").Obj(),
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Assignment("example.com/gpu", "model-b", "3").Obj()).Obj(),
 					).
 					Obj(),
 			},
@@ -2219,8 +2245,9 @@ func TestLocalQueueUsage(t *testing.T) {
 					Request("example.com/gpu", "5").
 					ReserveQuota(
 						utiltesting.MakeAdmission("foo").
-							Assignment(corev1.ResourceCPU, "default", "5000m").
-							Assignment("example.com/gpu", "model-a", "5").Obj(),
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "5000m").
+								Assignment("example.com/gpu", "model-a", "5").Obj()).Obj(),
 					).Obj(),
 				*utiltesting.MakeWorkload("two", "ns1").
 					Queue("test").
@@ -2386,8 +2413,9 @@ func TestCacheQueueOperations(t *testing.T) {
 			Request("memory", "8Gi").
 			ReserveQuota(
 				utiltesting.MakeAdmission("foo").
-					Assignment("cpu", "spot", "2").
-					Assignment("memory", "spot", "8Gi").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "spot", "2").
+						Assignment("memory", "spot", "8Gi").Obj()).Obj(),
 			).
 			Condition(metav1.Condition{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue}).
 			Obj(),
@@ -2396,7 +2424,8 @@ func TestCacheQueueOperations(t *testing.T) {
 			Request("example.com/gpu", "2").
 			ReserveQuota(
 				utiltesting.MakeAdmission("foo").
-					Assignment("example.com/gpu", "model-a", "2").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("example.com/gpu", "model-a", "2").Obj()).Obj(),
 			).
 			Condition(metav1.Condition{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue}).
 			Obj(),
@@ -2406,15 +2435,17 @@ func TestCacheQueueOperations(t *testing.T) {
 			Request("memory", "16Gi").
 			ReserveQuota(
 				utiltesting.MakeAdmission("bar").
-					Assignment("cpu", "ondemand", "5").
-					Assignment("memory", "ondemand", "16Gi").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "ondemand", "5").
+						Assignment("memory", "ondemand", "16Gi").Obj()).Obj(),
 			).Obj(),
 		utiltesting.MakeWorkload("job4", "ns2").
 			Queue("beta").
 			Request("example.com/gpu", "5").
 			ReserveQuota(
 				utiltesting.MakeAdmission("foo").
-					Assignment("example.com/gpu", "model-a", "5").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("example.com/gpu", "model-a", "5").Obj()).Obj(),
 			).Obj(),
 	}
 	insertAllClusterQueues := func(ctx context.Context, cl client.Client, cache *Cache) error {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1966,12 +1966,12 @@ func TestClusterQueueUsage(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("partial-one", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("foo").Assignment(corev1.ResourceCPU, "default", "4000m").AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("foo").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "4000m").Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("partial-two", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("foo").Assignment(corev1.ResourceCPU, "default", "4000m").AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("foo").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "4000m").Count(2).Obj()).Obj()).
 					Obj(),
 			},
 			wantReservedResources: []kueue.FlavorUsage{

--- a/pkg/cache/fair_sharing_test.go
+++ b/pkg/cache/fair_sharing_test.go
@@ -714,7 +714,9 @@ func TestDominantResourceShare(t *testing.T) {
 			for fr, v := range tc.usage {
 				admission := utiltesting.MakeAdmission("cq")
 				quantity := resources.ResourceQuantity(fr.Resource, v)
-				admission.Assignment(fr.Resource, fr.Flavor, quantity.String())
+				admission.PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(fr.Resource, fr.Flavor, quantity.String()).
+					Obj())
 
 				wl := utiltesting.MakeWorkload(fmt.Sprintf("workload-%d", i), "default-namespace").ReserveQuota(admission.Obj()).Obj()
 

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -176,7 +176,7 @@ func TestSnapshot(t *testing.T) {
 				utiltesting.MakeWorkload("alpha", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "demand", "10000m").AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "demand").ResourceUsage(corev1.ResourceCPU, "10000m").Count(5).Obj()).Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("beta", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
@@ -184,10 +184,14 @@ func TestSnapshot(t *testing.T) {
 						Request("example.com/gpu", "2").
 						Obj(),
 					).
-					ReserveQuota(utiltesting.MakeAdmission("b", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "spot", "5000m").
-						Assignment("example.com/gpu", "default", "10").
-						AssignmentPodCount(5).
+					ReserveQuota(utiltesting.MakeAdmission("b").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "spot").
+							ResourceUsage(corev1.ResourceCPU, "5000m").
+							Flavor("example.com/gpu", "default").
+							ResourceUsage("example.com/gpu", "10").
+							Count(5).
+							Obj()).
 						Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("gamma", "").
@@ -196,10 +200,14 @@ func TestSnapshot(t *testing.T) {
 						Request("example.com/gpu", "1").
 						Obj(),
 					).
-					ReserveQuota(utiltesting.MakeAdmission("b", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "spot", "5000m").
-						Assignment("example.com/gpu", "default", "5").
-						AssignmentPodCount(5).
+					ReserveQuota(utiltesting.MakeAdmission("b").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "spot").
+							ResourceUsage(corev1.ResourceCPU, "5000m").
+							Flavor("example.com/gpu", "default").
+							ResourceUsage("example.com/gpu", "5").
+							Count(5).
+							Obj()).
 						Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("sigma", "").
@@ -259,9 +267,12 @@ func TestSnapshot(t *testing.T) {
 									"/alpha": workload.NewInfo(utiltesting.MakeWorkload("alpha", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "demand", "10000m").
-											AssignmentPodCount(5).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "demand").
+												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Count(5).
+												Obj()).
 											Obj()).
 										Obj()),
 								},
@@ -305,10 +316,14 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "1").
 											Request("example.com/gpu", "2").
 											Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("b", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "spot", "5000m").
-											Assignment("example.com/gpu", "default", "10").
-											AssignmentPodCount(5).
+										ReserveQuota(utiltesting.MakeAdmission("b").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "spot").
+												ResourceUsage(corev1.ResourceCPU, "5000m").
+												Flavor("example.com/gpu", "default").
+												ResourceUsage("example.com/gpu", "10").
+												Count(5).
+												Obj()).
 											Obj()).
 										Obj()),
 									"/gamma": workload.NewInfo(utiltesting.MakeWorkload("gamma", "").
@@ -317,10 +332,14 @@ func TestSnapshot(t *testing.T) {
 											Request("example.com/gpu", "1").
 											Obj(),
 										).
-										ReserveQuota(utiltesting.MakeAdmission("b", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "spot", "5000m").
-											Assignment("example.com/gpu", "default", "5").
-											AssignmentPodCount(5).
+										ReserveQuota(utiltesting.MakeAdmission("b").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "spot").
+												ResourceUsage(corev1.ResourceCPU, "5000m").
+												Flavor("example.com/gpu", "default").
+												ResourceUsage("example.com/gpu", "5").
+												Count(5).
+												Obj()).
 											Obj()).
 										Obj()),
 								},
@@ -440,23 +459,35 @@ func TestSnapshot(t *testing.T) {
 				utiltesting.MakeWorkload("alpha", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "arm", "10000m").
-						AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "arm").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(5).
+							Obj()).
+						Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("beta", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "arm", "5000m").
-						AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "arm").
+							ResourceUsage(corev1.ResourceCPU, "5000m").
+							Count(5).
+							Obj()).
+						Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("gamma", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "x86", "10000m").
-						AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "x86").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(5).
+							Obj()).
+						Obj()).
 					Obj(),
 			},
 			wantSnapshot: func() Snapshot {
@@ -508,23 +539,35 @@ func TestSnapshot(t *testing.T) {
 									"/alpha": workload.NewInfo(utiltesting.MakeWorkload("alpha", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "arm", "10000m").
-											AssignmentPodCount(5).Obj()).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "arm").
+												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Count(5).
+												Obj()).
+											Obj()).
 										Obj()),
 									"/beta": workload.NewInfo(utiltesting.MakeWorkload("beta", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "1").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "arm", "5000m").
-											AssignmentPodCount(5).Obj()).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "arm").
+												ResourceUsage(corev1.ResourceCPU, "5000m").
+												Count(5).
+												Obj()).
+											Obj()).
 										Obj()),
 									"/gamma": workload.NewInfo(utiltesting.MakeWorkload("gamma", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "x86", "10000m").
-											AssignmentPodCount(5).Obj()).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "x86").
+												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Count(5).
+												Obj()).
+											Obj()).
 										Obj()),
 								},
 								Preemption:        defaultPreemption,
@@ -594,23 +637,35 @@ func TestSnapshot(t *testing.T) {
 				utiltesting.MakeWorkload("alpha", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "arm", "10000m").
-						AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "arm").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(5).
+							Obj()).
+						Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("beta", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "arm", "5000m").
-						AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "arm").
+							ResourceUsage(corev1.ResourceCPU, "5000m").
+							Count(5).
+							Obj()).
+						Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("gamma", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "x86", "10000m").
-						AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "x86").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(5).
+							Obj()).
+						Obj()).
 					Obj(),
 			},
 			wantSnapshot: func() Snapshot {
@@ -663,23 +718,35 @@ func TestSnapshot(t *testing.T) {
 									"/alpha": workload.NewInfo(utiltesting.MakeWorkload("alpha", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "arm", "10000m").
-											AssignmentPodCount(5).Obj()).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "arm").
+												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Count(5).
+												Obj()).
+											Obj()).
 										Obj()),
 									"/beta": workload.NewInfo(utiltesting.MakeWorkload("beta", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "1").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "arm", "5000m").
-											AssignmentPodCount(5).Obj()).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "arm").
+												ResourceUsage(corev1.ResourceCPU, "5000m").
+												Count(5).
+												Obj()).
+											Obj()).
 										Obj()),
 									"/gamma": workload.NewInfo(utiltesting.MakeWorkload("gamma", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "x86", "10000m").
-											AssignmentPodCount(5).Obj()).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "x86").
+												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Count(5).
+												Obj()).
+											Obj()).
 										Obj()),
 								},
 								Preemption:        defaultPreemption,

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -1034,23 +1034,43 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 	workloads := []kueue.Workload{
 		*utiltesting.MakeWorkload("c1-cpu", "").
 			Request(corev1.ResourceCPU, "1").
-			ReserveQuota(utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "1000m").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("c1").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "1000m").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("c1-memory-alpha", "").
 			Request(corev1.ResourceMemory, "1Gi").
-			ReserveQuota(utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceMemory, "alpha", "1Gi").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("c1").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceMemory, "alpha", "1Gi").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("c1-memory-beta", "").
 			Request(corev1.ResourceMemory, "1Gi").
-			ReserveQuota(utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceMemory, "beta", "1Gi").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("c1").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceMemory, "beta", "1Gi").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("c2-cpu-1", "").
 			Request(corev1.ResourceCPU, "1").
-			ReserveQuota(utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "1000m").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("c2").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "1000m").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("c2-cpu-2", "").
 			Request(corev1.ResourceCPU, "1").
-			ReserveQuota(utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "1000m").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("c2").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "1000m").
+					Obj()).
+				Obj()).
 			Obj(),
 	}
 
@@ -1332,19 +1352,35 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 	workloads := []kueue.Workload{
 		*utiltesting.MakeWorkload("lend-a-1", "").
 			Request(corev1.ResourceCPU, "1").
-			ReserveQuota(utiltesting.MakeAdmission("lend-a").Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("lend-a").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "1").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("lend-a-2", "").
 			Request(corev1.ResourceCPU, "9").
-			ReserveQuota(utiltesting.MakeAdmission("lend-a").Assignment(corev1.ResourceCPU, "default", "9").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("lend-a").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "9").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("lend-a-3", "").
 			Request(corev1.ResourceCPU, "6").
-			ReserveQuota(utiltesting.MakeAdmission("lend-a").Assignment(corev1.ResourceCPU, "default", "6").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("lend-a").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "6").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("lend-b-1", "").
 			Request(corev1.ResourceCPU, "4").
-			ReserveQuota(utiltesting.MakeAdmission("lend-b").Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("lend-b").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "4").
+					Obj()).
+				Obj()).
 			Obj(),
 	}
 

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -176,7 +176,7 @@ func TestSnapshot(t *testing.T) {
 				utiltesting.MakeWorkload("alpha", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "demand").ResourceUsage(corev1.ResourceCPU, "10000m").Count(5).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "demand", "10000m").Count(5).Obj()).Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("beta", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
@@ -186,10 +186,8 @@ func TestSnapshot(t *testing.T) {
 					).
 					ReserveQuota(utiltesting.MakeAdmission("b").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "spot").
-							ResourceUsage(corev1.ResourceCPU, "5000m").
-							Flavor("example.com/gpu", "default").
-							ResourceUsage("example.com/gpu", "10").
+							Assignment(corev1.ResourceCPU, "spot", "5000m").
+							Assignment("example.com/gpu", "default", "10").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -202,10 +200,8 @@ func TestSnapshot(t *testing.T) {
 					).
 					ReserveQuota(utiltesting.MakeAdmission("b").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "spot").
-							ResourceUsage(corev1.ResourceCPU, "5000m").
-							Flavor("example.com/gpu", "default").
-							ResourceUsage("example.com/gpu", "5").
+							Assignment(corev1.ResourceCPU, "spot", "5000m").
+							Assignment("example.com/gpu", "default", "5").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -269,8 +265,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "2").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "demand").
-												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Assignment(corev1.ResourceCPU, "demand", "10000m").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -318,10 +313,8 @@ func TestSnapshot(t *testing.T) {
 											Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("b").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "spot").
-												ResourceUsage(corev1.ResourceCPU, "5000m").
-												Flavor("example.com/gpu", "default").
-												ResourceUsage("example.com/gpu", "10").
+												Assignment(corev1.ResourceCPU, "spot", "5000m").
+												Assignment("example.com/gpu", "default", "10").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -334,10 +327,8 @@ func TestSnapshot(t *testing.T) {
 										).
 										ReserveQuota(utiltesting.MakeAdmission("b").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "spot").
-												ResourceUsage(corev1.ResourceCPU, "5000m").
-												Flavor("example.com/gpu", "default").
-												ResourceUsage("example.com/gpu", "5").
+												Assignment(corev1.ResourceCPU, "spot", "5000m").
+												Assignment("example.com/gpu", "default", "5").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -461,8 +452,7 @@ func TestSnapshot(t *testing.T) {
 						Request(corev1.ResourceCPU, "2").Obj()).
 					ReserveQuota(utiltesting.MakeAdmission("a").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "arm").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "arm", "10000m").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -472,8 +462,7 @@ func TestSnapshot(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(utiltesting.MakeAdmission("a").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "arm").
-							ResourceUsage(corev1.ResourceCPU, "5000m").
+							Assignment(corev1.ResourceCPU, "arm", "5000m").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -483,8 +472,7 @@ func TestSnapshot(t *testing.T) {
 						Request(corev1.ResourceCPU, "2").Obj()).
 					ReserveQuota(utiltesting.MakeAdmission("a").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "x86").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "x86", "10000m").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -541,8 +529,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "2").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "arm").
-												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Assignment(corev1.ResourceCPU, "arm", "10000m").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -552,8 +539,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "1").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "arm").
-												ResourceUsage(corev1.ResourceCPU, "5000m").
+												Assignment(corev1.ResourceCPU, "arm", "5000m").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -563,8 +549,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "2").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "x86").
-												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Assignment(corev1.ResourceCPU, "x86", "10000m").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -639,8 +624,7 @@ func TestSnapshot(t *testing.T) {
 						Request(corev1.ResourceCPU, "2").Obj()).
 					ReserveQuota(utiltesting.MakeAdmission("a").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "arm").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "arm", "10000m").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -650,8 +634,7 @@ func TestSnapshot(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(utiltesting.MakeAdmission("a").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "arm").
-							ResourceUsage(corev1.ResourceCPU, "5000m").
+							Assignment(corev1.ResourceCPU, "arm", "5000m").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -661,8 +644,7 @@ func TestSnapshot(t *testing.T) {
 						Request(corev1.ResourceCPU, "2").Obj()).
 					ReserveQuota(utiltesting.MakeAdmission("a").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "x86").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "x86", "10000m").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -720,8 +702,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "2").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "arm").
-												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Assignment(corev1.ResourceCPU, "arm", "10000m").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -731,8 +712,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "1").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "arm").
-												ResourceUsage(corev1.ResourceCPU, "5000m").
+												Assignment(corev1.ResourceCPU, "arm", "5000m").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -742,8 +722,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "2").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "x86").
-												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Assignment(corev1.ResourceCPU, "x86", "10000m").
 												Count(5).
 												Obj()).
 											Obj()).

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -409,7 +409,11 @@ func TestReconcile(t *testing.T) {
 	}{
 		"assign Admission Checks from ClusterQueue.spec.AdmissionCheckStrategy": {
 			workload: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Queue("queue").
 				Obj(),
 			cq: utiltesting.MakeClusterQueue("cq").
@@ -419,7 +423,11 @@ func TestReconcile(t *testing.T) {
 				Obj(),
 			lq: utiltesting.MakeLocalQueue("queue", "ns").ClusterQueue("cq").Obj(),
 			wantWorkload: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Queue("queue").
 				AdmissionChecks(
 					kueue.AdmissionCheckState{
@@ -434,7 +442,11 @@ func TestReconcile(t *testing.T) {
 		},
 		"assign Admission Checks from ClusterQueue.spec.AdmissionChecks": {
 			workload: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Queue("queue").
 				Obj(),
 			cq: utiltesting.MakeClusterQueue("cq").
@@ -442,7 +454,11 @@ func TestReconcile(t *testing.T) {
 				Obj(),
 			lq: utiltesting.MakeLocalQueue("queue", "ns").ClusterQueue("cq").Obj(),
 			wantWorkload: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Queue("queue").
 				AdmissionChecks(
 					kueue.AdmissionCheckState{

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -491,7 +491,7 @@ func TestReconciler(t *testing.T) {
 	baseWorkloadWrapper := utiltesting.MakeWorkload("wl", "ns").
 		Finalizers(kueue.ResourceInUseFinalizerName).
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
-		ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj())
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(10).Obj()).Obj())
 
 	baseWPCWrapper := utiltesting.MakeWorkloadPriorityClass("test-wpc").
 		PriorityValue(100)
@@ -2446,7 +2446,7 @@ func TestReconciler(t *testing.T) {
 				*utiltesting.MakeWorkload("a", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(8).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(8).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -2459,7 +2459,7 @@ func TestReconciler(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(8).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(8).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -2493,7 +2493,7 @@ func TestReconciler(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(8).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(8).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -2729,7 +2729,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(10).Obj()).Obj()).
 					Admitted(true).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "parent", "parent-uid").
 					Obj(),
@@ -2737,7 +2737,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(10).Obj()).Obj()).
 					Admitted(true).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "parent", "parent-uid").
 					Obj(),
@@ -2809,7 +2809,7 @@ func TestReconciler(t *testing.T) {
 				*utiltesting.MakeWorkload("parent-workload", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(10).Obj()).Obj()).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "parent", "parent-uid").
 					Admitted(true).
 					Obj(),
@@ -2818,7 +2818,7 @@ func TestReconciler(t *testing.T) {
 				*utiltesting.MakeWorkload("parent-workload", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(10).Obj()).Obj()).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "parent", "parent-uid").
 					Admitted(true).
 					Obj(),

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -302,8 +302,11 @@ func TestReconciler(t *testing.T) {
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -315,8 +318,11 @@ func TestReconciler(t *testing.T) {
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -343,7 +349,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Obj(),
@@ -490,7 +496,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Obj(),
@@ -498,7 +504,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -544,7 +550,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Obj(),
@@ -552,7 +558,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -1064,9 +1070,12 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
-							AssignmentPodCount(2).
+						utiltesting.MakeAdmission("cq").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1078,9 +1087,12 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
-							AssignmentPodCount(2).
+						utiltesting.MakeAdmission("cq").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1148,7 +1160,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Admitted(true).
@@ -1162,7 +1174,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Admitted(true).
@@ -1216,7 +1228,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1230,7 +1242,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1276,7 +1288,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1295,7 +1307,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1412,7 +1424,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    "Finished",
@@ -1437,7 +1449,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    "Finished",
@@ -1541,8 +1553,11 @@ func TestReconciler(t *testing.T) {
 					Queue("test-queue").
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
-							AssignmentPodCount(2).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1614,7 +1629,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1634,7 +1649,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1701,7 +1716,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(3).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(3).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1754,7 +1769,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(3).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(3).Obj()).Obj()).
 					ReclaimablePods(kueue.ReclaimablePod{
 						Name:  kueue.NewPodSetReference(podUID),
 						Count: 1,
@@ -1845,7 +1860,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1860,7 +1875,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1915,7 +1930,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -1941,7 +1956,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -1994,7 +2009,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					AdmittedAt(true, testStartTime.Add(-time.Second)).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -2021,7 +2036,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					PastAdmittedTime(1).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadAdmitted,
@@ -2115,8 +2130,11 @@ func TestReconciler(t *testing.T) {
 					Queue("test-queue").
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
-							AssignmentPodCount(2).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -2192,7 +2210,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2212,7 +2230,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2256,7 +2274,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -2278,7 +2296,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -2520,7 +2538,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2545,7 +2563,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2647,7 +2665,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2669,7 +2687,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -2765,7 +2783,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2787,7 +2805,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -2999,7 +3017,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -3021,7 +3039,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -3117,7 +3135,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3129,7 +3147,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3201,7 +3219,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "pod2").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3216,7 +3234,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "pod2").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3418,7 +3436,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3439,7 +3457,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement-for-pod1", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3821,7 +3839,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "deleted", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3845,7 +3863,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3942,7 +3960,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "active-pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3956,7 +3974,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "active-pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4055,7 +4073,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error-no-finalizer", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4076,7 +4094,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error-no-finalizer", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4293,7 +4311,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					Priority(0).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4323,7 +4341,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					Priority(0).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4380,7 +4398,7 @@ func TestReconciler(t *testing.T) {
 					Priority(0).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4407,7 +4425,7 @@ func TestReconciler(t *testing.T) {
 					Priority(0).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4474,7 +4492,7 @@ func TestReconciler(t *testing.T) {
 					Priority(0).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4513,7 +4531,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4566,7 +4584,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4602,7 +4620,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4641,7 +4659,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4677,7 +4695,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4723,7 +4741,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4760,7 +4778,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4806,7 +4824,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -4849,7 +4867,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -4903,7 +4921,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadEvicted,
@@ -4951,7 +4969,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadEvicted,
@@ -5002,7 +5020,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -5052,7 +5070,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -5105,7 +5123,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -5147,7 +5165,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -5474,7 +5492,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					AdmittedAt(true, testStartTime.Add(-time.Second)).
 					Active(false).
 					Condition(metav1.Condition{
@@ -5495,7 +5513,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					PastAdmittedTime(1).
 					Active(false).
 					Condition(metav1.Condition{
@@ -5649,7 +5667,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 
 	wl := *utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-		ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 		Admitted(true).
 		Obj()
 
@@ -5729,7 +5747,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 	// Workload should be finished after the second reconcile
 	wantWl := *utiltesting.MakeWorkload("unit-test", "ns").
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-		ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 		ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 		Admitted(true).
 		Condition(
@@ -5872,7 +5890,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 		OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 		OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 		OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "excessPod", "test-uid").
-		ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 		Admitted(true).
 		Obj()
 

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -303,9 +303,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								Obj()).
 							Obj(),
 					).
@@ -319,9 +317,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								Obj()).
 							Obj(),
 					).
@@ -349,7 +345,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Obj(),
@@ -496,7 +492,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Obj(),
@@ -504,7 +500,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -550,7 +546,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Obj(),
@@ -558,7 +554,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -1072,8 +1068,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 								Count(2).
 								Obj()).
 							Obj(),
@@ -1089,8 +1084,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 								Count(2).
 								Obj()).
 							Obj(),
@@ -1160,7 +1154,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Admitted(true).
@@ -1174,7 +1168,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Admitted(true).
@@ -1228,7 +1222,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1242,7 +1236,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1288,7 +1282,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1307,7 +1301,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1424,7 +1418,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    "Finished",
@@ -1449,7 +1443,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    "Finished",
@@ -1554,8 +1548,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 								Count(2).
 								Obj()).
 							Obj(),
@@ -1629,7 +1622,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1649,7 +1642,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1860,7 +1853,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1875,7 +1868,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1930,7 +1923,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -1956,7 +1949,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -2009,7 +2002,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					AdmittedAt(true, testStartTime.Add(-time.Second)).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -2036,7 +2029,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					PastAdmittedTime(1).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadAdmitted,
@@ -2131,8 +2124,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 								Count(2).
 								Obj()).
 							Obj(),
@@ -2210,7 +2202,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2230,7 +2222,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2274,7 +2266,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -2296,7 +2288,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -2538,7 +2530,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2563,7 +2555,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2665,7 +2657,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2687,7 +2679,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -2783,7 +2775,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2805,7 +2797,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -3017,7 +3009,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -3039,7 +3031,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -3135,7 +3127,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3147,7 +3139,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3219,7 +3211,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "pod2").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3234,7 +3226,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "pod2").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3436,7 +3428,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3457,7 +3449,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement-for-pod1", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3839,7 +3831,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "deleted", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3863,7 +3855,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3960,7 +3952,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "active-pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3974,7 +3966,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "active-pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4073,7 +4065,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error-no-finalizer", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4094,7 +4086,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error-no-finalizer", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4311,7 +4303,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					Priority(0).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4341,7 +4333,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					Priority(0).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4398,7 +4390,7 @@ func TestReconciler(t *testing.T) {
 					Priority(0).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4425,7 +4417,7 @@ func TestReconciler(t *testing.T) {
 					Priority(0).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -5492,7 +5484,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					AdmittedAt(true, testStartTime.Add(-time.Second)).
 					Active(false).
 					Condition(metav1.Condition{
@@ -5513,7 +5505,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					PastAdmittedTime(1).
 					Active(false).
 					Condition(metav1.Condition{
@@ -5667,7 +5659,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 
 	wl := *utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 		Admitted(true).
 		Obj()
 
@@ -5747,7 +5739,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 	// Workload should be finished after the second reconcile
 	wantWl := *utiltesting.MakeWorkload("unit-test", "ns").
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 		ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 		Admitted(true).
 		Condition(
@@ -5890,7 +5882,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 		OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 		OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 		OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "excessPod", "test-uid").
-		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 		Admitted(true).
 		Obj()
 

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -360,12 +360,9 @@ func TestReconciler(t *testing.T) {
 						utiltesting.MakeAdmission("cq").
 							PodSets(
 								utiltesting.MakePodSetAssignment("head").
-									Flavor(corev1.ResourceCPU, "unit-test-flavor").
-									ResourceUsage(corev1.ResourceCPU, "1").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 									Obj(),
 								utiltesting.MakePodSetAssignment("workers-group-0").
-									Count(1).
 									Obj(),
 							).
 							Obj(),
@@ -416,12 +413,9 @@ func TestReconciler(t *testing.T) {
 						utiltesting.MakeAdmission("cq").
 							PodSets(
 								utiltesting.MakePodSetAssignment("head").
-									Flavor(corev1.ResourceCPU, "unit-test-flavor").
-									ResourceUsage(corev1.ResourceCPU, "1").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 									Obj(),
 								utiltesting.MakePodSetAssignment("workers-group-0").
-									Count(1).
 									Obj(),
 							).
 							Obj(),
@@ -480,7 +474,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Request(corev1.ResourceCPU, "10").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment("head").Count(1).Obj(), utiltesting.MakePodSetAssignment("workers-group-0").Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment("head").Obj(), utiltesting.MakePodSetAssignment("workers-group-0").Obj()).Obj()).
 					Generation(1).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -516,7 +510,7 @@ func TestReconciler(t *testing.T) {
 							}).
 							Obj(),
 					).
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment("head").Count(1).Obj(), utiltesting.MakePodSetAssignment("workers-group-0").Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment("head").Obj(), utiltesting.MakePodSetAssignment("workers-group-0").Obj()).Obj()).
 					Generation(1).
 					PastAdmittedTime(1).
 					Condition(metav1.Condition{
@@ -596,8 +590,7 @@ func TestReconciler(t *testing.T) {
 						utiltesting.MakeAdmission("cq").
 							PodSets(
 								utiltesting.MakePodSetAssignment("head").
-									Flavor(corev1.ResourceCPU, "unit-test-flavor").
-									ResourceUsage(corev1.ResourceCPU, "1").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 									Count(2).
 									Obj(),
 								utiltesting.MakePodSetAssignment("workers-group-0").
@@ -650,8 +643,7 @@ func TestReconciler(t *testing.T) {
 						utiltesting.MakeAdmission("cq").
 							PodSets(
 								utiltesting.MakePodSetAssignment("head").
-									Flavor(corev1.ResourceCPU, "unit-test-flavor").
-									ResourceUsage(corev1.ResourceCPU, "1").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 									Count(2).
 									Obj(),
 								utiltesting.MakePodSetAssignment("workers-group-0").

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -357,9 +357,17 @@ func TestReconciler(t *testing.T) {
 					).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", "head", "workers-group-0").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
+						utiltesting.MakeAdmission("cq").
+							PodSets(
+								utiltesting.MakePodSetAssignment("head").
+									Flavor(corev1.ResourceCPU, "unit-test-flavor").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(1).
+									Obj(),
+								utiltesting.MakePodSetAssignment("workers-group-0").
+									Count(1).
+									Obj(),
+							).
 							Obj(),
 					).
 					Admitted(true).
@@ -405,9 +413,17 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", "head", "workers-group-0").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
+						utiltesting.MakeAdmission("cq").
+							PodSets(
+								utiltesting.MakePodSetAssignment("head").
+									Flavor(corev1.ResourceCPU, "unit-test-flavor").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(1).
+									Obj(),
+								utiltesting.MakePodSetAssignment("workers-group-0").
+									Count(1).
+									Obj(),
+							).
 							Obj(),
 					).
 					Admitted(true).
@@ -464,7 +480,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Request(corev1.ResourceCPU, "10").
-					ReserveQuota(utiltesting.MakeAdmission("cq", "head", "workers-group-0").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment("head").Count(1).Obj(), utiltesting.MakePodSetAssignment("workers-group-0").Count(1).Obj()).Obj()).
 					Generation(1).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -500,7 +516,7 @@ func TestReconciler(t *testing.T) {
 							}).
 							Obj(),
 					).
-					ReserveQuota(utiltesting.MakeAdmission("cq", "head", "workers-group-0").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment("head").Count(1).Obj(), utiltesting.MakePodSetAssignment("workers-group-0").Count(1).Obj()).Obj()).
 					Generation(1).
 					PastAdmittedTime(1).
 					Condition(metav1.Condition{
@@ -577,9 +593,17 @@ func TestReconciler(t *testing.T) {
 					).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", "head", "workers-group-0").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(2).
+						utiltesting.MakeAdmission("cq").
+							PodSets(
+								utiltesting.MakePodSetAssignment("head").
+									Flavor(corev1.ResourceCPU, "unit-test-flavor").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(2).
+									Obj(),
+								utiltesting.MakePodSetAssignment("workers-group-0").
+									Count(2).
+									Obj(),
+							).
 							Obj(),
 					).
 					Admitted(true).
@@ -623,9 +647,17 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", "head", "workers-group-0").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(2).
+						utiltesting.MakeAdmission("cq").
+							PodSets(
+								utiltesting.MakePodSetAssignment("head").
+									Flavor(corev1.ResourceCPU, "unit-test-flavor").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(2).
+									Obj(),
+								utiltesting.MakePodSetAssignment("workers-group-0").
+									Count(2).
+									Obj(),
+							).
 							Obj(),
 					).
 					Admitted(true).

--- a/pkg/controller/tas/node_failure_controller_test.go
+++ b/pkg/controller/tas/node_failure_controller_test.go
@@ -64,19 +64,14 @@ func TestNodeFailureReconciler(t *testing.T) {
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 		ReserveQuota(
 			utiltesting.MakeAdmission("cq").
-				Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-				AssignmentPodCount(1).
-				TopologyAssignment(&kueue.TopologyAssignment{
-					Levels: []string{corev1.LabelHostname},
-					Domains: []kueue.TopologyDomainAssignment{
-						{
-							Count: 1,
-							Values: []string{
-								nodeName,
-							},
-						},
-					},
-				}).
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Flavor(corev1.ResourceCPU, "unit-test-flavor").
+					ResourceUsage(corev1.ResourceCPU, "1").
+					Count(1).
+					TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domains(utiltesting.MakeTopologyDomainAssignment([]string{nodeName}, 1).Obj()).
+						Obj()).
+					Obj()).
 				Obj(),
 		).
 		Admitted(true).
@@ -92,15 +87,17 @@ func TestNodeFailureReconciler(t *testing.T) {
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 		ReserveQuota(
 			utiltesting.MakeAdmission("cq").
-				Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-				AssignmentPodCount(2).
-				TopologyAssignment(&kueue.TopologyAssignment{
-					Levels: []string{corev1.LabelHostname},
-					Domains: []kueue.TopologyDomainAssignment{
-						{Count: 1, Values: []string{nodeName}},
-						{Count: 1, Values: []string{nodeName2}},
-					},
-				}).
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Flavor(corev1.ResourceCPU, "unit-test-flavor").
+					ResourceUsage(corev1.ResourceCPU, "1").
+					Count(2).
+					TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domains(
+							utiltesting.MakeTopologyDomainAssignment([]string{nodeName}, 1).Obj(),
+							utiltesting.MakeTopologyDomainAssignment([]string{nodeName2}, 1).Obj(),
+						).
+						Obj()).
+					Obj()).
 				Obj(),
 		).
 		Admitted(true).

--- a/pkg/controller/tas/node_failure_controller_test.go
+++ b/pkg/controller/tas/node_failure_controller_test.go
@@ -65,9 +65,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 		ReserveQuota(
 			utiltesting.MakeAdmission("cq").
 				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-					Flavor(corev1.ResourceCPU, "unit-test-flavor").
-					ResourceUsage(corev1.ResourceCPU, "1").
-					Count(1).
+					Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 					TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
 						Domains(utiltesting.MakeTopologyDomainAssignment([]string{nodeName}, 1).Obj()).
 						Obj()).
@@ -88,8 +86,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 		ReserveQuota(
 			utiltesting.MakeAdmission("cq").
 				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-					Flavor(corev1.ResourceCPU, "unit-test-flavor").
-					ResourceUsage(corev1.ResourceCPU, "1").
+					Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 					Count(2).
 					TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
 						Domains(

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -123,9 +123,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -165,8 +163,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								Count(3).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 3).Obj()).
@@ -216,8 +213,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -298,8 +294,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								Count(2).
 								Obj()).
 							Obj(),
@@ -329,8 +324,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
@@ -363,9 +357,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -395,9 +387,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -427,9 +417,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -474,9 +462,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -520,9 +506,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -577,9 +561,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -635,8 +617,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj()).
@@ -691,9 +672,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -748,8 +727,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj()).
@@ -807,8 +785,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "5").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "5").
 								Count(5).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -929,8 +906,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "5").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "5").
 								Count(5).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -1050,8 +1026,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -1148,9 +1123,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -1216,8 +1189,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -1341,8 +1313,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -1468,8 +1439,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(&kueue.TopologyAssignment{
 									Levels: defaultTestLevels,
@@ -1569,8 +1539,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -1682,8 +1651,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -1797,8 +1765,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -1904,8 +1871,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -122,20 +122,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -170,20 +164,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(3).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 3,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(3).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 3).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -227,27 +215,17 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -319,8 +297,11 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(2).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(2).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -347,20 +328,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(false).
@@ -387,20 +362,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -425,20 +394,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -463,20 +426,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -516,20 +473,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -568,20 +519,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -631,20 +576,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -695,20 +634,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
-							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -757,20 +690,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -820,20 +747,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
-							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -885,34 +806,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "5").
-							AssignmentPodCount(5).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 2,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(5).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 2).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1023,34 +928,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "5").
-							AssignmentPodCount(5).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 2,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(5).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 2).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1160,34 +1049,18 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 4).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1274,20 +1147,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1348,34 +1215,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1489,34 +1340,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1632,34 +1467,37 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(&kueue.TopologyAssignment{
+									Levels: defaultTestLevels,
+									Domains: []kueue.TopologyDomainAssignment{
+										{
+											Count: 2,
+											Values: []string{
+												"b1",
+												"r1",
+											},
+										},
+										{
+											Count: 1,
+											Values: []string{
+												"b1",
+												"r2",
+											},
+										},
+										{
+											Count: 1,
+											Values: []string{
+												"b2",
+												"r1",
+											},
 										},
 									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+								}).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1730,34 +1568,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1859,34 +1681,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1990,34 +1796,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -2113,34 +1903,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -1299,10 +1299,16 @@ func TestQueueSecondPassIfNeeded(t *testing.T) {
 			Obj())
 	baseWorkloadNeedingSecondPass := baseWorkloadBuilder.Clone().
 		ReserveQuota(
-			utiltesting.MakeAdmission("tas-main", "one").
-				Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-				DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-				AssignmentPodCount(1).Obj(),
+			utiltesting.MakeAdmission("tas-main").
+				PodSets(
+					utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+						Count(1).
+						Obj(),
+				).
+				Obj(),
 		).
 		AdmissionCheck(kueue.AdmissionCheckState{
 			Name:  "prov-check",

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -1302,10 +1302,8 @@ func TestQueueSecondPassIfNeeded(t *testing.T) {
 			utiltesting.MakeAdmission("tas-main").
 				PodSets(
 					utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-						Count(1).
 						Obj(),
 				).
 				Obj(),

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -294,14 +294,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -309,7 +317,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -334,14 +346,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -349,7 +369,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -375,14 +399,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -406,14 +438,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -436,14 +476,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "1000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "1000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -451,7 +499,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -476,14 +528,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "1000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -491,7 +551,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -516,14 +580,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceMemory, "2Gi").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceMemory, "alpha", "2Gi").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceMemory, "alpha", "2Gi").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceMemory, "1Gi").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceMemory, "beta", "1Gi").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceMemory, "beta", "1Gi").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -531,7 +603,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceMemory, "1Gi").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceMemory, "beta", "1Gi").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceMemory, "beta", "1Gi").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -561,14 +637,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("c2-mid", "").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -576,7 +660,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "6").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "6000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "6000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -638,7 +726,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -646,7 +738,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -670,7 +766,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -678,7 +778,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -686,7 +790,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -710,7 +818,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -718,7 +830,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -726,7 +842,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -756,7 +876,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -764,7 +888,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -772,7 +900,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -797,7 +929,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("d1").Assignment(corev1.ResourceCPU, "default", "4").Obj(),
+						utiltesting.MakeAdmission("d1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -805,7 +941,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("d1").Assignment(corev1.ResourceCPU, "default", "4").Obj(),
+						utiltesting.MakeAdmission("d1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -813,7 +953,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("d2").Assignment(corev1.ResourceCPU, "default", "4").Obj(),
+						utiltesting.MakeAdmission("d2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -838,7 +982,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -846,7 +994,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "5").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "5000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "5000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -854,7 +1006,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "1000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -862,7 +1018,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "1000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -892,7 +1052,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("l1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("l1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -900,7 +1064,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("l1").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("l1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -924,21 +1092,33 @@ func TestPreemption(t *testing.T) {
 				*utiltesting.MakeWorkload("c1", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("c2-1", "").
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("c2-2", "").
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -960,7 +1140,11 @@ func TestPreemption(t *testing.T) {
 				*utiltesting.MakeWorkload("c1-1", "").
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -968,14 +1152,22 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("c2", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -999,14 +1191,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("c1-mid", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1014,14 +1214,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("c2-mid", "").
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1045,7 +1253,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1069,7 +1281,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceMemory, "2Gi").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceMemory, "alpha", "2Gi").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceMemory, "alpha", "2Gi").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1077,7 +1293,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceMemory, "2Gi").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceMemory, "beta", "2Gi").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceMemory, "beta", "2Gi").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1124,7 +1344,11 @@ func TestPreemption(t *testing.T) {
 					Priority(2).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("preventStarvation").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
+						utiltesting.MakeAdmission("preventStarvation").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1133,7 +1357,11 @@ func TestPreemption(t *testing.T) {
 					Creation(now).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("preventStarvation").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
+						utiltesting.MakeAdmission("preventStarvation").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2").
+								Obj()).
+							Obj(),
 						now.Add(time.Second),
 					).
 					Obj(),
@@ -1142,7 +1370,11 @@ func TestPreemption(t *testing.T) {
 					Creation(now).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("preventStarvation").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
+						utiltesting.MakeAdmission("preventStarvation").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1178,7 +1410,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a_best_effort").Assignment(corev1.ResourceCPU, "default", "10").Obj(),
+						utiltesting.MakeAdmission("a_best_effort").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "10").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1186,7 +1422,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_best_effort").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b_best_effort").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1210,7 +1450,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_standard").Assignment(corev1.ResourceCPU, "default", "10000m").Obj(),
+						utiltesting.MakeAdmission("b_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "10000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1235,7 +1479,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "13").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_standard").Assignment(corev1.ResourceCPU, "default", "13000m").Obj(),
+						utiltesting.MakeAdmission("b_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "13000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1261,7 +1509,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "13").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a_standard").Assignment(corev1.ResourceCPU, "default", "13000m").Obj(),
+						utiltesting.MakeAdmission("a_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "13000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1285,7 +1537,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a_standard").Assignment(corev1.ResourceCPU, "default", "10").Obj(),
+						utiltesting.MakeAdmission("a_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "10").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1293,7 +1549,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a_standard").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1301,7 +1561,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_standard").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1309,7 +1573,11 @@ func TestPreemption(t *testing.T) {
 					Priority(2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_standard").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1334,7 +1602,11 @@ func TestPreemption(t *testing.T) {
 					Priority(2).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_standard").Assignment(corev1.ResourceCPU, "default", "10").Obj(),
+						utiltesting.MakeAdmission("b_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "10").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1342,7 +1614,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_standard").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1350,7 +1626,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a_best_effort").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a_best_effort").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1358,7 +1638,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a_best_effort").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a_best_effort").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1383,14 +1667,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend1").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("lend1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("lend2-mid", "").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend2").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("lend2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1398,7 +1690,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("lend2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1423,14 +1719,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend1").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("lend1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("lend1-mid", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend1").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("lend1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1438,14 +1742,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend2").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("lend2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("lend2-mid", "").
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("lend2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1469,7 +1781,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend2").Assignment(corev1.ResourceCPU, "default", "10").Obj(),
+						utiltesting.MakeAdmission("lend2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "10").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1493,7 +1809,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1501,7 +1821,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1509,7 +1833,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1517,7 +1845,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1525,7 +1857,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1533,7 +1869,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1559,7 +1899,12 @@ func TestPreemption(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Assignment(corev1.ResourceMemory, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Assignment(corev1.ResourceMemory, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1568,7 +1913,12 @@ func TestPreemption(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Assignment(corev1.ResourceMemory, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Assignment(corev1.ResourceMemory, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1577,7 +1927,12 @@ func TestPreemption(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Assignment(corev1.ResourceMemory, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Assignment(corev1.ResourceMemory, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1586,7 +1941,12 @@ func TestPreemption(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Assignment(corev1.ResourceMemory, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Assignment(corev1.ResourceMemory, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1595,7 +1955,12 @@ func TestPreemption(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Assignment(corev1.ResourceMemory, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Assignment(corev1.ResourceMemory, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1604,7 +1969,12 @@ func TestPreemption(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Assignment(corev1.ResourceMemory, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Assignment(corev1.ResourceMemory, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1634,7 +2004,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1642,7 +2016,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1650,7 +2028,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1658,7 +2040,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1666,7 +2052,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1674,7 +2064,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1704,7 +2098,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1712,7 +2110,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1720,7 +2122,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1728,7 +2134,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1736,7 +2146,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1744,7 +2158,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1788,7 +2206,11 @@ func TestPreemption(t *testing.T) {
 				*utiltesting.MakeWorkload("to-be-preempted", "").
 					Request(corev1.ResourceCPU, "5").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("cq-right").Assignment(corev1.ResourceCPU, "default", "5").Obj(),
+						utiltesting.MakeAdmission("cq-right").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "5").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -2928,7 +3350,8 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -2988,13 +3411,15 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-10).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_nominal").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted2", "").
 					Priority(0).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3046,13 +3471,15 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted2", "").
 					Priority(2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3110,19 +3537,22 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_preemptible", "").
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_own_queue", "").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3176,13 +3606,15 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_queue", "").
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3248,13 +3680,15 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-10).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_nominal").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_cohort", "").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3315,13 +3749,15 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(10).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "3").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_cohort", "").
 					Priority(10).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "3").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3389,19 +3825,22 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_cohort_preemptible", "").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_not_preemptible", "").
 					Priority(1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3469,19 +3908,22 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_queue_preemptible", "").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_not_preemptible", "").
 					Priority(1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3543,25 +3985,29 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(8).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_prio_9", "").
 					Priority(9).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_prio_10", "").
 					Priority(9).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_nominal", "").
 					Priority(-2).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_nominal").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3626,19 +4072,22 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-10).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_other").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_other_2", "").
 					Priority(-10).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_other").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_cohort", "").
 					Priority(0).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3702,16 +4151,18 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Request(corev1.ResourceCPU, "3").
 					Request(corev1.ResourceMemory, "1Gi").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "3").
-						Assignment(corev1.ResourceMemory, "default", "1Gi").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").
+							Assignment(corev1.ResourceMemory, "default", "1Gi").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_cohort", "").
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "3Gi").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "1").
-						Assignment(corev1.ResourceMemory, "default", "3Gi").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").
+							Assignment(corev1.ResourceMemory, "default", "3Gi").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3780,13 +4231,15 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-10).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("evicted_same_cohort", "").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					SetOrReplaceCondition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
 						Status:             metav1.ConditionTrue,
@@ -3845,7 +4298,8 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3955,49 +4409,57 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-6).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuota(utiltesting.MakeAdmission("q1").
-						Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_2", "").
 					Priority(-5).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuota(utiltesting.MakeAdmission("q1").
-						Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_3", "").
 					Priority(-9).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuota(utiltesting.MakeAdmission("q2").
-						Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_4", "").
 					Priority(-10).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuota(utiltesting.MakeAdmission("q2").
-						Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_5", "").
 					Priority(-4).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuota(utiltesting.MakeAdmission("q3").
-						Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_6", "").
 					Priority(-3).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("q3").
-						Assignment(corev1.ResourceCPU, "default", "3").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_7", "").
 					Priority(4).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q4").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_8", "").
 					Priority(2).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("q4").
-						Assignment(corev1.ResourceCPU, "default", "3").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4548,15 +4548,23 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "launcher", "worker").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Obj()).
-					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "0").
-					AssignmentPodCountWithIndex(1, 0).
-					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("launcher").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+						utiltesting.MakePodSetAssignment("worker").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "0").
+							Count(0).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -4919,34 +4927,50 @@ func TestScheduleForTAS(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one", "two").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
-								Obj()).
-							AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCountWithIndex(1, 1).
-							TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-								Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(
+								utiltesting.MakePodSetAssignment("one").
+									Flavor(corev1.ResourceCPU, "tas-default").
+									ResourceUsage(corev1.ResourceCPU, "1000m").
+									Count(1).
+									TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+										Obj()).
+									Obj(),
+								utiltesting.MakePodSetAssignment("two").
+									Flavor(corev1.ResourceCPU, "tas-default").
+									ResourceUsage(corev1.ResourceCPU, "1000m").
+									Count(1).
+									TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+										Obj()).
+									Obj(),
+							).
 							Obj(),
 					).
 					Admitted(true).
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one", "two").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
-						Obj()).
-					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCountWithIndex(1, 1).
-					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+								Obj()).
+							Obj(),
+						utiltesting.MakePodSetAssignment("two").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 		},
@@ -5907,18 +5931,26 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "launcher", "worker").
-					AssignmentWithIndex(0, corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCountWithIndex(0, 1).
-					TopologyAssignmentWithIndex(0, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Obj()).
-					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "15000m").
-					AssignmentPodCountWithIndex(1, 15).
-					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 8).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("launcher").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+						utiltesting.MakePodSetAssignment("worker").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "15000m").
+							Count(15).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 8).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5974,18 +6006,26 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "launcher", "worker").
-					AssignmentWithIndex(0, corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCountWithIndex(0, 1).
-					TopologyAssignmentWithIndex(0, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Obj()).
-					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "15000m").
-					AssignmentPodCountWithIndex(1, 15).
-					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 8).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("launcher").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+						utiltesting.MakePodSetAssignment("worker").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "15000m").
+							Count(15).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 8).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4696,22 +4696,12 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "launcher", "worker").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
 					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "0").
 					AssignmentPodCountWithIndex(1, 0).
-					TopologyAssignmentWithIndex(1, &kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-					}).
+					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).Obj()).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -4750,17 +4740,10 @@ func TestScheduleForTAS(t *testing.T) {
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
 					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -4818,17 +4801,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-reservation", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -4854,17 +4830,9 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -4874,17 +4842,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 		},
 		"workload with nodeToReplace annotation; second pass; preferred; fit in different rack": {
@@ -4905,23 +4866,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -4931,23 +4879,11 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-							{
-								Count: 1,
-								Values: []string{
-									"x5",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x5"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 		},
 		"workload with nodeToReplace annotation; second pass; preferred; no fit": {
@@ -4968,17 +4904,9 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "3000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -4988,17 +4916,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "3000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x0",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "foo", "SecondPassFailed", corev1.EventTypeWarning).
@@ -5024,23 +4945,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"x2",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -5050,23 +4958,11 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x2",
-								},
-							},
-							{
-								Count: 1,
-								Values: []string{
-									"x3",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x3"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 		},
 		"workload with nodeToReplace annotation; second pass; required rack for a single node; fit": {
@@ -5087,17 +4983,9 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -5107,17 +4995,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 		},
 		"workload with nodeToReplace annotation; second pass; required rack; no fit": {
@@ -5138,23 +5019,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -5164,23 +5032,11 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x0",
-								},
-							},
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "foo", "SecondPassFailed", corev1.EventTypeWarning).
@@ -5211,30 +5067,14 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one", "two").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
 							AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCountWithIndex(1, 1).
-							TopologyAssignmentWithIndex(1, &kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).
+							TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -5244,30 +5084,14 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one", "two").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x2",
-								},
-							},
-						},
-					}).
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+						Obj()).
 					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCountWithIndex(1, 1).
-					TopologyAssignmentWithIndex(1, &kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).
+					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
 					Obj(),
 			},
 		},
@@ -5315,17 +5139,10 @@ func TestScheduleForTAS(t *testing.T) {
 					Assignment(corev1.ResourceCPU, "tas-default", "26").
 					AssignmentPodCount(26).
 					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 26,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 26).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -5394,17 +5211,10 @@ func TestScheduleForTAS(t *testing.T) {
 					Assignment(corev1.ResourceCPU, "tas-second", "1000m").
 					AssignmentPodCount(1).
 					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -5478,17 +5288,9 @@ func TestScheduleForTAS(t *testing.T) {
 										corev1.ResourceCPU: resource.MustParse("1"),
 									},
 									Count: ptr.To[int32](1),
-									TopologyAssignment: &kueue.TopologyAssignment{
-										Levels: utiltas.Levels(&defaultSingleLevelTopology),
-										Domains: []kueue.TopologyDomainAssignment{
-											{
-												Count: 1,
-												Values: []string{
-													"x1",
-												},
-											},
-										},
-									},
+									TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+										Obj(),
 								},
 								kueue.PodSetAssignment{
 									Name: "two",
@@ -5521,17 +5323,9 @@ func TestScheduleForTAS(t *testing.T) {
 								corev1.ResourceCPU: resource.MustParse("1"),
 							},
 							Count: ptr.To[int32](1),
-							TopologyAssignment: &kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							},
+							TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj(),
 						},
 						kueue.PodSetAssignment{
 							Name: "two",
@@ -5543,17 +5337,9 @@ func TestScheduleForTAS(t *testing.T) {
 							},
 							Count:                  ptr.To[int32](1),
 							DelayedTopologyRequest: ptr.To(kueue.DelayedTopologyRequestStateReady),
-							TopologyAssignment: &kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							},
+							TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj(),
 						},
 					).Obj(),
 			},
@@ -5652,17 +5438,10 @@ func TestScheduleForTAS(t *testing.T) {
 					Assignment(corev1.ResourceCPU, "tas-second", "1000m").
 					AssignmentPodCount(1).
 					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -5722,17 +5501,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -5762,17 +5534,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -5806,17 +5571,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -5905,17 +5663,9 @@ func TestScheduleForTAS(t *testing.T) {
 								corev1.ResourceCPU: resource.MustParse("500m"),
 							},
 							Count: ptr.To[int32](1),
-							TopologyAssignment: &kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							},
+							TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj(),
 						},
 					).
 					Obj(),
@@ -5944,17 +5694,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6030,17 +5773,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-custom-flavor", "1").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: []string{"cloud.com/custom-level"},
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{"cloud.com/custom-level"}).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6090,17 +5826,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -6174,17 +5903,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "400m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -6197,17 +5919,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "500m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6236,17 +5951,10 @@ func TestScheduleForTAS(t *testing.T) {
 							Assignment(corev1.ResourceCPU, "tas-default", "500m").
 							Assignment(corev1.ResourceMemory, "tas-default", "500Mi").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -6261,17 +5969,10 @@ func TestScheduleForTAS(t *testing.T) {
 					Assignment(corev1.ResourceCPU, "tas-default", "500m").
 					Assignment(corev1.ResourceMemory, "tas-default", "500Mi").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6384,36 +6085,15 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "launcher", "worker").
 					AssignmentWithIndex(0, corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCountWithIndex(0, 1).
-					TopologyAssignmentWithIndex(0, &kueue.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).
+					TopologyAssignmentWithIndex(0, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
 					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "15000m").
 					AssignmentPodCountWithIndex(1, 15).
-					TopologyAssignmentWithIndex(1, &kueue.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 7,
-								Values: []string{
-									"x1",
-								},
-							},
-							{
-								Count: 8,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).
+					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 8).Obj()).
+						Obj()).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -6472,36 +6152,15 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "launcher", "worker").
 					AssignmentWithIndex(0, corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCountWithIndex(0, 1).
-					TopologyAssignmentWithIndex(0, &kueue.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).
+					TopologyAssignmentWithIndex(0, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
 					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "15000m").
 					AssignmentPodCountWithIndex(1, 15).
-					TopologyAssignmentWithIndex(1, &kueue.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 7,
-								Values: []string{
-									"x1",
-								},
-							},
-							{
-								Count: 8,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).
+					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 8).Obj()).
+						Obj()).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -6550,17 +6209,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -6573,17 +6225,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6648,17 +6293,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6685,17 +6323,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6739,17 +6370,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "150m").
 							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 2).
@@ -6786,17 +6410,10 @@ func TestScheduleForTAS(t *testing.T) {
 					Assignment(corev1.ResourceCPU, "tas-default", "0").
 					Assignment(corev1.ResourceMemory, "tas-default", "10Mi").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -7030,17 +6647,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"z1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"z1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7085,17 +6695,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7144,17 +6747,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7199,17 +6795,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "2").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7224,17 +6813,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "2").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7281,17 +6863,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "4").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7306,17 +6881,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "4").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7372,17 +6940,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "4").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7626,23 +7187,11 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "6").
 					AssignmentPodCount(6).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-							{
-								Count: 5,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -7664,17 +7213,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(5).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 5,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 5).
@@ -7716,17 +7258,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(5).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 5,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 5).
@@ -7741,17 +7276,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "2").
 							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 2).
@@ -7766,17 +7294,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7820,17 +7341,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(5).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 5,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 4).
@@ -7845,17 +7359,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "3").
 							AssignmentPodCount(3).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 3,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 3).
@@ -7900,23 +7407,11 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(5).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 3,
-										Values: []string{
-											"x1",
-										},
-									},
-									{
-										Count: 2,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 5).
@@ -7931,17 +7426,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7956,17 +7444,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -8031,31 +7512,17 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "5").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 				"default/b1": *utiltesting.MakeAdmission("tas-cq-b", "one").
 					Assignment(corev1.ResourceMemory, "tas-default", "5").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -8092,31 +7559,17 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 				"default/b1": *utiltesting.MakeAdmission("tas-cq-b", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "2").
 					AssignmentPodCount(2).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 2,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -8153,17 +7606,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]string{
 				"tas-cq-b": {"default/b1"},
@@ -8205,17 +7651,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "5").
 					AssignmentPodCount(5).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 5,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -8253,17 +7692,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "2").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]string{
 				"tas-cq-b": {"default/b1"},
@@ -8297,17 +7729,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "2").
 							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 2).
@@ -8366,17 +7791,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "2").
 							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 2).
@@ -8435,17 +7853,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "2").
 							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 2).
@@ -8485,17 +7896,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/b1": *utiltesting.MakeAdmission("tas-cq-b", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "3").
 					AssignmentPodCount(3).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 3,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 3).Obj()).
+						Obj()).
+					Obj(),
 			},
 		},
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -235,7 +235,11 @@ func TestSchedule(t *testing.T) {
 				*utiltesting.MakeWorkload("admitted", "eng-alpha").
 					Queue("other").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("new", "eng-alpha").
@@ -645,20 +649,40 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 				*utiltesting.MakeWorkload("user-on-demand", "eng-beta").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "50000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50000m").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("user-spot", "eng-beta").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "spot", "1000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "spot", "1000m").
+							Obj()).
+						Obj()).
 					Obj(),
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]string{
 				"eng-alpha": {"eng-alpha/can-reclaim"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-beta/user-spot":       *utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "spot", "1000m").Obj(),
-				"eng-beta/user-on-demand":  *utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "50000m").Obj(),
-				"eng-beta/needs-to-borrow": *utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "1000m").Obj(),
+				"eng-beta/user-spot": *utiltesting.MakeAdmission("eng-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "1000m").
+						Obj()).
+					Obj(),
+				"eng-beta/user-on-demand": *utiltesting.MakeAdmission("eng-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "50000m").
+						Obj()).
+					Obj(),
+				"eng-beta/needs-to-borrow": *utiltesting.MakeAdmission("eng-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1000m").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []string{
 				"eng-beta/needs-to-borrow",
@@ -668,7 +692,11 @@ func TestSchedule(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "lend").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("lend-b").Assignment(corev1.ResourceCPU, "default", "2000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("lend-b").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2000m").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b", "lend").
 					Queue("lend-b-queue").
@@ -676,7 +704,11 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"lend/a": *utiltesting.MakeAdmission("lend-b").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+				"lend/a": *utiltesting.MakeAdmission("lend-b").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2000m").
+						Obj()).
+					Obj(),
 			},
 			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]string{
 				"lend-b": {"lend/b"},
@@ -687,7 +719,11 @@ func TestSchedule(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "lend").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("lend-b").Assignment(corev1.ResourceCPU, "default", "2000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("lend-b").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2000m").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b", "lend").
 					Queue("lend-b-queue").
@@ -695,8 +731,16 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"lend/a": *utiltesting.MakeAdmission("lend-b").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
-				"lend/b": *utiltesting.MakeAdmission("lend-b").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+				"lend/a": *utiltesting.MakeAdmission("lend-b").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2000m").
+						Obj()).
+					Obj(),
+				"lend/b": *utiltesting.MakeAdmission("lend-b").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "3000m").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []string{
 				"lend/b",
@@ -710,21 +754,37 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 				*utiltesting.MakeWorkload("use-all-spot", "eng-alpha").
 					Request(corev1.ResourceCPU, "100").
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "spot", "100000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "spot", "100000m").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("low-1", "eng-beta").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "30").
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "30000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "30000m").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("low-2", "eng-beta").
 					Priority(-2).
 					Request(corev1.ResourceCPU, "10").
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "10000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "10000m").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("borrower", "eng-alpha").
 					Request(corev1.ResourceCPU, "60").
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "60000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "60000m").
+							Obj()).
+						Obj()).
 					Obj(),
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]string{
@@ -733,11 +793,27 @@ func TestSchedule(t *testing.T) {
 			},
 			wantPreempted: sets.New("eng-alpha/borrower", "eng-beta/low-2"),
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/use-all-spot": *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "spot", "100").Obj(),
-				"eng-beta/low-1":         *utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "30").Obj(),
+				"eng-alpha/use-all-spot": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "100").
+						Obj()).
+					Obj(),
+				"eng-beta/low-1": *utiltesting.MakeAdmission("eng-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "30").
+						Obj()).
+					Obj(),
 				// Removal from cache for the preempted workloads is deferred until we receive Workload updates
-				"eng-beta/low-2":     *utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
-				"eng-alpha/borrower": *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "60").Obj(),
+				"eng-beta/low-2": *utiltesting.MakeAdmission("eng-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
+				"eng-alpha/borrower": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "60").
+						Obj()).
+					Obj(),
 			},
 		},
 		"multiple CQs need preemption": {
@@ -778,7 +854,11 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 				*utiltesting.MakeWorkload("use-all", "eng-alpha").
 					Request(corev1.ResourceCPU, "100").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "100").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "100").
+							Obj()).
+						Obj()).
 					Obj(),
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]string{
@@ -791,7 +871,11 @@ func TestSchedule(t *testing.T) {
 			wantPreempted: sets.New("eng-alpha/use-all"),
 			wantAssignments: map[string]kueue.Admission{
 				// Removal from cache for the preempted workloads is deferred until we receive Workload updates
-				"eng-alpha/use-all": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "100").Obj(),
+				"eng-alpha/use-all": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "100").
+						Obj()).
+					Obj(),
 			},
 		},
 		"cannot borrow resource not listed in clusterQueue": {
@@ -1473,21 +1557,33 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 1).
 						Request(corev1.ResourceCPU, "10").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("d", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("d", "one").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Assignment(corev1.ResourceCPU, "on-demand", "10").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("e0", "eng-alpha").
 					Queue("lq-e").
 					PodSets(*utiltesting.MakePodSet("one", 1).
 						Request(corev1.ResourceCPU, "20").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("e", "one").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("e", "one").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Assignment(corev1.ResourceCPU, "on-demand", "20").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("g0", "eng-alpha").
 					Queue("lq-g").
 					PodSets(*utiltesting.MakePodSet("one", 1).
 						Request(corev1.ResourceCPU, "100").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("g", "one").Assignment(corev1.ResourceCPU, "on-demand", "100").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("g", "one").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Assignment(corev1.ResourceCPU, "on-demand", "100").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("d1", "eng-alpha").
 					Queue("lq-d").
@@ -1515,10 +1611,26 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/d0": *utiltesting.MakeAdmission("d", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
-				"eng-alpha/e0": *utiltesting.MakeAdmission("e", "one").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-alpha/g0": *utiltesting.MakeAdmission("g", "one").Assignment(corev1.ResourceCPU, "on-demand", "100").Obj(),
-				"eng-alpha/d1": *utiltesting.MakeAdmission("d", "one").Assignment(corev1.ResourceCPU, "on-demand", "70").Obj(),
+				"eng-alpha/d0": *utiltesting.MakeAdmission("d", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
+				"eng-alpha/e0": *utiltesting.MakeAdmission("e", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-alpha/g0": *utiltesting.MakeAdmission("g", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "100").
+						Obj()).
+					Obj(),
+				"eng-alpha/d1": *utiltesting.MakeAdmission("d", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "70").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []string{"eng-alpha/d1"},
 			wantLeft: map[kueue.ClusterQueueReference][]string{
@@ -1565,7 +1677,11 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 1).
 						Request(corev1.ResourceCPU, "10").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("b", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("b", "one").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Assignment(corev1.ResourceCPU, "on-demand", "10").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-alpha").
 					Queue("lq-b").
@@ -1581,8 +1697,16 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/b0": *utiltesting.MakeAdmission("b", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
-				"eng-alpha/b1": *utiltesting.MakeAdmission("b", "one").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj(),
+				"eng-alpha/b0": *utiltesting.MakeAdmission("b", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
+				"eng-alpha/b1": *utiltesting.MakeAdmission("b", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "50").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []string{"eng-alpha/b1"},
 			wantLeft: map[kueue.ClusterQueueReference][]string{
@@ -1658,9 +1782,21 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("a", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
-				"eng-alpha/b1": *utiltesting.MakeAdmission("b", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
-				"eng-alpha/c1": *utiltesting.MakeAdmission("c", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("a", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
+				"eng-alpha/b1": *utiltesting.MakeAdmission("b", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
+				"eng-alpha/c1": *utiltesting.MakeAdmission("c", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []string{"eng-alpha/a1", "eng-alpha/b1", "eng-alpha/c1"},
 			wantLeft:      nil,
@@ -1710,7 +1846,11 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/c1": *utiltesting.MakeAdmission("c", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
+				"eng-alpha/c1": *utiltesting.MakeAdmission("c", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []string{"eng-alpha/c1"},
 			wantLeft: map[kueue.ClusterQueueReference][]string{
@@ -1764,7 +1904,11 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/c1": *utiltesting.MakeAdmission("c", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
+				"eng-alpha/c1": *utiltesting.MakeAdmission("c", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []string{"eng-alpha/c1"},
 			wantLeft: map[kueue.ClusterQueueReference][]string{
@@ -1809,37 +1953,61 @@ func TestSchedule(t *testing.T) {
 					Priority(-2).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("a2", "eng-alpha").
 					Priority(-2).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("a3", "eng-alpha").
 					Priority(-1).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b2", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b3", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("incoming", "eng-alpha").
 					Priority(0).
@@ -1852,12 +2020,36 @@ func TestSchedule(t *testing.T) {
 				"other-alpha": {"eng-alpha/incoming"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
-				"eng-alpha/a2": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
-				"eng-alpha/a3": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
-				"eng-beta/b2":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
-				"eng-beta/b3":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-alpha/a2": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-alpha/a3": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-beta/b2": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-beta/b3": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
 			},
 		},
 		"A workload is only eligible to do preemptions if it fits fully within nominal quota": {
@@ -1890,13 +2082,21 @@ func TestSchedule(t *testing.T) {
 					Priority(-1).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-beta").
 					Priority(-1).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("incoming", "eng-alpha").
 					Priority(1).
@@ -1908,8 +2108,16 @@ func TestSchedule(t *testing.T) {
 				"other-alpha": {"eng-alpha/incoming"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
 			},
 		},
 		"with fair sharing: preempt workload from CQ with the highest share": {
@@ -1961,15 +2169,51 @@ func TestSchedule(t *testing.T) {
 				"eng-beta": {"eng-beta/preemptor"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/all_spot": *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "spot", "100").Obj(),
-				"eng-alpha/alpha1":   *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-alpha/alpha2":   *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-alpha/alpha3":   *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-alpha/alpha4":   *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-gamma/gamma1":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
-				"eng-gamma/gamma2":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-gamma/gamma3":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-gamma/gamma4":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"eng-alpha/all_spot": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "100").
+						Obj()).
+					Obj(),
+				"eng-alpha/alpha1": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-alpha/alpha2": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-alpha/alpha3": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-alpha/alpha4": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-gamma/gamma1": *utiltesting.MakeAdmission("eng-gamma").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
+				"eng-gamma/gamma2": *utiltesting.MakeAdmission("eng-gamma").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-gamma/gamma3": *utiltesting.MakeAdmission("eng-gamma").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-gamma/gamma4": *utiltesting.MakeAdmission("eng-gamma").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 		},
 		"multiple preemptions without borrowing": {
@@ -2007,13 +2251,21 @@ func TestSchedule(t *testing.T) {
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("preemptor", "eng-alpha").
 					Priority(100).
@@ -2032,8 +2284,16 @@ func TestSchedule(t *testing.T) {
 				"other-beta":  {"eng-beta/preemptor"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2").
+						Obj()).
+					Obj(),
 			},
 			wantSkippedPreemptions: map[string]int{
 				"other-alpha": 0,
@@ -2075,7 +2335,11 @@ func TestSchedule(t *testing.T) {
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("fit", "eng-alpha").
 					Priority(100).
@@ -2093,8 +2357,16 @@ func TestSchedule(t *testing.T) {
 				"other-beta": {"eng-beta/preemptor"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/fit": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
-				"eng-beta/b1":   *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
+				"eng-alpha/fit": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "1").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []string{"eng-alpha/fit"},
 			wantSkippedPreemptions: map[string]int{
@@ -2155,13 +2427,21 @@ func TestSchedule(t *testing.T) {
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("preemptor", "eng-alpha").
 					Priority(100).
@@ -2180,8 +2460,16 @@ func TestSchedule(t *testing.T) {
 				"other-beta":  {"eng-beta/pretending-preemptor"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2").
+						Obj()).
+					Obj(),
 			},
 			wantSkippedPreemptions: map[string]int{
 				"other-alpha": 0,
@@ -2245,22 +2533,25 @@ func TestSchedule(t *testing.T) {
 					Queue("other").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
-						Assignment(corev1.ResourceCPU, "default", "3").
-						Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").
+							Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("other-beta").
-						Assignment(corev1.ResourceCPU, "default", "3").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("c1", "eng-gamma").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("other-gamma").
-						Assignment(corev1.ResourceCPU, "default", "3").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("preemptor", "eng-alpha").
 					Priority(100).
@@ -2286,11 +2577,14 @@ func TestSchedule(t *testing.T) {
 			},
 			wantAssignments: map[string]kueue.Admission{
 				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
-					Assignment(corev1.ResourceCPU, "default", "3").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(),
 				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
-					Assignment(corev1.ResourceCPU, "default", "3").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(),
 				"eng-gamma/c1": *utiltesting.MakeAdmission("other-gamma").
-					Assignment(corev1.ResourceCPU, "default", "3").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(),
 			},
 			wantSkippedPreemptions: map[string]int{
 				"other-alpha": 0,
@@ -2361,15 +2655,17 @@ func TestSchedule(t *testing.T) {
 					Queue("other").
 					Request("alpha-resource", "1").
 					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
-						Assignment("alpha-resource", "default", "1").
-						Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment("alpha-resource", "default", "1").
+							Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request("beta-resource", "1").
 					ReserveQuota(utiltesting.MakeAdmission("other-beta").
-						Assignment("beta-resource", "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment("beta-resource", "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("c1", "eng-gamma").
 					Priority(0).
@@ -2377,7 +2673,8 @@ func TestSchedule(t *testing.T) {
 					Request(corev1.ResourceCPU, "9").
 					Request("gamma-resource", "1").
 					ReserveQuota(utiltesting.MakeAdmission("other-gamma").
-						Assignment(corev1.ResourceCPU, "default", "9").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "9").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("preemptor", "eng-alpha").
 					Priority(100).
@@ -2399,11 +2696,14 @@ func TestSchedule(t *testing.T) {
 			},
 			wantAssignments: map[string]kueue.Admission{
 				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
-					Assignment("alpha-resource", "default", "1").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("alpha-resource", "default", "1").Obj()).Obj(),
 				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
-					Assignment("beta-resource", "default", "1").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("beta-resource", "default", "1").Obj()).Obj(),
 				"eng-gamma/c1": *utiltesting.MakeAdmission("other-gamma").
-					Assignment(corev1.ResourceCPU, "default", "9").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "9").Obj()).Obj(),
 			},
 			wantSkippedPreemptions: map[string]int{
 				"other-alpha": 0,
@@ -2551,8 +2851,16 @@ func TestSchedule(t *testing.T) {
 				"other-alpha": {"eng-alpha/preemptor"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment("gpu", "on-demand", "5").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment("gpu", "spot", "5").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "5").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "5").
+						Obj()).
+					Obj(),
 			},
 		},
 		"with fair sharing: prefer reclamation over cq priority based preemption; with preemption while borrowing": {
@@ -2610,8 +2918,16 @@ func TestSchedule(t *testing.T) {
 				"other-alpha": {"eng-alpha/preemptor"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment("gpu", "on-demand", "5").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment("gpu", "spot", "5").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "5").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "5").
+						Obj()).
+					Obj(),
 			},
 		},
 		"prefer first preemption flavor when second flavor requires both reclaim and cq priority preemption": {
@@ -2672,9 +2988,21 @@ func TestSchedule(t *testing.T) {
 				"other-alpha": {"eng-alpha/preemptor"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment("gpu", "on-demand", "5").Obj(),
-				"eng-alpha/a2": *utiltesting.MakeAdmission("other-alpha").Assignment("gpu", "spot", "5").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment("gpu", "spot", "5").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "5").
+						Obj()).
+					Obj(),
+				"eng-alpha/a2": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "5").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "5").
+						Obj()).
+					Obj(),
 			},
 		},
 		"prefer first preemption flavor when second flavor also requires cq preemption": {
@@ -2737,9 +3065,21 @@ func TestSchedule(t *testing.T) {
 				"other-alpha": {"eng-alpha/preemptor"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment("gpu", "on-demand", "6").Obj(),
-				"eng-alpha/a2": *utiltesting.MakeAdmission("other-alpha").Assignment("gpu", "spot", "5").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment("gpu", "spot", "5").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "6").
+						Obj()).
+					Obj(),
+				"eng-alpha/a2": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "5").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "5").
+						Obj()).
+					Obj(),
 			},
 		},
 		"workload requiring reclaimation prioritized over wl in another full cq": {
@@ -2841,9 +3181,21 @@ func TestSchedule(t *testing.T) {
 				"CQ1": {"eng-alpha/WL1"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/Admitted-Workload-1": *utiltesting.MakeAdmission("CQ1").Assignment("gpu", "on-demand", "5").Obj(),
-				"eng-gamma/Admitted-Workload-2": *utiltesting.MakeAdmission("CQ3").Assignment("gpu", "on-demand", "5").Obj(),
-				"eng-gamma/Admitted-Workload-3": *utiltesting.MakeAdmission("CQ3").Assignment("gpu", "on-demand", "5").Obj(),
+				"eng-alpha/Admitted-Workload-1": *utiltesting.MakeAdmission("CQ1").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "5").
+						Obj()).
+					Obj(),
+				"eng-gamma/Admitted-Workload-2": *utiltesting.MakeAdmission("CQ3").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "5").
+						Obj()).
+					Obj(),
+				"eng-gamma/Admitted-Workload-3": *utiltesting.MakeAdmission("CQ3").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "5").
+						Obj()).
+					Obj(),
 			},
 		},
 		// ClusterQueueA has 2 capacity, 1 admitted workload (req=1), and 1 pending workload (req=2)
@@ -2895,8 +3247,16 @@ func TestSchedule(t *testing.T) {
 				"eng-beta/b1-pending",
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/a1-admitted": *utiltesting.MakeAdmission("ClusterQueueA").Assignment("gpu", "on-demand", "1").Obj(),
-				"eng-beta/b1-pending":   *utiltesting.MakeAdmission("ClusterQueueB").Assignment("gpu", "on-demand", "1").Obj(),
+				"eng-alpha/a1-admitted": *utiltesting.MakeAdmission("ClusterQueueA").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-beta/b1-pending": *utiltesting.MakeAdmission("ClusterQueueB").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "1").
+						Obj()).
+					Obj(),
 			},
 		},
 		// ClusterQueueA has 2 capacity, 1 admitted workload (req=1), and 1 pending workload (req=2)
@@ -2947,7 +3307,11 @@ func TestSchedule(t *testing.T) {
 				"ClusterQueueA": {"eng-alpha/a2-pending"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/a1-admitted": *utiltesting.MakeAdmission("ClusterQueueA").Assignment("gpu", "on-demand", "1").Obj(),
+				"eng-alpha/a1-admitted": *utiltesting.MakeAdmission("ClusterQueueA").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "1").
+						Obj()).
+					Obj(),
 			},
 		},
 		// ClusterQueueA has 2 capacity, 1 admitted workload (req=1), and 1 pending workload (req=2)
@@ -2998,7 +3362,11 @@ func TestSchedule(t *testing.T) {
 				"ClusterQueueA": {"eng-alpha/a2-pending"},
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/a1-admitted": *utiltesting.MakeAdmission("ClusterQueueA").Assignment("gpu", "on-demand", "1").Obj(),
+				"eng-alpha/a1-admitted": *utiltesting.MakeAdmission("ClusterQueueA").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "1").
+						Obj()).
+					Obj(),
 			},
 		},
 		//
@@ -3055,7 +3423,11 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/guaranteed": *utiltesting.MakeAdmission("guaranteed", "one").Assignment(corev1.ResourceCPU, "default", "4").Obj(),
+				"eng-alpha/guaranteed": *utiltesting.MakeAdmission("guaranteed", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "default", "4").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []string{"eng-alpha/guaranteed"},
 			wantLeft: map[kueue.ClusterQueueReference][]string{
@@ -3120,8 +3492,16 @@ func TestSchedule(t *testing.T) {
 			},
 			wantScheduled: []string{"eng-alpha/new"},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/new":      *utiltesting.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "spot", "1").Obj(),
-				"eng-alpha/admitted": *utiltesting.MakeAdmission("cq2").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
+				"eng-alpha/new": *utiltesting.MakeAdmission("cq1").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "1").
+						Obj()).
+					Obj(),
+				"eng-alpha/admitted": *utiltesting.MakeAdmission("cq2").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
 			},
 		},
 	}
@@ -3668,7 +4048,11 @@ func TestLastSchedulingContext(t *testing.T) {
 				*utiltesting.MakeWorkload("low-1", "default").
 					Queue("main").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3682,14 +4066,20 @@ func TestLastSchedulingContext(t *testing.T) {
 				*utiltesting.MakeWorkload("low-1", "default").
 					Queue("main").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
+					ReserveQuota(
+						utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).Obj(),
+					).
 					Admitted(true).
 					Obj(),
 			},
 			wantPreempted:                 sets.Set[string]{},
 			wantAdmissionsOnFirstSchedule: map[string]kueue.Admission{},
 			wantAdmissionsOnSecondSchedule: map[string]kueue.Admission{
-				"default/preemptor": *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"default/preemptor": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 		},
 		{
@@ -3698,7 +4088,11 @@ func TestLastSchedulingContext(t *testing.T) {
 			admittedWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder", "default").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3715,13 +4109,33 @@ func TestLastSchedulingContext(t *testing.T) {
 			deleteWorkloads: []kueue.Workload{},
 			wantPreempted:   sets.Set[string]{},
 			wantAdmissionsOnFirstSchedule: map[string]kueue.Admission{
-				"default/workload1": *utiltesting.MakeAdmission("eng-cohort-beta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"default/borrower":  *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"default/workload1": *utiltesting.MakeAdmission("eng-cohort-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"default/borrower": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 			wantAdmissionsOnSecondSchedule: map[string]kueue.Admission{
-				"default/placeholder": *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj(),
-				"default/workload1":   *utiltesting.MakeAdmission("eng-cohort-beta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"default/borrower":    *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"default/placeholder": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "50").
+						Obj()).
+					Obj(),
+				"default/workload1": *utiltesting.MakeAdmission("eng-cohort-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"default/borrower": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 		},
 		{
@@ -3730,12 +4144,20 @@ func TestLastSchedulingContext(t *testing.T) {
 			admittedWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder", "default").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("placeholder1", "default").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3748,12 +4170,28 @@ func TestLastSchedulingContext(t *testing.T) {
 			deleteWorkloads: []kueue.Workload{},
 			wantPreempted:   sets.Set[string]{},
 			wantAdmissionsOnFirstSchedule: map[string]kueue.Admission{
-				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "20").Obj(),
+				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "20").
+						Obj()).
+					Obj(),
 			},
 			wantAdmissionsOnSecondSchedule: map[string]kueue.Admission{
-				"default/placeholder":  *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj(),
-				"default/placeholder1": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj(),
-				"default/workload":     *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "20").Obj(),
+				"default/placeholder": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "50").
+						Obj()).
+					Obj(),
+				"default/placeholder1": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "50").
+						Obj()).
+					Obj(),
+				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "20").
+						Obj()).
+					Obj(),
 			},
 		},
 		{
@@ -3762,17 +4200,29 @@ func TestLastSchedulingContext(t *testing.T) {
 			admittedWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder", "default").
 					Request(corev1.ResourceCPU, "40").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "40").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "40").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("placeholder1", "default").
 					Request(corev1.ResourceCPU, "40").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "40").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "40").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("placeholder2", "default").
 					Request(corev1.ResourceCPU, "100").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "100").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "spot", "100").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3785,13 +4235,33 @@ func TestLastSchedulingContext(t *testing.T) {
 			deleteWorkloads: []kueue.Workload{},
 			wantPreempted:   sets.Set[string]{},
 			wantAdmissionsOnFirstSchedule: map[string]kueue.Admission{
-				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 			wantAdmissionsOnSecondSchedule: map[string]kueue.Admission{
-				"default/placeholder":  *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "40").Obj(),
-				"default/placeholder1": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "40").Obj(),
-				"default/placeholder2": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "100").Obj(),
-				"default/workload":     *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"default/placeholder": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "40").
+						Obj()).
+					Obj(),
+				"default/placeholder1": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "40").
+						Obj()).
+					Obj(),
+				"default/placeholder2": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "100").
+						Obj()).
+					Obj(),
+				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 		},
 		{
@@ -3801,12 +4271,20 @@ func TestLastSchedulingContext(t *testing.T) {
 				*utiltesting.MakeWorkload("placeholder-alpha", "default").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "150").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "150").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "150").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("placeholder-theta-spot", "default").
 					Request(corev1.ResourceCPU, "100").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "100").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "spot", "100").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3820,8 +4298,16 @@ func TestLastSchedulingContext(t *testing.T) {
 			wantPreempted:                 sets.New("default/placeholder-alpha"),
 			wantAdmissionsOnFirstSchedule: map[string]kueue.Admission{},
 			wantAdmissionsOnSecondSchedule: map[string]kueue.Admission{
-				"default/placeholder-theta-spot": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "100").Obj(),
-				"default/new":                    *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"default/placeholder-theta-spot": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "100").
+						Obj()).
+					Obj(),
+				"default/new": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 		},
 		{
@@ -3902,10 +4388,26 @@ func TestLastSchedulingContext(t *testing.T) {
 			deleteWorkloads: []kueue.Workload{*utiltesting.MakeWorkload("alpha2", "default").Obj()},
 			wantPreempted:   sets.New("default/alpha2"),
 			wantAdmissionsOnSecondSchedule: map[string]kueue.Admission{
-				"default/alpha1": *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "22").Obj(),
-				"default/alpha3": *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "spot", "22").Obj(),
-				"default/beta1":  *utiltesting.MakeAdmission("eng-cohort-beta").Assignment(corev1.ResourceCPU, "spot", "22").Obj(),
-				"default/new":    *utiltesting.MakeAdmission("eng-cohort-beta").Assignment(corev1.ResourceCPU, "on-demand", "22").Obj(),
+				"default/alpha1": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "22").
+						Obj()).
+					Obj(),
+				"default/alpha3": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "22").
+						Obj()).
+					Obj(),
+				"default/beta1": *utiltesting.MakeAdmission("eng-cohort-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "22").
+						Obj()).
+					Obj(),
+				"default/new": *utiltesting.MakeAdmission("eng-cohort-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "22").
+						Obj()).
+					Obj(),
 			},
 		},
 	}
@@ -4348,8 +4850,12 @@ func TestResourcesToReserve(t *testing.T) {
 			i := 0
 			for fr, v := range tc.cqUsage {
 				quantity := resources.ResourceQuantity(fr.Resource, v)
-				admission := utiltesting.MakeAdmission("cq").Assignment(fr.Resource, fr.Flavor, quantity.String())
-				wl := utiltesting.MakeWorkload(fmt.Sprintf("workload-%d", i), "default-namespace").ReserveQuota(admission.Obj()).Obj()
+				admission := utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(fr.Resource, fr.Flavor, quantity.String()).
+						Obj()).
+					Obj()
+				wl := utiltesting.MakeWorkload(fmt.Sprintf("workload-%d", i), "default-namespace").ReserveQuota(admission).Obj()
 				cqCache.AddOrUpdateWorkload(log, wl)
 				i++
 			}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -167,78 +167,14 @@ func TestSchedule(t *testing.T) {
 			Obj(),
 	}
 	queues := []kueue.LocalQueue{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "sales",
-				Name:      "main",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "sales",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "sales",
-				Name:      "blocked",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-alpha",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "eng-alpha",
-				Name:      "main",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-alpha",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "eng-beta",
-				Name:      "main",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-beta",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "sales",
-				Name:      "flavor-nonexistent-queue",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "flavor-nonexistent-cq",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "sales",
-				Name:      "cq-nonexistent-queue",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "nonexistent-cq",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "lend",
-				Name:      "lend-a-queue",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "lend-a",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "lend",
-				Name:      "lend-b-queue",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "lend-b",
-			},
-		},
+		*utiltesting.MakeLocalQueue("main", "sales").ClusterQueue("sales").Obj(),
+		*utiltesting.MakeLocalQueue("blocked", "sales").ClusterQueue("eng-alpha").Obj(),
+		*utiltesting.MakeLocalQueue("main", "eng-alpha").ClusterQueue("eng-alpha").Obj(),
+		*utiltesting.MakeLocalQueue("main", "eng-beta").ClusterQueue("eng-beta").Obj(),
+		*utiltesting.MakeLocalQueue("flavor-nonexistent-queue", "sales").ClusterQueue("flavor-nonexistent-cq").Obj(),
+		*utiltesting.MakeLocalQueue("cq-nonexistent-queue", "sales").ClusterQueue("nonexistent-cq").Obj(),
+		*utiltesting.MakeLocalQueue("lend-a-queue", "lend").ClusterQueue("lend-a").Obj(),
+		*utiltesting.MakeLocalQueue("lend-b-queue", "lend").ClusterQueue("lend-b").Obj(),
 	}
 	cases := map[string]struct {
 		// Features
@@ -1091,15 +1027,7 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			additionalLocalQueues: []kueue.LocalQueue{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "eng-gamma",
-						Name:      "main",
-					},
-					Spec: kueue.LocalQueueSpec{
-						ClusterQueue: "eng-gamma",
-					},
-				},
+				*utiltesting.MakeLocalQueue("main", "eng-gamma").ClusterQueue("eng-gamma").Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
 				"eng-gamma/existing": *utiltesting.MakeAdmission("eng-gamma").
@@ -1469,24 +1397,8 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			additionalLocalQueues: []kueue.LocalQueue{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "eng-alpha",
-						Name:      "lq_a",
-					},
-					Spec: kueue.LocalQueueSpec{
-						ClusterQueue: "cq_a",
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "eng-beta",
-						Name:      "lq_b",
-					},
-					Spec: kueue.LocalQueueSpec{
-						ClusterQueue: "cq_b",
-					},
-				},
+				*utiltesting.MakeLocalQueue("lq_a", "eng-alpha").ClusterQueue("cq_a").Obj(),
+				*utiltesting.MakeLocalQueue("lq_b", "eng-beta").ClusterQueue("cq_b").Obj(),
 			},
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "eng-alpha").
@@ -3857,42 +3769,10 @@ func TestLastSchedulingContext(t *testing.T) {
 	}
 
 	queues := []kueue.LocalQueue{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "main",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-alpha",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "main-alpha",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-cohort-alpha",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "main-beta",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-cohort-beta",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "main-theta",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-cohort-theta",
-			},
-		},
+		*utiltesting.MakeLocalQueue("main", "default").ClusterQueue("eng-alpha").Obj(),
+		*utiltesting.MakeLocalQueue("main-alpha", "default").ClusterQueue("eng-cohort-alpha").Obj(),
+		*utiltesting.MakeLocalQueue("main-beta", "default").ClusterQueue("eng-cohort-beta").Obj(),
+		*utiltesting.MakeLocalQueue("main-theta", "default").ClusterQueue("eng-cohort-theta").Obj(),
 	}
 	cases := []struct {
 		name                           string
@@ -4778,15 +4658,7 @@ func TestScheduleForTAS(t *testing.T) {
 		AdmissionChecks(kueue.AdmissionCheckReference(defaultCustomCheck.Name)).
 		Obj()
 	queues := []kueue.LocalQueue{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "tas-main",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "tas-main",
-			},
-		},
+		*utiltesting.MakeLocalQueue("tas-main", "default").ClusterQueue("tas-main").Obj(),
 	}
 	eventIgnoreMessage := cmpopts.IgnoreFields(utiltesting.EventRecord{}, "Message")
 	cases := map[string]struct {
@@ -7308,15 +7180,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 			Resource(corev1.ResourceMemory, "50Gi").Obj()).
 		Obj()
 	queues := []kueue.LocalQueue{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "tas-main",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "tas-main",
-			},
-		},
+		*utiltesting.MakeLocalQueue("tas-main", "default").ClusterQueue("tas-main").Obj(),
 	}
 	cases := map[string]struct {
 		nodes           []corev1.Node
@@ -7954,33 +7818,9 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			Resource(corev1.ResourceMemory, "4Gi").Obj()).
 		Obj()
 	queues := []kueue.LocalQueue{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "tas-lq-a",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "tas-cq-a",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "tas-lq-b",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "tas-cq-b",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "tas-lq-c",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "tas-cq-c",
-			},
-		},
+		*utiltesting.MakeLocalQueue("tas-lq-a", "default").ClusterQueue("tas-cq-a").Obj(),
+		*utiltesting.MakeLocalQueue("tas-lq-b", "default").ClusterQueue("tas-cq-b").Obj(),
+		*utiltesting.MakeLocalQueue("tas-lq-c", "default").ClusterQueue("tas-cq-c").Obj(),
 	}
 	eventIgnoreMessage := cmpopts.IgnoreFields(utiltesting.EventRecord{}, "Message")
 	cases := map[string]struct {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -248,31 +248,21 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/admitted": {
 					ClusterQueue: "other-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "main",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("50"),
-							},
-							Count: ptr.To[int32](1),
-						},
+						utiltesting.MakePodSetAssignment("main").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "50").
+							Count(1).
+							Obj(),
 					},
 				},
 				"eng-alpha/new": {
 					ClusterQueue: "other-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "main",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "spot",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("20"),
-							},
-							Count: ptr.To[int32](1),
-						},
+						utiltesting.MakePodSetAssignment("main").
+							Flavor(corev1.ResourceCPU, "spot").
+							ResourceUsage(corev1.ResourceCPU, "20").
+							Count(1).
+							Obj(),
 					},
 				},
 			},
@@ -296,16 +286,11 @@ func TestSchedule(t *testing.T) {
 				"sales/foo": {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("10000m"),
-							},
-							Count: ptr.To[int32](10),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(10).
+							Obj(),
 					},
 				},
 			},
@@ -388,16 +373,11 @@ func TestSchedule(t *testing.T) {
 				"sales/foo": {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("10000m"),
-							},
-							Count: ptr.To[int32](10),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(10).
+							Obj(),
 					},
 				},
 			},
@@ -440,16 +420,11 @@ func TestSchedule(t *testing.T) {
 				"sales/assigned": {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("40000m"),
-							},
-							Count: ptr.To[int32](40),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Count(40).
+							Obj(),
 					},
 				},
 			},
@@ -489,31 +464,21 @@ func TestSchedule(t *testing.T) {
 				"sales/new": {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("1000m"),
-							},
-							Count: ptr.To[int32](1),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							Obj(),
 					},
 				},
 				"eng-alpha/new": {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("51000m"),
-							},
-							Count: ptr.To[int32](51),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "51000m").
+							Count(51).
+							Obj(),
 					},
 				},
 			},
@@ -538,31 +503,21 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/new": {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("40000m"),
-							},
-							Count: ptr.To[int32](40),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Count(40).
+							Obj(),
 					},
 				},
 				"eng-beta/new": {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("40000m"),
-							},
-							Count: ptr.To[int32](40),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Count(40).
+							Obj(),
 					},
 				},
 			},
@@ -587,28 +542,18 @@ func TestSchedule(t *testing.T) {
 				"eng-beta/new": {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-								"example.com/gpu":  "model-a",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("60000m"),
-								"example.com/gpu":  resource.MustParse("10"),
-							},
-							Count: ptr.To[int32](10),
-						},
-						{
-							Name: "two",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "spot",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("40000m"),
-							},
-							Count: ptr.To[int32](40),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							Flavor("example.com/gpu", "model-a").
+							ResourceUsage(corev1.ResourceCPU, "60000m").
+							ResourceUsage("example.com/gpu", "10").
+							Count(10).
+							Obj(),
+						utiltesting.MakePodSetAssignment("two").
+							Flavor(corev1.ResourceCPU, "spot").
+							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Count(40).
+							Obj(),
 					},
 				},
 			},
@@ -633,16 +578,11 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/new": {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("45000m"),
-							},
-							Count: ptr.To[int32](45),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "45000m").
+							Count(45).
+							Obj(),
 					},
 				},
 			},
@@ -670,31 +610,21 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/new": {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("45000m"),
-							},
-							Count: ptr.To[int32](45),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "45000m").
+							Count(45).
+							Obj(),
 					},
 				},
 				"eng-beta/new": {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("55000m"),
-							},
-							Count: ptr.To[int32](55),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "55000m").
+							Count(55).
+							Obj(),
 					},
 				},
 			},
@@ -891,31 +821,21 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/new": {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "spot",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("60000m"),
-							},
-							Count: ptr.To[int32](60),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "spot").
+							ResourceUsage(corev1.ResourceCPU, "60000m").
+							Count(60).
+							Obj(),
 					},
 				},
 				"eng-beta/existing": {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("45000m"),
-							},
-							Count: ptr.To[int32](45),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "45000m").
+							Count(45).
+							Obj(),
 					},
 				},
 			},
@@ -974,26 +894,16 @@ func TestSchedule(t *testing.T) {
 					).
 					ReserveQuota(utiltesting.MakeAdmission("eng-gamma").
 						PodSets(
-							kueue.PodSetAssignment{
-								Name: "borrow-on-demand",
-								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-									corev1.ResourceCPU: "on-demand",
-								},
-								ResourceUsage: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("51"),
-								},
-								Count: ptr.To[int32](51),
-							},
-							kueue.PodSetAssignment{
-								Name: "use-all-spot",
-								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-									corev1.ResourceCPU: "spot",
-								},
-								ResourceUsage: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("100"),
-								},
-								Count: ptr.To[int32](100),
-							},
+							utiltesting.MakePodSetAssignment("borrow-on-demand").
+								Flavor(corev1.ResourceCPU, "on-demand").
+								ResourceUsage(corev1.ResourceCPU, "51").
+								Count(51).
+								Obj(),
+							utiltesting.MakePodSetAssignment("use-all-spot").
+								Flavor(corev1.ResourceCPU, "spot").
+								ResourceUsage(corev1.ResourceCPU, "100").
+								Count(100).
+								Obj(),
 						).
 						Obj()).
 					Obj(),
@@ -1019,26 +929,16 @@ func TestSchedule(t *testing.T) {
 			wantAssignments: map[string]kueue.Admission{
 				"eng-gamma/existing": *utiltesting.MakeAdmission("eng-gamma").
 					PodSets(
-						kueue.PodSetAssignment{
-							Name: "borrow-on-demand",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("51"),
-							},
-							Count: ptr.To[int32](51),
-						},
-						kueue.PodSetAssignment{
-							Name: "use-all-spot",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "spot",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("100"),
-							},
-							Count: ptr.To[int32](100),
-						},
+						utiltesting.MakePodSetAssignment("borrow-on-demand").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "51").
+							Count(51).
+							Obj(),
+						utiltesting.MakePodSetAssignment("use-all-spot").
+							Flavor(corev1.ResourceCPU, "spot").
+							ResourceUsage(corev1.ResourceCPU, "100").
+							Count(100).
+							Obj(),
 					).Obj(),
 				"eng-beta/new":        *utiltesting.MakeAdmission("eng-beta", "one").Assignment(corev1.ResourceCPU, "on-demand", "50").AssignmentPodCount(50).Obj(),
 				"eng-alpha/new-alpha": *utiltesting.MakeAdmission("eng-alpha", "one").Assignment(corev1.ResourceCPU, "on-demand", "1").AssignmentPodCount(1).Obj(),
@@ -1067,16 +967,11 @@ func TestSchedule(t *testing.T) {
 				"sales/new": {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("50000m"),
-							},
-							Count: ptr.To[int32](25),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "50000m").
+							Count(25).
+							Obj(),
 					},
 				},
 			},
@@ -1104,16 +999,11 @@ func TestSchedule(t *testing.T) {
 				"eng-beta/old": {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								"example.com/gpu": "model-a",
-							},
-							ResourceUsage: corev1.ResourceList{
-								"example.com/gpu": resource.MustParse("10"),
-							},
-							Count: ptr.To[int32](10),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor("example.com/gpu", "model-a").
+							ResourceUsage("example.com/gpu", "10").
+							Count(10).
+							Obj(),
 					},
 				},
 			},
@@ -1144,16 +1034,11 @@ func TestSchedule(t *testing.T) {
 				"eng-beta/old": {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								"example.com/gpu": "model-a",
-							},
-							ResourceUsage: corev1.ResourceList{
-								"example.com/gpu": resource.MustParse("10"),
-							},
-							Count: ptr.To[int32](10),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor("example.com/gpu", "model-a").
+							ResourceUsage("example.com/gpu", "10").
+							Count(10).
+							Obj(),
 					},
 				},
 			},
@@ -1185,36 +1070,21 @@ func TestSchedule(t *testing.T) {
 				"sales/new": {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("20000m"),
-							},
-							Count: ptr.To[int32](20),
-						},
-						{
-							Name: "two",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("20000m"),
-							},
-							Count: ptr.To[int32](20),
-						},
-						{
-							Name: "three",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("10000m"),
-							},
-							Count: ptr.To[int32](10),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "20000m").
+							Count(20).
+							Obj(),
+						utiltesting.MakePodSetAssignment("two").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "20000m").
+							Count(20).
+							Obj(),
+						utiltesting.MakePodSetAssignment("three").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(10).
+							Obj(),
 					},
 				},
 			},
@@ -1411,16 +1281,11 @@ func TestSchedule(t *testing.T) {
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq_a").
 						PodSets(
-							kueue.PodSetAssignment{
-								Name: kueue.DefaultPodSetName,
-								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-									corev1.ResourceCPU: "default",
-								},
-								ResourceUsage: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("2"),
-								},
-								Count: ptr.To[int32](1),
-							},
+							utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(1).
+								Obj(),
 						).
 						Obj()).
 					Obj(),
@@ -1429,31 +1294,21 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/admitted_a": {
 					ClusterQueue: "cq_a",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: kueue.DefaultPodSetName,
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("2"),
-							},
-							Count: ptr.To[int32](1),
-						},
+						utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "2").
+							Count(1).
+							Obj(),
 					},
 				},
 				"eng-beta/b": {
 					ClusterQueue: "cq_b",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: kueue.DefaultPodSetName,
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("1"),
-							},
-							Count: ptr.To[int32](1),
-						},
+						utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "1").
+							Count(1).
+							Obj(),
 					},
 				},
 			},
@@ -5279,30 +5134,20 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main", "one", "two").
 							PodSets(
-								kueue.PodSetAssignment{
-									Name: "one",
-									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-										corev1.ResourceCPU: "tas-default",
-									},
-									ResourceUsage: corev1.ResourceList{
-										corev1.ResourceCPU: resource.MustParse("1"),
-									},
-									Count: ptr.To[int32](1),
-									TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								utiltesting.MakePodSetAssignment("one").
+									Flavor(corev1.ResourceCPU, "tas-default").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(1).
+									TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-										Obj(),
-								},
-								kueue.PodSetAssignment{
-									Name: "two",
-									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-										corev1.ResourceCPU: "tas-second",
-									},
-									ResourceUsage: corev1.ResourceList{
-										corev1.ResourceCPU: resource.MustParse("1"),
-									},
-									Count:                  ptr.To[int32](1),
-									DelayedTopologyRequest: ptr.To(kueue.DelayedTopologyRequestStatePending),
-								},
+										Obj()).
+									Obj(),
+								utiltesting.MakePodSetAssignment("two").
+									Flavor(corev1.ResourceCPU, "tas-second").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(1).
+									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+									Obj(),
 							).Obj(),
 					).
 					AdmissionCheck(kueue.AdmissionCheckState{
@@ -5314,33 +5159,23 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one", "two").
 					PodSets(
-						kueue.PodSetAssignment{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "tas-default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("1"),
-							},
-							Count: ptr.To[int32](1),
-							TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-								Obj(),
-						},
-						kueue.PodSetAssignment{
-							Name: "two",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "tas-second",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("1"),
-							},
-							Count:                  ptr.To[int32](1),
-							DelayedTopologyRequest: ptr.To(kueue.DelayedTopologyRequestStateReady),
-							TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Obj()).
+							Obj(),
+						utiltesting.MakePodSetAssignment("two").
+							Flavor(corev1.ResourceCPU, "tas-second").
+							ResourceUsage(corev1.ResourceCPU, "1").
+							Count(1).
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
-								Obj(),
-						},
+								Obj()).
+							Obj(),
 					).Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5644,29 +5479,19 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					PodSets(
-						kueue.PodSetAssignment{
-							Name: "launcher",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("500m"),
-							},
-							Count: ptr.To[int32](1),
-						},
-						kueue.PodSetAssignment{
-							Name: "worker",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "tas-default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("500m"),
-							},
-							Count: ptr.To[int32](1),
-							TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						utiltesting.MakePodSetAssignment("launcher").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "500m").
+							Count(1).
+							Obj(),
+						utiltesting.MakePodSetAssignment("worker").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "500m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-								Obj(),
-						},
+								Obj()).
+							Obj(),
 					).
 					Obj(),
 			},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -6079,23 +6079,16 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			topologies: []kueuealpha.Topology{defaultSingleLevelTopology},
-			resourceFlavors: []kueue.ResourceFlavor{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "tas-default",
-				},
-				Spec: kueue.ResourceFlavorSpec{
-					NodeLabels: map[string]string{
-						"tas-node": "true",
-					},
-					Tolerations: []corev1.Toleration{
-						{
-							Key:      "example.com/gpu",
-							Operator: corev1.TolerationOpExists,
-						},
-					},
-					TopologyName: ptr.To[kueue.TopologyReference]("tas-single-level"),
-				},
-			}},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltesting.MakeResourceFlavor("tas-default").
+					NodeLabel("tas-node", "true").
+					Toleration(corev1.Toleration{
+						Key:      "example.com/gpu",
+						Operator: corev1.TolerationOpExists,
+					}).
+					TopologyName("tas-single-level").
+					Obj(),
+			},
 			clusterQueues: []kueue.ClusterQueue{
 				*utiltesting.MakeClusterQueue("tas-main").
 					ResourceGroup(

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -253,20 +253,14 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "other-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("main").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "50").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
 							Obj(),
 					},
 				},
 				"eng-alpha/new": {
 					ClusterQueue: "other-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						utiltesting.MakePodSetAssignment("main").
-							Flavor(corev1.ResourceCPU, "spot").
-							ResourceUsage(corev1.ResourceCPU, "20").
-							Count(1).
-							Obj(),
+						utiltesting.MakePodSetAssignment("main").Assignment(corev1.ResourceCPU, "spot", "20").Obj(),
 					},
 				},
 			},
@@ -291,8 +285,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "default", "10000m").
 							Count(10).
 							Obj(),
 					},
@@ -319,8 +312,7 @@ func TestSchedule(t *testing.T) {
 					Admission(
 						utiltesting.MakeAdmission("sales").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "default").
-								ResourceUsage(corev1.ResourceCPU, "10000m").
+								Assignment(corev1.ResourceCPU, "default", "10000m").
 								Count(10).
 								Obj()).
 							Obj(),
@@ -381,8 +373,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "default", "10000m").
 							Count(10).
 							Obj(),
 					},
@@ -420,7 +411,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 40).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "40000m").Count(40).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "default", "40000m").Count(40).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
@@ -428,8 +419,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Assignment(corev1.ResourceCPU, "default", "40000m").
 							Count(40).
 							Obj(),
 					},
@@ -472,9 +462,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "default", "1000m").
 							Obj(),
 					},
 				},
@@ -482,8 +470,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "51000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "51000m").
 							Count(51).
 							Obj(),
 					},
@@ -511,8 +498,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "40000m").
 							Count(40).
 							Obj(),
 					},
@@ -521,8 +507,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "40000m").
 							Count(40).
 							Obj(),
 					},
@@ -550,15 +535,12 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							Flavor("example.com/gpu", "model-a").
-							ResourceUsage(corev1.ResourceCPU, "60000m").
-							ResourceUsage("example.com/gpu", "10").
+							Assignment(corev1.ResourceCPU, "on-demand", "60000m").
+							Assignment("example.com/gpu", "model-a", "10").
 							Count(10).
 							Obj(),
 						utiltesting.MakePodSetAssignment("two").
-							Flavor(corev1.ResourceCPU, "spot").
-							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Assignment(corev1.ResourceCPU, "spot", "40000m").
 							Count(40).
 							Obj(),
 					},
@@ -586,8 +568,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "45000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "45000m").
 							Count(45).
 							Obj(),
 					},
@@ -618,8 +599,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "45000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "45000m").
 							Count(45).
 							Obj(),
 					},
@@ -628,8 +608,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "55000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "55000m").
 							Count(55).
 							Obj(),
 					},
@@ -901,7 +880,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 45).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "45000m").Count(45).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "45000m").Count(45).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
@@ -909,8 +888,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "spot").
-							ResourceUsage(corev1.ResourceCPU, "60000m").
+							Assignment(corev1.ResourceCPU, "spot", "60000m").
 							Count(60).
 							Obj(),
 					},
@@ -919,8 +897,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "45000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "45000m").
 							Count(45).
 							Obj(),
 					},
@@ -982,13 +959,11 @@ func TestSchedule(t *testing.T) {
 					ReserveQuota(utiltesting.MakeAdmission("eng-gamma").
 						PodSets(
 							utiltesting.MakePodSetAssignment("borrow-on-demand").
-								Flavor(corev1.ResourceCPU, "on-demand").
-								ResourceUsage(corev1.ResourceCPU, "51").
+								Assignment(corev1.ResourceCPU, "on-demand", "51").
 								Count(51).
 								Obj(),
 							utiltesting.MakePodSetAssignment("use-all-spot").
-								Flavor(corev1.ResourceCPU, "spot").
-								ResourceUsage(corev1.ResourceCPU, "100").
+								Assignment(corev1.ResourceCPU, "spot", "100").
 								Count(100).
 								Obj(),
 						).
@@ -1017,18 +992,16 @@ func TestSchedule(t *testing.T) {
 				"eng-gamma/existing": *utiltesting.MakeAdmission("eng-gamma").
 					PodSets(
 						utiltesting.MakePodSetAssignment("borrow-on-demand").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "51").
+							Assignment(corev1.ResourceCPU, "on-demand", "51").
 							Count(51).
 							Obj(),
 						utiltesting.MakePodSetAssignment("use-all-spot").
-							Flavor(corev1.ResourceCPU, "spot").
-							ResourceUsage(corev1.ResourceCPU, "100").
+							Assignment(corev1.ResourceCPU, "spot", "100").
 							Count(100).
 							Obj(),
 					).Obj(),
-				"eng-beta/new":        *utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "50").Count(50).Obj()).Obj(),
-				"eng-alpha/new-alpha": *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj(),
+				"eng-beta/new":        *utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "50").Count(50).Obj()).Obj(),
+				"eng-alpha/new-alpha": *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).Obj(),
 			},
 			wantScheduled: []string{"eng-beta/new", "eng-alpha/new-alpha"},
 			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]string{
@@ -1055,8 +1028,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "50000m").
+							Assignment(corev1.ResourceCPU, "default", "50000m").
 							Count(25).
 							Obj(),
 					},
@@ -1079,7 +1051,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 10).
 						Request("example.com/gpu", "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor("example.com/gpu", "model-a").ResourceUsage("example.com/gpu", "10").Count(10).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Assignment("example.com/gpu", "model-a", "10").Count(10).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
@@ -1087,8 +1059,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor("example.com/gpu", "model-a").
-							ResourceUsage("example.com/gpu", "10").
+							Assignment("example.com/gpu", "model-a", "10").
 							Count(10).
 							Obj(),
 					},
@@ -1114,7 +1085,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 10).
 						Request("example.com/gpu", "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor("example.com/gpu", "model-a").ResourceUsage("example.com/gpu", "10").Count(10).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Assignment("example.com/gpu", "model-a", "10").Count(10).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
@@ -1122,8 +1093,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor("example.com/gpu", "model-a").
-							ResourceUsage("example.com/gpu", "10").
+							Assignment("example.com/gpu", "model-a", "10").
 							Count(10).
 							Obj(),
 					},
@@ -1158,18 +1128,15 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "20000m").
+							Assignment(corev1.ResourceCPU, "default", "20000m").
 							Count(20).
 							Obj(),
 						utiltesting.MakePodSetAssignment("two").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "20000m").
+							Assignment(corev1.ResourceCPU, "default", "20000m").
 							Count(20).
 							Obj(),
 						utiltesting.MakePodSetAssignment("three").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "default", "10000m").
 							Count(10).
 							Obj(),
 					},
@@ -1230,16 +1197,12 @@ func TestSchedule(t *testing.T) {
 			wantAssignments: map[string]kueue.Admission{
 				"sales/wl1": *utiltesting.MakeAdmission("cq1").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor("r1", "default").
-						ResourceUsage("r1", "16").
-						Count(1).
+						Assignment("r1", "default", "16").
 						Obj()).
 					Obj(),
 				"sales/wl2": *utiltesting.MakeAdmission("cq2").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor("r2", "default").
-						ResourceUsage("r2", "16").
-						Count(1).
+						Assignment("r2", "default", "16").
 						Obj()).
 					Obj(),
 			},
@@ -1273,16 +1236,12 @@ func TestSchedule(t *testing.T) {
 			wantAssignments: map[string]kueue.Admission{
 				"sales/wl1": *utiltesting.MakeAdmission("cq1").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor("r1", "default").
-						ResourceUsage("r1", "16").
-						Count(1).
+						Assignment("r1", "default", "16").
 						Obj()).
 					Obj(),
 				"sales/wl2": *utiltesting.MakeAdmission("cq2").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor("r1", "default").
-						ResourceUsage("r1", "14").
-						Count(1).
+						Assignment("r1", "default", "14").
 						Obj()).
 					Obj(),
 			},
@@ -1316,9 +1275,7 @@ func TestSchedule(t *testing.T) {
 			wantAssignments: map[string]kueue.Admission{
 				"sales/wl1": *utiltesting.MakeAdmission("cq1").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor("r1", "default").
-						ResourceUsage("r1", "16").
-						Count(1).
+						Assignment("r1", "default", "16").
 						Obj()).
 					Obj(),
 			},
@@ -1389,9 +1346,7 @@ func TestSchedule(t *testing.T) {
 					ReserveQuota(utiltesting.MakeAdmission("cq_a").
 						PodSets(
 							utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "default").
-								ResourceUsage(corev1.ResourceCPU, "2").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "default", "2").
 								Obj(),
 						).
 						Obj()).
@@ -1402,9 +1357,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "cq_a",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "2").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "default", "2").
 							Obj(),
 					},
 				},
@@ -1412,9 +1365,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "cq_b",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "1").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "default", "1").
 							Obj(),
 					},
 				},
@@ -1443,7 +1394,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 50).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "50").Count(50).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "50").Count(50).Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("borrowing", "eng-beta").
 					Queue("main").
@@ -1451,7 +1402,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 55).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "55").Count(55).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "55").Count(55).Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("older_new", "eng-beta").
 					Queue("main").
@@ -1469,9 +1420,9 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/all_nominal": *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "50").Count(50).Obj()).Obj(),
-				"eng-beta/borrowing":    *utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "55").Count(55).Obj()).Obj(),
-				"eng-alpha/new":         *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "5").Count(5).Obj()).Obj(),
+				"eng-alpha/all_nominal": *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "50").Count(50).Obj()).Obj(),
+				"eng-beta/borrowing":    *utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "55").Count(55).Obj()).Obj(),
+				"eng-alpha/new":         *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "5").Count(5).Obj()).Obj(),
 			},
 			wantScheduled: []string{"eng-alpha/new"},
 			wantLeft: map[kueue.ClusterQueueReference][]string{
@@ -5080,16 +5031,13 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("launcher").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
 							Obj(),
 						utiltesting.MakePodSetAssignment("worker").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "0").
+							Assignment(corev1.ResourceCPU, "tas-default", "0").
 							Count(0).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).Obj()).
 							Obj(),
@@ -5119,10 +5067,8 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
-									Flavor(corev1.ResourceCPU, "tas-default").
-									ResourceUsage(corev1.ResourceCPU, "1000m").
+									Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-									Count(1).
 									Obj(),
 							).
 							Obj(),
@@ -5137,9 +5083,7 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
@@ -5203,8 +5147,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-reservation").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-reservation", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -5234,8 +5177,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 									Obj()).
@@ -5248,8 +5190,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -5274,8 +5215,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
@@ -5290,8 +5230,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						Count(2).
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
@@ -5317,8 +5256,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "3000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "3000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 									Obj()).
@@ -5331,8 +5269,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "3000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "3000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 							Obj()).
@@ -5362,8 +5299,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
@@ -5377,8 +5313,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x3"}, 1).Obj()).
@@ -5404,8 +5339,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 									Obj()).
@@ -5418,8 +5352,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -5444,8 +5377,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
@@ -5459,8 +5391,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
@@ -5497,17 +5428,13 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
-									Flavor(corev1.ResourceCPU, "tas-default").
-									ResourceUsage(corev1.ResourceCPU, "1000m").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 									TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 										Obj()).
 									Obj(),
 								utiltesting.MakePodSetAssignment("two").
-									Flavor(corev1.ResourceCPU, "tas-default").
-									ResourceUsage(corev1.ResourceCPU, "1000m").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 									TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 										Obj()).
@@ -5522,17 +5449,13 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
 								Obj()).
 							Obj(),
 						utiltesting.MakePodSetAssignment("two").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
@@ -5572,8 +5495,7 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
-									Flavor(corev1.ResourceCPU, "tas-default").
-									ResourceUsage(corev1.ResourceCPU, "26").
+									Assignment(corev1.ResourceCPU, "tas-default", "26").
 									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
 									Count(26).
 									Obj(),
@@ -5590,8 +5512,7 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "26").
+							Assignment(corev1.ResourceCPU, "tas-default", "26").
 							Count(26).
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
@@ -5655,10 +5576,8 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
-									Flavor(corev1.ResourceCPU, "tas-second").
-									ResourceUsage(corev1.ResourceCPU, "1000m").
+									Assignment(corev1.ResourceCPU, "tas-second", "1000m").
 									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-									Count(1).
 									Obj(),
 							).
 							Obj(),
@@ -5673,9 +5592,7 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-second").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-second", "1000m").
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
@@ -5748,17 +5665,13 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
-									Flavor(corev1.ResourceCPU, "tas-default").
-									ResourceUsage(corev1.ResourceCPU, "1").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "tas-default", "1").
 									TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 										Obj()).
 									Obj(),
 								utiltesting.MakePodSetAssignment("two").
-									Flavor(corev1.ResourceCPU, "tas-second").
-									ResourceUsage(corev1.ResourceCPU, "1").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "tas-second", "1").
 									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
 									Obj(),
 							).Obj(),
@@ -5773,17 +5686,13 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
 							Obj(),
 						utiltesting.MakePodSetAssignment("two").
-							Flavor(corev1.ResourceCPU, "tas-second").
-							ResourceUsage(corev1.ResourceCPU, "1").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-second", "1").
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
@@ -5818,10 +5727,8 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-							Count(1).
 							Obj(),
 					).
 					Obj(),
@@ -5879,10 +5786,8 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
-									Flavor(corev1.ResourceCPU, "tas-second").
-									ResourceUsage(corev1.ResourceCPU, "1000m").
+									Assignment(corev1.ResourceCPU, "tas-second", "1000m").
 									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-									Count(1).
 									Obj(),
 							).
 							Obj(),
@@ -5897,9 +5802,7 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-second").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-second", "1000m").
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
@@ -5936,10 +5839,8 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-							Count(1).
 							Obj(),
 					).
 					Obj(),
@@ -5971,9 +5872,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6007,9 +5906,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6047,9 +5944,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6086,9 +5981,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "default", "1000m").
 						Obj()).
 					Obj(),
 			},
@@ -6128,14 +6021,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("launcher").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "500m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "default", "500m").
 							Obj(),
 						utiltesting.MakePodSetAssignment("worker").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "500m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "500m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
@@ -6166,9 +6055,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6248,8 +6135,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-custom-flavor").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "tas-custom-flavor", "1").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{"cloud.com/custom-level"}).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6303,9 +6189,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -6383,9 +6267,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "400m").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "400m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -6402,9 +6284,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "500m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "500m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6436,11 +6316,8 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								Flavor(corev1.ResourceMemory, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "500m").
-								ResourceUsage(corev1.ResourceMemory, "500Mi").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "500m").
+								Assignment(corev1.ResourceMemory, "tas-default", "500Mi").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -6458,11 +6335,8 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						Flavor(corev1.ResourceMemory, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "500m").
-						ResourceUsage(corev1.ResourceMemory, "500Mi").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "500m").
+						Assignment(corev1.ResourceMemory, "tas-default", "500Mi").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6580,16 +6454,13 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("launcher").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
 							Obj(),
 						utiltesting.MakePodSetAssignment("worker").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "15000m").
+							Assignment(corev1.ResourceCPU, "tas-default", "15000m").
 							Count(15).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
@@ -6655,16 +6526,13 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("launcher").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
 							Obj(),
 						utiltesting.MakePodSetAssignment("worker").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "15000m").
+							Assignment(corev1.ResourceCPU, "tas-default", "15000m").
 							Count(15).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
@@ -6719,9 +6587,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -6738,9 +6604,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
 							Obj()).
@@ -6802,9 +6666,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6835,9 +6697,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6885,8 +6745,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "150m").
+								Assignment(corev1.ResourceCPU, "tas-default", "150m").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
@@ -6927,11 +6786,8 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						Flavor(corev1.ResourceMemory, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "0").
-						ResourceUsage(corev1.ResourceMemory, "10Mi").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "0").
+						Assignment(corev1.ResourceMemory, "tas-default", "10Mi").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -7169,9 +7025,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"z1"}, 1).Obj()).
 									Obj()).
@@ -7220,9 +7074,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -7275,9 +7127,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -7326,9 +7176,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "2").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "2").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -7347,9 +7195,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "2").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "2").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -7400,9 +7246,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "4").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "4").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -7421,9 +7265,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "4").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "4").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
 									Obj()).
@@ -7483,9 +7325,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "4").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "4").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -7733,8 +7573,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "6").
+						Assignment(corev1.ResourceCPU, "tas-default", "6").
 						Count(6).
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
@@ -7762,8 +7601,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								Count(5).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
@@ -7810,8 +7648,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								Count(5).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
@@ -7831,8 +7668,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "tas-default", "2").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
@@ -7852,9 +7688,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
 									Obj()).
@@ -7902,8 +7736,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								Count(5).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
@@ -7923,8 +7756,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "3").
+								Assignment(corev1.ResourceCPU, "tas-default", "3").
 								Count(3).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
@@ -7974,8 +7806,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								Count(5).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
@@ -7996,9 +7827,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
 									Obj()).
@@ -8017,9 +7846,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
 									Obj()).
@@ -8088,9 +7915,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "5").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "5").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
 							Obj()).
@@ -8098,9 +7923,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 				"default/b1": *utiltesting.MakeAdmission("tas-cq-b").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceMemory, "tas-default").
-						ResourceUsage(corev1.ResourceMemory, "5").
-						Count(1).
+						Assignment(corev1.ResourceMemory, "tas-default", "5").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -8141,9 +7964,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -8151,8 +7972,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 				"default/b1": *utiltesting.MakeAdmission("tas-cq-b").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "2").
+						Assignment(corev1.ResourceCPU, "tas-default", "2").
 						Count(2).
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
@@ -8194,9 +8014,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -8242,8 +8060,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "5").
+						Assignment(corev1.ResourceCPU, "tas-default", "5").
 						Count(5).
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
@@ -8286,9 +8103,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "2").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "2").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -8326,8 +8141,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "tas-default", "2").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
@@ -8391,8 +8205,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "tas-default", "2").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
@@ -8456,8 +8269,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "tas-default", "2").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
@@ -8502,8 +8314,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[string]kueue.Admission{
 				"default/b1": *utiltesting.MakeAdmission("tas-cq-b").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "3").
+						Assignment(corev1.ResourceCPU, "tas-default", "3").
 						Count(3).
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 3).Obj()).

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4672,11 +4672,13 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-reservation", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-reservation").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -4701,11 +4703,13 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -4713,11 +4717,13 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -4737,12 +4743,15 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -4750,12 +4759,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x5"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(2).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -4775,11 +4786,13 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "3").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "3000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "3000m").
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -4787,11 +4800,13 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "3000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "3000m").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -4816,12 +4831,14 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -4829,12 +4846,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x3"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x3"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -4854,11 +4873,13 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -4866,11 +4887,13 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -4890,12 +4913,14 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -4903,12 +4928,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5189,7 +5216,7 @@ func TestScheduleForTAS(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one", "two").
+						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
 									Flavor(corev1.ResourceCPU, "tas-default").
@@ -5214,7 +5241,7 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one", "two").
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
 							Flavor(corev1.ResourceCPU, "tas-default").
@@ -5413,11 +5440,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5446,11 +5476,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5483,11 +5516,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5519,9 +5555,12 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "default", "1000m").
-					AssignmentPodCount(1).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						Obj()).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5557,7 +5596,7 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("launcher").
 							Flavor(corev1.ResourceCPU, "default").
@@ -5596,11 +5635,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5675,11 +5717,13 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-custom-flavor", "1").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{"cloud.com/custom-level"}).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-custom-flavor").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{"cloud.com/custom-level"}).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5728,11 +5772,14 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("bar-admitted", "default").
 					Queue("tas-main").
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -5805,11 +5852,14 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("bar-admitted", "default").
 					Queue("tas-main").
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "400m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "400m").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -5821,11 +5871,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "500m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "500m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5852,12 +5905,16 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("bar-admitted", "default").
 					Queue("tas-main").
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "500m").
-							Assignment(corev1.ResourceMemory, "tas-default", "500Mi").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								Flavor(corev1.ResourceMemory, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "500m").
+								ResourceUsage(corev1.ResourceMemory, "500Mi").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -5870,12 +5927,16 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "500m").
-					Assignment(corev1.ResourceMemory, "tas-default", "500Mi").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						Flavor(corev1.ResourceMemory, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "500m").
+						ResourceUsage(corev1.ResourceMemory, "500Mi").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -6127,11 +6188,14 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("bar-admitted", "default").
 					Queue("tas-main").
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6143,11 +6207,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -6204,11 +6271,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -6234,11 +6304,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -6281,11 +6354,14 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("bar-admitted", "default").
 					Queue("tas-main").
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "150m").
-							AssignmentPodCount(2).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "150m").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6320,12 +6396,16 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "0").
-					Assignment(corev1.ResourceMemory, "tas-default", "10Mi").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						Flavor(corev1.ResourceMemory, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "0").
+						ResourceUsage(corev1.ResourceMemory, "10Mi").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -6558,11 +6638,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"z1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"z1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6606,11 +6689,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6658,11 +6744,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6706,11 +6795,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "2").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6724,11 +6816,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "2").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6774,11 +6869,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "4").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6792,11 +6890,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "4").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6851,11 +6952,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "4").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7098,12 +7202,15 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "6").
-					AssignmentPodCount(6).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "6").
+						Count(6).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -7124,11 +7231,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				*utiltesting.MakeWorkload("a1-admitted", "default").
 					Queue("tas-lq-a").
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(5).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(5).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7169,11 +7279,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(5).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(5).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7187,11 +7300,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "2").
-							AssignmentPodCount(2).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7205,11 +7321,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7252,11 +7371,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(3).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(5).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(5).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7270,11 +7392,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "3").
-							AssignmentPodCount(3).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "3").
+								Count(3).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7318,12 +7443,15 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(5).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(5).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7337,11 +7465,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7355,11 +7486,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7423,18 +7557,24 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "5").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "5").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
-				"default/b1": *utiltesting.MakeAdmission("tas-cq-b", "one").
-					Assignment(corev1.ResourceMemory, "tas-default", "5").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/b1": *utiltesting.MakeAdmission("tas-cq-b").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceMemory, "tas-default").
+						ResourceUsage(corev1.ResourceMemory, "5").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -7470,18 +7610,24 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
-				"default/b1": *utiltesting.MakeAdmission("tas-cq-b", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "2").
-					AssignmentPodCount(2).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+				"default/b1": *utiltesting.MakeAdmission("tas-cq-b").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "2").
+						Count(2).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -7517,11 +7663,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -7562,11 +7711,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"tas-cq-b": {"default/b1"},
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "5").
-					AssignmentPodCount(5).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "5").
+						Count(5).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -7603,11 +7755,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "2").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "2").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -7640,11 +7795,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "2").
-							AssignmentPodCount(2).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7702,11 +7860,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "2").
-							AssignmentPodCount(2).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7764,11 +7925,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "2").
-							AssignmentPodCount(2).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7807,11 +7971,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/b1": *utiltesting.MakeAdmission("tas-cq-b", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "3").
-					AssignmentPodCount(3).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 3).Obj()).
+				"default/b1": *utiltesting.MakeAdmission("tas-cq-b").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "3").
+						Count(3).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 3).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -313,9 +313,12 @@ func TestSchedule(t *testing.T) {
 						State: kueue.CheckStateReady,
 					}).
 					Admission(
-						utiltesting.MakeAdmission("sales", "one").
-							Assignment(corev1.ResourceCPU, "default", "10000m").
-							AssignmentPodCount(10).
+						utiltesting.MakeAdmission("sales").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "default").
+								ResourceUsage(corev1.ResourceCPU, "10000m").
+								Count(10).
+								Obj()).
 							Obj(),
 					).
 					Generation(1).
@@ -413,7 +416,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 40).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("sales", "one").Assignment(corev1.ResourceCPU, "default", "40000m").AssignmentPodCount(40).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "40000m").Count(40).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
@@ -814,7 +817,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 45).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta", "one").Assignment(corev1.ResourceCPU, "on-demand", "45000m").AssignmentPodCount(45).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "45000m").Count(45).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
@@ -940,8 +943,8 @@ func TestSchedule(t *testing.T) {
 							Count(100).
 							Obj(),
 					).Obj(),
-				"eng-beta/new":        *utiltesting.MakeAdmission("eng-beta", "one").Assignment(corev1.ResourceCPU, "on-demand", "50").AssignmentPodCount(50).Obj(),
-				"eng-alpha/new-alpha": *utiltesting.MakeAdmission("eng-alpha", "one").Assignment(corev1.ResourceCPU, "on-demand", "1").AssignmentPodCount(1).Obj(),
+				"eng-beta/new":        *utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "50").Count(50).Obj()).Obj(),
+				"eng-alpha/new-alpha": *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj(),
 			},
 			wantScheduled: []string{"eng-beta/new", "eng-alpha/new-alpha"},
 			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]string{
@@ -992,7 +995,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 10).
 						Request("example.com/gpu", "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta", "one").Assignment("example.com/gpu", "model-a", "10").AssignmentPodCount(10).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor("example.com/gpu", "model-a").ResourceUsage("example.com/gpu", "10").Count(10).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
@@ -1027,7 +1030,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 10).
 						Request("example.com/gpu", "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta", "one").Assignment("example.com/gpu", "model-a", "10").AssignmentPodCount(10).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor("example.com/gpu", "model-a").ResourceUsage("example.com/gpu", "10").Count(10).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
@@ -1141,11 +1144,19 @@ func TestSchedule(t *testing.T) {
 			},
 			wantScheduled: []string{"sales/wl1", "sales/wl2"},
 			wantAssignments: map[string]kueue.Admission{
-				"sales/wl1": *utiltesting.MakeAdmission("cq1", kueue.DefaultPodSetName).
-					Assignment("r1", "default", "16").AssignmentPodCount(1).
+				"sales/wl1": *utiltesting.MakeAdmission("cq1").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor("r1", "default").
+						ResourceUsage("r1", "16").
+						Count(1).
+						Obj()).
 					Obj(),
-				"sales/wl2": *utiltesting.MakeAdmission("cq2", kueue.DefaultPodSetName).
-					Assignment("r2", "default", "16").AssignmentPodCount(1).
+				"sales/wl2": *utiltesting.MakeAdmission("cq2").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor("r2", "default").
+						ResourceUsage("r2", "16").
+						Count(1).
+						Obj()).
 					Obj(),
 			},
 		},
@@ -1176,11 +1187,19 @@ func TestSchedule(t *testing.T) {
 			},
 			wantScheduled: []string{"sales/wl1", "sales/wl2"},
 			wantAssignments: map[string]kueue.Admission{
-				"sales/wl1": *utiltesting.MakeAdmission("cq1", kueue.DefaultPodSetName).
-					Assignment("r1", "default", "16").AssignmentPodCount(1).
+				"sales/wl1": *utiltesting.MakeAdmission("cq1").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor("r1", "default").
+						ResourceUsage("r1", "16").
+						Count(1).
+						Obj()).
 					Obj(),
-				"sales/wl2": *utiltesting.MakeAdmission("cq2", kueue.DefaultPodSetName).
-					Assignment("r1", "default", "14").AssignmentPodCount(1).
+				"sales/wl2": *utiltesting.MakeAdmission("cq2").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor("r1", "default").
+						ResourceUsage("r1", "14").
+						Count(1).
+						Obj()).
 					Obj(),
 			},
 		},
@@ -1211,8 +1230,12 @@ func TestSchedule(t *testing.T) {
 			},
 			wantScheduled: []string{"sales/wl1"},
 			wantAssignments: map[string]kueue.Admission{
-				"sales/wl1": *utiltesting.MakeAdmission("cq1", kueue.DefaultPodSetName).
-					Assignment("r1", "default", "16").AssignmentPodCount(1).
+				"sales/wl1": *utiltesting.MakeAdmission("cq1").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor("r1", "default").
+						ResourceUsage("r1", "16").
+						Count(1).
+						Obj()).
 					Obj(),
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]string{
@@ -1336,7 +1359,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 50).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha", "one").Assignment(corev1.ResourceCPU, "on-demand", "50").AssignmentPodCount(50).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "50").Count(50).Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("borrowing", "eng-beta").
 					Queue("main").
@@ -1344,7 +1367,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 55).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta", "one").Assignment(corev1.ResourceCPU, "on-demand", "55").AssignmentPodCount(55).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "55").Count(55).Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("older_new", "eng-beta").
 					Queue("main").
@@ -1362,9 +1385,9 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[string]kueue.Admission{
-				"eng-alpha/all_nominal": *utiltesting.MakeAdmission("eng-alpha", "one").Assignment(corev1.ResourceCPU, "on-demand", "50").AssignmentPodCount(50).Obj(),
-				"eng-beta/borrowing":    *utiltesting.MakeAdmission("eng-beta", "one").Assignment(corev1.ResourceCPU, "on-demand", "55").AssignmentPodCount(55).Obj(),
-				"eng-alpha/new":         *utiltesting.MakeAdmission("eng-alpha", "one").Assignment(corev1.ResourceCPU, "on-demand", "5").AssignmentPodCount(5).Obj(),
+				"eng-alpha/all_nominal": *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "50").Count(50).Obj()).Obj(),
+				"eng-beta/borrowing":    *utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "55").Count(55).Obj()).Obj(),
+				"eng-alpha/new":         *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "5").Count(5).Obj()).Obj(),
 			},
 			wantScheduled: []string{"eng-alpha/new"},
 			wantLeft: map[kueue.ClusterQueueReference][]string{

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4587,10 +4587,16 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-							AssignmentPodCount(1).Obj(),
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(
+								utiltesting.MakePodSetAssignment("one").
+									Flavor(corev1.ResourceCPU, "tas-default").
+									ResourceUsage(corev1.ResourceCPU, "1000m").
+									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+									Count(1).
+									Obj(),
+							).
+							Obj(),
 					).
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:  "prov-check",
@@ -4599,13 +4605,18 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5002,10 +5013,16 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "26").
-							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-							AssignmentPodCount(26).Obj(),
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(
+								utiltesting.MakePodSetAssignment("one").
+									Flavor(corev1.ResourceCPU, "tas-default").
+									ResourceUsage(corev1.ResourceCPU, "26").
+									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+									Count(26).
+									Obj(),
+							).
+							Obj(),
 					).
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:  "prov-check",
@@ -5014,13 +5031,18 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "26").
-					AssignmentPodCount(26).
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 26).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "26").
+							Count(26).
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 26).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5074,10 +5096,16 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-second", "1000m").
-							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-							AssignmentPodCount(1).Obj(),
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(
+								utiltesting.MakePodSetAssignment("one").
+									Flavor(corev1.ResourceCPU, "tas-second").
+									ResourceUsage(corev1.ResourceCPU, "1000m").
+									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+									Count(1).
+									Obj(),
+							).
+							Obj(),
 					).
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:  "prov-check",
@@ -5086,13 +5114,18 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-second", "1000m").
-					AssignmentPodCount(1).
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-second").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5226,10 +5259,16 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-					AssignmentPodCount(1).Obj(),
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+							Count(1).
+							Obj(),
+					).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -5281,10 +5320,16 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-second", "1000m").
-							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-							AssignmentPodCount(1).Obj(),
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(
+								utiltesting.MakePodSetAssignment("one").
+									Flavor(corev1.ResourceCPU, "tas-second").
+									ResourceUsage(corev1.ResourceCPU, "1000m").
+									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+									Count(1).
+									Obj(),
+							).
+							Obj(),
 					).
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:  "prov-check",
@@ -5293,13 +5338,18 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-second", "1000m").
-					AssignmentPodCount(1).
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-second").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5327,10 +5377,16 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[string]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-					AssignmentPodCount(1).Obj(),
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+							Count(1).
+							Obj(),
+					).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -607,13 +607,6 @@ func (w *AdmissionWrapper) AssignmentPodCount(value int32) *AdmissionWrapper {
 	return w
 }
 
-func (w *AdmissionWrapper) TopologyAssignment(ts *kueue.TopologyAssignment) *AdmissionWrapper {
-	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
-	wrapper.TopologyAssignment(ts)
-	w.PodSetAssignments[0] = wrapper.PodSetAssignment
-	return w
-}
-
 func (w *AdmissionWrapper) PodSets(podSets ...kueue.PodSetAssignment) *AdmissionWrapper {
 	w.PodSetAssignments = podSets
 	return w

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -600,13 +600,6 @@ func (w *AdmissionWrapper) Assignment(r corev1.ResourceName, f kueue.ResourceFla
 	return w
 }
 
-func (w *AdmissionWrapper) AssignmentPodCount(value int32) *AdmissionWrapper {
-	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
-	wrapper.Count(value)
-	w.PodSetAssignments[0] = wrapper.PodSetAssignment
-	return w
-}
-
 func (w *AdmissionWrapper) PodSets(podSets ...kueue.PodSetAssignment) *AdmissionWrapper {
 	w.PodSetAssignments = podSets
 	return w

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -576,24 +576,14 @@ func MakeAdmission(cq string, podSetNames ...kueue.PodSetReference) *AdmissionWr
 
 	if len(podSetNames) == 0 {
 		wrap.PodSetAssignments = []kueue.PodSetAssignment{
-			{
-				Name:          kueue.DefaultPodSetName,
-				Flavors:       make(map[corev1.ResourceName]kueue.ResourceFlavorReference),
-				ResourceUsage: make(corev1.ResourceList),
-				Count:         ptr.To[int32](1),
-			},
+			MakePodSetAssignment(kueue.DefaultPodSetName).Obj(),
 		}
 		return wrap
 	}
 
 	var psFlavors []kueue.PodSetAssignment
 	for _, name := range podSetNames {
-		psFlavors = append(psFlavors, kueue.PodSetAssignment{
-			Name:          name,
-			Flavors:       make(map[corev1.ResourceName]kueue.ResourceFlavorReference),
-			ResourceUsage: make(corev1.ResourceList),
-			Count:         ptr.To[int32](1),
-		})
+		psFlavors = append(psFlavors, MakePodSetAssignment(name).Obj())
 	}
 	wrap.PodSetAssignments = psFlavors
 	return wrap
@@ -604,7 +594,9 @@ func (w *AdmissionWrapper) Obj() *kueue.Admission {
 }
 
 func (w *AdmissionWrapper) Assignment(r corev1.ResourceName, f kueue.ResourceFlavorReference, value string) *AdmissionWrapper {
-	w.AssignmentWithIndex(0, r, f, value)
+	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
+	wrapper.Flavor(r, f).ResourceUsage(r, value)
+	w.PodSetAssignments[0] = wrapper.PodSetAssignment
 	return w
 }
 
@@ -623,11 +615,6 @@ func (w *AdmissionWrapper) DelayedTopologyRequest(state kueue.DelayedTopologyReq
 	return w
 }
 
-func (w *AdmissionWrapper) AssignmentWithIndex(index int32, r corev1.ResourceName, f kueue.ResourceFlavorReference, value string) *AdmissionWrapper {
-	w.PodSetAssignments[index].Flavors[r] = f
-	w.PodSetAssignments[index].ResourceUsage[r] = resource.MustParse(value)
-	return w
-}
 
 func (w *AdmissionWrapper) AssignmentPodCountWithIndex(index, value int32) *AdmissionWrapper {
 	w.PodSetAssignments[index].Count = ptr.To(value)

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -1681,3 +1681,51 @@ func (e *EventRecordWrapper) Message(message string) *EventRecordWrapper {
 func (e *EventRecordWrapper) Obj() EventRecord {
 	return e.EventRecord
 }
+
+type TopologyDomainAssignmentWrapper struct {
+	kueue.TopologyDomainAssignment
+}
+
+func MakeTopologyDomainAssignment(values []string, count int32) *TopologyDomainAssignmentWrapper {
+	return &TopologyDomainAssignmentWrapper{
+		TopologyDomainAssignment: kueue.TopologyDomainAssignment{
+			Values: values,
+			Count:  count,
+		},
+	}
+}
+
+func (t *TopologyDomainAssignmentWrapper) Obj() kueue.TopologyDomainAssignment {
+	return t.TopologyDomainAssignment
+}
+
+type TopologyAssignmentWrapper struct {
+	kueue.TopologyAssignment
+}
+
+func MakeTopologyAssignment(levels []string) *TopologyAssignmentWrapper {
+	return &TopologyAssignmentWrapper{
+		TopologyAssignment: kueue.TopologyAssignment{
+			Levels: levels,
+		},
+	}
+}
+
+func (t *TopologyAssignmentWrapper) Levels(levels ...string) *TopologyAssignmentWrapper {
+	t.TopologyAssignment.Levels = levels
+	return t
+}
+
+func (t *TopologyAssignmentWrapper) Domains(domains ...kueue.TopologyDomainAssignment) *TopologyAssignmentWrapper {
+	t.TopologyAssignment.Domains = domains
+	return t
+}
+
+func (t *TopologyAssignmentWrapper) Domain(domain kueue.TopologyDomainAssignment) *TopologyAssignmentWrapper {
+	t.TopologyAssignment.Domains = append(t.TopologyAssignment.Domains, domain)
+	return t
+}
+
+func (t *TopologyAssignmentWrapper) Obj() *kueue.TopologyAssignment {
+	return &t.TopologyAssignment
+}

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -1658,3 +1658,26 @@ func AppendOwnerReference(obj client.Object, gvk schema.GroupVersionKind, name, 
 		BlockOwnerDeletion: blockDeletion,
 	}))
 }
+
+type EventRecordWrapper struct {
+	EventRecord
+}
+
+func MakeEventRecord(namespace, name, reason, eventType string) *EventRecordWrapper {
+	return &EventRecordWrapper{
+		EventRecord: EventRecord{
+			Key:       types.NamespacedName{Namespace: namespace, Name: name},
+			Reason:    reason,
+			EventType: eventType,
+		},
+	}
+}
+
+func (e *EventRecordWrapper) Message(message string) *EventRecordWrapper {
+	e.EventRecord.Message = message
+	return e
+}
+
+func (e *EventRecordWrapper) Obj() EventRecord {
+	return e.EventRecord
+}

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -593,13 +593,6 @@ func (w *AdmissionWrapper) Obj() *kueue.Admission {
 	return &w.Admission
 }
 
-func (w *AdmissionWrapper) Assignment(r corev1.ResourceName, f kueue.ResourceFlavorReference, value string) *AdmissionWrapper {
-	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
-	wrapper.Flavor(r, f).ResourceUsage(r, value)
-	w.PodSetAssignments[0] = wrapper.PodSetAssignment
-	return w
-}
-
 func (w *AdmissionWrapper) PodSets(podSets ...kueue.PodSetAssignment) *AdmissionWrapper {
 	w.PodSetAssignments = podSets
 	return w
@@ -1734,4 +1727,8 @@ func (p *PodSetAssignmentWrapper) TopologyAssignment(ta *kueue.TopologyAssignmen
 func (p *PodSetAssignmentWrapper) DelayedTopologyRequest(state kueue.DelayedTopologyRequestState) *PodSetAssignmentWrapper {
 	p.PodSetAssignment.DelayedTopologyRequest = ptr.To(state)
 	return p
+}
+
+func (p *PodSetAssignmentWrapper) Assignment(r corev1.ResourceName, f kueue.ResourceFlavorReference, value string) *PodSetAssignmentWrapper {
+	return p.Flavor(r, f).ResourceUsage(r, value)
 }

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -1729,3 +1729,53 @@ func (t *TopologyAssignmentWrapper) Domain(domain kueue.TopologyDomainAssignment
 func (t *TopologyAssignmentWrapper) Obj() *kueue.TopologyAssignment {
 	return &t.TopologyAssignment
 }
+
+type PodSetAssignmentWrapper struct {
+	kueue.PodSetAssignment
+}
+
+func MakePodSetAssignment(name kueue.PodSetReference) *PodSetAssignmentWrapper {
+	return &PodSetAssignmentWrapper{
+		PodSetAssignment: kueue.PodSetAssignment{
+			Name:          name,
+			Flavors:       make(map[corev1.ResourceName]kueue.ResourceFlavorReference),
+			ResourceUsage: make(corev1.ResourceList),
+			Count:         ptr.To[int32](1),
+		},
+	}
+}
+
+func (p *PodSetAssignmentWrapper) Obj() kueue.PodSetAssignment {
+	return p.PodSetAssignment
+}
+
+func (p *PodSetAssignmentWrapper) Flavor(resource corev1.ResourceName, flavor kueue.ResourceFlavorReference) *PodSetAssignmentWrapper {
+	if p.Flavors == nil {
+		p.Flavors = make(map[corev1.ResourceName]kueue.ResourceFlavorReference)
+	}
+	p.Flavors[resource] = flavor
+	return p
+}
+
+func (p *PodSetAssignmentWrapper) ResourceUsage(resourceName corev1.ResourceName, quantity string) *PodSetAssignmentWrapper {
+	if p.PodSetAssignment.ResourceUsage == nil {
+		p.PodSetAssignment.ResourceUsage = make(corev1.ResourceList)
+	}
+	p.PodSetAssignment.ResourceUsage[resourceName] = resource.MustParse(quantity)
+	return p
+}
+
+func (p *PodSetAssignmentWrapper) Count(count int32) *PodSetAssignmentWrapper {
+	p.PodSetAssignment.Count = ptr.To(count)
+	return p
+}
+
+func (p *PodSetAssignmentWrapper) TopologyAssignment(ta *kueue.TopologyAssignment) *PodSetAssignmentWrapper {
+	p.PodSetAssignment.TopologyAssignment = ta
+	return p
+}
+
+func (p *PodSetAssignmentWrapper) DelayedTopologyRequest(state kueue.DelayedTopologyRequestState) *PodSetAssignmentWrapper {
+	p.PodSetAssignment.DelayedTopologyRequest = ptr.To(state)
+	return p
+}

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -614,13 +614,6 @@ func (w *AdmissionWrapper) TopologyAssignment(ts *kueue.TopologyAssignment) *Adm
 	return w
 }
 
-func (w *AdmissionWrapper) DelayedTopologyRequest(state kueue.DelayedTopologyRequestState) *AdmissionWrapper {
-	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
-	wrapper.DelayedTopologyRequest(state)
-	w.PodSetAssignments[0] = wrapper.PodSetAssignment
-	return w
-}
-
 func (w *AdmissionWrapper) PodSets(podSets ...kueue.PodSetAssignment) *AdmissionWrapper {
 	w.PodSetAssignments = podSets
 	return w

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -601,33 +601,23 @@ func (w *AdmissionWrapper) Assignment(r corev1.ResourceName, f kueue.ResourceFla
 }
 
 func (w *AdmissionWrapper) AssignmentPodCount(value int32) *AdmissionWrapper {
-	w.AssignmentPodCountWithIndex(0, value)
+	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
+	wrapper.Count(value)
+	w.PodSetAssignments[0] = wrapper.PodSetAssignment
 	return w
 }
 
 func (w *AdmissionWrapper) TopologyAssignment(ts *kueue.TopologyAssignment) *AdmissionWrapper {
-	w.TopologyAssignmentWithIndex(0, ts)
+	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
+	wrapper.TopologyAssignment(ts)
+	w.PodSetAssignments[0] = wrapper.PodSetAssignment
 	return w
 }
 
 func (w *AdmissionWrapper) DelayedTopologyRequest(state kueue.DelayedTopologyRequestState) *AdmissionWrapper {
-	w.DelayedTopologyRequestWithIndex(0, state)
-	return w
-}
-
-
-func (w *AdmissionWrapper) AssignmentPodCountWithIndex(index, value int32) *AdmissionWrapper {
-	w.PodSetAssignments[index].Count = ptr.To(value)
-	return w
-}
-
-func (w *AdmissionWrapper) TopologyAssignmentWithIndex(index int32, ts *kueue.TopologyAssignment) *AdmissionWrapper {
-	w.PodSetAssignments[index].TopologyAssignment = ts
-	return w
-}
-
-func (w *AdmissionWrapper) DelayedTopologyRequestWithIndex(index int32, state kueue.DelayedTopologyRequestState) *AdmissionWrapper {
-	w.PodSetAssignments[index].DelayedTopologyRequest = ptr.To(state)
+	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
+	wrapper.DelayedTopologyRequest(state)
+	w.PodSetAssignments[0] = wrapper.PodSetAssignment
 	return w
 }
 

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -68,8 +68,7 @@ func TestValidateWorkload(t *testing.T) {
 					Obj()).
 				ReserveQuota(testingutil.MakeAdmission("cluster-queue").
 					PodSets(testingutil.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "flv").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "flv", "1").
 						Count(3).
 						Obj()).
 					Obj()).

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -67,8 +67,11 @@ func TestValidateWorkload(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(testingutil.MakeAdmission("cluster-queue").
-					Assignment(corev1.ResourceCPU, "flv", "1").
-					AssignmentPodCount(3).
+					PodSets(testingutil.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "flv").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(3).
+						Obj()).
 					Obj()).
 				Obj(),
 			wantErr: field.ErrorList{

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1248,10 +1248,16 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-						AssignmentPodCount(1).Obj(),
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(
+							utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+								Count(1).
+								Obj(),
+						).
+						Obj(),
 				).
 				AdmissionCheck(kueue.AdmissionCheckState{
 					Name:  "prov-check",
@@ -1268,10 +1274,16 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-						AssignmentPodCount(1).Obj(),
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(
+							utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+								Count(1).
+								Obj(),
+						).
+						Obj(),
 				).
 				AdmissionCheck(kueue.AdmissionCheckState{
 					Name:  "prov-check",

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -167,9 +167,13 @@ func TestNewInfo(t *testing.T) {
 				).
 				ReserveQuota(
 					utiltesting.MakeAdmission("").
-						Assignment(corev1.ResourceCPU, "f1", "30m").
-						Assignment(corev1.ResourceMemory, "f1", "30Ki").
-						AssignmentPodCount(3).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "f1").
+							ResourceUsage(corev1.ResourceCPU, "30m").
+							Flavor(corev1.ResourceMemory, "f1").
+							ResourceUsage(corev1.ResourceMemory, "30Ki").
+							Count(3).
+							Obj()).
 						Obj(),
 				).
 				ReclaimablePods(
@@ -206,9 +210,13 @@ func TestNewInfo(t *testing.T) {
 				).
 				ReserveQuota(
 					utiltesting.MakeAdmission("").
-						Assignment(corev1.ResourceCPU, "f1", "30m").
-						Assignment(corev1.ResourceMemory, "f1", "30Ki").
-						AssignmentPodCount(3).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "f1").
+							ResourceUsage(corev1.ResourceCPU, "30m").
+							Flavor(corev1.ResourceMemory, "f1").
+							ResourceUsage(corev1.ResourceMemory, "30Ki").
+							Count(3).
+							Obj()).
 						Obj(),
 				).
 				ReclaimablePods(
@@ -245,9 +253,13 @@ func TestNewInfo(t *testing.T) {
 				).
 				ReserveQuota(
 					utiltesting.MakeAdmission("").
-						Assignment(corev1.ResourceCPU, "f1", "30m").
-						Assignment(corev1.ResourceMemory, "f1", "30Ki").
-						AssignmentPodCount(3).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "f1").
+							ResourceUsage(corev1.ResourceCPU, "30m").
+							Flavor(corev1.ResourceMemory, "f1").
+							ResourceUsage(corev1.ResourceMemory, "30Ki").
+							Count(3).
+							Obj()).
 						Obj(),
 				).
 				Obj(),

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -168,10 +168,8 @@ func TestNewInfo(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "f1").
-							ResourceUsage(corev1.ResourceCPU, "30m").
-							Flavor(corev1.ResourceMemory, "f1").
-							ResourceUsage(corev1.ResourceMemory, "30Ki").
+							Assignment(corev1.ResourceCPU, "f1", "30m").
+							Assignment(corev1.ResourceMemory, "f1", "30Ki").
 							Count(3).
 							Obj()).
 						Obj(),
@@ -211,10 +209,8 @@ func TestNewInfo(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "f1").
-							ResourceUsage(corev1.ResourceCPU, "30m").
-							Flavor(corev1.ResourceMemory, "f1").
-							ResourceUsage(corev1.ResourceMemory, "30Ki").
+							Assignment(corev1.ResourceCPU, "f1", "30m").
+							Assignment(corev1.ResourceMemory, "f1", "30Ki").
 							Count(3).
 							Obj()).
 						Obj(),
@@ -254,10 +250,8 @@ func TestNewInfo(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "f1").
-							ResourceUsage(corev1.ResourceCPU, "30m").
-							Flavor(corev1.ResourceMemory, "f1").
-							ResourceUsage(corev1.ResourceMemory, "30Ki").
+							Assignment(corev1.ResourceCPU, "f1", "30m").
+							Assignment(corev1.ResourceMemory, "f1", "30Ki").
 							Count(3).
 							Obj()).
 						Obj(),
@@ -1133,9 +1127,7 @@ func TestNeedsSecondPass(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 								Obj()).
@@ -1156,9 +1148,7 @@ func TestNeedsSecondPass(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 								Obj()).
@@ -1180,9 +1170,7 @@ func TestNeedsSecondPass(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
@@ -1204,9 +1192,7 @@ func TestNeedsSecondPass(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 								Obj()).
@@ -1229,9 +1215,7 @@ func TestNeedsSecondPass(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 								Obj()).
@@ -1254,10 +1238,8 @@ func TestNeedsSecondPass(t *testing.T) {
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(
 							utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-								Count(1).
 								Obj(),
 						).
 						Obj(),
@@ -1280,10 +1262,8 @@ func TestNeedsSecondPass(t *testing.T) {
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(
 							utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-								Count(1).
 								Obj(),
 						).
 						Obj(),

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1103,20 +1103,15 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						AssignmentPodCount(1).
-						TopologyAssignment(&kueue.TopologyAssignment{
-							Levels: utiltas.Levels(&defaultSingleLevelTopology),
-							Domains: []kueue.TopologyDomainAssignment{
-								{
-									Count: 1,
-									Values: []string{
-										"x0",
-									},
-								},
-							},
-						}).
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
+							Obj()).
 						Obj(),
 				).
 				Admitted(true).
@@ -1131,20 +1126,15 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						AssignmentPodCount(1).
-						TopologyAssignment(&kueue.TopologyAssignment{
-							Levels: utiltas.Levels(&defaultSingleLevelTopology),
-							Domains: []kueue.TopologyDomainAssignment{
-								{
-									Count: 1,
-									Values: []string{
-										"x0",
-									},
-								},
-							},
-						}).
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
+							Obj()).
 						Obj(),
 				).
 				Admitted(true).
@@ -1160,20 +1150,15 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						AssignmentPodCount(1).
-						TopologyAssignment(&kueue.TopologyAssignment{
-							Levels: utiltas.Levels(&defaultSingleLevelTopology),
-							Domains: []kueue.TopologyDomainAssignment{
-								{
-									Count: 1,
-									Values: []string{
-										"x1",
-									},
-								},
-							},
-						}).
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj()).
 						Obj(),
 				).
 				Admitted(true).
@@ -1189,20 +1174,15 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						AssignmentPodCount(1).
-						TopologyAssignment(&kueue.TopologyAssignment{
-							Levels: utiltas.Levels(&defaultSingleLevelTopology),
-							Domains: []kueue.TopologyDomainAssignment{
-								{
-									Count: 1,
-									Values: []string{
-										"x0",
-									},
-								},
-							},
-						}).
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
+							Obj()).
 						Obj(),
 				).
 				Admitted(true).
@@ -1219,20 +1199,15 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						AssignmentPodCount(1).
-						TopologyAssignment(&kueue.TopologyAssignment{
-							Levels: utiltas.Levels(&defaultSingleLevelTopology),
-							Domains: []kueue.TopologyDomainAssignment{
-								{
-									Count: 1,
-									Values: []string{
-										"x0",
-									},
-								},
-							},
-						}).
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
+							Obj()).
 						Obj(),
 				).
 				Admitted(true).

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -845,7 +845,11 @@ func TestAdmissionCheckStrategy(t *testing.T) {
 	}{
 		"AdmissionCheckStrategy with a flavor": {
 			wl: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Obj(),
 			cq: utiltesting.MakeClusterQueue("cq").
 				AdmissionCheckStrategy(*utiltesting.MakeAdmissionCheckStrategyRule("ac1", "flavor1").Obj()).
@@ -854,7 +858,11 @@ func TestAdmissionCheckStrategy(t *testing.T) {
 		},
 		"AdmissionCheckStrategy with an unmatched flavor": {
 			wl: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Obj(),
 			cq: utiltesting.MakeClusterQueue("cq").
 				AdmissionCheckStrategy(*utiltesting.MakeAdmissionCheckStrategyRule("ac1", "unmatched-flavor").Obj()).
@@ -863,7 +871,11 @@ func TestAdmissionCheckStrategy(t *testing.T) {
 		},
 		"AdmissionCheckStrategy without a flavor": {
 			wl: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Obj(),
 			cq: utiltesting.MakeClusterQueue("cq").
 				AdmissionCheckStrategy(*utiltesting.MakeAdmissionCheckStrategyRule("ac1").Obj()).
@@ -872,7 +884,11 @@ func TestAdmissionCheckStrategy(t *testing.T) {
 		},
 		"Two AdmissionCheckStrategies, one with flavor, one without flavor": {
 			wl: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Obj(),
 			cq: utiltesting.MakeClusterQueue("cq").
 				AdmissionCheckStrategy(

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -145,26 +145,16 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 
 			admission = testing.MakeAdmission(cq.Name).
 				PodSets(
-					kueue.PodSetAssignment{
-						Name: "ps1",
-						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-							corev1.ResourceCPU: kueue.ResourceFlavorReference(rf.Name),
-						},
-						ResourceUsage: map[corev1.ResourceName]resource.Quantity{
-							corev1.ResourceCPU: resource.MustParse("3"),
-						},
-						Count: ptr.To[int32](3),
-					},
-					kueue.PodSetAssignment{
-						Name: "ps2",
-						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-							corev1.ResourceCPU: kueue.ResourceFlavorReference(rf.Name),
-						},
-						ResourceUsage: map[corev1.ResourceName]resource.Quantity{
-							corev1.ResourceCPU: resource.MustParse("2"),
-						},
-						Count: ptr.To[int32](4),
-					},
+					testing.MakePodSetAssignment("ps1").
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceCPU, "3").
+						Count(3).
+						Obj(),
+					testing.MakePodSetAssignment("ps2").
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceCPU, "2").
+						Count(4).
+						Obj(),
 				).
 				Obj()
 		})
@@ -879,26 +869,16 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			wlKey = client.ObjectKeyFromObject(wl)
 			admission = testing.MakeAdmission(cq.Name).
 				PodSets(
-					kueue.PodSetAssignment{
-						Name: "ps1",
-						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-							corev1.ResourceCPU: kueue.ResourceFlavorReference(rf.Name),
-						},
-						ResourceUsage: map[corev1.ResourceName]resource.Quantity{
-							corev1.ResourceCPU: resource.MustParse("3"),
-						},
-						Count: ptr.To[int32](3),
-					},
-					kueue.PodSetAssignment{
-						Name: "ps2",
-						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-							corev1.ResourceCPU: kueue.ResourceFlavorReference(rf.Name),
-						},
-						ResourceUsage: map[corev1.ResourceName]resource.Quantity{
-							corev1.ResourceCPU: resource.MustParse("2"),
-						},
-						Count: ptr.To[int32](4),
-					},
+					testing.MakePodSetAssignment("ps1").
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceCPU, "3").
+						Count(3).
+						Obj(),
+					testing.MakePodSetAssignment("ps2").
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceCPU, "2").
+						Count(4).
+						Obj(),
 				).
 				Obj()
 		})
@@ -1543,28 +1523,20 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 
 			admission = testing.MakeAdmission(cq.Name).
 				PodSets(
-					kueue.PodSetAssignment{
-						Name: "master",
-						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-							corev1.ResourceCPU: kueue.ResourceFlavorReference(rf.Name),
-						},
-						ResourceUsage: map[corev1.ResourceName]resource.Quantity{
-							corev1.ResourceCPU:    resource.MustParse("1"),
-							corev1.ResourceMemory: resource.MustParse("2Gi"),
-						},
-						Count: ptr.To[int32](1),
-					},
-					kueue.PodSetAssignment{
-						Name: "worker",
-						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-							corev1.ResourceCPU: kueue.ResourceFlavorReference(rf.Name),
-						},
-						ResourceUsage: map[corev1.ResourceName]resource.Quantity{
-							corev1.ResourceCPU:    resource.MustParse("1"),
-							corev1.ResourceMemory: resource.MustParse("2Gi"),
-						},
-						Count: ptr.To[int32](2),
-					},
+					testing.MakePodSetAssignment("master").
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Flavor(corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceMemory, "2Gi").
+						Count(1).
+						Obj(),
+					testing.MakePodSetAssignment("worker").
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Flavor(corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceMemory, "2Gi").
+						Count(2).
+						Obj(),
 				).
 				Obj()
 		})

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -25,11 +25,9 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1beta1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -1318,17 +1316,12 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 
 			wlKey = client.ObjectKeyFromObject(wl)
 			admission = testing.MakeAdmission(cq.Name).
-				PodSets(
-					kueue.PodSetAssignment{
-						Name: "ps1",
-						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-							corev1.ResourceCPU: kueue.ResourceFlavorReference(rf.Name),
-						},
-						ResourceUsage: map[corev1.ResourceName]resource.Quantity{
-							corev1.ResourceCPU: resource.MustParse("3"),
-						},
-						Count: ptr.To[int32](3),
-					}).Obj()
+				PodSets(testing.MakePodSetAssignment("ps1").
+					Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+					ResourceUsage(corev1.ResourceCPU, "3").
+					Count(3).
+					Obj()).
+				Obj()
 		})
 
 		ginkgo.AfterEach(func() {

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -144,13 +144,11 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			admission = testing.MakeAdmission(cq.Name).
 				PodSets(
 					testing.MakePodSetAssignment("ps1").
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceCPU, "3").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "3").
 						Count(3).
 						Obj(),
 					testing.MakePodSetAssignment("ps2").
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceCPU, "2").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "2").
 						Count(4).
 						Obj(),
 				).
@@ -868,13 +866,11 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			admission = testing.MakeAdmission(cq.Name).
 				PodSets(
 					testing.MakePodSetAssignment("ps1").
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceCPU, "3").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "3").
 						Count(3).
 						Obj(),
 					testing.MakePodSetAssignment("ps2").
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceCPU, "2").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "2").
 						Count(4).
 						Obj(),
 				).
@@ -1317,8 +1313,7 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			wlKey = client.ObjectKeyFromObject(wl)
 			admission = testing.MakeAdmission(cq.Name).
 				PodSets(testing.MakePodSetAssignment("ps1").
-					Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-					ResourceUsage(corev1.ResourceCPU, "3").
+					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "3").
 					Count(3).
 					Obj()).
 				Obj()
@@ -1517,17 +1512,12 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			admission = testing.MakeAdmission(cq.Name).
 				PodSets(
 					testing.MakePodSetAssignment("master").
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceCPU, "1").
-						Flavor(corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceMemory, "2Gi").
-						Count(1).
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "1").
+						Assignment(corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name), "2Gi").
 						Obj(),
 					testing.MakePodSetAssignment("worker").
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceCPU, "1").
-						Flavor(corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceMemory, "2Gi").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "1").
+						Assignment(corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name), "2Gi").
 						Count(2).
 						Obj(),
 				).

--- a/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
@@ -220,15 +220,20 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 			ginkgo.By("Set workloads quota reservation")
 			admissions := []*kueue.Admission{
 				testing.MakeAdmission(clusterQueue.Name).
-					Assignment(corev1.ResourceCPU, flavorOnDemand, "2").Assignment(resourceGPU, flavorModelA, "2").Obj(),
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, flavorOnDemand, "2").Assignment(resourceGPU, flavorModelA, "2").Obj()).Obj(),
 				testing.MakeAdmission(clusterQueue.Name).
-					Assignment(corev1.ResourceCPU, flavorOnDemand, "3").Assignment(resourceGPU, flavorModelA, "3").Obj(),
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, flavorOnDemand, "3").Assignment(resourceGPU, flavorModelA, "3").Obj()).Obj(),
 				testing.MakeAdmission(clusterQueue.Name).
-					Assignment(corev1.ResourceCPU, flavorOnDemand, "1").Assignment(resourceGPU, flavorModelB, "1").Obj(),
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, flavorOnDemand, "1").Assignment(resourceGPU, flavorModelB, "1").Obj()).Obj(),
 				testing.MakeAdmission(clusterQueue.Name).
-					Assignment(corev1.ResourceCPU, flavorSpot, "1").Assignment(resourceGPU, flavorModelB, "1").Obj(),
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, flavorSpot, "1").Assignment(resourceGPU, flavorModelB, "1").Obj()).Obj(),
 				testing.MakeAdmission("other").
-					Assignment(corev1.ResourceCPU, flavorSpot, "1").Assignment(resourceGPU, flavorModelB, "1").Obj(),
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, flavorSpot, "1").Assignment(resourceGPU, flavorModelB, "1").Obj()).Obj(),
 				nil,
 			}
 			for i, w := range workloads {

--- a/test/integration/singlecluster/controller/core/localqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/localqueue_controller_test.go
@@ -242,11 +242,14 @@ var _ = ginkgo.Describe("Queue controller", ginkgo.Ordered, ginkgo.ContinueOnFai
 		}
 		admissions := []*kueue.Admission{
 			testing.MakeAdmission(clusterQueue.Name).
-				Assignment(resourceGPU, flavorModelC, "2").Obj(),
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(resourceGPU, flavorModelC, "2").Obj()).Obj(),
 			testing.MakeAdmission(clusterQueue.Name).
-				Assignment(resourceGPU, flavorModelC, "3").Obj(),
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(resourceGPU, flavorModelC, "3").Obj()).Obj(),
 			testing.MakeAdmission(clusterQueue.Name).
-				Assignment(resourceGPU, flavorModelD, "1").Obj(),
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(resourceGPU, flavorModelD, "1").Obj()).Obj(),
 		}
 
 		ginkgo.By("Creating workloads")
@@ -476,11 +479,14 @@ var _ = ginkgo.Describe("Queue controller", ginkgo.Ordered, ginkgo.ContinueOnFai
 		}
 		admissions := []*kueue.Admission{
 			testing.MakeAdmission(clusterQueue.Name).
-				Assignment(resourceGPU, flavorModelC, "2").Obj(),
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(resourceGPU, flavorModelC, "2").Obj()).Obj(),
 			testing.MakeAdmission(clusterQueue.Name).
-				Assignment(resourceGPU, flavorModelC, "3").Obj(),
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(resourceGPU, flavorModelC, "3").Obj()).Obj(),
 			testing.MakeAdmission(clusterQueue.Name).
-				Assignment(resourceGPU, flavorModelD, "1").Obj(),
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(resourceGPU, flavorModelD, "1").Obj()).Obj(),
 		}
 
 		ginkgo.By("Creating workloads", func() {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -193,8 +193,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			).Obj()
 		admission := testing.MakeAdmission(clusterQueue.Name).
 			PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-				Flavor(corev1.ResourceCPU, "on-demand").
-				ResourceUsage(corev1.ResourceCPU, "1m").
+				Assignment(corev1.ResourceCPU, "on-demand", "1m").
 				Count(createdWorkload.Spec.PodSets[0].Count).
 				Obj()).
 			Obj()
@@ -246,8 +245,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 		ginkgo.By("checking the job is unsuspended and selectors added when workload is assigned again")
 		admission = testing.MakeAdmission(clusterQueue.Name).
 			PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-				Flavor(corev1.ResourceCPU, "spot").
-				ResourceUsage(corev1.ResourceCPU, "1m").
+				Assignment(corev1.ResourceCPU, "spot", "1m").
 				Count(createdWorkload.Spec.PodSets[0].Count).
 				Obj()).
 			Obj()
@@ -828,8 +826,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			ginkgo.By("admit the workload", func() {
 				admission := testing.MakeAdmission(clusterQueueAc.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "test-flavor").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "test-flavor", "1").
 						Count(createdWorkload.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -949,8 +946,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			ginkgo.By("attempt to admit the workload", func() {
 				admission := testing.MakeAdmission(clusterQueueAc.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "test-flavor").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "test-flavor", "1").
 						Count(createdWorkload.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -1026,8 +1022,7 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 			ginkgo.By("Admit the workload created for the job")
 			admission := testing.MakeAdmission("foo").
 				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-					Flavor(corev1.ResourceCPU, "default").
-					ResourceUsage(corev1.ResourceCPU, "1m").
+					Assignment(corev1.ResourceCPU, "default", "1m").
 					Count(createdWorkload.Spec.PodSets[0].Count).
 					Obj()).
 				Obj()
@@ -2540,8 +2535,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				admission = testing.MakeAdmission(cq.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "on-demand").
-						ResourceUsage(corev1.ResourceCPU, "1m").
+						Assignment(corev1.ResourceCPU, "on-demand", "1m").
 						Count(wl.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -2908,8 +2902,7 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 				ginkgo.By("Admitting the Workload", func() {
 					admission := testing.MakeAdmission(cq.Name).
 						PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
-							ResourceUsage(corev1.ResourceCPU, "1m").
+							Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1m").
 							Count(wl.Spec.PodSets[0].Count).
 							Obj()).
 						Obj()
@@ -2965,8 +2958,7 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 
 				admission := testing.MakeAdmission(cq.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
-						ResourceUsage(corev1.ResourceCPU, "1m").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1m").
 						Count(wl.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -3067,8 +3059,7 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 
 				admission := testing.MakeAdmission(cq.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
-						ResourceUsage(corev1.ResourceCPU, "1m").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1m").
 						Count(wl.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -192,8 +192,11 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				*testing.MakeFlavorQuotas("spot").Resource(corev1.ResourceCPU, "5").Obj(),
 			).Obj()
 		admission := testing.MakeAdmission(clusterQueue.Name).
-			Assignment(corev1.ResourceCPU, "on-demand", "1m").
-			AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+			PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+				Flavor(corev1.ResourceCPU, "on-demand").
+				ResourceUsage(corev1.ResourceCPU, "1m").
+				Count(createdWorkload.Spec.PodSets[0].Count).
+				Obj()).
 			Obj()
 		gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 		util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -242,8 +245,11 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 		ginkgo.By("checking the job is unsuspended and selectors added when workload is assigned again")
 		admission = testing.MakeAdmission(clusterQueue.Name).
-			Assignment(corev1.ResourceCPU, "spot", "1m").
-			AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+			PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+				Flavor(corev1.ResourceCPU, "spot").
+				ResourceUsage(corev1.ResourceCPU, "1m").
+				Count(createdWorkload.Spec.PodSets[0].Count).
+				Obj()).
 			Obj()
 		gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 		util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -821,8 +827,11 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 			ginkgo.By("admit the workload", func() {
 				admission := testing.MakeAdmission(clusterQueueAc.Name).
-					Assignment(corev1.ResourceCPU, "test-flavor", "1").
-					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "test-flavor").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(createdWorkload.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				gomega.Expect(k8sClient.Get(ctx, *wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
@@ -939,8 +948,11 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 			ginkgo.By("attempt to admit the workload", func() {
 				admission := testing.MakeAdmission(clusterQueueAc.Name).
-					Assignment(corev1.ResourceCPU, "test-flavor", "1").
-					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "test-flavor").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(createdWorkload.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				gomega.Expect(k8sClient.Get(ctx, *wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
@@ -1013,8 +1025,11 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 
 			ginkgo.By("Admit the workload created for the job")
 			admission := testing.MakeAdmission("foo").
-				Assignment(corev1.ResourceCPU, "default", "1m").
-				AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Flavor(corev1.ResourceCPU, "default").
+					ResourceUsage(corev1.ResourceCPU, "1m").
+					Count(createdWorkload.Spec.PodSets[0].Count).
+					Obj()).
 				Obj()
 			gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -2524,8 +2539,11 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				admission = testing.MakeAdmission(cq.Name).
-					Assignment(corev1.ResourceCPU, "on-demand", "1m").
-					AssignmentPodCount(wl.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "on-demand").
+						ResourceUsage(corev1.ResourceCPU, "1m").
+						Count(wl.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				g.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, admission)).Should(gomega.Succeed())
 				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
@@ -2889,8 +2907,11 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 
 				ginkgo.By("Admitting the Workload", func() {
 					admission := testing.MakeAdmission(cq.Name).
-						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1m").
-						AssignmentPodCount(wl.Spec.PodSets[0].Count).
+						PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
+							ResourceUsage(corev1.ResourceCPU, "1m").
+							Count(wl.Spec.PodSets[0].Count).
+							Obj()).
 						Obj()
 					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, admission)).Should(gomega.Succeed())
 					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
@@ -2943,8 +2964,11 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 				})
 
 				admission := testing.MakeAdmission(cq.Name).
-					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1m").
-					AssignmentPodCount(wl.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
+						ResourceUsage(corev1.ResourceCPU, "1m").
+						Count(wl.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 
 				ginkgo.By("Admitting the Workload", func() {
@@ -3042,8 +3066,11 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 				})
 
 				admission := testing.MakeAdmission(cq.Name).
-					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1m").
-					AssignmentPodCount(wl.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
+						ResourceUsage(corev1.ResourceCPU, "1m").
+						Count(wl.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 
 				ginkgo.By("Admitting the Workload", func() {

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -183,8 +183,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
 					).Obj()
 				admission := testing.MakeAdmission(clusterQueue.Name).
-					Assignment(corev1.ResourceCPU, "default", "1").
-					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(createdWorkload.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -241,8 +244,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
 					).Obj()
 				admission := testing.MakeAdmission(clusterQueue.Name).
-					Assignment(corev1.ResourceCPU, "default", "1").
-					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(createdWorkload.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -304,8 +310,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 							*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
 						).Obj()
 					admission := testing.MakeAdmission(clusterQueue.Name).
-						Assignment(corev1.ResourceCPU, "default", "1").
-						AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+						PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "1").
+							Count(createdWorkload.Spec.PodSets[0].Count).
+							Obj()).
 						Obj()
 					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -476,8 +485,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 					ginkgo.By("admit the workload", func() {
 						admission := testing.MakeAdmission(clusterQueueAc.Name).
-							Assignment(corev1.ResourceCPU, "test-flavor", "1").
-							AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+							PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(createdWorkload.Spec.PodSets[0].Count).
+								Obj()).
 							Obj()
 						gomega.Expect(k8sClient.Get(ctx, *wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 						gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
@@ -529,8 +541,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				ginkgo.By("Admit workload", func() {
 					admission := testing.MakeAdmission(clusterQueue.Name).
-						Assignment(corev1.ResourceCPU, "default", "1").
-						AssignmentPodCount(wl.Spec.PodSets[0].Count).
+						PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "1").
+							Count(wl.Spec.PodSets[0].Count).
+							Obj()).
 						Obj()
 					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, admission)).Should(gomega.Succeed())
 					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
@@ -758,9 +773,12 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName("test-queue")), "The Workload should have .spec.queueName set")
 				originalWorkloadUID := createdWorkload.UID
 
-				admission := testing.MakeAdmission(clusterQueue.Name, "bf90803c").
-					Assignment(corev1.ResourceCPU, "default", "1").
-					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+				admission := testing.MakeAdmission(clusterQueue.Name).
+					PodSets(testing.MakePodSetAssignment("bf90803c").
+						Flavor(corev1.ResourceCPU, "default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(createdWorkload.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				ginkgo.By("checking that all pods in group are unsuspended when workload is admitted", func() {
 					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
@@ -908,9 +926,12 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName("test-queue")), "The Workload should have .spec.queueName set")
 
 				ginkgo.By("checking that pod is unsuspended when workload is admitted")
-				admission := testing.MakeAdmission(clusterQueue.Name, "bf90803c").
-					Assignment(corev1.ResourceCPU, "default", "1").
-					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+				admission := testing.MakeAdmission(clusterQueue.Name).
+					PodSets(testing.MakePodSetAssignment("bf90803c").
+						Flavor(corev1.ResourceCPU, "default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(createdWorkload.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -1363,9 +1384,12 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 
-				admission := testing.MakeAdmission(cq.Name, wl.Spec.PodSets[0].Name).
-					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1").
-					AssignmentPodCount(wl.Spec.PodSets[0].Count).
+				admission := testing.MakeAdmission(cq.Name).
+					PodSets(testing.MakePodSetAssignment(wl.Spec.PodSets[0].Name).
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(wl.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 
 				ginkgo.By("admitting the workload", func() {
@@ -2010,9 +2034,12 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 				))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			admission := testing.MakeAdmission(cq.Name, wl.Spec.PodSets[0].Name).
-				Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1").
-				AssignmentPodCount(wl.Spec.PodSets[0].Count).
+			admission := testing.MakeAdmission(cq.Name).
+				PodSets(testing.MakePodSetAssignment(wl.Spec.PodSets[0].Name).
+					Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
+					ResourceUsage(corev1.ResourceCPU, "1").
+					Count(wl.Spec.PodSets[0].Count).
+					Obj()).
 				Obj()
 
 			ginkgo.By("admit the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -184,8 +184,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					).Obj()
 				admission := testing.MakeAdmission(clusterQueue.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "default").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "default", "1").
 						Count(createdWorkload.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -245,8 +244,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					).Obj()
 				admission := testing.MakeAdmission(clusterQueue.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "default").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "default", "1").
 						Count(createdWorkload.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -311,8 +309,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						).Obj()
 					admission := testing.MakeAdmission(clusterQueue.Name).
 						PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "1").
+							Assignment(corev1.ResourceCPU, "default", "1").
 							Count(createdWorkload.Spec.PodSets[0].Count).
 							Obj()).
 						Obj()
@@ -486,8 +483,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					ginkgo.By("admit the workload", func() {
 						admission := testing.MakeAdmission(clusterQueueAc.Name).
 							PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
+								Assignment(corev1.ResourceCPU, "test-flavor", "1").
 								Count(createdWorkload.Spec.PodSets[0].Count).
 								Obj()).
 							Obj()
@@ -542,8 +538,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				ginkgo.By("Admit workload", func() {
 					admission := testing.MakeAdmission(clusterQueue.Name).
 						PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "1").
+							Assignment(corev1.ResourceCPU, "default", "1").
 							Count(wl.Spec.PodSets[0].Count).
 							Obj()).
 						Obj()
@@ -775,8 +770,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				admission := testing.MakeAdmission(clusterQueue.Name).
 					PodSets(testing.MakePodSetAssignment("bf90803c").
-						Flavor(corev1.ResourceCPU, "default").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "default", "1").
 						Count(createdWorkload.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -928,8 +922,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				ginkgo.By("checking that pod is unsuspended when workload is admitted")
 				admission := testing.MakeAdmission(clusterQueue.Name).
 					PodSets(testing.MakePodSetAssignment("bf90803c").
-						Flavor(corev1.ResourceCPU, "default").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "default", "1").
 						Count(createdWorkload.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -1386,8 +1379,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				admission := testing.MakeAdmission(cq.Name).
 					PodSets(testing.MakePodSetAssignment(wl.Spec.PodSets[0].Name).
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1").
 						Count(wl.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -2036,8 +2028,7 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 
 			admission := testing.MakeAdmission(cq.Name).
 				PodSets(testing.MakePodSetAssignment(wl.Spec.PodSets[0].Name).
-					Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
-					ResourceUsage(corev1.ResourceCPU, "1").
+					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1").
 					Count(wl.Spec.PodSets[0].Count).
 					Obj()).
 				Obj()

--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -673,7 +673,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Await for the a-best-effort-low workload to be admitted")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, aBestEffortLowWl,
-				testing.MakeAdmission(aBestEffortCQ.Name).Assignment(corev1.ResourceCPU, "one", "5").Obj(),
+				testing.MakeAdmission(aBestEffortCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "one", "5").Obj()).Obj(),
 			)
 
 			ginkgo.By("Create a low priority workload which is not borrowing")
@@ -686,7 +686,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Await for the b-best-effort-low workload to be admitted")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, bBestEffortLowWl,
-				testing.MakeAdmission(bBestEffortCQ.Name).Assignment(corev1.ResourceCPU, "one", "1").Obj(),
+				testing.MakeAdmission(bBestEffortCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "one", "1").Obj()).Obj(),
 			)
 
 			ginkgo.By("Create a high priority workload (above MaxPriorityThreshold) which requires borrowing")
@@ -699,7 +699,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Await for the b-standard-high workload to be admitted")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, bStandardWl,
-				testing.MakeAdmission(bStandardCQ.Name).Assignment(corev1.ResourceCPU, "one", "5").Obj(),
+				testing.MakeAdmission(bStandardCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "one", "5").Obj()).Obj(),
 			)
 
 			ginkgo.By("Create the a-standard-very-high workload")
@@ -719,22 +719,22 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Verify the a-standard-very-high workload is admitted")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, aStandardVeryHighWl,
-				testing.MakeAdmission(aStandardCQ.Name).Assignment(corev1.ResourceCPU, "one", "7").Obj(),
+				testing.MakeAdmission(aStandardCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "one", "7").Obj()).Obj(),
 			)
 
 			ginkgo.By("Verify the a-best-effort-low workload is re-admitted, but using flavor 2")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, aBestEffortLowWl,
-				testing.MakeAdmission(aBestEffortCQ.Name).Assignment(corev1.ResourceCPU, "fallback", "5").Obj(),
+				testing.MakeAdmission(aBestEffortCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "fallback", "5").Obj()).Obj(),
 			)
 
 			ginkgo.By("Verify the b-standard-high workload remains admitted")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, bStandardWl,
-				testing.MakeAdmission(bStandardCQ.Name).Assignment(corev1.ResourceCPU, "one", "5").Obj(),
+				testing.MakeAdmission(bStandardCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "one", "5").Obj()).Obj(),
 			)
 
 			ginkgo.By("Verify for the b-best-effort-low workload remains admitted")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, bBestEffortLowWl,
-				testing.MakeAdmission(bBestEffortCQ.Name).Assignment(corev1.ResourceCPU, "one", "1").Obj(),
+				testing.MakeAdmission(bBestEffortCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "one", "1").Obj()).Obj(),
 			)
 		})
 	})
@@ -792,7 +792,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 			util.FinishEvictionForWorkloads(ctx, k8sClient, wl1)
 
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3,
-				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "alpha", "4").Obj())
+				testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "alpha", "4").Obj()).Obj())
 		})
 	})
 

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -334,10 +334,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.MustCreate(ctx, k8sClient, wl1)
 				wl1Admission := testing.MakeAdmission(podsCountClusterQ.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "on-demand").
-						ResourceUsage(corev1.ResourceCPU, "6").
-						Flavor(corev1.ResourcePods, "on-demand").
-						ResourceUsage(corev1.ResourcePods, "3").
+						Assignment(corev1.ResourceCPU, "on-demand", "6").
+						Assignment(corev1.ResourcePods, "on-demand", "3").
 						Count(3).
 						Obj()).
 					Obj()
@@ -400,8 +398,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.MustCreate(ctx, k8sClient, wl1)
 				wl1Admission := testing.MakeAdmission(podsCountOnlyClusterQ.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourcePods, "on-demand").
-						ResourceUsage(corev1.ResourcePods, "3").
+						Assignment(corev1.ResourcePods, "on-demand", "3").
 						Count(3).
 						Obj()).
 					Obj()
@@ -510,9 +507,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.MustCreate(ctx, k8sClient, wl1)
 				wl1Admission := testing.MakeAdmission(admissionCheckClusterQ.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(onDemandFlavor.Name)).
-						ResourceUsage(corev1.ResourceCPU, "2").
-						Count(1).
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(onDemandFlavor.Name), "2").
 						Obj()).
 					Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, wl1Admission)

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -255,7 +255,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("checking the first prod workload gets admitted")
 			prodWl1 := testing.MakeWorkload("prod-wl1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl1)
-			prodWl1Admission := testing.MakeAdmission(prodClusterQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "2").Obj()
+			prodWl1Admission := testing.MakeAdmission(prodClusterQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "2").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, prodWl1, prodWl1Admission)
 			util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
@@ -305,7 +305,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("checking a dev workload gets admitted")
 			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 			util.MustCreate(ctx, k8sClient, devWl)
-			spotUntaintedFlavorAdmission := testing.MakeAdmission(devClusterQ.Name).Assignment(corev1.ResourceCPU, "spot-untainted", "5").Obj()
+			spotUntaintedFlavorAdmission := testing.MakeAdmission(devClusterQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "spot-untainted", "5").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, devWl, spotUntaintedFlavorAdmission)
 			util.ExpectPendingWorkloadsMetric(devClusterQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(devClusterQ, 1)
@@ -314,7 +314,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("checking the second workload gets admitted when the first workload finishes")
 			util.FinishWorkloads(ctx, k8sClient, prodWl1)
-			prodWl2Admission := testing.MakeAdmission(prodClusterQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj()
+			prodWl2Admission := testing.MakeAdmission(prodClusterQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, prodWl2, prodWl2Admission)
 			util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
@@ -704,7 +704,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("First big workload starts")
 			wl1 := testing.MakeWorkload("on-demand-wl1", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "4").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
-			expectWl1Admission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "4").Obj()
+			expectWl1Admission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "4").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectWl1Admission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
@@ -723,7 +723,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("Third small workload starts")
 			wl3 := testing.MakeWorkload("on-demand-wl3", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
-			expectWl3Admission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()
+			expectWl3Admission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3, expectWl3Admission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 2)
@@ -732,7 +732,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("Second big workload starts after the first one is deleted")
 			gomega.Expect(k8sClient.Delete(ctx, wl1, client.PropagationPolicy(metav1.DeletePropagationBackground))).Should(gomega.Succeed())
-			expectWl2Admission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "4").Obj()
+			expectWl2Admission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "4").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, expectWl2Admission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 2)
@@ -756,7 +756,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("First big workload starts")
 			wl1 := testing.MakeWorkload("on-demand-wl1", ns.Name).Queue(kueue.LocalQueueName(fooQ.Name)).Request(corev1.ResourceCPU, "8").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
-			expectAdmission := testing.MakeAdmission(fooCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "8").Obj()
+			expectAdmission := testing.MakeAdmission(fooCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "8").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(fooCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(fooCQ, 1)
@@ -775,7 +775,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("Third small workload starts")
 			wl3 := testing.MakeWorkload("on-demand-wl3", ns.Name).Queue(kueue.LocalQueueName(fooQ.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
-			expectAdmission = testing.MakeAdmission(fooCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "2").Obj()
+			expectAdmission = testing.MakeAdmission(fooCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "2").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(fooCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(fooCQ, 2)
@@ -784,7 +784,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("Second big workload starts after the first one is deleted")
 			gomega.Expect(k8sClient.Delete(ctx, wl1, client.PropagationPolicy(metav1.DeletePropagationBackground))).Should(gomega.Succeed())
-			expectAdmission = testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "8").Obj()
+			expectAdmission = testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "8").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
@@ -836,7 +836,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				g.Expect(k8sClient.Update(ctx, updatedCq)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "6").Obj()
+			expectAdmission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "6").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
@@ -983,7 +983,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wl1 := testing.MakeWorkload("on-demand-wl1", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 
-			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj()
+			expectAdmission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
@@ -1003,7 +1003,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wl3 := testing.MakeWorkload("on-demand-wl3", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Toleration(spotToleration).Request(corev1.ResourceCPU, "5").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
 
-			expectAdmission = testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "spot-tainted", "5").Obj()
+			expectAdmission = testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "spot-tainted", "5").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 2)
@@ -1041,7 +1041,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("checking a workload without affinity gets admitted on the first flavor")
 			wl1 := testing.MakeWorkload("no-affinity-workload", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
-			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "spot-untainted", "1").Obj()
+			expectAdmission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "spot-untainted", "1").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectAdmission)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
 			util.ExpectQuotaReservedWorkloadsTotalMetric(cq, 1)
@@ -1054,7 +1054,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
 			gomega.Expect(wl2.Spec.PodSets[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(2))
-			expectAdmission = testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()
+			expectAdmission = testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 2)
@@ -1165,7 +1165,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				gomega.Expect(util.DeleteObject(ctx, k8sClient, fallbackClusterQueue)).ToNot(gomega.HaveOccurred())
 			}()
 
-			expectAdmission := testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()
+			expectAdmission := testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(prodCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(prodCQ, 1)
@@ -1302,15 +1302,15 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, wl1)
 			util.MustCreate(ctx, k8sClient, wl2)
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1,
-				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj())
+				testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).Obj())
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2,
-				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj())
+				testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).Obj())
 
 			ginkgo.By("Creating an additional workload that can't fit in the first flavor")
 			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3,
-				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "spot-untainted", "1").Obj())
+				testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "spot-untainted", "1").Obj()).Obj())
 			util.ExpectPendingWorkloadsMetric(prodCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(prodCQ, 3)
 			util.ExpectQuotaReservedWorkloadsTotalMetric(prodCQ, 3)
@@ -1342,7 +1342,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("Creating one workload")
 			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "9").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
-			prodWl1Admission := testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "9").Obj()
+			prodWl1Admission := testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "9").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, prodWl1Admission)
 			util.ExpectPendingWorkloadsMetric(prodCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(prodCQ, 1)
@@ -1352,7 +1352,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("Creating another workload")
 			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "11").Toleration(spotToleration).Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
-			prodWl2Admission := testing.MakeAdmission(devCQ.Name).Assignment(corev1.ResourceCPU, "spot-tainted", "11").Obj()
+			prodWl2Admission := testing.MakeAdmission(devCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "spot-tainted", "11").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, prodWl2Admission)
 			util.ExpectPendingWorkloadsMetric(devCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(devCQ, 1)
@@ -1401,7 +1401,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.FinishEvictionForWorkloads(ctx, k8sClient, wl1)
 
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3,
-				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj())
+				testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj()).Obj())
 		})
 	})
 
@@ -1450,7 +1450,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				cohort.Spec.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota = resource.MustParse("10")
 				g.Expect(k8sClient.Update(ctx, cohort)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()
+			expectAdmission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
@@ -1484,7 +1484,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				cq.Spec.Cohort = "cohort"
 				g.Expect(k8sClient.Update(ctx, cq)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()
+			expectAdmission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
@@ -1528,7 +1528,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 					*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "10").Obj(),
 				).Obj()
 			util.MustCreate(ctx, k8sClient, cohortBank)
-			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()
+			expectAdmission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
@@ -1580,7 +1580,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				gomega.Expect(util.DeleteObject(ctx, k8sClient, devCQ)).ToNot(gomega.HaveOccurred())
 			}()
 
-			expectAdmission := testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "9").Obj()
+			expectAdmission := testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "9").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(prodCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(prodCQ, 1)
@@ -2570,13 +2570,13 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			cq1LowPriority := createWorkloadWithPriority("cq1", "1", 0)
 			{
-				admission := testing.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f2", "1").Obj()
+				admission := testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f2", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq1LowPriority, admission)
 			}
 
 			cq2HighPriority := createWorkloadWithPriority("cq1", "1", 9999)
 			{
-				admission := testing.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj()
+				admission := testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f1", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2HighPriority, admission)
 			}
 
@@ -2585,7 +2585,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.ExpectWorkloadsToBePreempted(ctx, k8sClient, cq2HighPriority)
 				util.FinishEvictionForWorkloads(ctx, k8sClient, cq2HighPriority)
 
-				admission := testing.MakeAdmission("cq2").Assignment(corev1.ResourceCPU, "f1", "1").Obj()
+				admission := testing.MakeAdmission("cq2").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f1", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2MiddlePriority, admission)
 			}
 
@@ -2593,11 +2593,12 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.ExpectWorkloadsToBePreempted(ctx, k8sClient, cq1LowPriority)
 				util.FinishEvictionForWorkloads(ctx, k8sClient, cq1LowPriority)
 
-				admission := testing.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f2", "1").Obj()
+				admission := testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f2", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2HighPriority, admission)
 			}
 		})
 	})
+
 	ginkgo.When("Deleting ClusterQueue should update cohort borrowable resources", func() {
 		ginkgo.It("Should prevent incorrect admission through borrowing after ClusterQueue deletion", func() {
 			ginkgo.By("Creating two ClusterQueues in the same cohort")

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -333,9 +333,13 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("checking the first workload gets created and admitted", func() {
 				util.MustCreate(ctx, k8sClient, wl1)
 				wl1Admission := testing.MakeAdmission(podsCountClusterQ.Name).
-					Assignment(corev1.ResourceCPU, "on-demand", "6").
-					Assignment(corev1.ResourcePods, "on-demand", "3").
-					AssignmentPodCount(3).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "on-demand").
+						ResourceUsage(corev1.ResourceCPU, "6").
+						Flavor(corev1.ResourcePods, "on-demand").
+						ResourceUsage(corev1.ResourcePods, "3").
+						Count(3).
+						Obj()).
 					Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, wl1Admission)
 				util.ExpectPendingWorkloadsMetric(podsCountClusterQ, 0, 0)
@@ -395,8 +399,11 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("checking the first workload gets created and admitted", func() {
 				util.MustCreate(ctx, k8sClient, wl1)
 				wl1Admission := testing.MakeAdmission(podsCountOnlyClusterQ.Name).
-					Assignment(corev1.ResourcePods, "on-demand", "3").
-					AssignmentPodCount(3).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourcePods, "on-demand").
+						ResourceUsage(corev1.ResourcePods, "3").
+						Count(3).
+						Obj()).
 					Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, wl1Admission)
 				util.ExpectPendingWorkloadsMetric(podsCountOnlyClusterQ, 0, 0)
@@ -502,8 +509,11 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("checking the first workload gets created and gets quota reserved", func() {
 				util.MustCreate(ctx, k8sClient, wl1)
 				wl1Admission := testing.MakeAdmission(admissionCheckClusterQ.Name).
-					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(onDemandFlavor.Name), "2").
-					AssignmentPodCount(1).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(onDemandFlavor.Name)).
+						ResourceUsage(corev1.ResourceCPU, "2").
+						Count(1).
+						Obj()).
 					Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, wl1Admission)
 				util.ExpectPendingWorkloadsMetric(admissionCheckClusterQ, 0, 0)

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -338,8 +338,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				},
 				testing.MakeAdmission("cluster-queue").
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "flv").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "flv", "1").
 						Count(3).
 						Obj()).
 					Obj(),

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -539,7 +539,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				false,
 				func(newWL *kueue.Workload) {
 					newWL.Status = kueue.WorkloadStatus{
-						Admission: testing.MakeAdmission("cluster-queue").Assignment("on-demand", "5", "1").Obj(),
+						Admission: testing.MakeAdmission("cluster-queue").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment("on-demand", "5", "1").Obj()).Obj(),
 						Conditions: []metav1.Condition{{
 							Type:               kueue.WorkloadQuotaReserved,
 							Status:             metav1.ConditionTrue,
@@ -554,7 +554,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 			ginkgo.Entry("admission can be unset",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).ReserveQuota(
-						testing.MakeAdmission("cluster-queue").Assignment("on-demand", "5", "1").Obj(),
+						testing.MakeAdmission("cluster-queue").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment("on-demand", "5", "1").Obj()).Obj(),
 					).Obj()
 				},
 				false,
@@ -872,7 +872,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				var newWL kueue.Workload
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), &newWL)).To(gomega.Succeed())
-				newWL.Status.Admission = testing.MakeAdmission("cluster-queue").Assignment("on-demand", "5", "1").Obj()
+				newWL.Status.Admission = testing.MakeAdmission("cluster-queue").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment("on-demand", "5", "1").Obj()).Obj()
 				g.Expect(k8sClient.Status().Update(ctx, &newWL)).Should(testing.BeForbiddenError())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -337,8 +337,11 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						Obj()
 				},
 				testing.MakeAdmission("cluster-queue").
-					Assignment(corev1.ResourceCPU, "flv", "1").
-					AssignmentPodCount(3).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "flv").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(3).
+						Obj()).
 					Obj(),
 				testing.BeForbiddenError()),
 		)


### PR DESCRIPTION
Cherry pick of #6544 #6815 on release-0.12.

#6544: Reduce verbosity scheduler unit tests
#6815: Follow-up: Refactor assignment-related wrappers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```