### PR TITLE
WIP: Add integration test for DRA config change

### DIFF
--- a/test/integration/singlecluster/controller/dra/suite_test.go
+++ b/test/integration/singlecluster/controller/dra/suite_test.go
@@ -107,9 +107,6 @@ func managerSetup(modifyConfig func(*config.Configuration)) framework.ManagerSet
 			},
 		}
 
-		err = dra.CreateMapperFromConfiguration(mappings)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
 		// Controllers configuration
 		controllersCfg := &config.Configuration{
 			Namespace: ptr.To("kueue-system"),
@@ -122,6 +119,9 @@ func managerSetup(modifyConfig func(*config.Configuration)) framework.ManagerSet
 		if modifyConfig != nil {
 			modifyConfig(controllersCfg)
 		}
+
+		err = dra.CreateMapperFromConfiguration(controllersCfg.Resources.DeviceClassMappings)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		cCache := schdcache.New(mgr.GetClient())
 		queues := qcache.NewManager(mgr.GetClient(), cCache)

--- a/test/integration/singlecluster/controller/dra/suite_test.go
+++ b/test/integration/singlecluster/controller/dra/suite_test.go
@@ -82,59 +82,64 @@ var _ = ginkgo.AfterSuite(func() {
 })
 
 // Manager setup used by tests to start controllers with DRA ConfigMap configuration
-func managerSetup(ctx context.Context, mgr manager.Manager) {
-	// Indexes
-	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+func managerSetup(modifyConfig func(*config.Configuration)) framework.ManagerSetup {
+	return func(ctx context.Context, mgr manager.Manager) {
+		// Indexes
+		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	// Webhooks
-	failedWebhook, err := webhooks.Setup(mgr, config.MultiKueueDispatcherModeAllAtOnce)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
+		// Webhooks
+		failedWebhook, err := webhooks.Setup(mgr, config.MultiKueueDispatcherModeAllAtOnce)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
-	mappings := []config.DeviceClassMapping{
-		{
-			Name:             corev1.ResourceName("foo"),
-			DeviceClassNames: []corev1.ResourceName{"foo.example.com"},
-		},
-		{
-			Name:             corev1.ResourceName("res-1"),
-			DeviceClassNames: []corev1.ResourceName{"test-deviceclass-1"},
-		},
-		{
-			Name:             corev1.ResourceName("res-2"),
-			DeviceClassNames: []corev1.ResourceName{"test-deviceclass-2"},
-		},
+		mappings := []config.DeviceClassMapping{
+			{
+				Name:             corev1.ResourceName("foo"),
+				DeviceClassNames: []corev1.ResourceName{"foo.example.com"},
+			},
+			{
+				Name:             corev1.ResourceName("res-1"),
+				DeviceClassNames: []corev1.ResourceName{"test-deviceclass-1"},
+			},
+			{
+				Name:             corev1.ResourceName("res-2"),
+				DeviceClassNames: []corev1.ResourceName{"test-deviceclass-2"},
+			},
+		}
+
+		err = dra.CreateMapperFromConfiguration(mappings)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Controllers configuration
+		controllersCfg := &config.Configuration{
+			Namespace: ptr.To("kueue-system"),
+			Resources: &config.Resources{
+				DeviceClassMappings: mappings,
+			},
+		}
+		mgr.GetScheme().Default(controllersCfg)
+		controllersCfg.Metrics.EnableClusterQueueResources = true
+		if modifyConfig != nil {
+			modifyConfig(controllersCfg)
+		}
+
+		cCache := schdcache.New(mgr.GetClient())
+		queues := qcache.NewManager(mgr.GetClient(), cCache)
+
+		// Core controllers
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, controllersCfg)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+
+		// Scheduler - required for workload admission
+		sched := scheduler.New(
+			queues,
+			cCache,
+			mgr.GetClient(),
+			mgr.GetEventRecorderFor("kueue-admission"),
+		)
+		err = mgr.Add(sched)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
-
-	err = dra.CreateMapperFromConfiguration(mappings)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	// Controllers configuration
-	controllersCfg := &config.Configuration{
-		Namespace: ptr.To("kueue-system"),
-		Resources: &config.Resources{
-			DeviceClassMappings: mappings,
-		},
-	}
-	mgr.GetScheme().Default(controllersCfg)
-	controllersCfg.Metrics.EnableClusterQueueResources = true
-
-	cCache := schdcache.New(mgr.GetClient())
-	queues := qcache.NewManager(mgr.GetClient(), cCache)
-
-	// Core controllers
-	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, controllersCfg)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
-
-	// Scheduler - required for workload admission
-	sched := scheduler.New(
-		queues,
-		cCache,
-		mgr.GetClient(),
-		mgr.GetEventRecorderFor("kueue-admission"),
-	)
-	err = mgr.Add(sched)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
 // Helper function to create a ResourceClaim


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR addresses the first "Nice to have" item listed in #5873:
> * [ ]  Add integration for config change [Add support for DRA devices in kueue workloads #5873 (comment)](https://github.com/kubernetes-sigs/kueue/pull/5873#discussion_r2344377833)

This PR extends the existing DRA integration test that ensures a workload with an unmapped DeviceClass is not admitted. After the existing steps are done, this PR adds steps to restart the controllers with new configuration that maps the DeviceClass and ensures the workload is admitted.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```