### PR TITLE
Use TrainingRuntimes in integration tests

### DIFF
--- a/pkg/util/testingjobs/trainjob/wrappers.go
+++ b/pkg/util/testingjobs/trainjob/wrappers.go
@@ -157,3 +157,18 @@ func MakeClusterTrainingRuntime(name string, jobsetSpec jobsetapi.JobSetSpec) *k
 		},
 	}
 }
+
+// MakeTrainingRuntime creates a TrainingRuntime with the jobsetSpec provided
+func MakeTrainingRuntime(name, ns string, jobsetSpec jobsetapi.JobSetSpec) *kftrainerapi.TrainingRuntime {
+	return &kftrainerapi.TrainingRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: kftrainerapi.TrainingRuntimeSpec{
+			Template: kftrainerapi.JobSetTemplateSpec{
+				Spec: jobsetSpec,
+			},
+		},
+	}
+}

--- a/test/integration/singlecluster/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/trainjob/trainjob_controller_test.go
@@ -410,16 +410,16 @@ var _ = ginkgo.Describe("TrainJob controller interacting with scheduler", ginkgo
 			Request("node-1", corev1.ResourceCPU, "1").
 			Request("node-2", corev1.ResourceCPU, "1").
 			Obj()
-		testCtr := testingtrainjob.MakeClusterTrainingRuntime("test", testJobSet.Spec)
+		testTr := testingtrainjob.MakeTrainingRuntime("test", ns.Name, testJobSet.Spec)
 		trainJob := testingtrainjob.MakeTrainJob("trainjob-test", ns.Name).RuntimeRef(kftrainerapi.RuntimeRef{
 			APIGroup: ptr.To("trainer.kubeflow.org"),
 			Name:     "test",
-			Kind:     ptr.To("ClusterTrainingRuntime"),
+			Kind:     ptr.To(kftrainerapi.TrainingRuntimeKind),
 		}).
 			Queue("local-queue").
 			Obj()
 
-		util.MustCreate(ctx, k8sClient, testCtr)
+		util.MustCreate(ctx, k8sClient, testTr)
 		util.MustCreate(ctx, k8sClient, trainJob)
 		createdTrainJob := &kftrainerapi.TrainJob{}
 		gomega.Eventually(func(g gomega.Gomega) {
@@ -458,17 +458,17 @@ var _ = ginkgo.Describe("TrainJob controller interacting with scheduler", ginkgo
 			Request("node-1", corev1.ResourceCPU, "250m").
 			Request("node-2", corev1.ResourceCPU, "250m").
 			Obj()
-		testCtr1 := testingtrainjob.MakeClusterTrainingRuntime("ctr-1", testJobset1.Spec)
+		testTr1 := testingtrainjob.MakeTrainingRuntime("tr-1", ns.Name, testJobset1.Spec)
 		trainJob1 := testingtrainjob.MakeTrainJob("trainjob-test", ns.Name).RuntimeRef(kftrainerapi.RuntimeRef{
 			APIGroup: ptr.To("trainer.kubeflow.org"),
-			Name:     "ctr-1",
-			Kind:     ptr.To("ClusterTrainingRuntime"),
+			Name:     "tr-1",
+			Kind:     ptr.To(kftrainerapi.TrainingRuntimeKind),
 		}).
 			Queue("local-queue").
 			Suspend(true).
 			Obj()
 
-		util.MustCreate(ctx, k8sClient, testCtr1)
+		util.MustCreate(ctx, k8sClient, testTr1)
 		util.MustCreate(ctx, k8sClient, trainJob1)
 		ginkgo.By("checking the first trainjob starts", func() {
 			createdTrainJob1 := &kftrainerapi.TrainJob{}
@@ -497,17 +497,17 @@ var _ = ginkgo.Describe("TrainJob controller interacting with scheduler", ginkgo
 			Request("node-2", corev1.ResourceCPU, "1").
 			Obj()
 
-		testCtr2 := testingtrainjob.MakeClusterTrainingRuntime("ctr-2", testJobset2.Spec)
+		testTr2 := testingtrainjob.MakeTrainingRuntime("tr-2", ns.Name, testJobset2.Spec)
 		trainJob2 := testingtrainjob.MakeTrainJob("trainjob-test-2", ns.Name).RuntimeRef(kftrainerapi.RuntimeRef{
 			APIGroup: ptr.To("trainer.kubeflow.org"),
-			Name:     "ctr-2",
-			Kind:     ptr.To("ClusterTrainingRuntime"),
+			Name:     "tr-2",
+			Kind:     ptr.To(kftrainerapi.TrainingRuntimeKind),
 		}).
 			Queue("local-queue").
 			Suspend(true).
 			Obj()
 
-		util.MustCreate(ctx, k8sClient, testCtr2)
+		util.MustCreate(ctx, k8sClient, testTr2)
 		util.MustCreate(ctx, k8sClient, trainJob2)
 		ginkgo.By("checking a second no-fit trainjob does not start", func() {
 			createdTrainJob2 := &kftrainerapi.TrainJob{}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -131,6 +131,9 @@ func DeleteNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace)
 	if err := DeleteAllJobsInNamespace(ctx, c, ns); err != nil {
 		return err
 	}
+	if err := DeleteAllTrainingRuntimesInNamespace(ctx, c, ns); err != nil {
+		return err
+	}
 	if err := c.DeleteAllOf(ctx, &appsv1.StatefulSet{}, client.InNamespace(ns.Name)); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
@@ -167,6 +170,10 @@ func DeleteAllJobSetsInNamespace(ctx context.Context, c client.Client, ns *corev
 
 func DeleteAllTrainJobsInNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace) error {
 	return deleteAllObjectsInNamespace(ctx, c, ns, &kftrainerapi.TrainJob{})
+}
+
+func DeleteAllTrainingRuntimesInNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace) error {
+	return deleteAllObjectsInNamespace(ctx, c, ns, &kftrainerapi.TrainingRuntime{})
 }
 
 func DeleteAllLeaderWorkerSetsInNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace) error {


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This PR fixes a broken Trainjob integration test which used ClusterTrainingRuntimes (cluster scoped training runtimes) instead of `TrainingRuntimes`. The test tried to create a cluster scoped object on each run, which failed because it already existed.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7052

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```