### PR TITLE
[BestEffortFIFO] Implement Sticky ClusterQueue Head Policy

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -371,7 +371,6 @@ func (c *ClusterQueue) Pop() *workload.Info {
 	}
 
 	c.popCycle++
-	c.sw.clear()
 	if c.heap.Len() == 0 {
 		c.inflight = nil
 		return nil

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -56,6 +56,28 @@ var (
 	realClock = clock.RealClock{}
 )
 
+// stickyWorkload is the workload at the ClusterQueue head which is
+// currently preempting workloads. It is only enabled for
+// BestEffortFIFO policy, and prevents skipped over ineligible
+// workloads from going back to the head of the queue.  A workload is
+// considered sticky until it is admitted, unschedulable, or deleted.
+// See Kueue#6929 and Kueue#7101 for motivation.
+type stickyWorkload struct {
+	workloadName workload.Reference
+}
+
+func (s *stickyWorkload) matches(workload workload.Reference) bool {
+	return s.workloadName == workload
+}
+
+func (s *stickyWorkload) clear() {
+	s.workloadName = ""
+}
+
+func (s *stickyWorkload) set(workload workload.Reference) {
+	s.workloadName = workload
+}
+
 type ClusterQueue struct {
 	hierarchy.ClusterQueue[*cohort]
 	name              kueue.ClusterQueueReference
@@ -90,6 +112,8 @@ type ClusterQueue struct {
 
 	afsEntryPenalties         *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]
 	localQueuesInClusterQueue map[utilqueue.LocalQueueReference]bool
+
+	sw *stickyWorkload
 }
 
 func (c *ClusterQueue) GetName() kueue.ClusterQueueReference {
@@ -111,7 +135,8 @@ func newClusterQueue(ctx context.Context, client client.Client, cq *kueue.Cluste
 }
 
 func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.Ordering, clock clock.Clock, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]) *ClusterQueue {
-	lessFunc := queueOrderingFunc(ctx, client, wo, fsResWeights, enableAdmissionFs, afsEntryPenalties)
+	sw := stickyWorkload{}
+	lessFunc := queueOrderingFunc(ctx, client, wo, fsResWeights, enableAdmissionFs, afsEntryPenalties, &sw)
 	return &ClusterQueue{
 		heap:                      *heap.New(workloadKey, lessFunc),
 		inadmissibleWorkloads:     make(map[workload.Reference]*workload.Info),
@@ -121,6 +146,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 		clock:                     clock,
 		afsEntryPenalties:         afsEntryPenalties,
 		localQueuesInClusterQueue: make(map[utilqueue.LocalQueueReference]bool),
+		sw:                        &sw,
 	}
 }
 
@@ -223,6 +249,9 @@ func (c *ClusterQueue) delete(w *kueue.Workload) {
 	delete(c.inadmissibleWorkloads, key)
 	c.heap.Delete(key)
 	c.forgetInflightByKey(key)
+	if c.sw.matches(key) {
+		c.sw.clear()
+	}
 }
 
 // DeleteFromLocalQueue removes all workloads belonging to this queue from
@@ -342,6 +371,7 @@ func (c *ClusterQueue) Pop() *workload.Info {
 	}
 
 	c.popCycle++
+	c.sw.clear()
 	if c.heap.Len() == 0 {
 		c.inflight = nil
 		return nil
@@ -453,6 +483,13 @@ func (c *ClusterQueue) Active() bool {
 // The workload should not be reinserted if it's already in the ClusterQueue.
 // Returns true if the workload was inserted.
 func (c *ClusterQueue) RequeueIfNotPresent(wInfo *workload.Info, reason RequeueReason) bool {
+	// when preemptions are in-progress, we keep attempting to
+	// schedule the same workload for BestEffortFIFO queues. See
+	// documentation of stickyWorkload for more details
+	if reason == RequeueReasonPendingPreemption && c.queueingStrategy == kueue.BestEffortFIFO {
+		c.sw.set(workload.Key(wInfo.Obj))
+	}
+
 	if c.queueingStrategy == kueue.StrictFIFO {
 		return c.requeueIfNotPresent(wInfo, reason != RequeueReasonNamespaceMismatch)
 	}
@@ -463,7 +500,7 @@ func (c *ClusterQueue) RequeueIfNotPresent(wInfo *workload.Info, reason RequeueR
 // to sort workloads. The function sorts workloads based on their priority.
 // When priorities are equal, it uses the workload's creation or eviction
 // time.
-func queueOrderingFunc(ctx context.Context, c client.Client, wo workload.Ordering, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]) func(a, b *workload.Info) bool {
+func queueOrderingFunc(ctx context.Context, c client.Client, wo workload.Ordering, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList], sw *stickyWorkload) func(a, b *workload.Info) bool {
 	log := ctrl.LoggerFrom(ctx)
 	return func(a, b *workload.Info) bool {
 		if enableAdmissionFs {
@@ -482,6 +519,14 @@ func queueOrderingFunc(ctx context.Context, c client.Client, wo workload.Orderin
 				}
 			}
 		}
+
+		if sw.matches(workload.Key(a.Obj)) {
+			return true
+		}
+		if sw.matches(workload.Key(b.Obj)) {
+			return false
+		}
+
 		p1 := utilpriority.Priority(a.Obj)
 		p2 := utilpriority.Priority(b.Obj)
 

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -707,7 +707,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			for range 4 {
 				createWorkload("cq-p1", "2")
 			}
-			util.ExpectReservingActiveWorkloadsMetric(cqp1, 4)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, "", 4)
 
 			ginkgo.By("Create workload in queue2")
 			createWorkload("cq-p2", "5")
@@ -715,9 +715,9 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			ginkgo.By("Complete preemption")
 			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cqp1, 2)
 
-			ginkgo.By("Expect active workloads")
-			util.ExpectReservingActiveWorkloadsMetric(cqp1, 2)
-			util.ExpectReservingActiveWorkloadsMetric(cqp2, 1)
+			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, "", 4)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, "", 1)
 			util.ExpectClusterQueueWeightedShareMetric(cqp1, 445)
 			util.ExpectClusterQueueWeightedShareMetric(cqp2, 556)
 		})
@@ -734,13 +734,13 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			for range 4 {
 				createWorkload("cq-p1", "2")
 			}
-			util.ExpectReservingActiveWorkloadsMetric(cqp1, 4)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, "", 4)
 
 			ginkgo.By("Create workloads in queue2")
 			createWorkloadWithPriority("cq-p2", "6", 999)
 
 			ginkgo.By("Verify doesn't admit")
-			util.ExpectReservingActiveWorkloadsMetric(cqp2, 0)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, "", 0)
 
 			ginkgo.By("Create admissible workload in queue2")
 			createWorkloadWithPriority("cq-p2", "5", 0)
@@ -748,9 +748,9 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			ginkgo.By("Complete preemption")
 			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cqp1, 2)
 
-			ginkgo.By("Expect active workloads")
-			util.ExpectReservingActiveWorkloadsMetric(cqp1, 2)
-			util.ExpectReservingActiveWorkloadsMetric(cqp2, 1)
+			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, "", 4)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, "", 1)
 			util.ExpectClusterQueueWeightedShareMetric(cqp1, 445)
 			util.ExpectClusterQueueWeightedShareMetric(cqp2, 556)
 		})
@@ -760,13 +760,13 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			for range 4 {
 				createWorkload("cq-p1", "2")
 			}
-			util.ExpectReservingActiveWorkloadsMetric(cqp1, 4)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, "", 4)
 
 			ginkgo.By("Create workload in queue2")
 			createWorkloadWithPriority("cq-p2", "6", 999)
 
 			ginkgo.By("Verify doesn't admit")
-			util.ExpectReservingActiveWorkloadsMetric(cqp2, 0)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, "", 0)
 
 			ginkgo.By("Create admissible workload in queue2")
 			createWorkloadWithPriority("cq-p2", "4", 0)
@@ -774,9 +774,9 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			ginkgo.By("Complete preemption")
 			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cqp1, 2)
 
-			ginkgo.By("Expect active workloads")
-			util.ExpectReservingActiveWorkloadsMetric(cqp1, 2)
-			util.ExpectReservingActiveWorkloadsMetric(cqp2, 1)
+			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, "", 4)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, "", 1)
 			util.ExpectClusterQueueWeightedShareMetric(cqp1, 445)
 			util.ExpectClusterQueueWeightedShareMetric(cqp2, 445)
 		})
@@ -786,14 +786,14 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			for range 4 {
 				createWorkload("cq-p1", "2")
 			}
-			util.ExpectReservingActiveWorkloadsMetric(cqp1, 4)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, "", 4)
 
 			ginkgo.By("Create workloads in queue2")
 			createWorkloadWithPriority("cq-p2", "7", 999)
 			createWorkloadWithPriority("cq-p2", "6", 999)
 
 			ginkgo.By("Verify don't admit")
-			util.ExpectReservingActiveWorkloadsMetric(cqp2, 0)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, "", 0)
 
 			ginkgo.By("Create admissible workload in queue2")
 			createWorkloadWithPriority("cq-p2", "5", 0)
@@ -801,9 +801,9 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			ginkgo.By("Complete preemption")
 			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cqp1, 2)
 
-			ginkgo.By("Expect active workloads")
-			util.ExpectReservingActiveWorkloadsMetric(cqp1, 2)
-			util.ExpectReservingActiveWorkloadsMetric(cqp2, 1)
+			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, "", 4)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, "", 1)
 			util.ExpectClusterQueueWeightedShareMetric(cqp1, 445)
 			util.ExpectClusterQueueWeightedShareMetric(cqp2, 556)
 		})
@@ -849,13 +849,13 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				ginkgo.By("Creating borrowing workloads in queue2")
 				createWorkload("cq2", "1")
 				createWorkload("cq2", "1")
-				util.ExpectReservingActiveWorkloadsMetric(cq2, 2)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 2)
 
 				ginkgo.By("Create inadmissible workload in queue2")
 				createWorkloadWithPriority("cq1", "4", 999)
 
 				ginkgo.By("Verify doesn't admit")
-				util.ExpectReservingActiveWorkloadsMetric(cq1, 0)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 0)
 
 				ginkgo.By("Create admissible workload in queue2")
 				createWorkloadWithPriority("cq1", "3", 0)
@@ -863,9 +863,9 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				ginkgo.By("Complete preemption")
 				util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cq2, 2)
 
-				ginkgo.By("Expect active workloads")
-				util.ExpectReservingActiveWorkloadsMetric(cq1, 1)
-				util.ExpectReservingActiveWorkloadsMetric(cq2, 0)
+				ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 2)
 				util.ExpectClusterQueueWeightedShareMetric(cq1, 0)
 				util.ExpectClusterQueueWeightedShareMetric(cq2, 0)
 			})
@@ -874,13 +874,13 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				ginkgo.By("Creating borrowing workloads in queue2")
 				createWorkload("cq2", "1")
 				createWorkload("cq2", "1")
-				util.ExpectReservingActiveWorkloadsMetric(cq2, 2)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 2)
 
 				ginkgo.By("Create inadmissible workload in queue2")
 				createWorkloadWithPriority("cq1", "4", 999)
 
 				ginkgo.By("Verify doesn't admit")
-				util.ExpectReservingActiveWorkloadsMetric(cq1, 0)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 0)
 
 				ginkgo.By("Create admissible workloads in queue2")
 				stickyWorkload := createWorkloadWithPriority("cq1", "3", 99)
@@ -894,9 +894,9 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 				ginkgo.By("Complete preemption")
 				util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cq2, 2)
 
-				ginkgo.By("Expect active workloads")
-				util.ExpectReservingActiveWorkloadsMetric(cq1, 1)
-				util.ExpectReservingActiveWorkloadsMetric(cq2, 0)
+				ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, "", 1)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq2, "", 2)
 				util.ExpectClusterQueueWeightedShareMetric(cq1, 0)
 				util.ExpectClusterQueueWeightedShareMetric(cq2, 0)
 			})


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
When a workload, in a queue with BestEffortFIFO enabled, has preemption targets, we keep it at the head of the queue until it schedules (or returns inadmissible).

See original proposal here: https://github.com/kubernetes-sigs/kueue/issues/6929#issuecomment-3360978483

#### Which issue(s) this PR fixes:
Fixes #7101, #6929

#### Special notes for your reviewer:
Let's discuss whether we want to put this behind a feature gate.

#### Does this PR introduce a user-facing change?
```release-note
With BestEffortFIFO enabled, we will keep attempting to schedule a workload as long as
it is waiting for preemption targets to complete. This fixes a bugs where an inadmissible
workload went back to head of queue, in front of the preempting workload, allowing
preempted workloads to reschedule
```