### PR TITLE
Handle node replacement for slices

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -514,6 +514,8 @@ func (s *TASFlavorSnapshot) findReplacementAssignment(tr *TASPodSetRequests, exi
 		return nil, nil, fmt.Sprintf("Cannot replace the node, because the existing topologyAssignment is invalid, as it contains the stale domain %v", staleDomain)
 	}
 	requiredReplacementDomain := s.requiredReplacementDomain(tr, existingAssignment)
+	tr_copy := *tr
+	tr_copy.PodSet.TopologyRequest.PodSetSliceSize = ptr.To(int32(1))
 	replacementAssignment, reason := s.findTopologyAssignment(*tr, nil, assumedUsage, false, requiredReplacementDomain)
 	if reason != "" {
 		return nil, nil, reason
@@ -547,7 +549,6 @@ func findPSA(wl *kueue.Workload, psName kueue.PodSetReference) *kueue.PodSetAssi
 	return nil
 }
 
-// requiredReplacementDomain returns required domain for the next pass of findingTopologyAssignment to be compliant with the existing one
 func (s *TASFlavorSnapshot) requiredReplacementDomain(tr *TASPodSetRequests, ta *kueue.TopologyAssignment) utiltas.TopologyDomainID {
 	key := s.levelKeyWithImpliedFallback(tr)
 	if key == nil {
@@ -558,9 +559,19 @@ func (s *TASFlavorSnapshot) requiredReplacementDomain(tr *TASPodSetRequests, ta 
 		return ""
 	}
 	required := isRequired(tr.PodSet.TopologyRequest)
-	if !required {
+	if !required && !slicesConfigured(tr.PodSet.TopologyRequest) {
 		return ""
 	}
+	targetLevel := levelIdx
+	if slicesConfigured(tr.PodSet.TopologyRequest) && *tr.PodSet.TopologyRequest.PodSetSliceSize > 1 {
+		sliceTopologyKey := s.sliceLevelKeyWithDefault(tr.PodSet.TopologyRequest, s.lowestLevel())
+		sliceLevelIdx, resolved := s.resolveLevelIdx(sliceTopologyKey)
+		if !resolved {
+			return ""
+		}
+		targetLevel = max(targetLevel, sliceLevelIdx)
+	}
+
 	// no domain to comply with so we don't require any domain at all
 	// this happens when the faulty node was the only one in the assignment
 	if len(ta.Domains) == 0 {
@@ -574,7 +585,8 @@ func (s *TASFlavorSnapshot) requiredReplacementDomain(tr *TASPodSetRequests, ta 
 	nodeDomain := ta.Domains[0].Values[0]
 	domain := s.domainsPerLevel[nodeLevel][utiltas.TopologyDomainID(nodeDomain)]
 	// Find a domain that complies with the required policy
-	for i := nodeLevel; i > levelIdx; i-- {
+
+	for i := nodeLevel; i > targetLevel; i-- {
 		domain = domain.parent
 	}
 	return domain.id
@@ -1356,4 +1368,8 @@ func (s *TASFlavorSnapshot) notFitMessage(slicesFitCount, totalRequestsSlicesCou
 		return fmt.Sprintf("topology %q doesn't allow to fit any of %d slice(s)", s.topologyName, totalRequestsSlicesCount)
 	}
 	return fmt.Sprintf("topology %q allows to fit only %d out of %d slice(s)", s.topologyName, slicesFitCount, totalRequestsSlicesCount)
+}
+
+func slicesConfigured(tr *kueue.PodSetTopologyRequest) bool {
+	return tr != nil && tr.PodSetSliceRequiredTopology != nil && tr.PodSetSliceSize != nil
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -515,8 +515,11 @@ func (s *TASFlavorSnapshot) findReplacementAssignment(tr *TASPodSetRequests, exi
 	}
 	requiredReplacementDomain := s.requiredReplacementDomain(tr, existingAssignment)
 	tr_copy := *tr
-	tr_copy.PodSet.TopologyRequest.PodSetSliceSize = ptr.To(int32(1))
-	replacementAssignment, reason := s.findTopologyAssignment(*tr, nil, assumedUsage, false, requiredReplacementDomain)
+	if slicesConfigured(tr.PodSet.TopologyRequest) && requiredReplacementDomain != "" && tr.Count < *tr.PodSet.TopologyRequest.PodSetSliceSize {
+		tr_copy.PodSet = tr.PodSet.DeepCopy()
+		tr_copy.PodSet.TopologyRequest.PodSetSliceSize = ptr.To(int32(1))
+	}
+	replacementAssignment, reason := s.findTopologyAssignment(tr_copy, nil, assumedUsage, false, requiredReplacementDomain)
 	if reason != "" {
 		return nil, nil, reason
 	}
@@ -563,7 +566,7 @@ func (s *TASFlavorSnapshot) requiredReplacementDomain(tr *TASPodSetRequests, ta 
 		return ""
 	}
 	targetLevel := levelIdx
-	if slicesConfigured(tr.PodSet.TopologyRequest) && *tr.PodSet.TopologyRequest.PodSetSliceSize > 1 {
+	if slicesConfigured(tr.PodSet.TopologyRequest) && tr.Count < *tr.PodSet.TopologyRequest.PodSetSliceSize {
 		sliceTopologyKey := s.sliceLevelKeyWithDefault(tr.PodSet.TopologyRequest, s.lowestLevel())
 		sliceLevelIdx, resolved := s.resolveLevelIdx(sliceTopologyKey)
 		if !resolved {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR has the correct handling of node replacement in the case of slices. 

It solves two cases:

1. If the failed node was hosting a part of some slice, it tries to find the replacement within the same slice domain.
2. If the failed node was hosting a full slice (or a number of slices), it searches for the replacement in the `Required` domain or in the whole topology. 

If the search starts at the slice level (Case 1) it uses sliceSize = 1 because we are not assigning slices any more but individual pods to nodes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Node hotswap in TAS works correctly with slices.
```