### PR TITLE
fix cases where DRA resources are skipping workload reconcile on their way to scheduler queue

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -110,15 +110,16 @@ type WorkloadUpdateWatcher interface {
 
 // WorkloadReconciler reconciles a Workload object
 type WorkloadReconciler struct {
-	log               logr.Logger
-	queues            *qcache.Manager
-	cache             *schdcache.Cache
-	client            client.Client
-	watchers          []WorkloadUpdateWatcher
-	waitForPodsReady  *waitForPodsReadyConfig
-	recorder          record.EventRecorder
-	clock             clock.Clock
-	workloadRetention *workloadRetentionConfig
+	log                 logr.Logger
+	queues              *qcache.Manager
+	cache               *schdcache.Cache
+	client              client.Client
+	watchers            []WorkloadUpdateWatcher
+	waitForPodsReady    *waitForPodsReadyConfig
+	recorder            record.EventRecorder
+	clock               clock.Clock
+	workloadRetention   *workloadRetentionConfig
+	draReconcileChannel chan event.TypedGenericEvent[*kueue.Workload]
 }
 
 var _ reconcile.Reconciler = (*WorkloadReconciler)(nil)
@@ -126,12 +127,13 @@ var _ predicate.TypedPredicate[*kueue.Workload] = (*WorkloadReconciler)(nil)
 
 func NewWorkloadReconciler(client client.Client, queues *qcache.Manager, cache *schdcache.Cache, recorder record.EventRecorder, options ...Option) *WorkloadReconciler {
 	r := &WorkloadReconciler{
-		log:      ctrl.Log.WithName("workload-reconciler"),
-		client:   client,
-		queues:   queues,
-		cache:    cache,
-		recorder: recorder,
-		clock:    realClock,
+		log:                 ctrl.Log.WithName("workload-reconciler"),
+		client:              client,
+		queues:              queues,
+		cache:               cache,
+		recorder:            recorder,
+		clock:               realClock,
+		draReconcileChannel: make(chan event.TypedGenericEvent[*kueue.Workload], updateChBuffer),
 	}
 	for _, option := range options {
 		option(r)
@@ -192,13 +194,15 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	if features.Enabled(features.DynamicResourceAllocation) && workload.Status(&wl) == workload.StatusPending &&
-		r.workloadHasDRA(&wl) {
-		if r.workloadHasResourceClaim(&wl) {
+		workload.HasDRA(&wl) {
+		workload.AdjustResources(ctx, r.client, &wl)
+		if workload.HasResourceClaim(&wl) {
 			log.V(3).Info("Workload is inadmissible because it uses resource claims which is not supported")
-			if err := workload.PatchAdmissionStatus(ctx, r.client, &wl, true, r.clock, func() (*kueue.Workload, bool, error) {
-				return &wl, workload.UnsetQuotaReservationWithCondition(&wl, kueue.WorkloadInadmissible, "DynamicResourceAllocation feature does not support use of resource claims", r.clock.Now()), nil
-			}); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA resource claims error: %w", err)
+			if workload.UnsetQuotaReservationWithCondition(&wl, kueue.WorkloadInadmissible, "DynamicResourceAllocation feature does not support use of resource claims", r.clock.Now()) {
+				workload.SetRequeuedCondition(&wl, kueue.WorkloadInadmissible, "DRA resource claims not supported", false)
+				if err := workload.ApplyAdmissionStatus(ctx, r.client, &wl, true, r.clock); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA resource claims error: %w", err)
+				}
 			}
 			return ctrl.Result{}, nil
 		}
@@ -207,12 +211,30 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		draResources, err := dra.GetResourceRequestsForResourceClaimTemplates(ctx, r.client, &wl)
 		if err != nil {
 			log.Error(err, "Failed to process DRA resources for workload")
-			if updateErr := workload.PatchAdmissionStatus(ctx, r.client, &wl, true, r.clock, func() (*kueue.Workload, bool, error) {
-				return &wl, workload.UnsetQuotaReservationWithCondition(&wl, kueue.WorkloadInadmissible, err.Error(), r.clock.Now()), nil
-			}); updateErr != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA error: %w", updateErr)
+			if workload.UnsetQuotaReservationWithCondition(&wl, kueue.WorkloadInadmissible, err.Error(), r.clock.Now()) {
+				workload.SetRequeuedCondition(&wl, kueue.WorkloadInadmissible, err.Error(), false)
+				if updateErr := workload.ApplyAdmissionStatus(ctx, r.client, &wl, true, r.clock); updateErr != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA error: %w", updateErr)
+				}
 			}
 			return ctrl.Result{}, err
+		}
+
+		quotaReservedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
+		requeuedCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadRequeued)
+
+		var conditionsCleared bool
+		if quotaReservedCond != nil && quotaReservedCond.Status == metav1.ConditionFalse {
+			apimeta.RemoveStatusCondition(&wl.Status.Conditions, kueue.WorkloadQuotaReserved)
+			conditionsCleared = true
+		}
+		if requeuedCond != nil && requeuedCond.Status == metav1.ConditionFalse {
+			apimeta.RemoveStatusCondition(&wl.Status.Conditions, kueue.WorkloadRequeued)
+			conditionsCleared = true
+		}
+
+		if conditionsCleared {
+			log.V(3).Info("Cleared previous inadmissible conditions after successful DRA processing")
 		}
 
 		var queueOptions []workload.InfoOption
@@ -605,32 +627,6 @@ func (r *WorkloadReconciler) reconcileOnClusterQueueActiveState(ctx context.Cont
 	return false, nil
 }
 
-func (r *WorkloadReconciler) workloadHasDRA(wl *kueue.Workload) bool {
-	return r.workloadHasResourceClaim(wl) || r.workloadHasResourceClaimTemplates(wl)
-}
-
-func (r *WorkloadReconciler) workloadHasResourceClaimTemplates(wl *kueue.Workload) bool {
-	for _, ps := range wl.Spec.PodSets {
-		for _, prc := range ps.Template.Spec.ResourceClaims {
-			if prc.ResourceClaimTemplateName != nil {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func (r *WorkloadReconciler) workloadHasResourceClaim(wl *kueue.Workload) bool {
-	for _, ps := range wl.Spec.PodSets {
-		for _, prc := range ps.Template.Spec.ResourceClaims {
-			if prc.ResourceClaimName != nil {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 func syncAdmissionCheckConditions(conds []kueue.AdmissionCheckState, admissionChecks sets.Set[kueue.AdmissionCheckReference], c clock.Clock) ([]kueue.AdmissionCheckState, bool) {
 	if len(admissionChecks) == 0 {
 		return nil, len(conds) > 0
@@ -730,7 +726,7 @@ func (r *WorkloadReconciler) Create(e event.TypedCreateEvent[*kueue.Workload]) b
 
 	// It is intentional for this code to be not guarded behind a feature gate
 	// DRA workloads need to have certain error handling and hence to be handled in Reconcile loop
-	if features.Enabled(features.DynamicResourceAllocation) && r.workloadHasDRA(e.Object) {
+	if features.Enabled(features.DynamicResourceAllocation) && workload.HasDRA(e.Object) {
 		log.V(2).Info("Skipping DRA workload in Create event - will be handled in Reconcile")
 		return true
 	}
@@ -830,7 +826,7 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 
 	case prevStatus == workload.StatusPending && status == workload.StatusPending:
 		// Skip queue operations for DRA workloads - they are handled in Reconcile loop
-		if features.Enabled(features.DynamicResourceAllocation) && r.workloadHasDRA(e.ObjectNew) {
+		if features.Enabled(features.DynamicResourceAllocation) && workload.HasDRA(e.ObjectNew) {
 			log.V(2).Info("Skipping queue update for DRA workload - handled in Reconcile")
 		} else {
 			err := r.queues.UpdateWorkload(e.ObjectOld, wlCopy)
@@ -861,7 +857,7 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 			// function.
 			if immediate {
 				// Skip queue operations for DRA workloads - they are handled in Reconcile loop
-				if features.Enabled(features.DynamicResourceAllocation) && r.workloadHasDRA(e.ObjectNew) {
+				if features.Enabled(features.DynamicResourceAllocation) && workload.HasDRA(e.ObjectNew) {
 					log.V(2).Info("Skipping immediate requeue for DRA workload - handled in Reconcile")
 				} else {
 					if err := r.queues.AddOrUpdateWorkloadWithoutLock(wlCopy); err != nil {
@@ -875,7 +871,7 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 		if !immediate {
 			log.V(3).Info("Workload to be requeued after backoff", "backoff", backoff, "requeueAt", e.ObjectNew.Status.RequeueState.RequeueAt.Time)
 			// Skip delayed requeue for DRA workloads - they are handled in Reconcile loop
-			if features.Enabled(features.DynamicResourceAllocation) && r.workloadHasDRA(e.ObjectNew) {
+			if features.Enabled(features.DynamicResourceAllocation) && workload.HasDRA(e.ObjectNew) {
 				log.V(3).Info("Skipping delayed requeue for DRA workload - handled in Reconcile")
 			} else {
 				time.AfterFunc(backoff, func() {
@@ -929,6 +925,7 @@ func (r *WorkloadReconciler) notifyWatchers(oldWl, newWl *kueue.Workload) {
 func (r *WorkloadReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Configuration) error {
 	ruh := &resourceUpdatesHandler{r: r}
 	wqh := &workloadQueueHandler{r: r}
+	deh := &draEventHandler{}
 	return builder.TypedControllerManagedBy[reconcile.Request](mgr).
 		Named("workload_controller").
 		WatchesRawSource(source.TypedKind(
@@ -937,6 +934,7 @@ func (r *WorkloadReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Conf
 			&handler.TypedEnqueueRequestForObject[*kueue.Workload]{},
 			r,
 		)).
+		WatchesRawSource(source.Channel(r.draReconcileChannel, deh)).
 		WithOptions(controller.Options{
 			NeedLeaderElection:      ptr.To(false),
 			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[kueue.GroupVersion.WithKind("Workload").GroupKind().String()],
@@ -1031,7 +1029,7 @@ func (h *resourceUpdatesHandler) handle(ctx context.Context, obj client.Object, 
 	}
 }
 
-func (h *resourceUpdatesHandler) queueReconcileForPending(ctx context.Context, _ workqueue.TypedRateLimitingInterface[reconcile.Request], opts ...client.ListOption) {
+func (h *resourceUpdatesHandler) queueReconcileForPending(ctx context.Context, q workqueue.TypedRateLimitingInterface[reconcile.Request], opts ...client.ListOption) {
 	log := ctrl.LoggerFrom(ctx)
 	lst := kueue.WorkloadList{}
 	opts = append(opts, client.MatchingFields{indexer.WorkloadQuotaReservedKey: string(metav1.ConditionFalse)})
@@ -1045,6 +1043,19 @@ func (h *resourceUpdatesHandler) queueReconcileForPending(ctx context.Context, _
 		log := log.WithValues("workload", klog.KObj(wlCopy))
 		log.V(5).Info("Queue reconcile for")
 		workload.AdjustResources(ctrl.LoggerInto(ctx, log), h.r.client, wlCopy)
+
+		if features.Enabled(features.DynamicResourceAllocation) && workload.HasDRA(wlCopy) {
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      wlCopy.Name,
+					Namespace: wlCopy.Namespace,
+				},
+			}
+			q.Add(req)
+			log.V(2).Info("Queued reconcile for DRA workload due to resource update")
+			continue
+		}
+
 		if err = h.r.queues.AddOrUpdateWorkload(wlCopy); err != nil {
 			log.V(2).Info("ignored an error for now", "error", err)
 		}
@@ -1154,4 +1165,34 @@ func (w *workloadQueueHandler) queueReconcileForWorkloadsOfLocalQueue(ctx contex
 		wq.Add(req)
 		log.V(5).Info("Queued reconcile for workload")
 	}
+}
+
+type draEventHandler struct{}
+
+var _ handler.TypedEventHandler[*kueue.Workload, reconcile.Request] = (*draEventHandler)(nil)
+
+func (h *draEventHandler) Create(ctx context.Context, e event.TypedCreateEvent[*kueue.Workload], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *draEventHandler) Update(ctx context.Context, e event.TypedUpdateEvent[*kueue.Workload], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *draEventHandler) Delete(ctx context.Context, e event.TypedDeleteEvent[*kueue.Workload], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *draEventHandler) Generic(ctx context.Context, e event.TypedGenericEvent[*kueue.Workload], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	reconcileReq := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      e.Object.Name,
+			Namespace: e.Object.Namespace,
+		},
+	}
+	q.Add(reconcileReq)
+	log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(e.Object))
+	log.V(2).Info("Queued reconcile for DRA workload from event channel")
+}
+
+// GetDRAReconcileChannel returns the DRA reconcile channel for connecting to the queue manager.
+func (r *WorkloadReconciler) GetDRAReconcileChannel() chan<- event.TypedGenericEvent[*kueue.Workload] {
+	return r.draReconcileChannel
 }

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -456,6 +456,12 @@ func TestReconcile(t *testing.T) {
 					Reason:  kueue.WorkloadInadmissible,
 					Message: "DynamicResourceAllocation feature does not support use of resource claims",
 				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadRequeued,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadInadmissible,
+					Message: "DRA resource claims not supported",
+				}).
 				Obj(),
 			wantEvents: nil,
 		},
@@ -596,6 +602,12 @@ func TestReconcile(t *testing.T) {
 						Reason:  kueue.WorkloadInadmissible,
 						Message: "DeviceClass unmapped.example.com is not mapped in DRA configuration for workload wlUnmappedDRA podset main: DeviceClass is not mapped in DRA configuration",
 					}).
+					Condition(metav1.Condition{
+						Type:    kueue.WorkloadRequeued,
+						Status:  metav1.ConditionFalse,
+						Reason:  kueue.WorkloadInadmissible,
+						Message: "DeviceClass unmapped.example.com is not mapped in DRA configuration for workload wlUnmappedDRA podset main: DeviceClass is not mapped in DRA configuration",
+					}).
 					Obj()
 				wl.Spec.PodSets[0].Template.Spec.ResourceClaims = []corev1.PodResourceClaim{{
 					Name: "gpu", ResourceClaimTemplateName: ptr.To("gpu-template"),
@@ -629,6 +641,12 @@ func TestReconcile(t *testing.T) {
 					Obj()).
 				Condition(metav1.Condition{
 					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadInadmissible,
+					Message: `failed to get claim spec for ResourceClaimTemplate missing-template in workload wlMissingTemplate podset main: failed to get claim spec: resourceclaimtemplates.resource.k8s.io "missing-template" not found`,
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadRequeued,
 					Status:  metav1.ConditionFalse,
 					Reason:  kueue.WorkloadInadmissible,
 					Message: `failed to get claim spec for ResourceClaimTemplate missing-template in workload wlMissingTemplate podset main: failed to get claim spec: resourceclaimtemplates.resource.k8s.io "missing-template" not found`,
@@ -2390,7 +2408,7 @@ func TestReconcile(t *testing.T) {
 							break
 						}
 					}
-					if !foundInQueue {
+					if tc.wantWorkloadsInQueue != nil && !foundInQueue {
 						t.Errorf("DRA workload not found in queue - expected to be queued for processing")
 					}
 				} else {

--- a/pkg/dra/mapper.go
+++ b/pkg/dra/mapper.go
@@ -17,16 +17,13 @@ limitations under the License.
 package dra
 
 import (
-	"sync"
-
 	corev1 "k8s.io/api/core/v1"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta1"
 )
 
 var (
-	globalMapper     *ResourceMapper
-	globalMapperOnce sync.Once
+	globalMapper *ResourceMapper
 )
 
 // ResourceMapper provides device class to logical resource name mapping
@@ -64,11 +61,11 @@ func (m *ResourceMapper) populateFromConfiguration(mappings []configapi.DeviceCl
 	return nil
 }
 
-// Mapper returns the singleton DRA mapper instance initializing the mapper lazily on first access.
+// Mapper returns the singleton DRA mapper instance.
 func Mapper() *ResourceMapper {
-	globalMapperOnce.Do(func() {
+	if globalMapper == nil {
 		globalMapper = newDRAResourceMapper()
-	})
+	}
 	return globalMapper
 }
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -972,6 +972,35 @@ func IsActive(w *kueue.Workload) bool {
 	return ptr.Deref(w.Spec.Active, true)
 }
 
+// HasDRA returns true if the workload has DRA resources (ResourceClaims or ResourceClaimTemplates).
+func HasDRA(w *kueue.Workload) bool {
+	return HasResourceClaim(w) || HasResourceClaimTemplates(w)
+}
+
+// HasResourceClaimTemplates returns true if the workload has ResourceClaimTemplates.
+func HasResourceClaimTemplates(w *kueue.Workload) bool {
+	for _, ps := range w.Spec.PodSets {
+		for _, prc := range ps.Template.Spec.ResourceClaims {
+			if prc.ResourceClaimTemplateName != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// HasResourceClaim returns true if the workload has ResourceClaims.
+func HasResourceClaim(w *kueue.Workload) bool {
+	for _, ps := range w.Spec.PodSets {
+		for _, prc := range ps.Template.Spec.ResourceClaims {
+			if prc.ResourceClaimName != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // IsEvictedByDeactivation returns true if the workload is evicted by deactivation.
 func IsEvictedByDeactivation(w *kueue.Workload) bool {
 	cond := apimeta.FindStatusCondition(w.Status.Conditions, kueue.WorkloadEvicted)

--- a/test/integration/singlecluster/controller/dra/suite_test.go
+++ b/test/integration/singlecluster/controller/dra/suite_test.go
@@ -107,9 +107,6 @@ func managerSetup(modifyConfig func(*config.Configuration)) framework.ManagerSet
 			},
 		}
 
-		err = dra.CreateMapperFromConfiguration(mappings)
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
 		// Controllers configuration
 		controllersCfg := &config.Configuration{
 			Namespace: ptr.To("kueue-system"),
@@ -122,6 +119,9 @@ func managerSetup(modifyConfig func(*config.Configuration)) framework.ManagerSet
 		if modifyConfig != nil {
 			modifyConfig(controllersCfg)
 		}
+
+		err = dra.CreateMapperFromConfiguration(controllersCfg.Resources.DeviceClassMappings)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		cCache := schdcache.New(mgr.GetClient())
 		queues := qcache.NewManager(mgr.GetClient(), cCache)

--- a/test/integration/singlecluster/controller/dra/suite_test.go
+++ b/test/integration/singlecluster/controller/dra/suite_test.go
@@ -82,59 +82,64 @@ var _ = ginkgo.AfterSuite(func() {
 })
 
 // Manager setup used by tests to start controllers with DRA ConfigMap configuration
-func managerSetup(ctx context.Context, mgr manager.Manager) {
-	// Indexes
-	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+func managerSetup(modifyConfig func(*config.Configuration)) framework.ManagerSetup {
+	return func(ctx context.Context, mgr manager.Manager) {
+		// Indexes
+		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	// Webhooks
-	failedWebhook, err := webhooks.Setup(mgr, config.MultiKueueDispatcherModeAllAtOnce)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
+		// Webhooks
+		failedWebhook, err := webhooks.Setup(mgr, config.MultiKueueDispatcherModeAllAtOnce)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
-	mappings := []config.DeviceClassMapping{
-		{
-			Name:             corev1.ResourceName("foo"),
-			DeviceClassNames: []corev1.ResourceName{"foo.example.com"},
-		},
-		{
-			Name:             corev1.ResourceName("res-1"),
-			DeviceClassNames: []corev1.ResourceName{"test-deviceclass-1"},
-		},
-		{
-			Name:             corev1.ResourceName("res-2"),
-			DeviceClassNames: []corev1.ResourceName{"test-deviceclass-2"},
-		},
+		mappings := []config.DeviceClassMapping{
+			{
+				Name:             corev1.ResourceName("foo"),
+				DeviceClassNames: []corev1.ResourceName{"foo.example.com"},
+			},
+			{
+				Name:             corev1.ResourceName("res-1"),
+				DeviceClassNames: []corev1.ResourceName{"test-deviceclass-1"},
+			},
+			{
+				Name:             corev1.ResourceName("res-2"),
+				DeviceClassNames: []corev1.ResourceName{"test-deviceclass-2"},
+			},
+		}
+
+		err = dra.CreateMapperFromConfiguration(mappings)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		// Controllers configuration
+		controllersCfg := &config.Configuration{
+			Namespace: ptr.To("kueue-system"),
+			Resources: &config.Resources{
+				DeviceClassMappings: mappings,
+			},
+		}
+		mgr.GetScheme().Default(controllersCfg)
+		controllersCfg.Metrics.EnableClusterQueueResources = true
+		if modifyConfig != nil {
+			modifyConfig(controllersCfg)
+		}
+
+		cCache := schdcache.New(mgr.GetClient())
+		queues := qcache.NewManager(mgr.GetClient(), cCache)
+
+		// Core controllers
+		failedCtrl, err := core.SetupControllers(mgr, queues, cCache, controllersCfg)
+		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+
+		// Scheduler - required for workload admission
+		sched := scheduler.New(
+			queues,
+			cCache,
+			mgr.GetClient(),
+			mgr.GetEventRecorderFor("kueue-admission"),
+		)
+		err = mgr.Add(sched)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	}
-
-	err = dra.CreateMapperFromConfiguration(mappings)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-	// Controllers configuration
-	controllersCfg := &config.Configuration{
-		Namespace: ptr.To("kueue-system"),
-		Resources: &config.Resources{
-			DeviceClassMappings: mappings,
-		},
-	}
-	mgr.GetScheme().Default(controllersCfg)
-	controllersCfg.Metrics.EnableClusterQueueResources = true
-
-	cCache := schdcache.New(mgr.GetClient())
-	queues := qcache.NewManager(mgr.GetClient(), cCache)
-
-	// Core controllers
-	failedCtrl, err := core.SetupControllers(mgr, queues, cCache, controllersCfg)
-	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
-
-	// Scheduler - required for workload admission
-	sched := scheduler.New(
-		queues,
-		cCache,
-		mgr.GetClient(),
-		mgr.GetEventRecorderFor("kueue-admission"),
-	)
-	err = mgr.Add(sched)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 
 // Helper function to create a ResourceClaim


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

There is a difference between how DRA worklaods are processed and how other workloads are processed in Kueue. DRA workloads need some extra get calls, so they are skipped in event handlers and are instead processed in reconcile loop.

As a result, we need all the processing upon restart to happen through reconcile loop and avoid adding workloads to scheduler queue in all cases except the workload reconciler


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```