### PR TITLE
[release-0.13] Cherry Pick #7024, #7040

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -19,6 +19,7 @@ package flavorassigner
 import (
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 	"sort"
 	"strconv"
@@ -321,12 +322,39 @@ func (m FlavorAssignmentMode) String() string {
 	return "Unknown"
 }
 
+// borrowingLevel represents how locally the quota can be sourced. 0
+// indicates that quota is available within the ClusterQueue, while
+// progressively higher numbers indicate capacity comes from a more
+// distant cohort.  Please note that while this number is
+// monotonically increasing, it is not necessarily sequential.
+type borrowingLevel int
+
+// betterThan indicates that Flavor represented by b has NominalQuota
+// available more locally than the flavor represented by other.
+func (b borrowingLevel) betterThan(other borrowingLevel) bool {
+	return b < other
+}
+
+// optimal indicates that capacity is available at the ClusterQueue
+// level, i.e. no borrowing.
+func (b borrowingLevel) optimal() bool {
+	return b == 0
+}
+
 // granularMode is the FlavorAssignmentMode internal to
-// FlavorAssigner, which lets us distinguish priority based preemption,
-// reclamation within Cohort and borrowing.
+// FlavorAssigner, which lets us distinguish priority based
+// preemption, reclamation within Cohort and borrowing.
 type granularMode struct {
 	preemptionMode preemptionMode
-	needsBorrowing bool
+	borrowingLevel borrowingLevel
+}
+
+func worstGranularMode() granularMode {
+	return granularMode{preemptionMode: noFit, borrowingLevel: math.MaxInt}
+}
+
+func bestGranularMode() granularMode {
+	return granularMode{preemptionMode: fit, borrowingLevel: 0}
 }
 
 type preemptionMode int
@@ -354,20 +382,20 @@ func isPreferred(a, b granularMode, fungiblityConfig kueue.FlavorFungibility) bo
 		if a.preemptionMode != b.preemptionMode {
 			return a.preemptionMode > b.preemptionMode
 		} else {
-			return !a.needsBorrowing && b.needsBorrowing
+			return a.borrowingLevel.betterThan(b.borrowingLevel)
 		}
 	}
 
 	if fungiblityConfig.WhenCanBorrow == kueue.TryNextFlavor {
-		if a.needsBorrowing != b.needsBorrowing {
-			return !a.needsBorrowing
+		if a.borrowingLevel != b.borrowingLevel {
+			return a.borrowingLevel.betterThan(b.borrowingLevel)
 		}
 		return a.preemptionMode > b.preemptionMode
 	} else {
 		if a.preemptionMode != b.preemptionMode {
 			return a.preemptionMode > b.preemptionMode
 		}
-		return !a.needsBorrowing && b.needsBorrowing
+		return a.borrowingLevel.betterThan(b.borrowingLevel)
 	}
 }
 
@@ -664,7 +692,7 @@ func (a *FlavorAssigner) findFlavorForPodSetResource(
 	}
 
 	var bestAssignment ResourceAssignment
-	bestAssignmentMode := granularMode{preemptionMode: noFit, needsBorrowing: true}
+	bestAssignmentMode := worstGranularMode()
 
 	// We will only check against the flavors' labels for the resource.
 	attemptedFlavorIdx := -1
@@ -713,7 +741,7 @@ func (a *FlavorAssigner) findFlavorForPodSetResource(
 		}
 		assignments := make(ResourceAssignment, len(requests))
 		// Calculate representativeMode for this assignment as the worst mode among all requests.
-		representativeMode := granularMode{preemptionMode: fit, needsBorrowing: false}
+		representativeMode := bestGranularMode()
 		for rName, val := range requests {
 			// Ensure the same resource flavor is used for the workload slice as in the original admitted slice.
 			if features.Enabled(features.ElasticJobsViaWorkloadSlices) && a.replaceWorkloadSlice != nil {
@@ -723,7 +751,7 @@ func (a *FlavorAssigner) findFlavorForPodSetResource(
 					// Enforce consistent resource flavor assignment between slices.
 					if originalFlavor := preemptWorkloadRequests.Flavors[rName]; originalFlavor != fName {
 						// Flavor mismatch. Skip further checks for this resource.
-						representativeMode = granularMode{preemptionMode: noFit, needsBorrowing: true}
+						representativeMode = worstGranularMode()
 						status.reasons = append(status.reasons, fmt.Sprintf("could not assign %s flavor since the original workload is assigned: %s", fName, originalFlavor))
 						break
 					}
@@ -740,7 +768,7 @@ func (a *FlavorAssigner) findFlavorForPodSetResource(
 			if s != nil {
 				status.reasons = append(status.reasons, s.reasons...)
 			}
-			mode := granularMode{preemptionMode, borrow > 0}
+			mode := granularMode{preemptionMode, borrowingLevel(borrow)}
 			if isPreferred(representativeMode, mode, a.cq.FlavorFungibility) {
 				representativeMode = mode
 			}
@@ -795,16 +823,16 @@ func shouldTryNextFlavor(representativeMode granularMode, flavorFungibility kueu
 	policyPreempt := flavorFungibility.WhenCanPreempt
 	policyBorrow := flavorFungibility.WhenCanBorrow
 	if representativeMode.isPreemptMode() && policyPreempt == kueue.Preempt {
-		if !representativeMode.needsBorrowing || policyBorrow == kueue.Borrow {
+		if representativeMode.borrowingLevel.optimal() || policyBorrow == kueue.Borrow {
 			return false
 		}
 	}
 
-	if representativeMode.preemptionMode == fit && representativeMode.needsBorrowing && policyBorrow == kueue.Borrow {
+	if representativeMode.preemptionMode == fit && !representativeMode.borrowingLevel.optimal() && policyBorrow == kueue.Borrow {
 		return false
 	}
 
-	if representativeMode.preemptionMode == fit && !representativeMode.needsBorrowing {
+	if representativeMode.preemptionMode == fit && representativeMode.borrowingLevel.optimal() {
 		return false
 	}
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -3773,6 +3773,80 @@ func TestSchedule(t *testing.T) {
 				utiltesting.MakeEventRecord("sales", "foo-2", "Admitted", corev1.EventTypeNormal).Obj(),
 			},
 		},
+		"prefer flavor with most local capacity": {
+			enableFairSharing: true,
+			cohorts: []kueue.Cohort{
+				*utiltesting.MakeCohort("root").
+					ResourceGroup(
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "2").Obj(),
+						*utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "0").Obj(),
+					).
+					Obj(),
+				*utiltesting.MakeCohort("cohort-a").
+					Parent("root").
+					ResourceGroup(
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "5").Obj(),
+						*utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "7").Obj(),
+					).
+					Obj(),
+			},
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltesting.MakeClusterQueue("other-alpha").
+					Cohort("cohort-a").
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					FlavorFungibility(kueue.FlavorFungibility{
+						WhenCanPreempt: kueue.TryNextFlavor,
+						WhenCanBorrow:  kueue.TryNextFlavor,
+					}).
+					ResourceGroup(
+						*utiltesting.MakeFlavorQuotas("on-demand").Resource("gpu", "3").Obj(),
+						*utiltesting.MakeFlavorQuotas("spot").Resource("gpu", "3").Obj(),
+					).
+					Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltesting.MakeLocalQueue("other", "eng-alpha").ClusterQueue("other-alpha").Obj(),
+			},
+			workloads: []kueue.Workload{
+				// exhaust quota in on-demand in CohortA
+				*utiltesting.MakeWorkload("a1", "eng-alpha").
+					Queue("other").
+					Request("gpu", "8").
+					SimpleReserveQuota("other-alpha", "on-demand", now).
+					Obj(),
+				// exhaust quota in spot in OtherAlpha CQ
+				*utiltesting.MakeWorkload("a2", "eng-alpha").
+					Queue("other").
+					Request("gpu", "3").
+					SimpleReserveQuota("other-alpha", "spot", now).
+					Obj(),
+				*utiltesting.MakeWorkload("a3", "eng-alpha").
+					Queue("other").
+					Request("gpu", "1").
+					Obj(),
+			},
+			wantScheduled: []workload.Reference{"eng-alpha/a3"},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"eng-alpha/a1": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "on-demand", "8").
+						Obj()).
+					Obj(),
+				"eng-alpha/a2": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "3").
+						Obj()).
+					Obj(),
+				"eng-alpha/a3": *utiltesting.MakeAdmission("other-alpha").
+					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment("gpu", "spot", "1").
+						Obj()).
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Cherry-pick #7024, #7040

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
[Hierarchical Cohorts] When multiple borrowing flavors are available, prefer the flavor which
results in borrowing more locally (closer to the ClusterQueue, further from the root Cohort).

This fixes the scenario where a flavor would be selected which required borrowing
from the root Cohort in one flavor, while in a second flavor, quota was
available from the nearest parent Cohort.
```