### PR TITLE
[Doc] Add WorkloadRequestUseMergePatch documentation

### DIFF
--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -100,8 +100,10 @@ The MultiKueue Workload Controller synchronizes the Workload with the nominated 
 
 Known Limitation:
 {{% alert title="Warning" color="primary" %}}
-For the external controller to patch the `.status.nominatedClusterNames` field, it must use the kueue-admission field manager.
-This is required because the kueue-admission field manager is responsible for managing updates to the `.status.nominatedClusterNames` field.
+For the external controller to patch the `.status.nominatedClusterNames` field there are 2 options:
+* Use the `kueue-admission` field manager, because the kueue-admission field manager is responsible for managing updates to the `.status.nominatedClusterNames` field.
+* [Enable `WorkloadRequestUseMergePatch` feature gate](docs/concepts/workload#workload-updates-by-kueue) that drops the `kueue-admission` field manager from the `.status.nominatedClusterNames`.
+
 Without this, the Kueue is not able to admit the MultiKueue workloads.
 {{% /alert %}}
 

--- a/site/content/en/docs/concepts/workload.md
+++ b/site/content/en/docs/concepts/workload.md
@@ -172,7 +172,32 @@ If `maximumExecutionTimeSeconds` is not specified, the workload has no execution
 
 You can configure the `maximumExecutionTimeSeconds` of the Workload associated with any supported Kueue Job by specifying the desired value as `kueue.x-k8s.io/max-exec-time-seconds` label of the job. 
 
+## Workload updates by Kueue
 
+{{< feature-state state="alpha" for_version="v0.14" >}}
+
+{{% alert title="Note" color="primary" %}}
+`WorkloadRequestUseMergePatch` is currently an alpha feature and is disabled by default.
+
+You can enable it by editing the `WorkloadRequestUseMergePatch` feature gate. Refer to the
+[Installation guide](/docs/installation/#change-the-feature-gates-configuration)
+for instructions on configuring feature gates.
+{{% /alert %}}
+
+
+By default Workload status updates are performed by Kueue using the [Server-Side Apply (SSA)](https://kubernetes.io/docs/reference/using-api/server-side-apply/). 
+
+However due to the limitations of SSA ([missing support for duplicated key/value pairs](https://github.com/kubernetes/kubernetes/issues/113482)) we also offer to enable updating the Workload status
+with Merge Patches, by enabling the `WorkloadRequestUseMergePatch` feature gate. 
+
+In particular, this allows users of Kueue to handle the following two issues:
+- [Add option to disable strict pod spec validation](https://github.com/kubernetes-sigs/kueue/issues/3540) 
+Switching from ServerSideApply to Merge Patch allows partial updates without requiring the entire resource specification.
+This can bypass the strict validation rules causing issues with duplicated environment variables, aligning Kueue's behavior more closely with plain Kubernetes
+- [MultiKueue: remove the limitation that the external dispatches need to use kueue-admission field manager ](https://github.com/kubernetes-sigs/kueue/issues/6185)
+Using ServerSideApply blocked the ability for Workload Status to be modified from external controllers.
+Once the field e.g. `.status.nominatedClusterNames` was modified and owned by the controller (regardless if Kueue or external one) it can not be modified or cleared by the other.
+This effectively prevent External Dispatching mechanism to work properly in multi cluster enviroment.
 
 ## What's next
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #6158

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```