### PR TITLE
Refine IsActive logic to ignore Pods stuck terminating in pod-integration pod-groups

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -392,9 +392,27 @@ func (p *Pod) PodSets() ([]kueue.PodSet, error) {
 // IsActive returns true if there are any running pods.
 func (p *Pod) IsActive() bool {
 	for i := range p.list.Items {
-		if p.list.Items[i].Status.Phase == corev1.PodRunning {
-			return true
+		pod := p.list.Items[i]
+
+		// Pods that are not in the Running phase are never considered Active.
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
 		}
+
+		// If a pod is stuck terminating (e.g., due to a lost node), we should avoid
+		// charging quota for it, as doing so could block the user from scaling up
+		// replacement pods.
+		if pod.DeletionTimestamp != nil && pod.DeletionGracePeriodSeconds != nil {
+			now := p.clock.Now()
+			deletionTime := pod.DeletionTimestamp.Time
+			gracePeriod := time.Duration(*pod.DeletionGracePeriodSeconds) * time.Second
+			if now.After(deletionTime.Add(gracePeriod)) {
+				continue
+			}
+		}
+
+		// At this point, the pod is Running and not stuck terminating — count as active.
+		return true
 	}
 	return false
 }

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -389,7 +389,17 @@ func (p *Pod) PodSets() ([]kueue.PodSet, error) {
 	}
 }
 
-// IsActive returns true if there are any running pods.
+// IsActive reports whether a Pod or PodGroup should be considered active.
+//
+// For regular Pod, return value is always false.
+//
+// For Pod group, return true if there is at least a single Active pod in the group.
+// A Pod is considered active if it is in the Running phase and has not exceeded
+// its deletion grace period. Pods in other phases are ignored. If a Pod is
+// terminating (has a DeletionTimestamp) and its grace period has already
+// elapsed, it is treated as inactive. This prevents workloads from being
+// blocked by Pods that are stuck terminating, ensuring quota can be released
+// and new Pods admitted.
 func (p *Pod) IsActive() bool {
 	for i := range p.list.Items {
 		pod := p.list.Items[i]
@@ -400,13 +410,11 @@ func (p *Pod) IsActive() bool {
 		}
 
 		// If a pod is stuck terminating (e.g., due to a lost node), we should avoid
-		// charging quota for it, as doing so could block the user from scaling up
-		// replacement pods.
+		// counting as Active, as doing so could block the workload to release acquired quota.
 		if pod.DeletionTimestamp != nil && pod.DeletionGracePeriodSeconds != nil {
 			now := p.clock.Now()
-			deletionTime := pod.DeletionTimestamp.Time
 			gracePeriod := time.Duration(*pod.DeletionGracePeriodSeconds) * time.Second
-			if now.After(deletionTime.Add(gracePeriod)) {
+			if now.After(pod.DeletionTimestamp.Add(gracePeriod)) {
 				continue
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?

<!--  
Add one of the following kinds:  
/kind bug  
/kind cleanup  
/kind documentation  
/kind feature  

Optionally add one or more of the following kinds if applicable:  
/kind api-change  
/kind deprecation  
/kind failing-test  
/kind flake  
/kind regression  
-->

#### What this PR does / why we need it

This PR refines the pod-integration `IsActive` logic by adding support for pods that are stuck in the **Terminating** state. Without this change, terminating pods with an expired grace period may still be treated as active, blocking quota release and preventing forward progress.

#### Which issue(s) this PR fixes

<!--  
Automatically closes linked issue when PR is merged.  
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.  
If PR is about failing-tests or flakes, please post the related issues/tests in a comment and do not use `Fixes`.  
-->

Related to #6757

#### Special notes for your reviewer

N/A

#### Does this PR introduce a user-facing change?

```release-note
Pod-integration now correctly handles pods stuck in the Terminating state within pod groups, preventing them from being counted as active and avoiding blocked quota release.
```

