### PR TITLE
Rename the trainer annotation for podSpecOverrides

### DIFF
--- a/pkg/controller/jobs/kubeflow/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/trainjob/trainjob_controller.go
@@ -50,7 +50,8 @@ var (
 )
 
 const (
-	FirstOverrideIdx = "kueue.x-k8s.io/override-idx"
+	// This is alpha level annotation
+	firstOverrideIdx = "kueue.x-k8s.io/trainjob-override-idx"
 )
 
 func init() {
@@ -180,7 +181,7 @@ func (t *TrainJob) RunWithPodSetsInfo(podSetsInfo []podset.PodSetInfo) error {
 	if t.Annotations == nil {
 		t.Annotations = map[string]string{}
 	}
-	t.Annotations[FirstOverrideIdx] = strconv.Itoa(len(t.Spec.PodSpecOverrides))
+	t.Annotations[firstOverrideIdx] = strconv.Itoa(len(t.Spec.PodSpecOverrides))
 	for _, info := range podSetsInfo {
 		// The trainjob controller merges each podSpecOverride sequentially, so any existing user provided override will be processed first
 		t.Spec.PodSpecOverrides = append(t.Spec.PodSpecOverrides, kftrainerapi.PodSpecOverride{
@@ -223,7 +224,7 @@ func (t *TrainJob) Stop(ctx context.Context, c client.Client, podSetsInfo []pods
 		if !t.RestorePodSetsInfo(podSetsInfo) {
 			return t.Object(), false, errors.New("error restoring info to the trainjob")
 		}
-		delete(t.Annotations, FirstOverrideIdx)
+		delete(t.Annotations, firstOverrideIdx)
 		return t.Object(), true, nil
 	}); err != nil {
 		return false, err
@@ -232,7 +233,7 @@ func (t *TrainJob) Stop(ctx context.Context, c client.Client, podSetsInfo []pods
 }
 
 func (t *TrainJob) RestorePodSetsInfo(_ []podset.PodSetInfo) bool {
-	idx, ok := t.Annotations[FirstOverrideIdx]
+	idx, ok := t.Annotations[firstOverrideIdx]
 	if !ok {
 		// kueue didn't inject any config yet
 		return true

--- a/pkg/controller/jobs/kubeflow/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/trainjob/trainjob_controller_test.go
@@ -102,7 +102,7 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 				},
 			},
 			wantTrainJob: testTrainJob.Clone().
-				Annotation(FirstOverrideIdx, "0").
+				Annotation(firstOverrideIdx, "0").
 				PodSpecOverrides([]kftrainerapi.PodSpecOverride{
 					{
 						TargetJobs: []kftrainerapi.PodSpecOverrideTargetJob{
@@ -162,7 +162,7 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 				},
 			},
 			wantTrainJob: testTrainJob.Clone().
-				Annotation(FirstOverrideIdx, "1").
+				Annotation(firstOverrideIdx, "1").
 				PodSpecOverrides([]kftrainerapi.PodSpecOverride{
 					{
 						TargetJobs: []kftrainerapi.PodSpecOverrideTargetJob{
@@ -285,16 +285,16 @@ func TestRestorePodSetsInfo(t *testing.T) {
 		},
 		"should not modify the trainjob if it fails parsing the annotation": {
 			trainJob: testTrainJob.Clone().
-				Annotation(FirstOverrideIdx, "+").
+				Annotation(firstOverrideIdx, "+").
 				Obj(),
 			wantTrainJob: testTrainJob.Clone().
-				Annotation(FirstOverrideIdx, "+").
+				Annotation(firstOverrideIdx, "+").
 				Obj(),
 			wantReturn: false,
 		},
 		"should remove all the podSpecOverrides starting from the index specified in the annotation": {
 			trainJob: testTrainJob.Clone().
-				Annotation(FirstOverrideIdx, "2").
+				Annotation(firstOverrideIdx, "2").
 				PodSpecOverrides([]kftrainerapi.PodSpecOverride{
 					{
 						TargetJobs: []kftrainerapi.PodSpecOverrideTargetJob{
@@ -323,7 +323,7 @@ func TestRestorePodSetsInfo(t *testing.T) {
 				}).
 				Obj(),
 			wantTrainJob: testTrainJob.Clone().
-				Annotation(FirstOverrideIdx, "2").
+				Annotation(firstOverrideIdx, "2").
 				PodSpecOverrides([]kftrainerapi.PodSpecOverride{
 					{
 						TargetJobs: []kftrainerapi.PodSpecOverrideTargetJob{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This PR renames the annotation used to identify the first `PodSpecOverrides` Kueue injects as requested in [this comment](https://github.com/kubernetes-sigs/kueue/issues/6865#issuecomment-3329140412)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #6865

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```