### PR TITLE
fix: ensure webhook configurations use the correct resource name

### DIFF
--- a/pkg/util/cert/cert_test.go
+++ b/pkg/util/cert/cert_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cert
+
+import (
+	"testing"
+)
+
+func TestDeriveWebhookBaseName(t *testing.T) {
+	tests := []struct {
+		name               string
+		webhookServiceName string
+		expectedBaseName   string
+	}{
+		{
+			name:               "default kueue service name",
+			webhookServiceName: "kueue-webhook-service",
+			expectedBaseName:   "kueue",
+		},
+		{
+			name:               "custom release name",
+			webhookServiceName: "test-kueue-webhook-service",
+			expectedBaseName:   "test-kueue",
+		},
+		{
+			name:               "production release name",
+			webhookServiceName: "prod-kueue-webhook-service",
+			expectedBaseName:   "prod-kueue",
+		},
+		{
+			name:               "complex release name",
+			webhookServiceName: "my-company-staging-kueue-webhook-service",
+			expectedBaseName:   "my-company-staging-kueue",
+		},
+		{
+			name:               "service name without expected suffix",
+			webhookServiceName: "kueue-service",
+			expectedBaseName:   "kueue-service",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := deriveWebhookBaseName(tt.webhookServiceName)
+			if result != tt.expectedBaseName {
+				t.Errorf("deriveWebhookBaseName(%q) = %q, want %q",
+					tt.webhookServiceName, result, tt.expectedBaseName)
+			}
+		})
+	}
+}
+
+func TestBuildWebhookConfigurationName(t *testing.T) {
+	tests := []struct {
+		name         string
+		baseName     string
+		webhookType  string
+		expectedName string
+	}{
+		{
+			name:         "mutating webhook for kueue",
+			baseName:     "kueue",
+			webhookType:  "mutating",
+			expectedName: "kueue-mutating-webhook-configuration",
+		},
+		{
+			name:         "validating webhook for kueue",
+			baseName:     "kueue",
+			webhookType:  "validating",
+			expectedName: "kueue-validating-webhook-configuration",
+		},
+		{
+			name:         "mutating webhook for custom release",
+			baseName:     "custome-kueue-name",
+			webhookType:  "mutating",
+			expectedName: "custome-kueue-name-mutating-webhook-configuration",
+		},
+		{
+			name:         "validating webhook for custom release",
+			baseName:     "custome-kueue-name",
+			webhookType:  "validating",
+			expectedName: "custome-kueue-name-validating-webhook-configuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildWebhookConfigurationName(tt.baseName, tt.webhookType)
+			if result != tt.expectedName {
+				t.Errorf("buildWebhookConfigurationName(%q, %q) = %q, want %q",
+					tt.baseName, tt.webhookType, result, tt.expectedName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This is a follow up to this [previous PR](https://github.com/kubernetes-sigs/kueue/pull/6869) which fixed an issue where the controller-manager would not start up properly when using a name other than kueue with internal cert management enabled. The helm chart takes into account the helm installation name when templating the MutatingWebhookConfiguration and ValidatingWebhookConfiguration. The controller, however, assumes a hard coded name of kueue. This updates the ManageCerts function to use the correct resource names when setting up the webhooks.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [# 6866](https://github.com/kubernetes-sigs/kueue/issues/6866) 

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Helm: Fixed bug where webhook configurations assumed a helm install name as "kueue".
```