### PR TITLE
TAS: stop injecting the TAS Label into Pods

### DIFF
--- a/apis/kueue/v1beta1/topology_types.go
+++ b/apis/kueue/v1beta1/topology_types.go
@@ -74,6 +74,8 @@ const (
 	// PodSet is admitted using TopologyAwareScheduling, and all Pods created
 	// from the Job's PodTemplate also have the label. For the Pod-based
 	// integrations the label is added in webhook during the Pod creation.
+	// Depracted. This label is no longer added by TAS to Pod. The constant is
+	// only kept to support "reading" the label until 0.16.
 	TASLabel = "kueue.x-k8s.io/tas"
 
 	// PodGroupPodIndexLabel is a label set on the Pod's metadata belonging

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -25,8 +25,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/fields"
 	resourcehelpers "k8s.io/component-helpers/resource"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -115,13 +114,8 @@ func (c *TASFlavorCache) snapshot(ctx context.Context) (*TASFlavorSnapshot, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to list nodes for TAS: %w", err)
 	}
-	r, err := labels.NewRequirement(kueue.TASLabel, selection.DoesNotExist, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build requirement for non-TAS pods: %w", err)
-	}
 	podListOpts := &client.ListOptions{}
-	podListOpts.LabelSelector = labels.NewSelector()
-	podListOpts.LabelSelector = podListOpts.LabelSelector.Add(*r)
+	podListOpts.FieldSelector = fields.OneTermEqualSelector(indexer.TASKey, "false")
 	pods := corev1.PodList{}
 	err = c.client.List(ctx, &pods, podListOpts)
 	if err != nil {

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -359,7 +359,7 @@ func (c *Controller) createPodTemplate(ctx context.Context, wl *kueue.Workload, 
 	}
 
 	// apply the admission node selectors to the Template
-	psi, err := podset.FromAssignment(ctx, c.client, psa, ptr.Deref(psa.Count, ps.Count))
+	psi, err := podset.FromAssignment(ctx, c.client, psa, ps)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1287,7 +1287,7 @@ func getPodSetsInfoFromStatus(ctx context.Context, c client.Client, w *kueue.Wor
 	podSetsInfo := make([]podset.PodSetInfo, len(w.Status.Admission.PodSetAssignments))
 
 	for i, psAssignment := range w.Status.Admission.PodSetAssignments {
-		info, err := podset.FromAssignment(ctx, c, &psAssignment, w.Spec.PodSets[i].Count)
+		info, err := podset.FromAssignment(ctx, c, &psAssignment, &w.Spec.PodSets[i])
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -134,7 +134,7 @@ func (h *podHandler) queueReconcileForPod(ctx context.Context, object client.Obj
 	if !isPod {
 		return
 	}
-	if _, found := pod.Labels[kueue.TASLabel]; !found {
+	if !utiltas.IsTAS(pod) {
 		// skip non-TAS pods
 		return
 	}

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -188,8 +188,8 @@ func TestFromAssignment(t *testing.T) {
 			wantInfo: PodSetInfo{
 				Name:  "name",
 				Count: 4,
-				Labels: map[string]string{
-					kueue.TASLabel: "true",
+				Annotations: map[string]string{
+					kueue.PodSetUnconstrainedTopologyAnnotation: "true",
 				},
 				NodeSelector: map[string]string{
 					"f1l1": "f1v1",
@@ -238,7 +238,10 @@ func TestFromAssignment(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, tc.enableTopologyAwareScheduling)
 			client := utiltesting.NewClientBuilder().WithLists(&kueue.ResourceFlavorList{Items: tc.flavors}).Build()
 
-			gotInfo, gotError := FromAssignment(ctx, client, tc.assignment, tc.defaultCount)
+			podSet := kueue.PodSet{
+				Count: tc.defaultCount,
+			}
+			gotInfo, gotError := FromAssignment(ctx, client, tc.assignment, &podSet)
 
 			if diff := cmp.Diff(tc.wantError, gotError); diff != "" {
 				t.Errorf("Unexpected error (-want/+got):\n%s", diff)

--- a/pkg/util/tas/tas.go
+++ b/pkg/util/tas/tas.go
@@ -21,13 +21,37 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	kueuealpha "sigs.k8s.io/kueue/apis/kueue/v1beta1"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
 )
 
 type TopologyDomainID string
 
 func DomainID(levelValues []string) TopologyDomainID {
 	return TopologyDomainID(strings.Join(levelValues, ","))
+}
+
+func IsTAS(pod *corev1.Pod) bool {
+	if IsExplicitTAS(pod.Annotations) {
+		return true
+	}
+	if _, ok := pod.Annotations[kueue.PodSetUnconstrainedTopologyAnnotation]; ok {
+		return true
+	}
+	// TODO: remove after 0.16
+	if _, ok := pod.Labels[kueue.TASLabel]; ok {
+		return true
+	}
+	return false
+}
+
+func IsExplicitTAS(annots map[string]string) bool {
+	if _, ok := annots[kueue.PodSetPreferredTopologyAnnotation]; ok {
+		return true
+	}
+	if _, ok := annots[kueue.PodSetRequiredTopologyAnnotation]; ok {
+		return true
+	}
+	return false
 }
 
 func NodeLabelsFromKeysAndValues(keys, values []string) map[string]string {
@@ -46,7 +70,7 @@ func LevelValues(levelKeys []string, objectLabels map[string]string) []string {
 	return levelValues
 }
 
-func Levels(topology *kueuealpha.Topology) []string {
+func Levels(topology *kueue.Topology) []string {
 	result := make([]string, len(topology.Spec.Levels))
 	for i, level := range topology.Spec.Levels {
 		result[i] = level.NodeLabel


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #3450

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: stop setting the "kueue.x-k8s.io/tas" label on Pods. 

In case the implicit TAS mode is used, then the `kueue.x-k8s.io/podset-unconstrained-topology=true` annotation
is set on Pods.
```