### PR TITLE
Clean up multikueue integration tests removing "debug" helpers.

### DIFF
--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -42,7 +42,6 @@ import (
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta1"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta1"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadappwrapper "sigs.k8s.io/kueue/pkg/controller/jobs/appwrapper"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
@@ -1728,8 +1727,6 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 		/*
 			Scale-up Section
 		*/
-		ginkgo.By("DEBUG Before Scale")
-		debugAll(job.Namespace)
 
 		ginkgo.By("scale-up the job", func() {
 			getJob(manager.ctx, manager.client, job)
@@ -1739,17 +1736,11 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.By("DEBUG After Scale")
-		debugAll(job.Namespace)
-
 		ginkgo.By("observe: a new workload slice is created")
 		newWorkloadKey := getWorkloadKey(job)
 		gomega.Eventually(func(g gomega.Gomega) {
 			getWorkload(g, manager.ctx, manager.client, newWorkloadKey)
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		ginkgo.By("DEBUG After new slice created")
-		debugAll(job.Namespace)
 
 		ginkgo.By("copy clusterName from the old workload to the new workload", func() {
 			oldWorkload := getWorkload(gomega.Default, manager.ctx, manager.client, workloadKey)
@@ -1764,9 +1755,6 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 			gomega.Expect(newWorkload.Status.ClusterName).Should(gomega.BeEquivalentTo(oldWorkload.Status.ClusterName))
 		})
 
-		ginkgo.By("DEBUG After new slice copy cluster name")
-		debugAll(job.Namespace)
-
 		ginkgo.By("admit the new workload and finish the old workload in the manager cluster", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				oldWorkload := getWorkload(g, manager.ctx, manager.client, workloadKey)
@@ -1774,9 +1762,6 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			util.SetQuotaReservation(manager.ctx, manager.client, newWorkloadKey, utiltesting.MakeAdmission(managerCq.Name).Obj())
 		})
-
-		ginkgo.By("DEBUG After new slice admission")
-		debugAll(job.Namespace)
 
 		ginkgo.By("observe: the new workload is created in the worker1 cluster")
 		gomega.Eventually(func(g gomega.Gomega) {
@@ -1793,9 +1778,6 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 			gomega.Expect(worker2.client.List(worker2.ctx, jobs, client.InNamespace(job.Namespace))).To(gomega.Succeed())
 			gomega.Expect(jobs.Items).To(gomega.BeEmpty())
 		})
-
-		ginkgo.By("DEBUG After new slice created on worker1")
-		debugAll(job.Namespace)
 
 		ginkgo.By("observe: the old workload is still admitted in the worker1 cluster", func() {
 			workload := getWorkload(gomega.Default, worker1.ctx, worker1.client, workloadKey)
@@ -1928,34 +1910,6 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Ordered, ginkgo.ContinueOnFailure, 
 		})
 	})
 })
-
-func debugAll(ns string) {
-	debug(ns, "MANAGER", managerTestCluster)
-	debug(ns, "WORKER1", worker1TestCluster)
-	debug(ns, "WORKER2", worker2TestCluster)
-}
-
-func debug(ns, clusterName string, c cluster) {
-	log := ginkgo.GinkgoLogr.WithName(clusterName)
-
-	jobs := &batchv1.JobList{}
-	gomega.Expect(c.client.List(c.ctx, jobs, client.InNamespace(ns))).To(gomega.Succeed())
-	if len(jobs.Items) == 0 {
-		log.Info("no jobs")
-	}
-	for _, job := range jobs.Items {
-		log.Info("job", "name", job.Name, "uid", job.UID, "prebuild", job.Labels[constants.PrebuiltWorkloadLabel], "pods", job.Spec.Parallelism, "suspend", job.Spec.Suspend)
-	}
-
-	wls := &kueue.WorkloadList{}
-	gomega.Expect(c.client.List(c.ctx, wls, client.InNamespace(ns))).To(gomega.Succeed())
-	if len(wls.Items) == 0 {
-		log.Info("no workloads")
-	}
-	for _, wl := range wls.Items {
-		log.Info("wl", "name", wl.Name, "pods", wl.Spec.PodSets[0].Count, "labels", wl.Labels, "status", wl.Status)
-	}
-}
 
 func admitWorkloadAndCheckWorkerCopies(acName string, wlLookupKey types.NamespacedName, admission *utiltesting.AdmissionWrapper) {
 	ginkgo.By("setting workload reservation in the management cluster", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This is a follow up to: https://github.com/kubernetes-sigs/kueue/pull/7068 to clean up left behind "debug" helpers.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #7093

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```