### PR TITLE
cleanup(tas): remove deprecated "kueue.x-k8s.io/tas" label

### DIFF
--- a/apis/kueue/v1beta1/topology_types.go
+++ b/apis/kueue/v1beta1/topology_types.go
@@ -70,14 +70,6 @@ const (
 	// annotation is set when starting the Job, and removed on stopping the Job.
 	WorkloadAnnotation = "kueue.x-k8s.io/workload"
 
-	// TASLabel is a label set on the Job's PodTemplate to indicate that the
-	// PodSet is admitted using TopologyAwareScheduling, and all Pods created
-	// from the Job's PodTemplate also have the label. For the Pod-based
-	// integrations the label is added in webhook during the Pod creation.
-	// Depracted. This label is no longer added by TAS to Pod. The constant is
-	// only kept to support "reading" the label until 0.16.
-	TASLabel = "kueue.x-k8s.io/tas"
-
 	// PodGroupPodIndexLabel is a label set on the Pod's metadata belonging
 	// to a Pod group. It indicates the Pod's index within the group.
 	PodGroupPodIndexLabel = "kueue.x-k8s.io/pod-group-pod-index"

--- a/pkg/controller/tas/node_failure_controller_test.go
+++ b/pkg/controller/tas/node_failure_controller_test.go
@@ -94,7 +94,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 
 	basePod := testingpod.MakePod("test-pod", nsName).
 		Annotation(kueue.WorkloadAnnotation, wlName).
-		Label(kueue.TASLabel, "true").
+		Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
 		NodeName(nodeName).
 		Obj()
 

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -436,21 +436,21 @@ func TestMergeRestore(t *testing.T) {
 		},
 		"podset with tas label; empty info": {
 			podSet: utiltesting.MakePodSet("", 1).
-				Labels(map[string]string{kueue.TASLabel: "true"}).
+				Annotations(map[string]string{kueue.PodSetUnconstrainedTopologyAnnotation: "true"}).
 				Obj(),
 			wantPodSet: utiltesting.MakePodSet("", 1).
-				Labels(map[string]string{kueue.TASLabel: "true"}).
+				Annotations(map[string]string{kueue.PodSetUnconstrainedTopologyAnnotation: "true"}).
 				Obj(),
 		},
 		"podset with tas label; info re-adds the same": {
 			podSet: utiltesting.MakePodSet("", 1).
-				Labels(map[string]string{kueue.TASLabel: "true"}).
+				Annotations(map[string]string{kueue.PodSetUnconstrainedTopologyAnnotation: "true"}).
 				Obj(),
 			info: PodSetInfo{
-				Labels: map[string]string{kueue.TASLabel: "true"},
+				Annotations: map[string]string{kueue.PodSetUnconstrainedTopologyAnnotation: "true"},
 			},
 			wantPodSet: utiltesting.MakePodSet("", 1).
-				Labels(map[string]string{kueue.TASLabel: "true"}).
+				Annotations(map[string]string{kueue.PodSetUnconstrainedTopologyAnnotation: "true"}).
 				Obj(),
 		},
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -6471,7 +6471,7 @@ func TestScheduleForTAS(t *testing.T) {
 					StatusPhase(corev1.PodRunning).
 					Request(corev1.ResourceCPU, "400m").
 					NodeSelector(corev1.LabelHostname, "x1").
-					Label(kueue.TASLabel, "true").
+					Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
 					Obj(),
 			},
 			topologies:      []kueue.Topology{defaultSingleLevelTopology},

--- a/pkg/util/tas/tas.go
+++ b/pkg/util/tas/tas.go
@@ -37,10 +37,6 @@ func IsTAS(pod *corev1.Pod) bool {
 	if _, ok := pod.Annotations[kueue.PodSetUnconstrainedTopologyAnnotation]; ok {
 		return true
 	}
-	// TODO: remove after 0.16
-	if _, ok := pod.Labels[kueue.TASLabel]; ok {
-		return true
-	}
 	return false
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

TAS Label has been deprecated and is no longer set by TAS on the Pods. The label and the corresponding check have been kept in the TAS utils for backwards compatibility with the existing Pods when upgrading Kueue from 0.13 to 0.14.

This commit cleans up the label and the check and should be merged when all of the Pods are created with Kueue 0.14+ (likely with the Kueue 0.16 release).

#### Which issue(s) this PR fixes:
Fixes #6911

#### Does this PR introduce a user-facing change?
```release-note
Drop deprecated "kueue.x-k8s.io/tas" pod label
```