### PR TITLE
Fix limit for ClusterQueue Resources, FlavorReservation and FlavorUsage

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -208,11 +208,11 @@ type FlavorQuotas struct {
 	Name ResourceFlavorReference `json:"name"`
 
 	// resources is the list of quotas for this flavor per resource.
-	// There could be up to 16 resources.
+	// There could be up to 64 resources.
 	// +listType=map
 	// +listMapKey=name
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	Resources []ResourceQuota `json:"resources"`
 }
 
@@ -278,7 +278,7 @@ type ClusterQueueStatus struct {
 	// workloads assigned to this ClusterQueue.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	FlavorsReservation []FlavorUsage `json:"flavorsReservation"`
 
@@ -286,7 +286,7 @@ type ClusterQueueStatus struct {
 	// workloads admitted in this ClusterQueue.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	// +optional
 	FlavorsUsage []FlavorUsage `json:"flavorsUsage"`
 
@@ -348,7 +348,7 @@ type FlavorUsage struct {
 	// resources lists the quota usage for the resources in this flavor.
 	// +listType=map
 	// +listMapKey=name
-	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:MaxItems=64
 	Resources []ResourceUsage `json:"resources"`
 }
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_clusterqueues.yaml
@@ -395,7 +395,7 @@ spec:
                             resources:
                               description: |-
                                 resources is the list of quotas for this flavor per resource.
-                                There could be up to 16 resources.
+                                There could be up to 64 resources.
                               items:
                                 properties:
                                   borrowingLimit:
@@ -456,7 +456,7 @@ spec:
                                   - name
                                   - nominalQuota
                                 type: object
-                              maxItems: 16
+                              maxItems: 64
                               minItems: 1
                               type: array
                               x-kubernetes-list-map-keys:
@@ -654,7 +654,7 @@ spec:
                           required:
                             - name
                           type: object
-                        maxItems: 16
+                        maxItems: 64
                         type: array
                         x-kubernetes-list-map-keys:
                           - name
@@ -663,7 +663,7 @@ spec:
                       - name
                       - resources
                     type: object
-                  maxItems: 16
+                  maxItems: 64
                   type: array
                   x-kubernetes-list-map-keys:
                     - name
@@ -707,7 +707,7 @@ spec:
                           required:
                             - name
                           type: object
-                        maxItems: 16
+                        maxItems: 64
                         type: array
                         x-kubernetes-list-map-keys:
                           - name
@@ -716,7 +716,7 @@ spec:
                       - name
                       - resources
                     type: object
-                  maxItems: 16
+                  maxItems: 64
                   type: array
                   x-kubernetes-list-map-keys:
                     - name

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_cohorts.yaml
@@ -164,7 +164,7 @@ spec:
                             resources:
                               description: |-
                                 resources is the list of quotas for this flavor per resource.
-                                There could be up to 16 resources.
+                                There could be up to 64 resources.
                               items:
                                 properties:
                                   borrowingLimit:
@@ -225,7 +225,7 @@ spec:
                                   - name
                                   - nominalQuota
                                 type: object
-                              maxItems: 16
+                              maxItems: 64
                               minItems: 1
                               type: array
                               x-kubernetes-list-map-keys:

--- a/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_clusterqueues.yaml
@@ -386,7 +386,7 @@ spec:
                           resources:
                             description: |-
                               resources is the list of quotas for this flavor per resource.
-                              There could be up to 16 resources.
+                              There could be up to 64 resources.
                             items:
                               properties:
                                 borrowingLimit:
@@ -447,7 +447,7 @@ spec:
                               - name
                               - nominalQuota
                               type: object
-                            maxItems: 16
+                            maxItems: 64
                             minItems: 1
                             type: array
                             x-kubernetes-list-map-keys:
@@ -651,7 +651,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -660,7 +660,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name
@@ -705,7 +705,7 @@ spec:
                         required:
                         - name
                         type: object
-                      maxItems: 16
+                      maxItems: 64
                       type: array
                       x-kubernetes-list-map-keys:
                       - name
@@ -714,7 +714,7 @@ spec:
                   - name
                   - resources
                   type: object
-                maxItems: 16
+                maxItems: 64
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_cohorts.yaml
@@ -149,7 +149,7 @@ spec:
                           resources:
                             description: |-
                               resources is the list of quotas for this flavor per resource.
-                              There could be up to 16 resources.
+                              There could be up to 64 resources.
                             items:
                               properties:
                                 borrowingLimit:
@@ -210,7 +210,7 @@ spec:
                               - name
                               - nominalQuota
                               type: object
-                            maxItems: 16
+                            maxItems: 64
                             minItems: 1
                             type: array
                             x-kubernetes-list-map-keys:

--- a/site/content/en/docs/reference/kueue.v1beta1.md
+++ b/site/content/en/docs/reference/kueue.v1beta1.md
@@ -1512,7 +1512,7 @@ ClusterQueue will have an Active condition set to False.</p>
 </td>
 <td>
    <p>resources is the list of quotas for this flavor per resource.
-There could be up to 16 resources.</p>
+There could be up to 64 resources.</p>
 </td>
 </tr>
 </tbody>

--- a/test/integration/singlecluster/webhook/core/clusterqueue_test.go
+++ b/test/integration/singlecluster/webhook/core/clusterqueue_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	resourcesMaxItems = 16
+	resourcesMaxItems = 64
 	flavorsMaxItems   = 64
 )
 

--- a/test/integration/singlecluster/webhook/core/cohort_test.go
+++ b/test/integration/singlecluster/webhook/core/cohort_test.go
@@ -102,7 +102,7 @@ var _ = ginkgo.Describe("Cohort Webhook", ginkgo.Ordered, func() {
 			ginkgo.Entry("Should reject too many resources in resource group",
 				func() *kueue.Cohort {
 					fq := testing.MakeFlavorQuotas("flavor")
-					for i := range 17 {
+					for i := range 65 {
 						fq = fq.Resource(corev1.ResourceName(fmt.Sprintf("cpu%d", i)))
 					}
 					return testing.MakeCohort("cohort").


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

In PR https://github.com/kubernetes-sigs/kueue/pull/6906, the ClusterQueue coveredResource and Flavors limits where increased to 64. However, some fields still use the old limit of 16, including the [Resources under FlavorQuotas](https://github.com/kubernetes-sigs/kueue/blob/c05bfbd980952fd47b9957c9c5952dada41f0996/apis/kueue/v1beta1/clusterqueue_types.go#L215-L216) and [FlavorsReservation and FlavorsUsage under ClusterQueueStatus](https://github.com/kubernetes-sigs/kueue/blob/c05bfbd980952fd47b9957c9c5952dada41f0996/apis/kueue/v1beta1/clusterqueue_types.go#L277-L291). This PR increases those limits to 64 to make them consistent.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes-sigs/kueue/issues/7063


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
Increases ClusterQueue limit on Resources under FlavorQuotas, and FlavorsReservation and FlavorsUsage under ClusterQueueStatus.

```release-note
NONE
```