### PR TITLE
Fix release sync-notes script

### DIFF
--- a/hack/releasing/sync-notes.sh
+++ b/hack/releasing/sync-notes.sh
@@ -151,7 +151,7 @@ fi
 RELEASE_ISSUE_NAME="Release ${RELEASE_VERSION}"
 declare RELEASE_ISSUE_NAME
 
-RELEASE_ISSUE_NUMBER=$(gh issue list --repo="${MAIN_REPO_ORG}/${MAIN_REPO_NAME}" | grep "${RELEASE_ISSUE_NAME}" | awk '{print $1}' || true)
+RELEASE_ISSUE_NUMBER=$(gh issue list --repo="${MAIN_REPO_ORG}/${MAIN_REPO_NAME}" --search "in:title ${RELEASE_ISSUE_NAME}" | awk '{print $1}' || true)
 if [ -z "$RELEASE_ISSUE_NUMBER" ]; then
   echo "!!! No release issue found for version ${RELEASE_VERSION}. Please create 'Release ${RELEASE_VERSION}' issue first."
   exit 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The current issue searching command does not work well in some case due to default limit in the following:

```shell
++ gh issue list --repo=kubernetes-sigs/kueue
++ grep 'Release v0.14.0'
++ awk '{print $1}'
++ true
+ RELEASE_ISSUE_NUMBER=
+ '[' -z '' ']'
+ echo '!!! No release issue found for version v0.14.0. Please create '\''Release v0.14.0'\'' issue first.'
!!! No release issue found for version v0.14.0. Please create 'Release v0.14.0' issue first.
+ exit 1
```

```shell
...
USAGE
  gh issue list [flags]

ALIASES
  gh issue ls

FLAGS
...
  -L, --limit int          Maximum number of issues to fetch (default 30)
```

So, I introduced the GitHub custom searching query `in:title` w/ `--seach` option

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

After this fix, I succeeded to obtain proper issue number in the following:

```shell
+ read -p '+++ Do you want to update release issue? [y/N] ' -r
+++ Do you want to update release issue? [y/N] y
+ [[ y =~ ^[yY]$ ]]
+ RELEASE_ISSUE_NAME='Release v0.14.0'
+ declare RELEASE_ISSUE_NAME
++ gh issue list --repo=kubernetes-sigs/kueue --search 'in:title Release v0.14.0'
++ awk '{print $1}'
+ RELEASE_ISSUE_NUMBER=6756
+ '[' -z 6756 ']'
++ gh issue view 6756 --repo=kubernetes-sigs/kueue --json body
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```