### PR TITLE
Follow-up: Refactor reconcile_test to use AfterEach for default namespace cleanup

### DIFF
--- a/test/e2e/customconfigs/reconcile_test.go
+++ b/test/e2e/customconfigs/reconcile_test.go
@@ -19,6 +19,7 @@ package customconfigse2e
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,11 +41,10 @@ var _ = ginkgo.Describe("Job reconciliation with ManagedJobsNamespaceSelectorAlw
 	)
 
 	var (
-		rf               *kueue.ResourceFlavor
-		lq               *kueue.LocalQueue
-		cq               *kueue.ClusterQueue
-		ns               *corev1.Namespace
-		defaultNsObjects []client.Object
+		rf *kueue.ResourceFlavor
+		lq *kueue.LocalQueue
+		cq *kueue.ClusterQueue
+		ns *corev1.Namespace
 	)
 
 	ginkgo.BeforeAll(func() {
@@ -83,65 +83,65 @@ var _ = ginkgo.Describe("Job reconciliation with ManagedJobsNamespaceSelectorAlw
 		gomega.Expect(k8sClient.Create(ctx, lq)).To(gomega.Succeed())
 	})
 
-	ginkgo.BeforeEach(func() {
-		defaultNsObjects = []client.Object{}
-	})
-
-	ginkgo.AfterEach(func() {
-		for _, obj := range defaultNsObjects {
-			gomega.Expect(k8sClient.Delete(ctx, obj)).To(gomega.Succeed())
-		}
-	})
-
 	ginkgo.AfterAll(func() {
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, cq, true, util.LongTimeout)
 		util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, rf, true, util.LongTimeout)
 	})
 
-	ginkgo.It("should not reconcile a job in the default (unmanaged) namespace", func() {
-		job := testingjob.MakeJob("unmanaged-job", metav1.NamespaceDefault).
-			Queue(kueue.LocalQueueName(lq.Name)).
-			Suspend(true).
-			Image(util.GetAgnHostImage(), util.BehaviorExitFast).
-			Obj()
+	ginkgo.When("Testing namespace selector behavior", func() {
+		var (
+			testJob *batchv1.Job
+			testPod *corev1.Pod
+		)
 
-		gomega.Expect(k8sClient.Create(ctx, job)).To(gomega.Succeed())
-		defaultNsObjects = append(defaultNsObjects, job)
-
-		wls := &kueue.WorkloadList{}
-		gomega.Expect(k8sClient.List(ctx, wls, client.InNamespace(metav1.NamespaceDefault))).To(gomega.Succeed())
-		gomega.Expect(wls.Items).To(gomega.BeEmpty(), "Expected no workload in unmanaged namespace")
-	})
-
-	ginkgo.It("should reconcile a job in managed namespace and create a workload", func() {
-		job := testingjob.MakeJob("managed-job", ns.Name).
-			Queue(kueue.LocalQueueName(lq.Name)).
-			Suspend(true).
-			Image(util.GetAgnHostImage(), util.BehaviorExitFast).
-			Obj()
-
-		gomega.Expect(k8sClient.Create(ctx, job)).To(gomega.Succeed())
-
-		ginkgo.By("check that only one workload is created", func() {
-			createdWorkloads := &kueue.WorkloadList{}
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.List(ctx, createdWorkloads, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				g.Expect(createdWorkloads.Items).To(gomega.HaveLen(1))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, testJob, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, testPod, true)
 		})
-	})
 
-	ginkgo.It("Verify existing behavior - should not reconcile a pod in the default (unmanaged) namespace", func() {
-		testPod := testingpod.MakePod("test-pod", metav1.NamespaceDefault).
-			Queue(lq.Name).
-			Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-			Obj()
-		gomega.Expect(k8sClient.Create(ctx, testPod)).To(gomega.Succeed())
-		defaultNsObjects = append(defaultNsObjects, testPod)
+		ginkgo.It("should not reconcile a job in the default (unmanaged) namespace", func() {
+			testJob = testingjob.MakeJob("unmanaged-job", metav1.NamespaceDefault).
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Suspend(true).
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				Obj()
 
-		wls := &kueue.WorkloadList{}
-		gomega.Expect(k8sClient.List(ctx, wls, client.InNamespace(metav1.NamespaceDefault))).To(gomega.Succeed())
-		gomega.Expect(wls.Items).To(gomega.BeEmpty(), "Expected no workload for pod in unmanaged namespace")
+			gomega.Expect(k8sClient.Create(ctx, testJob)).To(gomega.Succeed())
+
+			wls := &kueue.WorkloadList{}
+			gomega.Expect(k8sClient.List(ctx, wls, client.InNamespace(metav1.NamespaceDefault))).To(gomega.Succeed())
+			gomega.Expect(wls.Items).To(gomega.BeEmpty(), "Expected no workload in unmanaged namespace")
+		})
+
+		ginkgo.It("should reconcile a job in managed namespace and create a workload", func() {
+			testJob = testingjob.MakeJob("managed-job", ns.Name).
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Suspend(true).
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				Obj()
+
+			gomega.Expect(k8sClient.Create(ctx, testJob)).To(gomega.Succeed())
+
+			ginkgo.By("check that only one workload is created", func() {
+				createdWorkloads := &kueue.WorkloadList{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.List(ctx, createdWorkloads, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					g.Expect(createdWorkloads.Items).To(gomega.HaveLen(1))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should not reconcile a pod in the default (unmanaged) namespace", func() {
+			testPod = testingpod.MakePod("test-pod", metav1.NamespaceDefault).
+				Queue(lq.Name).
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, testPod)).To(gomega.Succeed())
+
+			wls := &kueue.WorkloadList{}
+			gomega.Expect(k8sClient.List(ctx, wls, client.InNamespace(metav1.NamespaceDefault))).To(gomega.Succeed())
+			gomega.Expect(wls.Items).To(gomega.BeEmpty(), "Expected no workload for pod in unmanaged namespace")
+		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
See https://github.com/kubernetes-sigs/kueue/pull/7048#discussion_r2390375173

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #7048 

#### Special notes for your reviewer:

I considered simplifying this by deleting all objects in the namespace, but wasn't sure if that would be safe. Instead, I went with tracking the jobs created in the default namespace and cleaning them up.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```