### PR TITLE
bump DRA version from v1beta2 to v1

### DIFF
--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	resourcev1beta2 "k8s.io/api/resource/v1beta2"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -407,8 +407,8 @@ func TestReconcile(t *testing.T) {
 		workload                  *kueue.Workload
 		cq                        *kueue.ClusterQueue
 		lq                        *kueue.LocalQueue
-		resourceClaims            []*resourcev1beta2.ResourceClaim
-		resourceClaimTemplates    []*resourcev1beta2.ResourceClaimTemplate
+		resourceClaims            []*resourcev1.ResourceClaim
+		resourceClaimTemplates    []*resourcev1.ResourceClaimTemplate
 		wantDRAResourceTotal      *int64
 		wantWorkloadsInQueue      *int
 		wantWorkload              *kueue.Workload
@@ -426,14 +426,14 @@ func TestReconcile(t *testing.T) {
 					ResourceClaim("gpu", "rc1").
 					Obj()).
 				Obj(),
-			resourceClaims: []*resourcev1beta2.ResourceClaim{{
+			resourceClaims: []*resourcev1.ResourceClaim{{
 				ObjectMeta: metav1.ObjectMeta{Name: "rc1", Namespace: "ns"},
-				Spec: resourcev1beta2.ResourceClaimSpec{
-					Devices: resourcev1beta2.DeviceClaim{
-						Requests: []resourcev1beta2.DeviceRequest{{
-							Exactly: &resourcev1beta2.ExactDeviceRequest{
+				Spec: resourcev1.ResourceClaimSpec{
+					Devices: resourcev1.DeviceClaim{
+						Requests: []resourcev1.DeviceRequest{{
+							Exactly: &resourcev1.ExactDeviceRequest{
 								DeviceClassName: "gpu.example.com",
-								AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+								AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 								Count:           1,
 							},
 						}},
@@ -476,16 +476,16 @@ func TestReconcile(t *testing.T) {
 					ResourceClaimTemplate("gpu", "gpu-template").
 					Obj()).
 				Obj(),
-			resourceClaimTemplates: []*resourcev1beta2.ResourceClaimTemplate{{
+			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{{
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "ns"},
-				Spec: resourcev1beta2.ResourceClaimTemplateSpec{
-					Spec: resourcev1beta2.ResourceClaimSpec{
-						Devices: resourcev1beta2.DeviceClaim{
-							Requests: []resourcev1beta2.DeviceRequest{{
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{{
 								Name: "gpu-request",
-								Exactly: &resourcev1beta2.ExactDeviceRequest{
+								Exactly: &resourcev1.ExactDeviceRequest{
 									DeviceClassName: "gpu.example.com",
-									AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 									Count:           1,
 								},
 							}},
@@ -523,16 +523,16 @@ func TestReconcile(t *testing.T) {
 					ResourceClaimTemplate("gpu", "gpu-template").
 					Obj()).
 				Obj(),
-			resourceClaimTemplates: []*resourcev1beta2.ResourceClaimTemplate{{
+			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{{
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "ns"},
-				Spec: resourcev1beta2.ResourceClaimTemplateSpec{
-					Spec: resourcev1beta2.ResourceClaimSpec{
-						Devices: resourcev1beta2.DeviceClaim{
-							Requests: []resourcev1beta2.DeviceRequest{{
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{{
 								Name: "gpu-request",
-								Exactly: &resourcev1beta2.ExactDeviceRequest{
+								Exactly: &resourcev1.ExactDeviceRequest{
 									DeviceClassName: "gpu.example.com",
-									AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 									Count:           2,
 								},
 							}},
@@ -568,16 +568,16 @@ func TestReconcile(t *testing.T) {
 					ResourceClaimTemplate("gpu", "gpu-template").
 					Obj()).
 				Obj(),
-			resourceClaimTemplates: []*resourcev1beta2.ResourceClaimTemplate{{
+			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{{
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "ns"},
-				Spec: resourcev1beta2.ResourceClaimTemplateSpec{
-					Spec: resourcev1beta2.ResourceClaimSpec{
-						Devices: resourcev1beta2.DeviceClaim{
-							Requests: []resourcev1beta2.DeviceRequest{{
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{{
 								Name: "gpu-request",
-								Exactly: &resourcev1beta2.ExactDeviceRequest{
+								Exactly: &resourcev1.ExactDeviceRequest{
 									DeviceClassName: "unmapped.example.com",
-									AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 									Count:           1,
 								},
 							}},

--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
-	resourcev1beta2 "k8s.io/api/resource/v1beta2"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -41,7 +41,7 @@ var (
 // countDevicesPerClass returns a resources.Requests representing the
 // total number of devices requested for each DeviceClass inside the provided
 // ResourceClaimSpec.
-func countDevicesPerClass(claimSpec *resourcev1beta2.ResourceClaimSpec) resources.Requests {
+func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) resources.Requests {
 	out := resources.Requests{}
 	if claimSpec == nil {
 		return out
@@ -53,7 +53,7 @@ func countDevicesPerClass(claimSpec *resourcev1beta2.ResourceClaimSpec) resource
 		var q int64
 		if req.Exactly != nil {
 			dcName = req.Exactly.DeviceClassName
-			if req.Exactly.AllocationMode == resourcev1beta2.DeviceAllocationModeExactCount {
+			if req.Exactly.AllocationMode == resourcev1.DeviceAllocationModeExactCount {
 				q = req.Exactly.Count
 			}
 		}
@@ -70,16 +70,16 @@ func countDevicesPerClass(claimSpec *resourcev1beta2.ResourceClaimSpec) resource
 // getClaimSpec resolves the ResourceClaim(Template) referenced by the PodResourceClaim
 // and returns its *ResourceClaimSpec. A nil spec and nil error mean the reference is
 // empty (both name pointers are nil) and should be skipped.
-func getClaimSpec(ctx context.Context, cl client.Client, namespace string, prc corev1.PodResourceClaim) (*resourcev1beta2.ResourceClaimSpec, error) {
+func getClaimSpec(ctx context.Context, cl client.Client, namespace string, prc corev1.PodResourceClaim) (*resourcev1.ResourceClaimSpec, error) {
 	switch {
 	case prc.ResourceClaimTemplateName != nil:
-		var tmpl resourcev1beta2.ResourceClaimTemplate
+		var tmpl resourcev1.ResourceClaimTemplate
 		if err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: *prc.ResourceClaimTemplateName}, &tmpl); err != nil {
 			return nil, err
 		}
 		return &tmpl.Spec.Spec, nil
 	case prc.ResourceClaimName != nil:
-		var claim resourcev1beta2.ResourceClaim
+		var claim resourcev1.ResourceClaim
 		if err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: *prc.ResourceClaimName}, &claim); err != nil {
 			return nil, err
 		}

--- a/pkg/dra/claims_test.go
+++ b/pkg/dra/claims_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	resourcev1beta2 "k8s.io/api/resource/v1beta2"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,16 +40,16 @@ func Test_GetResourceRequests(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = clientgoscheme.AddToScheme(scheme)
 	_ = kueuev1beta1.AddToScheme(scheme)
-	_ = resourcev1beta2.AddToScheme(scheme)
+	_ = resourcev1.AddToScheme(scheme)
 
-	tmpl := &resourcev1beta2.ResourceClaimTemplate{
+	tmpl := &resourcev1.ResourceClaimTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "claim-tmpl-1", Namespace: "ns1"},
-		Spec: resourcev1beta2.ResourceClaimTemplateSpec{
-			Spec: resourcev1beta2.ResourceClaimSpec{
-				Devices: resourcev1beta2.DeviceClaim{
-					Requests: []resourcev1beta2.DeviceRequest{{
-						Exactly: &resourcev1beta2.ExactDeviceRequest{
-							AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+		Spec: resourcev1.ResourceClaimTemplateSpec{
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{
+					Requests: []resourcev1.DeviceRequest{{
+						Exactly: &resourcev1.ExactDeviceRequest{
+							AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 							Count:           2,
 							DeviceClassName: "test-deviceclass-1",
 						},
@@ -59,13 +59,13 @@ func Test_GetResourceRequests(t *testing.T) {
 		},
 	}
 
-	claim := &resourcev1beta2.ResourceClaim{
+	claim := &resourcev1.ResourceClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: "claim-2", Namespace: "ns1"},
-		Spec: resourcev1beta2.ResourceClaimSpec{
-			Devices: resourcev1beta2.DeviceClaim{
-				Requests: []resourcev1beta2.DeviceRequest{{
-					Exactly: &resourcev1beta2.ExactDeviceRequest{
-						AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+		Spec: resourcev1.ResourceClaimSpec{
+			Devices: resourcev1.DeviceClaim{
+				Requests: []resourcev1.DeviceRequest{{
+					Exactly: &resourcev1.ExactDeviceRequest{
+						AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 						Count:           1,
 						DeviceClassName: "test-deviceclass-2",
 					},
@@ -147,9 +147,9 @@ func Test_GetResourceRequests(t *testing.T) {
 				}
 			},
 			extraObjects: []runtime.Object{
-				&resourcev1beta2.ResourceClaimTemplate{
+				&resourcev1.ResourceClaimTemplate{
 					ObjectMeta: metav1.ObjectMeta{Name: "claim-tmpl-2", Namespace: "ns1"},
-					Spec:       resourcev1beta2.ResourceClaimTemplateSpec{Spec: resourcev1beta2.ResourceClaimSpec{Devices: resourcev1beta2.DeviceClaim{Requests: []resourcev1beta2.DeviceRequest{{Exactly: &resourcev1beta2.ExactDeviceRequest{AllocationMode: resourcev1beta2.DeviceAllocationModeExactCount, Count: 1, DeviceClassName: "test-deviceclass-2"}}}}}},
+					Spec:       resourcev1.ResourceClaimTemplateSpec{Spec: resourcev1.ResourceClaimSpec{Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{{Exactly: &resourcev1.ExactDeviceRequest{AllocationMode: resourcev1.DeviceAllocationModeExactCount, Count: 1, DeviceClassName: "test-deviceclass-2"}}}}}},
 				},
 			},
 			lookup: func(dc corev1.ResourceName) (corev1.ResourceName, bool) {
@@ -193,9 +193,9 @@ func Test_GetResourceRequests(t *testing.T) {
 		{
 			name: "Single template requesting two devices",
 			extraObjects: []runtime.Object{
-				&resourcev1beta2.ResourceClaimTemplate{
+				&resourcev1.ResourceClaimTemplate{
 					ObjectMeta: metav1.ObjectMeta{Name: "claim-tmpl-3", Namespace: "ns1"},
-					Spec:       resourcev1beta2.ResourceClaimTemplateSpec{Spec: resourcev1beta2.ResourceClaimSpec{Devices: resourcev1beta2.DeviceClaim{Requests: []resourcev1beta2.DeviceRequest{{Exactly: &resourcev1beta2.ExactDeviceRequest{AllocationMode: resourcev1beta2.DeviceAllocationModeExactCount, Count: 2, DeviceClassName: "test-deviceclass-1"}}}}}},
+					Spec:       resourcev1.ResourceClaimTemplateSpec{Spec: resourcev1.ResourceClaimSpec{Devices: resourcev1.DeviceClaim{Requests: []resourcev1.DeviceRequest{{Exactly: &resourcev1.ExactDeviceRequest{AllocationMode: resourcev1.DeviceAllocationModeExactCount, Count: 2, DeviceClassName: "test-deviceclass-1"}}}}}},
 				},
 			},
 			modifyWL: func(w *kueuev1beta1.Workload) {

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -34,7 +34,7 @@ import (
 	"github.com/onsi/gomega"
 	awv1beta2 "github.com/project-codeflare/appwrapper/api/v1beta2"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
-	resourcev1beta2 "k8s.io/api/resource/v1beta2"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -135,7 +135,7 @@ func (f *Framework) SetupClient(cfg *rest.Config) (context.Context, client.Clien
 	err = kftrainer.AddToScheme(f.scheme)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
-	err = resourcev1beta2.AddToScheme(f.scheme)
+	err = resourcev1.AddToScheme(f.scheme)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
 
 	k8sClient, err := client.New(cfg, client.Options{Scheme: f.scheme})

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	resourcev1beta2 "k8s.io/api/resource/v1beta2"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -159,19 +159,19 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 
 		ginkgo.It("Should handle multiple workloads sharing DRA quota", func() {
 			ginkgo.By("Creating ResourceClaimTemplates")
-			rct1 := &resourcev1beta2.ResourceClaimTemplate{
+			rct1 := &resourcev1.ResourceClaimTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "quota-template-1",
 					Namespace: ns.Name,
 				},
-				Spec: resourcev1beta2.ResourceClaimTemplateSpec{
-					Spec: resourcev1beta2.ResourceClaimSpec{
-						Devices: resourcev1beta2.DeviceClaim{
-							Requests: []resourcev1beta2.DeviceRequest{{
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{{
 								Name: "device-request",
-								Exactly: &resourcev1beta2.ExactDeviceRequest{
+								Exactly: &resourcev1.ExactDeviceRequest{
 									DeviceClassName: "foo.example.com",
-									AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 									Count:           4,
 								},
 							}},
@@ -181,19 +181,19 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			}
 			gomega.Expect(k8sClient.Create(ctx, rct1)).To(gomega.Succeed())
 
-			rct2 := &resourcev1beta2.ResourceClaimTemplate{
+			rct2 := &resourcev1.ResourceClaimTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "quota-template-2",
 					Namespace: ns.Name,
 				},
-				Spec: resourcev1beta2.ResourceClaimTemplateSpec{
-					Spec: resourcev1beta2.ResourceClaimSpec{
-						Devices: resourcev1beta2.DeviceClaim{
-							Requests: []resourcev1beta2.DeviceRequest{{
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{{
 								Name: "device-request",
-								Exactly: &resourcev1beta2.ExactDeviceRequest{
+								Exactly: &resourcev1.ExactDeviceRequest{
 									DeviceClassName: "foo.example.com",
-									AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 									Count:           4,
 								},
 							}},
@@ -265,19 +265,19 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 
 		ginkgo.It("Should admit workload with DRA resource claim templates", func() {
 			ginkgo.By("Creating a ResourceClaimTemplate")
-			rct := &resourcev1beta2.ResourceClaimTemplate{
+			rct := &resourcev1.ResourceClaimTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "device-template",
 					Namespace: ns.Name,
 				},
-				Spec: resourcev1beta2.ResourceClaimTemplateSpec{
-					Spec: resourcev1beta2.ResourceClaimSpec{
-						Devices: resourcev1beta2.DeviceClaim{
-							Requests: []resourcev1beta2.DeviceRequest{{
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{{
 								Name: "device-request",
-								Exactly: &resourcev1beta2.ExactDeviceRequest{
+								Exactly: &resourcev1.ExactDeviceRequest{
 									DeviceClassName: "foo.example.com",
-									AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 									Count:           2,
 								},
 							}},
@@ -318,19 +318,19 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 
 		ginkgo.It("Should handle multiple workloads with ResourceClaimTemplates", func() {
 			ginkgo.By("Creating ResourceClaimTemplates")
-			rct1 := &resourcev1beta2.ResourceClaimTemplate{
+			rct1 := &resourcev1.ResourceClaimTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "device-template-1",
 					Namespace: ns.Name,
 				},
-				Spec: resourcev1beta2.ResourceClaimTemplateSpec{
-					Spec: resourcev1beta2.ResourceClaimSpec{
-						Devices: resourcev1beta2.DeviceClaim{
-							Requests: []resourcev1beta2.DeviceRequest{{
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{{
 								Name: "device-request",
-								Exactly: &resourcev1beta2.ExactDeviceRequest{
+								Exactly: &resourcev1.ExactDeviceRequest{
 									DeviceClassName: "foo.example.com",
-									AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 									Count:           3,
 								},
 							}},
@@ -340,19 +340,19 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			}
 			gomega.Expect(k8sClient.Create(ctx, rct1)).To(gomega.Succeed())
 
-			rct2 := &resourcev1beta2.ResourceClaimTemplate{
+			rct2 := &resourcev1.ResourceClaimTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "device-template-2",
 					Namespace: ns.Name,
 				},
-				Spec: resourcev1beta2.ResourceClaimTemplateSpec{
-					Spec: resourcev1beta2.ResourceClaimSpec{
-						Devices: resourcev1beta2.DeviceClaim{
-							Requests: []resourcev1beta2.DeviceRequest{{
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{{
 								Name: "device-request",
-								Exactly: &resourcev1beta2.ExactDeviceRequest{
+								Exactly: &resourcev1.ExactDeviceRequest{
 									DeviceClassName: "foo.example.com",
-									AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 									Count:           3,
 								},
 							}},
@@ -424,19 +424,19 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 
 		ginkgo.It("Should handle ResourceClaimTemplate with insufficient quota", func() {
 			ginkgo.By("Creating a ResourceClaimTemplate that exceeds quota")
-			rct := &resourcev1beta2.ResourceClaimTemplate{
+			rct := &resourcev1.ResourceClaimTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "device-template-large",
 					Namespace: ns.Name,
 				},
-				Spec: resourcev1beta2.ResourceClaimTemplateSpec{
-					Spec: resourcev1beta2.ResourceClaimSpec{
-						Devices: resourcev1beta2.DeviceClaim{
-							Requests: []resourcev1beta2.DeviceRequest{{
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{{
 								Name: "device-request",
-								Exactly: &resourcev1beta2.ExactDeviceRequest{
+								Exactly: &resourcev1.ExactDeviceRequest{
 									DeviceClassName: "foo.example.com",
-									AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 									Count:           12,
 								},
 							}},
@@ -471,19 +471,19 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 
 		ginkgo.It("Should handle unmapped device classes with proper error", func() {
 			ginkgo.By("Creating a ResourceClaimTemplate with unmapped device class")
-			rct := &resourcev1beta2.ResourceClaimTemplate{
+			rct := &resourcev1.ResourceClaimTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "unmapped-template",
 					Namespace: ns.Name,
 				},
-				Spec: resourcev1beta2.ResourceClaimTemplateSpec{
-					Spec: resourcev1beta2.ResourceClaimSpec{
-						Devices: resourcev1beta2.DeviceClaim{
-							Requests: []resourcev1beta2.DeviceRequest{{
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{{
 								Name: "device-request",
-								Exactly: &resourcev1beta2.ExactDeviceRequest{
+								Exactly: &resourcev1.ExactDeviceRequest{
 									DeviceClassName: "unmapped.example.com",
-									AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 									Count:           2,
 								},
 							}},
@@ -557,19 +557,19 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 
 		ginkgo.It("Should handle multi-pod workloads with correct DRA resource calculation", func() {
 			ginkgo.By("Creating a ResourceClaimTemplate")
-			rct := &resourcev1beta2.ResourceClaimTemplate{
+			rct := &resourcev1.ResourceClaimTemplate{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "multi-pod-template",
 					Namespace: ns.Name,
 				},
-				Spec: resourcev1beta2.ResourceClaimTemplateSpec{
-					Spec: resourcev1beta2.ResourceClaimSpec{
-						Devices: resourcev1beta2.DeviceClaim{
-							Requests: []resourcev1beta2.DeviceRequest{{
+				Spec: resourcev1.ResourceClaimTemplateSpec{
+					Spec: resourcev1.ResourceClaimSpec{
+						Devices: resourcev1.DeviceClaim{
+							Requests: []resourcev1.DeviceRequest{{
 								Name: "device-request",
-								Exactly: &resourcev1beta2.ExactDeviceRequest{
+								Exactly: &resourcev1.ExactDeviceRequest{
 									DeviceClassName: "foo.example.com",
-									AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+									AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 									Count:           1,
 								},
 							}},

--- a/test/integration/singlecluster/controller/dra/suite_test.go
+++ b/test/integration/singlecluster/controller/dra/suite_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	resourcev1beta2 "k8s.io/api/resource/v1beta2"
+	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
@@ -143,16 +143,16 @@ func managerSetup(modifyConfig func(*config.Configuration)) framework.ManagerSet
 }
 
 // Helper function to create a ResourceClaim
-func makeResourceClaim(name, namespace, deviceClassName string, count int64) *resourcev1beta2.ResourceClaim {
-	return &resourcev1beta2.ResourceClaim{
+func makeResourceClaim(name, namespace, deviceClassName string, count int64) *resourcev1.ResourceClaim {
+	return &resourcev1.ResourceClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec: resourcev1beta2.ResourceClaimSpec{
-			Devices: resourcev1beta2.DeviceClaim{
-				Requests: []resourcev1beta2.DeviceRequest{{
+		Spec: resourcev1.ResourceClaimSpec{
+			Devices: resourcev1.DeviceClaim{
+				Requests: []resourcev1.DeviceRequest{{
 					Name: "device-request",
-					Exactly: &resourcev1beta2.ExactDeviceRequest{
+					Exactly: &resourcev1.ExactDeviceRequest{
 						DeviceClassName: deviceClassName,
-						AllocationMode:  resourcev1beta2.DeviceAllocationModeExactCount,
+						AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
 						Count:           count,
 					},
 				}},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
/kind bug
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind regression

#### What this PR does / why we need it:
When testing latest [DRA example driver](https://github.com/kubernetes-sigs/dra-example-driver) the `kueue` would fail because upstream has GAed DRA structured params in 1.34 which moved the API from `v1beta2` to `v1`.  This PR aligns the DRA API version with the upstream k8s. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
If you bring up the kind cluster using the example DRA driver using `make setup-e2e` kueue will won't be able to fetch any `ResourceClaimTemplates` because of the mismatch in DRA API version. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update DRA API used from `v1beta2` to `v1`

ACTION REQUIRED: in order to use DRA integration by enabling the DynamicResourceAllocation feature gate in Kueue you need to use k8s 1.34+.
```