### PR TITLE
Automated cherry pick of #6544: Reduce verbosity scheduler unit tests
#6815: Follow-up: Refactor assignment-related wrappers

### DIFF
--- a/cmd/importer/pod/import_test.go
+++ b/cmd/importer/pod/import_test.go
@@ -49,7 +49,9 @@ func TestImportNamespace(t *testing.T) {
 			Request(corev1.ResourceCPU, "1").
 			Obj()).
 		ReserveQuota(utiltesting.MakeAdmission("cq1").
-			Assignment(corev1.ResourceCPU, "f1", "1").
+			PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+				Assignment(corev1.ResourceCPU, "f1", "1").
+				Obj()).
 			Obj()).
 		Condition(metav1.Condition{
 			Type:    kueue.WorkloadQuotaReserved,

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1990,12 +1990,12 @@ func TestClusterQueueUsage(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("partial-one", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("foo").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "4000m").Count(2).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("foo").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "4000m").Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("partial-two", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("foo").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "4000m").Count(2).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("foo").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "4000m").Count(2).Obj()).Obj()).
 					Obj(),
 			},
 			wantReservedResources: []kueue.FlavorUsage{

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -424,8 +424,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				wl := utiltesting.MakeWorkload("one", "").
 					Request(corev1.ResourceCPU, "5").
 					ReserveQuota(utiltesting.MakeAdmission("a").
-						Assignment(corev1.ResourceCPU, "default", "5000m").
-						Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "5000m").
+							Obj()).Obj()).
 					Condition(metav1.Condition{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue}).
 					Obj()
 
@@ -465,8 +466,9 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							Obj: utiltesting.MakeWorkload("one", "").
 								Request(corev1.ResourceCPU, "5").
 								ReserveQuota(utiltesting.MakeAdmission("a").
-									Assignment(corev1.ResourceCPU, "default", "5000m").
-									Obj()).
+									PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+										Assignment(corev1.ResourceCPU, "default", "5000m").
+										Obj()).Obj()).
 								Condition(metav1.Condition{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue}).
 								Obj(),
 							TotalRequests: []workload.PodSetResources{
@@ -853,13 +855,25 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				utiltesting.MakeLocalQueue("lq1", "ns").ClusterQueue("cq1").Obj(),
 				utiltesting.MakeWorkload("pending", "ns").Obj(),
 				utiltesting.MakeWorkload("reserving", "ns").ReserveQuota(
-					utiltesting.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj(),
+					utiltesting.MakeAdmission("cq1").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "f1", "1").
+							Obj()).
+						Obj(),
 				).Obj(),
 				utiltesting.MakeWorkload("admitted", "ns").ReserveQuota(
-					utiltesting.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj(),
+					utiltesting.MakeAdmission("cq1").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "f1", "1").
+							Obj()).
+						Obj(),
 				).Admitted(true).Obj(),
 				utiltesting.MakeWorkload("finished", "ns").ReserveQuota(
-					utiltesting.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj(),
+					utiltesting.MakeAdmission("cq1").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "f1", "1").
+							Obj()).
+						Obj(),
 				).Admitted(true).Finished().Obj(),
 			},
 			operation: func(log logr.Logger, cache *Cache) error {
@@ -1740,13 +1754,23 @@ func TestClusterQueueUsage(t *testing.T) {
 		*utiltesting.MakeWorkload("one", "").
 			Request(corev1.ResourceCPU, "8").
 			Request("example.com/gpu", "5").
-			ReserveQuota(utiltesting.MakeAdmission("foo").Assignment(corev1.ResourceCPU, "default", "8000m").Assignment("example.com/gpu", "model_a", "5").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("foo").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "8000m").
+					Assignment("example.com/gpu", "model_a", "5").
+					Obj()).
+				Obj()).
 			Condition(metav1.Condition{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue}).
 			Obj(),
 		*utiltesting.MakeWorkload("two", "").
 			Request(corev1.ResourceCPU, "5").
 			Request("example.com/gpu", "6").
-			ReserveQuota(utiltesting.MakeAdmission("foo").Assignment(corev1.ResourceCPU, "default", "5000m").Assignment("example.com/gpu", "model_b", "6").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("foo").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "5000m").
+					Assignment("example.com/gpu", "model_b", "6").
+					Obj()).
+				Obj()).
 			Obj(),
 	}
 	cases := map[string]struct {
@@ -2157,8 +2181,9 @@ func TestLocalQueueUsage(t *testing.T) {
 					Request("example.com/gpu", "5").
 					ReserveQuota(
 						utiltesting.MakeAdmission("foo").
-							Assignment(corev1.ResourceCPU, "default", "5000m").
-							Assignment("example.com/gpu", "model-a", "5").Obj(),
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "5000m").
+								Assignment("example.com/gpu", "model-a", "5").Obj()).Obj(),
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("two", "ns1").
@@ -2167,8 +2192,9 @@ func TestLocalQueueUsage(t *testing.T) {
 					Request("example.com/gpu", "3").
 					ReserveQuota(
 						utiltesting.MakeAdmission("foo").
-							Assignment(corev1.ResourceCPU, "default", "3000m").
-							Assignment("example.com/gpu", "model-b", "3").Obj(),
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Assignment("example.com/gpu", "model-b", "3").Obj()).Obj(),
 					).
 					Obj(),
 			},
@@ -2219,8 +2245,9 @@ func TestLocalQueueUsage(t *testing.T) {
 					Request("example.com/gpu", "5").
 					ReserveQuota(
 						utiltesting.MakeAdmission("foo").
-							Assignment(corev1.ResourceCPU, "default", "5000m").
-							Assignment("example.com/gpu", "model-a", "5").Obj(),
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "5000m").
+								Assignment("example.com/gpu", "model-a", "5").Obj()).Obj(),
 					).Obj(),
 				*utiltesting.MakeWorkload("two", "ns1").
 					Queue("test").
@@ -2386,8 +2413,9 @@ func TestCacheQueueOperations(t *testing.T) {
 			Request("memory", "8Gi").
 			ReserveQuota(
 				utiltesting.MakeAdmission("foo").
-					Assignment("cpu", "spot", "2").
-					Assignment("memory", "spot", "8Gi").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "spot", "2").
+						Assignment("memory", "spot", "8Gi").Obj()).Obj(),
 			).
 			Condition(metav1.Condition{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue}).
 			Obj(),
@@ -2396,7 +2424,8 @@ func TestCacheQueueOperations(t *testing.T) {
 			Request("example.com/gpu", "2").
 			ReserveQuota(
 				utiltesting.MakeAdmission("foo").
-					Assignment("example.com/gpu", "model-a", "2").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("example.com/gpu", "model-a", "2").Obj()).Obj(),
 			).
 			Condition(metav1.Condition{Type: kueue.WorkloadAdmitted, Status: metav1.ConditionTrue}).
 			Obj(),
@@ -2406,15 +2435,17 @@ func TestCacheQueueOperations(t *testing.T) {
 			Request("memory", "16Gi").
 			ReserveQuota(
 				utiltesting.MakeAdmission("bar").
-					Assignment("cpu", "ondemand", "5").
-					Assignment("memory", "ondemand", "16Gi").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "ondemand", "5").
+						Assignment("memory", "ondemand", "16Gi").Obj()).Obj(),
 			).Obj(),
 		utiltesting.MakeWorkload("job4", "ns2").
 			Queue("beta").
 			Request("example.com/gpu", "5").
 			ReserveQuota(
 				utiltesting.MakeAdmission("foo").
-					Assignment("example.com/gpu", "model-a", "5").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("example.com/gpu", "model-a", "5").Obj()).Obj(),
 			).Obj(),
 	}
 	insertAllClusterQueues := func(ctx context.Context, cl client.Client, cache *Cache) error {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1966,12 +1966,12 @@ func TestClusterQueueUsage(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("partial-one", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("foo").Assignment(corev1.ResourceCPU, "default", "4000m").AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("foo").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "4000m").Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("partial-two", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("foo").Assignment(corev1.ResourceCPU, "default", "4000m").AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("foo").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "4000m").Count(2).Obj()).Obj()).
 					Obj(),
 			},
 			wantReservedResources: []kueue.FlavorUsage{

--- a/pkg/cache/fair_sharing_test.go
+++ b/pkg/cache/fair_sharing_test.go
@@ -713,7 +713,9 @@ func TestDominantResourceShare(t *testing.T) {
 			for fr, v := range tc.usage {
 				admission := utiltesting.MakeAdmission("cq")
 				quantity := resources.ResourceQuantity(fr.Resource, v)
-				admission.Assignment(fr.Resource, fr.Flavor, quantity.String())
+				admission.PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(fr.Resource, fr.Flavor, quantity.String()).
+					Obj())
 
 				wl := utiltesting.MakeWorkload(fmt.Sprintf("workload-%d", i), "default-namespace").ReserveQuota(admission.Obj()).Obj()
 

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -1033,23 +1033,43 @@ func TestSnapshotAddRemoveWorkload(t *testing.T) {
 	workloads := []kueue.Workload{
 		*utiltesting.MakeWorkload("c1-cpu", "").
 			Request(corev1.ResourceCPU, "1").
-			ReserveQuota(utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "1000m").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("c1").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "1000m").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("c1-memory-alpha", "").
 			Request(corev1.ResourceMemory, "1Gi").
-			ReserveQuota(utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceMemory, "alpha", "1Gi").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("c1").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceMemory, "alpha", "1Gi").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("c1-memory-beta", "").
 			Request(corev1.ResourceMemory, "1Gi").
-			ReserveQuota(utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceMemory, "beta", "1Gi").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("c1").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceMemory, "beta", "1Gi").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("c2-cpu-1", "").
 			Request(corev1.ResourceCPU, "1").
-			ReserveQuota(utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "1000m").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("c2").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "1000m").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("c2-cpu-2", "").
 			Request(corev1.ResourceCPU, "1").
-			ReserveQuota(utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "1000m").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("c2").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "1000m").
+					Obj()).
+				Obj()).
 			Obj(),
 	}
 
@@ -1331,19 +1351,35 @@ func TestSnapshotAddRemoveWorkloadWithLendingLimit(t *testing.T) {
 	workloads := []kueue.Workload{
 		*utiltesting.MakeWorkload("lend-a-1", "").
 			Request(corev1.ResourceCPU, "1").
-			ReserveQuota(utiltesting.MakeAdmission("lend-a").Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("lend-a").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "1").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("lend-a-2", "").
 			Request(corev1.ResourceCPU, "9").
-			ReserveQuota(utiltesting.MakeAdmission("lend-a").Assignment(corev1.ResourceCPU, "default", "9").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("lend-a").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "9").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("lend-a-3", "").
 			Request(corev1.ResourceCPU, "6").
-			ReserveQuota(utiltesting.MakeAdmission("lend-a").Assignment(corev1.ResourceCPU, "default", "6").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("lend-a").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "6").
+					Obj()).
+				Obj()).
 			Obj(),
 		*utiltesting.MakeWorkload("lend-b-1", "").
 			Request(corev1.ResourceCPU, "4").
-			ReserveQuota(utiltesting.MakeAdmission("lend-b").Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+			ReserveQuota(utiltesting.MakeAdmission("lend-b").
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "4").
+					Obj()).
+				Obj()).
 			Obj(),
 	}
 

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -175,7 +175,7 @@ func TestSnapshot(t *testing.T) {
 				utiltesting.MakeWorkload("alpha", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "demand", "10000m").AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "demand").ResourceUsage(corev1.ResourceCPU, "10000m").Count(5).Obj()).Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("beta", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
@@ -183,10 +183,14 @@ func TestSnapshot(t *testing.T) {
 						Request("example.com/gpu", "2").
 						Obj(),
 					).
-					ReserveQuota(utiltesting.MakeAdmission("b", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "spot", "5000m").
-						Assignment("example.com/gpu", "default", "10").
-						AssignmentPodCount(5).
+					ReserveQuota(utiltesting.MakeAdmission("b").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "spot").
+							ResourceUsage(corev1.ResourceCPU, "5000m").
+							Flavor("example.com/gpu", "default").
+							ResourceUsage("example.com/gpu", "10").
+							Count(5).
+							Obj()).
 						Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("gamma", "").
@@ -195,10 +199,14 @@ func TestSnapshot(t *testing.T) {
 						Request("example.com/gpu", "1").
 						Obj(),
 					).
-					ReserveQuota(utiltesting.MakeAdmission("b", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "spot", "5000m").
-						Assignment("example.com/gpu", "default", "5").
-						AssignmentPodCount(5).
+					ReserveQuota(utiltesting.MakeAdmission("b").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "spot").
+							ResourceUsage(corev1.ResourceCPU, "5000m").
+							Flavor("example.com/gpu", "default").
+							ResourceUsage("example.com/gpu", "5").
+							Count(5).
+							Obj()).
 						Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("sigma", "").
@@ -258,9 +266,12 @@ func TestSnapshot(t *testing.T) {
 									"/alpha": workload.NewInfo(utiltesting.MakeWorkload("alpha", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "demand", "10000m").
-											AssignmentPodCount(5).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "demand").
+												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Count(5).
+												Obj()).
 											Obj()).
 										Obj()),
 								},
@@ -304,10 +315,14 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "1").
 											Request("example.com/gpu", "2").
 											Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("b", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "spot", "5000m").
-											Assignment("example.com/gpu", "default", "10").
-											AssignmentPodCount(5).
+										ReserveQuota(utiltesting.MakeAdmission("b").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "spot").
+												ResourceUsage(corev1.ResourceCPU, "5000m").
+												Flavor("example.com/gpu", "default").
+												ResourceUsage("example.com/gpu", "10").
+												Count(5).
+												Obj()).
 											Obj()).
 										Obj()),
 									"/gamma": workload.NewInfo(utiltesting.MakeWorkload("gamma", "").
@@ -316,10 +331,14 @@ func TestSnapshot(t *testing.T) {
 											Request("example.com/gpu", "1").
 											Obj(),
 										).
-										ReserveQuota(utiltesting.MakeAdmission("b", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "spot", "5000m").
-											Assignment("example.com/gpu", "default", "5").
-											AssignmentPodCount(5).
+										ReserveQuota(utiltesting.MakeAdmission("b").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "spot").
+												ResourceUsage(corev1.ResourceCPU, "5000m").
+												Flavor("example.com/gpu", "default").
+												ResourceUsage("example.com/gpu", "5").
+												Count(5).
+												Obj()).
 											Obj()).
 										Obj()),
 								},
@@ -439,23 +458,35 @@ func TestSnapshot(t *testing.T) {
 				utiltesting.MakeWorkload("alpha", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "arm", "10000m").
-						AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "arm").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(5).
+							Obj()).
+						Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("beta", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "arm", "5000m").
-						AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "arm").
+							ResourceUsage(corev1.ResourceCPU, "5000m").
+							Count(5).
+							Obj()).
+						Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("gamma", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "x86", "10000m").
-						AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "x86").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(5).
+							Obj()).
+						Obj()).
 					Obj(),
 			},
 			wantSnapshot: func() Snapshot {
@@ -507,23 +538,35 @@ func TestSnapshot(t *testing.T) {
 									"/alpha": workload.NewInfo(utiltesting.MakeWorkload("alpha", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "arm", "10000m").
-											AssignmentPodCount(5).Obj()).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "arm").
+												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Count(5).
+												Obj()).
+											Obj()).
 										Obj()),
 									"/beta": workload.NewInfo(utiltesting.MakeWorkload("beta", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "1").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "arm", "5000m").
-											AssignmentPodCount(5).Obj()).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "arm").
+												ResourceUsage(corev1.ResourceCPU, "5000m").
+												Count(5).
+												Obj()).
+											Obj()).
 										Obj()),
 									"/gamma": workload.NewInfo(utiltesting.MakeWorkload("gamma", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "x86", "10000m").
-											AssignmentPodCount(5).Obj()).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "x86").
+												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Count(5).
+												Obj()).
+											Obj()).
 										Obj()),
 								},
 								Preemption:        defaultPreemption,
@@ -593,23 +636,35 @@ func TestSnapshot(t *testing.T) {
 				utiltesting.MakeWorkload("alpha", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "arm", "10000m").
-						AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "arm").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(5).
+							Obj()).
+						Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("beta", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "arm", "5000m").
-						AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "arm").
+							ResourceUsage(corev1.ResourceCPU, "5000m").
+							Count(5).
+							Obj()).
+						Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("gamma", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "x86", "10000m").
-						AssignmentPodCount(5).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "x86").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(5).
+							Obj()).
+						Obj()).
 					Obj(),
 			},
 			wantSnapshot: func() Snapshot {
@@ -662,23 +717,35 @@ func TestSnapshot(t *testing.T) {
 									"/alpha": workload.NewInfo(utiltesting.MakeWorkload("alpha", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "arm", "10000m").
-											AssignmentPodCount(5).Obj()).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "arm").
+												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Count(5).
+												Obj()).
+											Obj()).
 										Obj()),
 									"/beta": workload.NewInfo(utiltesting.MakeWorkload("beta", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "1").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "arm", "5000m").
-											AssignmentPodCount(5).Obj()).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "arm").
+												ResourceUsage(corev1.ResourceCPU, "5000m").
+												Count(5).
+												Obj()).
+											Obj()).
 										Obj()),
 									"/gamma": workload.NewInfo(utiltesting.MakeWorkload("gamma", "").
 										PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 											Request(corev1.ResourceCPU, "2").Obj()).
-										ReserveQuota(utiltesting.MakeAdmission("a", kueue.DefaultPodSetName).
-											Assignment(corev1.ResourceCPU, "x86", "10000m").
-											AssignmentPodCount(5).Obj()).
+										ReserveQuota(utiltesting.MakeAdmission("a").
+											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+												Flavor(corev1.ResourceCPU, "x86").
+												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Count(5).
+												Obj()).
+											Obj()).
 										Obj()),
 								},
 								Preemption:        defaultPreemption,

--- a/pkg/cache/snapshot_test.go
+++ b/pkg/cache/snapshot_test.go
@@ -175,7 +175,7 @@ func TestSnapshot(t *testing.T) {
 				utiltesting.MakeWorkload("alpha", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "2").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("a").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "demand").ResourceUsage(corev1.ResourceCPU, "10000m").Count(5).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("a").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "demand", "10000m").Count(5).Obj()).Obj()).
 					Obj(),
 				utiltesting.MakeWorkload("beta", "").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).
@@ -185,10 +185,8 @@ func TestSnapshot(t *testing.T) {
 					).
 					ReserveQuota(utiltesting.MakeAdmission("b").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "spot").
-							ResourceUsage(corev1.ResourceCPU, "5000m").
-							Flavor("example.com/gpu", "default").
-							ResourceUsage("example.com/gpu", "10").
+							Assignment(corev1.ResourceCPU, "spot", "5000m").
+							Assignment("example.com/gpu", "default", "10").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -201,10 +199,8 @@ func TestSnapshot(t *testing.T) {
 					).
 					ReserveQuota(utiltesting.MakeAdmission("b").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "spot").
-							ResourceUsage(corev1.ResourceCPU, "5000m").
-							Flavor("example.com/gpu", "default").
-							ResourceUsage("example.com/gpu", "5").
+							Assignment(corev1.ResourceCPU, "spot", "5000m").
+							Assignment("example.com/gpu", "default", "5").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -268,8 +264,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "2").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "demand").
-												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Assignment(corev1.ResourceCPU, "demand", "10000m").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -317,10 +312,8 @@ func TestSnapshot(t *testing.T) {
 											Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("b").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "spot").
-												ResourceUsage(corev1.ResourceCPU, "5000m").
-												Flavor("example.com/gpu", "default").
-												ResourceUsage("example.com/gpu", "10").
+												Assignment(corev1.ResourceCPU, "spot", "5000m").
+												Assignment("example.com/gpu", "default", "10").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -333,10 +326,8 @@ func TestSnapshot(t *testing.T) {
 										).
 										ReserveQuota(utiltesting.MakeAdmission("b").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "spot").
-												ResourceUsage(corev1.ResourceCPU, "5000m").
-												Flavor("example.com/gpu", "default").
-												ResourceUsage("example.com/gpu", "5").
+												Assignment(corev1.ResourceCPU, "spot", "5000m").
+												Assignment("example.com/gpu", "default", "5").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -460,8 +451,7 @@ func TestSnapshot(t *testing.T) {
 						Request(corev1.ResourceCPU, "2").Obj()).
 					ReserveQuota(utiltesting.MakeAdmission("a").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "arm").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "arm", "10000m").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -471,8 +461,7 @@ func TestSnapshot(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(utiltesting.MakeAdmission("a").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "arm").
-							ResourceUsage(corev1.ResourceCPU, "5000m").
+							Assignment(corev1.ResourceCPU, "arm", "5000m").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -482,8 +471,7 @@ func TestSnapshot(t *testing.T) {
 						Request(corev1.ResourceCPU, "2").Obj()).
 					ReserveQuota(utiltesting.MakeAdmission("a").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "x86").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "x86", "10000m").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -540,8 +528,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "2").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "arm").
-												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Assignment(corev1.ResourceCPU, "arm", "10000m").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -551,8 +538,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "1").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "arm").
-												ResourceUsage(corev1.ResourceCPU, "5000m").
+												Assignment(corev1.ResourceCPU, "arm", "5000m").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -562,8 +548,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "2").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "x86").
-												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Assignment(corev1.ResourceCPU, "x86", "10000m").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -638,8 +623,7 @@ func TestSnapshot(t *testing.T) {
 						Request(corev1.ResourceCPU, "2").Obj()).
 					ReserveQuota(utiltesting.MakeAdmission("a").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "arm").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "arm", "10000m").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -649,8 +633,7 @@ func TestSnapshot(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(utiltesting.MakeAdmission("a").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "arm").
-							ResourceUsage(corev1.ResourceCPU, "5000m").
+							Assignment(corev1.ResourceCPU, "arm", "5000m").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -660,8 +643,7 @@ func TestSnapshot(t *testing.T) {
 						Request(corev1.ResourceCPU, "2").Obj()).
 					ReserveQuota(utiltesting.MakeAdmission("a").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "x86").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "x86", "10000m").
 							Count(5).
 							Obj()).
 						Obj()).
@@ -719,8 +701,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "2").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "arm").
-												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Assignment(corev1.ResourceCPU, "arm", "10000m").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -730,8 +711,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "1").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "arm").
-												ResourceUsage(corev1.ResourceCPU, "5000m").
+												Assignment(corev1.ResourceCPU, "arm", "5000m").
 												Count(5).
 												Obj()).
 											Obj()).
@@ -741,8 +721,7 @@ func TestSnapshot(t *testing.T) {
 											Request(corev1.ResourceCPU, "2").Obj()).
 										ReserveQuota(utiltesting.MakeAdmission("a").
 											PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-												Flavor(corev1.ResourceCPU, "x86").
-												ResourceUsage(corev1.ResourceCPU, "10000m").
+												Assignment(corev1.ResourceCPU, "x86", "10000m").
 												Count(5).
 												Obj()).
 											Obj()).

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -409,7 +409,11 @@ func TestReconcile(t *testing.T) {
 	}{
 		"assign Admission Checks from ClusterQueue.spec.AdmissionCheckStrategy": {
 			workload: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Queue("queue").
 				Obj(),
 			cq: utiltesting.MakeClusterQueue("cq").
@@ -419,7 +423,11 @@ func TestReconcile(t *testing.T) {
 				Obj(),
 			lq: utiltesting.MakeLocalQueue("queue", "ns").ClusterQueue("cq").Obj(),
 			wantWorkload: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Queue("queue").
 				AdmissionChecks(
 					kueue.AdmissionCheckState{
@@ -434,7 +442,11 @@ func TestReconcile(t *testing.T) {
 		},
 		"assign Admission Checks from ClusterQueue.spec.AdmissionChecks": {
 			workload: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Queue("queue").
 				Obj(),
 			cq: utiltesting.MakeClusterQueue("cq").
@@ -442,7 +454,11 @@ func TestReconcile(t *testing.T) {
 				Obj(),
 			lq: utiltesting.MakeLocalQueue("queue", "ns").ClusterQueue("cq").Obj(),
 			wantWorkload: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Queue("queue").
 				AdmissionChecks(
 					kueue.AdmissionCheckState{

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -568,7 +568,7 @@ func TestReconciler(t *testing.T) {
 	baseWorkloadWrapper := utiltesting.MakeWorkload("wl", "ns").
 		Finalizers(kueue.ResourceInUseFinalizerName).
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
-		ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj())
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(10).Obj()).Obj())
 
 	baseWPCWrapper := utiltesting.MakeWorkloadPriorityClass("test-wpc").
 		PriorityValue(100)
@@ -2524,7 +2524,7 @@ func TestReconciler(t *testing.T) {
 				*utiltesting.MakeWorkload("a", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(8).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(8).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -2537,7 +2537,7 @@ func TestReconciler(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(8).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(8).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -2571,7 +2571,7 @@ func TestReconciler(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Obj(),
 					).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(8).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(8).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -2807,7 +2807,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(10).Obj()).Obj()).
 					Admitted(true).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "parent", "parent-uid").
 					Obj(),
@@ -2815,7 +2815,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(10).Obj()).Obj()).
 					Admitted(true).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "parent", "parent-uid").
 					Obj(),
@@ -2887,7 +2887,7 @@ func TestReconciler(t *testing.T) {
 				*utiltesting.MakeWorkload("parent-workload", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(10).Obj()).Obj()).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "parent", "parent-uid").
 					Admitted(true).
 					Obj(),
@@ -2896,7 +2896,7 @@ func TestReconciler(t *testing.T) {
 				*utiltesting.MakeWorkload("parent-workload", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(10).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(10).Obj()).Obj()).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "parent", "parent-uid").
 					Admitted(true).
 					Obj(),

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -302,8 +302,11 @@ func TestReconciler(t *testing.T) {
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -315,8 +318,11 @@ func TestReconciler(t *testing.T) {
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -343,7 +349,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Obj(),
@@ -490,7 +496,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Obj(),
@@ -498,7 +504,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -544,7 +550,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Obj(),
@@ -552,7 +558,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -1064,9 +1070,12 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
-							AssignmentPodCount(2).
+						utiltesting.MakeAdmission("cq").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1078,9 +1087,12 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
-							AssignmentPodCount(2).
+						utiltesting.MakeAdmission("cq").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1148,7 +1160,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Admitted(true).
@@ -1162,7 +1174,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Admitted(true).
@@ -1216,7 +1228,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1230,7 +1242,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1276,7 +1288,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1295,7 +1307,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1412,7 +1424,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    "Finished",
@@ -1437,7 +1449,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    "Finished",
@@ -1541,8 +1553,11 @@ func TestReconciler(t *testing.T) {
 					Queue("test-queue").
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
-							AssignmentPodCount(2).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1614,7 +1629,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1634,7 +1649,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1701,7 +1716,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(3).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(3).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1754,7 +1769,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(3).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(3).Obj()).Obj()).
 					ReclaimablePods(kueue.ReclaimablePod{
 						Name:  kueue.NewPodSetReference(podUID),
 						Count: 1,
@@ -1845,7 +1860,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1860,7 +1875,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1915,7 +1930,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -1941,7 +1956,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -1994,7 +2009,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					AdmittedAt(true, testStartTime.Add(-time.Second)).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -2021,7 +2036,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					PastAdmittedTime(1).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadAdmitted,
@@ -2115,8 +2130,11 @@ func TestReconciler(t *testing.T) {
 					Queue("test-queue").
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
-							AssignmentPodCount(2).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -2192,7 +2210,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2212,7 +2230,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2256,7 +2274,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -2278,7 +2296,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -2520,7 +2538,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2545,7 +2563,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2647,7 +2665,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2669,7 +2687,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -2765,7 +2783,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2787,7 +2805,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -2999,7 +3017,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -3021,7 +3039,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -3117,7 +3135,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3129,7 +3147,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3201,7 +3219,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "pod2").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3216,7 +3234,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "pod2").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3418,7 +3436,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3439,7 +3457,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement-for-pod1", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3821,7 +3839,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "deleted", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3845,7 +3863,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3942,7 +3960,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "active-pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3956,7 +3974,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "active-pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4055,7 +4073,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error-no-finalizer", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4076,7 +4094,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error-no-finalizer", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4293,7 +4311,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					Priority(0).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4323,7 +4341,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					Priority(0).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4380,7 +4398,7 @@ func TestReconciler(t *testing.T) {
 					Priority(0).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4407,7 +4425,7 @@ func TestReconciler(t *testing.T) {
 					Priority(0).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4474,7 +4492,7 @@ func TestReconciler(t *testing.T) {
 					Priority(0).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4513,7 +4531,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4566,7 +4584,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4602,7 +4620,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4641,7 +4659,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4677,7 +4695,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4723,7 +4741,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4760,7 +4778,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4806,7 +4824,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -4849,7 +4867,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -4903,7 +4921,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadEvicted,
@@ -4951,7 +4969,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadEvicted,
@@ -5002,7 +5020,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -5052,7 +5070,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -5105,7 +5123,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -5147,7 +5165,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq", kueue.NewPodSetReference(podUID)).AssignmentPodCount(2).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -5474,7 +5492,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					AdmittedAt(true, testStartTime.Add(-time.Second)).
 					Active(false).
 					Condition(metav1.Condition{
@@ -5495,7 +5513,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 					PastAdmittedTime(1).
 					Active(false).
 					Condition(metav1.Condition{
@@ -5649,7 +5667,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 
 	wl := *utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-		ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 		Admitted(true).
 		Obj()
 
@@ -5729,7 +5747,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 	// Workload should be finished after the second reconcile
 	wantWl := *utiltesting.MakeWorkload("unit-test", "ns").
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-		ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 		ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 		Admitted(true).
 		Condition(
@@ -5872,7 +5890,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 		OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 		OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 		OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "excessPod", "test-uid").
-		ReserveQuota(utiltesting.MakeAdmission("cq").AssignmentPodCount(1).Obj()).
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
 		Admitted(true).
 		Obj()
 

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -303,9 +303,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								Obj()).
 							Obj(),
 					).
@@ -319,9 +317,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								Obj()).
 							Obj(),
 					).
@@ -349,7 +345,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Obj(),
@@ -496,7 +492,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Obj(),
@@ -504,7 +500,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -550,7 +546,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Obj(),
@@ -558,7 +554,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -1072,8 +1068,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 								Count(2).
 								Obj()).
 							Obj(),
@@ -1089,8 +1084,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 								Count(2).
 								Obj()).
 							Obj(),
@@ -1160,7 +1154,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Admitted(true).
@@ -1174,7 +1168,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Admitted(true).
@@ -1228,7 +1222,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1242,7 +1236,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1288,7 +1282,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1307,7 +1301,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1424,7 +1418,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    "Finished",
@@ -1449,7 +1443,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    "Finished",
@@ -1554,8 +1548,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 								Count(2).
 								Obj()).
 							Obj(),
@@ -1629,7 +1622,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1649,7 +1642,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -1860,7 +1853,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1875,7 +1868,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -1930,7 +1923,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -1956,7 +1949,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -2009,7 +2002,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					AdmittedAt(true, testStartTime.Add(-time.Second)).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -2036,7 +2029,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					PastAdmittedTime(1).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadAdmitted,
@@ -2131,8 +2124,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 								Count(2).
 								Obj()).
 							Obj(),
@@ -2210,7 +2202,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2230,7 +2222,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2274,7 +2266,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -2296,7 +2288,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -2538,7 +2530,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2563,7 +2555,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2665,7 +2657,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2687,7 +2679,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -2783,7 +2775,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -2805,7 +2797,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
@@ -3017,7 +3009,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -3039,7 +3031,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					Admitted(true).
 					Condition(metav1.Condition{
@@ -3135,7 +3127,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3147,7 +3139,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Queue("user-queue").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3219,7 +3211,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "pod2").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3234,7 +3226,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "pod2").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3436,7 +3428,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3457,7 +3449,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement-for-pod1", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3839,7 +3831,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "deleted", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3863,7 +3855,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -3960,7 +3952,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "active-pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3974,7 +3966,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "active-pod", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -4073,7 +4065,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error-no-finalizer", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4094,7 +4086,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "finished-with-error-no-finalizer", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "replacement", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(true).
 					Condition(metav1.Condition{
 						Type:    WorkloadWaitingForReplacementPods,
@@ -4311,7 +4303,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					Priority(0).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4341,7 +4333,7 @@ func TestReconciler(t *testing.T) {
 					Queue("user-queue").
 					Priority(0).
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4398,7 +4390,7 @@ func TestReconciler(t *testing.T) {
 					Priority(0).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -4425,7 +4417,7 @@ func TestReconciler(t *testing.T) {
 					Priority(0).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					Admitted(false).
 					Obj(),
 			},
@@ -5492,7 +5484,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					AdmittedAt(true, testStartTime.Add(-time.Second)).
 					Active(false).
 					Condition(metav1.Condition{
@@ -5513,7 +5505,7 @@ func TestReconciler(t *testing.T) {
 					).
 					Queue("user-queue").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 					PastAdmittedTime(1).
 					Active(false).
 					Condition(metav1.Condition{
@@ -5667,7 +5659,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 
 	wl := *utiltesting.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 		Admitted(true).
 		Obj()
 
@@ -5747,7 +5739,7 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 	// Workload should be finished after the second reconcile
 	wantWl := *utiltesting.MakeWorkload("unit-test", "ns").
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 		ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 		Admitted(true).
 		Condition(
@@ -5890,7 +5882,7 @@ func TestReconciler_DeletePodAfterTransientErrorsOnUpdateOrDeleteOps(t *testing.
 		OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 		OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 		OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "excessPod", "test-uid").
-		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Count(1).Obj()).Obj()).
+		ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj()).
 		Admitted(true).
 		Obj()
 

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -360,12 +360,9 @@ func TestReconciler(t *testing.T) {
 						utiltesting.MakeAdmission("cq").
 							PodSets(
 								utiltesting.MakePodSetAssignment("head").
-									Flavor(corev1.ResourceCPU, "unit-test-flavor").
-									ResourceUsage(corev1.ResourceCPU, "1").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 									Obj(),
 								utiltesting.MakePodSetAssignment("workers-group-0").
-									Count(1).
 									Obj(),
 							).
 							Obj(),
@@ -416,12 +413,9 @@ func TestReconciler(t *testing.T) {
 						utiltesting.MakeAdmission("cq").
 							PodSets(
 								utiltesting.MakePodSetAssignment("head").
-									Flavor(corev1.ResourceCPU, "unit-test-flavor").
-									ResourceUsage(corev1.ResourceCPU, "1").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 									Obj(),
 								utiltesting.MakePodSetAssignment("workers-group-0").
-									Count(1).
 									Obj(),
 							).
 							Obj(),
@@ -480,7 +474,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Request(corev1.ResourceCPU, "10").
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment("head").Count(1).Obj(), utiltesting.MakePodSetAssignment("workers-group-0").Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment("head").Obj(), utiltesting.MakePodSetAssignment("workers-group-0").Obj()).Obj()).
 					Generation(1).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -516,7 +510,7 @@ func TestReconciler(t *testing.T) {
 							}).
 							Obj(),
 					).
-					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment("head").Count(1).Obj(), utiltesting.MakePodSetAssignment("workers-group-0").Count(1).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment("head").Obj(), utiltesting.MakePodSetAssignment("workers-group-0").Obj()).Obj()).
 					Generation(1).
 					PastAdmittedTime(1).
 					Condition(metav1.Condition{
@@ -596,8 +590,7 @@ func TestReconciler(t *testing.T) {
 						utiltesting.MakeAdmission("cq").
 							PodSets(
 								utiltesting.MakePodSetAssignment("head").
-									Flavor(corev1.ResourceCPU, "unit-test-flavor").
-									ResourceUsage(corev1.ResourceCPU, "1").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 									Count(2).
 									Obj(),
 								utiltesting.MakePodSetAssignment("workers-group-0").
@@ -650,8 +643,7 @@ func TestReconciler(t *testing.T) {
 						utiltesting.MakeAdmission("cq").
 							PodSets(
 								utiltesting.MakePodSetAssignment("head").
-									Flavor(corev1.ResourceCPU, "unit-test-flavor").
-									ResourceUsage(corev1.ResourceCPU, "1").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 									Count(2).
 									Obj(),
 								utiltesting.MakePodSetAssignment("workers-group-0").

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -357,9 +357,17 @@ func TestReconciler(t *testing.T) {
 					).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", "head", "workers-group-0").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
+						utiltesting.MakeAdmission("cq").
+							PodSets(
+								utiltesting.MakePodSetAssignment("head").
+									Flavor(corev1.ResourceCPU, "unit-test-flavor").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(1).
+									Obj(),
+								utiltesting.MakePodSetAssignment("workers-group-0").
+									Count(1).
+									Obj(),
+							).
 							Obj(),
 					).
 					Admitted(true).
@@ -405,9 +413,17 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", "head", "workers-group-0").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
+						utiltesting.MakeAdmission("cq").
+							PodSets(
+								utiltesting.MakePodSetAssignment("head").
+									Flavor(corev1.ResourceCPU, "unit-test-flavor").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(1).
+									Obj(),
+								utiltesting.MakePodSetAssignment("workers-group-0").
+									Count(1).
+									Obj(),
+							).
 							Obj(),
 					).
 					Admitted(true).
@@ -464,7 +480,7 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					Request(corev1.ResourceCPU, "10").
-					ReserveQuota(utiltesting.MakeAdmission("cq", "head", "workers-group-0").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment("head").Count(1).Obj(), utiltesting.MakePodSetAssignment("workers-group-0").Count(1).Obj()).Obj()).
 					Generation(1).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
@@ -500,7 +516,7 @@ func TestReconciler(t *testing.T) {
 							}).
 							Obj(),
 					).
-					ReserveQuota(utiltesting.MakeAdmission("cq", "head", "workers-group-0").AssignmentPodCount(1).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("cq").PodSets(utiltesting.MakePodSetAssignment("head").Count(1).Obj(), utiltesting.MakePodSetAssignment("workers-group-0").Count(1).Obj()).Obj()).
 					Generation(1).
 					PastAdmittedTime(1).
 					Condition(metav1.Condition{
@@ -577,9 +593,17 @@ func TestReconciler(t *testing.T) {
 					).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", "head", "workers-group-0").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(2).
+						utiltesting.MakeAdmission("cq").
+							PodSets(
+								utiltesting.MakePodSetAssignment("head").
+									Flavor(corev1.ResourceCPU, "unit-test-flavor").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(2).
+									Obj(),
+								utiltesting.MakePodSetAssignment("workers-group-0").
+									Count(2).
+									Obj(),
+							).
 							Obj(),
 					).
 					Admitted(true).
@@ -623,9 +647,17 @@ func TestReconciler(t *testing.T) {
 							Obj(),
 					).
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", "head", "workers-group-0").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(2).
+						utiltesting.MakeAdmission("cq").
+							PodSets(
+								utiltesting.MakePodSetAssignment("head").
+									Flavor(corev1.ResourceCPU, "unit-test-flavor").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(2).
+									Obj(),
+								utiltesting.MakePodSetAssignment("workers-group-0").
+									Count(2).
+									Obj(),
+							).
 							Obj(),
 					).
 					Admitted(true).

--- a/pkg/controller/tas/node_failure_controller_test.go
+++ b/pkg/controller/tas/node_failure_controller_test.go
@@ -67,9 +67,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 		ReserveQuota(
 			utiltesting.MakeAdmission("cq").
 				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-					Flavor(corev1.ResourceCPU, "unit-test-flavor").
-					ResourceUsage(corev1.ResourceCPU, "1").
-					Count(1).
+					Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 					TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
 						Domains(utiltesting.MakeTopologyDomainAssignment([]string{nodeName}, 1).Obj()).
 						Obj()).
@@ -90,8 +88,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 		ReserveQuota(
 			utiltesting.MakeAdmission("cq").
 				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-					Flavor(corev1.ResourceCPU, "unit-test-flavor").
-					ResourceUsage(corev1.ResourceCPU, "1").
+					Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 					Count(2).
 					TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
 						Domains(

--- a/pkg/controller/tas/node_failure_controller_test.go
+++ b/pkg/controller/tas/node_failure_controller_test.go
@@ -66,19 +66,14 @@ func TestNodeFailureReconciler(t *testing.T) {
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 		ReserveQuota(
 			utiltesting.MakeAdmission("cq").
-				Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-				AssignmentPodCount(1).
-				TopologyAssignment(&kueue.TopologyAssignment{
-					Levels: []string{corev1.LabelHostname},
-					Domains: []kueue.TopologyDomainAssignment{
-						{
-							Count: 1,
-							Values: []string{
-								nodeName,
-							},
-						},
-					},
-				}).
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Flavor(corev1.ResourceCPU, "unit-test-flavor").
+					ResourceUsage(corev1.ResourceCPU, "1").
+					Count(1).
+					TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domains(utiltesting.MakeTopologyDomainAssignment([]string{nodeName}, 1).Obj()).
+						Obj()).
+					Obj()).
 				Obj(),
 		).
 		Admitted(true).
@@ -94,15 +89,17 @@ func TestNodeFailureReconciler(t *testing.T) {
 		PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 		ReserveQuota(
 			utiltesting.MakeAdmission("cq").
-				Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-				AssignmentPodCount(2).
-				TopologyAssignment(&kueue.TopologyAssignment{
-					Levels: []string{corev1.LabelHostname},
-					Domains: []kueue.TopologyDomainAssignment{
-						{Count: 1, Values: []string{nodeName}},
-						{Count: 1, Values: []string{nodeName2}},
-					},
-				}).
+				PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Flavor(corev1.ResourceCPU, "unit-test-flavor").
+					ResourceUsage(corev1.ResourceCPU, "1").
+					Count(2).
+					TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domains(
+							utiltesting.MakeTopologyDomainAssignment([]string{nodeName}, 1).Obj(),
+							utiltesting.MakeTopologyDomainAssignment([]string{nodeName2}, 1).Obj(),
+						).
+						Obj()).
+					Obj()).
 				Obj(),
 		).
 		Admitted(true).

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -123,20 +123,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -171,20 +165,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(3).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 3,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(3).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 3).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -228,27 +216,17 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -320,8 +298,11 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(2).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(2).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -348,20 +329,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(false).
@@ -388,20 +363,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -426,20 +395,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -464,20 +427,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -517,20 +474,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -569,20 +520,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -632,20 +577,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -696,20 +635,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
-							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -758,20 +691,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -821,20 +748,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
-							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -886,34 +807,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "5").
-							AssignmentPodCount(5).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 2,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(5).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 2).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1037,49 +942,21 @@ func TestReconcile(t *testing.T) {
 									Flavor(corev1.ResourceCPU, "unit-test-flavor").
 									ResourceUsage(corev1.ResourceCPU, "4").
 									Count(4).
-									TopologyAssignment(&kueue.TopologyAssignment{
-										Levels: defaultTestLevels,
-										Domains: []kueue.TopologyDomainAssignment{
-											{
-												Count: 1,
-												Values: []string{
-													"b1",
-													"r1",
-												},
-											},
-											{
-												Count: 1,
-												Values: []string{
-													"b1",
-													"r2",
-												},
-											},
-											{
-												Count: 2,
-												Values: []string{
-													"b2",
-													"r1",
-												},
-											},
-										},
-									}).
+									TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+										Domains(
+											utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj(),
+											utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+											utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 2).Obj(),
+										).
+										Obj()).
 									Obj(),
 								utiltesting.MakePodSetAssignment("leader").
 									Flavor(corev1.ResourceCPU, "unit-test-flavor").
 									ResourceUsage(corev1.ResourceCPU, "1").
 									Count(1).
-									TopologyAssignment(&kueue.TopologyAssignment{
-										Levels: defaultTestLevels,
-										Domains: []kueue.TopologyDomainAssignment{
-											{
-												Count: 1,
-												Values: []string{
-													"b1",
-													"r1",
-												},
-											},
-										},
-									}).
+									TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+										Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+										Obj()).
 									Obj(),
 							).
 							Obj(),
@@ -1190,34 +1067,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "5").
-							AssignmentPodCount(5).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 2,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(5).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 2).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1342,49 +1203,21 @@ func TestReconcile(t *testing.T) {
 									Flavor(corev1.ResourceCPU, "unit-test-flavor").
 									ResourceUsage(corev1.ResourceCPU, "4").
 									Count(4).
-									TopologyAssignment(&kueue.TopologyAssignment{
-										Levels: defaultTestLevels,
-										Domains: []kueue.TopologyDomainAssignment{
-											{
-												Count: 1,
-												Values: []string{
-													"b1",
-													"r1",
-												},
-											},
-											{
-												Count: 1,
-												Values: []string{
-													"b1",
-													"r2",
-												},
-											},
-											{
-												Count: 2,
-												Values: []string{
-													"b2",
-													"r1",
-												},
-											},
-										},
-									}).
+									TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+										Domains(
+											utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj(),
+											utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+											utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 2).Obj(),
+										).
+										Obj()).
 									Obj(),
 								utiltesting.MakePodSetAssignment("leader").
 									Flavor(corev1.ResourceCPU, "unit-test-flavor").
 									ResourceUsage(corev1.ResourceCPU, "1").
 									Count(1).
-									TopologyAssignment(&kueue.TopologyAssignment{
-										Levels: defaultTestLevels,
-										Domains: []kueue.TopologyDomainAssignment{
-											{
-												Count: 1,
-												Values: []string{
-													"b1",
-													"r1",
-												},
-											},
-										},
-									}).
+									TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+										Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+										Obj()).
 									Obj(),
 							).
 							Obj(),
@@ -1496,34 +1329,18 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 4).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1610,20 +1427,14 @@ func TestReconcile(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1684,34 +1495,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1825,34 +1620,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -1968,34 +1747,37 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(&kueue.TopologyAssignment{
+									Levels: defaultTestLevels,
+									Domains: []kueue.TopologyDomainAssignment{
+										{
+											Count: 2,
+											Values: []string{
+												"b1",
+												"r1",
+											},
+										},
+										{
+											Count: 1,
+											Values: []string{
+												"b1",
+												"r2",
+											},
+										},
+										{
+											Count: 1,
+											Values: []string{
+												"b2",
+												"r1",
+											},
 										},
 									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+								}).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -2066,34 +1848,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -2195,34 +1961,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -2326,34 +2076,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -2449,34 +2183,18 @@ func TestReconcile(t *testing.T) {
 						Obj()).
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
-							Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCount(4).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "unit-test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(4).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
+									Domains(
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										utiltesting.MakeTopologyDomainAssignment([]string{"b2", "r1"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -1031,49 +1031,57 @@ func TestReconcile(t *testing.T) {
 							Obj(),
 					).
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", "workers", "leader").
-							AssignmentWithIndex(0, corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCountWithIndex(0, 4).
-							TopologyAssignmentWithIndex(0, &kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
+						utiltesting.MakeAdmission("cq").
+							PodSets(
+								utiltesting.MakePodSetAssignment("workers").
+									Flavor(corev1.ResourceCPU, "unit-test-flavor").
+									ResourceUsage(corev1.ResourceCPU, "4").
+									Count(4).
+									TopologyAssignment(&kueue.TopologyAssignment{
+										Levels: defaultTestLevels,
+										Domains: []kueue.TopologyDomainAssignment{
+											{
+												Count: 1,
+												Values: []string{
+													"b1",
+													"r1",
+												},
+											},
+											{
+												Count: 1,
+												Values: []string{
+													"b1",
+													"r2",
+												},
+											},
+											{
+												Count: 2,
+												Values: []string{
+													"b2",
+													"r1",
+												},
+											},
 										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
+									}).
+									Obj(),
+								utiltesting.MakePodSetAssignment("leader").
+									Flavor(corev1.ResourceCPU, "unit-test-flavor").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(1).
+									TopologyAssignment(&kueue.TopologyAssignment{
+										Levels: defaultTestLevels,
+										Domains: []kueue.TopologyDomainAssignment{
+											{
+												Count: 1,
+												Values: []string{
+													"b1",
+													"r1",
+												},
+											},
 										},
-									},
-									{
-										Count: 2,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
-							AssignmentWithIndex(1, corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCountWithIndex(1, 1).
-							TopologyAssignmentWithIndex(1, &kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+									}).
+									Obj(),
+							).
 							Obj(),
 					).
 					Admitted(true).
@@ -1328,49 +1336,57 @@ func TestReconcile(t *testing.T) {
 							Obj(),
 					).
 					ReserveQuota(
-						utiltesting.MakeAdmission("cq", "workers", "leader").
-							AssignmentWithIndex(0, corev1.ResourceCPU, "unit-test-flavor", "4").
-							AssignmentPodCountWithIndex(0, 4).
-							TopologyAssignmentWithIndex(0, &kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
+						utiltesting.MakeAdmission("cq").
+							PodSets(
+								utiltesting.MakePodSetAssignment("workers").
+									Flavor(corev1.ResourceCPU, "unit-test-flavor").
+									ResourceUsage(corev1.ResourceCPU, "4").
+									Count(4).
+									TopologyAssignment(&kueue.TopologyAssignment{
+										Levels: defaultTestLevels,
+										Domains: []kueue.TopologyDomainAssignment{
+											{
+												Count: 1,
+												Values: []string{
+													"b1",
+													"r1",
+												},
+											},
+											{
+												Count: 1,
+												Values: []string{
+													"b1",
+													"r2",
+												},
+											},
+											{
+												Count: 2,
+												Values: []string{
+													"b2",
+													"r1",
+												},
+											},
 										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r2",
+									}).
+									Obj(),
+								utiltesting.MakePodSetAssignment("leader").
+									Flavor(corev1.ResourceCPU, "unit-test-flavor").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(1).
+									TopologyAssignment(&kueue.TopologyAssignment{
+										Levels: defaultTestLevels,
+										Domains: []kueue.TopologyDomainAssignment{
+											{
+												Count: 1,
+												Values: []string{
+													"b1",
+													"r1",
+												},
+											},
 										},
-									},
-									{
-										Count: 2,
-										Values: []string{
-											"b2",
-											"r1",
-										},
-									},
-								},
-							}).
-							AssignmentWithIndex(1, corev1.ResourceCPU, "unit-test-flavor", "1").
-							AssignmentPodCountWithIndex(1, 1).
-							TopologyAssignmentWithIndex(1, &kueue.TopologyAssignment{
-								Levels: defaultTestLevels,
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"b1",
-											"r1",
-										},
-									},
-								},
-							}).
+									}).
+									Obj(),
+							).
 							Obj(),
 					).
 					Admitted(true).

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -124,9 +124,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -166,8 +164,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								Count(3).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 3).Obj()).
@@ -217,8 +214,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -299,8 +295,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								Count(2).
 								Obj()).
 							Obj(),
@@ -330,8 +325,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
@@ -364,9 +358,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -396,9 +388,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -428,9 +418,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -475,9 +463,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -521,9 +507,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -578,9 +562,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -636,8 +618,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj()).
@@ -692,9 +673,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -749,8 +728,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 2).Obj()).
@@ -808,8 +786,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "5").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "5").
 								Count(5).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -939,8 +916,7 @@ func TestReconcile(t *testing.T) {
 						utiltesting.MakeAdmission("cq").
 							PodSets(
 								utiltesting.MakePodSetAssignment("workers").
-									Flavor(corev1.ResourceCPU, "unit-test-flavor").
-									ResourceUsage(corev1.ResourceCPU, "4").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 									Count(4).
 									TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 										Domains(
@@ -951,9 +927,7 @@ func TestReconcile(t *testing.T) {
 										Obj()).
 									Obj(),
 								utiltesting.MakePodSetAssignment("leader").
-									Flavor(corev1.ResourceCPU, "unit-test-flavor").
-									ResourceUsage(corev1.ResourceCPU, "1").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 									TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 										Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 										Obj()).
@@ -1068,8 +1042,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "5").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "5").
 								Count(5).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -1200,8 +1173,7 @@ func TestReconcile(t *testing.T) {
 						utiltesting.MakeAdmission("cq").
 							PodSets(
 								utiltesting.MakePodSetAssignment("workers").
-									Flavor(corev1.ResourceCPU, "unit-test-flavor").
-									ResourceUsage(corev1.ResourceCPU, "4").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 									Count(4).
 									TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 										Domains(
@@ -1212,9 +1184,7 @@ func TestReconcile(t *testing.T) {
 										Obj()).
 									Obj(),
 								utiltesting.MakePodSetAssignment("leader").
-									Flavor(corev1.ResourceCPU, "unit-test-flavor").
-									ResourceUsage(corev1.ResourceCPU, "1").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 									TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 										Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 										Obj()).
@@ -1330,8 +1300,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -1428,9 +1397,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(utiltesting.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj()).
 									Obj()).
@@ -1496,8 +1463,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -1621,8 +1587,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -1748,8 +1713,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(&kueue.TopologyAssignment{
 									Levels: defaultTestLevels,
@@ -1849,8 +1813,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -1962,8 +1925,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -2077,8 +2039,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(
@@ -2184,8 +2145,7 @@ func TestReconcile(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("cq").
 							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "unit-test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "4").
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "4").
 								Count(4).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(defaultTestLevels).
 									Domains(

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -1272,10 +1272,16 @@ func TestQueueSecondPassIfNeeded(t *testing.T) {
 			Obj())
 	baseWorkloadNeedingSecondPass := baseWorkloadBuilder.Clone().
 		ReserveQuota(
-			utiltesting.MakeAdmission("tas-main", "one").
-				Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-				DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-				AssignmentPodCount(1).Obj(),
+			utiltesting.MakeAdmission("tas-main").
+				PodSets(
+					utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+						Count(1).
+						Obj(),
+				).
+				Obj(),
 		).
 		AdmissionCheck(kueue.AdmissionCheckState{
 			Name:  "prov-check",

--- a/pkg/queue/manager_test.go
+++ b/pkg/queue/manager_test.go
@@ -1275,10 +1275,8 @@ func TestQueueSecondPassIfNeeded(t *testing.T) {
 			utiltesting.MakeAdmission("tas-main").
 				PodSets(
 					utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-						Count(1).
 						Obj(),
 				).
 				Obj(),

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -293,14 +293,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -308,7 +316,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -333,14 +345,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -348,7 +368,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -374,14 +398,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -405,14 +437,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -435,14 +475,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "1000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "1000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -450,7 +498,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -475,14 +527,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "1000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -490,7 +550,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -515,14 +579,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceMemory, "2Gi").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceMemory, "alpha", "2Gi").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceMemory, "alpha", "2Gi").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("mid", "").
 					Request(corev1.ResourceMemory, "1Gi").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceMemory, "beta", "1Gi").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceMemory, "beta", "1Gi").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -530,7 +602,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceMemory, "1Gi").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceMemory, "beta", "1Gi").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceMemory, "beta", "1Gi").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -560,14 +636,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("c2-mid", "").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -575,7 +659,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "6").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "6000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "6000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -637,7 +725,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -645,7 +737,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -669,7 +765,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -677,7 +777,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -685,7 +789,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -709,7 +817,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -717,7 +829,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -725,7 +841,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -755,7 +875,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -763,7 +887,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -771,7 +899,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -796,7 +928,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("d1").Assignment(corev1.ResourceCPU, "default", "4").Obj(),
+						utiltesting.MakeAdmission("d1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -804,7 +940,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("d1").Assignment(corev1.ResourceCPU, "default", "4").Obj(),
+						utiltesting.MakeAdmission("d1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -812,7 +952,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("d2").Assignment(corev1.ResourceCPU, "default", "4").Obj(),
+						utiltesting.MakeAdmission("d2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -837,7 +981,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -845,7 +993,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "5").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "5000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "5000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -853,7 +1005,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "1000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -861,7 +1017,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "1000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -891,7 +1051,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("l1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("l1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -899,7 +1063,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("l1").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("l1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -923,21 +1091,33 @@ func TestPreemption(t *testing.T) {
 				*utiltesting.MakeWorkload("c1", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("c2-1", "").
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("c2-2", "").
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -959,7 +1139,11 @@ func TestPreemption(t *testing.T) {
 				*utiltesting.MakeWorkload("c1-1", "").
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -967,14 +1151,22 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("c2", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -998,14 +1190,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("c1-mid", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c1").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("c1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1013,14 +1213,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("c2-mid", "").
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1044,7 +1252,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("c2").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("c2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1068,7 +1280,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceMemory, "2Gi").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceMemory, "alpha", "2Gi").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceMemory, "alpha", "2Gi").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1076,7 +1292,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceMemory, "2Gi").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("standalone").Assignment(corev1.ResourceMemory, "beta", "2Gi").Obj(),
+						utiltesting.MakeAdmission("standalone").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceMemory, "beta", "2Gi").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1123,7 +1343,11 @@ func TestPreemption(t *testing.T) {
 					Priority(2).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("preventStarvation").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
+						utiltesting.MakeAdmission("preventStarvation").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1132,7 +1356,11 @@ func TestPreemption(t *testing.T) {
 					Creation(now).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("preventStarvation").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
+						utiltesting.MakeAdmission("preventStarvation").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2").
+								Obj()).
+							Obj(),
 						now.Add(time.Second),
 					).
 					Obj(),
@@ -1141,7 +1369,11 @@ func TestPreemption(t *testing.T) {
 					Creation(now).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("preventStarvation").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
+						utiltesting.MakeAdmission("preventStarvation").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1177,7 +1409,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a_best_effort").Assignment(corev1.ResourceCPU, "default", "10").Obj(),
+						utiltesting.MakeAdmission("a_best_effort").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "10").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1185,7 +1421,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_best_effort").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b_best_effort").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1209,7 +1449,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_standard").Assignment(corev1.ResourceCPU, "default", "10000m").Obj(),
+						utiltesting.MakeAdmission("b_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "10000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1234,7 +1478,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "13").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_standard").Assignment(corev1.ResourceCPU, "default", "13000m").Obj(),
+						utiltesting.MakeAdmission("b_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "13000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1260,7 +1508,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "13").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a_standard").Assignment(corev1.ResourceCPU, "default", "13000m").Obj(),
+						utiltesting.MakeAdmission("a_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "13000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1284,7 +1536,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a_standard").Assignment(corev1.ResourceCPU, "default", "10").Obj(),
+						utiltesting.MakeAdmission("a_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "10").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1292,7 +1548,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a_standard").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1300,7 +1560,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_standard").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1308,7 +1572,11 @@ func TestPreemption(t *testing.T) {
 					Priority(2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_standard").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1333,7 +1601,11 @@ func TestPreemption(t *testing.T) {
 					Priority(2).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_standard").Assignment(corev1.ResourceCPU, "default", "10").Obj(),
+						utiltesting.MakeAdmission("b_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "10").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1341,7 +1613,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b_standard").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b_standard").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1349,7 +1625,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a_best_effort").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a_best_effort").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1357,7 +1637,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a_best_effort").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a_best_effort").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1382,14 +1666,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend1").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("lend1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("lend2-mid", "").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend2").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("lend2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1397,7 +1689,11 @@ func TestPreemption(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("lend2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1422,14 +1718,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend1").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("lend1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("lend1-mid", "").
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend1").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+						utiltesting.MakeAdmission("lend1").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "2000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1437,14 +1741,22 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend2").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+						utiltesting.MakeAdmission("lend2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "3000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
 				*utiltesting.MakeWorkload("lend2-mid", "").
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend2").Assignment(corev1.ResourceCPU, "default", "4000m").Obj(),
+						utiltesting.MakeAdmission("lend2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "4000m").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1468,7 +1780,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "10").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("lend2").Assignment(corev1.ResourceCPU, "default", "10").Obj(),
+						utiltesting.MakeAdmission("lend2").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "10").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1492,7 +1808,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1500,7 +1820,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1508,7 +1832,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1516,7 +1844,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1524,7 +1856,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1532,7 +1868,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1558,7 +1898,12 @@ func TestPreemption(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Assignment(corev1.ResourceMemory, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Assignment(corev1.ResourceMemory, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1567,7 +1912,12 @@ func TestPreemption(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Assignment(corev1.ResourceMemory, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Assignment(corev1.ResourceMemory, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1576,7 +1926,12 @@ func TestPreemption(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Assignment(corev1.ResourceMemory, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Assignment(corev1.ResourceMemory, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1585,7 +1940,12 @@ func TestPreemption(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Assignment(corev1.ResourceMemory, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Assignment(corev1.ResourceMemory, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1594,7 +1954,12 @@ func TestPreemption(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Assignment(corev1.ResourceMemory, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Assignment(corev1.ResourceMemory, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1603,7 +1968,12 @@ func TestPreemption(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Assignment(corev1.ResourceMemory, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Assignment(corev1.ResourceMemory, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1633,7 +2003,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1641,7 +2015,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1649,7 +2027,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1657,7 +2039,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1665,7 +2051,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1673,7 +2063,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1703,7 +2097,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("a").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("a").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1711,7 +2109,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1719,7 +2121,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1727,7 +2133,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1735,7 +2145,11 @@ func TestPreemption(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1743,7 +2157,11 @@ func TestPreemption(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("b").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
+						utiltesting.MakeAdmission("b").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "1").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -1787,7 +2205,11 @@ func TestPreemption(t *testing.T) {
 				*utiltesting.MakeWorkload("to-be-preempted", "").
 					Request(corev1.ResourceCPU, "5").
 					ReserveQuotaAt(
-						utiltesting.MakeAdmission("cq-right").Assignment(corev1.ResourceCPU, "default", "5").Obj(),
+						utiltesting.MakeAdmission("cq-right").
+							PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "default", "5").
+								Obj()).
+							Obj(),
 						now,
 					).
 					Obj(),
@@ -3001,7 +3423,8 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3061,13 +3484,15 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-10).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_nominal").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted2", "").
 					Priority(0).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3119,13 +3544,15 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted2", "").
 					Priority(2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3183,19 +3610,22 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_preemptible", "").
 					Priority(0).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_own_queue", "").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3249,13 +3679,15 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_queue", "").
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3321,13 +3753,15 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-10).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_nominal").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_cohort", "").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3388,13 +3822,15 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(10).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "3").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_cohort", "").
 					Priority(10).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "3").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3462,19 +3898,22 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_cohort_preemptible", "").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_not_preemptible", "").
 					Priority(1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3542,19 +3981,22 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_queue_preemptible", "").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_not_preemptible", "").
 					Priority(1).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3616,25 +4058,29 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(8).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_prio_9", "").
 					Priority(9).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_prio_10", "").
 					Priority(9).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_nominal", "").
 					Priority(-2).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_nominal").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3699,19 +4145,22 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-10).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_other").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_other_2", "").
 					Priority(-10).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_other").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_cohort", "").
 					Priority(0).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3775,16 +4224,18 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Request(corev1.ResourceCPU, "3").
 					Request(corev1.ResourceMemory, "1Gi").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "3").
-						Assignment(corev1.ResourceMemory, "default", "1Gi").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").
+							Assignment(corev1.ResourceMemory, "default", "1Gi").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_same_cohort", "").
 					Priority(-2).
 					Request(corev1.ResourceCPU, "1").
 					Request(corev1.ResourceMemory, "3Gi").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "1").
-						Assignment(corev1.ResourceMemory, "default", "3Gi").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").
+							Assignment(corev1.ResourceMemory, "default", "3Gi").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -3853,13 +4304,15 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-10).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("evicted_same_cohort", "").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "1").
 					ReserveQuota(utiltesting.MakeAdmission("q_same_cohort").
-						Assignment(corev1.ResourceCPU, "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 					SetOrReplaceCondition(metav1.Condition{
 						Type:               kueue.WorkloadEvicted,
 						Status:             metav1.ConditionTrue,
@@ -3918,7 +4371,8 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(0).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuota(utiltesting.MakeAdmission("q_borrowing").
-						Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").
@@ -4028,49 +4482,57 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Priority(-6).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuota(utiltesting.MakeAdmission("q1").
-						Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_2", "").
 					Priority(-5).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuota(utiltesting.MakeAdmission("q1").
-						Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_3", "").
 					Priority(-9).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuota(utiltesting.MakeAdmission("q2").
-						Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_4", "").
 					Priority(-10).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuota(utiltesting.MakeAdmission("q2").
-						Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_5", "").
 					Priority(-4).
 					Request(corev1.ResourceCPU, "4").
 					ReserveQuota(utiltesting.MakeAdmission("q3").
-						Assignment(corev1.ResourceCPU, "default", "4").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_6", "").
 					Priority(-3).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("q3").
-						Assignment(corev1.ResourceCPU, "default", "3").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_7", "").
 					Priority(4).
 					Request(corev1.ResourceCPU, "2").
 					ReserveQuota(utiltesting.MakeAdmission("q4").
-						Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("admitted_borrowing_8", "").
 					Priority(2).
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("q4").
-						Assignment(corev1.ResourceCPU, "default", "3").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj()).
 					Obj(),
 			},
 			incoming: utiltesting.MakeWorkload("incoming", "").

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -172,78 +172,14 @@ func TestSchedule(t *testing.T) {
 			Obj(),
 	}
 	queues := []kueue.LocalQueue{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "sales",
-				Name:      "main",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "sales",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "sales",
-				Name:      "blocked",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-alpha",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "eng-alpha",
-				Name:      "main",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-alpha",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "eng-beta",
-				Name:      "main",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-beta",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "sales",
-				Name:      "flavor-nonexistent-queue",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "flavor-nonexistent-cq",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "sales",
-				Name:      "cq-nonexistent-queue",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "nonexistent-cq",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "lend",
-				Name:      "lend-a-queue",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "lend-a",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "lend",
-				Name:      "lend-b-queue",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "lend-b",
-			},
-		},
+		*utiltesting.MakeLocalQueue("main", "sales").ClusterQueue("sales").Obj(),
+		*utiltesting.MakeLocalQueue("blocked", "sales").ClusterQueue("eng-alpha").Obj(),
+		*utiltesting.MakeLocalQueue("main", "eng-alpha").ClusterQueue("eng-alpha").Obj(),
+		*utiltesting.MakeLocalQueue("main", "eng-beta").ClusterQueue("eng-beta").Obj(),
+		*utiltesting.MakeLocalQueue("flavor-nonexistent-queue", "sales").ClusterQueue("flavor-nonexistent-cq").Obj(),
+		*utiltesting.MakeLocalQueue("cq-nonexistent-queue", "sales").ClusterQueue("nonexistent-cq").Obj(),
+		*utiltesting.MakeLocalQueue("lend-a-queue", "lend").ClusterQueue("lend-a").Obj(),
+		*utiltesting.MakeLocalQueue("lend-b-queue", "lend").ClusterQueue("lend-b").Obj(),
 	}
 	cases := map[string]struct {
 		// Features
@@ -1102,15 +1038,7 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			additionalLocalQueues: []kueue.LocalQueue{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "eng-gamma",
-						Name:      "main",
-					},
-					Spec: kueue.LocalQueueSpec{
-						ClusterQueue: "eng-gamma",
-					},
-				},
+				*utiltesting.MakeLocalQueue("main", "eng-gamma").ClusterQueue("eng-gamma").Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
 				"eng-gamma/existing": *utiltesting.MakeAdmission("eng-gamma").
@@ -1480,24 +1408,8 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			additionalLocalQueues: []kueue.LocalQueue{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "eng-alpha",
-						Name:      "lq_a",
-					},
-					Spec: kueue.LocalQueueSpec{
-						ClusterQueue: "cq_a",
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "eng-beta",
-						Name:      "lq_b",
-					},
-					Spec: kueue.LocalQueueSpec{
-						ClusterQueue: "cq_b",
-					},
-				},
+				*utiltesting.MakeLocalQueue("lq_a", "eng-alpha").ClusterQueue("cq_a").Obj(),
+				*utiltesting.MakeLocalQueue("lq_b", "eng-beta").ClusterQueue("cq_b").Obj(),
 			},
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "eng-alpha").
@@ -4039,42 +3951,10 @@ func TestLastSchedulingContext(t *testing.T) {
 	}
 
 	queues := []kueue.LocalQueue{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "main",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-alpha",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "main-alpha",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-cohort-alpha",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "main-beta",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-cohort-beta",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "main-theta",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "eng-cohort-theta",
-			},
-		},
+		*utiltesting.MakeLocalQueue("main", "default").ClusterQueue("eng-alpha").Obj(),
+		*utiltesting.MakeLocalQueue("main-alpha", "default").ClusterQueue("eng-cohort-alpha").Obj(),
+		*utiltesting.MakeLocalQueue("main-beta", "default").ClusterQueue("eng-cohort-beta").Obj(),
+		*utiltesting.MakeLocalQueue("main-theta", "default").ClusterQueue("eng-cohort-theta").Obj(),
 	}
 	cases := []struct {
 		name                           string
@@ -4960,15 +4840,7 @@ func TestScheduleForTAS(t *testing.T) {
 		AdmissionChecks(kueue.AdmissionCheckReference(defaultCustomCheck.Name)).
 		Obj()
 	queues := []kueue.LocalQueue{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "tas-main",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "tas-main",
-			},
-		},
+		*utiltesting.MakeLocalQueue("tas-main", "default").ClusterQueue("tas-main").Obj(),
 	}
 	eventIgnoreMessage := cmpopts.IgnoreFields(utiltesting.EventRecord{}, "Message")
 	cases := map[string]struct {
@@ -7556,15 +7428,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 			Resource(corev1.ResourceMemory, "50Gi").Obj()).
 		Obj()
 	queues := []kueue.LocalQueue{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "tas-main",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "tas-main",
-			},
-		},
+		*utiltesting.MakeLocalQueue("tas-main", "default").ClusterQueue("tas-main").Obj(),
 	}
 	cases := map[string]struct {
 		nodes           []corev1.Node
@@ -8202,33 +8066,9 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			Resource(corev1.ResourceMemory, "4Gi").Obj()).
 		Obj()
 	queues := []kueue.LocalQueue{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "tas-lq-a",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "tas-cq-a",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "tas-lq-b",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "tas-cq-b",
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "tas-lq-c",
-			},
-			Spec: kueue.LocalQueueSpec{
-				ClusterQueue: "tas-cq-c",
-			},
-		},
+		*utiltesting.MakeLocalQueue("tas-lq-a", "default").ClusterQueue("tas-cq-a").Obj(),
+		*utiltesting.MakeLocalQueue("tas-lq-b", "default").ClusterQueue("tas-cq-b").Obj(),
+		*utiltesting.MakeLocalQueue("tas-lq-c", "default").ClusterQueue("tas-cq-c").Obj(),
 	}
 	eventIgnoreMessage := cmpopts.IgnoreFields(utiltesting.EventRecord{}, "Message")
 	cases := map[string]struct {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4868,22 +4868,12 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "launcher", "worker").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
 					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "0").
 					AssignmentPodCountWithIndex(1, 0).
-					TopologyAssignmentWithIndex(1, &kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-					}).
+					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).Obj()).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -4922,17 +4912,10 @@ func TestScheduleForTAS(t *testing.T) {
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
 					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -4990,17 +4973,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-reservation", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -5026,17 +5002,9 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -5046,17 +5014,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 		},
 		"workload with nodeToReplace annotation; second pass; preferred; fit in different rack": {
@@ -5077,23 +5038,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -5103,23 +5051,11 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-							{
-								Count: 1,
-								Values: []string{
-									"x5",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x5"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 		},
 		"workload with nodeToReplace annotation; second pass; preferred; no fit": {
@@ -5140,17 +5076,9 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "3000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -5160,17 +5088,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "3000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x0",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "foo", "SecondPassFailed", corev1.EventTypeWarning).
@@ -5196,17 +5117,9 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "3000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -5216,17 +5129,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "3000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x0",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "foo", "EvictedDueToNodeFailures", corev1.EventTypeNormal).
@@ -5253,23 +5159,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"x2",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -5279,23 +5172,11 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x2",
-								},
-							},
-							{
-								Count: 1,
-								Values: []string{
-									"x3",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x3"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 		},
 		"workload with nodeToReplace annotation; second pass; required rack for a single node; fit": {
@@ -5316,17 +5197,9 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -5336,17 +5209,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 		},
 		"workload with nodeToReplace annotation; second pass; required rack; no fit": {
@@ -5367,23 +5233,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -5393,23 +5246,11 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x0",
-								},
-							},
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "foo", "SecondPassFailed", corev1.EventTypeWarning).
@@ -5440,30 +5281,14 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one", "two").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x0",
-										},
-									},
-								},
-							}).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
 							AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCountWithIndex(1, 1).
-							TopologyAssignmentWithIndex(1, &kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).
+							TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
 							Obj(),
 					).
 					Admitted(true).
@@ -5473,30 +5298,14 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one", "two").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x2",
-								},
-							},
-						},
-					}).
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+						Obj()).
 					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCountWithIndex(1, 1).
-					TopologyAssignmentWithIndex(1, &kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).
+					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
 					Obj(),
 			},
 		},
@@ -5544,17 +5353,10 @@ func TestScheduleForTAS(t *testing.T) {
 					Assignment(corev1.ResourceCPU, "tas-default", "26").
 					AssignmentPodCount(26).
 					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 26,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 26).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -5623,17 +5425,10 @@ func TestScheduleForTAS(t *testing.T) {
 					Assignment(corev1.ResourceCPU, "tas-second", "1000m").
 					AssignmentPodCount(1).
 					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -5707,17 +5502,9 @@ func TestScheduleForTAS(t *testing.T) {
 										corev1.ResourceCPU: resource.MustParse("1"),
 									},
 									Count: ptr.To[int32](1),
-									TopologyAssignment: &kueue.TopologyAssignment{
-										Levels: utiltas.Levels(&defaultSingleLevelTopology),
-										Domains: []kueue.TopologyDomainAssignment{
-											{
-												Count: 1,
-												Values: []string{
-													"x1",
-												},
-											},
-										},
-									},
+									TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+										Obj(),
 								},
 								kueue.PodSetAssignment{
 									Name: "two",
@@ -5750,17 +5537,9 @@ func TestScheduleForTAS(t *testing.T) {
 								corev1.ResourceCPU: resource.MustParse("1"),
 							},
 							Count: ptr.To[int32](1),
-							TopologyAssignment: &kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							},
+							TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj(),
 						},
 						kueue.PodSetAssignment{
 							Name: "two",
@@ -5772,17 +5551,9 @@ func TestScheduleForTAS(t *testing.T) {
 							},
 							Count:                  ptr.To[int32](1),
 							DelayedTopologyRequest: ptr.To(kueue.DelayedTopologyRequestStateReady),
-							TopologyAssignment: &kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							},
+							TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj(),
 						},
 					).Obj(),
 			},
@@ -5881,17 +5652,10 @@ func TestScheduleForTAS(t *testing.T) {
 					Assignment(corev1.ResourceCPU, "tas-second", "1000m").
 					AssignmentPodCount(1).
 					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -5951,17 +5715,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -5991,17 +5748,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6035,17 +5785,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6134,17 +5877,9 @@ func TestScheduleForTAS(t *testing.T) {
 								corev1.ResourceCPU: resource.MustParse("500m"),
 							},
 							Count: ptr.To[int32](1),
-							TopologyAssignment: &kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							},
+							TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj(),
 						},
 					).
 					Obj(),
@@ -6173,17 +5908,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6259,17 +5987,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-custom-flavor", "1").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: []string{"cloud.com/custom-level"},
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{"cloud.com/custom-level"}).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6319,17 +6040,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -6403,17 +6117,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "400m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -6426,17 +6133,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "500m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6465,17 +6165,10 @@ func TestScheduleForTAS(t *testing.T) {
 							Assignment(corev1.ResourceCPU, "tas-default", "500m").
 							Assignment(corev1.ResourceMemory, "tas-default", "500Mi").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -6490,17 +6183,10 @@ func TestScheduleForTAS(t *testing.T) {
 					Assignment(corev1.ResourceCPU, "tas-default", "500m").
 					Assignment(corev1.ResourceMemory, "tas-default", "500Mi").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6613,36 +6299,15 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "launcher", "worker").
 					AssignmentWithIndex(0, corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCountWithIndex(0, 1).
-					TopologyAssignmentWithIndex(0, &kueue.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).
+					TopologyAssignmentWithIndex(0, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
 					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "15000m").
 					AssignmentPodCountWithIndex(1, 15).
-					TopologyAssignmentWithIndex(1, &kueue.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 7,
-								Values: []string{
-									"x1",
-								},
-							},
-							{
-								Count: 8,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).
+					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 8).Obj()).
+						Obj()).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -6701,36 +6366,15 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "launcher", "worker").
 					AssignmentWithIndex(0, corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCountWithIndex(0, 1).
-					TopologyAssignmentWithIndex(0, &kueue.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).
+					TopologyAssignmentWithIndex(0, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
 					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "15000m").
 					AssignmentPodCountWithIndex(1, 15).
-					TopologyAssignmentWithIndex(1, &kueue.TopologyAssignment{
-						Levels: []string{corev1.LabelHostname},
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 7,
-								Values: []string{
-									"x1",
-								},
-							},
-							{
-								Count: 8,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).
+					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 8).Obj()).
+						Obj()).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -6779,17 +6423,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -6802,17 +6439,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6877,17 +6507,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6914,17 +6537,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -6968,17 +6584,10 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "150m").
 							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 2).
@@ -7015,17 +6624,10 @@ func TestScheduleForTAS(t *testing.T) {
 					Assignment(corev1.ResourceCPU, "tas-default", "0").
 					Assignment(corev1.ResourceMemory, "tas-default", "10Mi").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -7263,17 +6865,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"z1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"z1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7318,17 +6913,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7377,17 +6965,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7432,17 +7013,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "2").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7457,17 +7031,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "2").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7514,17 +7081,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "4").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7539,17 +7099,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "4").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7605,17 +7158,10 @@ func TestScheduleForTASPreemption(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "4").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -7859,23 +7405,11 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "6").
 					AssignmentPodCount(6).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-							{
-								Count: 5,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -7897,17 +7431,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(5).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 5,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 5).
@@ -7949,17 +7476,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(5).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 5,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 5).
@@ -7974,17 +7494,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "2").
 							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 2).
@@ -7999,17 +7512,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -8053,17 +7559,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(5).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 5,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 4).
@@ -8078,17 +7577,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "3").
 							AssignmentPodCount(3).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 3,
-										Values: []string{
-											"x1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 3).
@@ -8133,23 +7625,11 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "5").
 							AssignmentPodCount(5).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 3,
-										Values: []string{
-											"x1",
-										},
-									},
-									{
-										Count: 2,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 5).
@@ -8164,17 +7644,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -8189,17 +7662,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "1").
 							AssignmentPodCount(1).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 1,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 1).
@@ -8264,31 +7730,17 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "5").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 				"default/b1": *utiltesting.MakeAdmission("tas-cq-b", "one").
 					Assignment(corev1.ResourceMemory, "tas-default", "5").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -8325,31 +7777,17 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 				"default/b1": *utiltesting.MakeAdmission("tas-cq-b", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "2").
 					AssignmentPodCount(2).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 2,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -8386,17 +7824,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "1").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"tas-cq-b": {"default/b1"},
@@ -8438,17 +7869,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "5").
 					AssignmentPodCount(5).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 5,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+						Obj()).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -8486,17 +7910,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "2").
 					AssignmentPodCount(1).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 1,
-								Values: []string{
-									"x1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						Obj()).
+					Obj(),
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"tas-cq-b": {"default/b1"},
@@ -8530,17 +7947,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "2").
 							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 2).
@@ -8599,17 +8009,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "2").
 							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 2).
@@ -8668,17 +8071,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						utiltesting.MakeAdmission("tas-cq-a", "one").
 							Assignment(corev1.ResourceCPU, "tas-default", "2").
 							AssignmentPodCount(2).
-							TopologyAssignment(&kueue.TopologyAssignment{
-								Levels: utiltas.Levels(&defaultSingleLevelTopology),
-								Domains: []kueue.TopologyDomainAssignment{
-									{
-										Count: 2,
-										Values: []string{
-											"y1",
-										},
-									},
-								},
-							}).Obj(),
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+								Obj()).
+							Obj(),
 					).
 					Admitted(true).
 					PodSets(*utiltesting.MakePodSet("one", 2).
@@ -8718,17 +8114,10 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"default/b1": *utiltesting.MakeAdmission("tas-cq-b", "one").
 					Assignment(corev1.ResourceCPU, "tas-default", "3").
 					AssignmentPodCount(3).
-					TopologyAssignment(&kueue.TopologyAssignment{
-						Levels: utiltas.Levels(&defaultSingleLevelTopology),
-						Domains: []kueue.TopologyDomainAssignment{
-							{
-								Count: 3,
-								Values: []string{
-									"y1",
-								},
-							},
-						},
-					}).Obj(),
+					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 3).Obj()).
+						Obj()).
+					Obj(),
 			},
 		},
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -259,31 +259,21 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/admitted": {
 					ClusterQueue: "other-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "main",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("50"),
-							},
-							Count: ptr.To[int32](1),
-						},
+						utiltesting.MakePodSetAssignment("main").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "50").
+							Count(1).
+							Obj(),
 					},
 				},
 				"eng-alpha/new": {
 					ClusterQueue: "other-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "main",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "spot",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("20"),
-							},
-							Count: ptr.To[int32](1),
-						},
+						utiltesting.MakePodSetAssignment("main").
+							Flavor(corev1.ResourceCPU, "spot").
+							ResourceUsage(corev1.ResourceCPU, "20").
+							Count(1).
+							Obj(),
 					},
 				},
 			},
@@ -307,16 +297,11 @@ func TestSchedule(t *testing.T) {
 				"sales/foo": {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("10000m"),
-							},
-							Count: ptr.To[int32](10),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(10).
+							Obj(),
 					},
 				},
 			},
@@ -399,16 +384,11 @@ func TestSchedule(t *testing.T) {
 				"sales/foo": {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("10000m"),
-							},
-							Count: ptr.To[int32](10),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(10).
+							Obj(),
 					},
 				},
 			},
@@ -451,16 +431,11 @@ func TestSchedule(t *testing.T) {
 				"sales/assigned": {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("40000m"),
-							},
-							Count: ptr.To[int32](40),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Count(40).
+							Obj(),
 					},
 				},
 			},
@@ -500,31 +475,21 @@ func TestSchedule(t *testing.T) {
 				"sales/new": {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("1000m"),
-							},
-							Count: ptr.To[int32](1),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							Obj(),
 					},
 				},
 				"eng-alpha/new": {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("51000m"),
-							},
-							Count: ptr.To[int32](51),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "51000m").
+							Count(51).
+							Obj(),
 					},
 				},
 			},
@@ -549,31 +514,21 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/new": {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("40000m"),
-							},
-							Count: ptr.To[int32](40),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Count(40).
+							Obj(),
 					},
 				},
 				"eng-beta/new": {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("40000m"),
-							},
-							Count: ptr.To[int32](40),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Count(40).
+							Obj(),
 					},
 				},
 			},
@@ -598,28 +553,18 @@ func TestSchedule(t *testing.T) {
 				"eng-beta/new": {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-								"example.com/gpu":  "model-a",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("60000m"),
-								"example.com/gpu":  resource.MustParse("10"),
-							},
-							Count: ptr.To[int32](10),
-						},
-						{
-							Name: "two",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "spot",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("40000m"),
-							},
-							Count: ptr.To[int32](40),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							Flavor("example.com/gpu", "model-a").
+							ResourceUsage(corev1.ResourceCPU, "60000m").
+							ResourceUsage("example.com/gpu", "10").
+							Count(10).
+							Obj(),
+						utiltesting.MakePodSetAssignment("two").
+							Flavor(corev1.ResourceCPU, "spot").
+							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Count(40).
+							Obj(),
 					},
 				},
 			},
@@ -644,16 +589,11 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/new": {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("45000m"),
-							},
-							Count: ptr.To[int32](45),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "45000m").
+							Count(45).
+							Obj(),
 					},
 				},
 			},
@@ -681,31 +621,21 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/new": {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("45000m"),
-							},
-							Count: ptr.To[int32](45),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "45000m").
+							Count(45).
+							Obj(),
 					},
 				},
 				"eng-beta/new": {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("55000m"),
-							},
-							Count: ptr.To[int32](55),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "55000m").
+							Count(55).
+							Obj(),
 					},
 				},
 			},
@@ -902,31 +832,21 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/new": {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "spot",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("60000m"),
-							},
-							Count: ptr.To[int32](60),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "spot").
+							ResourceUsage(corev1.ResourceCPU, "60000m").
+							Count(60).
+							Obj(),
 					},
 				},
 				"eng-beta/existing": {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("45000m"),
-							},
-							Count: ptr.To[int32](45),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "45000m").
+							Count(45).
+							Obj(),
 					},
 				},
 			},
@@ -985,26 +905,16 @@ func TestSchedule(t *testing.T) {
 					).
 					ReserveQuota(utiltesting.MakeAdmission("eng-gamma").
 						PodSets(
-							kueue.PodSetAssignment{
-								Name: "borrow-on-demand",
-								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-									corev1.ResourceCPU: "on-demand",
-								},
-								ResourceUsage: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("51"),
-								},
-								Count: ptr.To[int32](51),
-							},
-							kueue.PodSetAssignment{
-								Name: "use-all-spot",
-								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-									corev1.ResourceCPU: "spot",
-								},
-								ResourceUsage: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("100"),
-								},
-								Count: ptr.To[int32](100),
-							},
+							utiltesting.MakePodSetAssignment("borrow-on-demand").
+								Flavor(corev1.ResourceCPU, "on-demand").
+								ResourceUsage(corev1.ResourceCPU, "51").
+								Count(51).
+								Obj(),
+							utiltesting.MakePodSetAssignment("use-all-spot").
+								Flavor(corev1.ResourceCPU, "spot").
+								ResourceUsage(corev1.ResourceCPU, "100").
+								Count(100).
+								Obj(),
 						).
 						Obj()).
 					Obj(),
@@ -1030,26 +940,16 @@ func TestSchedule(t *testing.T) {
 			wantAssignments: map[workload.Reference]kueue.Admission{
 				"eng-gamma/existing": *utiltesting.MakeAdmission("eng-gamma").
 					PodSets(
-						kueue.PodSetAssignment{
-							Name: "borrow-on-demand",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "on-demand",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("51"),
-							},
-							Count: ptr.To[int32](51),
-						},
-						kueue.PodSetAssignment{
-							Name: "use-all-spot",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "spot",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("100"),
-							},
-							Count: ptr.To[int32](100),
-						},
+						utiltesting.MakePodSetAssignment("borrow-on-demand").
+							Flavor(corev1.ResourceCPU, "on-demand").
+							ResourceUsage(corev1.ResourceCPU, "51").
+							Count(51).
+							Obj(),
+						utiltesting.MakePodSetAssignment("use-all-spot").
+							Flavor(corev1.ResourceCPU, "spot").
+							ResourceUsage(corev1.ResourceCPU, "100").
+							Count(100).
+							Obj(),
 					).Obj(),
 				"eng-beta/new":        *utiltesting.MakeAdmission("eng-beta", "one").Assignment(corev1.ResourceCPU, "on-demand", "50").AssignmentPodCount(50).Obj(),
 				"eng-alpha/new-alpha": *utiltesting.MakeAdmission("eng-alpha", "one").Assignment(corev1.ResourceCPU, "on-demand", "1").AssignmentPodCount(1).Obj(),
@@ -1078,16 +978,11 @@ func TestSchedule(t *testing.T) {
 				"sales/new": {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("50000m"),
-							},
-							Count: ptr.To[int32](25),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "50000m").
+							Count(25).
+							Obj(),
 					},
 				},
 			},
@@ -1115,16 +1010,11 @@ func TestSchedule(t *testing.T) {
 				"eng-beta/old": {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								"example.com/gpu": "model-a",
-							},
-							ResourceUsage: corev1.ResourceList{
-								"example.com/gpu": resource.MustParse("10"),
-							},
-							Count: ptr.To[int32](10),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor("example.com/gpu", "model-a").
+							ResourceUsage("example.com/gpu", "10").
+							Count(10).
+							Obj(),
 					},
 				},
 			},
@@ -1155,16 +1045,11 @@ func TestSchedule(t *testing.T) {
 				"eng-beta/old": {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								"example.com/gpu": "model-a",
-							},
-							ResourceUsage: corev1.ResourceList{
-								"example.com/gpu": resource.MustParse("10"),
-							},
-							Count: ptr.To[int32](10),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor("example.com/gpu", "model-a").
+							ResourceUsage("example.com/gpu", "10").
+							Count(10).
+							Obj(),
 					},
 				},
 			},
@@ -1196,36 +1081,21 @@ func TestSchedule(t *testing.T) {
 				"sales/new": {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("20000m"),
-							},
-							Count: ptr.To[int32](20),
-						},
-						{
-							Name: "two",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("20000m"),
-							},
-							Count: ptr.To[int32](20),
-						},
-						{
-							Name: "three",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("10000m"),
-							},
-							Count: ptr.To[int32](10),
-						},
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "20000m").
+							Count(20).
+							Obj(),
+						utiltesting.MakePodSetAssignment("two").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "20000m").
+							Count(20).
+							Obj(),
+						utiltesting.MakePodSetAssignment("three").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Count(10).
+							Obj(),
 					},
 				},
 			},
@@ -1422,16 +1292,11 @@ func TestSchedule(t *testing.T) {
 					).
 					ReserveQuota(utiltesting.MakeAdmission("cq_a").
 						PodSets(
-							kueue.PodSetAssignment{
-								Name: kueue.DefaultPodSetName,
-								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-									corev1.ResourceCPU: "default",
-								},
-								ResourceUsage: corev1.ResourceList{
-									corev1.ResourceCPU: resource.MustParse("2"),
-								},
-								Count: ptr.To[int32](1),
-							},
+							utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(1).
+								Obj(),
 						).
 						Obj()).
 					Obj(),
@@ -1440,31 +1305,21 @@ func TestSchedule(t *testing.T) {
 				"eng-alpha/admitted_a": {
 					ClusterQueue: "cq_a",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: kueue.DefaultPodSetName,
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("2"),
-							},
-							Count: ptr.To[int32](1),
-						},
+						utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "2").
+							Count(1).
+							Obj(),
 					},
 				},
 				"eng-beta/b": {
 					ClusterQueue: "cq_b",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						{
-							Name: kueue.DefaultPodSetName,
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("1"),
-							},
-							Count: ptr.To[int32](1),
-						},
+						utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "1").
+							Count(1).
+							Obj(),
 					},
 				},
 			},
@@ -5493,30 +5348,20 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main", "one", "two").
 							PodSets(
-								kueue.PodSetAssignment{
-									Name: "one",
-									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-										corev1.ResourceCPU: "tas-default",
-									},
-									ResourceUsage: corev1.ResourceList{
-										corev1.ResourceCPU: resource.MustParse("1"),
-									},
-									Count: ptr.To[int32](1),
-									TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								utiltesting.MakePodSetAssignment("one").
+									Flavor(corev1.ResourceCPU, "tas-default").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(1).
+									TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-										Obj(),
-								},
-								kueue.PodSetAssignment{
-									Name: "two",
-									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-										corev1.ResourceCPU: "tas-second",
-									},
-									ResourceUsage: corev1.ResourceList{
-										corev1.ResourceCPU: resource.MustParse("1"),
-									},
-									Count:                  ptr.To[int32](1),
-									DelayedTopologyRequest: ptr.To(kueue.DelayedTopologyRequestStatePending),
-								},
+										Obj()).
+									Obj(),
+								utiltesting.MakePodSetAssignment("two").
+									Flavor(corev1.ResourceCPU, "tas-second").
+									ResourceUsage(corev1.ResourceCPU, "1").
+									Count(1).
+									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+									Obj(),
 							).Obj(),
 					).
 					AdmissionCheck(kueue.AdmissionCheckState{
@@ -5528,33 +5373,23 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one", "two").
 					PodSets(
-						kueue.PodSetAssignment{
-							Name: "one",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "tas-default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("1"),
-							},
-							Count: ptr.To[int32](1),
-							TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-								Obj(),
-						},
-						kueue.PodSetAssignment{
-							Name: "two",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "tas-second",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("1"),
-							},
-							Count:                  ptr.To[int32](1),
-							DelayedTopologyRequest: ptr.To(kueue.DelayedTopologyRequestStateReady),
-							TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Obj()).
+							Obj(),
+						utiltesting.MakePodSetAssignment("two").
+							Flavor(corev1.ResourceCPU, "tas-second").
+							ResourceUsage(corev1.ResourceCPU, "1").
+							Count(1).
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
-								Obj(),
-						},
+								Obj()).
+							Obj(),
 					).Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5858,29 +5693,19 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
 					PodSets(
-						kueue.PodSetAssignment{
-							Name: "launcher",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("500m"),
-							},
-							Count: ptr.To[int32](1),
-						},
-						kueue.PodSetAssignment{
-							Name: "worker",
-							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-								corev1.ResourceCPU: "tas-default",
-							},
-							ResourceUsage: corev1.ResourceList{
-								corev1.ResourceCPU: resource.MustParse("500m"),
-							},
-							Count: ptr.To[int32](1),
-							TopologyAssignment: utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+						utiltesting.MakePodSetAssignment("launcher").
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "500m").
+							Count(1).
+							Obj(),
+						utiltesting.MakePodSetAssignment("worker").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "500m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-								Obj(),
-						},
+								Obj()).
+							Obj(),
 					).
 					Obj(),
 			},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -264,20 +264,14 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "other-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("main").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "50").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
 							Obj(),
 					},
 				},
 				"eng-alpha/new": {
 					ClusterQueue: "other-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
-						utiltesting.MakePodSetAssignment("main").
-							Flavor(corev1.ResourceCPU, "spot").
-							ResourceUsage(corev1.ResourceCPU, "20").
-							Count(1).
-							Obj(),
+						utiltesting.MakePodSetAssignment("main").Assignment(corev1.ResourceCPU, "spot", "20").Obj(),
 					},
 				},
 			},
@@ -302,8 +296,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "default", "10000m").
 							Count(10).
 							Obj(),
 					},
@@ -330,8 +323,7 @@ func TestSchedule(t *testing.T) {
 					Admission(
 						utiltesting.MakeAdmission("sales").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "default").
-								ResourceUsage(corev1.ResourceCPU, "10000m").
+								Assignment(corev1.ResourceCPU, "default", "10000m").
 								Count(10).
 								Obj()).
 							Obj(),
@@ -392,8 +384,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "default", "10000m").
 							Count(10).
 							Obj(),
 					},
@@ -431,7 +422,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 40).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "40000m").Count(40).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "default", "40000m").Count(40).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
@@ -439,8 +430,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Assignment(corev1.ResourceCPU, "default", "40000m").
 							Count(40).
 							Obj(),
 					},
@@ -483,9 +473,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "default", "1000m").
 							Obj(),
 					},
 				},
@@ -493,8 +481,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "51000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "51000m").
 							Count(51).
 							Obj(),
 					},
@@ -522,8 +509,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "40000m").
 							Count(40).
 							Obj(),
 					},
@@ -532,8 +518,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "40000m").
 							Count(40).
 							Obj(),
 					},
@@ -561,15 +546,12 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							Flavor("example.com/gpu", "model-a").
-							ResourceUsage(corev1.ResourceCPU, "60000m").
-							ResourceUsage("example.com/gpu", "10").
+							Assignment(corev1.ResourceCPU, "on-demand", "60000m").
+							Assignment("example.com/gpu", "model-a", "10").
 							Count(10).
 							Obj(),
 						utiltesting.MakePodSetAssignment("two").
-							Flavor(corev1.ResourceCPU, "spot").
-							ResourceUsage(corev1.ResourceCPU, "40000m").
+							Assignment(corev1.ResourceCPU, "spot", "40000m").
 							Count(40).
 							Obj(),
 					},
@@ -597,8 +579,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "45000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "45000m").
 							Count(45).
 							Obj(),
 					},
@@ -629,8 +610,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "45000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "45000m").
 							Count(45).
 							Obj(),
 					},
@@ -639,8 +619,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "55000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "55000m").
 							Count(55).
 							Obj(),
 					},
@@ -912,7 +891,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 45).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "45000m").Count(45).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "45000m").Count(45).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
@@ -920,8 +899,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-alpha",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "spot").
-							ResourceUsage(corev1.ResourceCPU, "60000m").
+							Assignment(corev1.ResourceCPU, "spot", "60000m").
 							Count(60).
 							Obj(),
 					},
@@ -930,8 +908,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "45000m").
+							Assignment(corev1.ResourceCPU, "on-demand", "45000m").
 							Count(45).
 							Obj(),
 					},
@@ -993,13 +970,11 @@ func TestSchedule(t *testing.T) {
 					ReserveQuota(utiltesting.MakeAdmission("eng-gamma").
 						PodSets(
 							utiltesting.MakePodSetAssignment("borrow-on-demand").
-								Flavor(corev1.ResourceCPU, "on-demand").
-								ResourceUsage(corev1.ResourceCPU, "51").
+								Assignment(corev1.ResourceCPU, "on-demand", "51").
 								Count(51).
 								Obj(),
 							utiltesting.MakePodSetAssignment("use-all-spot").
-								Flavor(corev1.ResourceCPU, "spot").
-								ResourceUsage(corev1.ResourceCPU, "100").
+								Assignment(corev1.ResourceCPU, "spot", "100").
 								Count(100).
 								Obj(),
 						).
@@ -1028,18 +1003,16 @@ func TestSchedule(t *testing.T) {
 				"eng-gamma/existing": *utiltesting.MakeAdmission("eng-gamma").
 					PodSets(
 						utiltesting.MakePodSetAssignment("borrow-on-demand").
-							Flavor(corev1.ResourceCPU, "on-demand").
-							ResourceUsage(corev1.ResourceCPU, "51").
+							Assignment(corev1.ResourceCPU, "on-demand", "51").
 							Count(51).
 							Obj(),
 						utiltesting.MakePodSetAssignment("use-all-spot").
-							Flavor(corev1.ResourceCPU, "spot").
-							ResourceUsage(corev1.ResourceCPU, "100").
+							Assignment(corev1.ResourceCPU, "spot", "100").
 							Count(100).
 							Obj(),
 					).Obj(),
-				"eng-beta/new":        *utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "50").Count(50).Obj()).Obj(),
-				"eng-alpha/new-alpha": *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj(),
+				"eng-beta/new":        *utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "50").Count(50).Obj()).Obj(),
+				"eng-alpha/new-alpha": *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).Obj(),
 			},
 			wantScheduled: []workload.Reference{"eng-beta/new", "eng-alpha/new-alpha"},
 			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
@@ -1066,8 +1039,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "50000m").
+							Assignment(corev1.ResourceCPU, "default", "50000m").
 							Count(25).
 							Obj(),
 					},
@@ -1090,7 +1062,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 10).
 						Request("example.com/gpu", "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor("example.com/gpu", "model-a").ResourceUsage("example.com/gpu", "10").Count(10).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Assignment("example.com/gpu", "model-a", "10").Count(10).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
@@ -1098,8 +1070,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor("example.com/gpu", "model-a").
-							ResourceUsage("example.com/gpu", "10").
+							Assignment("example.com/gpu", "model-a", "10").
 							Count(10).
 							Obj(),
 					},
@@ -1125,7 +1096,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 10).
 						Request("example.com/gpu", "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor("example.com/gpu", "model-a").ResourceUsage("example.com/gpu", "10").Count(10).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Assignment("example.com/gpu", "model-a", "10").Count(10).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
@@ -1133,8 +1104,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "eng-beta",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor("example.com/gpu", "model-a").
-							ResourceUsage("example.com/gpu", "10").
+							Assignment("example.com/gpu", "model-a", "10").
 							Count(10).
 							Obj(),
 					},
@@ -1169,18 +1139,15 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "sales",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "20000m").
+							Assignment(corev1.ResourceCPU, "default", "20000m").
 							Count(20).
 							Obj(),
 						utiltesting.MakePodSetAssignment("two").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "20000m").
+							Assignment(corev1.ResourceCPU, "default", "20000m").
 							Count(20).
 							Obj(),
 						utiltesting.MakePodSetAssignment("three").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "10000m").
+							Assignment(corev1.ResourceCPU, "default", "10000m").
 							Count(10).
 							Obj(),
 					},
@@ -1241,16 +1208,12 @@ func TestSchedule(t *testing.T) {
 			wantAssignments: map[workload.Reference]kueue.Admission{
 				"sales/wl1": *utiltesting.MakeAdmission("cq1").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor("r1", "default").
-						ResourceUsage("r1", "16").
-						Count(1).
+						Assignment("r1", "default", "16").
 						Obj()).
 					Obj(),
 				"sales/wl2": *utiltesting.MakeAdmission("cq2").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor("r2", "default").
-						ResourceUsage("r2", "16").
-						Count(1).
+						Assignment("r2", "default", "16").
 						Obj()).
 					Obj(),
 			},
@@ -1284,16 +1247,12 @@ func TestSchedule(t *testing.T) {
 			wantAssignments: map[workload.Reference]kueue.Admission{
 				"sales/wl1": *utiltesting.MakeAdmission("cq1").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor("r1", "default").
-						ResourceUsage("r1", "16").
-						Count(1).
+						Assignment("r1", "default", "16").
 						Obj()).
 					Obj(),
 				"sales/wl2": *utiltesting.MakeAdmission("cq2").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor("r1", "default").
-						ResourceUsage("r1", "14").
-						Count(1).
+						Assignment("r1", "default", "14").
 						Obj()).
 					Obj(),
 			},
@@ -1327,9 +1286,7 @@ func TestSchedule(t *testing.T) {
 			wantAssignments: map[workload.Reference]kueue.Admission{
 				"sales/wl1": *utiltesting.MakeAdmission("cq1").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor("r1", "default").
-						ResourceUsage("r1", "16").
-						Count(1).
+						Assignment("r1", "default", "16").
 						Obj()).
 					Obj(),
 			},
@@ -1400,9 +1357,7 @@ func TestSchedule(t *testing.T) {
 					ReserveQuota(utiltesting.MakeAdmission("cq_a").
 						PodSets(
 							utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "default").
-								ResourceUsage(corev1.ResourceCPU, "2").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "default", "2").
 								Obj(),
 						).
 						Obj()).
@@ -1413,9 +1368,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "cq_a",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "2").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "default", "2").
 							Obj(),
 					},
 				},
@@ -1423,9 +1376,7 @@ func TestSchedule(t *testing.T) {
 					ClusterQueue: "cq_b",
 					PodSetAssignments: []kueue.PodSetAssignment{
 						utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "1").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "default", "1").
 							Obj(),
 					},
 				},
@@ -1454,7 +1405,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 50).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "50").Count(50).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "50").Count(50).Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("borrowing", "eng-beta").
 					Queue("main").
@@ -1462,7 +1413,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 55).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "55").Count(55).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "55").Count(55).Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("older_new", "eng-beta").
 					Queue("main").
@@ -1480,9 +1431,9 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/all_nominal": *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "50").Count(50).Obj()).Obj(),
-				"eng-beta/borrowing":    *utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "55").Count(55).Obj()).Obj(),
-				"eng-alpha/new":         *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "5").Count(5).Obj()).Obj(),
+				"eng-alpha/all_nominal": *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "50").Count(50).Obj()).Obj(),
+				"eng-beta/borrowing":    *utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "55").Count(55).Obj()).Obj(),
+				"eng-alpha/new":         *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "5").Count(5).Obj()).Obj(),
 			},
 			wantScheduled: []workload.Reference{"eng-alpha/new"},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
@@ -3527,7 +3478,7 @@ func TestSchedule(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Generation(1).
-					ReserveQuota(utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "10000m").Count(10).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "default", "10000m").Count(10).Obj()).Obj()).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionTrue,
@@ -3555,8 +3506,8 @@ func TestSchedule(t *testing.T) {
 			},
 			// wantAssignments is a map of workload name to the status assignments expected to be in the cache after the scheduling cycle.
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"sales/foo-1": *utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "10").Count(10).Obj()).Obj(),
-				"sales/foo-2": *utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "15").Count(15).Obj()).Obj(),
+				"sales/foo-1": *utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "default", "10").Count(10).Obj()).Obj(),
+				"sales/foo-2": *utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "default", "15").Count(15).Obj()).Obj(),
 			},
 			// wantScheduled is a list of workloads admission status expected to be added to the cache after the scheduling cycle.
 			wantScheduled: []workload.Reference{"sales/foo-2"},
@@ -3572,8 +3523,7 @@ func TestSchedule(t *testing.T) {
 					Admission(
 						utiltesting.MakeAdmission("sales").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "default").
-								ResourceUsage(corev1.ResourceCPU, "10000m").
+								Assignment(corev1.ResourceCPU, "default", "10000m").
 								Count(10).
 								Obj()).
 							Obj(),
@@ -3610,8 +3560,7 @@ func TestSchedule(t *testing.T) {
 					Admission(
 						utiltesting.MakeAdmission("sales").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "default").
-								ResourceUsage(corev1.ResourceCPU, "15000m").
+								Assignment(corev1.ResourceCPU, "default", "15000m").
 								Count(15).
 								Obj()).
 							Obj(),
@@ -5256,16 +5205,13 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("launcher").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
 							Obj(),
 						utiltesting.MakePodSetAssignment("worker").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "0").
+							Assignment(corev1.ResourceCPU, "tas-default", "0").
 							Count(0).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).Obj()).
 							Obj(),
@@ -5295,10 +5241,8 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
-									Flavor(corev1.ResourceCPU, "tas-default").
-									ResourceUsage(corev1.ResourceCPU, "1000m").
+									Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-									Count(1).
 									Obj(),
 							).
 							Obj(),
@@ -5313,9 +5257,7 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
@@ -5379,8 +5321,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-reservation").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-reservation", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -5410,8 +5351,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 									Obj()).
@@ -5424,8 +5364,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -5450,8 +5389,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
@@ -5466,8 +5404,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						Count(2).
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
@@ -5493,8 +5430,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "3000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "3000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 									Obj()).
@@ -5507,8 +5443,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "3000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "3000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 							Obj()).
@@ -5538,8 +5473,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "3000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "3000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 									Obj()).
@@ -5552,8 +5486,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "3000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "3000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 							Obj()).
@@ -5584,8 +5517,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
@@ -5599,8 +5531,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x3"}, 1).Obj()).
@@ -5626,8 +5557,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 									Obj()).
@@ -5640,8 +5570,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -5666,8 +5595,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
@@ -5681,8 +5609,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
@@ -5719,17 +5646,13 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
-									Flavor(corev1.ResourceCPU, "tas-default").
-									ResourceUsage(corev1.ResourceCPU, "1000m").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 									TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 										Obj()).
 									Obj(),
 								utiltesting.MakePodSetAssignment("two").
-									Flavor(corev1.ResourceCPU, "tas-default").
-									ResourceUsage(corev1.ResourceCPU, "1000m").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 									TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 										Obj()).
@@ -5744,17 +5667,13 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
 								Obj()).
 							Obj(),
 						utiltesting.MakePodSetAssignment("two").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
@@ -5794,8 +5713,7 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
-									Flavor(corev1.ResourceCPU, "tas-default").
-									ResourceUsage(corev1.ResourceCPU, "26").
+									Assignment(corev1.ResourceCPU, "tas-default", "26").
 									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
 									Count(26).
 									Obj(),
@@ -5812,8 +5730,7 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "26").
+							Assignment(corev1.ResourceCPU, "tas-default", "26").
 							Count(26).
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
@@ -5877,10 +5794,8 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
-									Flavor(corev1.ResourceCPU, "tas-second").
-									ResourceUsage(corev1.ResourceCPU, "1000m").
+									Assignment(corev1.ResourceCPU, "tas-second", "1000m").
 									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-									Count(1).
 									Obj(),
 							).
 							Obj(),
@@ -5895,9 +5810,7 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-second").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-second", "1000m").
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
@@ -5970,17 +5883,13 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
-									Flavor(corev1.ResourceCPU, "tas-default").
-									ResourceUsage(corev1.ResourceCPU, "1").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "tas-default", "1").
 									TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 										Obj()).
 									Obj(),
 								utiltesting.MakePodSetAssignment("two").
-									Flavor(corev1.ResourceCPU, "tas-second").
-									ResourceUsage(corev1.ResourceCPU, "1").
-									Count(1).
+									Assignment(corev1.ResourceCPU, "tas-second", "1").
 									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
 									Obj(),
 							).Obj(),
@@ -5995,17 +5904,13 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
 							Obj(),
 						utiltesting.MakePodSetAssignment("two").
-							Flavor(corev1.ResourceCPU, "tas-second").
-							ResourceUsage(corev1.ResourceCPU, "1").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-second", "1").
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
@@ -6040,10 +5945,8 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-							Count(1).
 							Obj(),
 					).
 					Obj(),
@@ -6101,10 +6004,8 @@ func TestScheduleForTAS(t *testing.T) {
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
-									Flavor(corev1.ResourceCPU, "tas-second").
-									ResourceUsage(corev1.ResourceCPU, "1000m").
+									Assignment(corev1.ResourceCPU, "tas-second", "1000m").
 									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-									Count(1).
 									Obj(),
 							).
 							Obj(),
@@ -6119,9 +6020,7 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-second").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-second", "1000m").
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
@@ -6158,10 +6057,8 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-							Count(1).
 							Obj(),
 					).
 					Obj(),
@@ -6193,9 +6090,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6229,9 +6124,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6269,9 +6162,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6308,9 +6199,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "default", "1000m").
 						Obj()).
 					Obj(),
 			},
@@ -6350,14 +6239,10 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("launcher").
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "500m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "default", "500m").
 							Obj(),
 						utiltesting.MakePodSetAssignment("worker").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "500m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "500m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
@@ -6388,9 +6273,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6470,8 +6353,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-custom-flavor").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "tas-custom-flavor", "1").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{"cloud.com/custom-level"}).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6525,9 +6407,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -6605,9 +6485,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "400m").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "400m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -6624,9 +6502,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "500m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "500m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6658,11 +6534,8 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								Flavor(corev1.ResourceMemory, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "500m").
-								ResourceUsage(corev1.ResourceMemory, "500Mi").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "500m").
+								Assignment(corev1.ResourceMemory, "tas-default", "500Mi").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -6680,11 +6553,8 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						Flavor(corev1.ResourceMemory, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "500m").
-						ResourceUsage(corev1.ResourceMemory, "500Mi").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "500m").
+						Assignment(corev1.ResourceMemory, "tas-default", "500Mi").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -6802,16 +6672,13 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("launcher").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
 							Obj(),
 						utiltesting.MakePodSetAssignment("worker").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "15000m").
+							Assignment(corev1.ResourceCPU, "tas-default", "15000m").
 							Count(15).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
@@ -6877,16 +6744,13 @@ func TestScheduleForTAS(t *testing.T) {
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("launcher").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
 							Obj(),
 						utiltesting.MakePodSetAssignment("worker").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "15000m").
+							Assignment(corev1.ResourceCPU, "tas-default", "15000m").
 							Count(15).
 							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
 								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
@@ -6941,9 +6805,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -6960,9 +6822,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
 							Obj()).
@@ -7024,9 +6884,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1000m").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -7057,9 +6915,7 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -7107,8 +6963,7 @@ func TestScheduleForTAS(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "150m").
+								Assignment(corev1.ResourceCPU, "tas-default", "150m").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
@@ -7149,11 +7004,8 @@ func TestScheduleForTAS(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						Flavor(corev1.ResourceMemory, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "0").
-						ResourceUsage(corev1.ResourceMemory, "10Mi").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "0").
+						Assignment(corev1.ResourceMemory, "tas-default", "10Mi").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -7395,9 +7247,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"z1"}, 1).Obj()).
 									Obj()).
@@ -7446,9 +7296,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -7501,9 +7349,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -7552,9 +7398,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "2").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "2").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -7573,9 +7417,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "2").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "2").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -7626,9 +7468,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "4").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "4").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -7647,9 +7487,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "4").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "4").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
 									Obj()).
@@ -7709,9 +7547,7 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-main").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "4").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "4").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 									Obj()).
@@ -7959,8 +7795,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "6").
+						Assignment(corev1.ResourceCPU, "tas-default", "6").
 						Count(6).
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
@@ -7988,8 +7823,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								Count(5).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
@@ -8036,8 +7870,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								Count(5).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
@@ -8057,8 +7890,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "tas-default", "2").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
@@ -8078,9 +7910,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
 									Obj()).
@@ -8128,8 +7958,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								Count(5).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
@@ -8149,8 +7978,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "3").
+								Assignment(corev1.ResourceCPU, "tas-default", "3").
 								Count(3).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
@@ -8200,8 +8028,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "5").
+								Assignment(corev1.ResourceCPU, "tas-default", "5").
 								Count(5).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
@@ -8222,9 +8049,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
 									Obj()).
@@ -8243,9 +8068,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1").
-								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-default", "1").
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
 									Obj()).
@@ -8314,9 +8137,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "5").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "5").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
 							Obj()).
@@ -8324,9 +8145,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 				"default/b1": *utiltesting.MakeAdmission("tas-cq-b").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceMemory, "tas-default").
-						ResourceUsage(corev1.ResourceMemory, "5").
-						Count(1).
+						Assignment(corev1.ResourceMemory, "tas-default", "5").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -8367,9 +8186,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -8377,8 +8194,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 				"default/b1": *utiltesting.MakeAdmission("tas-cq-b").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "2").
+						Assignment(corev1.ResourceCPU, "tas-default", "2").
 						Count(2).
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
@@ -8420,9 +8236,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "1").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "1").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -8468,8 +8282,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "5").
+						Assignment(corev1.ResourceCPU, "tas-default", "5").
 						Count(5).
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
@@ -8512,9 +8325,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "2").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "tas-default", "2").
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 							Obj()).
@@ -8552,8 +8363,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "tas-default", "2").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
@@ -8617,8 +8427,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "tas-default", "2").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
@@ -8682,8 +8491,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					ReserveQuota(
 						utiltesting.MakeAdmission("tas-cq-a").
 							PodSets(utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "2").
+								Assignment(corev1.ResourceCPU, "tas-default", "2").
 								Count(2).
 								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
@@ -8728,8 +8536,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
 				"default/b1": *utiltesting.MakeAdmission("tas-cq-b").
 					PodSets(utiltesting.MakePodSetAssignment("one").
-						Flavor(corev1.ResourceCPU, "tas-default").
-						ResourceUsage(corev1.ResourceCPU, "3").
+						Assignment(corev1.ResourceCPU, "tas-default", "3").
 						Count(3).
 						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 3).Obj()).

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -6293,23 +6293,16 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			topologies: []kueuealpha.Topology{defaultSingleLevelTopology},
-			resourceFlavors: []kueue.ResourceFlavor{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "tas-default",
-				},
-				Spec: kueue.ResourceFlavorSpec{
-					NodeLabels: map[string]string{
-						"tas-node": "true",
-					},
-					Tolerations: []corev1.Toleration{
-						{
-							Key:      "example.com/gpu",
-							Operator: corev1.TolerationOpExists,
-						},
-					},
-					TopologyName: ptr.To[kueue.TopologyReference]("tas-single-level"),
-				},
-			}},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltesting.MakeResourceFlavor("tas-default").
+					NodeLabel("tas-node", "true").
+					Toleration(corev1.Toleration{
+						Key:      "example.com/gpu",
+						Operator: corev1.TolerationOpExists,
+					}).
+					TopologyName("tas-single-level").
+					Obj(),
+			},
 			clusterQueues: []kueue.ClusterQueue{
 				*utiltesting.MakeClusterQueue("tas-main").
 					ResourceGroup(

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -246,7 +246,11 @@ func TestSchedule(t *testing.T) {
 				*utiltesting.MakeWorkload("admitted", "eng-alpha").
 					Queue("other").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("new", "eng-alpha").
@@ -656,20 +660,40 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 				*utiltesting.MakeWorkload("user-on-demand", "eng-beta").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "50000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50000m").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("user-spot", "eng-beta").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "spot", "1000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "spot", "1000m").
+							Obj()).
+						Obj()).
 					Obj(),
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"eng-alpha": {"eng-alpha/can-reclaim"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-beta/user-spot":       *utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "spot", "1000m").Obj(),
-				"eng-beta/user-on-demand":  *utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "50000m").Obj(),
-				"eng-beta/needs-to-borrow": *utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "1000m").Obj(),
+				"eng-beta/user-spot": *utiltesting.MakeAdmission("eng-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "1000m").
+						Obj()).
+					Obj(),
+				"eng-beta/user-on-demand": *utiltesting.MakeAdmission("eng-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "50000m").
+						Obj()).
+					Obj(),
+				"eng-beta/needs-to-borrow": *utiltesting.MakeAdmission("eng-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1000m").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []workload.Reference{
 				"eng-beta/needs-to-borrow",
@@ -679,7 +703,11 @@ func TestSchedule(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "lend").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("lend-b").Assignment(corev1.ResourceCPU, "default", "2000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("lend-b").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2000m").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b", "lend").
 					Queue("lend-b-queue").
@@ -687,7 +715,11 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"lend/a": *utiltesting.MakeAdmission("lend-b").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
+				"lend/a": *utiltesting.MakeAdmission("lend-b").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2000m").
+						Obj()).
+					Obj(),
 			},
 			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"lend-b": {"lend/b"},
@@ -698,7 +730,11 @@ func TestSchedule(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("a", "lend").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("lend-b").Assignment(corev1.ResourceCPU, "default", "2000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("lend-b").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2000m").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b", "lend").
 					Queue("lend-b-queue").
@@ -706,8 +742,16 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"lend/a": *utiltesting.MakeAdmission("lend-b").Assignment(corev1.ResourceCPU, "default", "2000m").Obj(),
-				"lend/b": *utiltesting.MakeAdmission("lend-b").Assignment(corev1.ResourceCPU, "default", "3000m").Obj(),
+				"lend/a": *utiltesting.MakeAdmission("lend-b").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2000m").
+						Obj()).
+					Obj(),
+				"lend/b": *utiltesting.MakeAdmission("lend-b").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "3000m").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []workload.Reference{
 				"lend/b",
@@ -721,21 +765,37 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 				*utiltesting.MakeWorkload("use-all-spot", "eng-alpha").
 					Request(corev1.ResourceCPU, "100").
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "spot", "100000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "spot", "100000m").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("low-1", "eng-beta").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "30").
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "30000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "30000m").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("low-2", "eng-beta").
 					Priority(-2).
 					Request(corev1.ResourceCPU, "10").
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "10000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "10000m").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("borrower", "eng-alpha").
 					Request(corev1.ResourceCPU, "60").
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "60000m").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "60000m").
+							Obj()).
+						Obj()).
 					Obj(),
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
@@ -744,11 +804,27 @@ func TestSchedule(t *testing.T) {
 			},
 			wantPreempted: sets.New[workload.Reference]("eng-alpha/borrower", "eng-beta/low-2"),
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/use-all-spot": *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "spot", "100").Obj(),
-				"eng-beta/low-1":         *utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "30").Obj(),
+				"eng-alpha/use-all-spot": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "100").
+						Obj()).
+					Obj(),
+				"eng-beta/low-1": *utiltesting.MakeAdmission("eng-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "30").
+						Obj()).
+					Obj(),
 				// Removal from cache for the preempted workloads is deferred until we receive Workload updates
-				"eng-beta/low-2":     *utiltesting.MakeAdmission("eng-beta").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
-				"eng-alpha/borrower": *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "60").Obj(),
+				"eng-beta/low-2": *utiltesting.MakeAdmission("eng-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
+				"eng-alpha/borrower": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "60").
+						Obj()).
+					Obj(),
 			},
 		},
 		"multiple CQs need preemption": {
@@ -789,7 +865,11 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 				*utiltesting.MakeWorkload("use-all", "eng-alpha").
 					Request(corev1.ResourceCPU, "100").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "100").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "100").
+							Obj()).
+						Obj()).
 					Obj(),
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
@@ -802,7 +882,11 @@ func TestSchedule(t *testing.T) {
 			wantPreempted: sets.New[workload.Reference]("eng-alpha/use-all"),
 			wantAssignments: map[workload.Reference]kueue.Admission{
 				// Removal from cache for the preempted workloads is deferred until we receive Workload updates
-				"eng-alpha/use-all": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "100").Obj(),
+				"eng-alpha/use-all": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "100").
+						Obj()).
+					Obj(),
 			},
 		},
 		"cannot borrow resource not listed in clusterQueue": {
@@ -1484,21 +1568,33 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 1).
 						Request(corev1.ResourceCPU, "10").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("d", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("d", "one").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Assignment(corev1.ResourceCPU, "on-demand", "10").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("e0", "eng-alpha").
 					Queue("lq-e").
 					PodSets(*utiltesting.MakePodSet("one", 1).
 						Request(corev1.ResourceCPU, "20").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("e", "one").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("e", "one").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Assignment(corev1.ResourceCPU, "on-demand", "20").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("g0", "eng-alpha").
 					Queue("lq-g").
 					PodSets(*utiltesting.MakePodSet("one", 1).
 						Request(corev1.ResourceCPU, "100").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("g", "one").Assignment(corev1.ResourceCPU, "on-demand", "100").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("g", "one").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Assignment(corev1.ResourceCPU, "on-demand", "100").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("d1", "eng-alpha").
 					Queue("lq-d").
@@ -1526,10 +1622,26 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/d0": *utiltesting.MakeAdmission("d", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
-				"eng-alpha/e0": *utiltesting.MakeAdmission("e", "one").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-alpha/g0": *utiltesting.MakeAdmission("g", "one").Assignment(corev1.ResourceCPU, "on-demand", "100").Obj(),
-				"eng-alpha/d1": *utiltesting.MakeAdmission("d", "one").Assignment(corev1.ResourceCPU, "on-demand", "70").Obj(),
+				"eng-alpha/d0": *utiltesting.MakeAdmission("d", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
+				"eng-alpha/e0": *utiltesting.MakeAdmission("e", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-alpha/g0": *utiltesting.MakeAdmission("g", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "100").
+						Obj()).
+					Obj(),
+				"eng-alpha/d1": *utiltesting.MakeAdmission("d", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "70").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []workload.Reference{"eng-alpha/d1"},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
@@ -1576,7 +1688,11 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 1).
 						Request(corev1.ResourceCPU, "10").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("b", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("b", "one").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Assignment(corev1.ResourceCPU, "on-demand", "10").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-alpha").
 					Queue("lq-b").
@@ -1592,8 +1708,16 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/b0": *utiltesting.MakeAdmission("b", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
-				"eng-alpha/b1": *utiltesting.MakeAdmission("b", "one").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj(),
+				"eng-alpha/b0": *utiltesting.MakeAdmission("b", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
+				"eng-alpha/b1": *utiltesting.MakeAdmission("b", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "50").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []workload.Reference{"eng-alpha/b1"},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
@@ -1669,9 +1793,21 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("a", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
-				"eng-alpha/b1": *utiltesting.MakeAdmission("b", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
-				"eng-alpha/c1": *utiltesting.MakeAdmission("c", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("a", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
+				"eng-alpha/b1": *utiltesting.MakeAdmission("b", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
+				"eng-alpha/c1": *utiltesting.MakeAdmission("c", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []workload.Reference{"eng-alpha/a1", "eng-alpha/b1", "eng-alpha/c1"},
 			wantLeft:      nil,
@@ -1721,7 +1857,11 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/c1": *utiltesting.MakeAdmission("c", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
+				"eng-alpha/c1": *utiltesting.MakeAdmission("c", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []workload.Reference{"eng-alpha/c1"},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
@@ -1775,7 +1915,11 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/c1": *utiltesting.MakeAdmission("c", "one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
+				"eng-alpha/c1": *utiltesting.MakeAdmission("c", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []workload.Reference{"eng-alpha/c1"},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
@@ -1820,37 +1964,61 @@ func TestSchedule(t *testing.T) {
 					Priority(-2).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("a2", "eng-alpha").
 					Priority(-2).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("a3", "eng-alpha").
 					Priority(-1).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b2", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b3", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("incoming", "eng-alpha").
 					Priority(0).
@@ -1863,12 +2031,36 @@ func TestSchedule(t *testing.T) {
 				"other-alpha": {"eng-alpha/incoming"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
-				"eng-alpha/a2": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
-				"eng-alpha/a3": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
-				"eng-beta/b2":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
-				"eng-beta/b3":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-alpha/a2": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-alpha/a3": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-beta/b2": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-beta/b3": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
 			},
 		},
 		"A workload is only eligible to do preemptions if it fits fully within nominal quota": {
@@ -1901,13 +2093,21 @@ func TestSchedule(t *testing.T) {
 					Priority(-1).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-beta").
 					Priority(-1).
 					Queue("other").
 					Request(corev1.ResourceCPU, "1").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "1").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("incoming", "eng-alpha").
 					Priority(1).
@@ -1919,8 +2119,16 @@ func TestSchedule(t *testing.T) {
 				"other-alpha": {"eng-alpha/incoming"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
 			},
 		},
 		"with fair sharing: preempt workload from CQ with the highest share": {
@@ -1972,15 +2180,51 @@ func TestSchedule(t *testing.T) {
 				"eng-beta": {"eng-beta/preemptor"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/all_spot": *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "spot", "100").Obj(),
-				"eng-alpha/alpha1":   *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-alpha/alpha2":   *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-alpha/alpha3":   *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-alpha/alpha4":   *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-gamma/gamma1":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj(),
-				"eng-gamma/gamma2":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-gamma/gamma3":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"eng-gamma/gamma4":   *utiltesting.MakeAdmission("eng-gamma").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"eng-alpha/all_spot": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "100").
+						Obj()).
+					Obj(),
+				"eng-alpha/alpha1": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-alpha/alpha2": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-alpha/alpha3": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-alpha/alpha4": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-gamma/gamma1": *utiltesting.MakeAdmission("eng-gamma").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
+				"eng-gamma/gamma2": *utiltesting.MakeAdmission("eng-gamma").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-gamma/gamma3": *utiltesting.MakeAdmission("eng-gamma").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"eng-gamma/gamma4": *utiltesting.MakeAdmission("eng-gamma").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 		},
 		"multiple preemptions without borrowing": {
@@ -2018,13 +2262,21 @@ func TestSchedule(t *testing.T) {
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("preemptor", "eng-alpha").
 					Priority(100).
@@ -2043,8 +2295,16 @@ func TestSchedule(t *testing.T) {
 				"other-beta":  {"eng-beta/preemptor"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2").
+						Obj()).
+					Obj(),
 			},
 			wantSkippedPreemptions: map[string]int{
 				"other-alpha": 0,
@@ -2086,7 +2346,11 @@ func TestSchedule(t *testing.T) {
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("fit", "eng-alpha").
 					Priority(100).
@@ -2104,8 +2368,16 @@ func TestSchedule(t *testing.T) {
 				"other-beta": {"eng-beta/preemptor"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/fit": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "default", "1").Obj(),
-				"eng-beta/b1":   *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
+				"eng-alpha/fit": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "1").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []workload.Reference{"eng-alpha/fit"},
 			wantSkippedPreemptions: map[string]int{
@@ -2166,13 +2438,21 @@ func TestSchedule(t *testing.T) {
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "2").
-					ReserveQuota(utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("other-beta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").
+							Obj()).
+						Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("preemptor", "eng-alpha").
 					Priority(100).
@@ -2191,8 +2471,16 @@ func TestSchedule(t *testing.T) {
 				"other-beta":  {"eng-beta/pretending-preemptor"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment(corev1.ResourceCPU, "default", "2").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "2").
+						Obj()).
+					Obj(),
 			},
 			wantSkippedPreemptions: map[string]int{
 				"other-alpha": 0,
@@ -2256,22 +2544,25 @@ func TestSchedule(t *testing.T) {
 					Queue("other").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
-						Assignment(corev1.ResourceCPU, "default", "3").
-						Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").
+							Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("other-beta").
-						Assignment(corev1.ResourceCPU, "default", "3").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("c1", "eng-gamma").
 					Priority(0).
 					Queue("other").
 					Request(corev1.ResourceCPU, "3").
 					ReserveQuota(utiltesting.MakeAdmission("other-gamma").
-						Assignment(corev1.ResourceCPU, "default", "3").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("preemptor", "eng-alpha").
 					Priority(100).
@@ -2297,11 +2588,14 @@ func TestSchedule(t *testing.T) {
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
 				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
-					Assignment(corev1.ResourceCPU, "default", "3").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(),
 				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
-					Assignment(corev1.ResourceCPU, "default", "3").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(),
 				"eng-gamma/c1": *utiltesting.MakeAdmission("other-gamma").
-					Assignment(corev1.ResourceCPU, "default", "3").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(),
 			},
 			wantSkippedPreemptions: map[string]int{
 				"other-alpha": 0,
@@ -2372,15 +2666,17 @@ func TestSchedule(t *testing.T) {
 					Queue("other").
 					Request("alpha-resource", "1").
 					ReserveQuota(utiltesting.MakeAdmission("other-alpha").
-						Assignment("alpha-resource", "default", "1").
-						Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment("alpha-resource", "default", "1").
+							Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("b1", "eng-beta").
 					Priority(0).
 					Queue("other").
 					Request("beta-resource", "1").
 					ReserveQuota(utiltesting.MakeAdmission("other-beta").
-						Assignment("beta-resource", "default", "1").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment("beta-resource", "default", "1").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("c1", "eng-gamma").
 					Priority(0).
@@ -2388,7 +2684,8 @@ func TestSchedule(t *testing.T) {
 					Request(corev1.ResourceCPU, "9").
 					Request("gamma-resource", "1").
 					ReserveQuota(utiltesting.MakeAdmission("other-gamma").
-						Assignment(corev1.ResourceCPU, "default", "9").Obj()).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "9").Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("preemptor", "eng-alpha").
 					Priority(100).
@@ -2410,11 +2707,14 @@ func TestSchedule(t *testing.T) {
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
 				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
-					Assignment("alpha-resource", "default", "1").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("alpha-resource", "default", "1").Obj()).Obj(),
 				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
-					Assignment("beta-resource", "default", "1").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("beta-resource", "default", "1").Obj()).Obj(),
 				"eng-gamma/c1": *utiltesting.MakeAdmission("other-gamma").
-					Assignment(corev1.ResourceCPU, "default", "9").Obj(),
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "9").Obj()).Obj(),
 			},
 			wantSkippedPreemptions: map[string]int{
 				"other-alpha": 0,
@@ -2562,8 +2862,16 @@ func TestSchedule(t *testing.T) {
 				"other-alpha": {"eng-alpha/preemptor"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment("gpu", "on-demand", "5").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment("gpu", "spot", "5").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "5").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "5").
+						Obj()).
+					Obj(),
 			},
 		},
 		"with fair sharing: prefer reclamation over cq priority based preemption; with preemption while borrowing": {
@@ -2621,8 +2929,16 @@ func TestSchedule(t *testing.T) {
 				"other-alpha": {"eng-alpha/preemptor"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment("gpu", "on-demand", "5").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment("gpu", "spot", "5").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "5").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "5").
+						Obj()).
+					Obj(),
 			},
 		},
 		"prefer first preemption flavor when second flavor requires both reclaim and cq priority preemption": {
@@ -2683,9 +2999,21 @@ func TestSchedule(t *testing.T) {
 				"other-alpha": {"eng-alpha/preemptor"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment("gpu", "on-demand", "5").Obj(),
-				"eng-alpha/a2": *utiltesting.MakeAdmission("other-alpha").Assignment("gpu", "spot", "5").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment("gpu", "spot", "5").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "5").
+						Obj()).
+					Obj(),
+				"eng-alpha/a2": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "5").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "5").
+						Obj()).
+					Obj(),
 			},
 		},
 		"prefer first preemption flavor when second flavor also requires cq preemption": {
@@ -2748,9 +3076,21 @@ func TestSchedule(t *testing.T) {
 				"other-alpha": {"eng-alpha/preemptor"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").Assignment("gpu", "on-demand", "6").Obj(),
-				"eng-alpha/a2": *utiltesting.MakeAdmission("other-alpha").Assignment("gpu", "spot", "5").Obj(),
-				"eng-beta/b1":  *utiltesting.MakeAdmission("other-beta").Assignment("gpu", "spot", "5").Obj(),
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "6").
+						Obj()).
+					Obj(),
+				"eng-alpha/a2": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "5").
+						Obj()).
+					Obj(),
+				"eng-beta/b1": *utiltesting.MakeAdmission("other-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "5").
+						Obj()).
+					Obj(),
 			},
 		},
 		"workload requiring reclaimation prioritized over wl in another full cq": {
@@ -2850,9 +3190,21 @@ func TestSchedule(t *testing.T) {
 				"CQ1": {"eng-alpha/WL1"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/Admitted-Workload-1": *utiltesting.MakeAdmission("CQ1").Assignment("gpu", "on-demand", "5").Obj(),
-				"eng-gamma/Admitted-Workload-2": *utiltesting.MakeAdmission("CQ3").Assignment("gpu", "on-demand", "5").Obj(),
-				"eng-gamma/Admitted-Workload-3": *utiltesting.MakeAdmission("CQ3").Assignment("gpu", "on-demand", "5").Obj(),
+				"eng-alpha/Admitted-Workload-1": *utiltesting.MakeAdmission("CQ1").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "5").
+						Obj()).
+					Obj(),
+				"eng-gamma/Admitted-Workload-2": *utiltesting.MakeAdmission("CQ3").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "5").
+						Obj()).
+					Obj(),
+				"eng-gamma/Admitted-Workload-3": *utiltesting.MakeAdmission("CQ3").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "5").
+						Obj()).
+					Obj(),
 			},
 		},
 		// ClusterQueueA has 2 capacity, 1 admitted workload (req=1), and 1 pending workload (req=2)
@@ -2904,8 +3256,16 @@ func TestSchedule(t *testing.T) {
 				"eng-beta/b1-pending",
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/a1-admitted": *utiltesting.MakeAdmission("ClusterQueueA").Assignment("gpu", "on-demand", "1").Obj(),
-				"eng-beta/b1-pending":   *utiltesting.MakeAdmission("ClusterQueueB").Assignment("gpu", "on-demand", "1").Obj(),
+				"eng-alpha/a1-admitted": *utiltesting.MakeAdmission("ClusterQueueA").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "1").
+						Obj()).
+					Obj(),
+				"eng-beta/b1-pending": *utiltesting.MakeAdmission("ClusterQueueB").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "1").
+						Obj()).
+					Obj(),
 			},
 		},
 		// ClusterQueueA has 2 capacity, 1 admitted workload (req=1), and 1 pending workload (req=2)
@@ -2956,7 +3316,11 @@ func TestSchedule(t *testing.T) {
 				"ClusterQueueA": {"eng-alpha/a2-pending"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/a1-admitted": *utiltesting.MakeAdmission("ClusterQueueA").Assignment("gpu", "on-demand", "1").Obj(),
+				"eng-alpha/a1-admitted": *utiltesting.MakeAdmission("ClusterQueueA").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "1").
+						Obj()).
+					Obj(),
 			},
 		},
 		// ClusterQueueA has 2 capacity, 1 admitted workload (req=1), and 1 pending workload (req=2)
@@ -3007,7 +3371,11 @@ func TestSchedule(t *testing.T) {
 				"ClusterQueueA": {"eng-alpha/a2-pending"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/a1-admitted": *utiltesting.MakeAdmission("ClusterQueueA").Assignment("gpu", "on-demand", "1").Obj(),
+				"eng-alpha/a1-admitted": *utiltesting.MakeAdmission("ClusterQueueA").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "1").
+						Obj()).
+					Obj(),
 			},
 		},
 		//
@@ -3064,7 +3432,11 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/guaranteed": *utiltesting.MakeAdmission("guaranteed", "one").Assignment(corev1.ResourceCPU, "default", "4").Obj(),
+				"eng-alpha/guaranteed": *utiltesting.MakeAdmission("guaranteed", "one").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "default", "4").
+						Obj()).
+					Obj(),
 			},
 			wantScheduled: []workload.Reference{"eng-alpha/guaranteed"},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
@@ -3129,8 +3501,16 @@ func TestSchedule(t *testing.T) {
 			},
 			wantScheduled: []workload.Reference{"eng-alpha/new"},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/new":      *utiltesting.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "spot", "1").Obj(),
-				"eng-alpha/admitted": *utiltesting.MakeAdmission("cq2").Assignment(corev1.ResourceCPU, "on-demand", "1").Obj(),
+				"eng-alpha/new": *utiltesting.MakeAdmission("cq1").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "1").
+						Obj()).
+					Obj(),
+				"eng-alpha/admitted": *utiltesting.MakeAdmission("cq2").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "1").
+						Obj()).
+					Obj(),
 			},
 		},
 		// Workload-slice scheduling test case.
@@ -3844,7 +4224,11 @@ func TestLastSchedulingContext(t *testing.T) {
 				*utiltesting.MakeWorkload("low-1", "default").
 					Queue("main").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3858,14 +4242,18 @@ func TestLastSchedulingContext(t *testing.T) {
 				*utiltesting.MakeWorkload("low-1", "default").
 					Queue("main").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).Obj()).
 					Admitted(true).
 					Obj(),
 			},
 			wantPreempted:                 sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
-				"default/preemptor": *utiltesting.MakeAdmission("eng-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"default/preemptor": *utiltesting.MakeAdmission("eng-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 		},
 		{
@@ -3874,7 +4262,11 @@ func TestLastSchedulingContext(t *testing.T) {
 			admittedWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder", "default").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3891,13 +4283,33 @@ func TestLastSchedulingContext(t *testing.T) {
 			deleteWorkloads: []kueue.Workload{},
 			wantPreempted:   sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
-				"default/workload1": *utiltesting.MakeAdmission("eng-cohort-beta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"default/borrower":  *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"default/workload1": *utiltesting.MakeAdmission("eng-cohort-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"default/borrower": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
-				"default/placeholder": *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj(),
-				"default/workload1":   *utiltesting.MakeAdmission("eng-cohort-beta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
-				"default/borrower":    *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"default/placeholder": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "50").
+						Obj()).
+					Obj(),
+				"default/workload1": *utiltesting.MakeAdmission("eng-cohort-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
+				"default/borrower": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 		},
 		{
@@ -3906,12 +4318,20 @@ func TestLastSchedulingContext(t *testing.T) {
 			admittedWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder", "default").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("placeholder1", "default").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3924,12 +4344,28 @@ func TestLastSchedulingContext(t *testing.T) {
 			deleteWorkloads: []kueue.Workload{},
 			wantPreempted:   sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
-				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "20").Obj(),
+				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "20").
+						Obj()).
+					Obj(),
 			},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
-				"default/placeholder":  *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj(),
-				"default/placeholder1": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "50").Obj(),
-				"default/workload":     *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "20").Obj(),
+				"default/placeholder": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "50").
+						Obj()).
+					Obj(),
+				"default/placeholder1": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "50").
+						Obj()).
+					Obj(),
+				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "20").
+						Obj()).
+					Obj(),
 			},
 		},
 		{
@@ -3938,17 +4374,29 @@ func TestLastSchedulingContext(t *testing.T) {
 			admittedWorkloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder", "default").
 					Request(corev1.ResourceCPU, "40").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "40").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "40").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("placeholder1", "default").
 					Request(corev1.ResourceCPU, "40").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "40").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "40").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("placeholder2", "default").
 					Request(corev1.ResourceCPU, "100").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "100").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "spot", "100").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3961,13 +4409,33 @@ func TestLastSchedulingContext(t *testing.T) {
 			deleteWorkloads: []kueue.Workload{},
 			wantPreempted:   sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
-				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
-				"default/placeholder":  *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "40").Obj(),
-				"default/placeholder1": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "40").Obj(),
-				"default/placeholder2": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "100").Obj(),
-				"default/workload":     *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"default/placeholder": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "40").
+						Obj()).
+					Obj(),
+				"default/placeholder1": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "40").
+						Obj()).
+					Obj(),
+				"default/placeholder2": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "100").
+						Obj()).
+					Obj(),
+				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 		},
 		{
@@ -3977,12 +4445,20 @@ func TestLastSchedulingContext(t *testing.T) {
 				*utiltesting.MakeWorkload("placeholder-alpha", "default").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "150").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "150").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "150").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 				*utiltesting.MakeWorkload("placeholder-theta-spot", "default").
 					Request(corev1.ResourceCPU, "100").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "100").Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "spot", "100").
+							Obj()).
+						Obj()).
 					Admitted(true).
 					Obj(),
 			},
@@ -3996,8 +4472,16 @@ func TestLastSchedulingContext(t *testing.T) {
 			wantPreempted:                 sets.New[workload.Reference]("default/placeholder-alpha"),
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
-				"default/placeholder-theta-spot": *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "spot", "100").Obj(),
-				"default/new":                    *utiltesting.MakeAdmission("eng-cohort-theta").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj(),
+				"default/placeholder-theta-spot": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "100").
+						Obj()).
+					Obj(),
+				"default/new": *utiltesting.MakeAdmission("eng-cohort-theta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "20").
+						Obj()).
+					Obj(),
 			},
 		},
 		{
@@ -4078,10 +4562,26 @@ func TestLastSchedulingContext(t *testing.T) {
 			deleteWorkloads: []kueue.Workload{*utiltesting.MakeWorkload("alpha2", "default").Obj()},
 			wantPreempted:   sets.New[workload.Reference]("default/alpha2"),
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
-				"default/alpha1": *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "on-demand", "22").Obj(),
-				"default/alpha3": *utiltesting.MakeAdmission("eng-cohort-alpha").Assignment(corev1.ResourceCPU, "spot", "22").Obj(),
-				"default/beta1":  *utiltesting.MakeAdmission("eng-cohort-beta").Assignment(corev1.ResourceCPU, "spot", "22").Obj(),
-				"default/new":    *utiltesting.MakeAdmission("eng-cohort-beta").Assignment(corev1.ResourceCPU, "on-demand", "22").Obj(),
+				"default/alpha1": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "22").
+						Obj()).
+					Obj(),
+				"default/alpha3": *utiltesting.MakeAdmission("eng-cohort-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "22").
+						Obj()).
+					Obj(),
+				"default/beta1": *utiltesting.MakeAdmission("eng-cohort-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "22").
+						Obj()).
+					Obj(),
+				"default/new": *utiltesting.MakeAdmission("eng-cohort-beta").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "22").
+						Obj()).
+					Obj(),
 			},
 		},
 	}
@@ -4524,8 +5024,12 @@ func TestResourcesToReserve(t *testing.T) {
 			i := 0
 			for fr, v := range tc.cqUsage {
 				quantity := resources.ResourceQuantity(fr.Resource, v)
-				admission := utiltesting.MakeAdmission("cq").Assignment(fr.Resource, fr.Flavor, quantity.String())
-				wl := utiltesting.MakeWorkload(fmt.Sprintf("workload-%d", i), "default-namespace").ReserveQuota(admission.Obj()).Obj()
+				admission := utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(fr.Resource, fr.Flavor, quantity.String()).
+						Obj()).
+					Obj()
+				wl := utiltesting.MakeWorkload(fmt.Sprintf("workload-%d", i), "default-namespace").ReserveQuota(admission).Obj()
 				cqCache.AddOrUpdateWorkload(log, wl)
 				i++
 			}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4720,15 +4720,23 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "launcher", "worker").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Obj()).
-					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "0").
-					AssignmentPodCountWithIndex(1, 0).
-					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("launcher").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+						utiltesting.MakePodSetAssignment("worker").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "0").
+							Count(0).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5133,34 +5141,50 @@ func TestScheduleForTAS(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one", "two").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
-								Obj()).
-							AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCountWithIndex(1, 1).
-							TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-								Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(
+								utiltesting.MakePodSetAssignment("one").
+									Flavor(corev1.ResourceCPU, "tas-default").
+									ResourceUsage(corev1.ResourceCPU, "1000m").
+									Count(1).
+									TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+										Obj()).
+									Obj(),
+								utiltesting.MakePodSetAssignment("two").
+									Flavor(corev1.ResourceCPU, "tas-default").
+									ResourceUsage(corev1.ResourceCPU, "1000m").
+									Count(1).
+									TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+										Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+										Obj()).
+									Obj(),
+							).
 							Obj(),
 					).
 					Admitted(true).
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one", "two").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
-						Obj()).
-					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCountWithIndex(1, 1).
-					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+								Obj()).
+							Obj(),
+						utiltesting.MakePodSetAssignment("two").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 		},
@@ -6121,18 +6145,26 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "launcher", "worker").
-					AssignmentWithIndex(0, corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCountWithIndex(0, 1).
-					TopologyAssignmentWithIndex(0, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Obj()).
-					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "15000m").
-					AssignmentPodCountWithIndex(1, 15).
-					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 8).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("launcher").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+						utiltesting.MakePodSetAssignment("worker").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "15000m").
+							Count(15).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 8).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -6188,18 +6220,26 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "launcher", "worker").
-					AssignmentWithIndex(0, corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCountWithIndex(0, 1).
-					TopologyAssignmentWithIndex(0, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Obj()).
-					AssignmentWithIndex(1, corev1.ResourceCPU, "tas-default", "15000m").
-					AssignmentPodCountWithIndex(1, 15).
-					TopologyAssignmentWithIndex(1, utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 8).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("launcher").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+						utiltesting.MakePodSetAssignment("worker").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "15000m").
+							Count(15).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 7).Obj()).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 8).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4844,11 +4844,13 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-reservation", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-reservation").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -4873,11 +4875,13 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -4885,11 +4889,13 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -4909,12 +4915,15 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -4922,12 +4931,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x5"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(2).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -4947,11 +4958,13 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "3").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "3000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "3000m").
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -4959,11 +4972,13 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "3000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "3000m").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -4988,11 +5003,13 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "3").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "3000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "3000m").
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -5000,11 +5017,13 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "3000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "3000m").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5030,12 +5049,14 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -5043,12 +5064,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x3"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x3"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5068,11 +5091,13 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -5080,11 +5105,13 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5104,12 +5131,14 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -5117,12 +5146,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5403,7 +5434,7 @@ func TestScheduleForTAS(t *testing.T) {
 							Request(corev1.ResourceCPU, "1").
 							Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one", "two").
+						utiltesting.MakeAdmission("tas-main").
 							PodSets(
 								utiltesting.MakePodSetAssignment("one").
 									Flavor(corev1.ResourceCPU, "tas-default").
@@ -5428,7 +5459,7 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one", "two").
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("one").
 							Flavor(corev1.ResourceCPU, "tas-default").
@@ -5627,11 +5658,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5660,11 +5694,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5697,11 +5734,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5733,9 +5773,12 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "default", "1000m").
-					AssignmentPodCount(1).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						Obj()).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5771,7 +5814,7 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
 					PodSets(
 						utiltesting.MakePodSetAssignment("launcher").
 							Flavor(corev1.ResourceCPU, "default").
@@ -5810,11 +5853,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5889,11 +5935,13 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-custom-flavor", "1").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{"cloud.com/custom-level"}).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-custom-flavor").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						TopologyAssignment(utiltesting.MakeTopologyAssignment([]string{"cloud.com/custom-level"}).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -5942,11 +5990,14 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("bar-admitted", "default").
 					Queue("tas-main").
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6019,11 +6070,14 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("bar-admitted", "default").
 					Queue("tas-main").
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "400m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "400m").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6035,11 +6089,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "500m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "500m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -6066,12 +6123,16 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("bar-admitted", "default").
 					Queue("tas-main").
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "500m").
-							Assignment(corev1.ResourceMemory, "tas-default", "500Mi").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								Flavor(corev1.ResourceMemory, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "500m").
+								ResourceUsage(corev1.ResourceMemory, "500Mi").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6084,12 +6145,16 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "500m").
-					Assignment(corev1.ResourceMemory, "tas-default", "500Mi").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						Flavor(corev1.ResourceMemory, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "500m").
+						ResourceUsage(corev1.ResourceMemory, "500Mi").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -6341,11 +6406,14 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("bar-admitted", "default").
 					Queue("tas-main").
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6357,11 +6425,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -6418,11 +6489,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1000m").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -6448,11 +6522,14 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -6495,11 +6572,14 @@ func TestScheduleForTAS(t *testing.T) {
 				*utiltesting.MakeWorkload("bar-admitted", "default").
 					Queue("tas-main").
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "150m").
-							AssignmentPodCount(2).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "150m").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6534,12 +6614,16 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "0").
-					Assignment(corev1.ResourceMemory, "tas-default", "10Mi").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						Flavor(corev1.ResourceMemory, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "0").
+						ResourceUsage(corev1.ResourceMemory, "10Mi").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -6776,11 +6860,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"z1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"z1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6824,11 +6911,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6876,11 +6966,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6924,11 +7017,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "2").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6942,11 +7038,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "2").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -6992,11 +7091,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "4").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7010,11 +7112,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "4").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7069,11 +7174,14 @@ func TestScheduleForTASPreemption(t *testing.T) {
 					Queue("tas-main").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "4").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "4").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7316,12 +7424,15 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "6").
-					AssignmentPodCount(6).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "6").
+						Count(6).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -7342,11 +7453,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				*utiltesting.MakeWorkload("a1-admitted", "default").
 					Queue("tas-lq-a").
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(5).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(5).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7387,11 +7501,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(5).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(5).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 5).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7405,11 +7522,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "2").
-							AssignmentPodCount(2).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7423,11 +7543,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7470,11 +7593,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(3).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(5).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(5).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7488,11 +7614,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "3").
-							AssignmentPodCount(3).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "3").
+								Count(3).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7536,12 +7665,15 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "5").
-							AssignmentPodCount(5).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "5").
+								Count(5).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 3).Obj()).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7555,11 +7687,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7573,11 +7708,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1").
-							AssignmentPodCount(1).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(1).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7641,18 +7779,24 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "5").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "5").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
-				"default/b1": *utiltesting.MakeAdmission("tas-cq-b", "one").
-					Assignment(corev1.ResourceMemory, "tas-default", "5").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/b1": *utiltesting.MakeAdmission("tas-cq-b").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceMemory, "tas-default").
+						ResourceUsage(corev1.ResourceMemory, "5").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -7688,18 +7832,24 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
-				"default/b1": *utiltesting.MakeAdmission("tas-cq-b", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "2").
-					AssignmentPodCount(2).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+				"default/b1": *utiltesting.MakeAdmission("tas-cq-b").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "2").
+						Count(2).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 2).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -7735,11 +7885,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -7780,11 +7933,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 				"tas-cq-b": {"default/b1"},
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "5").
-					AssignmentPodCount(5).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "5").
+						Count(5).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 5).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -7821,11 +7977,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/a1": *utiltesting.MakeAdmission("tas-cq-a", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "2").
-					AssignmentPodCount(1).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+				"default/a1": *utiltesting.MakeAdmission("tas-cq-a").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "2").
+						Count(1).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},
@@ -7858,11 +8017,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(1).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "2").
-							AssignmentPodCount(2).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7920,11 +8082,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "2").
-							AssignmentPodCount(2).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -7982,11 +8147,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Queue("tas-lq-a").
 					Priority(2).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-cq-a", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "2").
-							AssignmentPodCount(2).
-							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+						utiltesting.MakeAdmission("tas-cq-a").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "2").
+								Count(2).
+								TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 2).Obj()).
+									Obj()).
 								Obj()).
 							Obj(),
 					).
@@ -8025,11 +8193,14 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/b1": *utiltesting.MakeAdmission("tas-cq-b", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "3").
-					AssignmentPodCount(3).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 3).Obj()).
+				"default/b1": *utiltesting.MakeAdmission("tas-cq-b").
+					PodSets(utiltesting.MakePodSetAssignment("one").
+						Flavor(corev1.ResourceCPU, "tas-default").
+						ResourceUsage(corev1.ResourceCPU, "3").
+						Count(3).
+						TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 3).Obj()).
+							Obj()).
 						Obj()).
 					Obj(),
 			},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -324,9 +324,12 @@ func TestSchedule(t *testing.T) {
 						State: kueue.CheckStateReady,
 					}).
 					Admission(
-						utiltesting.MakeAdmission("sales", "one").
-							Assignment(corev1.ResourceCPU, "default", "10000m").
-							AssignmentPodCount(10).
+						utiltesting.MakeAdmission("sales").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "default").
+								ResourceUsage(corev1.ResourceCPU, "10000m").
+								Count(10).
+								Obj()).
 							Obj(),
 					).
 					Generation(1).
@@ -424,7 +427,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 40).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("sales", "one").Assignment(corev1.ResourceCPU, "default", "40000m").AssignmentPodCount(40).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "40000m").Count(40).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
@@ -825,7 +828,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 45).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta", "one").Assignment(corev1.ResourceCPU, "on-demand", "45000m").AssignmentPodCount(45).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "45000m").Count(45).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
@@ -951,8 +954,8 @@ func TestSchedule(t *testing.T) {
 							Count(100).
 							Obj(),
 					).Obj(),
-				"eng-beta/new":        *utiltesting.MakeAdmission("eng-beta", "one").Assignment(corev1.ResourceCPU, "on-demand", "50").AssignmentPodCount(50).Obj(),
-				"eng-alpha/new-alpha": *utiltesting.MakeAdmission("eng-alpha", "one").Assignment(corev1.ResourceCPU, "on-demand", "1").AssignmentPodCount(1).Obj(),
+				"eng-beta/new":        *utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "50").Count(50).Obj()).Obj(),
+				"eng-alpha/new-alpha": *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj(),
 			},
 			wantScheduled: []workload.Reference{"eng-beta/new", "eng-alpha/new-alpha"},
 			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
@@ -1003,7 +1006,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 10).
 						Request("example.com/gpu", "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta", "one").Assignment("example.com/gpu", "model-a", "10").AssignmentPodCount(10).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor("example.com/gpu", "model-a").ResourceUsage("example.com/gpu", "10").Count(10).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
@@ -1038,7 +1041,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 10).
 						Request("example.com/gpu", "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta", "one").Assignment("example.com/gpu", "model-a", "10").AssignmentPodCount(10).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor("example.com/gpu", "model-a").ResourceUsage("example.com/gpu", "10").Count(10).Obj()).Obj()).
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
@@ -1152,11 +1155,19 @@ func TestSchedule(t *testing.T) {
 			},
 			wantScheduled: []workload.Reference{"sales/wl1", "sales/wl2"},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"sales/wl1": *utiltesting.MakeAdmission("cq1", kueue.DefaultPodSetName).
-					Assignment("r1", "default", "16").AssignmentPodCount(1).
+				"sales/wl1": *utiltesting.MakeAdmission("cq1").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor("r1", "default").
+						ResourceUsage("r1", "16").
+						Count(1).
+						Obj()).
 					Obj(),
-				"sales/wl2": *utiltesting.MakeAdmission("cq2", kueue.DefaultPodSetName).
-					Assignment("r2", "default", "16").AssignmentPodCount(1).
+				"sales/wl2": *utiltesting.MakeAdmission("cq2").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor("r2", "default").
+						ResourceUsage("r2", "16").
+						Count(1).
+						Obj()).
 					Obj(),
 			},
 		},
@@ -1187,11 +1198,19 @@ func TestSchedule(t *testing.T) {
 			},
 			wantScheduled: []workload.Reference{"sales/wl1", "sales/wl2"},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"sales/wl1": *utiltesting.MakeAdmission("cq1", kueue.DefaultPodSetName).
-					Assignment("r1", "default", "16").AssignmentPodCount(1).
+				"sales/wl1": *utiltesting.MakeAdmission("cq1").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor("r1", "default").
+						ResourceUsage("r1", "16").
+						Count(1).
+						Obj()).
 					Obj(),
-				"sales/wl2": *utiltesting.MakeAdmission("cq2", kueue.DefaultPodSetName).
-					Assignment("r1", "default", "14").AssignmentPodCount(1).
+				"sales/wl2": *utiltesting.MakeAdmission("cq2").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor("r1", "default").
+						ResourceUsage("r1", "14").
+						Count(1).
+						Obj()).
 					Obj(),
 			},
 		},
@@ -1222,8 +1241,12 @@ func TestSchedule(t *testing.T) {
 			},
 			wantScheduled: []workload.Reference{"sales/wl1"},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"sales/wl1": *utiltesting.MakeAdmission("cq1", kueue.DefaultPodSetName).
-					Assignment("r1", "default", "16").AssignmentPodCount(1).
+				"sales/wl1": *utiltesting.MakeAdmission("cq1").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor("r1", "default").
+						ResourceUsage("r1", "16").
+						Count(1).
+						Obj()).
 					Obj(),
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
@@ -1347,7 +1370,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 50).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha", "one").Assignment(corev1.ResourceCPU, "on-demand", "50").AssignmentPodCount(50).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "50").Count(50).Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("borrowing", "eng-beta").
 					Queue("main").
@@ -1355,7 +1378,7 @@ func TestSchedule(t *testing.T) {
 					PodSets(*utiltesting.MakePodSet("one", 55).
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("eng-beta", "one").Assignment(corev1.ResourceCPU, "on-demand", "55").AssignmentPodCount(55).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "55").Count(55).Obj()).Obj()).
 					Obj(),
 				*utiltesting.MakeWorkload("older_new", "eng-beta").
 					Queue("main").
@@ -1373,9 +1396,9 @@ func TestSchedule(t *testing.T) {
 					Obj(),
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"eng-alpha/all_nominal": *utiltesting.MakeAdmission("eng-alpha", "one").Assignment(corev1.ResourceCPU, "on-demand", "50").AssignmentPodCount(50).Obj(),
-				"eng-beta/borrowing":    *utiltesting.MakeAdmission("eng-beta", "one").Assignment(corev1.ResourceCPU, "on-demand", "55").AssignmentPodCount(55).Obj(),
-				"eng-alpha/new":         *utiltesting.MakeAdmission("eng-alpha", "one").Assignment(corev1.ResourceCPU, "on-demand", "5").AssignmentPodCount(5).Obj(),
+				"eng-alpha/all_nominal": *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "50").Count(50).Obj()).Obj(),
+				"eng-beta/borrowing":    *utiltesting.MakeAdmission("eng-beta").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "55").Count(55).Obj()).Obj(),
+				"eng-alpha/new":         *utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "on-demand").ResourceUsage(corev1.ResourceCPU, "5").Count(5).Obj()).Obj(),
 			},
 			wantScheduled: []workload.Reference{"eng-alpha/new"},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
@@ -3124,7 +3147,7 @@ func TestSchedule(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Generation(1).
-					ReserveQuota(utiltesting.MakeAdmission("sales", "one").Assignment(corev1.ResourceCPU, "default", "10000m").AssignmentPodCount(10).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "10000m").Count(10).Obj()).Obj()).
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionTrue,
@@ -3152,8 +3175,8 @@ func TestSchedule(t *testing.T) {
 			},
 			// wantAssignments is a map of workload name to the status assignments expected to be in the cache after the scheduling cycle.
 			wantAssignments: map[workload.Reference]kueue.Admission{
-				"sales/foo-1": *utiltesting.MakeAdmission("sales", "one").Assignment(corev1.ResourceCPU, "default", "10").AssignmentPodCount(10).Obj(),
-				"sales/foo-2": *utiltesting.MakeAdmission("sales", "one").Assignment(corev1.ResourceCPU, "default", "15").AssignmentPodCount(15).Obj(),
+				"sales/foo-1": *utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "10").Count(10).Obj()).Obj(),
+				"sales/foo-2": *utiltesting.MakeAdmission("sales").PodSets(utiltesting.MakePodSetAssignment("one").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "15").Count(15).Obj()).Obj(),
 			},
 			// wantScheduled is a list of workloads admission status expected to be added to the cache after the scheduling cycle.
 			wantScheduled: []workload.Reference{"sales/foo-2"},
@@ -3167,9 +3190,12 @@ func TestSchedule(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Admission(
-						utiltesting.MakeAdmission("sales", "one").
-							Assignment(corev1.ResourceCPU, "default", "10000m").
-							AssignmentPodCount(10).
+						utiltesting.MakeAdmission("sales").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "default").
+								ResourceUsage(corev1.ResourceCPU, "10000m").
+								Count(10).
+								Obj()).
 							Obj(),
 					).
 					Generation(1).
@@ -3202,9 +3228,12 @@ func TestSchedule(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					Admission(
-						utiltesting.MakeAdmission("sales", "one").
-							Assignment(corev1.ResourceCPU, "default", "15000m").
-							AssignmentPodCount(15).
+						utiltesting.MakeAdmission("sales").
+							PodSets(utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "default").
+								ResourceUsage(corev1.ResourceCPU, "15000m").
+								Count(15).
+								Obj()).
 							Obj(),
 					).
 					Generation(1).

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -4759,10 +4759,16 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-							AssignmentPodCount(1).Obj(),
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(
+								utiltesting.MakePodSetAssignment("one").
+									Flavor(corev1.ResourceCPU, "tas-default").
+									ResourceUsage(corev1.ResourceCPU, "1000m").
+									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+									Count(1).
+									Obj(),
+							).
+							Obj(),
 					).
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:  "prov-check",
@@ -4771,13 +4777,18 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					AssignmentPodCount(1).
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5216,10 +5227,16 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-default", "26").
-							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-							AssignmentPodCount(26).Obj(),
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(
+								utiltesting.MakePodSetAssignment("one").
+									Flavor(corev1.ResourceCPU, "tas-default").
+									ResourceUsage(corev1.ResourceCPU, "26").
+									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+									Count(26).
+									Obj(),
+							).
+							Obj(),
 					).
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:  "prov-check",
@@ -5228,13 +5245,18 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "26").
-					AssignmentPodCount(26).
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 26).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "26").
+							Count(26).
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 26).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5288,10 +5310,16 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-second", "1000m").
-							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-							AssignmentPodCount(1).Obj(),
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(
+								utiltesting.MakePodSetAssignment("one").
+									Flavor(corev1.ResourceCPU, "tas-second").
+									ResourceUsage(corev1.ResourceCPU, "1000m").
+									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+									Count(1).
+									Obj(),
+							).
+							Obj(),
 					).
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:  "prov-check",
@@ -5300,13 +5328,18 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-second", "1000m").
-					AssignmentPodCount(1).
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-second").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5440,10 +5473,16 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-					AssignmentPodCount(1).Obj(),
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+							Count(1).
+							Obj(),
+					).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{
@@ -5495,10 +5534,16 @@ func TestScheduleForTAS(t *testing.T) {
 						Request(corev1.ResourceCPU, "1").
 						Obj()).
 					ReserveQuota(
-						utiltesting.MakeAdmission("tas-main", "one").
-							Assignment(corev1.ResourceCPU, "tas-second", "1000m").
-							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-							AssignmentPodCount(1).Obj(),
+						utiltesting.MakeAdmission("tas-main").
+							PodSets(
+								utiltesting.MakePodSetAssignment("one").
+									Flavor(corev1.ResourceCPU, "tas-second").
+									ResourceUsage(corev1.ResourceCPU, "1000m").
+									DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+									Count(1).
+									Obj(),
+							).
+							Obj(),
 					).
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:  "prov-check",
@@ -5507,13 +5552,18 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-second", "1000m").
-					AssignmentPodCount(1).
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
-					TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
-						Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
-						Obj()).
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-second").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStateReady).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domain(utiltesting.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+								Obj()).
+							Obj(),
+					).
 					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
@@ -5541,10 +5591,16 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
-				"default/foo": *utiltesting.MakeAdmission("tas-main", "one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-					AssignmentPodCount(1).Obj(),
+				"default/foo": *utiltesting.MakeAdmission("tas-main").
+					PodSets(
+						utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+							Count(1).
+							Obj(),
+					).
+					Obj(),
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 			wantEvents: []utiltesting.EventRecord{

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -628,13 +628,6 @@ func (w *AdmissionWrapper) Obj() *kueue.Admission {
 	return &w.Admission
 }
 
-func (w *AdmissionWrapper) Assignment(r corev1.ResourceName, f kueue.ResourceFlavorReference, value string) *AdmissionWrapper {
-	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
-	wrapper.Flavor(r, f).ResourceUsage(r, value)
-	w.PodSetAssignments[0] = wrapper.PodSetAssignment
-	return w
-}
-
 func (w *AdmissionWrapper) PodSets(podSets ...kueue.PodSetAssignment) *AdmissionWrapper {
 	w.PodSetAssignments = podSets
 	return w
@@ -1767,4 +1760,8 @@ func (p *PodSetAssignmentWrapper) TopologyAssignment(ta *kueue.TopologyAssignmen
 func (p *PodSetAssignmentWrapper) DelayedTopologyRequest(state kueue.DelayedTopologyRequestState) *PodSetAssignmentWrapper {
 	p.PodSetAssignment.DelayedTopologyRequest = ptr.To(state)
 	return p
+}
+
+func (p *PodSetAssignmentWrapper) Assignment(r corev1.ResourceName, f kueue.ResourceFlavorReference, value string) *PodSetAssignmentWrapper {
+	return p.Flavor(r, f).ResourceUsage(r, value)
 }

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -1762,3 +1762,53 @@ func (t *TopologyAssignmentWrapper) Domain(domain kueue.TopologyDomainAssignment
 func (t *TopologyAssignmentWrapper) Obj() *kueue.TopologyAssignment {
 	return &t.TopologyAssignment
 }
+
+type PodSetAssignmentWrapper struct {
+	kueue.PodSetAssignment
+}
+
+func MakePodSetAssignment(name kueue.PodSetReference) *PodSetAssignmentWrapper {
+	return &PodSetAssignmentWrapper{
+		PodSetAssignment: kueue.PodSetAssignment{
+			Name:          name,
+			Flavors:       make(map[corev1.ResourceName]kueue.ResourceFlavorReference),
+			ResourceUsage: make(corev1.ResourceList),
+			Count:         ptr.To[int32](1),
+		},
+	}
+}
+
+func (p *PodSetAssignmentWrapper) Obj() kueue.PodSetAssignment {
+	return p.PodSetAssignment
+}
+
+func (p *PodSetAssignmentWrapper) Flavor(resource corev1.ResourceName, flavor kueue.ResourceFlavorReference) *PodSetAssignmentWrapper {
+	if p.Flavors == nil {
+		p.Flavors = make(map[corev1.ResourceName]kueue.ResourceFlavorReference)
+	}
+	p.Flavors[resource] = flavor
+	return p
+}
+
+func (p *PodSetAssignmentWrapper) ResourceUsage(resourceName corev1.ResourceName, quantity string) *PodSetAssignmentWrapper {
+	if p.PodSetAssignment.ResourceUsage == nil {
+		p.PodSetAssignment.ResourceUsage = make(corev1.ResourceList)
+	}
+	p.PodSetAssignment.ResourceUsage[resourceName] = resource.MustParse(quantity)
+	return p
+}
+
+func (p *PodSetAssignmentWrapper) Count(count int32) *PodSetAssignmentWrapper {
+	p.PodSetAssignment.Count = ptr.To(count)
+	return p
+}
+
+func (p *PodSetAssignmentWrapper) TopologyAssignment(ta *kueue.TopologyAssignment) *PodSetAssignmentWrapper {
+	p.PodSetAssignment.TopologyAssignment = ta
+	return p
+}
+
+func (p *PodSetAssignmentWrapper) DelayedTopologyRequest(state kueue.DelayedTopologyRequestState) *PodSetAssignmentWrapper {
+	p.PodSetAssignment.DelayedTopologyRequest = ptr.To(state)
+	return p
+}

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -635,13 +635,6 @@ func (w *AdmissionWrapper) Assignment(r corev1.ResourceName, f kueue.ResourceFla
 	return w
 }
 
-func (w *AdmissionWrapper) AssignmentPodCount(value int32) *AdmissionWrapper {
-	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
-	wrapper.Count(value)
-	w.PodSetAssignments[0] = wrapper.PodSetAssignment
-	return w
-}
-
 func (w *AdmissionWrapper) PodSets(podSets ...kueue.PodSetAssignment) *AdmissionWrapper {
 	w.PodSetAssignments = podSets
 	return w

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -649,13 +649,6 @@ func (w *AdmissionWrapper) TopologyAssignment(ts *kueue.TopologyAssignment) *Adm
 	return w
 }
 
-func (w *AdmissionWrapper) DelayedTopologyRequest(state kueue.DelayedTopologyRequestState) *AdmissionWrapper {
-	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
-	wrapper.DelayedTopologyRequest(state)
-	w.PodSetAssignments[0] = wrapper.PodSetAssignment
-	return w
-}
-
 func (w *AdmissionWrapper) PodSets(podSets ...kueue.PodSetAssignment) *AdmissionWrapper {
 	w.PodSetAssignments = podSets
 	return w

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -1691,3 +1691,26 @@ func AppendOwnerReference(obj client.Object, gvk schema.GroupVersionKind, name, 
 		BlockOwnerDeletion: blockDeletion,
 	}))
 }
+
+type EventRecordWrapper struct {
+	EventRecord
+}
+
+func MakeEventRecord(namespace, name, reason, eventType string) *EventRecordWrapper {
+	return &EventRecordWrapper{
+		EventRecord: EventRecord{
+			Key:       types.NamespacedName{Namespace: namespace, Name: name},
+			Reason:    reason,
+			EventType: eventType,
+		},
+	}
+}
+
+func (e *EventRecordWrapper) Message(message string) *EventRecordWrapper {
+	e.EventRecord.Message = message
+	return e
+}
+
+func (e *EventRecordWrapper) Obj() EventRecord {
+	return e.EventRecord
+}

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -636,33 +636,23 @@ func (w *AdmissionWrapper) Assignment(r corev1.ResourceName, f kueue.ResourceFla
 }
 
 func (w *AdmissionWrapper) AssignmentPodCount(value int32) *AdmissionWrapper {
-	w.AssignmentPodCountWithIndex(0, value)
+	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
+	wrapper.Count(value)
+	w.PodSetAssignments[0] = wrapper.PodSetAssignment
 	return w
 }
 
 func (w *AdmissionWrapper) TopologyAssignment(ts *kueue.TopologyAssignment) *AdmissionWrapper {
-	w.TopologyAssignmentWithIndex(0, ts)
+	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
+	wrapper.TopologyAssignment(ts)
+	w.PodSetAssignments[0] = wrapper.PodSetAssignment
 	return w
 }
 
 func (w *AdmissionWrapper) DelayedTopologyRequest(state kueue.DelayedTopologyRequestState) *AdmissionWrapper {
-	w.DelayedTopologyRequestWithIndex(0, state)
-	return w
-}
-
-
-func (w *AdmissionWrapper) AssignmentPodCountWithIndex(index, value int32) *AdmissionWrapper {
-	w.PodSetAssignments[index].Count = ptr.To(value)
-	return w
-}
-
-func (w *AdmissionWrapper) TopologyAssignmentWithIndex(index int32, ts *kueue.TopologyAssignment) *AdmissionWrapper {
-	w.PodSetAssignments[index].TopologyAssignment = ts
-	return w
-}
-
-func (w *AdmissionWrapper) DelayedTopologyRequestWithIndex(index int32, state kueue.DelayedTopologyRequestState) *AdmissionWrapper {
-	w.PodSetAssignments[index].DelayedTopologyRequest = ptr.To(state)
+	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
+	wrapper.DelayedTopologyRequest(state)
+	w.PodSetAssignments[0] = wrapper.PodSetAssignment
 	return w
 }
 

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -1714,3 +1714,51 @@ func (e *EventRecordWrapper) Message(message string) *EventRecordWrapper {
 func (e *EventRecordWrapper) Obj() EventRecord {
 	return e.EventRecord
 }
+
+type TopologyDomainAssignmentWrapper struct {
+	kueue.TopologyDomainAssignment
+}
+
+func MakeTopologyDomainAssignment(values []string, count int32) *TopologyDomainAssignmentWrapper {
+	return &TopologyDomainAssignmentWrapper{
+		TopologyDomainAssignment: kueue.TopologyDomainAssignment{
+			Values: values,
+			Count:  count,
+		},
+	}
+}
+
+func (t *TopologyDomainAssignmentWrapper) Obj() kueue.TopologyDomainAssignment {
+	return t.TopologyDomainAssignment
+}
+
+type TopologyAssignmentWrapper struct {
+	kueue.TopologyAssignment
+}
+
+func MakeTopologyAssignment(levels []string) *TopologyAssignmentWrapper {
+	return &TopologyAssignmentWrapper{
+		TopologyAssignment: kueue.TopologyAssignment{
+			Levels: levels,
+		},
+	}
+}
+
+func (t *TopologyAssignmentWrapper) Levels(levels ...string) *TopologyAssignmentWrapper {
+	t.TopologyAssignment.Levels = levels
+	return t
+}
+
+func (t *TopologyAssignmentWrapper) Domains(domains ...kueue.TopologyDomainAssignment) *TopologyAssignmentWrapper {
+	t.TopologyAssignment.Domains = domains
+	return t
+}
+
+func (t *TopologyAssignmentWrapper) Domain(domain kueue.TopologyDomainAssignment) *TopologyAssignmentWrapper {
+	t.TopologyAssignment.Domains = append(t.TopologyAssignment.Domains, domain)
+	return t
+}
+
+func (t *TopologyAssignmentWrapper) Obj() *kueue.TopologyAssignment {
+	return &t.TopologyAssignment
+}

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -642,13 +642,6 @@ func (w *AdmissionWrapper) AssignmentPodCount(value int32) *AdmissionWrapper {
 	return w
 }
 
-func (w *AdmissionWrapper) TopologyAssignment(ts *kueue.TopologyAssignment) *AdmissionWrapper {
-	wrapper := &PodSetAssignmentWrapper{PodSetAssignment: w.PodSetAssignments[0]}
-	wrapper.TopologyAssignment(ts)
-	w.PodSetAssignments[0] = wrapper.PodSetAssignment
-	return w
-}
-
 func (w *AdmissionWrapper) PodSets(podSets ...kueue.PodSetAssignment) *AdmissionWrapper {
 	w.PodSetAssignments = podSets
 	return w

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -69,8 +69,11 @@ func TestValidateWorkload(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(testingutil.MakeAdmission("cluster-queue").
-					Assignment(corev1.ResourceCPU, "flv", "1").
-					AssignmentPodCount(3).
+					PodSets(testingutil.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "flv").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(3).
+						Obj()).
 					Obj()).
 				Obj(),
 			wantErr: field.ErrorList{

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -70,8 +70,7 @@ func TestValidateWorkload(t *testing.T) {
 					Obj()).
 				ReserveQuota(testingutil.MakeAdmission("cluster-queue").
 					PodSets(testingutil.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "flv").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "flv", "1").
 						Count(3).
 						Obj()).
 					Obj()).

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1248,10 +1248,16 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-						AssignmentPodCount(1).Obj(),
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(
+							utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+								Count(1).
+								Obj(),
+						).
+						Obj(),
 				).
 				AdmissionCheck(kueue.AdmissionCheckState{
 					Name:  "prov-check",
@@ -1268,10 +1274,16 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-						AssignmentPodCount(1).Obj(),
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(
+							utiltesting.MakePodSetAssignment("one").
+								Flavor(corev1.ResourceCPU, "tas-default").
+								ResourceUsage(corev1.ResourceCPU, "1000m").
+								DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+								Count(1).
+								Obj(),
+						).
+						Obj(),
 				).
 				AdmissionCheck(kueue.AdmissionCheckState{
 					Name:  "prov-check",

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -167,9 +167,13 @@ func TestNewInfo(t *testing.T) {
 				).
 				ReserveQuota(
 					utiltesting.MakeAdmission("").
-						Assignment(corev1.ResourceCPU, "f1", "30m").
-						Assignment(corev1.ResourceMemory, "f1", "30Ki").
-						AssignmentPodCount(3).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "f1").
+							ResourceUsage(corev1.ResourceCPU, "30m").
+							Flavor(corev1.ResourceMemory, "f1").
+							ResourceUsage(corev1.ResourceMemory, "30Ki").
+							Count(3).
+							Obj()).
 						Obj(),
 				).
 				ReclaimablePods(
@@ -206,9 +210,13 @@ func TestNewInfo(t *testing.T) {
 				).
 				ReserveQuota(
 					utiltesting.MakeAdmission("").
-						Assignment(corev1.ResourceCPU, "f1", "30m").
-						Assignment(corev1.ResourceMemory, "f1", "30Ki").
-						AssignmentPodCount(3).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "f1").
+							ResourceUsage(corev1.ResourceCPU, "30m").
+							Flavor(corev1.ResourceMemory, "f1").
+							ResourceUsage(corev1.ResourceMemory, "30Ki").
+							Count(3).
+							Obj()).
 						Obj(),
 				).
 				ReclaimablePods(
@@ -245,9 +253,13 @@ func TestNewInfo(t *testing.T) {
 				).
 				ReserveQuota(
 					utiltesting.MakeAdmission("").
-						Assignment(corev1.ResourceCPU, "f1", "30m").
-						Assignment(corev1.ResourceMemory, "f1", "30Ki").
-						AssignmentPodCount(3).
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "f1").
+							ResourceUsage(corev1.ResourceCPU, "30m").
+							Flavor(corev1.ResourceMemory, "f1").
+							ResourceUsage(corev1.ResourceMemory, "30Ki").
+							Count(3).
+							Obj()).
 						Obj(),
 				).
 				Obj(),

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -168,10 +168,8 @@ func TestNewInfo(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "f1").
-							ResourceUsage(corev1.ResourceCPU, "30m").
-							Flavor(corev1.ResourceMemory, "f1").
-							ResourceUsage(corev1.ResourceMemory, "30Ki").
+							Assignment(corev1.ResourceCPU, "f1", "30m").
+							Assignment(corev1.ResourceMemory, "f1", "30Ki").
 							Count(3).
 							Obj()).
 						Obj(),
@@ -211,10 +209,8 @@ func TestNewInfo(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "f1").
-							ResourceUsage(corev1.ResourceCPU, "30m").
-							Flavor(corev1.ResourceMemory, "f1").
-							ResourceUsage(corev1.ResourceMemory, "30Ki").
+							Assignment(corev1.ResourceCPU, "f1", "30m").
+							Assignment(corev1.ResourceMemory, "f1", "30Ki").
 							Count(3).
 							Obj()).
 						Obj(),
@@ -254,10 +250,8 @@ func TestNewInfo(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "f1").
-							ResourceUsage(corev1.ResourceCPU, "30m").
-							Flavor(corev1.ResourceMemory, "f1").
-							ResourceUsage(corev1.ResourceMemory, "30Ki").
+							Assignment(corev1.ResourceCPU, "f1", "30m").
+							Assignment(corev1.ResourceMemory, "f1", "30Ki").
 							Count(3).
 							Obj()).
 						Obj(),
@@ -1133,9 +1127,7 @@ func TestNeedsSecondPass(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 								Obj()).
@@ -1156,9 +1148,7 @@ func TestNeedsSecondPass(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 								Obj()).
@@ -1180,9 +1170,7 @@ func TestNeedsSecondPass(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
 								Obj()).
@@ -1204,9 +1192,7 @@ func TestNeedsSecondPass(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 								Obj()).
@@ -1229,9 +1215,7 @@ func TestNeedsSecondPass(t *testing.T) {
 				ReserveQuota(
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(utiltesting.MakePodSetAssignment("one").
-							Flavor(corev1.ResourceCPU, "tas-default").
-							ResourceUsage(corev1.ResourceCPU, "1000m").
-							Count(1).
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
 								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
 								Obj()).
@@ -1254,10 +1238,8 @@ func TestNeedsSecondPass(t *testing.T) {
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(
 							utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-								Count(1).
 								Obj(),
 						).
 						Obj(),
@@ -1280,10 +1262,8 @@ func TestNeedsSecondPass(t *testing.T) {
 					utiltesting.MakeAdmission("tas-main").
 						PodSets(
 							utiltesting.MakePodSetAssignment("one").
-								Flavor(corev1.ResourceCPU, "tas-default").
-								ResourceUsage(corev1.ResourceCPU, "1000m").
+								Assignment(corev1.ResourceCPU, "tas-default", "1000m").
 								DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-								Count(1).
 								Obj(),
 						).
 						Obj(),

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1103,20 +1103,15 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						AssignmentPodCount(1).
-						TopologyAssignment(&kueue.TopologyAssignment{
-							Levels: utiltas.Levels(&defaultSingleLevelTopology),
-							Domains: []kueue.TopologyDomainAssignment{
-								{
-									Count: 1,
-									Values: []string{
-										"x0",
-									},
-								},
-							},
-						}).
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
+							Obj()).
 						Obj(),
 				).
 				Admitted(true).
@@ -1131,20 +1126,15 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						AssignmentPodCount(1).
-						TopologyAssignment(&kueue.TopologyAssignment{
-							Levels: utiltas.Levels(&defaultSingleLevelTopology),
-							Domains: []kueue.TopologyDomainAssignment{
-								{
-									Count: 1,
-									Values: []string{
-										"x0",
-									},
-								},
-							},
-						}).
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
+							Obj()).
 						Obj(),
 				).
 				Admitted(true).
@@ -1160,20 +1150,15 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						AssignmentPodCount(1).
-						TopologyAssignment(&kueue.TopologyAssignment{
-							Levels: utiltas.Levels(&defaultSingleLevelTopology),
-							Domains: []kueue.TopologyDomainAssignment{
-								{
-									Count: 1,
-									Values: []string{
-										"x1",
-									},
-								},
-							},
-						}).
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj()).
 						Obj(),
 				).
 				Admitted(true).
@@ -1189,20 +1174,15 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						AssignmentPodCount(1).
-						TopologyAssignment(&kueue.TopologyAssignment{
-							Levels: utiltas.Levels(&defaultSingleLevelTopology),
-							Domains: []kueue.TopologyDomainAssignment{
-								{
-									Count: 1,
-									Values: []string{
-										"x0",
-									},
-								},
-							},
-						}).
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
+							Obj()).
 						Obj(),
 				).
 				Admitted(true).
@@ -1219,20 +1199,15 @@ func TestNeedsSecondPass(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					Obj()).
 				ReserveQuota(
-					utiltesting.MakeAdmission("tas-main", "one").
-						Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-						AssignmentPodCount(1).
-						TopologyAssignment(&kueue.TopologyAssignment{
-							Levels: utiltas.Levels(&defaultSingleLevelTopology),
-							Domains: []kueue.TopologyDomainAssignment{
-								{
-									Count: 1,
-									Values: []string{
-										"x0",
-									},
-								},
-							},
-						}).
+					utiltesting.MakeAdmission("tas-main").
+						PodSets(utiltesting.MakePodSetAssignment("one").
+							Flavor(corev1.ResourceCPU, "tas-default").
+							ResourceUsage(corev1.ResourceCPU, "1000m").
+							Count(1).
+							TopologyAssignment(utiltesting.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+								Domains(utiltesting.MakeTopologyDomainAssignment([]string{"x0"}, 1).Obj()).
+								Obj()).
+							Obj()).
 						Obj(),
 				).
 				Admitted(true).

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -845,7 +845,11 @@ func TestAdmissionCheckStrategy(t *testing.T) {
 	}{
 		"AdmissionCheckStrategy with a flavor": {
 			wl: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Obj(),
 			cq: utiltesting.MakeClusterQueue("cq").
 				AdmissionCheckStrategy(*utiltesting.MakeAdmissionCheckStrategyRule("ac1", "flavor1").Obj()).
@@ -854,7 +858,11 @@ func TestAdmissionCheckStrategy(t *testing.T) {
 		},
 		"AdmissionCheckStrategy with an unmatched flavor": {
 			wl: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Obj(),
 			cq: utiltesting.MakeClusterQueue("cq").
 				AdmissionCheckStrategy(*utiltesting.MakeAdmissionCheckStrategyRule("ac1", "unmatched-flavor").Obj()).
@@ -863,7 +871,11 @@ func TestAdmissionCheckStrategy(t *testing.T) {
 		},
 		"AdmissionCheckStrategy without a flavor": {
 			wl: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Obj(),
 			cq: utiltesting.MakeClusterQueue("cq").
 				AdmissionCheckStrategy(*utiltesting.MakeAdmissionCheckStrategyRule("ac1").Obj()).
@@ -872,7 +884,11 @@ func TestAdmissionCheckStrategy(t *testing.T) {
 		},
 		"Two AdmissionCheckStrategies, one with flavor, one without flavor": {
 			wl: utiltesting.MakeWorkload("wl", "ns").
-				ReserveQuota(utiltesting.MakeAdmission("cq").Assignment("cpu", "flavor1", "1").Obj()).
+				ReserveQuota(utiltesting.MakeAdmission("cq").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("cpu", "flavor1", "1").
+						Obj()).
+					Obj()).
 				Obj(),
 			cq: utiltesting.MakeClusterQueue("cq").
 				AdmissionCheckStrategy(

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -538,7 +538,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 						ResourceVersion("1").
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 						Obj()).Build(),
 				jobPodSets:   []kueue.PodSet{*utiltesting.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()},
 				jobObject:    testJobObject,
@@ -562,9 +562,9 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						).
 						ReserveQuota(utiltesting.MakeAdmission("default").
 							PodSets(
-								utiltesting.MakePodSetAssignment("scaled-up").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
-								utiltesting.MakePodSetAssignment("scale-down").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
-								utiltesting.MakePodSetAssignment("stay-the-same").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
+								utiltesting.MakePodSetAssignment("scaled-up").Assignment(corev1.ResourceCPU, "default", "1").Count(3).Obj(),
+								utiltesting.MakePodSetAssignment("scale-down").Assignment(corev1.ResourceCPU, "default", "1").Count(3).Obj(),
+								utiltesting.MakePodSetAssignment("stay-the-same").Assignment(corev1.ResourceCPU, "default", "1").Count(3).Obj(),
 							).
 							Obj()).
 						Obj()).Build(),
@@ -588,7 +588,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 						ResourceVersion("1").
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj()).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Count(3).Obj()).Obj()).
 						Obj()).Build(),
 				jobPodSets:   []kueue.PodSet{*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()},
 				jobObject:    testJobObject,
@@ -600,7 +600,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 					OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 					ResourceVersion("2").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj()).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Count(3).Obj()).Obj()).
 					Obj(),
 			},
 		},
@@ -616,8 +616,8 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 							*utiltesting.MakePodSet("stay-the-same", 3).Request(corev1.ResourceCPU, "1").Obj()).
 						ReserveQuota(utiltesting.MakeAdmission("default").
 							PodSets(
-								utiltesting.MakePodSetAssignment("scale-down").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
-								utiltesting.MakePodSetAssignment("stay-the-same").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
+								utiltesting.MakePodSetAssignment("scale-down").Assignment(corev1.ResourceCPU, "default", "1").Count(3).Obj(),
+								utiltesting.MakePodSetAssignment("stay-the-same").Assignment(corev1.ResourceCPU, "default", "1").Count(3).Obj(),
 							).
 							Obj()).
 						Obj()).Build(),
@@ -638,8 +638,8 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						*utiltesting.MakePodSet("stay-the-same", 3).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuota(utiltesting.MakeAdmission("default").
 						PodSets(
-							utiltesting.MakePodSetAssignment("scale-down").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
-							utiltesting.MakePodSetAssignment("stay-the-same").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
+							utiltesting.MakePodSetAssignment("scale-down").Assignment(corev1.ResourceCPU, "default", "1").Count(3).Obj(),
+							utiltesting.MakePodSetAssignment("stay-the-same").Assignment(corev1.ResourceCPU, "default", "1").Count(3).Obj(),
 						).
 						Obj()).
 					Obj(),
@@ -787,7 +787,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						ResourceVersion("1").
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 						Obj(),
 					utiltesting.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -810,14 +810,14 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						ResourceVersion("1").
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 						Obj(),
 					utiltesting.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 						ResourceVersion("1").
 						Creation(now).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj()).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Count(3).Obj()).Obj()).
 						Obj()).
 					Build(),
 				jobPodSets:   []kueue.PodSet{*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()},
@@ -838,7 +838,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						ResourceVersion("1").
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 						Obj(),
 					utiltesting.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -869,7 +869,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						ResourceVersion("1").
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 						Obj(),
 					utiltesting.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -901,7 +901,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						ResourceVersion("1").
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 						Obj(),
 					utiltesting.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -933,7 +933,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						ResourceVersion("1").
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj()).
 						Obj(),
 					utiltesting.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -538,7 +538,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 						ResourceVersion("1").
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default", kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").AssignmentPodCount(1).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
 						Obj()).Build(),
 				jobPodSets:   []kueue.PodSet{*utiltesting.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()},
 				jobObject:    testJobObject,
@@ -588,7 +588,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 						ResourceVersion("1").
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default", kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").AssignmentPodCount(3).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj()).Obj()).
 						Obj()).Build(),
 				jobPodSets:   []kueue.PodSet{*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()},
 				jobObject:    testJobObject,
@@ -600,7 +600,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 					OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 					ResourceVersion("2").
 					PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("default", kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").AssignmentPodCount(3).Obj()).
+					ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj()).Obj()).
 					Obj(),
 			},
 		},
@@ -787,7 +787,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						ResourceVersion("1").
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default", kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").AssignmentPodCount(1).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
 						Obj(),
 					utiltesting.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -810,14 +810,14 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						ResourceVersion("1").
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default", kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").AssignmentPodCount(1).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
 						Obj(),
 					utiltesting.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
 						ResourceVersion("1").
 						Creation(now).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default", kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").AssignmentPodCount(3).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj()).Obj()).
 						Obj()).
 					Build(),
 				jobPodSets:   []kueue.PodSet{*utiltesting.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()},
@@ -838,7 +838,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						ResourceVersion("1").
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default", kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").AssignmentPodCount(1).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
 						Obj(),
 					utiltesting.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -869,7 +869,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						ResourceVersion("1").
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default", kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").AssignmentPodCount(1).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
 						Obj(),
 					utiltesting.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -901,7 +901,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						ResourceVersion("1").
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default", kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").AssignmentPodCount(1).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
 						Obj(),
 					utiltesting.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -933,7 +933,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						ResourceVersion("1").
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltesting.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default", kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").AssignmentPodCount(1).Obj()).
+						ReserveQuota(utiltesting.MakeAdmission("default").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(1).Obj()).Obj()).
 						Obj(),
 					utiltesting.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -560,10 +560,12 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 							*utiltesting.MakePodSet("scale-down", 3).Request(corev1.ResourceCPU, "1").Obj(),
 							*utiltesting.MakePodSet("stay-the-same", 3).Request(corev1.ResourceCPU, "1").Obj(),
 						).
-						ReserveQuota(utiltesting.MakeAdmission("default", "scaled-up", "scale-down", "stay-the-same").
-							AssignmentWithIndex(0, corev1.ResourceCPU, "default", "1").AssignmentPodCountWithIndex(0, 3).
-							AssignmentWithIndex(1, corev1.ResourceCPU, "default", "1").AssignmentPodCountWithIndex(1, 3).
-							AssignmentWithIndex(1, corev1.ResourceCPU, "default", "1").AssignmentPodCountWithIndex(1, 3).
+						ReserveQuota(utiltesting.MakeAdmission("default").
+							PodSets(
+								utiltesting.MakePodSetAssignment("scaled-up").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
+								utiltesting.MakePodSetAssignment("scale-down").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
+								utiltesting.MakePodSetAssignment("stay-the-same").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
+							).
 							Obj()).
 						Obj()).Build(),
 				jobPodSets: []kueue.PodSet{
@@ -612,9 +614,11 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						PodSets(
 							*utiltesting.MakePodSet("scale-down", 3).Request(corev1.ResourceCPU, "1").Obj(),
 							*utiltesting.MakePodSet("stay-the-same", 3).Request(corev1.ResourceCPU, "1").Obj()).
-						ReserveQuota(utiltesting.MakeAdmission("default", "scale-down", "stay-the-same").
-							AssignmentWithIndex(0, corev1.ResourceCPU, "default", "1").AssignmentPodCountWithIndex(0, 3).
-							AssignmentWithIndex(1, corev1.ResourceCPU, "default", "1").AssignmentPodCountWithIndex(1, 3).
+						ReserveQuota(utiltesting.MakeAdmission("default").
+							PodSets(
+								utiltesting.MakePodSetAssignment("scale-down").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
+								utiltesting.MakePodSetAssignment("stay-the-same").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
+							).
 							Obj()).
 						Obj()).Build(),
 				jobPodSets: []kueue.PodSet{
@@ -632,9 +636,11 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 					PodSets(
 						*utiltesting.MakePodSet("scale-down", 1).Request(corev1.ResourceCPU, "1").Obj(),
 						*utiltesting.MakePodSet("stay-the-same", 3).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuota(utiltesting.MakeAdmission("default", "scale-down", "stay-the-same").
-						AssignmentWithIndex(0, corev1.ResourceCPU, "default", "1").AssignmentPodCountWithIndex(0, 3).
-						AssignmentWithIndex(1, corev1.ResourceCPU, "default", "1").AssignmentPodCountWithIndex(1, 3).
+					ReserveQuota(utiltesting.MakeAdmission("default").
+						PodSets(
+							utiltesting.MakePodSetAssignment("scale-down").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
+							utiltesting.MakePodSetAssignment("stay-the-same").Flavor(corev1.ResourceCPU, "default").ResourceUsage(corev1.ResourceCPU, "1").Count(3).Obj(),
+						).
 						Obj()).
 					Obj(),
 			},

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -1315,9 +1315,12 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			util.MustCreate(ctx, k8sClient, wl)
 
 			wlKey = client.ObjectKeyFromObject(wl)
-			admission = testing.MakeAdmission(cq.Name, "ps1").
-				Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "3").
-				AssignmentPodCount(3).
+			admission = testing.MakeAdmission(cq.Name).
+				PodSets(testing.MakePodSetAssignment("ps1").
+					Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+					ResourceUsage(corev1.ResourceCPU, "3").
+					Count(3).
+					Obj()).
 				Obj()
 		})
 

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -144,13 +144,11 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			admission = testing.MakeAdmission(cq.Name).
 				PodSets(
 					testing.MakePodSetAssignment("ps1").
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceCPU, "3").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "3").
 						Count(3).
 						Obj(),
 					testing.MakePodSetAssignment("ps2").
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceCPU, "2").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "2").
 						Count(4).
 						Obj(),
 				).
@@ -868,13 +866,11 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			admission = testing.MakeAdmission(cq.Name).
 				PodSets(
 					testing.MakePodSetAssignment("ps1").
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceCPU, "3").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "3").
 						Count(3).
 						Obj(),
 					testing.MakePodSetAssignment("ps2").
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceCPU, "2").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "2").
 						Count(4).
 						Obj(),
 				).
@@ -1317,8 +1313,7 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			wlKey = client.ObjectKeyFromObject(wl)
 			admission = testing.MakeAdmission(cq.Name).
 				PodSets(testing.MakePodSetAssignment("ps1").
-					Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-					ResourceUsage(corev1.ResourceCPU, "3").
+					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "3").
 					Count(3).
 					Obj()).
 				Obj()
@@ -1517,17 +1512,12 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			admission = testing.MakeAdmission(cq.Name).
 				PodSets(
 					testing.MakePodSetAssignment("master").
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceCPU, "1").
-						Flavor(corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceMemory, "2Gi").
-						Count(1).
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "1").
+						Assignment(corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name), "2Gi").
 						Obj(),
 					testing.MakePodSetAssignment("worker").
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceCPU, "1").
-						Flavor(corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name)).
-						ResourceUsage(corev1.ResourceMemory, "2Gi").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "1").
+						Assignment(corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name), "2Gi").
 						Count(2).
 						Obj(),
 				).

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -141,11 +141,19 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 				Name:      provisioning.ProvisioningRequestName(wlKey.Name, kueue.AdmissionCheckReference(ac.Name), 1),
 			}
 
-			admission = testing.MakeAdmission(cq.Name, "ps1", "ps2").
-				AssignmentWithIndex(0, corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "3").
-				AssignmentPodCountWithIndex(0, 3).
-				AssignmentWithIndex(1, corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "2").
-				AssignmentPodCountWithIndex(1, 4).
+			admission = testing.MakeAdmission(cq.Name).
+				PodSets(
+					testing.MakePodSetAssignment("ps1").
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceCPU, "3").
+						Count(3).
+						Obj(),
+					testing.MakePodSetAssignment("ps2").
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceCPU, "2").
+						Count(4).
+						Obj(),
+				).
 				Obj()
 		})
 
@@ -857,11 +865,19 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			util.MustCreate(ctx, k8sClient, wl)
 
 			wlKey = client.ObjectKeyFromObject(wl)
-			admission = testing.MakeAdmission(cq.Name, "ps1", "ps2").
-				AssignmentWithIndex(0, corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "3").
-				AssignmentPodCountWithIndex(0, 3).
-				AssignmentWithIndex(1, corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "2").
-				AssignmentPodCountWithIndex(1, 4).
+			admission = testing.MakeAdmission(cq.Name).
+				PodSets(
+					testing.MakePodSetAssignment("ps1").
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceCPU, "3").
+						Count(3).
+						Obj(),
+					testing.MakePodSetAssignment("ps2").
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceCPU, "2").
+						Count(4).
+						Obj(),
+				).
 				Obj()
 		})
 
@@ -1495,13 +1511,23 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Ordered, ginkgo.ContinueOnFailure
 				Name:      provisioning.ProvisioningRequestName(wlKey.Name, kueue.AdmissionCheckReference(ac.Name), 1),
 			}
 
-			admission = testing.MakeAdmission(cq.Name, "master", "worker").
-				AssignmentWithIndex(0, corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "1").
-				AssignmentWithIndex(0, corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name), "2Gi").
-				AssignmentPodCountWithIndex(0, 1).
-				AssignmentWithIndex(1, corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "1").
-				AssignmentWithIndex(1, corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name), "2Gi").
-				AssignmentPodCountWithIndex(1, 2).
+			admission = testing.MakeAdmission(cq.Name).
+				PodSets(
+					testing.MakePodSetAssignment("master").
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Flavor(corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceMemory, "2Gi").
+						Count(1).
+						Obj(),
+					testing.MakePodSetAssignment("worker").
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Flavor(corev1.ResourceMemory, kueue.ResourceFlavorReference(rf.Name)).
+						ResourceUsage(corev1.ResourceMemory, "2Gi").
+						Count(2).
+						Obj(),
+				).
 				Obj()
 		})
 

--- a/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
@@ -220,15 +220,20 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Ordered, ginkgo.Contin
 			ginkgo.By("Set workloads quota reservation")
 			admissions := []*kueue.Admission{
 				testing.MakeAdmission(clusterQueue.Name).
-					Assignment(corev1.ResourceCPU, flavorOnDemand, "2").Assignment(resourceGPU, flavorModelA, "2").Obj(),
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, flavorOnDemand, "2").Assignment(resourceGPU, flavorModelA, "2").Obj()).Obj(),
 				testing.MakeAdmission(clusterQueue.Name).
-					Assignment(corev1.ResourceCPU, flavorOnDemand, "3").Assignment(resourceGPU, flavorModelA, "3").Obj(),
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, flavorOnDemand, "3").Assignment(resourceGPU, flavorModelA, "3").Obj()).Obj(),
 				testing.MakeAdmission(clusterQueue.Name).
-					Assignment(corev1.ResourceCPU, flavorOnDemand, "1").Assignment(resourceGPU, flavorModelB, "1").Obj(),
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, flavorOnDemand, "1").Assignment(resourceGPU, flavorModelB, "1").Obj()).Obj(),
 				testing.MakeAdmission(clusterQueue.Name).
-					Assignment(corev1.ResourceCPU, flavorSpot, "1").Assignment(resourceGPU, flavorModelB, "1").Obj(),
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, flavorSpot, "1").Assignment(resourceGPU, flavorModelB, "1").Obj()).Obj(),
 				testing.MakeAdmission("other").
-					Assignment(corev1.ResourceCPU, flavorSpot, "1").Assignment(resourceGPU, flavorModelB, "1").Obj(),
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, flavorSpot, "1").Assignment(resourceGPU, flavorModelB, "1").Obj()).Obj(),
 				nil,
 			}
 			for i, w := range workloads {

--- a/test/integration/singlecluster/controller/core/localqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/localqueue_controller_test.go
@@ -242,11 +242,14 @@ var _ = ginkgo.Describe("Queue controller", ginkgo.Ordered, ginkgo.ContinueOnFai
 		}
 		admissions := []*kueue.Admission{
 			testing.MakeAdmission(clusterQueue.Name).
-				Assignment(resourceGPU, flavorModelC, "2").Obj(),
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(resourceGPU, flavorModelC, "2").Obj()).Obj(),
 			testing.MakeAdmission(clusterQueue.Name).
-				Assignment(resourceGPU, flavorModelC, "3").Obj(),
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(resourceGPU, flavorModelC, "3").Obj()).Obj(),
 			testing.MakeAdmission(clusterQueue.Name).
-				Assignment(resourceGPU, flavorModelD, "1").Obj(),
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(resourceGPU, flavorModelD, "1").Obj()).Obj(),
 		}
 
 		ginkgo.By("Creating workloads")
@@ -476,11 +479,14 @@ var _ = ginkgo.Describe("Queue controller", ginkgo.Ordered, ginkgo.ContinueOnFai
 		}
 		admissions := []*kueue.Admission{
 			testing.MakeAdmission(clusterQueue.Name).
-				Assignment(resourceGPU, flavorModelC, "2").Obj(),
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(resourceGPU, flavorModelC, "2").Obj()).Obj(),
 			testing.MakeAdmission(clusterQueue.Name).
-				Assignment(resourceGPU, flavorModelC, "3").Obj(),
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(resourceGPU, flavorModelC, "3").Obj()).Obj(),
 			testing.MakeAdmission(clusterQueue.Name).
-				Assignment(resourceGPU, flavorModelD, "1").Obj(),
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(resourceGPU, flavorModelD, "1").Obj()).Obj(),
 		}
 
 		ginkgo.By("Creating workloads", func() {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -194,8 +194,11 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				*testing.MakeFlavorQuotas("spot").Resource(corev1.ResourceCPU, "5").Obj(),
 			).Obj()
 		admission := testing.MakeAdmission(clusterQueue.Name).
-			Assignment(corev1.ResourceCPU, "on-demand", "1m").
-			AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+			PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+				Flavor(corev1.ResourceCPU, "on-demand").
+				ResourceUsage(corev1.ResourceCPU, "1m").
+				Count(createdWorkload.Spec.PodSets[0].Count).
+				Obj()).
 			Obj()
 		gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 		util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -244,8 +247,11 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 		ginkgo.By("checking the job is unsuspended and selectors added when workload is assigned again")
 		admission = testing.MakeAdmission(clusterQueue.Name).
-			Assignment(corev1.ResourceCPU, "spot", "1m").
-			AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+			PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+				Flavor(corev1.ResourceCPU, "spot").
+				ResourceUsage(corev1.ResourceCPU, "1m").
+				Count(createdWorkload.Spec.PodSets[0].Count).
+				Obj()).
 			Obj()
 		gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 		util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -823,8 +829,11 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 			ginkgo.By("admit the workload", func() {
 				admission := testing.MakeAdmission(clusterQueueAc.Name).
-					Assignment(corev1.ResourceCPU, "test-flavor", "1").
-					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "test-flavor").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(createdWorkload.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				gomega.Expect(k8sClient.Get(ctx, *wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
@@ -941,8 +950,11 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 			ginkgo.By("attempt to admit the workload", func() {
 				admission := testing.MakeAdmission(clusterQueueAc.Name).
-					Assignment(corev1.ResourceCPU, "test-flavor", "1").
-					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "test-flavor").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(createdWorkload.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				gomega.Expect(k8sClient.Get(ctx, *wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
@@ -1015,8 +1027,11 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 
 			ginkgo.By("Admit the workload created for the job")
 			admission := testing.MakeAdmission("foo").
-				Assignment(corev1.ResourceCPU, "default", "1m").
-				AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Flavor(corev1.ResourceCPU, "default").
+					ResourceUsage(corev1.ResourceCPU, "1m").
+					Count(createdWorkload.Spec.PodSets[0].Count).
+					Obj()).
 				Obj()
 			gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -2500,8 +2515,11 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				admission = testing.MakeAdmission(cq.Name).
-					Assignment(corev1.ResourceCPU, "on-demand", "1m").
-					AssignmentPodCount(wl.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "on-demand").
+						ResourceUsage(corev1.ResourceCPU, "1m").
+						Count(wl.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				g.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, admission)).Should(gomega.Succeed())
 				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
@@ -2865,8 +2883,11 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 
 				ginkgo.By("Admitting the Workload", func() {
 					admission := testing.MakeAdmission(cq.Name).
-						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1m").
-						AssignmentPodCount(wl.Spec.PodSets[0].Count).
+						PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
+							ResourceUsage(corev1.ResourceCPU, "1m").
+							Count(wl.Spec.PodSets[0].Count).
+							Obj()).
 						Obj()
 					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, admission)).Should(gomega.Succeed())
 					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
@@ -2919,8 +2940,11 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 				})
 
 				admission := testing.MakeAdmission(cq.Name).
-					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1m").
-					AssignmentPodCount(wl.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
+						ResourceUsage(corev1.ResourceCPU, "1m").
+						Count(wl.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 
 				ginkgo.By("Admitting the Workload", func() {
@@ -3018,8 +3042,11 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 				})
 
 				admission := testing.MakeAdmission(cq.Name).
-					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1m").
-					AssignmentPodCount(wl.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
+						ResourceUsage(corev1.ResourceCPU, "1m").
+						Count(wl.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 
 				ginkgo.By("Admitting the Workload", func() {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -195,8 +195,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			).Obj()
 		admission := testing.MakeAdmission(clusterQueue.Name).
 			PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-				Flavor(corev1.ResourceCPU, "on-demand").
-				ResourceUsage(corev1.ResourceCPU, "1m").
+				Assignment(corev1.ResourceCPU, "on-demand", "1m").
 				Count(createdWorkload.Spec.PodSets[0].Count).
 				Obj()).
 			Obj()
@@ -248,8 +247,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 		ginkgo.By("checking the job is unsuspended and selectors added when workload is assigned again")
 		admission = testing.MakeAdmission(clusterQueue.Name).
 			PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-				Flavor(corev1.ResourceCPU, "spot").
-				ResourceUsage(corev1.ResourceCPU, "1m").
+				Assignment(corev1.ResourceCPU, "spot", "1m").
 				Count(createdWorkload.Spec.PodSets[0].Count).
 				Obj()).
 			Obj()
@@ -830,8 +828,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			ginkgo.By("admit the workload", func() {
 				admission := testing.MakeAdmission(clusterQueueAc.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "test-flavor").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "test-flavor", "1").
 						Count(createdWorkload.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -951,8 +948,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 			ginkgo.By("attempt to admit the workload", func() {
 				admission := testing.MakeAdmission(clusterQueueAc.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "test-flavor").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "test-flavor", "1").
 						Count(createdWorkload.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -1028,8 +1024,7 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 			ginkgo.By("Admit the workload created for the job")
 			admission := testing.MakeAdmission("foo").
 				PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-					Flavor(corev1.ResourceCPU, "default").
-					ResourceUsage(corev1.ResourceCPU, "1m").
+					Assignment(corev1.ResourceCPU, "default", "1m").
 					Count(createdWorkload.Spec.PodSets[0].Count).
 					Obj()).
 				Obj()
@@ -2516,8 +2511,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				admission = testing.MakeAdmission(cq.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "on-demand").
-						ResourceUsage(corev1.ResourceCPU, "1m").
+						Assignment(corev1.ResourceCPU, "on-demand", "1m").
 						Count(wl.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -2884,8 +2878,7 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 				ginkgo.By("Admitting the Workload", func() {
 					admission := testing.MakeAdmission(cq.Name).
 						PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
-							ResourceUsage(corev1.ResourceCPU, "1m").
+							Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1m").
 							Count(wl.Spec.PodSets[0].Count).
 							Obj()).
 						Obj()
@@ -2941,8 +2934,7 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 
 				admission := testing.MakeAdmission(cq.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
-						ResourceUsage(corev1.ResourceCPU, "1m").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1m").
 						Count(wl.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -3043,8 +3035,7 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 
 				admission := testing.MakeAdmission(cq.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
-						ResourceUsage(corev1.ResourceCPU, "1m").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1m").
 						Count(wl.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -183,8 +183,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
 					).Obj()
 				admission := testing.MakeAdmission(clusterQueue.Name).
-					Assignment(corev1.ResourceCPU, "default", "1").
-					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(createdWorkload.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -241,8 +244,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
 					).Obj()
 				admission := testing.MakeAdmission(clusterQueue.Name).
-					Assignment(corev1.ResourceCPU, "default", "1").
-					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(createdWorkload.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -304,8 +310,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 							*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "1").Obj(),
 						).Obj()
 					admission := testing.MakeAdmission(clusterQueue.Name).
-						Assignment(corev1.ResourceCPU, "default", "1").
-						AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+						PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "1").
+							Count(createdWorkload.Spec.PodSets[0].Count).
+							Obj()).
 						Obj()
 					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -476,8 +485,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 					ginkgo.By("admit the workload", func() {
 						admission := testing.MakeAdmission(clusterQueueAc.Name).
-							Assignment(corev1.ResourceCPU, "test-flavor", "1").
-							AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+							PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Flavor(corev1.ResourceCPU, "test-flavor").
+								ResourceUsage(corev1.ResourceCPU, "1").
+								Count(createdWorkload.Spec.PodSets[0].Count).
+								Obj()).
 							Obj()
 						gomega.Expect(k8sClient.Get(ctx, *wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 						gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
@@ -529,8 +541,11 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				ginkgo.By("Admit workload", func() {
 					admission := testing.MakeAdmission(clusterQueue.Name).
-						Assignment(corev1.ResourceCPU, "default", "1").
-						AssignmentPodCount(wl.Spec.PodSets[0].Count).
+						PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Flavor(corev1.ResourceCPU, "default").
+							ResourceUsage(corev1.ResourceCPU, "1").
+							Count(wl.Spec.PodSets[0].Count).
+							Obj()).
 						Obj()
 					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, wl, admission)).Should(gomega.Succeed())
 					util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
@@ -758,9 +773,12 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName("test-queue")), "The Workload should have .spec.queueName set")
 				originalWorkloadUID := createdWorkload.UID
 
-				admission := testing.MakeAdmission(clusterQueue.Name, "bf90803c").
-					Assignment(corev1.ResourceCPU, "default", "1").
-					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+				admission := testing.MakeAdmission(clusterQueue.Name).
+					PodSets(testing.MakePodSetAssignment("bf90803c").
+						Flavor(corev1.ResourceCPU, "default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(createdWorkload.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				ginkgo.By("checking that all pods in group are unsuspended when workload is admitted", func() {
 					gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
@@ -908,9 +926,12 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				gomega.Expect(createdWorkload.Spec.QueueName).To(gomega.Equal(kueue.LocalQueueName("test-queue")), "The Workload should have .spec.queueName set")
 
 				ginkgo.By("checking that pod is unsuspended when workload is admitted")
-				admission := testing.MakeAdmission(clusterQueue.Name, "bf90803c").
-					Assignment(corev1.ResourceCPU, "default", "1").
-					AssignmentPodCount(createdWorkload.Spec.PodSets[0].Count).
+				admission := testing.MakeAdmission(clusterQueue.Name).
+					PodSets(testing.MakePodSetAssignment("bf90803c").
+						Flavor(corev1.ResourceCPU, "default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(createdWorkload.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 				gomega.Expect(util.SetQuotaReservation(ctx, k8sClient, createdWorkload, admission)).Should(gomega.Succeed())
 				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
@@ -1363,9 +1384,12 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 
-				admission := testing.MakeAdmission(cq.Name, wl.Spec.PodSets[0].Name).
-					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1").
-					AssignmentPodCount(wl.Spec.PodSets[0].Count).
+				admission := testing.MakeAdmission(cq.Name).
+					PodSets(testing.MakePodSetAssignment(wl.Spec.PodSets[0].Name).
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(wl.Spec.PodSets[0].Count).
+						Obj()).
 					Obj()
 
 				ginkgo.By("admitting the workload", func() {
@@ -2010,9 +2034,12 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 				))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			admission := testing.MakeAdmission(cq.Name, wl.Spec.PodSets[0].Name).
-				Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1").
-				AssignmentPodCount(wl.Spec.PodSets[0].Count).
+			admission := testing.MakeAdmission(cq.Name).
+				PodSets(testing.MakePodSetAssignment(wl.Spec.PodSets[0].Name).
+					Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
+					ResourceUsage(corev1.ResourceCPU, "1").
+					Count(wl.Spec.PodSets[0].Count).
+					Obj()).
 				Obj()
 
 			ginkgo.By("admit the workload", func() {

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -184,8 +184,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					).Obj()
 				admission := testing.MakeAdmission(clusterQueue.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "default").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "default", "1").
 						Count(createdWorkload.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -245,8 +244,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					).Obj()
 				admission := testing.MakeAdmission(clusterQueue.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "default").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "default", "1").
 						Count(createdWorkload.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -311,8 +309,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 						).Obj()
 					admission := testing.MakeAdmission(clusterQueue.Name).
 						PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "1").
+							Assignment(corev1.ResourceCPU, "default", "1").
 							Count(createdWorkload.Spec.PodSets[0].Count).
 							Obj()).
 						Obj()
@@ -486,8 +483,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					ginkgo.By("admit the workload", func() {
 						admission := testing.MakeAdmission(clusterQueueAc.Name).
 							PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Flavor(corev1.ResourceCPU, "test-flavor").
-								ResourceUsage(corev1.ResourceCPU, "1").
+								Assignment(corev1.ResourceCPU, "test-flavor", "1").
 								Count(createdWorkload.Spec.PodSets[0].Count).
 								Obj()).
 							Obj()
@@ -542,8 +538,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				ginkgo.By("Admit workload", func() {
 					admission := testing.MakeAdmission(clusterQueue.Name).
 						PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-							Flavor(corev1.ResourceCPU, "default").
-							ResourceUsage(corev1.ResourceCPU, "1").
+							Assignment(corev1.ResourceCPU, "default", "1").
 							Count(wl.Spec.PodSets[0].Count).
 							Obj()).
 						Obj()
@@ -775,8 +770,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				admission := testing.MakeAdmission(clusterQueue.Name).
 					PodSets(testing.MakePodSetAssignment("bf90803c").
-						Flavor(corev1.ResourceCPU, "default").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "default", "1").
 						Count(createdWorkload.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -928,8 +922,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 				ginkgo.By("checking that pod is unsuspended when workload is admitted")
 				admission := testing.MakeAdmission(clusterQueue.Name).
 					PodSets(testing.MakePodSetAssignment("bf90803c").
-						Flavor(corev1.ResourceCPU, "default").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "default", "1").
 						Count(createdWorkload.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -1386,8 +1379,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 
 				admission := testing.MakeAdmission(cq.Name).
 					PodSets(testing.MakePodSetAssignment(wl.Spec.PodSets[0].Name).
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1").
 						Count(wl.Spec.PodSets[0].Count).
 						Obj()).
 					Obj()
@@ -2036,8 +2028,7 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 
 			admission := testing.MakeAdmission(cq.Name).
 				PodSets(testing.MakePodSetAssignment(wl.Spec.PodSets[0].Name).
-					Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name)).
-					ResourceUsage(corev1.ResourceCPU, "1").
+					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(fl.Name), "1").
 					Count(wl.Spec.PodSets[0].Count).
 					Obj()).
 				Obj()

--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -672,7 +672,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Await for the a-best-effort-low workload to be admitted")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, aBestEffortLowWl,
-				testing.MakeAdmission(aBestEffortCQ.Name).Assignment(corev1.ResourceCPU, "one", "5").Obj(),
+				testing.MakeAdmission(aBestEffortCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "one", "5").Obj()).Obj(),
 			)
 
 			ginkgo.By("Create a low priority workload which is not borrowing")
@@ -685,7 +685,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Await for the b-best-effort-low workload to be admitted")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, bBestEffortLowWl,
-				testing.MakeAdmission(bBestEffortCQ.Name).Assignment(corev1.ResourceCPU, "one", "1").Obj(),
+				testing.MakeAdmission(bBestEffortCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "one", "1").Obj()).Obj(),
 			)
 
 			ginkgo.By("Create a high priority workload (above MaxPriorityThreshold) which requires borrowing")
@@ -698,7 +698,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Await for the b-standard-high workload to be admitted")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, bStandardWl,
-				testing.MakeAdmission(bStandardCQ.Name).Assignment(corev1.ResourceCPU, "one", "5").Obj(),
+				testing.MakeAdmission(bStandardCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "one", "5").Obj()).Obj(),
 			)
 
 			ginkgo.By("Create the a-standard-very-high workload")
@@ -718,22 +718,22 @@ var _ = ginkgo.Describe("Preemption", func() {
 
 			ginkgo.By("Verify the a-standard-very-high workload is admitted")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, aStandardVeryHighWl,
-				testing.MakeAdmission(aStandardCQ.Name).Assignment(corev1.ResourceCPU, "one", "7").Obj(),
+				testing.MakeAdmission(aStandardCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "one", "7").Obj()).Obj(),
 			)
 
 			ginkgo.By("Verify the a-best-effort-low workload is re-admitted, but using flavor 2")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, aBestEffortLowWl,
-				testing.MakeAdmission(aBestEffortCQ.Name).Assignment(corev1.ResourceCPU, "fallback", "5").Obj(),
+				testing.MakeAdmission(aBestEffortCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "fallback", "5").Obj()).Obj(),
 			)
 
 			ginkgo.By("Verify the b-standard-high workload remains admitted")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, bStandardWl,
-				testing.MakeAdmission(bStandardCQ.Name).Assignment(corev1.ResourceCPU, "one", "5").Obj(),
+				testing.MakeAdmission(bStandardCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "one", "5").Obj()).Obj(),
 			)
 
 			ginkgo.By("Verify for the b-best-effort-low workload remains admitted")
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, bBestEffortLowWl,
-				testing.MakeAdmission(bBestEffortCQ.Name).Assignment(corev1.ResourceCPU, "one", "1").Obj(),
+				testing.MakeAdmission(bBestEffortCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "one", "1").Obj()).Obj(),
 			)
 		})
 	})
@@ -791,7 +791,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 			util.FinishEvictionForWorkloads(ctx, k8sClient, wl1)
 
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3,
-				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "alpha", "4").Obj())
+				testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "alpha", "4").Obj()).Obj())
 		})
 	})
 

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -333,10 +333,8 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.MustCreate(ctx, k8sClient, wl1)
 				wl1Admission := testing.MakeAdmission(podsCountClusterQ.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "on-demand").
-						ResourceUsage(corev1.ResourceCPU, "6").
-						Flavor(corev1.ResourcePods, "on-demand").
-						ResourceUsage(corev1.ResourcePods, "3").
+						Assignment(corev1.ResourceCPU, "on-demand", "6").
+						Assignment(corev1.ResourcePods, "on-demand", "3").
 						Count(3).
 						Obj()).
 					Obj()
@@ -399,8 +397,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.MustCreate(ctx, k8sClient, wl1)
 				wl1Admission := testing.MakeAdmission(podsCountOnlyClusterQ.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourcePods, "on-demand").
-						ResourceUsage(corev1.ResourcePods, "3").
+						Assignment(corev1.ResourcePods, "on-demand", "3").
 						Count(3).
 						Obj()).
 					Obj()
@@ -509,9 +506,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.MustCreate(ctx, k8sClient, wl1)
 				wl1Admission := testing.MakeAdmission(admissionCheckClusterQ.Name).
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(onDemandFlavor.Name)).
-						ResourceUsage(corev1.ResourceCPU, "2").
-						Count(1).
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(onDemandFlavor.Name), "2").
 						Obj()).
 					Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, wl1Admission)

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -254,7 +254,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("checking the first prod workload gets admitted")
 			prodWl1 := testing.MakeWorkload("prod-wl1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, prodWl1)
-			prodWl1Admission := testing.MakeAdmission(prodClusterQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "2").Obj()
+			prodWl1Admission := testing.MakeAdmission(prodClusterQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "2").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, prodWl1, prodWl1Admission)
 			util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
@@ -304,7 +304,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("checking a dev workload gets admitted")
 			devWl := testing.MakeWorkload("dev-wl", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 			util.MustCreate(ctx, k8sClient, devWl)
-			spotUntaintedFlavorAdmission := testing.MakeAdmission(devClusterQ.Name).Assignment(corev1.ResourceCPU, "spot-untainted", "5").Obj()
+			spotUntaintedFlavorAdmission := testing.MakeAdmission(devClusterQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "spot-untainted", "5").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, devWl, spotUntaintedFlavorAdmission)
 			util.ExpectPendingWorkloadsMetric(devClusterQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(devClusterQ, 1)
@@ -313,7 +313,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("checking the second workload gets admitted when the first workload finishes")
 			util.FinishWorkloads(ctx, k8sClient, prodWl1)
-			prodWl2Admission := testing.MakeAdmission(prodClusterQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj()
+			prodWl2Admission := testing.MakeAdmission(prodClusterQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, prodWl2, prodWl2Admission)
 			util.ExpectPendingWorkloadsMetric(prodClusterQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(prodClusterQ, 1)
@@ -703,7 +703,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("First big workload starts")
 			wl1 := testing.MakeWorkload("on-demand-wl1", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "4").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
-			expectWl1Admission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "4").Obj()
+			expectWl1Admission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "4").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectWl1Admission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
@@ -722,7 +722,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("Third small workload starts")
 			wl3 := testing.MakeWorkload("on-demand-wl3", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
-			expectWl3Admission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()
+			expectWl3Admission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3, expectWl3Admission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 2)
@@ -731,7 +731,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("Second big workload starts after the first one is deleted")
 			gomega.Expect(k8sClient.Delete(ctx, wl1, client.PropagationPolicy(metav1.DeletePropagationBackground))).Should(gomega.Succeed())
-			expectWl2Admission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "4").Obj()
+			expectWl2Admission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "4").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, expectWl2Admission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 2)
@@ -755,7 +755,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("First big workload starts")
 			wl1 := testing.MakeWorkload("on-demand-wl1", ns.Name).Queue(kueue.LocalQueueName(fooQ.Name)).Request(corev1.ResourceCPU, "8").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
-			expectAdmission := testing.MakeAdmission(fooCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "8").Obj()
+			expectAdmission := testing.MakeAdmission(fooCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "8").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(fooCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(fooCQ, 1)
@@ -774,7 +774,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("Third small workload starts")
 			wl3 := testing.MakeWorkload("on-demand-wl3", ns.Name).Queue(kueue.LocalQueueName(fooQ.Name)).Request(corev1.ResourceCPU, "2").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
-			expectAdmission = testing.MakeAdmission(fooCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "2").Obj()
+			expectAdmission = testing.MakeAdmission(fooCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "2").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(fooCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(fooCQ, 2)
@@ -783,7 +783,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("Second big workload starts after the first one is deleted")
 			gomega.Expect(k8sClient.Delete(ctx, wl1, client.PropagationPolicy(metav1.DeletePropagationBackground))).Should(gomega.Succeed())
-			expectAdmission = testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "8").Obj()
+			expectAdmission = testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "8").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
@@ -835,7 +835,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				g.Expect(k8sClient.Update(ctx, updatedCq)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "6").Obj()
+			expectAdmission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "6").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
@@ -982,7 +982,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wl1 := testing.MakeWorkload("on-demand-wl1", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "5").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 
-			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj()
+			expectAdmission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
@@ -1002,7 +1002,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			wl3 := testing.MakeWorkload("on-demand-wl3", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Toleration(spotToleration).Request(corev1.ResourceCPU, "5").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
 
-			expectAdmission = testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "spot-tainted", "5").Obj()
+			expectAdmission = testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "spot-tainted", "5").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 2)
@@ -1040,7 +1040,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("checking a workload without affinity gets admitted on the first flavor")
 			wl1 := testing.MakeWorkload("no-affinity-workload", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
-			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "spot-untainted", "1").Obj()
+			expectAdmission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "spot-untainted", "1").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, expectAdmission)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 1)
 			util.ExpectQuotaReservedWorkloadsTotalMetric(cq, 1)
@@ -1053,7 +1053,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
 			gomega.Expect(wl2.Spec.PodSets[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(2))
-			expectAdmission = testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()
+			expectAdmission = testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(cq, 2)
@@ -1164,7 +1164,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				gomega.Expect(util.DeleteObject(ctx, k8sClient, fallbackClusterQueue)).ToNot(gomega.HaveOccurred())
 			}()
 
-			expectAdmission := testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()
+			expectAdmission := testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(prodCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(prodCQ, 1)
@@ -1301,15 +1301,15 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.MustCreate(ctx, k8sClient, wl1)
 			util.MustCreate(ctx, k8sClient, wl2)
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1,
-				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj())
+				testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).Obj())
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2,
-				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj())
+				testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).Obj())
 
 			ginkgo.By("Creating an additional workload that can't fit in the first flavor")
 			wl3 := testing.MakeWorkload("wl-3", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3,
-				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "spot-untainted", "1").Obj())
+				testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "spot-untainted", "1").Obj()).Obj())
 			util.ExpectPendingWorkloadsMetric(prodCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(prodCQ, 3)
 			util.ExpectQuotaReservedWorkloadsTotalMetric(prodCQ, 3)
@@ -1341,7 +1341,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("Creating one workload")
 			wl1 := testing.MakeWorkload("wl-1", ns.Name).Queue(kueue.LocalQueueName(prodQueue.Name)).Request(corev1.ResourceCPU, "9").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
-			prodWl1Admission := testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "9").Obj()
+			prodWl1Admission := testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "9").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, prodWl1Admission)
 			util.ExpectPendingWorkloadsMetric(prodCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(prodCQ, 1)
@@ -1351,7 +1351,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("Creating another workload")
 			wl2 := testing.MakeWorkload("wl-2", ns.Name).Queue(kueue.LocalQueueName(devQueue.Name)).Request(corev1.ResourceCPU, "11").Toleration(spotToleration).Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
-			prodWl2Admission := testing.MakeAdmission(devCQ.Name).Assignment(corev1.ResourceCPU, "spot-tainted", "11").Obj()
+			prodWl2Admission := testing.MakeAdmission(devCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "spot-tainted", "11").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl2, prodWl2Admission)
 			util.ExpectPendingWorkloadsMetric(devCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(devCQ, 1)
@@ -1400,7 +1400,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.FinishEvictionForWorkloads(ctx, k8sClient, wl1)
 
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl3,
-				testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj())
+				testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "5").Obj()).Obj())
 		})
 	})
 
@@ -1449,7 +1449,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				cohort.Spec.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota = resource.MustParse("10")
 				g.Expect(k8sClient.Update(ctx, cohort)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()
+			expectAdmission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
@@ -1483,7 +1483,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				cq.Spec.Cohort = "cohort"
 				g.Expect(k8sClient.Update(ctx, cq)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()
+			expectAdmission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
@@ -1527,7 +1527,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 					*testing.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "10").Obj(),
 				).Obj()
 			util.MustCreate(ctx, k8sClient, cohortBank)
-			expectAdmission := testing.MakeAdmission(cq.Name).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()
+			expectAdmission := testing.MakeAdmission(cq.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, 1)
@@ -1579,7 +1579,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				gomega.Expect(util.DeleteObject(ctx, k8sClient, devCQ)).ToNot(gomega.HaveOccurred())
 			}()
 
-			expectAdmission := testing.MakeAdmission(prodCQ.Name).Assignment(corev1.ResourceCPU, "on-demand", "9").Obj()
+			expectAdmission := testing.MakeAdmission(prodCQ.Name).PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "9").Obj()).Obj()
 			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
 			util.ExpectPendingWorkloadsMetric(prodCQ, 0, 0)
 			util.ExpectReservingActiveWorkloadsMetric(prodCQ, 1)
@@ -2569,13 +2569,13 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			cq1LowPriority := createWorkloadWithPriority("cq1", "1", 0)
 			{
-				admission := testing.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f2", "1").Obj()
+				admission := testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f2", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq1LowPriority, admission)
 			}
 
 			cq2HighPriority := createWorkloadWithPriority("cq1", "1", 9999)
 			{
-				admission := testing.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj()
+				admission := testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f1", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2HighPriority, admission)
 			}
 
@@ -2584,7 +2584,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.ExpectWorkloadsToBePreempted(ctx, k8sClient, cq2HighPriority)
 				util.FinishEvictionForWorkloads(ctx, k8sClient, cq2HighPriority)
 
-				admission := testing.MakeAdmission("cq2").Assignment(corev1.ResourceCPU, "f1", "1").Obj()
+				admission := testing.MakeAdmission("cq2").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f1", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2MiddlePriority, admission)
 			}
 
@@ -2592,7 +2592,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.ExpectWorkloadsToBePreempted(ctx, k8sClient, cq1LowPriority)
 				util.FinishEvictionForWorkloads(ctx, k8sClient, cq1LowPriority)
 
-				admission := testing.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f2", "1").Obj()
+				admission := testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f2", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2HighPriority, admission)
 			}
 		})
@@ -2632,7 +2632,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			cq1LowPriority := createWorkloadWithPriority("cq1", "1", 0)
 			{
-				admission := testing.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f2", "1").Obj()
+				admission := testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f2", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq1LowPriority, admission)
 			}
 
@@ -2641,10 +2641,10 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.ExpectWorkloadsToBePreempted(ctx, k8sClient, cq1LowPriority)
 				util.FinishEvictionForWorkloads(ctx, k8sClient, cq1LowPriority)
 
-				admission := testing.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f2", "1").Obj()
+				admission := testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f2", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2HighPriority, admission)
 
-				admission = testing.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj()
+				admission = testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f1", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq1LowPriority, admission)
 			}
 
@@ -2653,7 +2653,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.ExpectWorkloadsToBePreempted(ctx, k8sClient, cq1LowPriority)
 				util.FinishEvictionForWorkloads(ctx, k8sClient, cq1LowPriority)
 
-				admission := testing.MakeAdmission("cq2").Assignment(corev1.ResourceCPU, "f1", "1").Obj()
+				admission := testing.MakeAdmission("cq2").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f1", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2MiddlePriority, admission)
 			}
 		})
@@ -2681,13 +2681,13 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			cq1LowPriority := createWorkloadWithPriority("cq1", "1", 0)
 			{
-				admission := testing.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj()
+				admission := testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f1", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq1LowPriority, admission)
 			}
 
 			cq2HighPriority := createWorkloadWithPriority("cq1", "1", 9999)
 			{
-				admission := testing.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f2", "1").Obj()
+				admission := testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f2", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2HighPriority, admission)
 			}
 
@@ -2696,7 +2696,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.ExpectWorkloadsToBePreempted(ctx, k8sClient, cq2HighPriority)
 				util.FinishEvictionForWorkloads(ctx, k8sClient, cq2HighPriority)
 
-				admission := testing.MakeAdmission("cq2").Assignment(corev1.ResourceCPU, "f2", "1").Obj()
+				admission := testing.MakeAdmission("cq2").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f2", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2MiddlePriority, admission)
 			}
 
@@ -2704,11 +2704,12 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				util.ExpectWorkloadsToBePreempted(ctx, k8sClient, cq1LowPriority)
 				util.FinishEvictionForWorkloads(ctx, k8sClient, cq1LowPriority)
 
-				admission := testing.MakeAdmission("cq1").Assignment(corev1.ResourceCPU, "f1", "1").Obj()
+				admission := testing.MakeAdmission("cq1").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "f1", "1").Obj()).Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, cq2HighPriority, admission)
 			}
 		})
 	})
+
 	ginkgo.When("Deleting ClusterQueue should update cohort borrowable resources", func() {
 		ginkgo.It("Should prevent incorrect admission through borrowing after ClusterQueue deletion", func() {
 			ginkgo.By("Creating two ClusterQueues in the same cohort")

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -332,9 +332,13 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("checking the first workload gets created and admitted", func() {
 				util.MustCreate(ctx, k8sClient, wl1)
 				wl1Admission := testing.MakeAdmission(podsCountClusterQ.Name).
-					Assignment(corev1.ResourceCPU, "on-demand", "6").
-					Assignment(corev1.ResourcePods, "on-demand", "3").
-					AssignmentPodCount(3).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "on-demand").
+						ResourceUsage(corev1.ResourceCPU, "6").
+						Flavor(corev1.ResourcePods, "on-demand").
+						ResourceUsage(corev1.ResourcePods, "3").
+						Count(3).
+						Obj()).
 					Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, wl1Admission)
 				util.ExpectPendingWorkloadsMetric(podsCountClusterQ, 0, 0)
@@ -394,8 +398,11 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("checking the first workload gets created and admitted", func() {
 				util.MustCreate(ctx, k8sClient, wl1)
 				wl1Admission := testing.MakeAdmission(podsCountOnlyClusterQ.Name).
-					Assignment(corev1.ResourcePods, "on-demand", "3").
-					AssignmentPodCount(3).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourcePods, "on-demand").
+						ResourceUsage(corev1.ResourcePods, "3").
+						Count(3).
+						Obj()).
 					Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, wl1Admission)
 				util.ExpectPendingWorkloadsMetric(podsCountOnlyClusterQ, 0, 0)
@@ -501,8 +508,11 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("checking the first workload gets created and gets quota reserved", func() {
 				util.MustCreate(ctx, k8sClient, wl1)
 				wl1Admission := testing.MakeAdmission(admissionCheckClusterQ.Name).
-					Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(onDemandFlavor.Name), "2").
-					AssignmentPodCount(1).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, kueue.ResourceFlavorReference(onDemandFlavor.Name)).
+						ResourceUsage(corev1.ResourceCPU, "2").
+						Count(1).
+						Obj()).
 					Obj()
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl1, wl1Admission)
 				util.ExpectPendingWorkloadsMetric(admissionCheckClusterQ, 0, 0)

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -360,8 +360,7 @@ var _ = ginkgo.Describe("Workload validating webhook", ginkgo.Ordered, func() {
 				},
 				testing.MakeAdmission("cluster-queue").
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "flv").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "flv", "1").
 						Count(3).
 						Obj()).
 					Obj(),
@@ -1007,9 +1006,7 @@ var _ = ginkgo.Describe("Workload validating webhook", ginkgo.Ordered, func() {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
 				admission := testing.MakeAdmission("default").
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "default").
-						ResourceUsage(corev1.ResourceCPU, "1").
-						Count(1).
+						Assignment(corev1.ResourceCPU, "default", "1").
 						Obj()).
 					Obj()
 				workload.SetQuotaReservation(wl, admission, realClock)
@@ -1041,8 +1038,7 @@ var _ = ginkgo.Describe("Workload validating webhook", ginkgo.Ordered, func() {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
 				admission := testing.MakeAdmission("default").
 					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Flavor(corev1.ResourceCPU, "default").
-						ResourceUsage(corev1.ResourceCPU, "1").
+						Assignment(corev1.ResourceCPU, "default", "1").
 						Count(10).
 						Obj()).
 					Obj()

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -560,7 +560,7 @@ var _ = ginkgo.Describe("Workload validating webhook", ginkgo.Ordered, func() {
 				false,
 				func(newWL *kueue.Workload) {
 					newWL.Status = kueue.WorkloadStatus{
-						Admission: testing.MakeAdmission("cluster-queue").Assignment("on-demand", "5", "1").Obj(),
+						Admission: testing.MakeAdmission("cluster-queue").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment("on-demand", "5", "1").Obj()).Obj(),
 						Conditions: []metav1.Condition{{
 							Type:               kueue.WorkloadQuotaReserved,
 							Status:             metav1.ConditionTrue,
@@ -575,7 +575,7 @@ var _ = ginkgo.Describe("Workload validating webhook", ginkgo.Ordered, func() {
 			ginkgo.Entry("admission can be unset",
 				func() *kueue.Workload {
 					return testing.MakeWorkload(workloadName, ns.Name).ReserveQuota(
-						testing.MakeAdmission("cluster-queue").Assignment("on-demand", "5", "1").Obj(),
+						testing.MakeAdmission("cluster-queue").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment("on-demand", "5", "1").Obj()).Obj(),
 					).Obj()
 				},
 				false,
@@ -893,7 +893,7 @@ var _ = ginkgo.Describe("Workload validating webhook", ginkgo.Ordered, func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				var newWL kueue.Workload
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), &newWL)).To(gomega.Succeed())
-				newWL.Status.Admission = testing.MakeAdmission("cluster-queue").Assignment("on-demand", "5", "1").Obj()
+				newWL.Status.Admission = testing.MakeAdmission("cluster-queue").PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment("on-demand", "5", "1").Obj()).Obj()
 				g.Expect(k8sClient.Status().Update(ctx, &newWL)).Should(testing.BeForbiddenError())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -359,8 +359,11 @@ var _ = ginkgo.Describe("Workload validating webhook", ginkgo.Ordered, func() {
 						Obj()
 				},
 				testing.MakeAdmission("cluster-queue").
-					Assignment(corev1.ResourceCPU, "flv", "1").
-					AssignmentPodCount(3).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "flv").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(3).
+						Obj()).
 					Obj(),
 				testing.BeForbiddenError()),
 		)
@@ -1003,8 +1006,11 @@ var _ = ginkgo.Describe("Workload validating webhook", ginkgo.Ordered, func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
 				admission := testing.MakeAdmission("default").
-					Assignment(corev1.ResourceCPU, "default", "1").
-					AssignmentPodCount(1).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(1).
+						Obj()).
 					Obj()
 				workload.SetQuotaReservation(wl, admission, realClock)
 				wl.Status.Admission = admission
@@ -1034,8 +1040,11 @@ var _ = ginkgo.Describe("Workload validating webhook", ginkgo.Ordered, func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
 				admission := testing.MakeAdmission("default").
-					Assignment(corev1.ResourceCPU, "default", "1").
-					AssignmentPodCount(10).
+					PodSets(testing.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, "default").
+						ResourceUsage(corev1.ResourceCPU, "1").
+						Count(10).
+						Obj()).
 					Obj()
 				workload.SetQuotaReservation(wl, admission, realClock)
 				wl.Status.Admission = admission


### PR DESCRIPTION
Cherry pick of #6544 #6815 on release-0.13.

#6544: Reduce verbosity scheduler unit tests
#6815: Follow-up: Refactor assignment-related wrappers

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
NONE
```