### PR TITLE
Optimize performance of controllers by skipping Reconcile if the object didn't change

### DIFF
--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -41,6 +41,8 @@ import (
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
+var realClock = clock.RealClock{}
+
 func Import(ctx context.Context, c client.Client, cache *util.ImportCache, jobs uint) error {
 	ch := make(chan corev1.Pod)
 	go func() {
@@ -86,42 +88,7 @@ func Import(ctx context.Context, c client.Client, cache *util.ImportCache, jobs 
 			return false, fmt.Errorf("creating workload: %w", err)
 		}
 
-		// make its admission and update its status
-		info := workload.NewInfo(wl)
-		cq := cache.ClusterQueues[string(lq.Spec.ClusterQueue)]
-		admission := kueue.Admission{
-			ClusterQueue: kueue.ClusterQueueReference(cq.Name),
-			PodSetAssignments: []kueue.PodSetAssignment{
-				{
-					Name:          info.TotalRequests[0].Name,
-					Flavors:       make(map[corev1.ResourceName]kueue.ResourceFlavorReference),
-					ResourceUsage: info.TotalRequests[0].Requests.ToResourceList(),
-					Count:         ptr.To[int32](1),
-				},
-			},
-		}
-		flv := cq.Spec.ResourceGroups[0].Flavors[0].Name
-		for r := range info.TotalRequests[0].Requests {
-			admission.PodSetAssignments[0].Flavors[r] = flv
-		}
-
-		wlOrig := wl.DeepCopy()
-		wl.Status.Admission = &admission
-		reservedCond := metav1.Condition{
-			Type:    kueue.WorkloadQuotaReserved,
-			Status:  metav1.ConditionTrue,
-			Reason:  "Imported",
-			Message: fmt.Sprintf("Imported into ClusterQueue %s", cq.Name),
-		}
-		apimeta.SetStatusCondition(&wl.Status.Conditions, reservedCond)
-		admittedCond := metav1.Condition{
-			Type:    kueue.WorkloadAdmitted,
-			Status:  metav1.ConditionTrue,
-			Reason:  "Imported",
-			Message: fmt.Sprintf("Imported into ClusterQueue %s", cq.Name),
-		}
-		apimeta.SetStatusCondition(&wl.Status.Conditions, admittedCond)
-		if err := admitWorkload(ctx, c, wlOrig, wl); err != nil {
+		if err := admitWorkload(ctx, c, wl, cache.ClusterQueues[string(lq.Spec.ClusterQueue)]); err != nil {
 			return false, err
 		}
 		log.V(2).Info("Successfully imported", "pod", klog.KObj(p), "workload", klog.KObj(wl))
@@ -200,11 +167,46 @@ func createWorkload(ctx context.Context, c client.Client, wl *kueue.Workload) er
 	return err
 }
 
-func admitWorkload(ctx context.Context, c client.Client, wlOrig, wl *kueue.Workload) error {
-	var realClock = clock.RealClock{}
-	err := workload.PatchAdmissionStatus(ctx, c, wlOrig, realClock, func() (*kueue.Workload, bool, error) {
+func admitWorkload(ctx context.Context, c client.Client, wl *kueue.Workload, cq *kueue.ClusterQueue) error {
+	update := func() (*kueue.Workload, bool, error) {
+		// make its admission and update its status
+		info := workload.NewInfo(wl)
+
+		admission := kueue.Admission{
+			ClusterQueue: kueue.ClusterQueueReference(cq.Name),
+			PodSetAssignments: []kueue.PodSetAssignment{
+				{
+					Name:          info.TotalRequests[0].Name,
+					Flavors:       make(map[corev1.ResourceName]kueue.ResourceFlavorReference),
+					ResourceUsage: info.TotalRequests[0].Requests.ToResourceList(),
+					Count:         ptr.To[int32](1),
+				},
+			},
+		}
+		flv := cq.Spec.ResourceGroups[0].Flavors[0].Name
+		for r := range info.TotalRequests[0].Requests {
+			admission.PodSetAssignments[0].Flavors[r] = flv
+		}
+
+		wl.Status.Admission = &admission
+		reservedCond := metav1.Condition{
+			Type:    kueue.WorkloadQuotaReserved,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Imported",
+			Message: fmt.Sprintf("Imported into ClusterQueue %s", cq.Name),
+		}
+		apimeta.SetStatusCondition(&wl.Status.Conditions, reservedCond)
+		admittedCond := metav1.Condition{
+			Type:    kueue.WorkloadAdmitted,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Imported",
+			Message: fmt.Sprintf("Imported into ClusterQueue %s", cq.Name),
+		}
+		apimeta.SetStatusCondition(&wl.Status.Conditions, admittedCond)
 		return wl, true, nil
-	})
+	}
+
+	err := workload.PatchAdmissionStatus(ctx, c, wl, realClock, update)
 	retry, _, timeout := checkError(err)
 	for retry {
 		if timeout >= 0 {
@@ -214,9 +216,7 @@ func admitWorkload(ctx context.Context, c client.Client, wlOrig, wl *kueue.Workl
 			case <-time.After(timeout):
 			}
 		}
-		err = workload.PatchAdmissionStatus(ctx, c, wlOrig, realClock, func() (*kueue.Workload, bool, error) {
-			return wl, true, nil
-		})
+		err = workload.PatchAdmissionStatus(ctx, c, wl, realClock, update)
 		retry, _, timeout = checkError(err)
 	}
 	return err

--- a/pkg/workload/admissionchecks.go
+++ b/pkg/workload/admissionchecks.go
@@ -99,9 +99,9 @@ func resetChecksOnEviction(w *kueue.Workload, now time.Time) {
 }
 
 // SetAdmissionCheckState - adds or updates newCheck in the provided checks list.
-func SetAdmissionCheckState(checks *[]kueue.AdmissionCheckState, newCheck kueue.AdmissionCheckState, clock clock.Clock) {
+func SetAdmissionCheckState(checks *[]kueue.AdmissionCheckState, newCheck kueue.AdmissionCheckState, clock clock.Clock) bool {
 	if checks == nil {
-		return
+		return false
 	}
 	existingCondition := admissioncheck.FindAdmissionCheck(*checks, newCheck.Name)
 	if existingCondition == nil {
@@ -109,7 +109,7 @@ func SetAdmissionCheckState(checks *[]kueue.AdmissionCheckState, newCheck kueue.
 			newCheck.LastTransitionTime = metav1.NewTime(clock.Now())
 		}
 		*checks = append(*checks, newCheck)
-		return
+		return true
 	}
 
 	if existingCondition.State != newCheck.State {
@@ -122,6 +122,7 @@ func SetAdmissionCheckState(checks *[]kueue.AdmissionCheckState, newCheck kueue.
 	}
 	existingCondition.Message = newCheck.Message
 	existingCondition.PodSetUpdates = newCheck.PodSetUpdates
+	return true
 }
 
 // RejectedChecks returns the list of Rejected admission checks

--- a/test/integration/multikueue/dispatcher_test.go
+++ b/test/integration/multikueue/dispatcher_test.go
@@ -217,12 +217,12 @@ var _ = ginkgo.Describe("MultiKueueDispatcherIncremental", ginkgo.Ordered, ginkg
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 				g.Expect(workload.PatchAdmissionStatus(managerTestCluster.ctx, managerTestCluster.client, createdWorkload, realClock, func() (*kueue.Workload, bool, error) {
-					workload.SetAdmissionCheckState(&createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckState{
+					acs := kueue.AdmissionCheckState{
 						Name:    kueue.AdmissionCheckReference(multiKueueAC.Name),
 						State:   kueue.CheckStateRejected,
 						Message: "check rejected",
-					}, realClock)
-					return createdWorkload, true, nil
+					}
+					return createdWorkload, workload.SetAdmissionCheckState(&createdWorkload.Status.AdmissionChecks, acs, realClock), nil
 				})).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
@@ -464,12 +464,12 @@ var _ = ginkgo.Describe("MultiKueueDispatcherExternal", ginkgo.Ordered, ginkgo.C
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 				g.Expect(workload.PatchAdmissionStatus(managerTestCluster.ctx, managerTestCluster.client, createdWorkload, realClock, func() (*kueue.Workload, bool, error) {
-					workload.SetAdmissionCheckState(&createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckState{
+					acs := kueue.AdmissionCheckState{
 						Name:    kueue.AdmissionCheckReference(multiKueueAC.Name),
 						State:   kueue.CheckStateRejected,
 						Message: "check rejected",
-					}, realClock)
-					return createdWorkload, true, nil
+					}
+					return createdWorkload, workload.SetAdmissionCheckState(&createdWorkload.Status.AdmissionChecks, acs, realClock), nil
 				})).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -501,8 +501,7 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Ordered, ginkgo.ContinueOn
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, key, wl)).To(gomega.Succeed())
 					g.Expect(workload.PatchAdmissionStatus(ctx, k8sClient, wl, realClock, func() (*kueue.Workload, bool, error) {
-						workload.SetEvictedCondition(wl, "ByTest", "by test")
-						return wl, true, nil
+						return wl, workload.SetEvictedCondition(wl, "ByTest", "by test"), nil
 					})).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				util.FinishEvictionForWorkloads(ctx, k8sClient, wl)

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -799,8 +799,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 						g.Expect(workload.PatchAdmissionStatus(ctx, k8sClient, createdWorkload, realClock, func() (*kueue.Workload, bool, error) {
-							workload.SetEvictedCondition(createdWorkload, "ByTest", "by test")
-							return createdWorkload, true, nil
+							return createdWorkload, workload.SetEvictedCondition(createdWorkload, "ByTest", "by test"), nil
 						})).Should(gomega.Succeed())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -1393,8 +1392,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Ordered, ginkgo.ContinueOnFailu
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 						g.Expect(workload.PatchAdmissionStatus(ctx, k8sClient, wl, realClock, func() (*kueue.Workload, bool, error) {
-							workload.SetEvictedCondition(wl, kueue.WorkloadEvictedByPreemption, "By test")
-							return wl, true, nil
+							return wl, workload.SetEvictedCondition(wl, kueue.WorkloadEvictedByPreemption, "By test"), nil
 						})).Should(gomega.Succeed())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})

--- a/test/integration/singlecluster/scheduler/podsready/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/podsready/scheduler_test.go
@@ -334,8 +334,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 				g.Expect(workload.IsActive(prodWl)).Should(gomega.BeFalse())
 				g.Expect(prodWl.Status.RequeueState).Should(gomega.BeNil())
 				g.Expect(workload.PatchAdmissionStatus(ctx, k8sClient, prodWl, realClock, func() (*kueue.Workload, bool, error) {
-					workload.SetRequeuedCondition(prodWl, kueue.WorkloadDeactivated, "by test", false)
-					return prodWl, true, nil
+					return prodWl, workload.SetRequeuedCondition(prodWl, kueue.WorkloadDeactivated, "by test", false), nil
 				})).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			util.FinishEvictionForWorkloads(ctx, k8sClient, prodWl)

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -319,8 +319,7 @@ var _ = ginkgo.Describe("Workload validating webhook", ginkgo.Ordered, func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
 				err := workload.PatchAdmissionStatus(ctx, k8sClient, wl, clock.RealClock{}, func() (*kueue.Workload, bool, error) {
-					workload.SetQuotaReservation(wl, a, clock.RealClock{})
-					return wl, true, nil
+					return wl, workload.SetQuotaReservation(wl, a, clock.RealClock{}), nil
 				})
 				if errorType != nil {
 					g.Expect(err).Should(errorType)

--- a/test/performance/scheduler/runner/controller/controller.go
+++ b/test/performance/scheduler/runner/controller/controller.go
@@ -121,8 +121,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// 1. finish the workloads eviction
 	if apimeta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted) {
 		err := workload.PatchAdmissionStatus(ctx, r.client, &wl, r.clock, func() (*kueue.Workload, bool, error) {
-			_ = workload.UnsetQuotaReservationWithCondition(&wl, "Pending", "Evicted by the test runner", time.Now())
-			return &wl, true, nil
+			return &wl, workload.UnsetQuotaReservationWithCondition(&wl, "Pending", "Evicted by the test runner", time.Now()), nil
 		})
 		if err == nil {
 			log.V(5).Info("Finish eviction")

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -402,9 +402,7 @@ func SetRequeuedConditionWithPodsReadyTimeout(ctx context.Context, k8sClient cli
 		var wl kueue.Workload
 		g.Expect(k8sClient.Get(ctx, wlKey, &wl)).Should(gomega.Succeed())
 		g.Expect(workload.PatchAdmissionStatus(ctx, k8sClient, &wl, clock.RealClock{}, func() (*kueue.Workload, bool, error) {
-			workload.SetRequeuedCondition(&wl, kueue.WorkloadEvictedByPodsReadyTimeout,
-				fmt.Sprintf("Exceeded the PodsReady timeout %s", klog.KObj(&wl).String()), false)
-			return &wl, true, nil
+			return &wl, workload.SetRequeuedCondition(&wl, kueue.WorkloadEvictedByPodsReadyTimeout, fmt.Sprintf("Exceeded the PodsReady timeout %s", klog.KObj(&wl).String()), false), nil
 		})).Should(gomega.Succeed())
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
@@ -763,12 +761,13 @@ func SetQuotaReservation(ctx context.Context, k8sClient client.Client, wlKey cli
 		updatedWl := &kueue.Workload{}
 		g.ExpectWithOffset(1, k8sClient.Get(ctx, wlKey, updatedWl)).To(gomega.Succeed())
 		g.ExpectWithOffset(1, workload.PatchAdmissionStatus(ctx, k8sClient, updatedWl, clk, func() (*kueue.Workload, bool, error) {
+			var updated bool
 			if admission == nil {
-				workload.UnsetQuotaReservationWithCondition(updatedWl, "EvictedByTest", "Evicted By Test", clk.Now())
+				updated = workload.UnsetQuotaReservationWithCondition(updatedWl, "EvictedByTest", "Evicted By Test", clk.Now())
 			} else {
-				workload.SetQuotaReservation(updatedWl, admission, clk)
+				updated = workload.SetQuotaReservation(updatedWl, admission, clk)
 			}
-			return updatedWl, true, nil
+			return updatedWl, updated, nil
 		})).To(gomega.Succeed())
 	}, Timeout, Interval).Should(gomega.Succeed())
 }
@@ -782,8 +781,7 @@ func SyncAdmittedConditionForWorkloads(ctx context.Context, k8sClient client.Cli
 		gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
 			g.ExpectWithOffset(1, k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWorkload)).To(gomega.Succeed())
 			g.ExpectWithOffset(1, workload.PatchAdmissionStatus(ctx, k8sClient, &updatedWorkload, clock.RealClock{}, func() (*kueue.Workload, bool, error) {
-				updated := workload.SyncAdmittedCondition(&updatedWorkload, time.Now())
-				return &updatedWorkload, updated, nil
+				return &updatedWorkload, workload.SyncAdmittedCondition(&updatedWorkload, time.Now()), nil
 			})).To(gomega.Succeed())
 		}, Timeout, Interval).Should(gomega.Succeed())
 	}
@@ -809,8 +807,7 @@ func FinishEvictionForWorkloads(ctx context.Context, k8sClient client.Client, wl
 			g.Expect(k8sClient.Get(ctx, key, &updatedWorkload)).Should(gomega.Succeed())
 			if apimeta.IsStatusConditionTrue(updatedWorkload.Status.Conditions, kueue.WorkloadQuotaReserved) {
 				g.Expect(workload.PatchAdmissionStatus(ctx, k8sClient, &updatedWorkload, clock.RealClock{}, func() (*kueue.Workload, bool, error) {
-					workload.UnsetQuotaReservationWithCondition(&updatedWorkload, "Pending", "By test", time.Now())
-					return &updatedWorkload, true, nil
+					return &updatedWorkload, workload.UnsetQuotaReservationWithCondition(&updatedWorkload, "Pending", "By test", time.Now()), nil
 				}),
 				).Should(gomega.Succeed(), fmt.Sprintf("Unable to unset quota reservation for %q", key))
 			}

--- a/test/util/util_scheduling.go
+++ b/test/util/util_scheduling.go
@@ -60,8 +60,7 @@ func FinishEvictionOfWorkloadsInCQ(ctx context.Context, k8sClient client.Client,
 			quotaReserved := meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
 			if evicted && quotaReserved {
 				g.Expect(workload.PatchAdmissionStatus(ctx, k8sClient, &wl, realClock, func() (*kueue.Workload, bool, error) {
-					workload.UnsetQuotaReservationWithCondition(&wl, "Pending", "Eviction finished by test", time.Now())
-					return &wl, true, nil
+					return &wl, workload.UnsetQuotaReservationWithCondition(&wl, "Pending", "Eviction finished by test", time.Now()), nil
 				}),
 				).To(gomega.Succeed())
 				finished.Insert(wl.UID)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Cleanup after prepare PatchAdmissionStatus().

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```