### PR TITLE
[Cleanup] Remove QueueVisibility config validation code

### DIFF
--- a/apis/config/v1beta1/defaults.go
+++ b/apis/config/v1beta1/defaults.go
@@ -30,29 +30,27 @@ import (
 )
 
 const (
-	DefaultNamespace                                    = "kueue-system"
-	DefaultWebhookServiceName                           = "kueue-webhook-service"
-	DefaultWebhookSecretName                            = "kueue-webhook-server-cert"
-	DefaultWebhookPort                                  = 9443
-	DefaultWebhookCertDir                               = "/tmp/k8s-webhook-server/serving-certs"
-	DefaultHealthProbeBindAddress                       = ":8081"
-	DefaultMetricsBindAddress                           = ":8443"
-	DefaultLeaderElectionID                             = "c1f6bfd2.kueue.x-k8s.io"
-	DefaultLeaderElectionLeaseDuration                  = 15 * time.Second
-	DefaultLeaderElectionRenewDeadline                  = 10 * time.Second
-	DefaultLeaderElectionRetryPeriod                    = 2 * time.Second
-	DefaultClientConnectionQPS                  float32 = 20.0
-	DefaultClientConnectionBurst                int32   = 30
-	defaultPodsReadyTimeout                             = 5 * time.Minute
-	DefaultQueueVisibilityUpdateIntervalSeconds int32   = 5
-	DefaultClusterQueuesMaxCount                int32   = 10
-	defaultJobFrameworkName                             = "batch/job"
-	DefaultMultiKueueGCInterval                         = time.Minute
-	DefaultMultiKueueOrigin                             = "multikueue"
-	DefaultMultiKueueWorkerLostTimeout                  = 15 * time.Minute
-	DefaultRequeuingBackoffBaseSeconds                  = 60
-	DefaultRequeuingBackoffMaxSeconds                   = 3600
-	DefaultResourceTransformationStrategy               = Retain
+	DefaultNamespace                              = "kueue-system"
+	DefaultWebhookServiceName                     = "kueue-webhook-service"
+	DefaultWebhookSecretName                      = "kueue-webhook-server-cert"
+	DefaultWebhookPort                            = 9443
+	DefaultWebhookCertDir                         = "/tmp/k8s-webhook-server/serving-certs"
+	DefaultHealthProbeBindAddress                 = ":8081"
+	DefaultMetricsBindAddress                     = ":8443"
+	DefaultLeaderElectionID                       = "c1f6bfd2.kueue.x-k8s.io"
+	DefaultLeaderElectionLeaseDuration            = 15 * time.Second
+	DefaultLeaderElectionRenewDeadline            = 10 * time.Second
+	DefaultLeaderElectionRetryPeriod              = 2 * time.Second
+	DefaultClientConnectionQPS            float32 = 20.0
+	DefaultClientConnectionBurst          int32   = 30
+	defaultPodsReadyTimeout                       = 5 * time.Minute
+	defaultJobFrameworkName                       = "batch/job"
+	DefaultMultiKueueGCInterval                   = time.Minute
+	DefaultMultiKueueOrigin                       = "multikueue"
+	DefaultMultiKueueWorkerLostTimeout            = 15 * time.Minute
+	DefaultRequeuingBackoffBaseSeconds            = 60
+	DefaultRequeuingBackoffMaxSeconds             = 3600
+	DefaultResourceTransformationStrategy         = Retain
 )
 
 func getOperatorNamespace() string {
@@ -108,12 +106,6 @@ func SetDefaults_Configuration(cfg *Configuration) {
 	if len(cfg.Integrations.Frameworks) == 0 {
 		cfg.Integrations.Frameworks = []string{defaultJobFrameworkName}
 	}
-
-	cfg.QueueVisibility = cmp.Or(cfg.QueueVisibility, &QueueVisibility{})
-	cfg.QueueVisibility.UpdateIntervalSeconds = cmp.Or(cfg.QueueVisibility.UpdateIntervalSeconds, DefaultQueueVisibilityUpdateIntervalSeconds)
-	cfg.QueueVisibility.ClusterQueues = cmp.Or(cfg.QueueVisibility.ClusterQueues, &ClusterQueueVisibility{
-		MaxCount: DefaultClusterQueuesMaxCount,
-	})
 
 	cfg.ManagedJobsNamespaceSelector = cmp.Or(cfg.ManagedJobsNamespaceSelector, &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{

--- a/apis/config/v1beta1/defaults_test.go
+++ b/apis/config/v1beta1/defaults_test.go
@@ -64,12 +64,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 	defaultIntegrations := &Integrations{
 		Frameworks: []string{defaultJobFrameworkName},
 	}
-	defaultQueueVisibility := &QueueVisibility{
-		UpdateIntervalSeconds: DefaultQueueVisibilityUpdateIntervalSeconds,
-		ClusterQueues: &ClusterQueueVisibility{
-			MaxCount: 10,
-		},
-	}
 	defaultManagedJobsNamespaceSelector := &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
@@ -122,7 +116,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             &WaitForPodsReady{},
@@ -166,7 +159,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             &WaitForPodsReady{},
@@ -197,8 +189,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				InternalCertManagement: &InternalCertManagement{
 					Enable: ptr.To(false),
 				},
-				Integrations:    defaultIntegrations,
-				QueueVisibility: defaultQueueVisibility,
+				Integrations: defaultIntegrations,
 			},
 			want: &Configuration{
 				Namespace: ptr.To(DefaultNamespace),
@@ -227,7 +218,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             &WaitForPodsReady{},
@@ -271,7 +261,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             &WaitForPodsReady{},
@@ -291,7 +280,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 overwriteNamespaceIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: overwriteNamespaceSelector,
 				WaitForPodsReady:             &WaitForPodsReady{},
@@ -312,7 +300,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 overwriteNamespaceIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: overwriteNamespaceSelector,
 				WaitForPodsReady:             &WaitForPodsReady{},
@@ -340,7 +327,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Burst: ptr.To[int32](456),
 				},
 				Integrations:                 overwriteNamespaceIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: overwriteNamespaceSelector,
 				WaitForPodsReady:             &WaitForPodsReady{},
@@ -362,7 +348,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 overwriteNamespaceIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: overwriteNamespaceSelector,
 				WaitForPodsReady:             &WaitForPodsReady{},
@@ -396,7 +381,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 			},
@@ -421,7 +405,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 			},
@@ -461,7 +444,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 			},
@@ -484,38 +466,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				ClientConnection: defaultClientConnection,
 				Integrations: &Integrations{
 					Frameworks: []string{"a", "b"},
-				},
-				QueueVisibility:              defaultQueueVisibility,
-				MultiKueue:                   defaultMultiKueue,
-				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
-				WaitForPodsReady:             &WaitForPodsReady{},
-			},
-		},
-		"queue visibility": {
-			original: &Configuration{
-				InternalCertManagement: &InternalCertManagement{
-					Enable: ptr.To(false),
-				},
-				QueueVisibility: &QueueVisibility{
-					UpdateIntervalSeconds: 10,
-					ClusterQueues: &ClusterQueueVisibility{
-						MaxCount: 0,
-					},
-				},
-			},
-			want: &Configuration{
-				Namespace:         ptr.To(DefaultNamespace),
-				ControllerManager: defaultCtrlManagerConfigurationSpec,
-				InternalCertManagement: &InternalCertManagement{
-					Enable: ptr.To(false),
-				},
-				ClientConnection: defaultClientConnection,
-				Integrations:     defaultIntegrations,
-				QueueVisibility: &QueueVisibility{
-					UpdateIntervalSeconds: 10,
-					ClusterQueues: &ClusterQueueVisibility{
-						MaxCount: 0,
-					},
 				},
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
@@ -542,7 +492,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection: defaultClientConnection,
 				Integrations:     defaultIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
 				MultiKueue: &MultiKueue{
 					GCInterval:        &metav1.Duration{Duration: time.Second},
 					Origin:            ptr.To("multikueue-manager1"),
@@ -573,7 +522,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection: defaultClientConnection,
 				Integrations:     defaultIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
 				MultiKueue: &MultiKueue{
 					GCInterval:        &metav1.Duration{Duration: time.Second},
 					Origin:            ptr.To(DefaultMultiKueueOrigin),
@@ -602,7 +550,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection: defaultClientConnection,
 				Integrations:     defaultIntegrations,
-				QueueVisibility:  defaultQueueVisibility,
 				MultiKueue: &MultiKueue{
 					GCInterval:        &metav1.Duration{},
 					Origin:            ptr.To("multikueue-manager1"),
@@ -630,7 +577,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				FairSharing: &FairSharing{
@@ -660,7 +606,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				ObjectRetentionPolicies: &ObjectRetentionPolicies{
@@ -693,7 +638,6 @@ func TestSetDefaults_Configuration(t *testing.T) {
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				Resources: &Resources{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -238,18 +238,6 @@ integrations:
 		t.Fatal(err)
 	}
 
-	queueVisibilityConfig := filepath.Join(tmpDir, "queueVisibility.yaml")
-	if err := os.WriteFile(queueVisibilityConfig, []byte(`
-apiVersion: config.kueue.x-k8s.io/v1beta1
-kind: Configuration
-queueVisibility:
-  updateIntervalSeconds: 10
-  clusterQueues:
-    maxCount: 0
-`), os.FileMode(0600)); err != nil {
-		t.Fatal(err)
-	}
-
 	podIntegrationOptionsConfig := filepath.Join(tmpDir, "podIntegrationOptions.yaml")
 	if err := os.WriteFile(podIntegrationOptionsConfig, []byte(`
 apiVersion: config.kueue.x-k8s.io/v1beta1
@@ -401,13 +389,6 @@ objectRetentionPolicies:
 		},
 	}
 
-	defaultQueueVisibility := &configapi.QueueVisibility{
-		UpdateIntervalSeconds: configapi.DefaultQueueVisibilityUpdateIntervalSeconds,
-		ClusterQueues: &configapi.ClusterQueueVisibility{
-			MaxCount: 10,
-		},
-	}
-
 	defaultMultiKueue := &configapi.MultiKueue{
 		GCInterval:        &metav1.Duration{Duration: configapi.DefaultMultiKueueGCInterval},
 		Origin:            ptr.To(configapi.DefaultMultiKueueOrigin),
@@ -432,7 +413,6 @@ objectRetentionPolicies:
 				InternalCertManagement:       enableDefaultInternalCertManagement,
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             defaultWaitForPodsReady,
@@ -481,8 +461,7 @@ objectRetentionPolicies:
 				Integrations: &configapi.Integrations{
 					Frameworks: []string{job.FrameworkName},
 				},
-				QueueVisibility: defaultQueueVisibility,
-				MultiKueue:      defaultMultiKueue,
+				MultiKueue: defaultMultiKueue,
 				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
@@ -509,7 +488,6 @@ objectRetentionPolicies:
 				InternalCertManagement:       enableDefaultInternalCertManagement,
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             defaultWaitForPodsReady,
@@ -551,7 +529,6 @@ objectRetentionPolicies:
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             defaultWaitForPodsReady,
@@ -573,7 +550,6 @@ objectRetentionPolicies:
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             defaultWaitForPodsReady,
@@ -593,7 +569,6 @@ objectRetentionPolicies:
 				InternalCertManagement:       enableDefaultInternalCertManagement,
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             defaultWaitForPodsReady,
@@ -643,7 +618,6 @@ objectRetentionPolicies:
 				},
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 			},
@@ -683,7 +657,6 @@ objectRetentionPolicies:
 					Burst: ptr.To[int32](100),
 				},
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             defaultWaitForPodsReady,
@@ -706,7 +679,6 @@ objectRetentionPolicies:
 					Burst: ptr.To[int32](100),
 				},
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             defaultWaitForPodsReady,
@@ -760,50 +732,6 @@ objectRetentionPolicies:
 					Frameworks:         []string{job.FrameworkName},
 					ExternalFrameworks: []string{"Foo.v1.example.com"},
 				},
-				QueueVisibility:              defaultQueueVisibility,
-				MultiKueue:                   defaultMultiKueue,
-				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
-				WaitForPodsReady:             defaultWaitForPodsReady,
-			},
-			wantOptions: ctrl.Options{
-				HealthProbeBindAddress: configapi.DefaultHealthProbeBindAddress,
-				Metrics: metricsserver.Options{
-					BindAddress: configapi.DefaultMetricsBindAddress,
-				},
-				LeaderElection:                true,
-				LeaderElectionID:              configapi.DefaultLeaderElectionID,
-				LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
-				LeaderElectionReleaseOnCancel: true,
-				LeaseDuration:                 ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
-				RenewDeadline:                 ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
-				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
-				WebhookServer: &webhook.DefaultServer{
-					Options: webhook.Options{
-						Port:    configapi.DefaultWebhookPort,
-						CertDir: configapi.DefaultWebhookCertDir,
-					},
-				},
-			},
-		},
-		{
-			name:       "queue visibility config",
-			configFile: queueVisibilityConfig,
-			wantConfiguration: configapi.Configuration{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: configapi.GroupVersion.String(),
-					Kind:       "Configuration",
-				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
-				ManageJobsWithoutQueueName: false,
-				InternalCertManagement:     enableDefaultInternalCertManagement,
-				ClientConnection:           defaultClientConnection,
-				Integrations:               defaultIntegrations,
-				QueueVisibility: &configapi.QueueVisibility{
-					UpdateIntervalSeconds: 10,
-					ClusterQueues: &configapi.ClusterQueueVisibility{
-						MaxCount: 0,
-					},
-				},
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				WaitForPodsReady:             defaultWaitForPodsReady,
@@ -840,7 +768,6 @@ objectRetentionPolicies:
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement:     enableDefaultInternalCertManagement,
 				ClientConnection:           defaultClientConnection,
-				QueueVisibility:            defaultQueueVisibility,
 				Integrations: &configapi.Integrations{
 					Frameworks: []string{
 						"pod",
@@ -903,7 +830,6 @@ objectRetentionPolicies:
 				InternalCertManagement:     enableDefaultInternalCertManagement,
 				ClientConnection:           defaultClientConnection,
 				Integrations:               defaultIntegrations,
-				QueueVisibility:            defaultQueueVisibility,
 				MultiKueue: &configapi.MultiKueue{
 					GCInterval:        &metav1.Duration{Duration: 90 * time.Second},
 					Origin:            ptr.To("multikueue-manager1"),
@@ -928,7 +854,6 @@ objectRetentionPolicies:
 				InternalCertManagement:       enableDefaultInternalCertManagement,
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				Resources: &configapi.Resources{
@@ -983,7 +908,6 @@ objectRetentionPolicies:
 				InternalCertManagement:       enableDefaultInternalCertManagement,
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
-				QueueVisibility:              defaultQueueVisibility,
 				MultiKueue:                   defaultMultiKueue,
 				ManagedJobsNamespaceSelector: defaultManagedJobsNamespaceSelector,
 				ObjectRetentionPolicies: &configapi.ObjectRetentionPolicies{
@@ -1096,10 +1020,6 @@ func TestEncode(t *testing.T) {
 				},
 				"integrations": map[string]any{
 					"frameworks": []any{"batch/job"},
-				},
-				"queueVisibility": map[string]any{
-					"updateIntervalSeconds": int64(configapi.DefaultQueueVisibilityUpdateIntervalSeconds),
-					"clusterQueues":         map[string]any{"maxCount": int64(10)},
 				},
 				"multiKueue": map[string]any{
 					"gcInterval":        "1m0s",

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -43,12 +43,6 @@ func TestValidate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defaultQueueVisibility := &configapi.QueueVisibility{
-		UpdateIntervalSeconds: configapi.DefaultQueueVisibilityUpdateIntervalSeconds,
-		ClusterQueues: &configapi.ClusterQueueVisibility{
-			MaxCount: configapi.DefaultClusterQueuesMaxCount,
-		},
-	}
 	systemNamespacesSelector := &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
@@ -77,48 +71,6 @@ func TestValidate(t *testing.T) {
 				&field.Error{
 					Type:  field.ErrorTypeRequired,
 					Field: "integrations",
-				},
-			},
-		},
-		"invalid queue visibility UpdateIntervalSeconds": {
-			cfg: &configapi.Configuration{
-				QueueVisibility: &configapi.QueueVisibility{
-					UpdateIntervalSeconds: 0,
-				},
-				Integrations: defaultIntegrations,
-			},
-			wantErr: field.ErrorList{
-				field.Invalid(field.NewPath("queueVisibility").Child("updateIntervalSeconds"), 0, fmt.Sprintf("greater than or equal to %d", queueVisibilityClusterQueuesUpdateIntervalSeconds)),
-			},
-		},
-		"invalid queue visibility cluster queue max count due to exceeding maximal value": {
-			cfg: &configapi.Configuration{
-				QueueVisibility: &configapi.QueueVisibility{
-					ClusterQueues: &configapi.ClusterQueueVisibility{
-						MaxCount: 4001,
-					},
-					UpdateIntervalSeconds: 1,
-				},
-				Integrations: defaultIntegrations,
-			},
-			wantErr: field.ErrorList{
-				field.Invalid(field.NewPath("queueVisibility").Child("clusterQueues").Child("maxCount"), 4001, fmt.Sprintf("must be less than %d", queueVisibilityClusterQueuesMaxValue)),
-			},
-		},
-		"negative queue visibility cluster queue max cont": {
-			cfg: &configapi.Configuration{
-				QueueVisibility: &configapi.QueueVisibility{
-					ClusterQueues: &configapi.ClusterQueueVisibility{
-						MaxCount: -1,
-					},
-					UpdateIntervalSeconds: 1,
-				},
-				Integrations: defaultIntegrations,
-			},
-			wantErr: field.ErrorList{
-				&field.Error{
-					Type:  field.ErrorTypeInvalid,
-					Field: "queueVisibility.clusterQueues.maxCount",
 				},
 			},
 		},
@@ -209,7 +161,6 @@ func TestValidate(t *testing.T) {
 		},
 		"nil PodIntegrationOptions and nil managedJobsNamespaceSelector": {
 			cfg: &configapi.Configuration{
-				QueueVisibility: defaultQueueVisibility,
 				Integrations: &configapi.Integrations{
 					Frameworks: []string{"pod"},
 					PodOptions: nil,
@@ -224,8 +175,7 @@ func TestValidate(t *testing.T) {
 		},
 		"emptyLabelSelector": {
 			cfg: &configapi.Configuration{
-				Namespace:       ptr.To("kueue-system"),
-				QueueVisibility: defaultQueueVisibility,
+				Namespace: ptr.To("kueue-system"),
 				Integrations: &configapi.Integrations{
 					Frameworks: []string{"pod"},
 					PodOptions: &configapi.PodIntegrationOptions{
@@ -246,7 +196,6 @@ func TestValidate(t *testing.T) {
 		},
 		"valid managedJobsNamespaceSelector ": {
 			cfg: &configapi.Configuration{
-				QueueVisibility:              defaultQueueVisibility,
 				ManagedJobsNamespaceSelector: systemNamespacesSelector,
 				Integrations:                 defaultIntegrations,
 			},
@@ -255,7 +204,6 @@ func TestValidate(t *testing.T) {
 
 		"prohibited namespace in MatchLabels": {
 			cfg: &configapi.Configuration{
-				QueueVisibility: defaultQueueVisibility,
 				Integrations: &configapi.Integrations{
 					Frameworks: []string{"pod"},
 					PodOptions: &configapi.PodIntegrationOptions{
@@ -276,7 +224,6 @@ func TestValidate(t *testing.T) {
 		},
 		"prohibited namespace in MatchLabels managedJobsNamespaceSelector": {
 			cfg: &configapi.Configuration{
-				QueueVisibility: defaultQueueVisibility,
 				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						corev1.LabelMetadataName: "kube-system",
@@ -293,7 +240,6 @@ func TestValidate(t *testing.T) {
 		},
 		"prohibited namespace in MatchExpressions with operator In": {
 			cfg: &configapi.Configuration{
-				QueueVisibility: defaultQueueVisibility,
 				Integrations: &configapi.Integrations{
 					Frameworks: []string{"pod"},
 					PodOptions: &configapi.PodIntegrationOptions{
@@ -318,7 +264,6 @@ func TestValidate(t *testing.T) {
 		},
 		"prohibited namespace in MatchExpressions with operator In managedJobsNamespaceSelector": {
 			cfg: &configapi.Configuration{
-				QueueVisibility: defaultQueueVisibility,
 				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{
@@ -339,7 +284,6 @@ func TestValidate(t *testing.T) {
 		},
 		"prohibited namespace in MatchExpressions with operator NotIn": {
 			cfg: &configapi.Configuration{
-				QueueVisibility: defaultQueueVisibility,
 				Integrations: &configapi.Integrations{
 					Frameworks: []string{"pod"},
 					PodOptions: &configapi.PodIntegrationOptions{
@@ -359,7 +303,6 @@ func TestValidate(t *testing.T) {
 		},
 		"prohibited namespace in MatchExpressions with operator NotIn managedJobsNamespaceSelector": {
 			cfg: &configapi.Configuration{
-				QueueVisibility: defaultQueueVisibility,
 				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{

--- a/test/integration/singlecluster/kueuectl/suite_test.go
+++ b/test/integration/singlecluster/kueuectl/suite_test.go
@@ -86,12 +86,6 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 	mgr.GetScheme().Default(controllersCfg)
 
 	controllersCfg.Metrics.EnableClusterQueueResources = true
-	controllersCfg.QueueVisibility = &config.QueueVisibility{
-		UpdateIntervalSeconds: 2,
-		ClusterQueues: &config.ClusterQueueVisibility{
-			MaxCount: 3,
-		},
-	}
 
 	cCache := schdcache.New(mgr.GetClient())
 	queues := qcache.NewManager(mgr.GetClient(), cCache)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR cleans up of QueueVisibility config validation codes by removing all unused validation logic related to QueueVisibility configuration.

- Removed QueueVisibility-related constants and default settings from `apis/config/v1beta1/defaults.go`
- Cleaned test cases to remove QueueVisibility assertions

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6958

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```