### PR TITLE
Fix invalid metadata path reported in `JobSet` validations

### DIFF
--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -145,15 +145,15 @@ func (w *JobSetWebhook) validateTopologyRequest(ctx context.Context, jobSet *Job
 	podSets, podSetsErr := jobSet.PodSets(ctx)
 
 	for i, rj := range jobSet.Spec.ReplicatedJobs {
-		replicaMetaPath := replicatedJobsPath.Index(i).Child("template", "metadata")
-		allErrs = append(allErrs, jobframework.ValidateTASPodSetRequest(replicaMetaPath, &jobSet.Spec.ReplicatedJobs[i].Template.Spec.Template.ObjectMeta)...)
+		replicaJobTemplateMetaPath := replicatedJobsPath.Index(i).Child("template", "spec", "template", "metadata")
+		allErrs = append(allErrs, jobframework.ValidateTASPodSetRequest(replicaJobTemplateMetaPath, &jobSet.Spec.ReplicatedJobs[i].Template.Spec.Template.ObjectMeta)...)
 
 		if podSetsErr != nil {
 			continue
 		}
 
 		podSet := podset.FindPodSetByName(podSets, kueue.NewPodSetReference(rj.Name))
-		allErrs = append(allErrs, jobframework.ValidateSliceSizeAnnotationUpperBound(replicaMetaPath, &jobSet.Spec.ReplicatedJobs[i].Template.Spec.Template.ObjectMeta, podSet)...)
+		allErrs = append(allErrs, jobframework.ValidateSliceSizeAnnotationUpperBound(replicaJobTemplateMetaPath, &jobSet.Spec.ReplicatedJobs[i].Template.Spec.Template.ObjectMeta, podSet)...)
 	}
 
 	if len(allErrs) > 0 {

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -96,7 +96,7 @@ func TestValidateCreate(t *testing.T) {
 					kueue.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
 				},
 			}).Obj(),
-			wantErr: field.ErrorList{field.Invalid(field.NewPath("spec.replicatedJobs[1].template.metadata.annotations"),
+			wantErr: field.ErrorList{field.Invalid(field.NewPath("spec.replicatedJobs[1].template.spec.template.metadata.annotations"),
 				field.OmitValueType{}, `must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 					`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`)}.ToAggregate(),
 			topologyAwareScheduling: true,
@@ -113,7 +113,7 @@ func TestValidateCreate(t *testing.T) {
 				}).
 				Obj(),
 			wantErr: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "replicatedJobs[0]", "template", "metadata", "annotations").
+				field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations").
 					Key("kueue.x-k8s.io/podset-slice-size"), "20", "must not be greater than pod set count 2"),
 			}.ToAggregate(),
 			topologyAwareScheduling: true,
@@ -171,7 +171,7 @@ func TestValidateUpdate(t *testing.T) {
 					kueue.PodSetRequiredTopologyAnnotation:  "cloud.com/block",
 				},
 			}).Obj(),
-			wantValidationErrs: field.ErrorList{field.Invalid(field.NewPath("spec.replicatedJobs[0].template.metadata.annotations"),
+			wantValidationErrs: field.ErrorList{field.Invalid(field.NewPath("spec.replicatedJobs[0].template.spec.template.metadata.annotations"),
 				field.OmitValueType{}, `must not contain more than one topology annotation: ["kueue.x-k8s.io/podset-required-topology", `+
 					`"kueue.x-k8s.io/podset-preferred-topology", "kueue.x-k8s.io/podset-unconstrained-topology"]`)},
 			topologyAwareScheduling: true,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The data being passed to the validators was changed in #4130, but the field path was not adjusted.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
I noticed it when working on #7061 [here](https://github.com/kubernetes-sigs/kueue/pull/7061/files#r2405374538).

#### Does this PR introduce a user-facing change?
```release-note
Fix invalid annotations path being reported in `JobSet` topology validations.
```