### PR TITLE
Fix typos in `RayJob` and `RayCluster` head group metadata paths

### DIFF
--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -44,7 +44,7 @@ import (
 
 var (
 	headGroupSpecsPath   = field.NewPath("spec", "headGroupSpec")
-	headGroupMetaPath    = headGroupSpecsPath.Child("template, metadata")
+	headGroupMetaPath    = headGroupSpecsPath.Child("template", "metadata")
 	workerGroupSpecsPath = field.NewPath("spec", "workerGroupSpecs")
 )
 

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -234,7 +234,7 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 			wantErr: field.ErrorList{
 				field.Invalid(
-					field.NewPath("spec.headGroupSpec.template, metadata.annotations"),
+					field.NewPath("spec.headGroupSpec.template.metadata.annotations"),
 					field.OmitValueType{},
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
@@ -289,7 +289,7 @@ func TestValidateCreate(t *testing.T) {
 				).
 				Obj(),
 			wantErr: field.ErrorList{
-				field.Invalid(field.NewPath("spec.headGroupSpec.template, metadata.annotations").
+				field.Invalid(field.NewPath("spec.headGroupSpec.template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "2", "must not be greater than pod set count 1"),
 				field.Invalid(field.NewPath("spec.workerGroupSpecs[0].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "10", "must not be greater than pod set count 5"),

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	headGroupSpecsPath   = field.NewPath("spec", "rayClusterSpec", "headGroupSpec")
-	headGroupMetaPath    = headGroupSpecsPath.Child("template, metadata")
+	headGroupMetaPath    = headGroupSpecsPath.Child("template", "metadata")
 	workerGroupSpecsPath = field.NewPath("spec", "rayClusterSpec", "workerGroupSpecs")
 )
 

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -269,7 +269,7 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 			wantErr: field.ErrorList{
 				field.Invalid(
-					field.NewPath("spec.rayClusterSpec.headGroupSpec.template, metadata.annotations"),
+					field.NewPath("spec.rayClusterSpec.headGroupSpec.template.metadata.annotations"),
 					field.OmitValueType{},
 					`must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 						`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`),
@@ -323,7 +323,7 @@ func TestValidateCreate(t *testing.T) {
 					},
 				).
 				Obj(),
-			wantErr: field.ErrorList{field.Invalid(field.NewPath("spec.rayClusterSpec.headGroupSpec.template, metadata.annotations").
+			wantErr: field.ErrorList{field.Invalid(field.NewPath("spec.rayClusterSpec.headGroupSpec.template.metadata.annotations").
 				Key("kueue.x-k8s.io/podset-slice-size"), "2", "must not be greater than pod set count 1"),
 				field.Invalid(field.NewPath("spec.rayClusterSpec.workerGroupSpecs[0].template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "10", "must not be greater than pod set count 5"),


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
While looking into `RayJob` validations for #7061, I noticed this weird path using a comma. Unless I'm missing something very obscure, this is a small typo. I figured I'll fix it.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix malformed annotations paths being reported for `RayJob` and `RayCluster` head group specs.
```