### PR TITLE
(cleanup): remove redundant type arguments again

### DIFF
--- a/apis/config/v1beta1/defaults_test.go
+++ b/apis/config/v1beta1/defaults_test.go
@@ -531,7 +531,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					GCInterval:        &metav1.Duration{Duration: time.Second},
 					Origin:            ptr.To("multikueue-manager1"),
 					WorkerLostTimeout: &metav1.Duration{Duration: time.Minute},
-					DispatcherName:    ptr.To[string](MultiKueueDispatcherModeIncremental),
+					DispatcherName:    ptr.To(MultiKueueDispatcherModeIncremental),
 				},
 			},
 			want: &Configuration{
@@ -547,7 +547,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					GCInterval:        &metav1.Duration{Duration: time.Second},
 					Origin:            ptr.To("multikueue-manager1"),
 					WorkerLostTimeout: &metav1.Duration{Duration: time.Minute},
-					DispatcherName:    ptr.To[string](MultiKueueDispatcherModeIncremental),
+					DispatcherName:    ptr.To(MultiKueueDispatcherModeIncremental),
 				},
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             &WaitForPodsReady{},

--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -122,7 +122,7 @@ func New(client client.Client, options ...Option) *Cache {
 		assumedWorkloads: make(map[workload.Reference]kueue.ClusterQueueReference),
 		resourceFlavors:  make(map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor),
 		admissionChecks:  make(map[kueue.AdmissionCheckReference]AdmissionCheck),
-		hm:               hierarchy.NewManager[*clusterQueue, *cohort](newCohort),
+		hm:               hierarchy.NewManager(newCohort),
 		tasCache:         NewTASCache(client),
 	}
 	for _, option := range options {

--- a/pkg/cache/scheduler/cohort.go
+++ b/pkg/cache/scheduler/cohort.go
@@ -38,7 +38,7 @@ type cohort struct {
 func newCohort(name kueue.CohortReference) *cohort {
 	return &cohort{
 		Name:         name,
-		Cohort:       hierarchy.NewCohort[*clusterQueue, *cohort](),
+		Cohort:       hierarchy.NewCohort[*clusterQueue](),
 		resourceNode: NewResourceNode(),
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -335,7 +335,7 @@ webhook:
 kind: Configuration
 namespace: kueue-system
 objectRetentionPolicies:
-  workloads: 
+  workloads:
     afterFinished: 30m
     afterDeactivatedByKueue: 30m
 `), os.FileMode(0600)); err != nil {
@@ -383,8 +383,8 @@ objectRetentionPolicies:
 	}
 
 	defaultClientConnection := &configapi.ClientConnection{
-		QPS:   ptr.To[float32](configapi.DefaultClientConnectionQPS),
-		Burst: ptr.To[int32](configapi.DefaultClientConnectionBurst),
+		QPS:   ptr.To(configapi.DefaultClientConnectionQPS),
+		Burst: ptr.To(configapi.DefaultClientConnectionBurst),
 	}
 
 	defaultIntegrations := &configapi.Integrations{
@@ -412,7 +412,7 @@ objectRetentionPolicies:
 		GCInterval:        &metav1.Duration{Duration: configapi.DefaultMultiKueueGCInterval},
 		Origin:            ptr.To(configapi.DefaultMultiKueueOrigin),
 		WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
-		DispatcherName:    ptr.To[string](configapi.MultiKueueDispatcherModeAllAtOnce),
+		DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeAllAtOnce),
 	}
 
 	defaultWaitForPodsReady := &configapi.WaitForPodsReady{}
@@ -908,7 +908,7 @@ objectRetentionPolicies:
 					GCInterval:        &metav1.Duration{Duration: 90 * time.Second},
 					Origin:            ptr.To("multikueue-manager1"),
 					WorkerLostTimeout: &metav1.Duration{Duration: 10 * time.Minute},
-					DispatcherName:    ptr.To[string](configapi.MultiKueueDispatcherModeIncremental),
+					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeIncremental),
 				},
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             defaultWaitForPodsReady,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```