### PR TITLE
Automated cherry pick of #7118: Replace scheduler stub with interceptor function in TestSchedule.

### DIFF
--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -283,6 +283,11 @@ func (w *WorkloadWrapper) AdmissionCheck(ac kueue.AdmissionCheckState) *Workload
 	return w
 }
 
+func (w *WorkloadWrapper) ResourceRequests(rr ...kueue.PodSetRequest) *WorkloadWrapper {
+	w.Status.ResourceRequests = rr
+	return w
+}
+
 func (w *WorkloadWrapper) SetOrReplaceCondition(condition metav1.Condition) *WorkloadWrapper {
 	existingCondition := apimeta.FindStatusCondition(w.Status.Conditions, condition.Type)
 	if existingCondition != nil {

--- a/pkg/workload/admissionchecks.go
+++ b/pkg/workload/admissionchecks.go
@@ -45,6 +45,7 @@ func SyncAdmittedCondition(w *kueue.Workload, now time.Time) bool {
 		Reason:             "Admitted",
 		Message:            "The workload is admitted",
 		ObservedGeneration: w.Generation,
+		LastTransitionTime: metav1.NewTime(now),
 	}
 	switch {
 	case !hasReservation && !hasAllChecksReady:

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -562,6 +562,7 @@ func UnsetQuotaReservationWithCondition(wl *kueue.Workload, reason, message stri
 		Status:             metav1.ConditionFalse,
 		Reason:             reason,
 		Message:            api.TruncateConditionMessage(message),
+		LastTransitionTime: metav1.NewTime(now),
 		ObservedGeneration: wl.Generation,
 	}
 	changed := apimeta.SetStatusCondition(&wl.Status.Conditions, condition)
@@ -686,6 +687,7 @@ func SetQuotaReservation(w *kueue.Workload, admission *kueue.Admission, clock cl
 		Reason:             "QuotaReserved",
 		Message:            api.TruncateConditionMessage(message),
 		ObservedGeneration: w.Generation,
+		LastTransitionTime: metav1.NewTime(clock.Now()),
 	}
 	apimeta.SetStatusCondition(&w.Status.Conditions, admittedCond)
 


### PR DESCRIPTION
Cherry pick of #7118 on release-0.13.

#7118: Replace scheduler stub with interceptor function in TestSchedule.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```