### PR TITLE
[release-0.13] Cherry-pick #7157, #7201

### DIFF
--- a/pkg/queue/cluster_queue.go
+++ b/pkg/queue/cluster_queue.go
@@ -55,6 +55,28 @@ var (
 	realClock = clock.RealClock{}
 )
 
+// stickyWorkload is the workload at the ClusterQueue head which is
+// currently preempting workloads. It is only enabled for
+// BestEffortFIFO policy, and prevents skipped over ineligible
+// workloads from going back to the head of the queue.  A workload is
+// considered sticky until it is admitted, unschedulable, or deleted.
+// See Kueue#6929 and Kueue#7101 for motivation.
+type stickyWorkload struct {
+	workloadName workload.Reference
+}
+
+func (s *stickyWorkload) matches(workload workload.Reference) bool {
+	return s.workloadName == workload
+}
+
+func (s *stickyWorkload) clear() {
+	s.workloadName = ""
+}
+
+func (s *stickyWorkload) set(workload workload.Reference) {
+	s.workloadName = workload
+}
+
 type ClusterQueue struct {
 	hierarchy.ClusterQueue[*cohort]
 	name              kueue.ClusterQueueReference
@@ -86,6 +108,8 @@ type ClusterQueue struct {
 	clock clock.Clock
 
 	AdmissionScope *kueue.AdmissionScope
+
+	sw *stickyWorkload
 }
 
 func (c *ClusterQueue) GetName() kueue.ClusterQueueReference {
@@ -107,7 +131,8 @@ func newClusterQueue(ctx context.Context, client client.Client, cq *kueue.Cluste
 }
 
 func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.Ordering, clock clock.Clock, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]) *ClusterQueue {
-	lessFunc := queueOrderingFunc(ctx, client, wo, fsResWeights, enableAdmissionFs, afsEntryPenalties)
+	sw := stickyWorkload{}
+	lessFunc := queueOrderingFunc(ctx, client, wo, fsResWeights, enableAdmissionFs, afsEntryPenalties, &sw)
 	return &ClusterQueue{
 		heap:                   *heap.New(workloadKey, lessFunc),
 		inadmissibleWorkloads:  make(map[workload.Reference]*workload.Info),
@@ -115,6 +140,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 		lessFunc:               lessFunc,
 		rwm:                    sync.RWMutex{},
 		clock:                  clock,
+		sw:                     &sw,
 	}
 }
 
@@ -217,6 +243,9 @@ func (c *ClusterQueue) delete(w *kueue.Workload) {
 	delete(c.inadmissibleWorkloads, key)
 	c.heap.Delete(key)
 	c.forgetInflightByKey(key)
+	if c.sw.matches(key) {
+		c.sw.clear()
+	}
 }
 
 // DeleteFromLocalQueue removes all workloads belonging to this queue from
@@ -418,6 +447,13 @@ func (c *ClusterQueue) Active() bool {
 // The workload should not be reinserted if it's already in the ClusterQueue.
 // Returns true if the workload was inserted.
 func (c *ClusterQueue) RequeueIfNotPresent(wInfo *workload.Info, reason RequeueReason) bool {
+	// when preemptions are in-progress, we keep attempting to
+	// schedule the same workload for BestEffortFIFO queues. See
+	// documentation of stickyWorkload for more details
+	if reason == RequeueReasonPendingPreemption && c.queueingStrategy == kueue.BestEffortFIFO {
+		c.sw.set(workload.Key(wInfo.Obj))
+	}
+
 	if c.queueingStrategy == kueue.StrictFIFO {
 		return c.requeueIfNotPresent(wInfo, reason != RequeueReasonNamespaceMismatch)
 	}
@@ -428,7 +464,7 @@ func (c *ClusterQueue) RequeueIfNotPresent(wInfo *workload.Info, reason RequeueR
 // to sort workloads. The function sorts workloads based on their priority.
 // When priorities are equal, it uses the workload's creation or eviction
 // time.
-func queueOrderingFunc(ctx context.Context, c client.Client, wo workload.Ordering, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]) func(a, b *workload.Info) bool {
+func queueOrderingFunc(ctx context.Context, c client.Client, wo workload.Ordering, fsResWeights map[corev1.ResourceName]float64, enableAdmissionFs bool, afsEntryPenalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList], sw *stickyWorkload) func(a, b *workload.Info) bool {
 	log := ctrl.LoggerFrom(ctx)
 	return func(a, b *workload.Info) bool {
 		if enableAdmissionFs {
@@ -447,6 +483,14 @@ func queueOrderingFunc(ctx context.Context, c client.Client, wo workload.Orderin
 				}
 			}
 		}
+
+		if sw.matches(workload.Key(a.Obj)) {
+			return true
+		}
+		if sw.matches(workload.Key(b.Obj)) {
+			return false
+		}
+
 		p1 := utilpriority.Priority(a.Obj)
 		p2 := utilpriority.Priority(b.Obj)
 

--- a/pkg/queue/cluster_queue.go
+++ b/pkg/queue/cluster_queue.go
@@ -446,11 +446,15 @@ func (c *ClusterQueue) Active() bool {
 // compete with other workloads, until cluster events free up quota.
 // The workload should not be reinserted if it's already in the ClusterQueue.
 // Returns true if the workload was inserted.
-func (c *ClusterQueue) RequeueIfNotPresent(wInfo *workload.Info, reason RequeueReason) bool {
+func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.Info, reason RequeueReason) bool {
 	// when preemptions are in-progress, we keep attempting to
 	// schedule the same workload for BestEffortFIFO queues. See
 	// documentation of stickyWorkload for more details
 	if reason == RequeueReasonPendingPreemption && c.queueingStrategy == kueue.BestEffortFIFO {
+		log := ctrl.LoggerFrom(ctx)
+		if logV := log.V(5); logV.Enabled() {
+			logV.Info("Setting sticky workload", "clusterQueue", wInfo.ClusterQueue, "workload", workload.Key(wInfo.Obj))
+		}
 		c.sw.set(workload.Key(wInfo.Obj))
 	}
 
@@ -485,9 +489,15 @@ func queueOrderingFunc(ctx context.Context, c client.Client, wo workload.Orderin
 		}
 
 		if sw.matches(workload.Key(a.Obj)) {
+			if logV := log.V(5); logV.Enabled() {
+				logV.Info("Prioritizing sticky workload", "workload", workload.Key(a.Obj))
+			}
 			return true
 		}
 		if sw.matches(workload.Key(b.Obj)) {
+			if logV := log.V(5); logV.Enabled() {
+				logV.Info("Prioritizing sticky workload", "workload", workload.Key(b.Obj))
+			}
 			return false
 		}
 

--- a/pkg/queue/cluster_queue_test.go
+++ b/pkg/queue/cluster_queue_test.go
@@ -618,7 +618,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 			wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
 			info := workload.NewInfo(wl)
 			info.LastAssignment = tc.lastAssignment
-			if ok := cq.RequeueIfNotPresent(info, tc.reason); !ok {
+			if ok := cq.RequeueIfNotPresent(t.Context(), info, tc.reason); !ok {
 				t.Error("failed to requeue nonexistent workload")
 			}
 
@@ -627,7 +627,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 				t.Errorf("Unexpected inadmissible status (-want,+got):\n%s", diff)
 			}
 
-			if ok := cq.RequeueIfNotPresent(workload.NewInfo(wl), tc.reason); ok {
+			if ok := cq.RequeueIfNotPresent(t.Context(), workload.NewInfo(wl), tc.reason); ok {
 				t.Error("Re-queued a workload that was already present")
 			}
 		})
@@ -892,7 +892,7 @@ func TestStrictFIFORequeueIfNotPresent(t *testing.T) {
 				workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
 				nil, nil)
 			wl := utiltesting.MakeWorkload("workload-1", defaultNamespace).Obj()
-			if ok := cq.RequeueIfNotPresent(workload.NewInfo(wl), reason); !ok {
+			if ok := cq.RequeueIfNotPresent(t.Context(), workload.NewInfo(wl), reason); !ok {
 				t.Error("failed to requeue nonexistent workload")
 			}
 
@@ -901,7 +901,7 @@ func TestStrictFIFORequeueIfNotPresent(t *testing.T) {
 				t.Errorf("Got inadmissible after requeue %t, want %t", gotInadmissible, test.wantInadmissible)
 			}
 
-			if ok := cq.RequeueIfNotPresent(workload.NewInfo(wl), reason); ok {
+			if ok := cq.RequeueIfNotPresent(t.Context(), workload.NewInfo(wl), reason); ok {
 				t.Error("Re-queued a workload that was already present")
 			}
 		})

--- a/pkg/queue/manager.go
+++ b/pkg/queue/manager.go
@@ -461,7 +461,7 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 		return false
 	}
 
-	added := cq.RequeueIfNotPresent(info, reason)
+	added := cq.RequeueIfNotPresent(ctx, info, reason)
 	m.reportPendingWorkloads(q.ClusterQueue, cq)
 	if features.Enabled(features.LocalQueueMetrics) {
 		m.reportLQPendingWorkloads(q)

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -649,6 +649,307 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Ordered, ginkgo.ContinueOnFailure, f
 		})
 	})
 
+	// kueue#7101
+	ginkgo.When("ClusterQueue head is ineligible for admission due to DominantResourceShare", func() {
+		var (
+			cqp1 *kueue.ClusterQueue
+			cqp2 *kueue.ClusterQueue
+		)
+		ginkgo.BeforeEach(func() {
+			createCohort(testing.MakeCohort("cohort-a").
+				Parent("root-cohort").
+				FairWeight(resource.MustParse("1")).
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("flavor1").Resource(corev1.ResourceCPU, "9").Obj(),
+				).
+				Obj())
+
+			fungibility := kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.TryNextFlavor,
+				WhenCanPreempt: kueue.TryNextFlavor,
+			}
+			preemption := kueue.ClusterQueuePreemption{
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+			}
+
+			cqp1 = createQueue(testing.MakeClusterQueue("cq-p1").
+				Cohort("cohort-a").
+				FairWeight(resource.MustParse("1")).
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("flavor1").Resource(corev1.ResourceCPU, "0").Obj(),
+				).
+				FlavorFungibility(fungibility).
+				Preemption(preemption).
+				Obj())
+
+			cqp2 = createQueue(testing.MakeClusterQueue("cq-p2").
+				Cohort("cohort-a").
+				FairWeight(resource.MustParse("1")).
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("flavor1").Resource(corev1.ResourceCPU, "0").Obj(),
+				).
+				FlavorFungibility(fungibility).
+				Preemption(preemption).
+				Obj())
+			_ = features.SetEnable(features.FlavorFungibilityImplicitPreferenceDefault, true)
+		})
+		ginkgo.AfterEach(func() {
+			_ = features.SetEnable(features.FlavorFungibilityImplicitPreferenceDefault, false)
+		})
+
+		// The first workload preempted satisfies
+		// LessThanOrEqualToFinalShare: 5 <= 6
+		// while the second workload preempted satisfies
+		// LessThanInitialShare policy: 5 < 6
+		ginkgo.It("workload of size 5 preempts using LessThanInitialShare policy and admits", func() {
+			ginkgo.By("Create workloads in queue1")
+			for range 4 {
+				createWorkload("cq-p1", "2")
+			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, 4)
+
+			ginkgo.By("Create workload in queue2")
+			createWorkload("cq-p2", "5")
+
+			ginkgo.By("Complete preemption")
+			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cqp1, 2)
+
+			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, 4)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, 1)
+			util.ExpectClusterQueueWeightedShareMetric(cqp1, 445)
+			util.ExpectClusterQueueWeightedShareMetric(cqp2, 556)
+		})
+
+		// The larger workload, size 6, satisfies
+		// LessThanOrEqualToInitialShare: 6 <= 6
+		// while not satisfying either policies for the 2nd workload:
+		// LessThanOrEqualToFinalShare: 6 <= 4 (FALSE)
+		// LessThanInitialShare: 6 < 6 (FALSE)
+		// Therefore, the workload of size 6 can't
+		// find enough preemption targets.
+		ginkgo.It("workload of size 5 admits with inadmissible higher priority workload at ClusterQueue head", func() {
+			ginkgo.By("Create workloads in queue1")
+			for range 4 {
+				createWorkload("cq-p1", "2")
+			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, 4)
+
+			ginkgo.By("Create workloads in queue2")
+			createWorkloadWithPriority("cq-p2", "6", 999)
+
+			ginkgo.By("Verify doesn't admit")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, 0)
+
+			ginkgo.By("Create admissible workload in queue2")
+			createWorkloadWithPriority("cq-p2", "5", 0)
+
+			ginkgo.By("Complete preemption")
+			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cqp1, 2)
+
+			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, 4)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, 1)
+			util.ExpectClusterQueueWeightedShareMetric(cqp1, 445)
+			util.ExpectClusterQueueWeightedShareMetric(cqp2, 556)
+		})
+
+		ginkgo.It("workload of size 4 admits with inadmissible higher priority workload at ClusterQueue head", func() {
+			ginkgo.By("Create workloads in queue1")
+			for range 4 {
+				createWorkload("cq-p1", "2")
+			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, 4)
+
+			ginkgo.By("Create workload in queue2")
+			createWorkloadWithPriority("cq-p2", "6", 999)
+
+			ginkgo.By("Verify doesn't admit")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, 0)
+
+			ginkgo.By("Create admissible workload in queue2")
+			createWorkloadWithPriority("cq-p2", "4", 0)
+
+			ginkgo.By("Complete preemption")
+			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cqp1, 2)
+
+			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, 4)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, 1)
+			util.ExpectClusterQueueWeightedShareMetric(cqp1, 445)
+			util.ExpectClusterQueueWeightedShareMetric(cqp2, 445)
+		})
+
+		ginkgo.It("workload admits when several higher priority blocking workloads in front", func() {
+			ginkgo.By("Create workloads in queue1")
+			for range 4 {
+				createWorkload("cq-p1", "2")
+			}
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, 4)
+
+			ginkgo.By("Create workloads in queue2")
+			createWorkloadWithPriority("cq-p2", "7", 999)
+			createWorkloadWithPriority("cq-p2", "6", 999)
+
+			ginkgo.By("Verify don't admit")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, 0)
+
+			ginkgo.By("Create admissible workload in queue2")
+			createWorkloadWithPriority("cq-p2", "5", 0)
+
+			ginkgo.By("Complete preemption")
+			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cqp1, 2)
+
+			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp1, 4)
+			util.ExpectAdmittedWorkloadsTotalMetric(cqp2, 1)
+			util.ExpectClusterQueueWeightedShareMetric(cqp1, 445)
+			util.ExpectClusterQueueWeightedShareMetric(cqp2, 556)
+		})
+	})
+
+	// kueue#6929
+	ginkgo.When("ClusterQueue head has inadmissible workload", func() {
+		var (
+			cq1     *kueue.ClusterQueue
+			cq2     *kueue.ClusterQueue
+			cohortA *kueue.Cohort
+		)
+		ginkgo.BeforeEach(func() {
+			fungibility := kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.TryNextFlavor,
+				WhenCanPreempt: kueue.TryNextFlavor,
+			}
+			preemption := kueue.ClusterQueuePreemption{
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+			}
+
+			cohortA = createCohort(testing.MakeCohort("cohort-a").
+				Parent("root").
+				FairWeight(resource.MustParse("1")).
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("flavor1").Resource(corev1.ResourceCPU, "3").Obj(),
+				).Obj())
+
+			cq1 = createQueue(testing.MakeClusterQueue("cq1").
+				Cohort("cohort-a").
+				FairWeight(resource.MustParse("1")).
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("flavor1").Resource(corev1.ResourceCPU, "0").Obj(),
+				).
+				FlavorFungibility(fungibility).
+				Preemption(preemption).
+				Obj())
+
+			cq2 = createQueue(testing.MakeClusterQueue("cq2").
+				Cohort("root").
+				FairWeight(resource.MustParse("1")).
+				ResourceGroup(
+					*testing.MakeFlavorQuotas("flavor1").Resource(corev1.ResourceCPU, "0").Obj(),
+				).
+				FlavorFungibility(fungibility).
+				Preemption(preemption).
+				Obj())
+		})
+
+		ginkgo.It("workload which fits behind ClusterQueue head is able to admit", func() {
+			ginkgo.By("Creating borrowing workloads in queue2")
+			createWorkload("cq2", "1")
+			createWorkload("cq2", "1")
+			util.ExpectAdmittedWorkloadsTotalMetric(cq2, 2)
+
+			ginkgo.By("Create inadmissible workload in queue2")
+			createWorkloadWithPriority("cq1", "4", 999)
+
+			ginkgo.By("Verify doesn't admit")
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 0)
+
+			ginkgo.By("Create admissible workload in queue2")
+			createWorkloadWithPriority("cq1", "3", 0)
+
+			ginkgo.By("Complete preemption")
+			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cq2, 2)
+
+			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 1)
+			util.ExpectAdmittedWorkloadsTotalMetric(cq2, 2)
+			util.ExpectClusterQueueWeightedShareMetric(cq1, 0)
+			util.ExpectClusterQueueWeightedShareMetric(cq2, 0)
+		})
+
+		ginkgo.It("sticky workload becomes inadmissible. next workload admits", func() {
+			ginkgo.By("Creating borrowing workloads in queue2")
+			createWorkload("cq2", "1")
+			createWorkload("cq2", "1")
+			util.ExpectAdmittedWorkloadsTotalMetric(cq2, 2)
+
+			ginkgo.By("Create admissible workload in queue1")
+			createWorkloadWithPriority("cq1", "3", 99)
+
+			ginkgo.By("Create another admissible workload in queue1")
+			createWorkloadWithPriority("cq1", "2", 9)
+
+			ginkgo.By("Validate pending workloads")
+			util.ExpectPendingWorkloadsMetric(cq1, 2, 0)
+
+			ginkgo.By("Decreasing cluster capacity, making 99 priority workload inadmissible")
+			updatedCohort := &kueue.Cohort{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cohortA), updatedCohort)).Should(gomega.Succeed())
+				updatedCohort.Spec.ResourceGroups[0].Flavors[0].Resources[0] = kueue.ResourceQuota{
+					Name:         corev1.ResourceCPU,
+					NominalQuota: resource.MustParse("2"),
+				}
+				g.Expect(k8sClient.Update(ctx, updatedCohort)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Validate pending workloads")
+			util.ExpectPendingWorkloadsMetric(cq1, 1, 1)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				util.FinishEvictionsOfAnyWorkloadsInCq(ctx, k8sClient, cq2)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, 1)
+				util.ExpectClusterQueueWeightedShareMetric(cq1, 0)
+				util.ExpectClusterQueueWeightedShareMetric(cq2, 0)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("sticky workload deleted, next workload can admit", func() {
+			ginkgo.By("Creating borrowing workloads in queue2")
+			createWorkload("cq2", "1")
+			createWorkload("cq2", "1")
+			util.ExpectAdmittedWorkloadsTotalMetric(cq2, 2)
+
+			ginkgo.By("Create inadmissible workload in queue1")
+			createWorkloadWithPriority("cq1", "4", 999)
+
+			ginkgo.By("Verify doesn't admit")
+			util.ExpectAdmittedWorkloadsTotalMetric(cq1, 0)
+
+			ginkgo.By("Create admissible workloads in queue1")
+			stickyWorkload := createWorkloadWithPriority("cq1", "3", 99)
+
+			ginkgo.By("Another admissible workload in queue1")
+			createWorkloadWithPriority("cq1", "3", 0)
+
+			ginkgo.By("Delete sticky workload")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, stickyWorkload, true)
+
+			ginkgo.By("Validate pending workloads")
+			util.ExpectPendingWorkloadsMetric(cq1, 1, 1)
+
+			ginkgo.By("Expected Total Admitted Workloads and Weighted Share")
+			gomega.Eventually(func(g gomega.Gomega) {
+				util.FinishEvictionsOfAnyWorkloadsInCq(ctx, k8sClient, cq2)
+				util.ExpectAdmittedWorkloadsTotalMetric(cq1, 1)
+				util.ExpectClusterQueueWeightedShareMetric(cq1, 0)
+				util.ExpectClusterQueueWeightedShareMetric(cq2, 0)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.When("Using AdmissionFairSharing at ClusterQueue level", func() {
 		var (
 			cq1 *kueue.ClusterQueue

--- a/test/util/util_scheduling.go
+++ b/test/util/util_scheduling.go
@@ -45,25 +45,30 @@ func FinishRunningWorkloadsInCQ(ctx context.Context, k8sClient client.Client, cq
 	gomega.ExpectWithOffset(1, finished).To(gomega.Equal(n), "Not enough workloads finished")
 }
 
-func FinishEvictionOfWorkloadsInCQ(ctx context.Context, k8sClient client.Client, cq *kueue.ClusterQueue, n int) {
+func FinishEvictionsOfAnyWorkloadsInCq(ctx context.Context, k8sClient client.Client, cq *kueue.ClusterQueue) int {
 	var realClock = clock.RealClock{}
 	finished := sets.New[types.UID]()
-	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
-		var wList kueue.WorkloadList
-		g.Expect(k8sClient.List(ctx, &wList)).To(gomega.Succeed())
-		for i := 0; i < len(wList.Items) && finished.Len() < n; i++ {
-			wl := wList.Items[i]
-			if wl.Status.Admission == nil || string(wl.Status.Admission.ClusterQueue) != cq.Name {
-				continue
-			}
-			evicted := meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted)
-			quotaReserved := meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
-			if evicted && quotaReserved {
-				workload.UnsetQuotaReservationWithCondition(&wl, "Pending", "Eviction finished by test", time.Now())
-				g.Expect(workload.ApplyAdmissionStatus(ctx, k8sClient, &wl, true, realClock)).To(gomega.Succeed())
-				finished.Insert(wl.UID)
-			}
+	var wList kueue.WorkloadList
+	gomega.Expect(k8sClient.List(ctx, &wList)).To(gomega.Succeed())
+	for _, wl := range wList.Items {
+		if wl.Status.Admission == nil || string(wl.Status.Admission.ClusterQueue) != cq.Name {
+			continue
 		}
-		g.Expect(finished.Len()).Should(gomega.Equal(n), "Not enough workloads evicted")
+		evicted := meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted)
+		quotaReserved := meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
+		if evicted && quotaReserved {
+			workload.UnsetQuotaReservationWithCondition(&wl, "Pending", "Eviction finished by test", time.Now())
+			gomega.Expect(workload.ApplyAdmissionStatus(ctx, k8sClient, &wl, true, realClock)).To(gomega.Succeed())
+			finished.Insert(wl.UID)
+		}
+	}
+	return finished.Len()
+}
+
+func FinishEvictionOfWorkloadsInCQ(ctx context.Context, k8sClient client.Client, cq *kueue.ClusterQueue, n int) {
+	finished := 0
+	gomega.EventuallyWithOffset(1, func(g gomega.Gomega) {
+		finished += FinishEvictionsOfAnyWorkloadsInCq(ctx, k8sClient, cq)
+		g.Expect(finished).Should(gomega.Equal(n), "Not enough workloads evicted")
 	}, Timeout, Interval).Should(gomega.Succeed())
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

Cherry-pick #7157, #7201

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
With BestEffortFIFO enabled, we will keep attempting to schedule a workload as long as
it is waiting for preemption targets to complete. This fixes a bugs where an inadmissible
workload went back to head of queue, in front of the preempting workload, allowing
preempted workloads to reschedule
```