### PR TITLE
[Cleanup] Replace `WithStrict(strict bool)` with `WithLoose()`

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -556,7 +556,7 @@ func (p *Pod) Finalize(ctx context.Context, c client.Client) error {
 		pod := &podsInGroup.Items[i]
 		return clientutil.Patch(ctx, c, pod, func() (client.Object, bool, error) {
 			return pod, controllerutil.RemoveFinalizer(pod, podconstants.PodFinalizer), nil
-		}, clientutil.WithStrict(false))
+		}, clientutil.WithLoose())
 	})
 }
 
@@ -919,7 +919,7 @@ func (p *Pod) removeExcessPods(ctx context.Context, c client.Client, r record.Ev
 				log.V(3).Info("Finalizing excess pod in group", "excessPod", klog.KObj(&pod))
 			}
 			return &pod, removed, nil
-		}, clientutil.WithStrict(false)); err != nil {
+		}, clientutil.WithLoose()); err != nil {
 			// We won't observe this cleanup in the event handler.
 			p.excessPodExpectations.ObservedUID(log, p.key, pod.UID)
 			return err
@@ -961,7 +961,7 @@ func (p *Pod) finalizePods(ctx context.Context, c client.Client, extraPods []cor
 				log.V(3).Info("Finalizing pod in group", "Pod", klog.KObj(&pod))
 			}
 			return &pod, removed, nil
-		}, clientutil.WithStrict(false)); err != nil {
+		}, clientutil.WithLoose()); err != nil {
 			// We won't observe this cleanup in the event handler.
 			p.excessPodExpectations.ObservedUID(log, p.key, pod.UID)
 			return err

--- a/pkg/util/client/client.go
+++ b/pkg/util/client/client.go
@@ -37,7 +37,7 @@ type PatchOption func(*PatchOptions)
 //     ResourceVersion.
 //
 // Typically, PatchOptions are constructed via DefaultPatchOptions and
-// modified using PatchOption functions (e.g., WithStrict).
+// modified using PatchOption functions (e.g., WithLoose).
 type PatchOptions struct {
 	Strict bool
 }
@@ -54,7 +54,7 @@ func DefaultPatchOptions() *PatchOptions {
 	}
 }
 
-// WithStrict returns a PatchOption that sets the Strict field on PatchOptions.
+// WithLoose returns a PatchOption that sets the Strict field on PatchOptions.
 //
 // By default, Strict is true. In strict mode, generated patches enforce stricter
 // behavior by clearing the ResourceVersion field from the "original" object.
@@ -65,10 +65,10 @@ func DefaultPatchOptions() *PatchOptions {
 //
 //	patch := clientutil.Patch(ctx, c, obj, true, func() (bool, error) {
 //	    return updateFn(obj), nil
-//	}, WithStrict(false)) // disables strict mode
-func WithStrict(strict bool) PatchOption {
+//	}, WithLoose()) // disables strict mode
+func WithLoose() PatchOption {
 	return func(o *PatchOptions) {
-		o.Strict = strict
+		o.Strict = false
 	}
 }
 
@@ -87,7 +87,7 @@ func patchCommon(obj client.Object, update func() (client.Object, bool, error), 
 // the changes. Finally, it applies the patch through the given client.Client.
 //
 // Behavior is influenced by PatchOptions, which can be customized using
-// PatchOption functional arguments (e.g., WithStrict).
+// PatchOption functional arguments (e.g., WithLoose).
 //
 // Returns:
 //   - error: If patch generation or application fails, an error is returned.
@@ -98,7 +98,7 @@ func patchCommon(obj client.Object, update func() (client.Object, bool, error), 
 //	    updated := obj.DeepCopyObject().(client.Object)
 //	    updated.SetLabels(map[string]string{"app": "demo"})
 //	    return updated, true, nil
-//	}, WithStrict(true))
+//	}, WithLoose())
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
@@ -122,7 +122,7 @@ func Patch(ctx context.Context, c client.Client, obj client.Object, update func(
 // (c.Status().Patch).
 //
 // Behavior is influenced by PatchOptions, which can be customized using
-// PatchOption functional arguments (e.g., WithStrict).
+// PatchOption functional arguments (e.g., WithLoose).
 //
 // Returns:
 //   - error: If patch generation or application fails, an error is returned.

--- a/pkg/util/client/client_test.go
+++ b/pkg/util/client/client_test.go
@@ -110,7 +110,7 @@ func TestPatch(t *testing.T) {
 					obj.Spec.Suspend = ptr.To(true)
 					return obj, true, nil
 				},
-				options: []PatchOption{WithStrict(false)},
+				options: []PatchOption{WithLoose()},
 			},
 			want: want{
 				// Unlike "Strict" version - this update is successful since the resource version is not
@@ -128,7 +128,7 @@ func TestPatch(t *testing.T) {
 					obj.Spec.Suspend = ptr.To(true)
 					return obj, true, nil
 				},
-				options: []PatchOption{WithStrict(false)},
+				options: []PatchOption{WithLoose()},
 			},
 			want: want{
 				obj: newObject("3", func(job *batchv1.Job) {
@@ -235,7 +235,7 @@ func TestPatchStatus(t *testing.T) {
 					obj.Status.Active = 1
 					return obj, true, nil
 				},
-				options: []PatchOption{WithStrict(false)},
+				options: []PatchOption{WithLoose()},
 			},
 			want: want{
 				obj: newObject("3", func(job *batchv1.Job) {
@@ -251,7 +251,7 @@ func TestPatchStatus(t *testing.T) {
 					obj.Status.Active = 1
 					return obj, true, nil
 				},
-				options: []PatchOption{WithStrict(false)},
+				options: []PatchOption{WithLoose()},
 			},
 			want: want{
 				obj: newObject("3", func(job *batchv1.Job) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR replaces the `WithStrict(strict bool)` function with a simpler `WithLoose()` function that always sets the Strict field to false.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6959

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```