### PR TITLE
logging for 7157

### DIFF
--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -627,7 +627,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 			wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 			info := workload.NewInfo(wl)
 			info.LastAssignment = tc.lastAssignment
-			if ok := cq.RequeueIfNotPresent(info, tc.reason); !ok {
+			if ok := cq.RequeueIfNotPresent(ctx, info, tc.reason); !ok {
 				t.Error("failed to requeue nonexistent workload")
 			}
 
@@ -636,7 +636,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 				t.Errorf("Unexpected inadmissible status (-want,+got):\n%s", diff)
 			}
 
-			if ok := cq.RequeueIfNotPresent(workload.NewInfo(wl), tc.reason); ok {
+			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), tc.reason); ok {
 				t.Error("Re-queued a workload that was already present")
 			}
 		})
@@ -904,7 +904,7 @@ func TestStrictFIFORequeueIfNotPresent(t *testing.T) {
 				workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
 				nil, nil)
 			wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
-			if ok := cq.RequeueIfNotPresent(workload.NewInfo(wl), reason); !ok {
+			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), reason); !ok {
 				t.Error("failed to requeue nonexistent workload")
 			}
 
@@ -913,7 +913,7 @@ func TestStrictFIFORequeueIfNotPresent(t *testing.T) {
 				t.Errorf("Got inadmissible after requeue %t, want %t", gotInadmissible, test.wantInadmissible)
 			}
 
-			if ok := cq.RequeueIfNotPresent(workload.NewInfo(wl), reason); ok {
+			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), reason); ok {
 				t.Error("Re-queued a workload that was already present")
 			}
 		})

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -492,7 +492,7 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 		return false
 	}
 
-	added := cq.RequeueIfNotPresent(info, reason)
+	added := cq.RequeueIfNotPresent(ctx, info, reason)
 	m.reportPendingWorkloads(q.ClusterQueue, cq)
 	if features.Enabled(features.LocalQueueMetrics) {
 		m.reportLQPendingWorkloads(q)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Logging for #7157 to help with debugging if it does not behave as expected

```
queue/cluster_queue.go:491      Setting sticky workload {"schedulingCycle": 124, "clusterQueue": "cq1", "workload": "core-nqz44/workload-ckr9x"}
queue/cluster_queue.go:528      Prioritizing sticky workload    {"clusterQueue": {"name":"cq1"}, "workload": "core-nqz44/workload-ckr9x"}
queue/cluster_queue.go:534      Prioritizing sticky workload    {"clusterQueue": {"name":"cq1"}, "workload": "core-nqz44/workload-ckr9x"}
```

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE

```