### PR TITLE
Update (clean up) client  patch utility.

### DIFF
--- a/pkg/util/client/client.go
+++ b/pkg/util/client/client.go
@@ -22,62 +22,152 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type ClientPatchOption func(*ClientPatchOptions)
+// PatchOption defines a functional option for customizing PatchOptions.
+// It follows the functional options pattern, allowing callers to configure
+// patch behavior at call sites without directly manipulating PatchOptions.
+type PatchOption func(*PatchOptions)
 
-type ClientPatchOptions struct {
+// PatchOptions contains configuration parameters that control how patches
+// are generated and applied.
+//
+// Fields:
+//   - Strict: Controls whether ResourceVersion should always be cleared
+//     from the "original" object to ensure its inclusion in the generated
+//     patch. Defaults to true. Setting Strict=false preserves the current
+//     ResourceVersion.
+//
+// Typically, PatchOptions are constructed via DefaultPatchOptions and
+// modified using PatchOption functions (e.g., WithStrict).
+type PatchOptions struct {
 	Strict bool
 }
 
-func DefaultClientPatchOptions() *ClientPatchOptions {
-	return &ClientPatchOptions{
+// DefaultPatchOptions returns a new PatchOptions instance configured with
+// default settings.
+//
+// By default, Strict is set to true, meaning ResourceVersion is cleared
+// from the original object so it will always be included in the generated
+// patch. This ensures stricter version handling during patch application.
+func DefaultPatchOptions() *PatchOptions {
+	return &PatchOptions{
 		Strict: true, // default is strict
 	}
 }
 
-func WithStrict(strict bool) ClientPatchOption {
-	return func(o *ClientPatchOptions) {
+// WithStrict returns a PatchOption that sets the Strict field on PatchOptions.
+//
+// By default, Strict is true. In strict mode, generated patches enforce stricter
+// behavior by clearing the ResourceVersion field from the "original" object.
+// This ensures that the ResourceVersion is always included in the generated patch
+// and taken into account during patch application.
+//
+// Example:
+//
+//	patch := clientutil.Patch(ctx, c, obj, true, func() (bool, error) {
+//	    return updateFn(obj), nil
+//	}, WithStrict(false)) // disables strict mode
+func WithStrict(strict bool) PatchOption {
+	return func(o *PatchOptions) {
 		o.Strict = strict
 	}
 }
 
-func patchCommon(obj client.Object, update func() (client.Object, bool, error), patchFunc func(patch client.Patch) error, options ...ClientPatchOption) error {
-	opts := DefaultClientPatchOptions()
+func patchCommon(obj client.Object, update func() (client.Object, bool, error), patchFunc func(patch client.Patch) error, options ...PatchOption) error {
+	opts := DefaultPatchOptions()
 	for _, opt := range options {
 		opt(opts)
 	}
-	strict := opts.Strict
-	return updateAndPatch(obj, strict, update, patchFunc)
+	return updateAndPatch(obj, *opts, update, patchFunc)
 }
 
-// Patch applies the merge patch of client.Object.
-// If strict is true, the resourceVersion will be part of the patch, make this call fail if
-// client.Object was changed.
-func Patch(ctx context.Context, c client.Client, obj client.Object, update func() (client.Object, bool, error), options ...ClientPatchOption) error {
+// Patch applies an update to a Kubernetes object using a patch-based workflow.
+//
+// The function first computes the "original" and "modified" states of the object
+// by invoking the provided update callback, then generates a patch describing
+// the changes. Finally, it applies the patch through the given client.Client.
+//
+// Behavior is influenced by PatchOptions, which can be customized using
+// PatchOption functional arguments (e.g., WithStrict).
+//
+// Returns:
+//   - error: If patch generation or application fails, an error is returned.
+//
+// Example:
+//
+//	err := Patch(ctx, client, obj, func() (client.Object, bool, error) {
+//	    updated := obj.DeepCopyObject().(client.Object)
+//	    updated.SetLabels(map[string]string{"app": "demo"})
+//	    return updated, true, nil
+//	}, WithStrict(true))
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+// Notes:
+//   - By default, patches are generated in "strict" mode (Strict=true).
+//     This clears the ResourceVersion field in the original object to ensure
+//     it is always included in the generated patch.
+func Patch(ctx context.Context, c client.Client, obj client.Object, update func() (client.Object, bool, error), options ...PatchOption) error {
 	return patchCommon(obj, update, func(patch client.Patch) error {
 		return c.Patch(ctx, obj, patch)
 	}, options...)
 }
 
-// PatchStatus applies the merge patch of client.Object status.
-// The resourceVersion will be part of the patch, make this call fail if
-// client.Object was changed.
-func PatchStatus(ctx context.Context, c client.Client, obj client.Object, update func() (client.Object, bool, error), options ...ClientPatchOption) error {
+// PatchStatus applies an update to the *status* subresource of a Kubernetes object
+// using a patch-based workflow.
+//
+// The function computes the "original" and "modified" states of the object by
+// invoking the provided update callback, generates a patch describing the changes,
+// and applies the patch specifically through the client's status interface
+// (c.Status().Patch).
+//
+// Behavior is influenced by PatchOptions, which can be customized using
+// PatchOption functional arguments (e.g., WithStrict).
+//
+// Returns:
+//   - error: If patch generation or application fails, an error is returned.
+//
+// Example:
+//
+//	err := PatchStatus(ctx, client, obj, func() (client.Object, bool, error) {
+//	    updated := obj.DeepCopyObject().(client.Object)
+//	    myObj := updated.(*myv1.MyCustomResource)
+//	    myObj.Status.Phase = "Ready"
+//	    return updated, true, nil
+//	})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+// Notes:
+//   - By default, patches are generated in "strict" mode (Strict=true).
+//     This clears the ResourceVersion field in the original object to ensure
+//     it is always included in the generated patch.
+func PatchStatus(ctx context.Context, c client.Client, obj client.Object, update func() (client.Object, bool, error), options ...PatchOption) error {
 	return patchCommon(obj, update, func(patch client.Patch) error {
 		return c.Status().Patch(ctx, obj, patch)
 	}, options...)
 }
 
-func getOriginalObject(obj client.Object, strict bool) client.Object {
+// getOriginalObject creates and returns a deep copy of the given client.Object.
+// The copy represents the "original" state of the object before applying any
+// modifications. This is typically used when generating a patch.
+//
+// If PatchOptions.Strict is set to true, the function clears the
+// ResourceVersion field on the copied object. This ensures that the
+// ResourceVersion is included in the generated patch, enforcing stricter
+// version handling during patch application.
+func getOriginalObject(obj client.Object, options PatchOptions) client.Object {
 	objOriginal := obj.DeepCopyObject().(client.Object)
-	if strict {
+	if options.Strict {
 		// Clearing ResourceVersion from the original object to make sure it is included in the generated patch.
 		objOriginal.SetResourceVersion("")
 	}
 	return objOriginal
 }
 
-func updateAndPatch(obj client.Object, strict bool, update func() (client.Object, bool, error), patchFn func(client.Patch) error) error {
-	objOriginal := getOriginalObject(obj, strict)
+func updateAndPatch(obj client.Object, options PatchOptions, update func() (client.Object, bool, error), patchFn func(client.Patch) error) error {
+	objOriginal := getOriginalObject(obj, options)
 	objPatched, updated, err := update()
 	if err != nil || !updated {
 		return err

--- a/pkg/util/client/client_test.go
+++ b/pkg/util/client/client_test.go
@@ -1,0 +1,322 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+// newObject creates and returns a new *batchv1.Job initialized with the given
+// resourceVersion and default metadata (Namespace="default", Name="test").
+//
+// The returned Job can be further customized by applying the provided option
+// functions. Each option is a function that mutates the Job before it is
+// returned, allowing flexible and reusable configuration in tests or setup code.
+//
+// Used in TestPatch and TestPatchStatus.
+func newObject(resourceVersion string, opts ...func(*batchv1.Job)) *batchv1.Job {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "default",
+			Name:            "test",
+			ResourceVersion: resourceVersion,
+		},
+	}
+	for _, opt := range opts {
+		opt(job)
+	}
+	return job
+}
+
+func TestPatch(t *testing.T) {
+	type args struct {
+		ctx     context.Context
+		clnt    client.Client
+		obj     client.Object
+		update  func() (client.Object, bool, error)
+		options []PatchOption
+	}
+	type want struct {
+		err bool
+		obj client.Object // To assert patched object.
+	}
+
+	tests := map[string]struct {
+		args args
+		want want
+	}{
+		"Strict_OutdatedLocalObject": {
+			args: args{
+				ctx:  t.Context(),
+				clnt: utiltesting.NewClientBuilder().WithObjects(newObject("2")).Build(),
+				obj:  newObject("1"), // outdated local object results in patch error.
+				update: func() (client.Object, bool, error) {
+					obj := newObject("1")
+					obj.Spec.Suspend = ptr.To(true)
+					return obj, true, nil
+				},
+			},
+			want: want{
+				err: true,           // object was modified error.
+				obj: newObject("2"), // unchanged.
+			},
+		},
+		"Strict_CurrentLocalObject": {
+			args: args{
+				ctx:  t.Context(),
+				clnt: utiltesting.NewClientBuilder().WithObjects(newObject("2")).Build(),
+				obj:  newObject("2"),
+				update: func() (client.Object, bool, error) {
+					obj := newObject("2")
+					obj.Spec.Suspend = ptr.To(true)
+					obj.Status.Active = 1
+					return obj, true, nil
+				},
+			},
+			want: want{
+				obj: newObject("3", // post-patch incremented resource version.
+					func(job *batchv1.Job) {
+						// Change to Spec is applied; Status change is ignored because Patch updates meta and spec only.
+						job.Spec.Suspend = ptr.To(true)
+					}),
+			},
+		},
+		"NotStrict_OutdatedLocalObject": {
+			args: args{
+				ctx:  t.Context(),
+				clnt: utiltesting.NewClientBuilder().WithObjects(newObject("2")).Build(),
+				obj:  newObject("1"), // outdated local object.
+				update: func() (client.Object, bool, error) {
+					obj := newObject("1")
+					obj.Spec.Suspend = ptr.To(true)
+					return obj, true, nil
+				},
+				options: []PatchOption{WithStrict(false)},
+			},
+			want: want{
+				// Unlike "Strict" version - this update is successful since the resource version is not
+				// included in the patch.
+				obj: newObject("3", func(job *batchv1.Job) {
+					job.Spec.Suspend = ptr.To(true)
+				}),
+			},
+		},
+		"NotStrict_CurrentLocalObject": {
+			args: args{
+				ctx:  t.Context(),
+				clnt: utiltesting.NewClientBuilder().WithObjects(newObject("2")).Build(),
+				obj:  newObject("2"),
+				update: func() (client.Object, bool, error) {
+					obj := newObject("2")
+					obj.Spec.Suspend = ptr.To(true)
+					return obj, true, nil
+				},
+				options: []PatchOption{WithStrict(false)},
+			},
+			want: want{
+				obj: newObject("3", func(job *batchv1.Job) {
+					job.Spec.Suspend = ptr.To(true)
+				}),
+			},
+		},
+		"NoChanges": {
+			// Modeled after "Strict_OutdatedLocalObject"; however since we are returning
+			// updated: false - it makes no difference if the local object is outdated.
+			args: args{
+				ctx:  t.Context(),
+				clnt: utiltesting.NewClientBuilder().WithObjects(newObject("2")).Build(),
+				obj:  newObject("1"), // outdated local object results in patch error.
+				update: func() (client.Object, bool, error) {
+					return newObject("1"), false, nil
+				},
+			},
+			want: want{
+				obj: newObject("2"),
+			},
+		},
+		"Error": {
+			args: args{
+				ctx:  t.Context(),
+				clnt: utiltesting.NewClientBuilder().WithObjects(newObject("2")).Build(),
+				obj:  newObject("2"),
+				update: func() (client.Object, bool, error) {
+					return newObject("2"), true, errors.New("test-error")
+				},
+			},
+			want: want{
+				err: true,
+				obj: newObject("2"),
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := Patch(tt.args.ctx, tt.args.clnt, tt.args.obj, tt.args.update, tt.args.options...); (err != nil) != tt.want.err {
+				t.Errorf("Patch() error = %v, wantErr %v", err, tt.want.err)
+			}
+			if err := tt.args.clnt.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.obj), tt.args.obj); err != nil {
+				t.Errorf("Patch() unexpected error getting object: %v", err)
+			}
+			if diff := cmp.Diff(tt.want.obj, tt.args.obj); diff != "" {
+				t.Errorf("Patch() object (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPatchStatus(t *testing.T) {
+	type args struct {
+		ctx     context.Context
+		clnt    client.Client
+		obj     client.Object
+		update  func() (client.Object, bool, error)
+		options []PatchOption
+	}
+	type want struct {
+		err bool
+		obj client.Object // To assert patched object.
+	}
+
+	tests := map[string]struct {
+		args args
+		want want
+	}{
+		"Strict_OutdatedLocalObject": {
+			args: args{
+				ctx:  t.Context(),
+				clnt: utiltesting.NewClientBuilder().WithObjects(newObject("2")).Build(),
+				obj:  newObject("1"), // outdated local object results in patch error.
+				update: func() (client.Object, bool, error) {
+					return newObject("1"), true, nil
+				},
+			},
+			want: want{
+				err: true,           // object was modified error.
+				obj: newObject("2"), // unchanged.
+			},
+		},
+		"Strict_CurrentLocalObject": {
+			args: args{
+				ctx:  t.Context(),
+				clnt: utiltesting.NewClientBuilder().WithObjects(newObject("2")).Build(),
+				obj:  newObject("2"),
+				update: func() (client.Object, bool, error) {
+					obj := newObject("2")
+					obj.Status.Active = 1
+					obj.Spec.Suspend = ptr.To(true)
+					return obj, true, nil
+				},
+			},
+			want: want{
+				obj: newObject("3", func(job *batchv1.Job) {
+					// Change to Status is applied; Spec change is ignored because Patch updates status only.
+					job.Status.Active = 1
+				}), // incremented.
+			},
+		},
+		"NotStrict_OutdatedLocalObject": {
+			args: args{
+				ctx:  t.Context(),
+				clnt: utiltesting.NewClientBuilder().WithObjects(newObject("2")).Build(),
+				obj:  newObject("1"), // outdated local object.
+				update: func() (client.Object, bool, error) {
+					obj := newObject("1")
+					obj.Status.Active = 1
+					return obj, true, nil
+				},
+				options: []PatchOption{WithStrict(false)},
+			},
+			want: want{
+				obj: newObject("3", func(job *batchv1.Job) {
+					job.Status.Active = 1
+				}),
+			},
+		},
+		"NotStrict_CurrentLocalObject": {
+			args: args{
+				ctx:  t.Context(),
+				clnt: utiltesting.NewClientBuilder().WithObjects(newObject("2")).Build(),
+				obj:  newObject("2"),
+				update: func() (client.Object, bool, error) {
+					obj := newObject("2")
+					obj.Status.Active = 1
+					return obj, true, nil
+				},
+				options: []PatchOption{WithStrict(false)},
+			},
+			want: want{
+				obj: newObject("3", func(job *batchv1.Job) {
+					job.Status.Active = 1
+				}),
+			},
+		},
+		"NoChanges": {
+			// Modeled after "Strict_OutdatedLocalObject"; however since we are returning
+			// false - it makes no difference if the local object is outdated.
+			args: args{
+				ctx:  t.Context(),
+				clnt: utiltesting.NewClientBuilder().WithObjects(newObject("2")).Build(),
+				obj:  newObject("1"), // outdated local object results in patch error.
+				update: func() (client.Object, bool, error) {
+					return newObject("1"), false, nil
+				},
+			},
+			want: want{
+				obj: newObject("2"),
+			},
+		},
+		"Error": {
+			args: args{
+				ctx:  t.Context(),
+				clnt: utiltesting.NewClientBuilder().WithObjects(newObject("2")).Build(),
+				obj:  newObject("2"),
+				update: func() (client.Object, bool, error) {
+					obj := newObject("2")
+					obj.Status.Active = 1
+					return obj, true, errors.New("test-error")
+				},
+			},
+			want: want{
+				err: true,
+				obj: newObject("2"),
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := PatchStatus(tt.args.ctx, tt.args.clnt, tt.args.obj, tt.args.update, tt.args.options...); (err != nil) != tt.want.err {
+				t.Errorf("Patch() error = %v, wantErr %v", err, tt.want.err)
+			}
+			if err := tt.args.clnt.Get(tt.args.ctx, client.ObjectKeyFromObject(tt.args.obj), tt.args.obj); err != nil {
+				t.Errorf("Patch() unexpected error getting object: %v", err)
+			}
+			if diff := cmp.Diff(tt.want.obj, tt.args.obj); diff != "" {
+				t.Errorf("Patch() object (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:
This PR is a follow-up to the #6778 and #6792

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6862

#### Special notes for your reviewer:
This follow-up cleanup PR includes the following minor changes:
* Public code: remove stutter by renaming client.ClientPatch* → client.Patch* and similar.
* Private code: avoid early PatchOptions unwrapping and instead push options down the call stack.
* Tests: add unit test coverage.
* Docs: add GoDoc comments to clarify options and functionality.

Note: Although this PR touches public code, it only adjusts recently introduced changes and does not require any broader refactoring. If we agree this approach makes sense, it would be best to merge it before other work starts to depend on the newly added (and modified) public API.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```