### PR TITLE
Automated cherry pick of #7161: [release-0.13] Flaky Integration Test: Scheduler when Preemption is enabled in fairsharing and there are large values of quota and weights Queue can reclaim its nominal quota 

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -840,7 +840,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 			for range 10 {
 				createWorkload("a", "100")
 			}
-			util.ExpectReservingActiveWorkloadsMetric(cqA, 10)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqA, "", 10)
 			ginkgo.By("Creating a newer workload in cqB that needs only nominal quota")
 			createWorkload("b", "500")
 			ginkgo.By("Evict the some workloads in cqA and reclaim the nominal quota in cqB")


### PR DESCRIPTION
Cherry pick of #7161 on release-0.13.

#7161: [release-0.13] Flaky Integration Test: Scheduler when Preemption is enabled in fairsharing and there are large values of quota and weights Queue can reclaim its nominal quota 

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```