### PR TITLE
(cleanup): remove redundant type arguments

### DIFF
--- a/pkg/cache/hierarchy/manager_test.go
+++ b/pkg/cache/hierarchy/manager_test.go
@@ -498,7 +498,7 @@ type testCohort struct {
 func newCohort(name kueue.CohortReference) *testCohort {
 	return &testCohort{
 		name:   name,
-		Cohort: NewCohort[*testClusterQueue, *testCohort](),
+		Cohort: NewCohort[*testClusterQueue](),
 	}
 }
 

--- a/pkg/cache/queue/cohort.go
+++ b/pkg/cache/queue/cohort.go
@@ -31,7 +31,7 @@ type cohort struct {
 func newCohort(name kueue.CohortReference) *cohort {
 	return &cohort{
 		name,
-		hierarchy.NewCohort[*ClusterQueue, *cohort](),
+		hierarchy.NewCohort[*ClusterQueue](),
 	}
 }
 

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -131,7 +131,7 @@ func NewManager(client client.Client, checker StatusChecker, options ...Option) 
 			PodsReadyRequeuingTimestamp: config.EvictionTimestamp,
 		},
 		workloadInfoOptions: []workload.InfoOption{},
-		hm:                  hierarchy.NewManager[*ClusterQueue, *cohort](newCohort),
+		hm:                  hierarchy.NewManager(newCohort),
 
 		topologyUpdateWatchers: make([]TopologyUpdateWatcher, 0),
 		secondPassQueue:        newSecondPassQueue(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```