### PR TITLE
Use BehaviorWaitForDeletion in FS E2E Test

### DIFF
--- a/test/e2e/singlecluster/fair_sharing_test.go
+++ b/test/e2e/singlecluster/fair_sharing_test.go
@@ -96,7 +96,7 @@ var _ = ginkgo.Describe("Fair Sharing", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			for i := range 4 {
 				job := jobtesting.MakeJob(fmt.Sprintf("j%d", i+1), ns.Name).
 					Queue(v1beta1.LocalQueueName(lq1.Name)).
-					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 					Parallelism(3).
 					Completions(3).
 					RequestAndLimit(corev1.ResourceCPU, "1").


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Make test less flaky, as we remove possibility of some workload finishing running before we can measure it. See https://github.com/kubernetes-sigs/kueue/pull/6925#issuecomment-3313914818

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```