### PR TITLE
Automated cherry pick of #6701: [#5743] Cleanup deleteWorkloads from the TestLastSchedulingContext unit test.
#7141: [release-0.14] Replace scheduler stub with interceptor function in TestLastSchedulingContext.

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -7501,7 +7501,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Obj(),
 			},
 			deleteWorkloads: []client.ObjectKey{{
-				Namespace: "default",
+				Namespace: metav1.NamespaceDefault,
 				Name:      "low-1",
 			}},
 			wantPreempted:                 sets.Set[workload.Reference]{},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -7538,8 +7538,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deleteWorkloads: []client.ObjectKey{},
-			wantPreempted:   sets.Set[workload.Reference]{},
+			wantPreempted: sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
 				"default/workload1": *utiltesting.MakeAdmission("eng-cohort-beta").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
@@ -7599,8 +7598,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deleteWorkloads: []client.ObjectKey{},
-			wantPreempted:   sets.Set[workload.Reference]{},
+			wantPreempted: sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
 				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
@@ -7664,8 +7662,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deleteWorkloads: []client.ObjectKey{},
-			wantPreempted:   sets.Set[workload.Reference]{},
+			wantPreempted: sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
 				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -7384,7 +7384,7 @@ func TestEntryOrdering(t *testing.T) {
 }
 
 func TestLastSchedulingContext(t *testing.T) {
-	now := time.Now()
+	now := time.Now().Truncate(time.Second)
 	fakeClock := testingclock.NewFakeClock(now)
 
 	resourceFlavors := []*kueue.ResourceFlavor{
@@ -7454,11 +7454,10 @@ func TestLastSchedulingContext(t *testing.T) {
 	cases := []struct {
 		name                           string
 		cqs                            []kueue.ClusterQueue
-		admittedWorkloads              []kueue.Workload
 		workloads                      []kueue.Workload
 		deleteWorkloads                []client.ObjectKey
 		wantPreempted                  sets.Set[workload.Reference]
-		wantAdmissionsOnFirstSchedule  map[workload.Reference]kueue.Admission
+		wantWorkloads                  []kueue.Workload
 		wantAdmissionsOnSecondSchedule map[workload.Reference]kueue.Admission
 	}{
 		{
@@ -7482,19 +7481,17 @@ func TestLastSchedulingContext(t *testing.T) {
 							Resource(corev1.ResourceCPU, "10", "0").Obj(),
 					).Obj(),
 			},
-			admittedWorkloads: []kueue.Workload{
+			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("low-1", "default").
 					Queue("main").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-alpha").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
 							Assignment(corev1.ResourceCPU, "on-demand", "50").
 							Obj()).
-						Obj()).
-					Admitted(true).
+						Obj(), now).
+					AdmittedAt(true, now).
 					Obj(),
-			},
-			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("preemptor", "default").
 					Queue("main").
 					Request(corev1.ResourceCPU, "20").
@@ -7504,8 +7501,36 @@ func TestLastSchedulingContext(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 				Name:      "low-1",
 			}},
-			wantPreempted:                 sets.Set[workload.Reference]{},
-			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{},
+			wantPreempted: sets.Set[workload.Reference]{},
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("low-1", "default").
+					Queue("main").
+					Request(corev1.ResourceCPU, "50").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltesting.MakeWorkload("preemptor", "default").
+					Queue("main").
+					Request(corev1.ResourceCPU, "20").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             "Pending",
+						Message:            "couldn't assign flavors to pod set main: insufficient quota for cpu in flavor spot, request > maximum capacity (20 > 10), insufficient unused quota for cpu in flavor on-demand, 20 more needed",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("20"),
+						},
+					}).
+					Obj(),
+			},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
 				"default/preemptor": *utiltesting.MakeAdmission("eng-alpha").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
@@ -7517,18 +7542,16 @@ func TestLastSchedulingContext(t *testing.T) {
 		{
 			name: "borrow before next flavor",
 			cqs:  clusterQueueCohort,
-			admittedWorkloads: []kueue.Workload{
+			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder", "default").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-alpha").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
 							Assignment(corev1.ResourceCPU, "on-demand", "50").
 							Obj()).
-						Obj()).
-					Admitted(true).
+						Obj(), now).
+					AdmittedAt(true, now).
 					Obj(),
-			},
-			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("borrower", "default").
 					Queue("main-alpha").
 					Request(corev1.ResourceCPU, "20").
@@ -7539,16 +7562,71 @@ func TestLastSchedulingContext(t *testing.T) {
 					Obj(),
 			},
 			wantPreempted: sets.Set[workload.Reference]{},
-			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
-				"default/workload1": *utiltesting.MakeAdmission("eng-cohort-beta").
-					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "on-demand", "20").
-						Obj()).
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("borrower", "default").
+					Queue("main-alpha").
+					Request(corev1.ResourceCPU, "20").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue eng-cohort-alpha",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(
+						utiltesting.MakeAdmission("eng-cohort-alpha").
+							PodSets(
+								utiltesting.MakePodSetAssignment("main").
+									Assignment(corev1.ResourceCPU, "on-demand", "20").
+									Count(1).
+									Obj(),
+							).
+							Obj(),
+					).
 					Obj(),
-				"default/borrower": *utiltesting.MakeAdmission("eng-cohort-alpha").
-					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "on-demand", "20").
-						Obj()).
+				*utiltesting.MakeWorkload("placeholder", "default").
+					Request(corev1.ResourceCPU, "50").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltesting.MakeWorkload("workload1", "default").
+					Queue("main-beta").
+					Request(corev1.ResourceCPU, "20").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue eng-cohort-beta",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(
+						utiltesting.MakeAdmission("eng-cohort-beta").
+							PodSets(
+								utiltesting.MakePodSetAssignment("main").
+									Assignment(corev1.ResourceCPU, "on-demand", "20").
+									Count(1).
+									Obj(),
+							).
+							Obj(),
+					).
 					Obj(),
 			},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
@@ -7572,38 +7650,77 @@ func TestLastSchedulingContext(t *testing.T) {
 		{
 			name: "borrow after all flavors",
 			cqs:  clusterQueueCohort,
-			admittedWorkloads: []kueue.Workload{
+			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder", "default").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-alpha").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
 							Assignment(corev1.ResourceCPU, "on-demand", "50").
 							Obj()).
-						Obj()).
-					Admitted(true).
+						Obj(), now).
+					AdmittedAt(true, now).
 					Obj(),
 				*utiltesting.MakeWorkload("placeholder1", "default").
 					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-theta").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
 							Assignment(corev1.ResourceCPU, "on-demand", "50").
 							Obj()).
-						Obj()).
-					Admitted(true).
+						Obj(), now).
+					AdmittedAt(true, now).
 					Obj(),
-			},
-			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("workload", "default").
 					Queue("main-theta").
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
 			wantPreempted: sets.Set[workload.Reference]{},
-			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
-				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
-					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "spot", "20").
-						Obj()).
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("placeholder", "default").
+					Request(corev1.ResourceCPU, "50").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltesting.MakeWorkload("placeholder1", "default").
+					Request(corev1.ResourceCPU, "50").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-theta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "50").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltesting.MakeWorkload("workload", "default").
+					Queue("main-theta").
+					Request(corev1.ResourceCPU, "20").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue eng-cohort-theta",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(
+						utiltesting.MakeAdmission("eng-cohort-theta").
+							PodSets(
+								utiltesting.MakePodSetAssignment("main").
+									Assignment(corev1.ResourceCPU, "spot", "20").
+									Count(1).
+									Obj(),
+							).
+							Obj(),
+					).
 					Obj(),
 			},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
@@ -7627,47 +7744,95 @@ func TestLastSchedulingContext(t *testing.T) {
 		{
 			name: "when the next flavor is full, but can borrow on first",
 			cqs:  clusterQueueCohort,
-			admittedWorkloads: []kueue.Workload{
+			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder", "default").
 					Request(corev1.ResourceCPU, "40").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-alpha").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
 							Assignment(corev1.ResourceCPU, "on-demand", "40").
 							Obj()).
-						Obj()).
-					Admitted(true).
+						Obj(), now).
+					AdmittedAt(true, now).
 					Obj(),
 				*utiltesting.MakeWorkload("placeholder1", "default").
 					Request(corev1.ResourceCPU, "40").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-theta").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
 							Assignment(corev1.ResourceCPU, "on-demand", "40").
 							Obj()).
-						Obj()).
-					Admitted(true).
+						Obj(), now).
+					AdmittedAt(true, now).
 					Obj(),
 				*utiltesting.MakeWorkload("placeholder2", "default").
 					Request(corev1.ResourceCPU, "100").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-theta").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
 							Assignment(corev1.ResourceCPU, "spot", "100").
 							Obj()).
-						Obj()).
-					Admitted(true).
+						Obj(), now).
+					AdmittedAt(true, now).
 					Obj(),
-			},
-			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("workload", "default").
 					Queue("main-theta").
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
 			wantPreempted: sets.Set[workload.Reference]{},
-			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
-				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
-					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
-						Assignment(corev1.ResourceCPU, "on-demand", "20").
-						Obj()).
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("placeholder", "default").
+					Request(corev1.ResourceCPU, "40").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "40").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltesting.MakeWorkload("placeholder1", "default").
+					Request(corev1.ResourceCPU, "40").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-theta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "40").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltesting.MakeWorkload("placeholder2", "default").
+					Request(corev1.ResourceCPU, "100").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-theta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "spot", "100").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltesting.MakeWorkload("workload", "default").
+					Queue("main-theta").
+					Request(corev1.ResourceCPU, "20").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue eng-cohort-theta",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(
+						utiltesting.MakeAdmission("eng-cohort-theta").
+							PodSets(
+								utiltesting.MakePodSetAssignment("main").
+									Assignment(corev1.ResourceCPU, "on-demand", "20").
+									Count(1).
+									Obj(),
+							).
+							Obj(),
+					).
 					Obj(),
 			},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
@@ -7696,28 +7861,26 @@ func TestLastSchedulingContext(t *testing.T) {
 		{
 			name: "when the next flavor is full, but can preempt on first",
 			cqs:  clusterQueueCohort,
-			admittedWorkloads: []kueue.Workload{
+			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("placeholder-alpha", "default").
 					Priority(-1).
 					Request(corev1.ResourceCPU, "150").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-alpha").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-alpha").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
 							Assignment(corev1.ResourceCPU, "on-demand", "150").
 							Obj()).
-						Obj()).
-					Admitted(true).
+						Obj(), now).
+					AdmittedAt(true, now).
 					Obj(),
 				*utiltesting.MakeWorkload("placeholder-theta-spot", "default").
 					Request(corev1.ResourceCPU, "100").
-					ReserveQuota(utiltesting.MakeAdmission("eng-cohort-theta").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-theta").
 						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
 							Assignment(corev1.ResourceCPU, "spot", "100").
 							Obj()).
-						Obj()).
-					Admitted(true).
+						Obj(), now).
+					AdmittedAt(true, now).
 					Obj(),
-			},
-			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("new", "default").
 					Queue("main-theta").
 					Request(corev1.ResourceCPU, "20").
@@ -7727,8 +7890,45 @@ func TestLastSchedulingContext(t *testing.T) {
 				Namespace: metav1.NamespaceDefault,
 				Name:      "placeholder-alpha",
 			}},
-			wantPreempted:                 sets.New[workload.Reference]("default/placeholder-alpha"),
-			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{},
+			wantPreempted: sets.New[workload.Reference]("default/placeholder-alpha"),
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("new", "default").
+					Queue("main-theta").
+					Request(corev1.ResourceCPU, "20").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             "Pending",
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor on-demand, 20 more needed, insufficient unused quota for cpu in flavor spot, 20 more needed. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("20"),
+						},
+					}).
+					Obj(),
+				*utiltesting.MakeWorkload("placeholder-alpha", "default").
+					Priority(-1).
+					Request(corev1.ResourceCPU, "150").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-alpha").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "150").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltesting.MakeWorkload("placeholder-theta-spot", "default").
+					Request(corev1.ResourceCPU, "100").
+					ReserveQuotaAt(utiltesting.MakeAdmission("eng-cohort-theta").
+						PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "spot", "100").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
 				"default/placeholder-theta-spot": *utiltesting.MakeAdmission("eng-cohort-theta").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
@@ -7789,29 +7989,27 @@ func TestLastSchedulingContext(t *testing.T) {
 							Obj(),
 					).Obj(),
 			},
-			admittedWorkloads: []kueue.Workload{
+			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("alpha1", "default").
 					Request(corev1.ResourceCPU, "22").
 					SimpleReserveQuota("eng-cohort-alpha", "on-demand", now.Add(-time.Second)).
-					Admitted(true).
+					AdmittedAt(true, now).
 					Obj(),
 				*utiltesting.MakeWorkload("alpha2", "default").
 					Request(corev1.ResourceCPU, "22").
 					SimpleReserveQuota("eng-cohort-alpha", "on-demand", now).
-					Admitted(true).
+					AdmittedAt(true, now).
 					Obj(),
 				*utiltesting.MakeWorkload("alpha3", "default").
 					Request(corev1.ResourceCPU, "22").
 					SimpleReserveQuota("eng-cohort-alpha", "spot", now).
-					Admitted(true).
+					AdmittedAt(true, now).
 					Obj(),
 				*utiltesting.MakeWorkload("beta1", "default").
 					Request(corev1.ResourceCPU, "22").
 					SimpleReserveQuota("eng-cohort-beta", "spot", now).
-					Admitted(true).
+					AdmittedAt(true, now).
 					Obj(),
-			},
-			workloads: []kueue.Workload{
 				*utiltesting.MakeWorkload("new", "default").
 					Queue("main-beta").
 					Request(corev1.ResourceCPU, "22").
@@ -7822,6 +8020,45 @@ func TestLastSchedulingContext(t *testing.T) {
 				Name:      "alpha2",
 			}},
 			wantPreempted: sets.New[workload.Reference]("default/alpha2"),
+			wantWorkloads: []kueue.Workload{
+				*utiltesting.MakeWorkload("alpha1", "default").
+					Request(corev1.ResourceCPU, "22").
+					SimpleReserveQuota("eng-cohort-alpha", "on-demand", now.Add(-time.Second)).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltesting.MakeWorkload("alpha2", "default").
+					Request(corev1.ResourceCPU, "22").
+					SimpleReserveQuota("eng-cohort-alpha", "on-demand", now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltesting.MakeWorkload("alpha3", "default").
+					Request(corev1.ResourceCPU, "22").
+					SimpleReserveQuota("eng-cohort-alpha", "spot", now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltesting.MakeWorkload("beta1", "default").
+					Request(corev1.ResourceCPU, "22").
+					SimpleReserveQuota("eng-cohort-beta", "spot", now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltesting.MakeWorkload("new", "default").
+					Queue("main-beta").
+					Request(corev1.ResourceCPU, "22").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             "Pending",
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor on-demand, 6 more needed, insufficient unused quota for cpu in flavor spot, 6 more needed. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("22"),
+						},
+					}).
+					Obj(),
+			},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
 				"default/alpha1": *utiltesting.MakeAdmission("eng-cohort-alpha").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
@@ -7853,13 +8090,17 @@ func TestLastSchedulingContext(t *testing.T) {
 			scheme := runtime.NewScheme()
 
 			clientBuilder := utiltesting.NewClientBuilder().
-				WithLists(&kueue.WorkloadList{Items: tc.admittedWorkloads},
+				WithLists(
 					&kueue.WorkloadList{Items: tc.workloads},
 					&kueue.ClusterQueueList{Items: tc.cqs},
-					&kueue.LocalQueueList{Items: queues}).
+					&kueue.LocalQueueList{Items: queues},
+				).
 				WithObjects(
 					utiltesting.MakeNamespace("default"),
-				)
+				).
+				WithStatusSubresource(&kueue.Workload{}).
+				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
+
 			cl := clientBuilder.Build()
 			broadcaster := record.NewBroadcaster()
 			recorder := broadcaster.NewRecorder(scheme,
@@ -7884,19 +8125,14 @@ func TestLastSchedulingContext(t *testing.T) {
 				}
 			}
 			scheduler := New(qManager, cqCache, cl, recorder, WithClock(t, fakeClock))
-			gotScheduled := make(map[workload.Reference]kueue.Admission)
-			var mu sync.Mutex
-			scheduler.applyAdmission = func(ctx context.Context, w *kueue.Workload) error {
-				mu.Lock()
-				gotScheduled[workload.Key(w)] = *w.Status.Admission
-				mu.Unlock()
-				return nil
-			}
+
 			wg := sync.WaitGroup{}
 			scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
 				func() { wg.Add(1) },
 				func() { wg.Done() },
 			))
+
+			var mu sync.Mutex
 			gotPreempted := sets.New[workload.Reference]()
 			scheduler.preemptor.OverrideApply(func(_ context.Context, w *kueue.Workload, _, _ string) error {
 				mu.Lock()
@@ -7915,7 +8151,19 @@ func TestLastSchedulingContext(t *testing.T) {
 			if diff := cmp.Diff(tc.wantPreempted, gotPreempted); diff != "" {
 				t.Errorf("Unexpected preemptions (-want,+got):\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.wantAdmissionsOnFirstSchedule, gotScheduled, cmpopts.EquateEmpty()); diff != "" {
+
+			gotWorkloads := &kueue.WorkloadList{}
+			err := cl.List(ctx, gotWorkloads)
+			if err != nil {
+				t.Fatalf("Unexpected list workloads error: %v", err)
+			}
+
+			defaultWorkloadCmpOpts := cmp.Options{
+				cmpopts.EquateEmpty(),
+				cmpopts.IgnoreFields(kueue.Workload{}, "ObjectMeta.ResourceVersion"),
+			}
+
+			if diff := cmp.Diff(tc.wantWorkloads, gotWorkloads.Items, defaultWorkloadCmpOpts); diff != "" {
 				t.Errorf("Unexpected scheduled workloads (-want,+got):\n%s", diff)
 			}
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -7456,7 +7456,7 @@ func TestLastSchedulingContext(t *testing.T) {
 		cqs                            []kueue.ClusterQueue
 		admittedWorkloads              []kueue.Workload
 		workloads                      []kueue.Workload
-		deleteWorkloads                []kueue.Workload
+		deleteWorkloads                []*kueue.Workload
 		wantPreempted                  sets.Set[workload.Reference]
 		wantAdmissionsOnFirstSchedule  map[workload.Reference]kueue.Admission
 		wantAdmissionsOnSecondSchedule map[workload.Reference]kueue.Admission
@@ -7500,8 +7500,8 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deleteWorkloads: []kueue.Workload{
-				*utiltesting.MakeWorkload("low-1", "default").
+			deleteWorkloads: []*kueue.Workload{
+				utiltesting.MakeWorkload("low-1", "default").
 					Queue("main").
 					Request(corev1.ResourceCPU, "50").
 					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).Obj()).
@@ -7542,7 +7542,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deleteWorkloads: []kueue.Workload{},
+			deleteWorkloads: []*kueue.Workload{},
 			wantPreempted:   sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
 				"default/workload1": *utiltesting.MakeAdmission("eng-cohort-beta").
@@ -7603,7 +7603,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deleteWorkloads: []kueue.Workload{},
+			deleteWorkloads: []*kueue.Workload{},
 			wantPreempted:   sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
 				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
@@ -7668,7 +7668,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deleteWorkloads: []kueue.Workload{},
+			deleteWorkloads: []*kueue.Workload{},
 			wantPreempted:   sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
 				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
@@ -7730,7 +7730,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deleteWorkloads:               []kueue.Workload{*utiltesting.MakeWorkload("placeholder-alpha", "default").Obj()},
+			deleteWorkloads:               []*kueue.Workload{utiltesting.MakeWorkload("placeholder-alpha", "default").Obj()},
 			wantPreempted:                 sets.New[workload.Reference]("default/placeholder-alpha"),
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
@@ -7821,7 +7821,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "22").
 					Obj(),
 			},
-			deleteWorkloads: []kueue.Workload{*utiltesting.MakeWorkload("alpha2", "default").Obj()},
+			deleteWorkloads: []*kueue.Workload{utiltesting.MakeWorkload("alpha2", "default").Obj()},
 			wantPreempted:   sets.New[workload.Reference]("default/alpha2"),
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
 				"default/alpha1": *utiltesting.MakeAdmission("eng-cohort-alpha").
@@ -7921,15 +7921,15 @@ func TestLastSchedulingContext(t *testing.T) {
 			}
 
 			for _, wl := range tc.deleteWorkloads {
-				err := cl.Delete(ctx, &wl)
+				err := cl.Delete(ctx, wl)
 				if err != nil {
 					t.Errorf("Delete workload failed: %v", err)
 				}
-				err = cqCache.DeleteWorkload(log, &wl)
+				err = cqCache.DeleteWorkload(log, wl)
 				if err != nil {
 					t.Errorf("Delete workload failed: %v", err)
 				}
-				qManager.QueueAssociatedInadmissibleWorkloadsAfter(ctx, &wl, nil)
+				qManager.QueueAssociatedInadmissibleWorkloadsAfter(ctx, wl, nil)
 			}
 
 			scheduler.schedule(ctx)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -7456,7 +7456,7 @@ func TestLastSchedulingContext(t *testing.T) {
 		cqs                            []kueue.ClusterQueue
 		admittedWorkloads              []kueue.Workload
 		workloads                      []kueue.Workload
-		deleteWorkloads                []*kueue.Workload
+		deleteWorkloads                []client.ObjectKey
 		wantPreempted                  sets.Set[workload.Reference]
 		wantAdmissionsOnFirstSchedule  map[workload.Reference]kueue.Admission
 		wantAdmissionsOnSecondSchedule map[workload.Reference]kueue.Admission
@@ -7500,14 +7500,10 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deleteWorkloads: []*kueue.Workload{
-				utiltesting.MakeWorkload("low-1", "default").
-					Queue("main").
-					Request(corev1.ResourceCPU, "50").
-					ReserveQuota(utiltesting.MakeAdmission("eng-alpha").PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "50").Obj()).Obj()).
-					Admitted(true).
-					Obj(),
-			},
+			deleteWorkloads: []client.ObjectKey{{
+				Namespace: "default",
+				Name:      "low-1",
+			}},
 			wantPreempted:                 sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
@@ -7542,7 +7538,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deleteWorkloads: []*kueue.Workload{},
+			deleteWorkloads: []client.ObjectKey{},
 			wantPreempted:   sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
 				"default/workload1": *utiltesting.MakeAdmission("eng-cohort-beta").
@@ -7603,7 +7599,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deleteWorkloads: []*kueue.Workload{},
+			deleteWorkloads: []client.ObjectKey{},
 			wantPreempted:   sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
 				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
@@ -7668,7 +7664,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deleteWorkloads: []*kueue.Workload{},
+			deleteWorkloads: []client.ObjectKey{},
 			wantPreempted:   sets.Set[workload.Reference]{},
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{
 				"default/workload": *utiltesting.MakeAdmission("eng-cohort-theta").
@@ -7730,7 +7726,10 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "20").
 					Obj(),
 			},
-			deleteWorkloads:               []*kueue.Workload{utiltesting.MakeWorkload("placeholder-alpha", "default").Obj()},
+			deleteWorkloads: []client.ObjectKey{{
+				Namespace: "default",
+				Name:      "placeholder-alpha",
+			}},
 			wantPreempted:                 sets.New[workload.Reference]("default/placeholder-alpha"),
 			wantAdmissionsOnFirstSchedule: map[workload.Reference]kueue.Admission{},
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
@@ -7821,8 +7820,11 @@ func TestLastSchedulingContext(t *testing.T) {
 					Request(corev1.ResourceCPU, "22").
 					Obj(),
 			},
-			deleteWorkloads: []*kueue.Workload{utiltesting.MakeWorkload("alpha2", "default").Obj()},
-			wantPreempted:   sets.New[workload.Reference]("default/alpha2"),
+			deleteWorkloads: []client.ObjectKey{{
+				Namespace: "default",
+				Name:      "alpha2",
+			}},
+			wantPreempted: sets.New[workload.Reference]("default/alpha2"),
 			wantAdmissionsOnSecondSchedule: map[workload.Reference]kueue.Admission{
 				"default/alpha1": *utiltesting.MakeAdmission("eng-cohort-alpha").
 					PodSets(utiltesting.MakePodSetAssignment(kueue.DefaultPodSetName).
@@ -7920,16 +7922,21 @@ func TestLastSchedulingContext(t *testing.T) {
 				t.Errorf("Unexpected scheduled workloads (-want,+got):\n%s", diff)
 			}
 
-			for _, wl := range tc.deleteWorkloads {
-				err := cl.Delete(ctx, wl)
+			for _, workloadReference := range tc.deleteWorkloads {
+				var workload kueue.Workload
+				err := cl.Get(ctx, workloadReference, &workload)
+				if err != nil {
+					t.Errorf("Unable to get workload: %v", err)
+				}
+				err = cl.Delete(ctx, &workload)
 				if err != nil {
 					t.Errorf("Delete workload failed: %v", err)
 				}
-				err = cqCache.DeleteWorkload(log, wl)
+				err = cqCache.DeleteWorkload(log, &workload)
 				if err != nil {
 					t.Errorf("Delete workload failed: %v", err)
 				}
-				qManager.QueueAssociatedInadmissibleWorkloadsAfter(ctx, wl, nil)
+				qManager.QueueAssociatedInadmissibleWorkloadsAfter(ctx, &workload, nil)
 			}
 
 			scheduler.schedule(ctx)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -7724,7 +7724,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Obj(),
 			},
 			deleteWorkloads: []client.ObjectKey{{
-				Namespace: "default",
+				Namespace: metav1.NamespaceDefault,
 				Name:      "placeholder-alpha",
 			}},
 			wantPreempted:                 sets.New[workload.Reference]("default/placeholder-alpha"),
@@ -7818,7 +7818,7 @@ func TestLastSchedulingContext(t *testing.T) {
 					Obj(),
 			},
 			deleteWorkloads: []client.ObjectKey{{
-				Namespace: "default",
+				Namespace: metav1.NamespaceDefault,
 				Name:      "alpha2",
 			}},
 			wantPreempted: sets.New[workload.Reference]("default/alpha2"),


### PR DESCRIPTION
Cherry pick of #6701 #7141 on release-0.13.

#6701: [#5743] Cleanup deleteWorkloads from the TestLastSchedulingContext unit test.
#7141: [release-0.14] Replace scheduler stub with interceptor function in TestLastSchedulingContext.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
NONE
```