### PR TITLE
[Fair Sharing] Fix Rounding Bug

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -707,10 +707,10 @@ func (c *Cache) Usage(cqObj *kueue.ClusterQueue) (*ClusterQueueUsageStats, error
 	}
 
 	if c.fairSharingEnabled {
-		weightedShare, _ := dominantResourceShare(cq, nil)
-		stats.WeightedShare = int64(weightedShare)
+		drs := dominantResourceShare(cq, nil)
+		weightedShare, _ := drs.roundedWeightedShare()
+		stats.WeightedShare = weightedShare
 	}
-
 	return stats, nil
 }
 
@@ -729,8 +729,9 @@ func (c *Cache) CohortStats(cohortObj *kueue.Cohort) (*CohortUsageStats, error) 
 
 	stats := &CohortUsageStats{}
 	if c.fairSharingEnabled {
-		weightedShare, _ := dominantResourceShare(cohort, nil)
-		stats.WeightedShare = int64(weightedShare)
+		drs := dominantResourceShare(cohort, nil)
+		weightedShare, _ := drs.roundedWeightedShare()
+		stats.WeightedShare = weightedShare
 	}
 
 	return stats, nil

--- a/pkg/cache/scheduler/clusterqueue_snapshot.go
+++ b/pkg/cache/scheduler/clusterqueue_snapshot.go
@@ -200,9 +200,8 @@ func (c *ClusterQueueSnapshot) parentHRN() hierarchicalResourceNode {
 	return c.Parent()
 }
 
-func (c *ClusterQueueSnapshot) DominantResourceShare() int {
-	share, _ := dominantResourceShare(c, nil)
-	return share
+func (c *ClusterQueueSnapshot) DominantResourceShare() DRS {
+	return dominantResourceShare(c, nil)
 }
 
 type WorkloadTASRequests map[kueue.ResourceFlavorReference]FlavorTASRequests

--- a/pkg/cache/scheduler/cohort_snapshot.go
+++ b/pkg/cache/scheduler/cohort_snapshot.go
@@ -69,9 +69,8 @@ func (c *CohortSnapshot) subtreeClusterQueueCount() int {
 	return count
 }
 
-func (c *CohortSnapshot) DominantResourceShare() int {
-	share, _ := dominantResourceShare(c, nil)
-	return share
+func (c *CohortSnapshot) DominantResourceShare() DRS {
+	return dominantResourceShare(c, nil)
 }
 
 // implement flatResourceNode/hierarchicalResourceNode interfaces

--- a/pkg/cache/scheduler/fair_sharing.go
+++ b/pkg/cache/scheduler/fair_sharing.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scheduler
 
 import (
+	"cmp"
 	"math"
 
 	corev1 "k8s.io/api/core/v1"
@@ -38,7 +39,56 @@ type dominantResourceShareNode interface {
 	hierarchicalResourceNode
 }
 
-// dominantResourceShare returns a value ranging from 0 to math.MaxInt,
+// DRS contains the DominantResourceShare for some
+// node, with convenence methods for precise comparison.
+type DRS struct {
+	fairWeight       *resource.Quantity
+	unweightedRatio  float64
+	dominantResource corev1.ResourceName
+}
+
+// NegativeDRS is used as a starting point for comparisons.
+func NegativeDRS() DRS {
+	return DRS{unweightedRatio: -1, dominantResource: "", fairWeight: &oneQuantity}
+}
+
+// IsZero returns whether the DRS is 0. In other words,
+// the node for which this function was called is not
+// borrowing any resources.
+func (d DRS) IsZero() bool {
+	return d.unweightedRatio == 0
+}
+
+func (d DRS) PreciseWeightedShare() float64 {
+	if d.IsZero() {
+		return 0.0
+	}
+	if d.fairWeight.IsZero() {
+		// This branch is used only for logging; functional
+		// branches never reach here.
+		return math.Inf(1)
+	}
+	return d.unweightedRatio / d.fairWeight.AsFloat64Slow()
+}
+
+// CompareDRS compares two DRS values. A lower value
+// indicates that the ClusterQueue/Cohort with this
+// value should be preferred for scheduling, while
+// a higher value preferred for preemption.
+func CompareDRS(a, b DRS) int {
+	switch {
+	case a.zeroWeightBorrows() && b.zeroWeightBorrows():
+		return cmp.Compare(a.unweightedRatio, b.unweightedRatio)
+	case a.zeroWeightBorrows():
+		return 1
+	case b.zeroWeightBorrows():
+		return -1
+	default:
+		return cmp.Compare(a.PreciseWeightedShare(), b.PreciseWeightedShare())
+	}
+}
+
+// roundedWeightedShare returns a value ranging from 0 to math.MaxInt,
 // representing the maximum of the ratios of usage above nominal quota
 // to the lendable resources in the cohort, among all the resources
 // provided by the ClusterQueue, and divided by the weight.  If zero,
@@ -46,9 +96,26 @@ type dominantResourceShareNode interface {
 // quota.  The function also returns the resource name that yielded
 // this value.  When the FairSharing weight is 0, and the ClusterQueue
 // or Cohort is borrowing, we return math.MaxInt.
-func dominantResourceShare(node dominantResourceShareNode, wlReq resources.FlavorResourceQuantities) (int, corev1.ResourceName) {
+func (d DRS) roundedWeightedShare() (int64, corev1.ResourceName) {
+	var weightedShare int64
+	if d.zeroWeightBorrows() {
+		weightedShare = math.MaxInt64
+	} else {
+		weightedShare = int64(math.Ceil(d.PreciseWeightedShare()))
+	}
+	return weightedShare, d.dominantResource
+}
+
+// zeroWeightBorrows returns whether this DRS represents a
+// borrowing state for a ClusterQueue/Cohort with a zero weight.
+func (d DRS) zeroWeightBorrows() bool {
+	return d.fairWeight.IsZero() && !d.IsZero()
+}
+
+func dominantResourceShare(node dominantResourceShareNode, wlReq resources.FlavorResourceQuantities) DRS {
+	drs := DRS{fairWeight: node.fairWeight(), unweightedRatio: 0, dominantResource: ""}
 	if !node.HasParent() {
-		return 0, ""
+		return drs
 	}
 
 	borrowing := make(map[corev1.ResourceName]int64, len(node.getResourceNode().SubtreeQuota))
@@ -59,30 +126,21 @@ func dominantResourceShare(node dominantResourceShareNode, wlReq resources.Flavo
 		}
 	}
 	if len(borrowing) == 0 {
-		return 0, ""
+		return drs
 	}
-
-	var drs int64 = -1
-	var dRes corev1.ResourceName
 
 	lendable := calculateLendable(node.parentHRN())
 	for rName, b := range borrowing {
 		if lr := lendable[rName]; lr > 0 {
-			ratio := b * 1000 / lr
+			ratio := float64(b) * 1000.0 / float64(lr)
 			// Use alphabetical order to get a deterministic resource name.
-			if ratio > drs || (ratio == drs && rName < dRes) {
-				drs = ratio
-				dRes = rName
+			if ratio > drs.unweightedRatio || (ratio == drs.unweightedRatio && rName < drs.dominantResource) {
+				drs.unweightedRatio = ratio
+				drs.dominantResource = rName
 			}
 		}
 	}
-
-	if node.fairWeight().IsZero() {
-		return math.MaxInt, dRes
-	}
-
-	dws := drs * 1000 / node.fairWeight().MilliValue()
-	return max(1, int(dws)), dRes
+	return drs
 }
 
 // calculateLendable aggregates capacity for resources across all

--- a/pkg/cache/scheduler/fair_sharing_test.go
+++ b/pkg/cache/scheduler/fair_sharing_test.go
@@ -42,7 +42,7 @@ func TestDominantResourceShare(t *testing.T) {
 	type fairSharingResult struct {
 		Name     string
 		NodeType nodeType
-		DrValue  int
+		DrValue  int64
 		DrName   corev1.ResourceName
 	}
 
@@ -728,7 +728,8 @@ func TestDominantResourceShare(t *testing.T) {
 			cacheCohortsMap := cache.hm.Cohorts()
 			gotCache := make([]fairSharingResult, 0, len(cacheClusterQueuesMap)+len(cacheCohortsMap))
 			for _, cq := range cacheClusterQueuesMap {
-				drVal, drName := dominantResourceShare(cq, tc.flvResQ)
+				drs := dominantResourceShare(cq, tc.flvResQ)
+				drVal, drName := drs.roundedWeightedShare()
 				gotCache = append(gotCache, fairSharingResult{
 					Name:     string(cq.Name),
 					NodeType: nodeTypeCq,
@@ -737,7 +738,8 @@ func TestDominantResourceShare(t *testing.T) {
 				})
 			}
 			for _, cohort := range cacheCohortsMap {
-				drVal, drName := dominantResourceShare(cohort, tc.flvResQ)
+				drs := dominantResourceShare(cohort, tc.flvResQ)
+				drVal, drName := drs.roundedWeightedShare()
 				gotCache = append(gotCache, fairSharingResult{
 					Name:     string(cohort.Name),
 					NodeType: nodeTypeCohort,
@@ -753,7 +755,8 @@ func TestDominantResourceShare(t *testing.T) {
 			snapshotCohortsMap := snapshot.Cohorts()
 			gotSnapshot := make([]fairSharingResult, 0, len(snapshotClusterQueuesMap)+len(snapshotCohortsMap))
 			for _, cq := range snapshotClusterQueuesMap {
-				drVal, drName := dominantResourceShare(cq, tc.flvResQ)
+				drs := dominantResourceShare(cq, tc.flvResQ)
+				drVal, drName := drs.roundedWeightedShare()
 				gotSnapshot = append(gotSnapshot, fairSharingResult{
 					Name:     string(cq.Name),
 					NodeType: nodeTypeCq,
@@ -762,7 +765,8 @@ func TestDominantResourceShare(t *testing.T) {
 				})
 			}
 			for _, cohort := range snapshotCohortsMap {
-				drVal, drName := dominantResourceShare(cohort, tc.flvResQ)
+				drs := dominantResourceShare(cohort, tc.flvResQ)
+				drVal, drName := drs.roundedWeightedShare()
 				gotSnapshot = append(gotSnapshot, fairSharingResult{
 					Name:     string(cohort.Name),
 					NodeType: nodeTypeCohort,

--- a/pkg/scheduler/fair_sharing_iterator.go
+++ b/pkg/scheduler/fair_sharing_iterator.go
@@ -160,16 +160,17 @@ type drsKey struct {
 }
 
 type entryComparer struct {
-	drsValues        map[drsKey]int
+	drsValues        map[drsKey]schdcache.DRS
 	workloadOrdering workload.Ordering
 }
 
 func (e *entryComparer) less(a, b *entry, parentCohort kueue.CohortReference) bool {
 	aDrs := e.drsValues[drsKey{parentCohort: parentCohort, workloadKey: workload.Key(a.Obj)}]
 	bDrs := e.drsValues[drsKey{parentCohort: parentCohort, workloadKey: workload.Key(b.Obj)}]
+
 	// 1: DRF
-	if aDrs != bDrs {
-		return aDrs < bDrs
+	if cmp := schdcache.CompareDRS(aDrs, bDrs); cmp != 0 {
+		return cmp == -1
 	}
 
 	// 2: Priority
@@ -193,7 +194,7 @@ func (e *entryComparer) less(a, b *entry, parentCohort kueue.CohortReference) bo
 // all children the parentCohort, to select the child with the lowest
 // DRS after admission of its nominated workload.
 func (e *entryComparer) computeDRS(rootCohort *schdcache.CohortSnapshot, cqToEntry map[*schdcache.ClusterQueueSnapshot]*entry) {
-	e.drsValues = make(map[drsKey]int)
+	e.drsValues = make(map[drsKey]schdcache.DRS)
 	for _, cq := range rootCohort.SubtreeClusterQueues() {
 		entry, ok := cqToEntry[cq]
 		if !ok {
@@ -221,7 +222,7 @@ func (e *entryComparer) logDrsValuesWhenVerbose(log logr.Logger) {
 	if logV := log.V(5); logV.Enabled() {
 		serializableDrs := make([]string, 0, len(e.drsValues))
 		for k, v := range e.drsValues {
-			serializableDrs = append(serializableDrs, fmt.Sprintf("{parentCohort: %s, workload %s, drs: %d}", k.parentCohort, k.workloadKey, v))
+			serializableDrs = append(serializableDrs, fmt.Sprintf("{parentCohort: %s, workload %s, drs: %.3f}", k.parentCohort, k.workloadKey, v.PreciseWeightedShare()))
 		}
 		logV.Info("DominantResourceShare values used during tournament", "drsValues", serializableDrs)
 	}

--- a/pkg/scheduler/preemption/fairsharing/least_common_ancestor.go
+++ b/pkg/scheduler/preemption/fairsharing/least_common_ancestor.go
@@ -20,7 +20,7 @@ import schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 // the lowest shared node - the LeastCommonAncestor (LCA). While LCA
 // is always a Cohort, almostLCA may be a ClusterQueue or a Cohort.
 type almostLCA interface {
-	DominantResourceShare() int
+	DominantResourceShare() schdcache.DRS
 }
 
 // getAlmostLCAs returns almostLCAs of (preemptor, target).

--- a/pkg/scheduler/preemption/fairsharing/strategy.go
+++ b/pkg/scheduler/preemption/fairsharing/strategy.go
@@ -16,28 +16,30 @@ limitations under the License.
 
 package fairsharing
 
+import schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+
 // PreemptorNewShare is the DominantResourceShare of the Preemptor
 // after the incoming workload's usage has been added. It is used for
 // both rules S2-a and S2-b
-type PreemptorNewShare int
+type PreemptorNewShare schdcache.DRS
 
 // TargetNewShare is the DominantResourceShare of the Preemptee after
 // its preempted workload's usage has been removed. It is used for
 // rule S2-a.
-type TargetNewShare int
+type TargetNewShare schdcache.DRS
 
 // TargetOldShare is the DominantResourceShare of the Preemptee before
 // its workload has been removed. It is used for rule S2-b.
-type TargetOldShare int
+type TargetOldShare schdcache.DRS
 
 type Strategy func(PreemptorNewShare, TargetOldShare, TargetNewShare) bool
 
 // LessThanOrEqualToFinalShare implements Rule S2-a in https://sigs.k8s.io/kueue/keps/1714-fair-sharing#choosing-workloads-from-clusterqueues-for-preemption
 func LessThanOrEqualToFinalShare(preemptorNewShare PreemptorNewShare, _ TargetOldShare, targetNewShare TargetNewShare) bool {
-	return int(preemptorNewShare) <= int(targetNewShare)
+	return schdcache.CompareDRS(schdcache.DRS(preemptorNewShare), schdcache.DRS(targetNewShare)) <= 0
 }
 
 // LessThanInitialShare implements rule S2-b in https://sigs.k8s.io/kueue/keps/1714-fair-sharing#choosing-workloads-from-clusterqueues-for-preemption
 func LessThanInitialShare(preemptorNewShare PreemptorNewShare, targetOldShare TargetOldShare, _ TargetNewShare) bool {
-	return int(preemptorNewShare) < int(targetOldShare)
+	return schdcache.CompareDRS(schdcache.DRS(preemptorNewShare), schdcache.DRS(targetOldShare)) < 0
 }

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -362,7 +362,7 @@ func runSecondFsStrategy(retryCandidates []*workload.Info, preemptionCtx *preemp
 		preemptorNewShare, targetOldShare := candCQ.ComputeShares()
 		// Due to API validation, we can only reach here if the second strategy is LessThanInitialShare,
 		// in which case the last parameter for the strategy function is irrelevant.
-		if fairsharing.LessThanInitialShare(preemptorNewShare, targetOldShare, 0) {
+		if fairsharing.LessThanInitialShare(preemptorNewShare, targetOldShare, fairsharing.TargetNewShare{}) {
 			// The criteria doesn't depend on the preempted workload, so just preempt the first candidate.
 			candWl := candCQ.PopWorkload()
 			preemptionCtx.snapshot.RemoveWorkload(candWl)

--- a/test/e2e/singlecluster/fair_sharing_test.go
+++ b/test/e2e/singlecluster/fair_sharing_test.go
@@ -113,7 +113,7 @@ var _ = ginkgo.Describe("Fair Sharing", ginkgo.Ordered, ginkgo.ContinueOnFailure
 
 				g.Expect(cq1.Status.AdmittedWorkloads).Should(gomega.Equal(int32(4)))
 				g.Expect(cq1.Status.FairSharing).ShouldNot(gomega.BeNil())
-				g.Expect(cq1.Status.FairSharing.WeightedShare).Should(gomega.Equal(int64(111)))
+				g.Expect(cq1.Status.FairSharing.WeightedShare).Should(gomega.Equal(int64(112)))
 
 				g.Expect(cq2.Status.AdmittedWorkloads).Should(gomega.Equal(int32(0)))
 				g.Expect(cq2.Status.FairSharing).ShouldNot(gomega.BeNil())

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -258,7 +258,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			}
 			util.ExpectReservingActiveWorkloadsMetric(cqA, 9)
 			util.ExpectPendingWorkloadsMetric(cqA, 0, 1)
-			util.ExpectClusterQueueWeightedShareMetric(cqA, 666)
+			util.ExpectClusterQueueWeightedShareMetric(cqA, 667)
 			util.ExpectClusterQueueWeightedShareMetric(cqB, 0)
 			util.ExpectClusterQueueWeightedShareMetric(cqC, 0)
 
@@ -271,23 +271,23 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			ginkgo.By("Finishing eviction of 4 running workloads in cqA: shared quota is fair-shared")
 			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cqA, 4)
 			util.ExpectReservingActiveWorkloadsMetric(cqB, 4)
-			util.ExpectClusterQueueWeightedShareMetric(cqA, 222)
-			util.ExpectClusterQueueWeightedShareMetric(cqB, 111)
+			util.ExpectClusterQueueWeightedShareMetric(cqA, 223)
+			util.ExpectClusterQueueWeightedShareMetric(cqB, 112)
 			util.ExpectClusterQueueWeightedShareMetric(cqC, 0)
 
 			ginkgo.By("cq-c reclaims one unit, preemption happens in cq-a")
 			cWorkload := testing.MakeWorkload("c0", ns.Name).Queue("c").Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, cWorkload)
 			util.ExpectPendingWorkloadsMetric(cqC, 1, 0)
-			util.ExpectClusterQueueWeightedShareMetric(cqA, 222)
-			util.ExpectClusterQueueWeightedShareMetric(cqB, 111)
+			util.ExpectClusterQueueWeightedShareMetric(cqA, 223)
+			util.ExpectClusterQueueWeightedShareMetric(cqB, 112)
 			util.ExpectClusterQueueWeightedShareMetric(cqC, 0)
 
 			ginkgo.By("Finishing eviction of 1 running workloads in the CQ with highest usage: cqA")
 			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cqA, 1)
 			util.ExpectReservingActiveWorkloadsMetric(cqC, 1)
-			util.ExpectClusterQueueWeightedShareMetric(cqA, 111)
-			util.ExpectClusterQueueWeightedShareMetric(cqB, 111)
+			util.ExpectClusterQueueWeightedShareMetric(cqA, 112)
+			util.ExpectClusterQueueWeightedShareMetric(cqB, 112)
 			util.ExpectClusterQueueWeightedShareMetric(cqC, 0)
 
 			ginkgo.By("Checking that weight share status changed")
@@ -296,8 +296,76 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, cqAKey, createdCqA)).Should(gomega.Succeed())
 				g.Expect(createdCqA.Status.FairSharing).ShouldNot(gomega.BeNil())
-				g.Expect(createdCqA.Status.FairSharing).Should(gomega.BeComparableTo(&kueue.FairSharingStatus{WeightedShare: 111}))
+				g.Expect(createdCqA.Status.FairSharing).Should(gomega.BeComparableTo(&kueue.FairSharingStatus{WeightedShare: 112}))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.When("Preemption is enabled and CQs have 0 weight", func() {
+		var (
+			cqA *kueue.ClusterQueue
+			cqB *kueue.ClusterQueue
+		)
+		ginkgo.BeforeEach(func() {
+			createCohort(testing.MakeCohort("top-cohort").
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "8").Obj(),
+				).Obj())
+
+			cqA = createQueue(testing.MakeClusterQueue("best-effort-cq-a").
+				Cohort("top-cohort").
+				FairWeight(resource.MustParse("0")).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				}).
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "0").Obj(),
+				).Obj())
+
+			cqB = createQueue(testing.MakeClusterQueue("best-effort-cq-b").
+				Cohort("top-cohort").
+				FairWeight(resource.MustParse("0")).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				}).
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "0").Obj(),
+				).Obj())
+		})
+
+		ginkgo.It("should not cause an infinite preemption cycle", func() {
+			ginkgo.By("Creating two workloads in cqA")
+			wlA1 := createWorkloadWithPriority("best-effort-cq-a", "4", 9001)
+			wlA2 := createWorkloadWithPriority("best-effort-cq-a", "4", 100)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlA1, wlA2)
+			util.ExpectReservingActiveWorkloadsMetric(cqA, 2)
+			util.ExpectReservingActiveWorkloadsMetric(cqB, 0)
+
+			ginkgo.By("Creating a workload in cqB that should preempt one from cqA")
+			wlB1 := createWorkloadWithPriority("best-effort-cq-b", "4", 100)
+
+			ginkgo.By("Check Preemptions")
+			util.ExpectPreemptedWorkloadsTotalMetric(cqA.Name, "InCohortFairSharing", 0)
+			util.ExpectPreemptedWorkloadsTotalMetric(cqB.Name, "InCohortFairSharing", 1)
+
+			ginkgo.By("Waiting for preemption and eviction")
+			// wlA2 will be preempted as it is lower priority than wlA1
+			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, wlA2)
+			util.FinishEvictionForWorkloads(ctx, k8sClient, wlA2)
+			util.ExpectEvictedWorkloadsTotalMetric(cqA.Name, kueue.WorkloadEvictedByPreemption, "", "", 1)
+
+			ginkgo.By("Check Admission")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlB1)
+
+			ginkgo.By("Verify both workloads running")
+			util.ExpectReservingActiveWorkloadsMetric(cqA, 1)
+			util.ExpectReservingActiveWorkloadsMetric(cqB, 1)
+
+			ginkgo.By("Checking that there are no more preemptions")
+			util.ExpectPreemptedWorkloadsTotalMetric(cqA.Name, "InCohortFairSharing", 0)
+			util.ExpectPreemptedWorkloadsTotalMetric(cqB.Name, "InCohortFairSharing", 1)
+			util.ExpectEvictedWorkloadsTotalMetric(cqA.Name, kueue.WorkloadEvictedByPreemption, "", "", 1)
+			util.ExpectEvictedWorkloadsTotalMetric(cqB.Name, kueue.WorkloadEvictedByPreemption, "", "", 0)
 		})
 	})
 
@@ -342,10 +410,10 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 
 			util.ExpectReservingActiveWorkloadsMetric(cqSecondLeft, 5)
 			util.ExpectReservingActiveWorkloadsMetric(cqSecondRight, 5)
-			expectCohortWeightedShare(cohortFirstLeft.Name, 428)
+			expectCohortWeightedShare(cohortFirstLeft.Name, 429)
 			expectCohortWeightedShare(cohortFirstRight.Name, 0)
-			expectCohortWeightedShare(cohortSecondLeft.Name, 214)
-			expectCohortWeightedShare(cohortSecondRight.Name, 214)
+			expectCohortWeightedShare(cohortSecondLeft.Name, 215)
+			expectCohortWeightedShare(cohortSecondRight.Name, 215)
 			expectCohortWeightedShare(cohortBank.Name, 0)
 		})
 		ginkgo.It("preempts workloads to enforce fair share", func() {
@@ -399,12 +467,12 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 
 			ginkgo.By("share is fair with respect to each parent")
 			// parent root
-			expectCohortWeightedShare("best-effort", 666)
-			expectCohortWeightedShare("research", 666)
+			expectCohortWeightedShare("best-effort", 667)
+			expectCohortWeightedShare("research", 667)
 			// parent research
-			expectCohortWeightedShare("chemistry", 166)
-			expectCohortWeightedShare("physics", 166)
-			expectCohortWeightedShare("llm", 166)
+			expectCohortWeightedShare("chemistry", 167)
+			expectCohortWeightedShare("physics", 167)
+			expectCohortWeightedShare("llm", 167)
 
 			ginkgo.By("number workloads admitted proportional to share at each level")
 			util.ExpectReservingActiveWorkloadsMetric(bestEffortQueue, 4)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
We fix two FairSharing bugs:
1) Lack of precision when dividing integers in FairSharing. This is especially relevant to ClusterQueues/Cohorts with high FairSharing Weight, or large quotas
2) ClusterQueues/Cohorts with weight 0 infinite preemption loop.

#### Which issue(s) this PR fixes:
Fixes #6774

Potentially fixes https://github.com/kubernetes-sigs/kueue/issues/4247, though we should discuss there whether we want to surface a more precise value in metrics/status

See also https://github.com/kubernetes-sigs/kueue/issues/6577. This builds upon https://github.com/kubernetes-sigs/kueue/pull/6617, removing the 1 DRS special case, while still passing the unit tests introduced in that PR.

#### Special notes for your reviewer:

1) Please apply extra scrutiny to the use of `float64`.
2) Please note the change in logging in `fair_sharing_iterator.go` @amy 
  a) Does this precision LGTY?
  b) We will log +Inf for borrowing 0 weight Cohorts/ClusterQueues. I could also log the unweightedRatio. WDYT?

#### Does this PR introduce a user-facing change?
```release-note
- Fix FairSharing bug caused by rounding (large quotas or high FairSharing weight)
- Fix zero FairSharing weight preemption loop
```